### PR TITLE
Fix flakiness in fts_recovery_in_progress

### DIFF
--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -21,6 +21,14 @@ NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
 -- to make test deterministic and fast
 -- start_ignore
 \!gpconfig -c gp_fts_probe_retries -v 2 --masteronly
+-- end_ignore
+-- Allow extra time for mirror promotion to complete recovery to avoid
+-- gprecoverseg BEGIN failures due to gang creation failure as some primaries
+-- are not up. Setting these increase the number of retries in gang creation in
+-- case segment is in recovery. Approximately we want to wait 30 seconds.
+-- start_ignore
+\!gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly
+\!gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly
 \!gpstop -u
 -- end_ignore
 show gp_fts_probe_retries;
@@ -129,12 +137,14 @@ select role, preferred_role, mode from gp_segment_configuration where content = 
 
 -- start_ignore
 \!gpconfig -r gp_fts_probe_retries --masteronly
+\!gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly
+\!gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly
 \!gpstop -u
 -- end_ignore
 -- cleanup steps
 select gp_inject_fault('fts_recovery_in_progress', 'reset', '', '', '', -1, 0, dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=27127)
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=30929)
  gp_inject_fault 
 -----------------
  t


### PR DESCRIPTION
Issue is that during recovery in progress mirror can take longer than default
timeout to finish promotion. Because the timeout is sometimes too short
gprecoverseg would intermittently throw 'error 'can't start transaction' in
'BEGIN'. This commit leverages GUCS gp_gang_creation_retry_count and
gp_gang_creation_retry_timer to increase the timeout alotted for gang retriable
errors to approximately 30 seconds.

We will open a discussion on the mailing list to discuss whether the default values of the GUCs used in this commit should be changed to avoid failures in production for similar reasons.  If we decide to update the default values then the previous commit 8f0a0fa to address similar issue becomes redundant.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>