### PR TITLE
Backport fixes related to pg_upgrade

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1659,7 +1659,8 @@ heap_create_with_catalog(const char *relname,
 		 */
 		if (Gp_role == GP_ROLE_EXECUTE || IsBinaryUpgrade)
 		{
-			new_array_oid = GetPreassignedOidForType(relnamespace, relarrayname);
+			new_array_oid = GetPreassignedOidForType(relnamespace, relarrayname,
+													 true);
 
 			if (new_array_oid == InvalidOid && IsBinaryUpgrade)
 				new_array_oid = GetNewOid(pg_type);

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -671,9 +671,13 @@ GetPreassignedOidForRelation(Oid namespaceOid, const char *relname)
 /*
  * A specialized version of GetPreassignedOidForTuple(). To be used when we don't
  * have a whole pg_type tuple yet.
+ *
+ * The caller should set allowMissing if it can handle a missing preassignment
+ * for the type. This is useful in upgrade scenarios as new types are added.
  */
 Oid
-GetPreassignedOidForType(Oid namespaceOid, const char *typname)
+GetPreassignedOidForType(Oid namespaceOid, const char *typname,
+						 bool allowMissing)
 {
 	OidAssignment searchkey;
 	Oid			oid;
@@ -683,7 +687,7 @@ GetPreassignedOidForType(Oid namespaceOid, const char *typname)
 	searchkey.namespaceOid = namespaceOid;
 	searchkey.objname = (char *) typname;
 
-	if ((oid = GetPreassignedOid(&searchkey)) == InvalidOid)
+	if ((oid = GetPreassignedOid(&searchkey)) == InvalidOid && !allowMissing)
 		elog(ERROR, "no pre-assigned OID for type \"%s\"", typname);
 	return oid;
 }

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -660,6 +660,9 @@ GetPreassignedOidForRelation(Oid namespaceOid, const char *relname)
 			if (namespaceOid == PG_BITMAPINDEX_NAMESPACE)
 				return InvalidOid;
 
+			if (namespaceOid == PG_TOAST_NAMESPACE)
+				return InvalidOid;
+
 			if (namespaceOid == PG_AOSEGMENT_NAMESPACE)
 				return InvalidOid;
 		}

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -447,8 +447,14 @@ DefineType(List *names, List *parameters)
 	/* Preassign array type OID so we can insert it in pg_type.typarray */
 	if (Gp_role == GP_ROLE_EXECUTE || IsBinaryUpgrade)
 	{
-		array_oid = GetPreassignedOidForType(typeNamespace, array_type);
+		array_oid = GetPreassignedOidForType(typeNamespace, array_type, true);
 
+		/*
+		 * If we are expected to get a preassigned Oid but receive InvalidOid,
+		 * get a new Oid. This can happen during upgrades from GPDB4 to 5 where
+		 * array types over relation rowtypes were introduced so there are no
+		 * pre-existing array types to dump from the old cluster
+		 */
 		if (array_oid == InvalidOid && IsBinaryUpgrade)
 			array_oid = GetNewOid(pg_type);
 	}
@@ -1137,8 +1143,9 @@ DefineEnum(CreateEnumStmt *stmt)
 
 	if (Gp_role == GP_ROLE_EXECUTE || IsBinaryUpgrade)
 	{
-		enumTypeOid = GetPreassignedOidForType(enumNamespace, enumName);
-		enumArrayOid = GetPreassignedOidForType(enumNamespace, enumArrayName);
+		enumTypeOid = GetPreassignedOidForType(enumNamespace, enumName, false);
+		enumArrayOid = GetPreassignedOidForType(enumNamespace, enumArrayName,
+											    false);
 	}
 	else
 	{

--- a/src/include/catalog/oid_dispatch.h
+++ b/src/include/catalog/oid_dispatch.h
@@ -25,7 +25,8 @@ extern void AddPreassignedOidFromBinaryUpgrade(Oid oid, Oid catalog,
 			char *objname, Oid namespaceOid, Oid keyOid1, Oid keyOid2);
 extern Oid GetPreassignedOidForTuple(Relation catalogrel, HeapTuple tuple);
 extern Oid GetPreassignedOidForRelation(Oid namespaceOid, const char *relname);
-extern Oid GetPreassignedOidForType(Oid namespaceOid, const char *typname);
+extern Oid GetPreassignedOidForType(Oid namespaceOid, const char *typname,
+									bool allowMissing);
 extern Oid GetPreassignedOidForDatabase(const char *datname);
 
 /* Functions used in binary upgrade */

--- a/src/test/regress/expected/parruleord.out
+++ b/src/test/regress/expected/parruleord.out
@@ -705,9 +705,3 @@ SELECT parchildrelid::regclass, parname, parruleord
  test_partitioned_table_never_decrements_parruleord__1_prt_part5 | part5    |          7
 (6 rows)
 
--- PG_UPGRADE_FIXME:
--- This DROP TABLE needs to be removed after fixing issue where partition
--- typnames differ between CREATE TABLE vs. ADD PARTITION. Because of the
--- typname slightly differs, pg_upgrade fails due to the pre-assigned oid
--- going to the wrong typname.
-DROP TABLE test_partitioned_table_never_decrements_parruleord_to_zero;

--- a/src/test/regress/sql/parruleord.sql
+++ b/src/test/regress/sql/parruleord.sql
@@ -347,10 +347,3 @@ SELECT parchildrelid::regclass, parname, parruleord
    ON p.oid = r.paroid
    WHERE p.parrelid = 'test_partitioned_table_never_decrements_parruleord_to_zero'::regclass
    ORDER BY parruleord;
-
--- PG_UPGRADE_FIXME:
--- This DROP TABLE needs to be removed after fixing issue where partition
--- typnames differ between CREATE TABLE vs. ADD PARTITION. Because of the
--- typname slightly differs, pg_upgrade fails due to the pre-assigned oid
--- going to the wrong typname.
-DROP TABLE test_partitioned_table_never_decrements_parruleord_to_zero;


### PR DESCRIPTION
I had previously pushed 1b7f5202260ec60204e8074ab58194a1995199a9 to temporarily fix the pg_upgrade test in ICW.  The issue was not related to partition tables at all.  The issue was how preassigned oids worked during binary upgrade.  It would error out instead of generating a new oid.  The issue was already fixed in master so just need to backport them to 5X_STABLE branch.