### PR TITLE
 Remove Gp_segment, replace with GpIdentity.segindex.

### DIFF
--- a/contrib/gp_internal_tools/gp_instrument_shmem.c
+++ b/contrib/gp_internal_tools/gp_instrument_shmem.c
@@ -60,7 +60,7 @@ gp_instrument_shmem_summary(PG_FUNCTION_ARGS)
 
 	MemSet(nulls, 0, sizeof(nulls));
 
-	values[0] = Int32GetDatum(Gp_segment);
+	values[0] = Int32GetDatum(GpIdentity.segindex);
 	if (InstrumentGlobal)
 	{
 		values[1] = Int64GetDatum(InstrumentGlobal->free);

--- a/contrib/gp_internal_tools/gp_session_state_memory_stats.c
+++ b/contrib/gp_internal_tools/gp_session_state_memory_stats.c
@@ -117,7 +117,7 @@ gp_session_state_memory_entries(PG_FUNCTION_ARGS)
 			bool		nulls[NUM_SESSION_STATE_MEMORY_ELEM];
 			MemSet(nulls, 0, sizeof(nulls));
 
-			values[0] = Int32GetDatum(Gp_segment);
+			values[0] = Int32GetDatum(GpIdentity.segindex);
 			values[1] = Int32GetDatum(sessionState.sessionId);
 			values[2] = Int32GetDatum(VmemTracker_ConvertVmemChunksToMB(sessionState.sessionVmem));
 			values[3] = Int32GetDatum(sessionState.runawayStatus);

--- a/contrib/gp_internal_tools/gp_workfile_mgr.c
+++ b/contrib/gp_internal_tools/gp_workfile_mgr.c
@@ -143,7 +143,7 @@ gp_workfile_mgr_cache_entries(PG_FUNCTION_ARGS)
 			continue;
 		}
 
-		values[0] = Int32GetDatum(Gp_segment);
+		values[0] = Int32GetDatum(GpIdentity.segindex);
 		strlcpy(work_set_path, work_set->path, MAXPGPATH);
 
 		values[2] = UInt32GetDatum(crtEntry->hashvalue);
@@ -252,7 +252,7 @@ gp_workfile_mgr_used_diskspace(PG_FUNCTION_ARGS)
 	bool		nulls[NUM_USED_DISKSPACE_ELEM];
 	MemSet(nulls, 0, sizeof(nulls));
 
-	values[0] = Int32GetDatum(Gp_segment);
+	values[0] = Int32GetDatum(GpIdentity.segindex);
 	values[1] = Int64GetDatum(WorkfileSegspace_GetSize());
 
 	HeapTuple tuple = heap_form_tuple(tupdesc, values, nulls);

--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -65,7 +65,7 @@
 #include "executor/tuptable.h"
 
 #include "catalog/pg_type.h"
-#include "cdb/cdbvars.h"                /* Gp_segment */
+#include "cdb/cdbvars.h"                /* GpIdentity.segindex */
 
 /* Does att's datatype allow packing into the 1-byte-header varlena format? */
 #define ATT_IS_PACKABLE(att) \
@@ -593,7 +593,7 @@ heap_getsysattr(HeapTuple tup, int attnum, bool *isnull)
 			elog(ERROR, "Invalid reference to \"tableoid\" system attribute");
 			break;
 		case GpSegmentIdAttributeNumber:                       /*CDB*/
-			result = Int32GetDatum(Gp_segment);
+			result = Int32GetDatum(GpIdentity.segindex);
 			break;
 		default:
 			elog(ERROR, "invalid attnum: %d", attnum);

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -2488,7 +2488,7 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 
 	sprintf(extvar->GP_CID, "%x", QEDtxContextInfo.curcid);
 	sprintf(extvar->GP_SN, "%x", scancounter);
-	sprintf(extvar->GP_SEGMENT_ID, "%d", Gp_segment);
+	sprintf(extvar->GP_SEGMENT_ID, "%d", GpIdentity.segindex);
 	sprintf(extvar->GP_SEG_PORT, "%d", PostPortNumber);
 	sprintf(extvar->GP_SESSION_ID, "%d", gp_session_id);
 	sprintf(extvar->GP_SEGMENT_COUNT, "%d", GpIdentity.numsegments);

--- a/src/backend/access/transam/gp_distributed_log.c
+++ b/src/backend/access/transam/gp_distributed_log.c
@@ -16,7 +16,7 @@
 #include "access/clog.h"
 #include "access/distributedlog.h"
 #include "access/transam.h"
-#include "cdb/cdbvars.h"                /* Gp_segment */
+#include "cdb/cdbvars.h"                /* GpIdentity.segindex */
 
 Datum		gp_distributed_log(PG_FUNCTION_ARGS);
 
@@ -115,7 +115,7 @@ gp_distributed_log(PG_FUNCTION_ARGS)
 			MemSet(values, 0, sizeof(values));
 			MemSet(nulls, false, sizeof(nulls));
 
-			values[0] = Int16GetDatum((int16)Gp_segment);
+			values[0] = Int16GetDatum((int16)GpIdentity.segindex);
 			values[1] = Int16GetDatum((int16)GpIdentity.dbid);
 			values[2] = TransactionIdGetDatum(distribXid);
 

--- a/src/backend/access/transam/gp_transaction_log.c
+++ b/src/backend/access/transam/gp_transaction_log.c
@@ -16,7 +16,7 @@
 #include "access/clog.h"
 #include "access/distributedlog.h"
 #include "access/transam.h"
-#include "cdb/cdbvars.h"                /* Gp_segment */
+#include "cdb/cdbvars.h"                /* GpIdentity.segindex */
 
 Datum		gp_transaction_log(PG_FUNCTION_ARGS);
 
@@ -106,7 +106,7 @@ gp_transaction_log(PG_FUNCTION_ARGS)
 		MemSet(values, 0, sizeof(values));
 		MemSet(nulls, false, sizeof(nulls));
 
-		values[0] = Int16GetDatum((int16)Gp_segment);
+		values[0] = Int16GetDatum((int16)GpIdentity.segindex);
 		values[1] = Int16GetDatum((int16)GpIdentity.dbid);
 		values[2] = TransactionIdGetDatum(context->indexXid);
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7104,7 +7104,7 @@ StartupXLOG(void)
 	 * Hence it's okay to do the following only once on the segments as there
 	 * will be only one checkpoint to be analyzed.
 	 */
