### PR TITLE
Fix coverity CID 185522 and CID 185520.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2483,7 +2483,7 @@ gatherRMInDoubtTransactions(void)
 			{
 				elog(DEBUG3, "Found in-doubt transaction with GID: %s on remote RM", gid);
 
-				strcpy(lastDtx->gid, gid);
+				strncpy(lastDtx->gid, gid, TMGIDSIZE);
 			}
 
 		}

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1756,6 +1756,8 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	globalXminDistributedSnapshots = xmax;
 	count = 0;
 
+	Assert(ds->inProgressXidArray != NULL);
+
 	/*
 	 * Gather up current in-progress global transactions for the distributed
 	 * snapshot.


### PR DESCRIPTION
*** CID 185522:  Security best practices violations  (STRING_OVERFLOW)
/tmp/build/0e1b53a0/gpdb_src/src/backend/cdb/cdbtm.c: 2486 in gatherRMInDoubtTransactions()

and

*** CID 185520:  Null pointer dereferences  (FORWARD_NULL)
/tmp/build/0e1b53a0/gpdb_src/src/backend/storage/ipc/procarray.c: 2251 in GetSnapshotData()

This condition cannot happen as `GetDistributedSnapshotMaxCount()` doesn't
return 0 for DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE and hence `inProgressXidArray`
will always be initialzed. hence marked as ignore in coverity but still worth
adding Assert for the same.