### PR TITLE
Avoid generating XLOG_APPENDONLY_INSERT for temp AO/CO tables.

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -166,7 +166,7 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
 										blksz,
 										attr,
 										RelationGetRelationName(rel),
-										 /* title */ titleBuf.data);
+										/* title */ titleBuf.data, rel->rd_istemp);
 
 	}
 }
@@ -1840,7 +1840,7 @@ aocs_addcol_init(Relation rel,
 		blksz = opts[iattr]->blocksize;
 		desc->dsw[i] = create_datumstreamwrite(ct, clvl, rel->rd_appendonly->checksum, 0, blksz /* safeFSWriteSize */ ,
 											   attr, RelationGetRelationName(rel),
-											   titleBuf.data);
+											   titleBuf.data, rel->rd_istemp);
 	}
 	return desc;
 }

--- a/src/backend/access/aocs/test/aocsam_test.c
+++ b/src/backend/access/aocs/test/aocsam_test.c
@@ -87,18 +87,14 @@ test__aocs_addcol_init(void **state)
 	expect_string(create_datumstreamwrite, compName, "none");
 	expect_value(create_datumstreamwrite, compLevel, 2);
 	expect_value(create_datumstreamwrite, compLevel, 0);
-	expect_value(create_datumstreamwrite, checksum, true);
-	expect_value(create_datumstreamwrite, checksum, true);
-	expect_value(create_datumstreamwrite, safeFSWriteSize, 0);
-	expect_value(create_datumstreamwrite, safeFSWriteSize, 0);
+	expect_value_count(create_datumstreamwrite, checksum, true, 2);
+	expect_value_count(create_datumstreamwrite, safeFSWriteSize, 0, 2);
 	expect_value(create_datumstreamwrite, maxsz, 8192);
 	expect_value(create_datumstreamwrite, maxsz, 8192 * 2);
-	expect_any(create_datumstreamwrite, attr);
-	expect_any(create_datumstreamwrite, attr);
-	expect_any(create_datumstreamwrite, relname);
-	expect_any(create_datumstreamwrite, relname);
-	expect_any(create_datumstreamwrite, title);
-	expect_any(create_datumstreamwrite, title);
+	expect_any_count(create_datumstreamwrite, attr, 2);
+	expect_any_count(create_datumstreamwrite, relname, 2);
+	expect_any_count(create_datumstreamwrite, title, 2);
+	expect_any_count(create_datumstreamwrite, isTempRel, 2);
 	will_return_count(create_datumstreamwrite, NULL, 2);
 
 	pgappendonly.checksum = true;

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2714,6 +2714,7 @@ appendonly_insert_init(Relation rel, int segno, bool update_mode)
 								aoInsertDesc->usableBlockSize,
 								RelationGetRelationName(aoInsertDesc->aoi_rel),
 								aoInsertDesc->title,
+								aoInsertDesc->aoi_rel->rd_istemp,
 								&aoInsertDesc->storageAttributes);
 
 	aoInsertDesc->storageWrite.compression_functions = fns;

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -65,6 +65,7 @@ AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
 							int32 maxBufferLen,
 							char *relationName,
 							char *title,
