### PR TITLE
Fix crash_recovery_redundant_dtx test.

### DIFF
--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -17,11 +17,17 @@ t
 (1 row)
 1&:CHECKPOINT;  <waiting ...>
 
+-- wait till checkpoint reaches intended point
+2:select gp_wait_until_triggered_fault('checkpoint_dtx_info', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
 -- the 'COMMIT' record is logically after REDO pointer
 2&:insert into crash_test_redundant values (1);  <waiting ...>
 
 -- resume checkpoint
-3:select gp_inject_fault('checkpoint_dtx_info', 'resume', 1);
+3:select gp_inject_fault('checkpoint_dtx_info', 'reset', 1);
 gp_inject_fault
 ---------------
 t              
@@ -29,6 +35,12 @@ t
 1<:  <... completed>
 CHECKPOINT
 
+-- wait till insert reaches intended point
+1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
 -- trigger crash
 1:select gp_inject_fault('before_read_command', 'panic', 1);
 gp_inject_fault

--- a/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
+++ b/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
@@ -7,13 +7,17 @@
 1:select gp_inject_fault('checkpoint_dtx_info', 'suspend', 1);
 1&:CHECKPOINT;
 
+-- wait till checkpoint reaches intended point
+2:select gp_wait_until_triggered_fault('checkpoint_dtx_info', 1, 1);
 -- the 'COMMIT' record is logically after REDO pointer
 2&:insert into crash_test_redundant values (1);
 
 -- resume checkpoint
-3:select gp_inject_fault('checkpoint_dtx_info', 'resume', 1);
+3:select gp_inject_fault('checkpoint_dtx_info', 'reset', 1);
 1<:
 
+-- wait till insert reaches intended point
+1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 1, 1);
 -- trigger crash
 1:select gp_inject_fault('before_read_command', 'panic', 1);
 1:select 1;


### PR DESCRIPTION
The test can fail if PANIC happens before insert has even reached the intended
point of finishing commit on master. In this case select rightfully returns zero
rows compared to expected 1 row.