### PR TITLE
[gprecoverseg rebalance] Ensure failover is complete before bringing up the mirror

### DIFF
--- a/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
+++ b/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
@@ -9,6 +9,9 @@ from gppylib.operations.segment_reconfigurer import SegmentReconfigurer
 
 from gppylib.operations.segment_reconfigurer import ReconfigDetectionSQLQueryCommand
 
+MIRROR_PROMOTION_TIMEOUT=30
+
+
 class GpSegmentRebalanceOperation:
     def __init__(self, gpEnv, gpArray):
         self.gpEnv = gpEnv
@@ -58,7 +61,8 @@ class GpSegmentRebalanceOperation:
                 self.logger.info("gprecoverseg will continue with a partial rebalance.")
 
             pool.empty_completed_items()
-            segment_reconfigurer = SegmentReconfigurer(self.logger, pool)
+            segment_reconfigurer = SegmentReconfigurer(logger=self.logger,
+                    worker_pool=pool, timeout=MIRROR_PROMOTION_TIMEOUT)
             segment_reconfigurer.reconfigure()
 
             # Final step is to issue a recoverseg operation to resync segments

--- a/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
+++ b/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
@@ -1,15 +1,28 @@
 import sys
 import signal
 from gppylib.gparray import GpArray
+from gppylib.db import dbconn
 from gppylib.commands.gp import GpSegStopCmd, GpRecoverseg
 from gppylib.commands import base
 from gppylib import gplog
 
 from gppylib.operations.segment_reconfigurer import SegmentReconfigurer
 
-from gppylib.operations.segment_reconfigurer import ReconfigDetectionSQLQueryCommand
-
 MIRROR_PROMOTION_TIMEOUT=30
+
+
+class ReconfigDetectionSQLQueryCommand(base.SQLCommand):
+    """A distributed query that will cause the system to detect
+    the reconfiguration of the system"""
+
+    query = "SELECT * FROM gp_dist_random('gp_id')"
+
+    def __init__(self, conn):
+        base.SQLCommand.__init__(self, "Reconfig detection sql query")
+        self.cancel_conn = conn
+
+    def run(self):
+        dbconn.execSQL(self.cancel_conn, self.query)
 
 
 class GpSegmentRebalanceOperation:

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -41,7 +41,7 @@ class SegmentReconfigurer:
                 if now < start_time + self.timeout:
                     continue
                 else:
-                    raise
+                    raise RuntimeError("Mirror promotion did not complete in {0} seconds.".format(self.timeout))
             else:
                 conn.close()
                 break

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -7,20 +7,6 @@ import pygresql.pg
 
 FTS_PROBE_QUERY = 'SELECT gp_request_fts_probe_scan()'
 
-class ReconfigDetectionSQLQueryCommand(base.SQLCommand):
-    """A distributed query that will cause the system to detect
-    the reconfiguration of the system"""
-
-    query = "SELECT * FROM gp_dist_random('gp_id')"
-
-    def __init__(self, conn):
-        base.SQLCommand.__init__(self, "Reconfig detection sql query")
-        self.cancel_conn = conn
-
-    def run(self):
-        dbconn.execSQL(self.cancel_conn, self.query)
-
-
 class SegmentReconfigurer:
     def __init__(self, logger, worker_pool, timeout):
         self.logger = logger
@@ -57,8 +43,5 @@ class SegmentReconfigurer:
                 else:
                     raise
             else:
-                cmd = ReconfigDetectionSQLQueryCommand(conn)
-                self.pool.addCommand(cmd)
-                self.pool.wait_and_printdots(1, False)
                 conn.close()
                 break

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -1,3 +1,5 @@
+import time
+
 from gppylib.commands import base
 from gppylib.db import dbconn
 
@@ -26,12 +28,17 @@ class SegmentReconfigurer:
         # that we just caused by shutting down segments
         self.logger.info("Triggering segment reconfiguration")
         dburl = dbconn.DbURL()
+        start_time = time.time()
         while True:
