### PR TITLE
Support plpython cancellation.

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3513,6 +3513,7 @@ die(SIGNAL_ARGS)
 		InterruptPending = true;
 		ProcDiePending = true;
 		TermSignalReceived = true;
+
 		/* although we don't strictly need to set this to true since the
 		 * ProcDiePending will occur first.  We set this anyway since the
 		 * MPP dispatch code is triggered only off of QueryCancelPending

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -143,8 +143,6 @@ int			PostAuthDelay = 0;
  *
  * This gets called after setting ProcDiePending, QueryCancelPending, so
  * the hook function can check those to determine what event happened.
- *
- * NB: This is called from a signal handler!
  */
 cancel_pending_hook_type cancel_pending_hook = NULL;
 

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -93,6 +93,10 @@ extern void BackoffBackendTick(void);
 extern bool gp_enable_resqueue_priority;
 extern void gp_set_thread_sigmasks(void);
 
+/* Hook get notified when QueryCancelPending or ProcDiePending is raised */
+typedef void (*cancel_pending_hook_type) (void);
+extern PGDLLIMPORT cancel_pending_hook_type cancel_pending_hook;
+
 /* in utils/resource_manager.h */
 extern bool IsResQueueEnabled(void);
 

--- a/src/pl/plpython/plpython.c
+++ b/src/pl/plpython/plpython.c
@@ -1421,6 +1421,7 @@ PLy_procedure_call(PLyProcedure *proc, char *kargs, PyObject *vargs)
 	}
 	PG_CATCH();
 	{
+		PLy_enter_python_intepreter = false;
 		PLy_abort_open_subtransactions(save_subxact_level);
 		PG_RE_THROW();
 	}

--- a/src/test/isolation2/expected/cancel_plpython.out
+++ b/src/test/isolation2/expected/cancel_plpython.out
@@ -44,17 +44,17 @@ SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') FROM pg_stat_activit
 pg_cancel_backend
 -----------------
 t                
-(1 rows)
+(1 row)
 SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') FROM pg_stat_activity WHERE current_query LIKE 'select pynestsleep()%' ORDER BY procpid LIMIT 1;
 pg_cancel_backend
 -----------------
 t                
-(1 rows)
+(1 row)
 SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') FROM pg_stat_activity WHERE current_query LIKE 'select pynestsleep2()%' ORDER BY procpid LIMIT 1;
 pg_cancel_backend
 -----------------
 t                
-(1 rows)
+(1 row)
 -- start_ignore
 -- start_ignore
 -- start_ignore

--- a/src/test/isolation2/expected/cancel_plpython.out
+++ b/src/test/isolation2/expected/cancel_plpython.out
@@ -1,0 +1,98 @@
+CREATE OR REPLACE FUNCTION pybusyloop() RETURNS double precision AS $$ import math while True: a = 1 return 1 $$ LANGUAGE plpythonu;
+CREATE
+
+CREATE OR REPLACE FUNCTION pysleep() RETURNS double precision AS $$ import time time.sleep(100) return 1 $$ LANGUAGE plpythonu;
+CREATE
+
+CREATE OR REPLACE FUNCTION pyspisleep() RETURNS double precision AS $$ # container: plc_python_shared rv = plpy.execute("select pg_sleep(100)") return 1 $$ LANGUAGE plpythonu;
+CREATE
+
+CREATE OR REPLACE FUNCTION pynestsleep() RETURNS double precision AS $$ # container: plc_python_shared rv = plpy.execute("select pyspisleep()") return 1 $$ LANGUAGE plpythonu;
+CREATE
+
+CREATE OR REPLACE FUNCTION pynestsleep2() RETURNS double precision AS $$ # container: plc_python_shared rv = plpy.execute("select pysleep()") return 1 $$ LANGUAGE plpythonu;
+CREATE
+
+
+CREATE TABLE a(i int);
+CREATE
+insert into a values(1),(10),(20),(100);
+INSERT 4
+
+1&: select pybusyloop();  <waiting ...>
+2&: select pybusyloop() from a;  <waiting ...>
+3&: select pysleep();  <waiting ...>
+4&: select pysleep() from a;  <waiting ...>
+5&: select pyspisleep();  <waiting ...>
+6&: select pynestsleep();  <waiting ...>
+7&: select pynestsleep2();  <waiting ...>
+
+
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') FROM pg_stat_activity WHERE current_query LIKE 'select pybusyloop()%' ORDER BY procpid LIMIT 2;
+pg_cancel_backend
+-----------------
+t                
+t                
+(2 rows)
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') FROM pg_stat_activity WHERE current_query LIKE 'select pysleep()%' ORDER BY procpid LIMIT 2;
+pg_cancel_backend
+-----------------
+t                
+t                
+(2 rows)
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') FROM pg_stat_activity WHERE current_query LIKE 'select pyspisleep()%' ORDER BY procpid LIMIT 1;
+pg_cancel_backend
+-----------------
+t                
+(1 rows)
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') FROM pg_stat_activity WHERE current_query LIKE 'select pynestsleep()%' ORDER BY procpid LIMIT 1;
+pg_cancel_backend
+-----------------
+t                
+(1 rows)
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') FROM pg_stat_activity WHERE current_query LIKE 'select pynestsleep2()%' ORDER BY procpid LIMIT 1;
+pg_cancel_backend
+-----------------
+t                
+(1 rows)
+-- start_ignore
+-- start_ignore
+-- start_ignore
+-- start_ignore
+1<:  <... completed>
+ERROR:  canceling statement due to user request: "test pg_cancel_backend"
+CONTEXT:  PL/Python function "pybusyloop"
+1q: ... <quitting>
+2<:  <... completed>
+ERROR:  canceling statement due to user request: "test pg_cancel_backend"
+2q: ... <quitting>
+3<:  <... completed>
+ERROR:  canceling statement due to user request: "test pg_cancel_backend"
+CONTEXT:  PL/Python function "pysleep"
+3q: ... <quitting>
+4<:  <... completed>
+ERROR:  canceling statement due to user request: "test pg_cancel_backend"
+4q: ... <quitting>
+5<:  <... completed>
+ERROR:  plpy.SPIError: canceling statement due to user request: "test pg_cancel_backend"
+CONTEXT:  Traceback (most recent call last):
+  PL/Python function "pyspisleep", line 3, in <module>
+    rv = plpy.execute("select pg_sleep(100)")
+PL/Python function "pyspisleep"
+5q: ... <quitting>
+6<:  <... completed>
+ERROR:  plpy.SPIError: plpy.SPIError: canceling statement due to user request: "test pg_cancel_backend"
+CONTEXT:  Traceback (most recent call last):
+  PL/Python function "pynestsleep", line 3, in <module>
+    rv = plpy.execute("select pyspisleep()")
+PL/Python function "pynestsleep"
+6q: ... <quitting>
+7<:  <... completed>
+ERROR:  plpy.SPIError: canceling statement due to user request: "test pg_cancel_backend"
+CONTEXT:  Traceback (most recent call last):
+  PL/Python function "pynestsleep2", line 3, in <module>
+    rv = plpy.execute("select pysleep()")
+PL/Python function "pynestsleep2"
+7q: ... <quitting>
+-- end_ignore
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -140,3 +140,6 @@ test: reindex/serializable_reindex_with_drop_index_ao reindex/serializable_reind
 test: reindex/serializable_reindex_with_insert_heap
 test: reindex/serializable_reindex_with_insert_part_heap reindex/vacuum_anal_while_reindex_ao_btree
 test: reindex/vacuum_while_reindex_ao_bitmap reindex/vacuum_while_reindex_heap_btree reindex/vacuum_while_reindex_heap_btree_toast
