### PR TITLE
Correctly set pg_exttable.logerrors

### DIFF
--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -48,7 +48,6 @@
 void
 InsertExtTableEntry(Oid 	tbloid,
 					bool 	iswritable,
-					bool 	isweb,
 					bool	issreh,
 					char	formattype,
 					char	rejectlimittype,

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -68,7 +68,6 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	DefElem    *dencoding = NULL;
 	ListCell   *option;
 	Oid			reloid = 0;
-	Oid			fmtErrTblOid = InvalidOid;
 	Datum		formatOptStr;
 	Datum		optionsStr;
 	Datum		locationUris = 0;
@@ -420,12 +419,11 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	else
 		reloid = RangeVarGetRelid(createExtStmt->relation, true);
 
-	/*
-	 * In the case of error log file, set fmtErrorTblOid to the external table
-	 * itself.
-	 */
+	bool logerrors;
 	if (issreh)
-		fmtErrTblOid = reloid;
+		logerrors = singlerowerrorDesc->into_file;
+	else
+		logerrors = false;
 
 	/*
 	 * create a pg_exttable entry for this external table.
@@ -438,7 +436,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 						rejectlimittype,
 						commandString,
 						rejectlimit,
-						fmtErrTblOid,
+						logerrors,
 						encoding,
 						formatOptStr,
 						optionsStr,

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -79,6 +79,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	int			rejectlimit = -1;
 	int			encoding = -1;
 	bool		issreh = false; /* is single row error handling requested? */
+	bool 		logerrors = false;
 	bool		iswritable = createExtStmt->iswritable;
 	bool		isweb = createExtStmt->isweb;
 	bool		shouldDispatch = (Gp_role == GP_ROLE_DISPATCH &&
@@ -313,6 +314,8 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 
 		issreh = true;
 
+		logerrors = singlerowerrorDesc->into_file;
+
 		/* get reject limit, and reject limit type */
 		rejectlimit = singlerowerrorDesc->rejectlimit;
 		rejectlimittype = (singlerowerrorDesc->is_limit_in_rows ? 'r' : 'p');
@@ -418,12 +421,6 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 		Assert(reloid != InvalidOid);
 	else
 		reloid = RangeVarGetRelid(createExtStmt->relation, true);
-
-	bool logerrors;
-	if (issreh)
-		logerrors = singlerowerrorDesc->into_file;
-	else
-		logerrors = false;
 
 	/*
 	 * create a pg_exttable entry for this external table.

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -427,7 +427,6 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	 */
 	InsertExtTableEntry(reloid,
 						iswritable,
-						isweb,
 						issreh,
 						formattype,
 						rejectlimittype,

--- a/src/include/catalog/pg_exttable.h
+++ b/src/include/catalog/pg_exttable.h
@@ -100,7 +100,6 @@ typedef struct ExtTableEntry
 
 extern void InsertExtTableEntry(Oid 	tbloid,
 					bool 	iswritable,
-					bool 	isweb,
 					bool	issreh,
 					char	formattype,
 					char	rejectlimittype,

--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -874,6 +874,24 @@ External options: {}
 External location: file:///tmp/test.txt
 Execute on: all segments
 
+create external table ext_error_logging_off (a int, b int)
+    location ('file:///tmp/test.txt') format 'text'
+    segment reject limit 100;
+\d+ ext_error_logging_off
+    External table "public.ext_error_logging_off"
+ Column |  Type   | Modifiers | Storage | Description 
+--------+---------+-----------+---------+-------------
+ a      | integer |           | plain   | 
+ b      | integer |           | plain   | 
+Type: readable
+Encoding: UTF8
+Format type: text
+Format options: delimiter '	' null '\N' escape '\'
+External options: {}
+External location: file:///tmp/test.txt
+Execute on: all segments
+Segment reject limit: 100 rows
+
 create external table ext_t2 (a int, b int)
     location ('file:///tmp/test.txt') format 'text'
     log errors segment reject limit 100;

--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -386,6 +386,7 @@ select attrelid::regclass,attnum,attoptions
  co7      |      3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (24 rows)
 
+drop database if exists dsp3;
 create database dsp3;
 \c dsp3
 set gp_default_storage_options=
@@ -892,8 +893,6 @@ Execute on: all segments
 Segment reject limit: 100 rows
 Error Log in File
 
-drop external table ext_t1;
-drop external table ext_t2;
 -- Make sure gp_default_storage_options GUC value is set in newly created cdbgangs
 -- after previous idle cdbgang is stopped
 SET gp_vmem_idle_resource_timeout=30;
@@ -1064,9 +1063,6 @@ select relname, relkind, relstorage, reloptions from pg_class where relname like
 RESET gp_default_storage_options;
 -- cleanup
 \c postgres
-drop database dsp1;
-drop database dsp2;
-drop database dsp3;
 -- start_matchsubs
 -- m/.*\[ERROR\]*/
 -- s/.*\[ERROR\]/[ERROR]/gm

--- a/src/test/regress/sql/dsp.sql
+++ b/src/test/regress/sql/dsp.sql
@@ -355,6 +355,10 @@ set gp_default_storage_options='appendonly=true';
 create external table ext_t1 (a int, b int)
     location ('file:///tmp/test.txt') format 'text';
 \d+ ext_t1
+create external table ext_error_logging_off (a int, b int)
+    location ('file:///tmp/test.txt') format 'text'
+    segment reject limit 100;
+\d+ ext_error_logging_off
 create external table ext_t2 (a int, b int)
     location ('file:///tmp/test.txt') format 'text'
     log errors segment reject limit 100;

--- a/src/test/regress/sql/dsp.sql
+++ b/src/test/regress/sql/dsp.sql
@@ -164,6 +164,7 @@ select relid::regclass,compresslevel,compresstype,blocksize,checksum,columnstore
 	from pg_appendonly order by 1;
 select attrelid::regclass,attnum,attoptions
 	from pg_attribute_encoding order by 1,2;
+drop database if exists dsp3;
 create database dsp3;
 \c dsp3
 set gp_default_storage_options=
@@ -358,8 +359,6 @@ create external table ext_t2 (a int, b int)
     location ('file:///tmp/test.txt') format 'text'
     log errors segment reject limit 100;
 \d+ ext_t2
-drop external table ext_t1;
-drop external table ext_t2;
 
 -- Make sure gp_default_storage_options GUC value is set in newly created cdbgangs
 -- after previous idle cdbgang is stopped
@@ -420,9 +419,6 @@ RESET gp_default_storage_options;
 
 -- cleanup
 \c postgres
-drop database dsp1;
-drop database dsp2;
-drop database dsp3;
 
 -- start_matchsubs
 -- m/.*\[ERROR\]*/


### PR DESCRIPTION
Consider the following SQL, we expect logging to be turned off for table `ext_error_logging_off`

```sql
create external table ext_error_logging_off (a int, b int)
    location ('file:///tmp/test.txt') format 'text'
    segment reject limit 100;
\d+ ext_error_logging_off
```
And then in this next case we expect error logging to be turned on for table `ext_t2`:
```sql
create external table ext_t2 (a int, b int)
    location ('file:///tmp/test.txt') format 'text'
    log errors segment reject limit 100;
\d+ ext_t2
```

Before this patch, we are making two mistakes in handling these external table DDL:

1. We intend to enable error logging *whenever* the user specifies `SEGMENT REJECT` clause, completely ignoring whether he or she specifies `LOG ERRORS`
1. Even then, we make the mistake of implicitly coercing the OID (an unsigned 32-bit integer) to a bool (which is really just a C `char`): that means, 255/256 of the time (99.6%) the result is `true`, and 0.4% of the time we get a `false` instead.

The `OID` to `bool` implicit conversion could have been caught by a `-Wconversion` GCC/Clang flag. It's most likely a leftover from commit 8f6fe2d60b6d7e93d35cca2d80cc360ad8732599.

This bug manifests itself in the `dsp` regression test mysteriously failing about once every 200 runs -- with the only diff on a `\d+` of an external table that should have error logging turned on, but the returned definition has it turned off.

While working on this we discovered that all of our existing external tables have both `LOG ERRORS` and `SEGMENT REJECT`, which is why this bug wasn't caught in the first place.

This patch fixes the issue by properly setting the catalog column `pg_exttable.logerrors` according to the user input.