+            conn = None
             try:
                 conn = dbconn.connect(dburl)
             except Exception as e:
-                # This exception is expected
-                continue
+                now = time.time()
+                if now < start_time + 30:
+                    continue
+                else:
+                    raise
             else:
                 cmd = ReconfigDetectionSQLQueryCommand(conn)
                 self.pool.addCommand(cmd)

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -5,7 +5,7 @@ from gppylib.db import dbconn
 import pygresql.pg
 
 
-fts_probe_query = 'SELECT gp_request_fts_probe_scan()'
+FTS_PROBE_QUERY = 'SELECT gp_request_fts_probe_scan()'
 
 class ReconfigDetectionSQLQueryCommand(base.SQLCommand):
     """A distributed query that will cause the system to detect
@@ -34,7 +34,7 @@ class SegmentReconfigurer:
                 dburl.pguser,
                 dburl.pgpass,
                 )
-        conn.query(fts_probe_query)
+        conn.query(FTS_PROBE_QUERY)
         conn.close()
 
     def reconfigure(self):

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -24,17 +24,17 @@ class SegmentReconfigurer:
     def reconfigure(self):
         # issue a distributed query to make sure we pick up the fault
         # that we just caused by shutting down segments
-        conn = None
-        try:
-            self.logger.info("Triggering segment reconfiguration")
-            dburl = dbconn.DbURL()
-            conn = dbconn.connect(dburl)
-            cmd = ReconfigDetectionSQLQueryCommand(conn)
-            self.pool.addCommand(cmd)
-            self.pool.wait_and_printdots(1, False)
-        except Exception:
-            # This exception is expected
-            pass
-        finally:
-            if conn:
+        self.logger.info("Triggering segment reconfiguration")
+        dburl = dbconn.DbURL()
+        while True:
+            try:
+                conn = dbconn.connect(dburl)
+            except Exception as e:
+                # This exception is expected
+                continue
+            else:
+                cmd = ReconfigDetectionSQLQueryCommand(conn)
+                self.pool.addCommand(cmd)
+                self.pool.wait_and_printdots(1, False)
                 conn.close()
+                break

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -22,9 +22,10 @@ class ReconfigDetectionSQLQueryCommand(base.SQLCommand):
 
 
 class SegmentReconfigurer:
-    def __init__(self, logger, pool):
+    def __init__(self, logger, worker_pool, timeout):
         self.logger = logger
-        self.pool = pool
+        self.pool = worker_pool
+        self.timeout = timeout
 
     def _trigger_fts_probe(self, dburl):
         conn = pygresql.pg.connect(dburl.pgdb,
@@ -51,7 +52,7 @@ class SegmentReconfigurer:
                 conn = dbconn.connect(dburl)
             except Exception as e:
                 now = time.time()
-                if now < start_time + 30:
+                if now < start_time + self.timeout:
                     continue
                 else:
                     raise

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -1,0 +1,40 @@
+from gppylib.commands import base
+from gppylib.db import dbconn
+
+
+class ReconfigDetectionSQLQueryCommand(base.SQLCommand):
+    """A distributed query that will cause the system to detect
+    the reconfiguration of the system"""
+
+    query = "SELECT * FROM gp_dist_random('gp_id')"
+
+    def __init__(self, conn):
+        base.SQLCommand.__init__(self, "Reconfig detection sql query")
+        self.cancel_conn = conn
+
+    def run(self):
+        dbconn.execSQL(self.cancel_conn, self.query)
+
+
+class SegmentReconfigurer:
+    def __init__(self, logger, pool):
+        self.logger = logger
+        self.pool = pool
+
+    def reconfigure(self):
+        # issue a distributed query to make sure we pick up the fault
+        # that we just caused by shutting down segments
+        conn = None
+        try:
+            self.logger.info("Triggering segment reconfiguration")
+            dburl = dbconn.DbURL()
+            conn = dbconn.connect(dburl)
+            cmd = ReconfigDetectionSQLQueryCommand(conn)
+            self.pool.addCommand(cmd)
+            self.pool.wait_and_printdots(1, False)
+        except Exception:
+            # This exception is expected
+            pass
+        finally:
+            if conn:
+                conn.close()

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -30,7 +30,6 @@ class SegmentReconfigurer:
         dburl = dbconn.DbURL()
         start_time = time.time()
         while True:
-            conn = None
             try:
                 conn = dbconn.connect(dburl)
             except Exception as e:

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
@@ -86,8 +86,9 @@ class SegmentReconfiguerTestCase(GpTestCase):
 
         reconfigurer = SegmentReconfigurer(logger=self.logger,
                 worker_pool=self.worker_pool, timeout=self.timeout)
-        with self.assertRaises(pgdb.DatabaseError):
+        with self.assertRaises(RuntimeError) as context:
             reconfigurer.reconfigure()
+            self.assertEqual("Mirror promotion did not complete in {0} seconds.".format(self.timeout), context.exception.message)
 
         self.connect.assert_has_calls([call(self.db_url), call(self.db_url), ])
         self.conn.close.assert_has_calls([])

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
@@ -1,23 +1,33 @@
 from gppylib.operations.segment_reconfigurer import SegmentReconfigurer
 
 from gppylib.test.unit.gp_unittest import GpTestCase
-from mock import Mock, patch
+from pygresql import pgdb
+import mock
+from mock import Mock, patch, call
 
 
 class SegmentReconfiguerTestCase(GpTestCase):
     @patch('gppylib.db.dbconn.connect')
     @patch('gppylib.db.dbconn.DbURL')
-    def test_it_closes_the_connection(self, db_url_mock, connect):
+    def test_it_retries_the_connection(self, db_url_mock, connect):
+        nonlocal = {'counter': 0}
+
+        def fail_twice(*args):
+            if nonlocal['counter'] < 2:
+                nonlocal['counter'] += 1
+                raise pgdb.DatabaseError
+            else:
+                return mock.DEFAULT
+
         db_url = 'dbUrl'
         db_url_mock.return_value = db_url
-        conn = Mock()
-        connect.return_value = conn
+        conn = Mock(name='conn')
+        connect.configure_mock(return_value=conn, side_effect=fail_twice)
         logger = Mock()
         worker_pool = Mock()
 
         reconfigurer = SegmentReconfigurer(logger, worker_pool)
         reconfigurer.reconfigure()
 
-        db_url_mock.assert_called_once_with()
-        connect.assert_called_once_with(db_url)
-        conn.close.assert_called_once_with()
+        connect.assert_has_calls([call(db_url), call(db_url), call(db_url), ])
+        conn.close.assert_any_call()

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
@@ -7,6 +7,7 @@ from gppylib.test.unit.gp_unittest import GpTestCase
 from pygresql import pgdb
 import mock
 from mock import Mock, patch, call, MagicMock
+import contextlib
 
 
 class SegmentReconfiguerTestCase(GpTestCase):
@@ -16,27 +17,28 @@ class SegmentReconfiguerTestCase(GpTestCase):
         self.worker_pool = Mock()
         self.db_url = 'dbUrl'
 
-        self.db_url_mock = MagicMock(return_value=self.db_url)
-        cm = patch('gppylib.db.dbconn.DbURL', new=(MagicMock(return_value=self.db_url)))
+        self.connect = MagicMock()
+        cm = contextlib.nested(
+                patch('gppylib.db.dbconn.connect', new=self.connect),
+                patch('gppylib.db.dbconn.DbURL', return_value=self.db_url),
+                )
         cm.__enter__()
         self.cm = cm
 
     def tearDown(self):
-        self.cm.__exit__()
+        self.cm.__exit__(None, None, None)
 
-    @patch('gppylib.db.dbconn.connect')
-    def test_it_retries_the_connection(self, connect):
-        connect.configure_mock(side_effect=[pgdb.DatabaseError, pgdb.DatabaseError, self.conn])
+    def test_it_retries_the_connection(self):
+        self.connect.configure_mock(side_effect=[pgdb.DatabaseError, pgdb.DatabaseError, self.conn])
 
         reconfigurer = SegmentReconfigurer(self.logger, self.worker_pool)
         reconfigurer.reconfigure()
 
-        connect.assert_has_calls([call(self.db_url), call(self.db_url), call(self.db_url), ])
+        self.connect.assert_has_calls([call(self.db_url), call(self.db_url), call(self.db_url), ])
         self.conn.close.assert_any_call()
 
     @patch('time.time')
-    @patch('gppylib.db.dbconn.connect')
-    def test_it_gives_up_after_30_seconds(self, connect, now_mock):
+    def test_it_gives_up_after_30_seconds(self, now_mock):
         start_datetime = datetime.datetime(2018, 5, 9, 16, 0, 0)
         start_time = time.mktime(start_datetime.timetuple())
         now_mock.configure_mock(return_value=start_time)
@@ -49,11 +51,11 @@ class SegmentReconfiguerTestCase(GpTestCase):
                 yield pgdb.DatabaseError
 
 
-        connect.configure_mock(side_effect=fail_for_half_a_minute())
+        self.connect.configure_mock(side_effect=fail_for_half_a_minute())
 
         reconfigurer = SegmentReconfigurer(self.logger, self.worker_pool)
         with self.assertRaises(pgdb.DatabaseError):
             reconfigurer.reconfigure()
 
-        connect.assert_has_calls([call(self.db_url), call(self.db_url), ])
+        self.connect.assert_has_calls([call(self.db_url), call(self.db_url), ])
         self.conn.close.assert_has_calls([])

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
@@ -1,7 +1,7 @@
 import datetime
 import time
 
-from gppylib.operations.segment_reconfigurer import SegmentReconfigurer, fts_probe_query
+from gppylib.operations.segment_reconfigurer import SegmentReconfigurer, FTS_PROBE_QUERY
 
 from gppylib.test.unit.gp_unittest import GpTestCase
 from pygresql import pgdb
@@ -50,7 +50,7 @@ class SegmentReconfiguerTestCase(GpTestCase):
         reconfigurer.reconfigure()
         pygresql.pg.connect.assert_has_calls([
             call(self.db, self.host, self.port, None, self.user, self.passwd),
-            call().query(fts_probe_query),
+            call().query(FTS_PROBE_QUERY),
             call().close(),
             ]
             )

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
@@ -1,0 +1,23 @@
+from gppylib.operations.segment_reconfigurer import SegmentReconfigurer
+
+from gppylib.test.unit.gp_unittest import GpTestCase
+from mock import Mock, patch
+
+
+class SegmentReconfiguerTestCase(GpTestCase):
+    @patch('gppylib.db.dbconn.connect')
+    @patch('gppylib.db.dbconn.DbURL')
+    def test_it_closes_the_connection(self, db_url_mock, connect):
+        db_url = 'dbUrl'
+        db_url_mock.return_value = db_url
+        conn = Mock()
+        connect.return_value = conn
+        logger = Mock()
+        worker_pool = Mock()
+
+        reconfigurer = SegmentReconfigurer(logger, worker_pool)
+        reconfigurer.reconfigure()
+
+        db_url_mock.assert_called_once_with()
+        connect.assert_called_once_with(db_url)
+        conn.close.assert_called_once_with()


### PR DESCRIPTION
To "rebalance" a primary-mirror pair, `gprecoverseg -r` performs the following steps:

1. bring down the acting primary
1. issue a query that triggers the failover
1. bring up the mirror (`gprecoverseg -F`)

Currently these 3 steps are happening in close succession. However, there is a chance that between step 2 and step 3, the mirror promotion happens slower than we expect. The implicit assumption here is that the acting mirror has finished transitioning to the primary role before step 3 is performed.

This patch adds a retry in "sort of step 2, definitely before step 3", to ensure a good state before we can bring up the mirror.

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>
Co-authored-by: David Kimura <dkimura@pivotal.io>