+
+# Cancel test
+test: cancel_plpython

--- a/src/test/isolation2/sql/cancel_plpython.sql
+++ b/src/test/isolation2/sql/cancel_plpython.sql
@@ -1,0 +1,74 @@
+CREATE OR REPLACE FUNCTION pybusyloop() RETURNS double precision AS $$
+import math
+while True:
+    a = 1
+return 1
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION pysleep() RETURNS double precision AS $$
+import time
+time.sleep(100)
+return 1
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION pyspisleep() RETURNS double precision AS $$
+# container: plc_python_shared
+rv = plpy.execute("select pg_sleep(100)")
+return 1
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION pynestsleep() RETURNS double precision AS $$
+# container: plc_python_shared
+rv = plpy.execute("select pyspisleep()")
+return 1
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION pynestsleep2() RETURNS double precision AS $$
+# container: plc_python_shared
+rv = plpy.execute("select pysleep()")
+return 1
+$$ LANGUAGE plpythonu;
+
+
+CREATE TABLE a(i int);
+insert into a values(1),(10),(20),(100);
+
+1&: select pybusyloop();
+2&: select pybusyloop() from a;
+3&: select pysleep();
+4&: select pysleep() from a;
+5&: select pyspisleep();
+6&: select pynestsleep();
+7&: select pynestsleep2();
+
+
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') 
+FROM pg_stat_activity WHERE current_query LIKE 'select pybusyloop()%' ORDER BY procpid LIMIT 2;
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend') 
+FROM pg_stat_activity WHERE current_query LIKE 'select pysleep()%' ORDER BY procpid LIMIT 2;
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend')
+FROM pg_stat_activity WHERE current_query LIKE 'select pyspisleep()%' ORDER BY procpid LIMIT 1;
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend')
+FROM pg_stat_activity WHERE current_query LIKE 'select pynestsleep()%' ORDER BY procpid LIMIT 1;
+SELECT pg_cancel_backend(procpid, 'test pg_cancel_backend')
+FROM pg_stat_activity WHERE current_query LIKE 'select pynestsleep2()%' ORDER BY procpid LIMIT 1;
+-- start_ignore
+-- start_ignore
+-- start_ignore
+-- start_ignore
+1<:
+1q:
+2<:
+2q:
+3<:
+3q:
+4<:
+4q:
+5<:
+5q:
+6<:
+6q:
+7<:
+7q:
+-- end_ignore
+


### PR DESCRIPTION
Add hook framework in signal handlers, e.g. StatementCancelHandler or die,
to cancel the slow function in a 3rd party library.

Add PLy_handle_cancel_interrupt hook to cancel plpython, which use
Py_AddPendingCall to cancel embedded python asynchronously.

This PR is based on Hekki's initial patch on cancel plpython on postgresql.