### PR TITLE
Bumps nokogiri to 1.8.2

### DIFF
--- a/gpdb-doc/book/Gemfile.lock
+++ b/gpdb-doc/book/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
     minitest (5.11.1)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)


### PR DESCRIPTION
Removes vulnerability warning

[ci skip]

Authored-by: Todd Sedano <tsedano@pivotal.io>