### PR TITLE
COPY: expand the type of numcompleted to 64 bits

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -449,7 +449,7 @@ processCopyEndResults(CdbCopy *c,
 					  bool *first_error,
 					  int *failed_count,
 					  int *total_rows_rejected,
-					  int *total_rows_completed)
+					  int64 *total_rows_completed)
 {
 	SegmentDatabaseDescriptor *q;
 	int			seg;
@@ -702,7 +702,7 @@ cdbCopyEnd(CdbCopy *c)
  * and fetch the total number of rows completed by all QEs
  */
 int
-cdbCopyEndAndFetchRejectNum(CdbCopy *c, int *total_rows_completed)
+cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed)
 {
 	SegmentDatabaseDescriptor *q;
 	SegmentDatabaseDescriptor **failedSegDBs;

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -293,7 +293,7 @@ ReportSrehResults(CdbSreh *cdbsreh, int total_rejected)
 }
 
 static void
-sendnumrows_internal(int numrejected, int numcompleted)
+sendnumrows_internal(int numrejected, int64 numcompleted)
 {
 	StringInfoData buf;
 
@@ -304,7 +304,7 @@ sendnumrows_internal(int numrejected, int numcompleted)
 	pq_sendint(&buf, numrejected, 4);
 	if (numcompleted > 0)		/* optional send completed num for COPY FROM
 								 * ON SEGMENT */
-		pq_sendint(&buf, numcompleted, 4);
+		pq_sendint64(&buf, numcompleted);
 	pq_endmessage(&buf);
 }
 
@@ -327,7 +327,7 @@ SendNumRowsRejected(int numrejected)
  * of rows that were rejected and completed in this last data load
  */
 void
-SendNumRows(int numrejected, int numcompleted)
+SendNumRows(int numrejected, int64 numcompleted)
 {
 	sendnumrows_internal(numrejected, numcompleted);
 }
@@ -470,7 +470,6 @@ GetNextSegid(CdbSreh *cdbsreh)
 
 	return (cdbsreh->lastsegid++ % total_segs);
 }
-
 
 /*
  * This function is called when we are preparing to insert a bad row that

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3254,7 +3254,7 @@ CopyFromDispatch(CopyState cstate)
 	bool	   *nulls;
 	int		   *attr_offsets;
 	int			total_rejected_from_qes = 0;
-	int			total_completed_from_qes = 0;
+	int64		total_completed_from_qes = 0;
 	bool		isnull;
 	bool	   *isvarlena;
 	ResultRelInfo *resultRelInfo;

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -70,6 +70,6 @@ void		cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes);
 void		cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer, int nbytes);
 bool		cdbCopyGetData(CdbCopy *c, bool cancel, uint64 *rows_processed);
 int			cdbCopyEnd(CdbCopy *c);
-int			cdbCopyEndAndFetchRejectNum(CdbCopy *c, int *total_rows_completed);
+int			cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed);
 
 #endif   /* CDBCOPY_H */

--- a/src/include/cdb/cdbsreh.h
+++ b/src/include/cdb/cdbsreh.h
@@ -93,7 +93,7 @@ extern CdbSreh *makeCdbSreh(int rejectlimit, bool is_limit_in_rows,
 extern void destroyCdbSreh(CdbSreh *cdbsreh);
 extern void HandleSingleRowError(CdbSreh *cdbsreh);
 extern void ReportSrehResults(CdbSreh *cdbsreh, int total_rejected);
-extern void SendNumRows(int numrejected, int numcompleted);
+extern void SendNumRows(int numrejected, int64 numcompleted);
 extern void SendNumRowsRejected(int numrejected);
 extern bool IsErrorTable(Relation rel);
 extern void ErrorIfRejectLimitReached(CdbSreh *cdbsreh, CdbCopy *cdbCopy);

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -85,7 +85,7 @@ pqParseInput3(PGconn *conn)
 	int			avail;
 #ifndef FRONTEND
 	int			numRejected  = 0;
-	int			numCompleted = 0;
+	int64		numCompleted = 0;
 #endif
 
 
@@ -458,7 +458,7 @@ pqParseInput3(PGconn *conn)
 					conn->result->numRejected += numRejected;
 
 					/* Optionally receive completed number when COPY FROM ON SEGMENT */
-					if (msgLength >= 8 && !pqGetInt(&numCompleted, 4, conn))
+					if (msgLength >= 8 && !pqGetInt64(&numCompleted, conn))
 					{
 						conn->result->numCompleted += numCompleted;
 					}

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -243,7 +243,7 @@ struct pg_result
 	/* GPDB: number of rows rejected in SREH (protocol message 'j') */
 	int			numRejected;
 	/* GPDB: number of rows completed when COPY FROM ON SEGMENT */
-	int			numCompleted;
+	int64		numCompleted;
 	/* GPDB: number of processed tuples for each AO partition */
 	int			naotupcounts;
 	PQaoRelTupCount *aotupcounts;


### PR DESCRIPTION
Integer overflow occurs without this when copied more than 2^31 rows,
under the `COPY ON SEGMENT` mode.

Errors happen when it is casted to uint64, the type of `processed` in
`CopyStateData`, third-party Postgres driver, which takes it as an int64,
fails out of range.

About tests:
I hacked the codes, confirmed it works, but better not to COPY a table
with that many rows in ICW.

Why not uint64?
int64 is large enough, third-party driver takes it as an int64, Greenplum
has no relevant functions yet.

Why not changing numrejected also?
It errors out when reaches user specified limit, probably won't be that
large, and it will change many codes, catalog maybe, better another
story.