### PR TITLE
Do not dump protocols in filtered pg_dump

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1530,7 +1530,7 @@ selectDumpableObject(DumpableObject *dobj)
 	if (dobj->namespace)
 		dobj->dump = dobj->namespace->dobj.dump;
 	else
-		dobj->dump = true;
+		dobj->dump = include_everything;
 }
 
 /*


### PR DESCRIPTION
Since protocols do not belong to a namespace, we do not want to dump
them in table or schema filtered backups. They will only be dumped in a
full backup. This will be backported to 5X_STABLE

Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>