### PR TITLE
Fixup Deduplication for Queries with IN Clause

### DIFF
--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -182,8 +182,7 @@ add_IN_vars_to_tlists(PlannerInfo *root)
 		if (in_vars != NIL)
 		{
 			add_vars_to_targetlist(root, in_vars,
-								   bms_union(ininfo->lefthand,
-											 ininfo->righthand));
+								   ininfo->righthand);
 			list_free(in_vars);
 		}
 	}

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -1517,7 +1517,6 @@ typedef struct OuterJoinInfo
 typedef struct InClauseInfo
 {
 	NodeTag		type;
-	Relids		lefthand;		/* base relids in lefthand expressions */
 	Relids		righthand;		/* base relids coming from the subselect */
 	List	   *sub_targetlist; /* RHS expressions of the IN's comparisons */
 	List	   *in_operators;	/* OIDs of the IN's equality operators */

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1737,6 +1737,34 @@ SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e
  1 | 1 | 1 | 1
 (1 row)
 
+-- Test planner to check if it optimizes the join and marks it as a dummy join
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=0)
+   One-Time Filter: false
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT a FROM dedup_test1);
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=0)
+   One-Time Filter: false
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b FROM dedup_test1) AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.53..0.54 rows=1 width=0)
+   One-Time Filter: false
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(4 rows)
+
 -- start_ignore
 DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1689,3 +1689,56 @@ EXPLAIN select count(distinct ss.ten) from
  Optimizer status: legacy query optimizer
 (16 rows)
 
+--
+-- Test planner to catch dedup information for semi join queries is calculated
+-- appropriately, and deduplication is applied after the join relation is made
+--
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+NOTICE:  table "dedup_test1" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test2;
+NOTICE:  table "dedup_test2" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test3;
+NOTICE:  table "dedup_test3" does not exist, skipping
+-- end_ignore
+CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
+CREATE TABLE dedup_test2 ( e int, f int ) DISTRIBUTED BY (e);
+CREATE TABLE dedup_test3 ( a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY RANGE(c) (START(1) END(2) EVERY(1)); 
+NOTICE:  CREATE TABLE will create partition "dedup_test3_1_prt_1" for table "dedup_test3"
+INSERT INTO dedup_test1 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test2 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test3 select 1, 1, 1 from generate_series(1,10);
+ANALYZE dedup_test1;
+ANALYZE dedup_test2;
+ANALYZE dedup_test3;
+EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=5.54..5.64 rows=10 width=28)
+   ->  HashAggregate  (cost=5.54..5.64 rows=4 width=28)
+         Group By: dedup_test1.ctid::bigint, dedup_test2.ctid::bigint
+         ->  Hash Join  (cost=4.24..5.49 rows=4 width=28)
+               Hash Cond: subselect_gp.dedup_test3.a = dedup_test1.a
+               ->  Append  (cost=0.00..1.10 rows=4 width=4)
+                     ->  Seq Scan on dedup_test3_1_prt_1 dedup_test3  (cost=0.00..1.10 rows=4 width=4)
+               ->  Hash  (cost=4.19..4.19 rows=2 width=28)
+                     ->  Hash Join  (cost=2.09..4.19 rows=2 width=28)
+                           Hash Cond: dedup_test1.a = dedup_test2.e
+                           ->  Seq Scan on dedup_test1  (cost=0.00..2.04 rows=2 width=14)
+                           ->  Hash  (cost=2.04..2.04 rows=2 width=14)
+                                 ->  Seq Scan on dedup_test2  (cost=0.00..2.04 rows=2 width=14)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
+SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+ a | b | e | f 
+---+---+---+---
+ 1 | 1 | 1 | 1
+(1 row)
+
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test2;
+DROP TABLE IF EXISTS dedup_test3;
+-- end_ignore

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1715,6 +1715,7 @@ EXPLAIN select count(distinct ss.ten) from
  Settings:  optimizer=on
  Optimizer status: PQO version 2.34.1
 (27 rows)
+
 --
 -- Test planner to catch dedup information for semi join queries is calculated
 -- appropriately, and deduplication is applied after the join relation is made
@@ -1773,6 +1774,98 @@ SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e
 ---+---+---+---
  1 | 1 | 1 | 1
 (1 row)
