### PR TITLE
docs - add a pl/container upgrade procedure

### DIFF
--- a/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
@@ -410,12 +410,10 @@ plcontainer runtime-replace -r r_run1 -i pivotaldata/plcontainer_r_shared:devel 
                 to a file named <codeph>plcontainer110-backup.xml</codeph> in the local
               directory:<codeblock>$ plcontainer runtime-backup -f plcontainer110-backup.xml</codeblock></li>
             <li>Use the Greenplum Database <codeph>gppkg</codeph> utility with the
-                <codeph>-r</codeph> option to uninstall the PL/Container language extension. For
-              example, the following command uninstalls the PL/Container language extension on a Linux
-              system:<codeblock>$ gppkg -r plcontainer-1.1.0</codeblock></li>
-            <li>Run the package installation command to install PL/Container 1.2.
-              The following command installs the language extension on a Linux
-              system:<codeblock>$ gppkg -i plcontainer-1.2.0-rhel7-x86_64.gppkg</codeblock></li>
+                <codeph>-u</codeph> option to update the PL/Container language extension. For
+              example, the following command updates the PL/Container language extension
+              to version 1.2 on a Linux
+              system:<codeblock>$ gppkg -u plcontainer-1.2.0-rhel7-x86_64.gppkg</codeblock></li>
             <li>Source the Greenplum Database environment file
               <codeph>$GPHOME/greenplum_path.sh</codeph>.<codeblock>$ source $GPHOME/greenplum_path.sh</codeblock></li>
             <li>Restore the PL/Container configuration. For example, this command restores

--- a/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
@@ -12,6 +12,7 @@
         <xref href="#topic_tcm_htd_gw" format="dita"/></li>
       <li id="pz213664" otherprops="pivotal"><xref href="#topic3" type="topic" format="dita"/></li>
       <li otherprops="op-pivotal"><xref href="#topic_qbl_dkq_vcb" format="dita"/></li>
+      <li otherprops="op-pivotal"><xref href="#topic_upg110" format="dita"/></li>
       <li id="pz213668"><xref href="#topic6" type="topic" format="dita"/>
       </li>
       <li id="pz215253"><xref href="#topic_rh3_p3q_dw" format="dita"/></li>
@@ -161,10 +162,12 @@
     <body>
       <p>To use Greenplum Database resource groups to manage PL/Container resources,
         you must explicitly configure both resource groups and PL/Container.</p>
-      <note>If you downgrade to Greenplum Database version 5.7 or earlier after you
-        configure resource groups for PL/Container, you must also downgrade PL/Container
-        to version 1.1 and remove all <codeph>resource_group_id</codeph> settings from
-        your PL/Container runtime configurations.</note>
+      <note>PL/Container version 1.2 utilizes the new resource group capabilities
+        introduced in Greenplum Database version 5.8.0. If you downgrade to a
+        Greenplum Database system that uses PL/Container version 1.1. or earlier,
+        you must use <codeph>plcontainer runtime-edit</codeph> to 
+        remove any <codeph>resource_group_id</codeph> settings from
+        your PL/Container runtime configuration.</note>
     </body>
     <topic id="topic_resgroupcfg_proc">
       <title>Procedure</title>
@@ -389,6 +392,53 @@ plcontainer runtime-replace -r r_run1 -i pivotaldata/plcontainer_r_shared:devel 
           UDFs that are required.</p>
       </body>
     </topic>
+
+
+    <topic id="topic_upg110" otherprops="pivotal">
+      <title>Upgrading from PL/Container 1.1</title>
+      <body>
+        <p>To upgrade from PL/Container version 1.1 or higher, you save the current
+          configuration, upgrade PL/Container, and then restore the configuration after upgrade.
+          There is no need to update the Docker images when you upgrade PL/Container.</p>
+        <note>Before you perform this upgrade procedure, ensure that you have migrated
+          your PL/Container 1.1 package from your previous Greenplum Database
+          installation to your new Greenplum Database installation. Refer to the
+          <xref href="../../utility_guide/admin_utilities/gppkg.html#topic1" format="dita" scope="peer">gppkg</xref>
+          command for package installation and migration information.</note>
+        <p>Perform the following procedure to upgrade from PL/Container 1.1 to PL/Container version 1.2 or later.<ol id="ol_axf_mmq_vcb">
+            <li>Save the PL/Container configuration. For example, to save the configuration
+                to a file named <codeph>plcontainer110-backup.xml</codeph> in the local
+              directory:<codeblock>$ plcontainer runtime-backup -f plcontainer110-backup.xml</codeblock></li>
+            <li>Use the Greenplum Database <codeph>gppkg</codeph> utility with the
+                <codeph>-r</codeph> option to uninstall the PL/Container language extension. For
+              example, the following command uninstalls the PL/Container language extension on a Linux
+              system:<codeblock>$ gppkg -r plcontainer-1.1.0</codeblock></li>
+            <li>Run the package installation command to install PL/Container 1.2.
+              The following command installs the language extension on a Linux
+              system:<codeblock>$ gppkg -i plcontainer-1.2.0-rhel7-x86_64.gppkg</codeblock></li>
+            <li>Source the Greenplum Database environment file
+              <codeph>$GPHOME/greenplum_path.sh</codeph>.<codeblock>$ source $GPHOME/greenplum_path.sh</codeblock></li>
+            <li>Restore the PL/Container configuration. For example, this command restores
+              the PL/Container configuration that you saved in a previous step:
+             <codeblock>$ plcontainer runtime-restore -f plcontainer110-backup.xml</codeblock></li>
+            <li>Restart Greenplum Database.<codeblock>$ gpstop -ra</codeblock></li>
+            <li>You do not need to re-register the PL/Container extension in the databases
+              in which you previously created the extension. Do register the
+              PL/Container extension in each new database that will run
+              PL/Container UDFs. For example, the following command registers PL/Container
+              in a database named <codeph>mytest</codeph>:
+                <codeblock>$ psql -d mytest -c 'CREATE EXTENSION plcontainer;'</codeblock>
+              <p>The command also creates PL/Container-specific functions and views.</p></li>
+          </ol></p>
+       <note>PL/Container version 1.2 utilizes the new resource group capabilities
+        introduced in Greenplum Database version 5.8.0. If you downgrade to a
+        Greenplum Database system that uses PL/Container version 1.1. or earlier,
+        you must use <codeph>plcontainer runtime-edit</codeph> to
+        remove any <codeph>resource_group_id</codeph> settings from
+        your PL/Container runtime configuration.</note>
+      </body>
+    </topic>
+
     <topic id="topic_i2t_v2n_sbb" otherprops="oss-only">
       <title>Building and Installing the PL/Container Language Extension</title>
       <!--oss only conent-->


### PR DESCRIPTION
added a pl/container 1.1->1.2 upgrade procedure.  instructing the user to migrate the package, save the pl/container config, remove 1.1.0, install 1.2.0, and restore the pl/container config.  i tried this out, it works.  i am not that familiar with gppkg, there might be a more streamlined set of commands to do this.

link to new section on doc staging review site:
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/extensions/pl_container.html#topic_upg110