### PR TITLE
Speedup gpinitsystem by few secs.

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1293,7 +1293,6 @@ CREATE_QD_DB () {
 		BACKOUT_COMMAND "if [ -d $GP_DIR ]; then $EXPORT_LIB_PATH;export PGPORT=$GP_PORT; $PG_CTL -D $GP_DIR stop; fi"
 		BACKOUT_COMMAND "$ECHO \"Stopping Master instance\""
 		LOG_MSG "[INFO]:-Completed starting the Master in admin mode"
-		$SLEEP 2
 		GP_HOSTNAME=`HOST_LOOKUP $GP_HOSTADDRESS`
 		if [ x"$GP_HOSTNAME" = x"__lookup_of_hostname_failed__" ]; then
 			ERROR_EXIT "[FATAL]:-Hostname lookup for host $GP_HOSTADDRESS failed." 2
@@ -1492,7 +1491,7 @@ STOP_QD_PRODUCTION () {
     if [ -f $GPSTOP ]; then
 	GPSTOP_OPTS=$(OUTPUT_LEVEL_OPTS)
 	export MASTER_DATA_DIRECTORY=${MASTER_DIRECTORY}/${SEG_PREFIX}-1
-	$GPSTOP -a -l $LOG_DIR -i -m -d $MASTER_DATA_DIRECTORY $GPSTOP_OPTS
+	$GPSTOP -a -l $LOG_DIR -m -d $MASTER_DATA_DIRECTORY $GPSTOP_OPTS
 	RETVAL=$?
 	case $RETVAL in
 	    0 ) LOG_MSG "[INFO]:-Successfully shutdown the new Greenplum instance" ;;
@@ -1621,7 +1620,6 @@ FORCE_FTS_PROBE () {
         fi
 
         $PSQL -p $GP_PORT -d "$DEFAULTDB" -c "select gp_request_fts_probe_scan()" >> /dev/null 2>&1
-        sleep 1;
     done
     LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
@@ -2059,7 +2057,6 @@ if [ -f $DCA_VERSION_FILE ]; then
 	SET_DCA_CONFIG_SETTINGS	
 fi
 
-env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -c "CHECKPOINT;" >> $LOG_FILE 2>&1
 STOP_QD_PRODUCTION
 START_QD_PRODUCTION
 

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -141,7 +141,7 @@ PROCESS_QE () {
         RUN_COMMAND_REMOTE ${COPY_FROM_PRIMARY_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; echo 'host  replication ${GP_USER} samenet trust' >> ${COPY_FROM_PRIMARY_DIR}/pg_hba.conf; pg_ctl -D ${COPY_FROM_PRIMARY_DIR} reload"
         RUN_COMMAND_REMOTE ${GP_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; rm -rf ${GP_DIR}; ${GPHOME}/bin/pg_basebackup -x -R -c fast -E ./pg_log -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D ${GP_DIR} -h ${COPY_FROM_PRIMARY_HOSTADDRESS} -p ${COPY_FROM_PRIMARY_PORT}; mkdir ${GP_DIR}/pg_log; mkdir ${GP_DIR}/pg_xlog/archive_status"
         REGISTER_MIRROR
-        START_QE ""
+        START_QE "-w"
         RETVAL=$?
         PARA_EXIT $RETVAL "pg_basebackup of segment data directory from ${COPY_FROM_PRIMARY_HOSTADDRESS} to ${GP_HOSTADDRESS}"
     fi
@@ -213,9 +213,6 @@ PROCESS_QE () {
 	        CIDR_ADDR=$(GET_CIDRADDR $ADDR)
 	        $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          $USER_NAME         $CIDR_ADDR      trust >> ${GP_DIR}/$PG_HBA"
         done
-
-        # start primary
-        START_QE "-w"
     fi
 
     LOG_MSG "[INFO][$INST_COUNT]:-End Function $FUNCNAME"


### PR DESCRIPTION
This patch helps cut-down 8 secs out of 30 secs (for single node gpinitsystem as
part of gpdemo), mostly more for multinode setups.

- Removes explicit 2 sec and 1 sleep.
- Removes explicit call to CHECKPOINT, not required.
- Avoid starting primaries after initdb. As they were started and then shutdown
  pretty soon to start back cluster with required cmdline arguments.
- Add -w to mirror start.

Still more room for improvement and speedup, this just gets us started.