+							bool isTempRel,
 							AppendOnlyStorageAttributes *storageAttributes)
 {
 	int			relationNameLen;
@@ -147,7 +148,8 @@ AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
 					   memoryLen,
 					    /* maxBufferLen */ storageWrite->maxBufferWithCompressionOverrrunLen,
 					   storageWrite->largeWriteLen,
-					   relationName);
+					   relationName,
+					   isTempRel);
 
 	elogif(Debug_appendonly_print_insert || Debug_appendonly_print_append_block, LOG,
 		   "Append-Only Storage Write initialize for table '%s' (compression = %s, compression level %d, maximum buffer length %d, large write length %d)",
@@ -275,7 +277,8 @@ AppendOnlyStorageWrite_TransactionCreateFile(AppendOnlyStorageWrite *storageWrit
 	 * gp_replica_check tool, to compare primary and mirror, will complain if
 	 * a file exists in master but not in mirror, even if it's empty.
 	 */
-	xlog_ao_insert(*relFileNode, segmentFileNum, 0, NULL, 0);
+	if (!storageWrite->bufferedAppend.isTempRel)
+		xlog_ao_insert(*relFileNode, segmentFileNum, 0, NULL, 0);
 }
 
 /*

--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -54,7 +54,8 @@ BufferedAppendInit(BufferedAppend *bufferedAppend,
 				   int32 memoryLen,
 				   int32 maxBufferLen,
 				   int32 maxLargeWriteLen,
-				   char *relationName)
+				   char *relationName,
+				   bool isTempRel)
 {
 	Assert(bufferedAppend != NULL);
 	Assert(memory != NULL);
@@ -96,6 +97,7 @@ BufferedAppendInit(BufferedAppend *bufferedAppend,
 	bufferedAppend->file = -1;
 	bufferedAppend->filePathName = NULL;
 	bufferedAppend->fileLen = 0;
+	bufferedAppend->isTempRel = isTempRel;
 }
 
 /*
@@ -206,8 +208,10 @@ BufferedAppendWrite(BufferedAppend *bufferedAppend)
 	 * controls the visibility of data in AO / CO files, writing xlog
 	 * record after writing to file works fine.
 	 */
-	xlog_ao_insert(bufferedAppend->relFileNode, bufferedAppend->segmentFileNum,
-				   bufferedAppend->largeWritePosition, largeWriteMemory, bytestotal);
+	if (!bufferedAppend->isTempRel)
+		xlog_ao_insert(bufferedAppend->relFileNode, bufferedAppend->segmentFileNum,
+					   bufferedAppend->largeWritePosition,
+					   largeWriteMemory, bytestotal);
 
 	bufferedAppend->largeWritePosition += bufferedAppend->largeWriteLen;
 	bufferedAppend->largeWriteLen = 0;

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -493,7 +493,8 @@ create_datumstreamwrite(
 						int32 maxsz,
 						Form_pg_attribute attr,
 						char *relname,
-						char *title)
+						char *title,
+						bool isTempRel)
 {
 	DatumStreamWrite *acc = palloc0(sizeof(DatumStreamWrite));
 
@@ -561,6 +562,7 @@ create_datumstreamwrite(
 								acc->maxAoBlockSize,
 								relname,
 								title,
+								isTempRel,
 								&acc->ao_attr);
 
 	acc->ao_write.compression_functions = compressionFunctions;

--- a/src/include/cdb/cdbappendonlystoragewrite.h
+++ b/src/include/cdb/cdbappendonlystoragewrite.h
@@ -175,11 +175,12 @@ typedef struct AppendOnlyStorageWrite
 } AppendOnlyStorageWrite;
 
 extern void AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
-							MemoryContext memoryContext,
-							int32 maxBufferLen,
-							char *relationName,
-							char *title,
-							AppendOnlyStorageAttributes *storageAttributes);
+										MemoryContext memoryContext,
+										int32 maxBufferLen,
+										char *relationName,
+										char *title,
+										bool isTempRel,
+										AppendOnlyStorageAttributes *storageAttributes);
 extern void AppendOnlyStorageWrite_FinishSession(AppendOnlyStorageWrite *storageWrite);
 
 extern void AppendOnlyStorageWrite_TransactionCreateFile(AppendOnlyStorageWrite *storageWrite,

--- a/src/include/cdb/cdbbufferedappend.h
+++ b/src/include/cdb/cdbbufferedappend.h
@@ -27,6 +27,7 @@ typedef struct BufferedAppend
 	 * Init level.
 	 */
 	char				*relationName;
+	bool isTempRel;
 
 	/*
 	 * Large-write memory level members.
@@ -94,12 +95,13 @@ extern int32 BufferedAppendMemoryLen(
  * determine the amount of memory to supply.
  */
 extern void BufferedAppendInit(
-    BufferedAppend       *bufferedAppend,
-    uint8                *memory,
-    int32                memoryLen,
-    int32                maxBufferLen,
-    int32                maxLargeWriteLen,
-    char				 *relationName);
+	BufferedAppend *bufferedAppend,
+	uint8          *memory,
+	int32          memoryLen,
+	int32          maxBufferLen,
+	int32          maxLargeWriteLen,
+	char           *relationName,
+	bool           isTempRel);
 
 /*
  * Takes an open file handle for the next file.

--- a/src/include/utils/datumstream.h
+++ b/src/include/utils/datumstream.h
@@ -260,7 +260,8 @@ extern DatumStreamWrite *create_datumstreamwrite(
 						int32 maxsz,
 						Form_pg_attribute attr,
 						char *relname,
-						char *title);
+						char *title,
+						bool isTempRel);
 
 extern DatumStreamRead *create_datumstreamread(
 					   char *compName,


### PR DESCRIPTION
Temp tables don't have to be replicated neither crash safe and hence avoid
generating xlog records for them. Heap already avoids, this patch skips for
AO/CO tables as well. Adding new variable `isTempRel` to `BufferedAppend` to
help perform the check for temp tables and skip generating xlog records.