### PR TITLE
Fixes issue 4437: could not save history to file "/home/ftian/.psql_history": No such file or directory

### DIFF
--- a/src/bin/psql/input.c
+++ b/src/bin/psql/input.c
@@ -340,6 +340,7 @@ bool
 saveHistory(char *fname, int max_lines, bool appendFlag, bool encodeFlag)
 {
 #ifdef USE_READLINE
+	int			errnum;
 
 	/*
 	 * Suppressing the write attempt when HISTFILE is set to /dev/null may
@@ -359,10 +360,6 @@ saveHistory(char *fname, int max_lines, bool appendFlag, bool encodeFlag)
 		 * history from other concurrent sessions (although there are still
 		 * race conditions when two sessions exit at about the same time). If
 		 * we don't have those functions, fall back to write_history().
-		 *
-		 * Note: return value of write_history is not standardized across GNU
-		 * readline and libedit.  Therefore, check for errno becoming set to
-		 * see if the write failed.  Similarly for append_history.
 		 */
 #if defined(HAVE_HISTORY_TRUNCATE_FILE) && defined(HAVE_APPEND_HISTORY)
 		if (appendFlag)
@@ -385,9 +382,8 @@ saveHistory(char *fname, int max_lines, bool appendFlag, bool encodeFlag)
 				nlines = Min(max_lines, history_lines_added);
 			else
 				nlines = history_lines_added;
-			errno = 0;
-			(void) append_history(nlines, fname);
-			if (errno == 0)
+			errnum = append_history(nlines, fname);
+			if (errnum == 0)
 				return true;
 		}
 		else
@@ -396,15 +392,15 @@ saveHistory(char *fname, int max_lines, bool appendFlag, bool encodeFlag)
 			/* truncate what we have ... */
 			if (max_lines >= 0)
 				stifle_history(max_lines);
-			/* ... and overwrite file.	Tough luck for concurrent sessions. */
-			errno = 0;
-			(void) write_history(fname);
-			if (errno == 0)
+
+			/* ... and overwrite file.  Tough luck for concurrent sessions. */
+			errnum = write_history(fname);
+			if (errnum == 0)
 				return true;
 		}
 
 		psql_error("could not save history to file \"%s\": %s\n",
-				   fname, strerror(errno));
+				   fname, strerror(errnum));
 	}
 #else
 	/* only get here in \s case, so complain */


### PR DESCRIPTION
This is just cherry-pick of upstream commit.

---
Remove workaround for ancient incompatibility between readline and libedit.

GNU readline defines the return value of write_history() as "zero if OK,
else an errno code".  libedit's version of that function used to have a
different definition (to wit, "-1 if error, else the number of lines
written to the file").  We tried to work around that by checking whether
errno had become nonzero, but this method has never been kosher according
to the published API of either library.  It's reportedly completely broken
in recent Ubuntu releases: psql bleats about "No such file or directory"
when saving ~/.psql_history, even though the write worked fine.

However, libedit has been following the readline definition since somewhere
around 2006, so it seems all right to finally break compatibility with
ancient libedit releases and trust that the return value is what readline
specifies.  (I'm not sure when the various Linux distributions incorporated
this fix, but I did find that OS X has been shipping fixed versions since
10.5/Leopard.)

If anyone is still using such an ancient libedit, they will find that psql
complains it can't write ~/.psql_history at exit, even when the file was
written correctly.  This is no worse than the behavior we're fixing for
current releases.

Back-patch to all supported branches.

---

(cherry picked from commit df9ebf1eeaf98481e00cd77bf6056d42310731b7)
Fixes #4437.