+
+-- Test planner to check if it optimizes the join and marks it as a dummy join
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324463.71 rows=4 width=20)
+   ->  Hash EXISTS Join  (cost=0.00..1324463.71 rows=2 width=20)
+         Hash Cond: dedup_test3.b = subselect_gp.dedup_test1.b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324032.71 rows=2 width=20)
+               Hash Key: dedup_test3.b
+               ->  Nested Loop  (cost=0.00..1324032.71 rows=2 width=20)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                       Filter: dedup_test3.c = 7
+                                       Partitions selected: 0 (out of 1)
+                                 ->  Dynamic Table Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                       Filter: c = 7
+                     ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                     Hash Key: subselect_gp.dedup_test1.b
+                     ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.56.2
+(21 rows)
+
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT a FROM dedup_test1);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324463.71 rows=4 width=20)
+   ->  Hash EXISTS Join  (cost=0.00..1324463.71 rows=2 width=20)
+         Hash Cond: dedup_test3.b = subselect_gp.dedup_test1.a
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324032.71 rows=2 width=20)
+               Hash Key: dedup_test3.b
+               ->  Nested Loop  (cost=0.00..1324032.71 rows=2 width=20)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                       Filter: dedup_test3.c = 7
+                                       Partitions selected: 0 (out of 1)
+                                 ->  Dynamic Table Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                       Filter: c = 7
+                     ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.56.2
+(18 rows)
+
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b FROM dedup_test1) AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..2648064.92 rows=4 width=20)
+   ->  Hash Join  (cost=0.00..2648064.92 rows=2 width=20)
+         Hash Cond: dedup_test3.b = subselect_gp.dedup_test1.b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324032.71 rows=2 width=20)
+               Hash Key: dedup_test3.b
+               ->  Nested Loop  (cost=0.00..1324032.71 rows=2 width=20)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                       Filter: dedup_test3.c = 7
+                                       Partitions selected: 0 (out of 1)
+                                 ->  Dynamic Table Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                       Filter: c = 7
+                     ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=1324032.22..1324032.22 rows=2 width=4)
+               ->  Nested Loop EXISTS Join  (cost=0.00..1324032.22 rows=2 width=4)
+                     Join Filter: true
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
+                           Group By: subselect_gp.dedup_test1.b
+                           ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                                 Sort Key: subselect_gp.dedup_test1.b
+                                 ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                       Hash Key: subselect_gp.dedup_test1.b
+                                       ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
+                                             Group By: subselect_gp.dedup_test1.b
+                                             ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                                                   Sort Key: subselect_gp.dedup_test1.b
+                                                   ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=4)
+                     ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Broadcast Motion 1:3  (slice4)  (cost=0.00..431.00 rows=3 width=1)
+                                 ->  Limit  (cost=0.00..431.00 rows=1 width=1)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Limit  (cost=0.00..431.00 rows=1 width=1)
+                                                   ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=1)
+ Optimizer status: PQO version 2.56.2
+(36 rows)
 
 -- start_ignore
 DROP TABLE IF EXISTS dedup_test1;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1715,4 +1715,67 @@ EXPLAIN select count(distinct ss.ten) from
  Settings:  optimizer=on
  Optimizer status: PQO version 2.34.1
 (27 rows)
+--
+-- Test planner to catch dedup information for semi join queries is calculated
+-- appropriately, and deduplication is applied after the join relation is made
+--
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+NOTICE:  table "dedup_test1" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test2;
+NOTICE:  table "dedup_test2" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test3;
+NOTICE:  table "dedup_test3" does not exist, skipping
+-- end_ignore
+CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
+CREATE TABLE dedup_test2 ( e int, f int ) DISTRIBUTED BY (e);
+CREATE TABLE dedup_test3 ( a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY RANGE(c) (START(1) END(2) EVERY(1)); 
+NOTICE:  CREATE TABLE will create partition "dedup_test3_1_prt_1" for table "dedup_test3"
+INSERT INTO dedup_test1 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test2 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test3 select 1, 1, 1 from generate_series(1,10);
+ANALYZE dedup_test1;
+ANALYZE dedup_test2;
+ANALYZE dedup_test3;
+EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=2 width=16)
+   ->  Hash Join  (cost=0.00..1293.00 rows=1 width=16)
+         Hash Cond: dedup_test2.e = dedup_test1.a
+         ->  Table Scan on dedup_test2  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=862.00..862.00 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                     Hash Cond: dedup_test1.a = dedup_test3.a
+                     ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                 Group By: dedup_test3.a
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                       Sort Key: dedup_test3.a
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             Hash Key: dedup_test3.a
+                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                                   Group By: dedup_test3.a
+                                                   ->  Sort  (cost=0.00..431.00 rows=4 width=4)
+                                                         Sort Key: dedup_test3.a
+                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                                                               ->  Sequence  (cost=0.00..431.00 rows=4 width=4)
+                                                                     ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                                                           Partitions selected: 1 (out of 1)
+                                                                     ->  Dynamic Table Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=4 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.56.2
+(26 rows)
 
+SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+ a | b | e | f 
+---+---+---+---
+ 1 | 1 | 1 | 1
+(1 row)
+
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test2;
+DROP TABLE IF EXISTS dedup_test3;
+-- end_ignore

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -714,3 +714,30 @@ EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
 
+--
+-- Test planner to catch dedup information for semi join queries is calculated
+-- appropriately, and deduplication is applied after the join relation is made
+--
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test2;
+DROP TABLE IF EXISTS dedup_test3;
+-- end_ignore
+CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
+CREATE TABLE dedup_test2 ( e int, f int ) DISTRIBUTED BY (e);
+CREATE TABLE dedup_test3 ( a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY RANGE(c) (START(1) END(2) EVERY(1)); 
+
+INSERT INTO dedup_test1 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test2 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test3 select 1, 1, 1 from generate_series(1,10);
+ANALYZE dedup_test1;
+ANALYZE dedup_test2;
+ANALYZE dedup_test3;
+
+EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test2;
+DROP TABLE IF EXISTS dedup_test3;
+-- end_ignore

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -736,6 +736,12 @@ ANALYZE dedup_test3;
 
 EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
 SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+
+-- Test planner to check if it optimizes the join and marks it as a dummy join
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT a FROM dedup_test1);
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b FROM dedup_test1) AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+
 -- start_ignore
 DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;


