### PR TITLE
Add tests for subqueries nested inside a scalar expression

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.62.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.63.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.62.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.63.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13251,7 +13251,7 @@ int
 main ()
 {
 
-return strncmp("2.62.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.63.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13261,7 +13261,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.62.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.63.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.62.0@gpdb/stable
+orca/v2.63.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.62.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.63.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -1298,6 +1298,79 @@ select * from TblUp2;
  5 | 6
 (3 rows)
 
+--
+-- Check for correct results for subqueries nested inside a scalar expression
+--
+-- start_ignore
+create table subselect_tab1 (a int, b text, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table subselect_tab2 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table subselect_tab3 (a int, b text, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into subselect_tab1 VALUES (100, 'false', 1);
+insert into subselect_tab1 VALUES (200, 'true', 2);
+insert into subselect_tab2 VALUES (2,2,2);
+insert into subselect_tab3 VALUES (200, 'falseg', 1);
+-- end_ignore
+-- scalar subquery in a null test expression
+select * from subselect_tab1 where (select b from subselect_tab2) is null;
+ a | b | c 
+---+---+---
+(0 rows)
+
+-- ANY subquery nested in a scalar comparison expression
+select * from subselect_tab1 where b::bool = ( c = any(select c from subselect_tab2));
+  a  |   b   | c 
+-----+-------+---
+ 100 | false | 1
+ 200 | true  | 2
+(2 rows)
+
+-- ALL subquery deeply nested in a scalar expression
+select * from subselect_tab3 where b = ( a < all(select c from subselect_tab2) || 'g');
+  a  |   b    | c 
+-----+--------+---
+ 200 | falseg | 1
+(1 row)
+
+-- EXISTS subquery nested in a boolean expression
+select * from subselect_tab1 where b::bool = (exists(select c from subselect_tab2) and not exists (select c from subselect_tab3));
+  a  |   b   | c 
+-----+-------+---
+ 100 | false | 1
+(1 row)
+
+-- ALL and EXISTS nested in a CASE-WHEN-THEN expression
+select * from subselect_tab1 where case when b is not null then (subselect_tab1.c < all(select c from subselect_tab2 where exists (select * from subselect_tab3))) else false end;
+  a  |   b   | c 
+-----+-------+---
+ 100 | false | 1
+(1 row)
+
+-- EXISTS subquery nested in a scalar comparison expression
+select * from subselect_tab1 where b::bool = exists(select c from subselect_tab2);
+  a  |  b   | c 
+-----+------+---
+ 200 | true | 2
+(1 row)
+
+-- a few more complex combinations..
+SELECT * FROM subselect_tab3 WHERE (EXISTS(SELECT c FROM subselect_tab2) AND NOT EXISTS (SELECT c from subselect_tab3)) IN (SELECT b::BOOL from subselect_tab1);
+  a  |   b    | c 
+-----+--------+---
+ 200 | falseg | 1
+(1 row)
+
+SELECT * FROM subselect_tab3 WHERE (NOT EXISTS(SELECT c FROM subselect_tab2)) IN (SELECT b::boolean  from subselect_tab1);
+  a  |   b    | c 
+-----+--------+---
+ 200 | falseg | 1
+(1 row)
+
 -- start_ignore
 drop schema qp_subquery cascade;
 -- end_ignore

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1301,6 +1301,79 @@ select * from TblUp2;
  100 | 6
 (3 rows)
 
+--
+-- Check for correct results for subqueries nested inside a scalar expression
+--
+-- start_ignore
+create table subselect_tab1 (a int, b text, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table subselect_tab2 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table subselect_tab3 (a int, b text, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into subselect_tab1 VALUES (100, 'false', 1);
+insert into subselect_tab1 VALUES (200, 'true', 2);
+insert into subselect_tab2 VALUES (2,2,2);
+insert into subselect_tab3 VALUES (200, 'falseg', 1);
+-- end_ignore
+-- scalar subquery in a null test expression
+select * from subselect_tab1 where (select b from subselect_tab2) is null;
+ a | b | c 
+---+---+---
+(0 rows)
+
+-- ANY subquery nested in a scalar comparison expression
+select * from subselect_tab1 where b::bool = ( c = any(select c from subselect_tab2));
+  a  |   b   | c 
+-----+-------+---
+ 200 | true  | 2
+ 100 | false | 1
+(2 rows)
+
+-- ALL subquery deeply nested in a scalar expression
+select * from subselect_tab3 where b = ( a < all(select c from subselect_tab2) || 'g');
+  a  |   b    | c 
+-----+--------+---
+ 200 | falseg | 1
+(1 row)
+
+-- EXISTS subquery nested in a boolean expression
+select * from subselect_tab1 where b::bool = (exists(select c from subselect_tab2) and not exists (select c from subselect_tab3));
+  a  |   b   | c 
+-----+-------+---
+ 100 | false | 1
+(1 row)
+
+-- ALL and EXISTS nested in a CASE-WHEN-THEN expression
+select * from subselect_tab1 where case when b is not null then (subselect_tab1.c < all(select c from subselect_tab2 where exists (select * from subselect_tab3))) else false end;
+  a  |   b   | c 
+-----+-------+---
+ 100 | false | 1
+(1 row)
+
+-- EXISTS subquery nested in a scalar comparison expression
+select * from subselect_tab1 where b::bool = exists(select c from subselect_tab2);
+  a  |  b   | c 
+-----+------+---
+ 200 | true | 2
+(1 row)
+
+-- a few more complex combinations..
+SELECT * FROM subselect_tab3 WHERE (EXISTS(SELECT c FROM subselect_tab2) AND NOT EXISTS (SELECT c from subselect_tab3)) IN (SELECT b::BOOL from subselect_tab1);
+  a  |   b    | c 
+-----+--------+---
+ 200 | falseg | 1
+(1 row)
+
+SELECT * FROM subselect_tab3 WHERE (NOT EXISTS(SELECT c FROM subselect_tab2)) IN (SELECT b::boolean  from subselect_tab1);
+  a  |   b    | c 
+-----+--------+---
+ 200 | falseg | 1
+(1 row)
+
 -- start_ignore
 drop schema qp_subquery cascade;
 -- end_ignore

--- a/src/test/regress/sql/qp_subquery.sql
+++ b/src/test/regress/sql/qp_subquery.sql
@@ -608,6 +608,43 @@ update TblUp1 set a=100 where a not in (select a from TblUp3);
 select * from TblUp1;
 update TblUp2 set a=100 where a not in (select a from TblUp4);
 select * from TblUp2;
+
+--
+-- Check for correct results for subqueries nested inside a scalar expression
+--
+-- start_ignore
+create table subselect_tab1 (a int, b text, c int);
+create table subselect_tab2 (a int, b int, c int);
+create table subselect_tab3 (a int, b text, c int);
+
+insert into subselect_tab1 VALUES (100, 'false', 1);
+insert into subselect_tab1 VALUES (200, 'true', 2);
+insert into subselect_tab2 VALUES (2,2,2);
+insert into subselect_tab3 VALUES (200, 'falseg', 1);
+-- end_ignore
+
+-- scalar subquery in a null test expression
+select * from subselect_tab1 where (select b from subselect_tab2) is null;
+
+-- ANY subquery nested in a scalar comparison expression
+select * from subselect_tab1 where b::bool = ( c = any(select c from subselect_tab2));
+
+-- ALL subquery deeply nested in a scalar expression
+select * from subselect_tab3 where b = ( a < all(select c from subselect_tab2) || 'g');
+
+-- EXISTS subquery nested in a boolean expression
+select * from subselect_tab1 where b::bool = (exists(select c from subselect_tab2) and not exists (select c from subselect_tab3));
+
+-- ALL and EXISTS nested in a CASE-WHEN-THEN expression
+select * from subselect_tab1 where case when b is not null then (subselect_tab1.c < all(select c from subselect_tab2 where exists (select * from subselect_tab3))) else false end;
+
+-- EXISTS subquery nested in a scalar comparison expression
+select * from subselect_tab1 where b::bool = exists(select c from subselect_tab2);
+
+-- a few more complex combinations..
+SELECT * FROM subselect_tab3 WHERE (EXISTS(SELECT c FROM subselect_tab2) AND NOT EXISTS (SELECT c from subselect_tab3)) IN (SELECT b::BOOL from subselect_tab1);
+SELECT * FROM subselect_tab3 WHERE (NOT EXISTS(SELECT c FROM subselect_tab2)) IN (SELECT b::boolean  from subselect_tab1);
+
 -- start_ignore
 drop schema qp_subquery cascade;
 -- end_ignore


### PR DESCRIPTION
This is related to [ORCA PR](https://github.com/greenplum-db/gporca/pull/372) which aims at correctly handling the ANY/ALL/EXISTS/NOT-EXISTS subqueries nested inside a scalar expression.

Currently we do not have a test coverage for these types of queries in `installcheck-good`. 
This PR adds a few tests to ensure sane behavior in such scenarios. The intent is to check for correct results.

