### PR TITLE
Fix crash issues in global deadlock detector.

### DIFF
--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -439,7 +439,7 @@ findSuperuser(char *superuser, bool try_bootstrap)
 
 	if (!*superuser)
 		ereport(FATAL,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				(errcode(ERRCODE_INVALID_NAME),
 				 errmsg("no super user is found")));
 }
 

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -158,6 +158,7 @@ NON_EXEC_STATIC void
 GlobalDeadLockDetectorMain(int argc, char *argv[])
 {
 	sigjmp_buf	local_sigjmp_buf;
+	Port		portbuf;
 	char	   *fullpath;
 	char	   *ddtUser;
 	char	   *knownDatabase = "postgres";
@@ -305,10 +306,10 @@ GlobalDeadLockDetectorMain(int argc, char *argv[])
 	RelationCacheInitializePhase3();
 
 	ddtUser = findSuperuser(true);
-	MyProcPort = (Port *) calloc(1, sizeof(Port));
-	if (MyProcPort == NULL)
-		elog(FATAL, "Lack of memory for MyProcPort allocation in global deadlock detector backend.");
-	MyProcPort->user_name = MemoryContextStrdup(TopMemoryContext, ddtUser);
+	memset(&portbuf, 0, sizeof(portbuf));
+
+	MyProcPort = &portbuf;
+	MyProcPort->user_name = strdup(ddtUser);
 	MyProcPort->database_name = knownDatabase;
 
 	/* close the transaction we started above */

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -450,7 +450,7 @@ findSuperuser(char *superuser, bool try_bootstrap)
 								RelationGetDescr(auth_rel), &isNull);
 		Assert(!isNull);
 		strncpy(superuser, DatumGetCString(attrName), NAMEDATALEN);
-		superuser[NAMEDATALEN - 1] = 0;
+		superuser[NAMEDATALEN - 1] = '\0';
 
 		userOid = HeapTupleGetOid(auth_tup);
 		SetSessionUserId(userOid, true);

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -159,7 +159,7 @@ GlobalDeadLockDetectorMain(int argc, char *argv[])
 {
 	sigjmp_buf	local_sigjmp_buf;
 	Port		portbuf;
-	char		superuser[NAMEDATALEN + 1];
+	char		superuser[NAMEDATALEN];
 	char	   *fullpath;
 	char	   *knownDatabase = "postgres";
 
@@ -375,7 +375,9 @@ GlobalDeadLockDetectorLoop(void)
 /*
  * Find a super user.
  *
- * superuser is used to store the username, its size should be >= NAMEDATALEN+1.
+ * superuser is used to store the username, its size should be >= NAMEDATALEN.
+ *
+ * This functions is derived from getSuperuser() @cdbtm.c
  */
 static void
 findSuperuser(char *superuser, bool try_bootstrap)
@@ -387,7 +389,7 @@ findSuperuser(char *superuser, bool try_bootstrap)
 	int			nkeys;
 	bool	isNull;
 
-	*superuser = 0;
+	*superuser = '\0';
 
 	auth_rel = heap_open(AuthIdRelationId, AccessShareLock);
 
@@ -425,8 +427,8 @@ findSuperuser(char *superuser, bool try_bootstrap)
 		attrName = heap_getattr(auth_tup, Anum_pg_authid_rolname,
 								RelationGetDescr(auth_rel), &isNull);
 		Assert(!isNull);
-		strncpy(superuser, DatumGetCString(attrName), NAMEDATALEN + 1);
-		superuser[NAMEDATALEN] = 0;
+		strncpy(superuser, DatumGetCString(attrName), NAMEDATALEN);
+		superuser[NAMEDATALEN - 1] = 0;
 
 		userOid = HeapTupleGetOid(auth_tup);
 		SetSessionUserId(userOid, true);


### PR DESCRIPTION
It's reported that gdd (global deadlock detector) crashes occasionally in gprecoverseg test:

            (gdb) bt
            0x00007f56b506794f in __strlen_sse42 () from /lib64/libc.so.6
            0x00000000009f7894 in write_message_to_server_log ()
            0x00000000009fc200 in send_message_to_server_log ()
            0x00000000009ffb85 in EmitErrorReport ()
            0x00000000009fccf5 in errfinish ()
            0x0000000000acd99f in FtsTestSegmentDBIsDown ()

The root cause be the unchecked pointers allocated with `malloc()` and `strdup()` in the gdd backend. Now we make the allocation on stack directly.

Test cases are not included as we can not figure out a way to trigger it steadily. But according to the report it should be covered in existing gprecoverseg tests, although the failrate is low.