### PR DESCRIPTION
This PR introduces 2 commits:

- Fix postjoin deduplication handling
- Mark join rel as dummmy even if any of the rel requires post dedup

1.  Fix postjoin deduplication handling

    With the merge, in convert_IN_to_join InClauseInfo->lefthand information
    was included in the InClauseInfo, which impacted the implementation of
    post join deduplication in case of semi join queries.

    InClauseInfo was used in add_IN_vars_to_tlists to populate the
    targetlist of the resulting relation, and this information was also
    maintained with attr_needed which is further used in creating target
    list of the join rel in build_joinrel_tlist.

    Using this information, dedup information was attached to the rel in
    `cdb_make_rel_dedup_info`, however the calculation to decide post join
    or prejoin depends on the targetlist for the relation and due to the
    inclusion of the lefthand relid in InClauseInfo, the targetlist of join
    rel include the projection from the in clause which is not expected. Due
    to it the subquery deduplication cannot be completed and planner failed
    to create a plan. Consider the below setup.
    ```sql
    CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
    CREATE TABLE dedup_test2 ( e int, f int ) DISTRIBUTED BY (e);
    CREATE TABLE dedup_test3 ( a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY RANGE(c) (START(1) END(2) EVERY(1));
    EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
    ERROR:  Unexpected internal error (planmain.c:276)
    ```

    This patch fixes the above issue and removes lefthand relid from the
    InClauseInfo as it is not required to decide if post join dedup is
    required on the In clause of the query. For the above setup, the join
    between t1, t2, and t3 should not project the column of t3, also
    lefthand relids are only populated in convert_IN_to_join and not used
    anywhere, so removed the code all together.

2. Mark join rel as dummmy even if any of the rel requires post dedup

    Currently if there is dedup information attached to any of the input
    relations the optimization of creating a dummy rel is not performed and
    a join path is constructed.  This can further result in assertion
    failure in `cdbpath_dedup_fixup_append` as for the below setup

    ```sql
    CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
    CREATE TABLE dedup_test3 ( a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY RANGE(c) (START(1) END(2) EVERY(1));
    EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT b FROM dedup_test1);
    FATAL:  Unexpected internal error (cdbpath.c:1266)
    DETAIL:  FailedAssertion("!(partkey)", File: "cdbpath.c", Line: 1266)
    HINT:  Process 4093 will wait for gp_debug_linger=120 seconds before termination.
    Note that its locks and other resources will not be released until then.
    server closed the connection unexpectedly
            This probably means the server terminated abnormally
            before or while processing the request.
    The connection to the server was lost. Attempting reset: Succeeded.
    ```
    or result in an inferior plan like below where one of the input to join
    is `One-Time Filter: false`. It could have been further optimized
    marking the entire join as dummy.

    ```sql
    explain select * from dedup_test3 where c = 7 and a in (select a from dedup_test1);

                                         QUERY PLAN
    ------------------------------------------------------------------------------------
     Gather Motion 3:1  (slice1; segments: 3)  (cost=1176.42..1176.58 rows=17 width=12)
       ->  HashAggregate  (cost=1176.42..1176.58 rows=6 width=12)
             ->  Hash Join  (cost=0.00..1176.42 rows=6 width=4)
                   Hash Cond: dedup_test1.a = public.dedup_test3.a
                   ->  Seq Scan on dedup_test1  (cost=0.00..961.00 rows=28700 width=4)
                   ->  Hash  (cost=0.01..0.01 rows=1 width=0)
                         ->  Result  (cost=0.00..0.01 rows=1 width=0)
                               One-Time Filter: false

    Expected plan:
                    QUERY PLAN
    ------------------------------------------
     Result  (cost=0.00..0.01 rows=1 width=0)
       One-Time Filter: false
     Settings:  optimizer=off
     Optimizer status: legacy query optimizer
    ```

    The fix is two fold:
    1. In `make_join_rel()`, when the inner or outer(depending on the join
    type) relations are dummy then the joinrel can be marked as a dummy
    join, this optimization is also required even if there is de-duplication
    information attached to any of the input rels.

    2. Additionally, we observed that in some scenarios, the dummy join rels
    constructed by # 1 above still resulted in no final plan being generated.
    The joinrel marked as dummy by # 1 later gets excluded since
    `mark_dummy_join()` does not set the dummy path in pathlist resulting in
    an empty pathlist for this joinrel and this join getting excluded by
    standard_join_search().
    This commit fixes `mark_dummy_join()` by setting rel->dedupinfo to NULL
    before calling add_path. add_path looks the dedup_info and sets the
    pathlist conditionally. Since, the joinrel is being marked as dummy, the
    dedup info is obsolete and must not influence the decision of setting
    the dummy pathlist.