-	if (GpIdentity.segindex != MASTER_CONTENT_ID)
+	if (!IS_QUERY_DISPATCHER())
 	{
 		CheckpointExtendedRecord ckptExtended;
 		UnpackCheckPointRecord(record, &ckptExtended);
@@ -7878,7 +7878,7 @@ StartupXLOG(void)
 	 * apply to a mirror (standby of a GPDB segment) because it is
 	 * managed by FTS.
 	 */
-	bool needToPromoteCatalog = (GpIdentity.segindex == MASTER_CONTENT_ID &&
+	bool needToPromoteCatalog = (IS_QUERY_DISPATCHER() &&
 								 ControlFile->state == DB_IN_STANDBY_PROMOTED);
 
 	LWLockAcquire(ControlFileLock, LW_EXCLUSIVE);

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -224,7 +224,7 @@ rel_is_default_partition(Oid relid)
 	 * entry database, we accept calls from QEs running a segment, but return
 	 * false.
 	 */
-	if (Gp_segment != -1)
+	if (!IS_QUERY_DISPATCHER())
 		return false;
 
 	partrulerel = heap_open(PartitionRuleRelationId, AccessShareLock);
@@ -270,7 +270,7 @@ rel_is_partitioned(Oid relid)
 	 * entry database, we accept calls from QEs running a segment, but return
 	 * false.
 	 */
-	if (Gp_segment != -1)
+	if (!IS_QUERY_DISPATCHER())
 		return false;
 
 	ScanKeyInit(&scankey, Anum_pg_partition_parrelid,
@@ -545,7 +545,7 @@ rel_is_child_partition(Oid relid)
 	 * entry database, are some unguarded calles that may come from segments,
 	 * so we return false, even though we don't actually know.
 	 */
-	if (Gp_segment != -1)
+	if (!IS_QUERY_DISPATCHER())
 		return false;
 
 	ScanKeyInit(&scankey, Anum_pg_partition_rule_parchildrelid,
@@ -1487,7 +1487,7 @@ get_part_oid(Oid rootrelid, int16 parlevel, bool istemplate)
 	 * pg_partition and  pg_partition_rule are populated only on the entry
 	 * database, so our result is only meaningful there.
 	 */
-	Insist(Gp_segment == -1);
+	Insist(IS_QUERY_DISPATCHER());
 
 	partrel = heap_open(PartitionRelationId, AccessShareLock);
 	ScanKeyInit(&scankey[0], Anum_pg_partition_parrelid,
@@ -2208,7 +2208,7 @@ get_parts(Oid relid, int2 level, Oid parent, bool inctemplate,
 	 * but always return NULL; so our result is only meaningful on the entry
 	 * database.
 	 */
-	if (Gp_segment != -1)
+	if (!IS_QUERY_DISPATCHER())
 		return pnode;
 
 	/*
@@ -2346,7 +2346,7 @@ get_partition_key_bitmapset(Oid relid)
 	 * Reject calls from QEs running on a segment database, since pg_partition
 	 * and  pg_partition_rule are populated only on the entry database.
 	 */
-	Insist(Gp_segment == -1);
+	Insist(IS_QUERY_DISPATCHER());
 
 	/*
 	 * select paratts from pg_partition where parrelid = :relid and not
@@ -3215,7 +3215,7 @@ rel_partition_get_master(Oid relid)
 	 * pg_partition and  pg_partition_rule are populated only on the entry
 	 * database, so our result is only meaningful there.
 	 */
-	Insist(Gp_segment == -1);
+	Insist(IS_QUERY_DISPATCHER());
 
 	partrulerel = heap_open(PartitionRuleRelationId, AccessShareLock);
 
@@ -3269,7 +3269,7 @@ rel_get_part_path1(Oid relid)
 	 * pg_partition and  pg_partition_rule are populated only on the entry
 	 * database, so our result is only meaningful there.
 	 */
-	Insist(Gp_segment == -1);
+	Insist(IS_QUERY_DISPATCHER());
 
 	partrulerel = heap_open(PartitionRuleRelationId, AccessShareLock);
 
@@ -7113,7 +7113,7 @@ exchange_part_rule(Oid oldrelid, Oid newrelid)
 	 * pg_partition and  pg_partition_rule are populated only on the entry
 	 * database, so a call to this function is only meaningful there.
 	 */
-	Insist(Gp_segment == -1);
+	Insist(IS_QUERY_DISPATCHER());
 
 	catalogRelation = heap_open(PartitionRuleRelationId, RowExclusiveLock);
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2798,7 +2798,7 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 	switch (Gp_role)
 	{
 		case GP_ROLE_EXECUTE:
-			if (Gp_segment == -1 && !Gp_is_writer)
+			if (IS_QUERY_DISPATCHER() && !Gp_is_writer)
 			{
 				isEntryDbSingleton = true;
 			}

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -340,7 +340,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 	{
 		cdbInfo = &component_databases->entry_db_info[i];
 
-		if (cdbInfo->dbid == GpIdentity.dbid && cdbInfo->segindex == Gp_segment)
+		if (cdbInfo->dbid == GpIdentity.dbid && cdbInfo->segindex == GpIdentity.segindex)
 		{
 			break;
 		}
@@ -350,7 +350,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_EXCEPTION),
 				 errmsg("Cannot locate entry database represented by this db in gp_segment_configuration: dbid %d content %d",
-						GpIdentity.dbid, Gp_segment)));
+						GpIdentity.dbid, GpIdentity.segindex)));
 	}
 
 	/*

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -939,7 +939,7 @@ master_standby_dbid(void)
 	 * Can only run on a master node, this restriction is due to the reliance
 	 * on the gp_segment_configuration table.
 	 */
-	if (GpIdentity.segindex != MASTER_CONTENT_ID)
+	if (!IS_QUERY_DISPATCHER())
 		elog(ERROR, "master_standby_dbid() executed on execution segment");
 
 	/*
@@ -989,7 +989,7 @@ dbid_get_dbinfo(int16 dbid)
 	 * on the gp_segment_configuration table.  This may be able to be relaxed
 	 * by switching to a different method of checking.
 	 */
-	if (GpIdentity.segindex != MASTER_CONTENT_ID)
+	if (!IS_QUERY_DISPATCHER())
 		elog(ERROR, "dbid_get_dbinfo() executed on execution segment");
 
 	rel = heap_open(GpSegmentConfigRelationId, AccessShareLock);
@@ -1116,7 +1116,7 @@ contentid_get_dbid(int16 contentid, char role, bool getPreferredRoleNotCurrentRo
 	 * on the gp_segment_configuration table.  This may be able to be relaxed
 	 * by switching to a different method of checking.
 	 */
-	if (GpIdentity.segindex != MASTER_CONTENT_ID)
+	if (!IS_QUERY_DISPATCHER())
 		elog(ERROR, "contentid_get_dbid() executed on execution segment");
 
 	rel = heap_open(GpSegmentConfigRelationId, AccessShareLock);

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -90,8 +90,6 @@ int			gp_connections_per_thread;	/* How many libpq connections are
 int			gp_cached_gang_threshold;	/* How many gangs to keep around from
 										 * stmt to stmt. */
 
-int			Gp_segment = UNDEF_SEGMENT; /* What content this QE is handling. */
-
 bool		Gp_write_shared_snapshot;	/* tell the writer QE to write the
 										 * shared snapshot */
 
@@ -484,9 +482,6 @@ assign_gp_session_role(const char *newval, bool doit, GucSource source __attribu
 		Gp_session_role = newrole;
 		Gp_role = Gp_session_role;
 
-		if (Gp_role == GP_ROLE_DISPATCH)
-			Gp_segment = -1;
-
 		if (Gp_role == GP_ROLE_UTILITY && MyProc != NULL)
 			MyProc->mppIsWriter = false;
 	}
@@ -862,7 +857,7 @@ Datum gp_execution_dbid(PG_FUNCTION_ARGS);
 Datum
 mpp_execution_segment(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_INT32(Gp_segment);
+	PG_RETURN_INT32(GpIdentity.segindex);
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -313,7 +313,7 @@ cdbconn_doConnect(SegmentDatabaseDescriptor *segdbDesc,
 	 * For other QE connections, we set "hostaddr". "host" is not used.
 	 */
 	if (segdbDesc->segindex == MASTER_CONTENT_ID &&
-		GpIdentity.segindex == MASTER_CONTENT_ID)
+		IS_QUERY_DISPATCHER())
 	{
 		keywords[nkeywords] = "hostaddr";
 		values[nkeywords] = "";
@@ -458,7 +458,7 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 	 * For other QE connections, we set "hostaddr". "host" is not used.
 	 */
 	if (segdbDesc->segindex == MASTER_CONTENT_ID &&
-		GpIdentity.segindex == MASTER_CONTENT_ID)
+		IS_QUERY_DISPATCHER())
 	{
 		keywords[nkeywords] = "hostaddr";
 		values[nkeywords] = "";

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -670,7 +670,7 @@ makeOptions(void)
  * thread, so mustn't use palloc/elog/ereport/etc.
  */
 void
-build_gpqeid_param(char *buf, int bufsz, int segIndex,
+build_gpqeid_param(char *buf, int bufsz,
 				   bool is_writer, int gangId, int hostSegs)
 {
 #ifdef HAVE_INT64_TIMESTAMP
@@ -683,8 +683,8 @@ build_gpqeid_param(char *buf, int bufsz, int segIndex,
 #endif
 #endif
 
-	snprintf(buf, bufsz, "%d;%d;" TIMESTAMP_FORMAT ";%s;%d;%d",
-			 gp_session_id, segIndex, PgStartTime,
+	snprintf(buf, bufsz, "%d;" TIMESTAMP_FORMAT ";%s;%d;%d",
+			 gp_session_id, PgStartTime,
 			 (is_writer ? "true" : "false"), gangId, hostSegs);
 }
 
@@ -728,10 +728,6 @@ void
 	/* gp_session_id */
 	if (gpqeid_next_param(&cp, &np))
 		SetConfigOption("gp_session_id", cp, PGC_POSTMASTER, PGC_S_OVERRIDE);
-
-	/* gp_segment */
-	if (gpqeid_next_param(&cp, &np))
-		SetConfigOption("gp_segment", cp, PGC_POSTMASTER, PGC_S_OVERRIDE);
 
 	/* PgStartTime */
 	if (gpqeid_next_param(&cp, &np))

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -123,7 +123,6 @@ create_gang_retry:
 			 * options are recognized.
 			 */
 			build_gpqeid_param(gpqeid, sizeof(gpqeid),
-							   segdbDesc->segindex,
 							   type == GANGTYPE_PRIMARY_WRITER,
 							   gang_id,
 							   segdbDesc->segment_database_info->hostSegs);

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -315,7 +315,6 @@ thread_DoConnect(void *arg)
 		 * are recognized.
 		 */
 		build_gpqeid_param(gpqeid, sizeof(gpqeid),
-						   segdbDesc->segindex,
 						   pParms->type == GANGTYPE_PRIMARY_WRITER,
 						   pParms->gangId,
 						   segdbDesc->segment_database_info->hostSegs);

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -923,7 +923,7 @@ EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool flushCommLa
 			elog(LOG, "Interconnect seg%d slice%d sent " UINT64_FORMAT " tuples, "
 				 UINT64_FORMAT " total bytes, " UINT64_FORMAT " tuple bytes, "
 				 UINT64_FORMAT " chunks; waited " UINT64_FORMAT " usec.",
-				 Gp_segment,
+				 GpIdentity.segindex,
 				 currentSliceId,
 				 pMNEntry->stat_total_sends,
 				 pMNEntry->stat_total_bytes_sent,
@@ -938,7 +938,7 @@ EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool flushCommLa
 			elog(LOG, "Interconnect seg%d slice%d received from slice%d: " UINT64_FORMAT " tuples, "
 				 UINT64_FORMAT " total bytes, " UINT64_FORMAT " tuple bytes, "
 				 UINT64_FORMAT " chunks; waited " UINT64_FORMAT " usec.",
-				 Gp_segment,
+				 GpIdentity.segindex,
 				 currentSliceId,
 				 motNodeID,
 				 pMNEntry->stat_total_recvs,

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -575,7 +575,7 @@ startOutgoingConnections(ChunkTransportState *transportStates,
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		elog(DEBUG4, "Interconnect seg%d slice%d setting up sending motion node (aggressive retry is %s)",
-			 Gp_segment, sendSlice->sliceIndex,
+			 GpIdentity.segindex, sendSlice->sliceIndex,
 			 (transportStates->aggressiveRetry ? "active" : "inactive"));
 
 	pEntry = createChunkTransportState(transportStates,
@@ -949,7 +949,7 @@ sendRegisterMessage(ChunkTransportState *transportStates, ChunkTransportStateEnt
 								 pEntry->recvSlice->sliceIndex,
 								 conn->remoteHostAndPort,
 								 conn->cdbProc->pid,
-								 Gp_segment,
+								 GpIdentity.segindex,
 								 pEntry->sendSlice->sliceIndex,
 								 conn->localHostAndPort,
 								 conn->sockfd)));
@@ -958,7 +958,7 @@ sendRegisterMessage(ChunkTransportState *transportStates, ChunkTransportStateEnt
 		regMsg->recvSliceIndex = pEntry->recvSlice->sliceIndex;
 		regMsg->sendSliceIndex = pEntry->sendSlice->sliceIndex;
 
-		regMsg->srcContentId = Gp_segment;
+		regMsg->srcContentId = GpIdentity.segindex;
 		regMsg->srcListenerPort = Gp_listener_port & 0x0ffff;
 		regMsg->srcPid = MyProcPid;
 		regMsg->srcSessionId = gp_session_id;
@@ -1199,7 +1199,7 @@ readRegisterMessage(ChunkTransportState *transportStates,
 	{
 		ereport(LOG, (errmsg("Interconnect seg%d slice%d sockfd=%d accepted "
 							 "registration message from seg%d slice%d %s pid=%d",
-							 Gp_segment,
+							 GpIdentity.segindex,
 							 msg.recvSliceIndex,
 							 conn->sockfd,
 							 msg.srcContentId,
@@ -1992,7 +1992,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates,
 		if (elevel)
 			ereport(elevel, (errmsg("Interconnect seg%d slice%d cleanup state: "
 									"%s; setup was %s",
-									Gp_segment, mySlice->sliceIndex,
+									GpIdentity.segindex, mySlice->sliceIndex,
 									forceEOS ? "force" : "normal",
 									transportStates->activated ? "completed" : "exited")));
 
@@ -2065,7 +2065,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates,
 		/* cleanup a Sending motion node. */
 		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 			elog(DEBUG3, "Interconnect seg%d slice%d closing connections to slice%d",
-				 Gp_segment, mySlice->sliceIndex, mySlice->parentIndex);
+				 GpIdentity.segindex, mySlice->sliceIndex, mySlice->parentIndex);
 
 		getChunkTransportState(transportStates, mySlice->sliceIndex, &pEntry);
 
@@ -2762,7 +2762,7 @@ SendEosTCP(ChunkTransportState *transportStates,
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		elog(DEBUG3, "Interconnect seg%d slice%d sending end-of-stream to slice%d",
-			 Gp_segment, motNodeID, pEntry->recvSlice->sliceIndex);
+			 GpIdentity.segindex, motNodeID, pEntry->recvSlice->sliceIndex);
 
 	/*
 	 * we want to add our tcItem onto each of the outgoing buffers -- this is

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -2600,7 +2600,7 @@ startOutgoingUDPConnections(ChunkTransportState *transportStates,
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		elog(DEBUG1, "Interconnect seg%d slice%d setting up sending motion node",
-			 Gp_segment, sendSlice->sliceIndex);
+			 GpIdentity.segindex, sendSlice->sliceIndex);
 
 	pEntry = createChunkTransportState(transportStates,
 									   sendSlice,
@@ -2847,12 +2847,12 @@ setupOutgoingUDPConnection(ChunkTransportState *transportStates, ChunkTransportS
 
 	conn->conn_info.recvSliceIndex = pEntry->recvSlice->sliceIndex;
 	conn->conn_info.sendSliceIndex = pEntry->sendSlice->sliceIndex;
-	conn->conn_info.srcContentId = Gp_segment;
+	conn->conn_info.srcContentId = GpIdentity.segindex;
 	conn->conn_info.dstContentId = conn->cdbProc->contentid;
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		elog(DEBUG1, "setupOutgoingUDPConnection: node %d route %d srccontent %d dstcontent %d: %s",
-			 pEntry->motNodeId, conn->route, Gp_segment, conn->cdbProc->contentid, conn->remoteHostAndPort);
+			 pEntry->motNodeId, conn->route, GpIdentity.segindex, conn->cdbProc->contentid, conn->remoteHostAndPort);
 
 	conn->conn_info.srcListenerPort = (Gp_listener_port >> 16) & 0x0ffff;
 	conn->conn_info.srcPid = MyProcPid;
@@ -3088,7 +3088,7 @@ SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable)
 				conn->conn_info.sendSliceIndex = aSlice->sliceIndex;
 
 				conn->conn_info.srcContentId = conn->cdbProc->contentid;
-				conn->conn_info.dstContentId = Gp_segment;
+				conn->conn_info.dstContentId = GpIdentity.segindex;
 
 				conn->conn_info.srcListenerPort = conn->cdbProc->listenerPort;
 				conn->conn_info.srcPid = conn->cdbProc->pid;
@@ -3312,7 +3312,7 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 		if (elevel)
 			ereport(elevel, (errmsg("Interconnect seg%d slice%d cleanup state: "
 									"%s; setup was %s",
-									Gp_segment, mySlice->sliceIndex,
+									GpIdentity.segindex, mySlice->sliceIndex,
 									forceEOS ? "force" : "normal",
 									transportStates->activated ? "completed" : "exited")));
 
@@ -3344,7 +3344,7 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 		/* cleanup a Sending motion node. */
 		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 			elog(DEBUG1, "Interconnect seg%d slice%d closing connections to slice%d (%d peers)",
-				 Gp_segment, mySlice->sliceIndex, mySlice->parentIndex,
+				 GpIdentity.segindex, mySlice->sliceIndex, mySlice->parentIndex,
 				 list_length(parentSlice->primaryProcesses));
 
 		/*
@@ -4226,7 +4226,7 @@ handleAcks(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntr
 		 * acks. QD (never be a sender) does not. QD may have several
 		 * concurrent running interconnect instances.
 		 */
-		if (pkt->srcContentId == Gp_segment &&
+		if (pkt->srcContentId == GpIdentity.segindex &&
 			pkt->srcPid == MyProcPid &&
 			pkt->srcListenerPort == ((Gp_listener_port >> 16) & 0x0ffff) &&
 			pkt->sessionId == gp_session_id &&
@@ -4363,7 +4363,7 @@ handleAcks(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntr
 		else if (DEBUG1 >= log_min_messages)
 			write_log("handleAck: not the ack we're looking for (flags 0x%x)...mot(%d) content(%d:%d) srcpid(%d:%d) dstpid(%d) srcport(%d:%d) dstport(%d) sess(%d:%d) cmd(%d:%d)",
 					  pkt->flags, pkt->motNodeId,
-					  pkt->srcContentId, Gp_segment,
+					  pkt->srcContentId, GpIdentity.segindex,
 					  pkt->srcPid, MyProcPid,
 					  pkt->dstPid,
 					  pkt->srcListenerPort, ((Gp_listener_port >> 16) & 0x0ffff),
@@ -5410,7 +5410,7 @@ SendEosUDPIFC(ChunkTransportState *transportStates,
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		elog(DEBUG1, "Interconnect seg%d slice%d sending end-of-stream to slice%d",
-			 Gp_segment, motNodeID, pEntry->recvSlice->sliceIndex);
+			 GpIdentity.segindex, motNodeID, pEntry->recvSlice->sliceIndex);
 
 	/*
 	 * we want to add our tcItem onto each of the outgoing buffers -- this is

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -25,7 +25,7 @@
 #include "cdb/cdbpathlocus.h"
 #include "cdb/cdbpullup.h"              /* cdbpullup_targetlist() */
 #include "cdb/cdbutil.h"
-#include "cdb/cdbvars.h"		/* Gp_segment */
+#include "cdb/cdbvars.h"		/* GpIdentity.segindex */
 #include "cdb/memquota.h"
 #include "libpq/pqformat.h"		/* pq_beginmessage() etc. */
 #include "miscadmin.h"
@@ -444,7 +444,7 @@ cdbexplain_localExecStats(struct PlanState *planstate,
 
 	/* Set up a temporary StatHdr for both collecting and depositing stats. */
 	ctx.msgptrs[0] = &ctx.send.hdr;
-	ctx.send.hdr.segindex = Gp_segment;
+	ctx.send.hdr.segindex = GpIdentity.segindex;
 	ctx.send.hdr.nInst = 1;
 
 	/* Set up receive context area referencing our temp StatHdr. */
@@ -538,7 +538,7 @@ cdbexplain_sendExecStats(QueryDesc *queryDesc)
 	/* Start building the message header in our context area. */
 	memset(&ctx, 0, sizeof(ctx));
 	ctx.hdr.type = T_CdbExplain_StatHdr;
-	ctx.hdr.segindex = Gp_segment;
+	ctx.hdr.segindex = GpIdentity.segindex;
 	ctx.hdr.nInst = 0;
 
 	/* Allocate a separate buffer where nodes can append extra message text. */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16616,7 +16616,7 @@ CheckDropRelStorage(RangeVar *rel, ObjectType removeType)
 	 * it again on QE.
 	 */
 	if (relstorage == RELSTORAGE_EXTERNAL &&
-		(Gp_segment != -1 || rel_is_child_partition(relOid)))
+		(!IS_QUERY_DISPATCHER() || rel_is_child_partition(relOid)))
 		return;
 
 	if ((removeType == OBJECT_EXTTABLE && relstorage != RELSTORAGE_EXTERNAL) ||

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -296,7 +296,7 @@ CreateTableSpace(CreateTableSpaceStmt *stmt)
 								 errmsg("segment content ID %d does not exist", contentId),
 								 errhint("Segment content IDs can be found in gp_segment_configuration table.")));
 				}
-				else if (contentId == Gp_segment)
+				else if (contentId == GpIdentity.segindex)
 				{
 					location = pstrdup(strVal(defel->arg));
 					break;

--- a/src/backend/executor/execCurrent.c
+++ b/src/backend/executor/execCurrent.c
@@ -97,7 +97,7 @@ execCurrentOf(CurrentOfExpr *cexpr,
 	/*
 	 * Found the cursor. Does the table and segment match?
 	 */
-	if (current_gp_segment_id == Gp_segment &&
+	if (current_gp_segment_id == GpIdentity.segindex &&
 		(current_table_oid == InvalidOid || current_table_oid == table_oid))
 	{
 		return true;

--- a/src/backend/executor/execGpmon.c
+++ b/src/backend/executor/execGpmon.c
@@ -69,7 +69,7 @@ void InitPlanNodeGpmonPkt(Plan *plan, gpmon_packet_t *gpmon_pkt, EState *estate)
 	gpmon_gettmid(&gpmon_pkt->u.qexec.key.tmid);
 	gpmon_pkt->u.qexec.key.ssid = gp_session_id;
 	gpmon_pkt->u.qexec.key.ccnt = gp_command_count;
-	gpmon_pkt->u.qexec.key.hash_key.segid = Gp_segment;
+	gpmon_pkt->u.qexec.key.hash_key.segid = GpIdentity.segindex;
 	gpmon_pkt->u.qexec.key.hash_key.pid = MyProcPid;
 	gpmon_pkt->u.qexec.key.hash_key.nid = plan->plan_node_id;
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -626,7 +626,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 			if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 				elog(DEBUG1, "seg%d executing slice%d under root slice%d",
-					 Gp_segment,
+					 GpIdentity.segindex,
 					 LocallyExecutingSliceIndex(estate),
 					 RootSliceIndex(estate));
 		}

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -548,7 +548,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	 *
 	 * TODO: eliminate aliens even on master, if not EXPLAIN ANALYZE
 	 */
-	estate->eliminateAliens = execute_pruned_plan && queryDesc->plannedstmt->nMotionNodes > 0 && Gp_segment != -1;
+	estate->eliminateAliens = execute_pruned_plan && queryDesc->plannedstmt->nMotionNodes > 0 && !IS_QUERY_DISPATCHER();
 
 	/*
 	 * Assign a Motion Node to every Plan Node. This makes it

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -244,7 +244,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 	 * gathering stats from all slices.
 	 */
 	bool isAlienPlanNode = !((localMotionId == parentMotionId) || (parentMotionId == UNSET_SLICE_ID) ||
-			(nodeTag(node) == T_Motion && ((Motion*)node)->motionID == localMotionId) || Gp_segment == -1);
+							 (nodeTag(node) == T_Motion && ((Motion*)node)->motionID == localMotionId) || IS_QUERY_DISPATCHER());
 
 	/* We cannot have alien nodes if we are eliminating aliens */
 	AssertImply(estate->eliminateAliens, !isAlienPlanNode);

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -882,7 +882,7 @@ ExecProcNode(PlanState *node)
 		return NULL;
 
 	if (node->plan)
-		TRACE_POSTGRESQL_EXECPROCNODE_ENTER(Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);
+		TRACE_POSTGRESQL_EXECPROCNODE_ENTER(GpIdentity.segindex, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 
 	if (node->chgParam != NULL) /* something changed */
 		ExecReScan(node, NULL); /* let ReScan handle this */
@@ -1097,7 +1097,7 @@ ExecProcNode(PlanState *node)
 		INSTR_STOP_NODE(node->instrument, TupIsNull(result) ? 0 : 1);
 
 	if (node->plan)
-		TRACE_POSTGRESQL_EXECPROCNODE_EXIT(Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);
+		TRACE_POSTGRESQL_EXECPROCNODE_EXIT(GpIdentity.segindex, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 
 	/*
 	 * Eager free and squelch the subplans, unless it's a nested subplan.
@@ -1153,7 +1153,7 @@ MultiExecProcNode(PlanState *node)
 
 	START_MEMORY_ACCOUNT(node->plan->memoryAccountId);
 {
-	TRACE_POSTGRESQL_EXECPROCNODE_ENTER(Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);
+	TRACE_POSTGRESQL_EXECPROCNODE_ENTER(GpIdentity.segindex, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 
 	if (node->chgParam != NULL) /* something changed */
 		ExecReScan(node, NULL); /* let ReScan handle this */
@@ -1190,7 +1190,7 @@ MultiExecProcNode(PlanState *node)
 			break;
 	}
 
-	TRACE_POSTGRESQL_EXECPROCNODE_EXIT(Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);
+	TRACE_POSTGRESQL_EXECPROCNODE_EXIT(GpIdentity.segindex, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 }
 	END_MEMORY_ACCOUNT();
 	return result;

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -101,7 +101,7 @@
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
 
-#include "cdb/cdbvars.h"                    /* Gp_segment */
+#include "cdb/cdbvars.h"                    /* GpIdentity.segindex */
 
 static TupleDesc ExecTypeFromTLInternal(List *targetList,
 					   bool hasoid, bool skipjunk);
@@ -1447,7 +1447,7 @@ slot_getsysattr(TupleTableSlot *slot, int attnum, bool *isnull)
 								result = ObjectIdGetDatum(InvalidOid);
 							break;
                         case GpSegmentIdAttributeNumber:
-							result = Int32GetDatum(Gp_segment);
+							result = Int32GetDatum(GpIdentity.segindex);
 							break;
                         case TableOidAttributeNumber:
 							result = ObjectIdGetDatum(slot->tts_tableOid);

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -350,7 +350,7 @@ pickInstrFromShmem(const Plan *plan, int instrument_options)
 		memset(slot, 0x00, sizeof(InstrumentationSlot));
 		/* initialize the picked slot */
 		instr = &(slot->data);
-		slot->segid = (int16) Gp_segment;
+		slot->segid = (int16) GpIdentity.segindex;
 		slot->pid = MyProcPid;
 		gpmon_gettmid(&(slot->tmid));
 		slot->ssid = gp_session_id;

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -401,7 +401,7 @@ sisc_lockname(char *p, int size, int share_id, const char* name)
 
 	snprintf(filename, sizeof(filename),
 			 "gpcdb2.sisc_%d_%d_%d_%d_%s",
-			 Gp_segment, gp_session_id, gp_command_count, share_id, name);
+			 GpIdentity.segindex, gp_session_id, gp_command_count, share_id, name);
 
 	path = GetTempFilePath(filename, true);
 	if (strlen(path) >= size)

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -335,7 +335,7 @@ auth_failed(Port *port, int status)
 static bool
 internal_client_authentication(Port *port)
 {
-	if (GpIdentity.segindex == MASTER_CONTENT_ID)
+	if (IS_QUERY_DISPATCHER())
 	{
 		/* 
 		 * The entry-DB (or QE at the master) case.

--- a/src/backend/libpq/pqcomm.c
+++ b/src/backend/libpq/pqcomm.c
@@ -677,7 +677,7 @@ StreamConnection(pgsocket server_fd, Port *port)
 	 * Set a send timeout on the socket if specified, on the master only
 	 * Solaris doesn't support setting SO_SNDTIMEO, so setting this won't work on Solaris (MPP-22526) 
 	 */ 
-	if (GpIdentity.segindex == MASTER_CONTENT_ID && gp_connection_send_timeout > 0)
+	if (IS_QUERY_DISPATCHER() && gp_connection_send_timeout > 0)
 	{
 	  struct timeval timeout;
 	  timeout.tv_sec = gp_connection_send_timeout;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -204,7 +204,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	 */
 	if (optimizer &&
 		GP_ROLE_DISPATCH == Gp_role &&
-		MASTER_CONTENT_ID == GpIdentity.segindex)
+		IS_QUERY_DISPATCHER())
 	{
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2076,7 +2076,7 @@ retry1:
 			{
 				if (strcmp(valptr, GPCONN_TYPE_FTS) == 0)
 				{
-					if (GpIdentity.segindex == MASTER_CONTENT_ID)
+					if (IS_QUERY_DISPATCHER())
 						ereport(FATAL,
 								(errcode(ERRCODE_PROTOCOL_VIOLATION),
 								 errmsg("cannot handle FTS connection on master")));

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -115,7 +115,7 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 		return;
 	}
 
-	if (GpIdentity.segindex != MASTER_CONTENT_ID)
+	if (!IS_QUERY_DISPATCHER())
 	{
 		/* Fast exit if user has not requested sync replication. */
 		if (!SyncRepRequested())
@@ -128,7 +128,7 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 	LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
 	Assert(MyProc->syncRepState == SYNC_REP_NOT_WAITING);
 
-	if (GpIdentity.segindex == MASTER_CONTENT_ID)
+	if (IS_QUERY_DISPATCHER())
 	{
 		/*
 		 * There could be a better way to figure out if there is any active
@@ -173,7 +173,7 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 	 * condition but we'll be fetching that cache line anyway so its likely to
 	 * be a low cost check.
 	 */
-	if (((GpIdentity.segindex != MASTER_CONTENT_ID) && !WalSndCtl->sync_standbys_defined) ||
+	if (((!IS_QUERY_DISPATCHER()) && !WalSndCtl->sync_standbys_defined) ||
 		XLByteLE(XactCommitLSN, WalSndCtl->lsn[mode]))
 	{
 		elogif(debug_walrepl_syncrep, LOG,

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -795,7 +795,7 @@ WalSndKill(int code, Datum arg)
 
 	Assert(walsnd != NULL);
 
-	if (GpIdentity.segindex == MASTER_CONTENT_ID)
+	if (IS_QUERY_DISPATCHER())
 	{
 		/*
 		 * Acquire the SyncRepLock here to avoid any race conditions

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -838,7 +838,7 @@ ProcKill(int code, Datum arg)
 			SharedSnapshotRemove(SharedLocalSnapshotSlot,
 								 "Query Dispatcher");
 		}
-	    else if (Gp_segment == -1 && Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer)
+	    else if (IS_QUERY_DISPATCHER() && Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer)
 	    {
 			/* 
 			 * Entry db singleton QE is a user of the shared snapshot -- not a creator.
@@ -2136,7 +2136,7 @@ void ProcNewMppSessionId(int *newSessionId)
     if (NULL != MySessionState)
     {
     	/* This should not happen outside of dispatcher on the master */
-    	Assert(GpIdentity.segindex == MASTER_CONTENT_ID && Gp_role == GP_ROLE_DISPATCH);
+    	Assert(IS_QUERY_DISPATCHER() && Gp_role == GP_ROLE_DISPATCH);
 
     	ereport(gp_sessionstate_loglevel, (errmsg("ProcNewMppSessionId: changing session id (old: %d, new: %d), pinCount: %d, activeProcessCount: %d",
     			MySessionState->sessionId, *newSessionId, MySessionState->pinCount, MySessionState->activeProcessCount), errprintstack(true)));

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1447,13 +1447,13 @@ CheckDebugDtmActionProtocol(DtxProtocolCommand dtxProtocolCommand,
 	{
 		return (Debug_dtm_action_target == DEBUG_DTM_ACTION_TARGET_PROTOCOL &&
 			Debug_dtm_action_protocol == dtxProtocolCommand &&
-			Debug_dtm_action_segment == Gp_segment);
+			Debug_dtm_action_segment == GpIdentity.segindex);
 	}
 	else
 	{
 		return (Debug_dtm_action_target == DEBUG_DTM_ACTION_TARGET_PROTOCOL &&
 			Debug_dtm_action_protocol == dtxProtocolCommand &&
-			Debug_dtm_action_segment == Gp_segment &&
+			Debug_dtm_action_segment == GpIdentity.segindex &&
 			Debug_dtm_action_nestinglevel == contextInfo->nestingLevel);
 	}
 }
@@ -1532,7 +1532,7 @@ CheckDebugDtmActionSqlCommandTag(const char *sqlCommandTag)
 
 	result = (Debug_dtm_action_target == DEBUG_DTM_ACTION_TARGET_SQL &&
 			  strcmp(Debug_dtm_action_sql_command_tag, sqlCommandTag) == 0 &&
-			  Debug_dtm_action_segment == Gp_segment);
+			  Debug_dtm_action_segment == GpIdentity.segindex);
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),"CheckDebugDtmActionSqlCommandTag Debug_dtm_action_target = %d, Debug_dtm_action_sql_command_tag = '%s' check '%s', Debug_dtm_action_segment = %d, Debug_dtm_action_primary = %s, result = %s.",
 		Debug_dtm_action_target,

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -458,7 +458,7 @@ pg_relation_size(PG_FUNCTION_ARGS)
 	 * It does not work on entry db since we do not support dispatching
 	 * from entry-db currently.
 	 */
-	if (Gp_role == GP_ROLE_EXECUTE && Gp_segment == -1)
+	if (Gp_role == GP_ROLE_EXECUTE && IS_QUERY_DISPATCHER())
 		elog(ERROR, "This query is not currently supported by GPDB.");
 
 	rel = try_relation_open(relOid, AccessShareLock, false);

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -449,7 +449,7 @@ pg_lock_status(PG_FUNCTION_ARGS)
 
 		values[15] = BoolGetDatum(proc->mppIsWriter);
 
-		values[16] = Int32GetDatum(Gp_segment);
+		values[16] = Int32GetDatum(GpIdentity.segindex);
 
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 		result = HeapTupleGetDatum(tuple);

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -83,7 +83,7 @@
 #include "utils/memutils.h"
 #include "utils/ps_status.h"
 
-#include "cdb/cdbvars.h"  /*Gp_segment */
+#include "cdb/cdbvars.h"  /* GpIdentity.segindex */
 #include "cdb/cdbtm.h"
 #include "utils/ps_status.h"    /* get_ps_display_username() */
 #include "cdb/cdbselect.h"
@@ -2601,8 +2601,8 @@ log_line_prefix(StringInfo buf, ErrorData *edata)
 				 * choose to not write anything for the very early log messages
 				 * before GUC variables are set.
 				 */
-				if( Gp_segment != UNDEF_SEGMENT )
-					appendStringInfo(buf, "%d", Gp_segment );
+				if( GpIdentity.segindex != UNDEF_SEGMENT )
+					appendStringInfo(buf, "%d", GpIdentity.segindex);
 				break;
 			case 'I':
 				/* prints a succinct description of an MPP process. */
@@ -2624,7 +2624,7 @@ log_line_prefix(StringInfo buf, ErrorData *edata)
 				if (gp_command_count > 0)
 					appendStringInfo(buf, "cmd%d ", gp_command_count);
 				if (Gp_role == GP_ROLE_EXECUTE)
-					appendStringInfo(buf, "seg%d ", Gp_segment);
+					appendStringInfo(buf, "seg%d ", GpIdentity.segindex);
 				if (currentSliceId > 0)
 					appendStringInfo(buf, "slice%d ", currentSliceId);
 				if (j < buf->len &&
@@ -3361,7 +3361,7 @@ write_syslogger_in_csv(ErrorData *edata, bool amsyslogger)
 	/* GPDB specific options */
 	syslogger_write_int32(true, "con", gp_session_id, amsyslogger, true);
 	syslogger_write_int32(true, "cmd", gp_command_count, amsyslogger, true);
-	syslogger_write_int32(false, "seg", Gp_segment, amsyslogger, true);
+	syslogger_write_int32(false, "seg", GpIdentity.segindex, amsyslogger, true);
 	syslogger_write_int32(true, "slice", currentSliceId, amsyslogger, true);
 	{
 		DistributedTransactionId dist_trans_id;
@@ -3498,7 +3498,7 @@ write_message_to_server_log(int elevel,
 	fix_fields.gp_is_primary = 't';
 	fix_fields.gp_session_id = gp_session_id;
 	fix_fields.gp_command_count = gp_command_count;
-	fix_fields.gp_segment_id = Gp_segment;
+	fix_fields.gp_segment_id = GpIdentity.segindex;
 	fix_fields.slice_id = currentSliceId;
 	fix_fields.error_cursor_pos = cursorpos;
 	fix_fields.internal_query_pos = internalpos;
@@ -4745,7 +4745,7 @@ StandardHandlerForSigillSigsegvSigbus_OnMainThread(char *processName, SIGNAL_ARG
 
 	errorData->gp_session_id = gp_session_id;
 	errorData->gp_command_count = gp_command_count;
-	errorData->gp_segment_id = Gp_segment;
+	errorData->gp_segment_id = GpIdentity.segindex;
 	errorData->slice_id = currentSliceId;
 	errorData->signal_num = (int32)postgres_signal_arg;
 	errorData->frame_depth = 0;

--- a/src/backend/utils/gdd/gddfuncs.c
+++ b/src/backend/utils/gdd/gddfuncs.c
@@ -257,7 +257,7 @@ pg_dist_wait_status(PG_FUNCTION_ARGS)
 				h_dxid = h_proc->localDistribXactData.distribXid;
 			}
 
-			values[0] = Int32GetDatum(Gp_segment);
+			values[0] = Int32GetDatum(GpIdentity.segindex);
 			values[1] = TransactionIdGetDatum(w_dxid);
 			values[2] = TransactionIdGetDatum(h_dxid);
 			values[3] = BoolGetDatum(lockIsPersistent(w_lock));

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -207,7 +207,7 @@ mirroring_sanity_check(int flags, const char *func)
 		if (GpIdentity.dbid == UNINITIALIZED_GP_IDENTITY_VALUE)
 			elog(ERROR, "%s requires valid GpIdentity dbid", func);
 
-		if (GpIdentity.segindex != MASTER_CONTENT_ID)
+		if (!IS_QUERY_DISPATCHER())
 			elog(ERROR, "%s must be run on the master", func);
 	}
 
@@ -234,7 +234,7 @@ mirroring_sanity_check(int flags, const char *func)
 		if (GpIdentity.dbid == UNINITIALIZED_GP_IDENTITY_VALUE)
 			elog(ERROR, "%s requires valid GpIdentity dbid", func);
 
-		if (GpIdentity.segindex == MASTER_CONTENT_ID)
+		if (IS_QUERY_DISPATCHER())
 			elog(ERROR, "%s cannot be run on the master", func);
 	}
 

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1035,7 +1035,7 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	{
 		addSharedSnapshot("Query Dispatcher", gp_session_id);
 	}
-    else if (Gp_segment == -1 && Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer)
+    else if (IS_QUERY_DISPATCHER() && Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer)
     {
 		/* 
 		 * Entry db singleton QE is a user of the shared snapshot -- not a creator.

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3432,16 +3432,6 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"gp_segment", PGC_BACKEND, GP_WORKER_IDENTITY,
-			gettext_noop("Segment id of the segment db which is local to this worker process."),
-			gettext_noop("-1 for a session's entry process (qDisp) or a worker on the entry db."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
-		},
-		&Gp_segment,
-		-999, INT_MIN, INT_MAX, NULL, NULL
-	},
-
-	{
 		{"gp_qd_port", PGC_BACKEND, GP_WORKER_IDENTITY,
 			gettext_noop("Shows the Master Postmaster port."),
 			gettext_noop("0 for a session's entry process (qDisp)"),

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -32,7 +32,7 @@
 #include "miscadmin.h"
 #include "utils/ps_status.h"
 
-#include "cdb/cdbvars.h"        /* Gp_role, Gp_segment, currentSliceId */
+#include "cdb/cdbvars.h"        /* Gp_role, GpIdentity.segindex, currentSliceId */
 
 extern char **environ;
 extern int PostPortNumber;
@@ -358,8 +358,8 @@ set_ps_display(const char *activity, bool force)
 
 	/* Which segment is accessed by this qExec? */
 	if (Gp_role == GP_ROLE_EXECUTE &&
-		Gp_segment >= -1 && ep - cp > 0)
-		cp += snprintf(cp, ep - cp, "seg%d ", Gp_segment);
+		GpIdentity.segindex >= -1 && ep - cp > 0)
+		cp += snprintf(cp, ep - cp, "seg%d ", GpIdentity.segindex);
 
 	/* Add count of commands received from client session. */
 	if (gp_command_count > 0 && ep - cp > 0)

--- a/src/backend/utils/misc/test/ps_status_test.c
+++ b/src/backend/utils/misc/test/ps_status_test.c
@@ -20,7 +20,7 @@ test__set_ps_display(void **state)
 
 	gp_session_id = 1024;
 	Gp_role = GP_ROLE_DISPATCH;
-	Gp_segment = 24;
+	GpIdentity.segindex = 24;
 	gp_command_count = 1024;
 	currentSliceId = 40;
 
@@ -49,7 +49,7 @@ test__set_ps_display__real_act_prefix_size_overflow(void **state)
 
 	gp_session_id = 26351;
 	Gp_role = GP_ROLE_DISPATCH;
-	Gp_segment = -1;
+	GpIdentity.segindex = -1;
 	gp_command_count = 964;
 	currentSliceId = -1;
 
@@ -81,7 +81,7 @@ test__set_ps_display__real_act_prefix_size(void **state)
 
 	gp_session_id = 26351;
 	Gp_role = GP_ROLE_DISPATCH;
-	Gp_segment = -1;
+	GpIdentity.segindex = -1;
 	gp_command_count = 964;
 	currentSliceId = -1;
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -516,7 +516,7 @@ InitResGroups(void)
 
 	if (Gp_role == GP_ROLE_DISPATCH && pResGroupControl->segmentsOnMaster == 0)
 	{
-		Assert(GpIdentity.segindex == MASTER_CONTENT_ID);
+		Assert(IS_QUERY_DISPATCHER());
 		cdbComponentDBs = getCdbComponentDatabases();
 		qdinfo = &cdbComponentDBs->entry_db_info[0];
 		pResGroupControl->segmentsOnMaster = qdinfo->hostSegs;

--- a/src/backend/utils/time/combocid.c
+++ b/src/backend/utils/time/combocid.c
@@ -239,7 +239,7 @@ GetComboCommandId(TransactionId xmin, CommandId cmin, CommandId cmax)
 
 	if (Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer)
 	{
-		if (Gp_segment == -1)
+		if (IS_QUERY_DISPATCHER())
 			elog(ERROR, "EntryReader qExec tried to allocate a Combo Command Id");
 		else
 			elog(ERROR, "Reader qExec tried to allocate a Combo Command Id");

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -103,7 +103,7 @@ extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang
 bool isPrimaryWriterGangAlive(void);
 
 Gang *buildGangDefinition(GangType type, int gang_id, int size, int content);
-void build_gpqeid_param(char *buf, int bufsz, int segIndex, bool is_writer, int gangId, int hostSegs);
+void build_gpqeid_param(char *buf, int bufsz, bool is_writer, int gangId, int hostSegs);
 char *makeOptions(void);
 extern bool segment_failure_due_to_recovery(const char *error_message);
 

--- a/src/include/cdb/cdbicudpfaultinjection.h
+++ b/src/include/cdb/cdbicudpfaultinjection.h
@@ -49,7 +49,7 @@ static inline bool
 testmode_inject_fault(int percent)
 {
 	if (udp_testmode &&
-		(gp_udpic_dropseg == UNDEF_SEGMENT || gp_udpic_dropseg == Gp_segment))
+		(gp_udpic_dropseg == UNDEF_SEGMENT || gp_udpic_dropseg == GpIdentity.segindex))
 	{
 			if (random() % 100 < percent)
 				return true;

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -463,18 +463,7 @@ extern bool gp_interconnect_log_stats;
 
 extern bool gp_interconnect_cache_future_packets;
 
-/*
- * Parameter gp_segment
- *
- * The segment (content) controlled by this QE
- * content indicator: -1 for entry database, 0, ..., n-1 for segment database
- *
- * This variable is in the PGC_BACKEND context; it is set internally by the
- * Query Dispatcher, and is propagated to Query Executors in the connection
- * parameters.	It is not modifiable by any user, ever.
- */
 #define UNDEF_SEGMENT -2
-extern int	Gp_segment;		/* GUC var */
 
 extern int	getgpsegmentCount(void);
 

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -285,7 +285,7 @@ extern void putTransportDirectBuffer(ChunkTransportState *transportStates,
 		int			*p_inactive = inactiveCountPtr; \
 		int			i, index, inactive = 0; \
 		/* add our tcItem to each of the outgoing buffers. */ \
-		index = Max(0, Gp_segment); /* entry-db has -1 */ \
+		index = Max(0, GpIdentity.segindex); /* entry-db has -1 */ \
 		for (i = 0; i < pEntry->numConns; i++, index++) \
 		{ \
 			if (index >= pEntry->numConns) \

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -179,8 +179,8 @@ INSERT INTO srf_testtab VALUES ('foo 1');
 INSERT INTO srf_testtab VALUES ('foo -1');
 create function srf_on_master () returns setof text as $$
 begin
-  return next 'foo ' || current_setting('gp_segment');
-  return next 'bar ' || current_setting('gp_segment');
+  return next 'foo ' || current_setting('gp_contentid');
+  return next 'bar ' || current_setting('gp_contentid');
 end;
 $$ language plpgsql EXECUTE ON MASTER;
 -- A function with ON MASTER or ON ALL SEGMENTS is only allowed in the target list
@@ -228,9 +228,9 @@ begin
 
   -- To make the output reproducible, regardless of the number of segments in
   -- the cluster, only return rows on segments 0 and 1
-  if current_setting('gp_segment')::integer < 2 then
-    return next 'foo ' || current_setting('gp_segment');
-    return next 'bar ' || current_setting('gp_segment');
+  if current_setting('gp_contentid')::integer < 2 then
+    return next 'foo ' || current_setting('gp_contentid');
+    return next 'bar ' || current_setting('gp_contentid');
   end if;
 end;
 $$ language plpgsql EXECUTE ON ALL SEGMENTS;

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -179,8 +179,8 @@ INSERT INTO srf_testtab VALUES ('foo 1');
 INSERT INTO srf_testtab VALUES ('foo -1');
 create function srf_on_master () returns setof text as $$
 begin
-  return next 'foo ' || current_setting('gp_segment');
-  return next 'bar ' || current_setting('gp_segment');
+  return next 'foo ' || current_setting('gp_contentid');
+  return next 'bar ' || current_setting('gp_contentid');
 end;
 $$ language plpgsql EXECUTE ON MASTER;
 -- A function with ON MASTER or ON ALL SEGMENTS is only allowed in the target list
@@ -228,9 +228,9 @@ begin
 
   -- To make the output reproducible, regardless of the number of segments in
   -- the cluster, only return rows on segments 0 and 1
-  if current_setting('gp_segment')::integer < 2 then
-    return next 'foo ' || current_setting('gp_segment');
-    return next 'bar ' || current_setting('gp_segment');
+  if current_setting('gp_contentid')::integer < 2 then
+    return next 'foo ' || current_setting('gp_contentid');
+    return next 'bar ' || current_setting('gp_contentid');
   end if;
 end;
 $$ language plpgsql EXECUTE ON ALL SEGMENTS;

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -143,8 +143,8 @@ INSERT INTO srf_testtab VALUES ('foo -1');
 
 create function srf_on_master () returns setof text as $$
 begin
-  return next 'foo ' || current_setting('gp_segment');
-  return next 'bar ' || current_setting('gp_segment');
+  return next 'foo ' || current_setting('gp_contentid');
+  return next 'bar ' || current_setting('gp_contentid');
 end;
 $$ language plpgsql EXECUTE ON MASTER;
 
@@ -169,9 +169,9 @@ begin
 
   -- To make the output reproducible, regardless of the number of segments in
   -- the cluster, only return rows on segments 0 and 1
-  if current_setting('gp_segment')::integer < 2 then
-    return next 'foo ' || current_setting('gp_segment');
-    return next 'bar ' || current_setting('gp_segment');
+  if current_setting('gp_contentid')::integer < 2 then
+    return next 'foo ' || current_setting('gp_contentid');
+    return next 'bar ' || current_setting('gp_contentid');
   end if;
 end;
 $$ language plpgsql EXECUTE ON ALL SEGMENTS;


### PR DESCRIPTION
Code had these two variables (GUCs), serving same purpose. GpIdentity.segindex
is set to content-id, based on command line argument at start-up and inherited
by all processes from postmaster. Whereas Gp_segment, was session level guc only
set for backends, by dispatching the same from QD. So. essentially Gp_segment
was not available and had incorrect value in auxiliary processes.

Hence replaced all usages with GpIdentity.segindex. As a side effect log files
now have correct value reported for segment number (content-id) in each and
every line of file, irrespective of which process generated the log message.

Discussion:
https://groups.google.com/a/greenplum.org/forum/#!msg/gpdb-dev/Yr8-LZIiNfA/ob4KLgmkAQAJ


Use IS_QUERY_DISPATCHER() wherever relevant. (There could be more places, we will replace as we find them)