### PR TITLE
Introduce RelationIsAppendOptimized() macro.

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1486,7 +1486,7 @@ gp_update_ao_master_stats_internal(Oid relid, Snapshot appendOnlyMetaDataSnapsho
 	/* open the parent (main) relation */
 	parentrel = heap_open(relid, RowExclusiveLock);
 
-	if (!RelationIsAoRows(parentrel) && !RelationIsAoCols(parentrel))
+	if (!RelationIsAppendOptimized(parentrel))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("'%s' is not an append-only relation",
@@ -1603,7 +1603,7 @@ get_ao_distribution_oid(PG_FUNCTION_ARGS)
 		/*
 		 * verify this is an AO relation
 		 */
-		if (!RelationIsAoRows(parentrel) && !RelationIsAoCols(parentrel))
+		if (!RelationIsAppendOptimized(parentrel))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("'%s' is not an append-only relation",
@@ -1790,7 +1790,7 @@ get_ao_distribution_name(PG_FUNCTION_ARGS)
 		/*
 		 * verify this is an AO relation
 		 */
-		if (!RelationIsAoRows(parentrel) && !RelationIsAoCols(parentrel))
+		if (!RelationIsAppendOptimized(parentrel))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("'%s' is not an append-only relation",
@@ -2078,7 +2078,7 @@ ao_compression_ratio_internal(Oid relid)
 	/* open the parent (main) relation */
 	parentrel = heap_open(relid, AccessShareLock);
 
-	if (!RelationIsAoRows(parentrel) && !RelationIsAoCols(parentrel))
+	if (!RelationIsAppendOptimized(parentrel))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("'%s' is not an append-only relation",

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -121,7 +121,7 @@ AppendOnlyCompaction_ShouldCompact(
 	int64		hiddenTupcount;
 	double		hideRatio;
 
-	Assert(RelationIsAoRows(aoRelation) || RelationIsAoCols(aoRelation));
+	Assert(RelationIsAppendOptimized(aoRelation));
 
 	if (!gp_appendonly_compaction)
 	{
@@ -770,7 +770,7 @@ AppendOnlyCompaction_IsRelationEmpty(Relation aorel)
 	int			Anum_tupcount;
 	bool		empty = true;
 
-	Assert(RelationIsAoRows(aorel) || RelationIsAoCols(aorel));
+	Assert(RelationIsAppendOptimized(aorel));
 
 	pg_aoseg_rel = heap_open(aorel->rd_appendonly->segrelid, AccessShareLock);
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);

--- a/src/backend/access/appendonly/appendonly_visimap_udf.c
+++ b/src/backend/access/appendonly/appendonly_visimap_udf.c
@@ -77,7 +77,7 @@ gp_aovisimap_internal(PG_FUNCTION_ARGS, Oid aoRelOid)
 		context = (Context *) palloc0(sizeof(Context));
 
 		context->aorel = heap_open(aoRelOid, AccessShareLock);
-		if (!(RelationIsAoRows(context->aorel) || RelationIsAoCols(context->aorel)))
+		if (!RelationIsAppendOptimized(context->aorel))
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -207,7 +207,7 @@ gp_aovisimap_hidden_info_internal(PG_FUNCTION_ARGS, Oid aoRelOid)
 		context = (Context *) palloc0(sizeof(Context));
 
 		context->parentRelation = heap_open(aoRelOid, AccessShareLock);
-		if (!(RelationIsAoRows(context->parentRelation) || RelationIsAoCols(context->parentRelation)))
+		if (!RelationIsAppendOptimized(context->parentRelation))
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -403,7 +403,7 @@ gp_aovisimap_entry_internal(PG_FUNCTION_ARGS, Oid aoRelOid)
 		context = (Context *) palloc0(sizeof(Context));
 
 		context->parentRelation = heap_open(aoRelOid, AccessShareLock);
-		if (!(RelationIsAoRows(context->parentRelation) || RelationIsAoCols(context->parentRelation)))
+		if (!RelationIsAppendOptimized(context->parentRelation))
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -1255,7 +1255,7 @@ assignPerRelSegno(List *all_relids)
 		Oid			cur_relid = lfirst_oid(cell);
 		Relation	rel = heap_open(cur_relid, NoLock);
 
-		if (RelationIsAoCols(rel) || RelationIsAoRows(rel))
+		if (RelationIsAppendOptimized(rel))
 		{
 			SegfileMapNode *n;
 
@@ -1405,7 +1405,7 @@ GetFileSegStateInfoFromSegments(Relation parentrel)
 	Oid			save_userid;
 	bool		save_secdefcxt;
 
-	Assert(RelationIsAoRows(parentrel) || RelationIsAoCols(parentrel));
+	Assert(RelationIsAppendOptimized(parentrel));
 
 	/*
 	 * get the name of the aoseg relation
@@ -1525,7 +1525,7 @@ UpdateMasterAosegTotalsFromSegments(Relation parentrel,
 	ListCell   *l;
 	int64	   *total_tupcount;
 
-	Assert(RelationIsAoRows(parentrel) || RelationIsAoCols(parentrel));
+	Assert(RelationIsAppendOptimized(parentrel));
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
 	/* Give -1 for segno, so that we'll have all segfile tupcount. */

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1029,7 +1029,7 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 			return NULL;
 
 		if (Gp_role == GP_ROLE_DISPATCH &&
-			(RelationIsAoRows(rel) || RelationIsAoCols(rel)))
+			RelationIsAppendOptimized(rel))
 		{
 			lockmode = ExclusiveLock;
 			if (lockUpgraded != NULL)
@@ -1050,8 +1050,7 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 	 * okay.
 	 */
 	if (lockmode == RowExclusiveLock &&
-		Gp_role == GP_ROLE_DISPATCH &&
-		(RelationIsAoRows(rel) || RelationIsAoCols(rel)))
+		Gp_role == GP_ROLE_DISPATCH && RelationIsAppendOptimized(rel))
 	{
 		elog(ERROR, "relation \"%s\" concurrently updated", 
 			 RelationGetRelationName(rel));
@@ -2832,7 +2831,7 @@ heap_update_internal(Relation relation, ItemPointer otid, HeapTuple newtup,
 	bool		all_visible_cleared_new = false;
 
 	Assert(ItemPointerIsValid(otid));
-	Assert(!(RelationIsAoRows(relation) || RelationIsAoCols(relation)));
+	Assert(!RelationIsAppendOptimized(relation));
 
 	/*
 	 * Fetch the list of attributes to be checked for HOT update.  This is

--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -221,8 +221,7 @@ _bt_ao_check_unique(Relation rel, Relation aoRel, ItemPointer tid)
 	SnapshotData SnapshotDirty;
 	TransactionId xwait = InvalidTransactionId;
 	
-	Assert(RelationIsAoRows(aoRel) ||
-		   RelationIsAoCols(aoRel));
+	Assert(RelationIsAppendOptimized(aoRel));
 
 	InitDirtySnapshot(SnapshotDirty);
 	
@@ -377,7 +376,7 @@ _bt_check_unique(Relation rel, IndexTuple itup, Relation heapRel,
 				 * If the parent relation is an AO/CO table, we have to find out
 				 * if this tuple is actually in the table.
 				 */
-				if (RelationIsAoRows(heapRel) || RelationIsAoCols(heapRel))
+				if (RelationIsAppendOptimized(heapRel))
 				{
 					TransactionId xwait =
 						_bt_ao_check_unique(rel, heapRel, &curitup->t_tid);

--- a/src/backend/catalog/aoblkdir.c
+++ b/src/backend/catalog/aoblkdir.c
@@ -42,7 +42,8 @@ AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child)
 	else
 		rel = heap_open(relOid, AccessExclusiveLock);
 
-	if (!RelationIsAoRows(rel) && !RelationIsAoCols(rel)) {
+	if (!RelationIsAppendOptimized(rel))
+	{
 		heap_close(rel, NoLock);
 		return;
 	}

--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -56,7 +56,7 @@ CreateAOAuxiliaryTable(
 	Oid			namespaceid;
 
 	Assert(RelationIsValid(rel));
-	Assert(RelationIsAoRows(rel) || RelationIsAoCols(rel));
+	Assert(RelationIsAppendOptimized(rel));
 	Assert(auxiliaryNamePrefix);
 	Assert(tupledesc);
 	if (relkind != RELKIND_AOSEGMENTS)

--- a/src/backend/catalog/aovisimap.c
+++ b/src/backend/catalog/aovisimap.c
@@ -46,7 +46,7 @@ AlterTableCreateAoVisimapTable(Oid relOid, bool is_part_child)
 	else
 		rel = heap_open(relOid, AccessExclusiveLock);
 
-	if (!RelationIsAoRows(rel) && !RelationIsAoCols(rel))
+	if (!RelationIsAppendOptimized(rel))
 	{
 		heap_close(rel, NoLock);
 		return;

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2220,7 +2220,7 @@ heap_drop_with_catalog(Oid relid)
 
 	relkind = rel->rd_rel->relkind;
 
-	is_appendonly_rel = (RelationIsAoRows(rel) || RelationIsAoCols(rel));
+	is_appendonly_rel = RelationIsAppendOptimized(rel);
 	is_external_rel = RelationIsExternal(rel);
 
 	/*
@@ -3244,7 +3244,7 @@ ao_aux_tables_truncate(Relation rel)
 	Oid			aoblkdir_relid = InvalidOid;
 	Oid			aovisimap_relid = InvalidOid;
 
-	if (!RelationIsAoRows(rel) && !RelationIsAoCols(rel))
+	if (!RelationIsAppendOptimized(rel))
 		return;
 
 	GetAppendOnlyEntryAuxOids(ao_base_relid, SnapshotNow,

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2034,8 +2034,7 @@ IndexBuildScan(Relation parentRelation,
 		OldestXmin = InvalidTransactionId;		/* not used */
 	}
 	else if (indexInfo->ii_Concurrent ||
-			 RelationIsAoRows(parentRelation) ||
-			 RelationIsAoCols(parentRelation))
+			 RelationIsAppendOptimized(parentRelation))
 	{
 		snapshot = RegisterSnapshot(GetTransactionSnapshot());
 		registered_snapshot = true;
@@ -3530,7 +3529,7 @@ reindex_relation(Oid relid, int flags)
 	 */
 	rel = heap_open(relid, ShareLock);
 
-	relIsAO = (RelationIsAoRows(rel) || RelationIsAoCols(rel));
+	relIsAO = RelationIsAppendOptimized(rel);
 
 	toast_relid = rel->rd_rel->reltoastrelid;
 

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -511,7 +511,7 @@ rel_has_appendonly_partition(Oid relid)
 
 		heap_close(rel, NoLock);
 
-		if (RelationIsAoRows(rel) || RelationIsAoCols(rel))
+		if (RelationIsAppendOptimized(rel))
 		{
 			return true;
 		}

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -329,7 +329,7 @@ cluster_rel(Oid tableOid, Oid indexOid, bool recheck, bool verbose, bool printEr
 	 * We don't support cluster on an AO table. We print out a warning/error to
 	 * the user, and simply return.
 	 */
-	if (RelationIsAoRows(OldHeap) || RelationIsAoCols(OldHeap))
+	if (RelationIsAppendOptimized(OldHeap))
 	{
 		ereport((printError ? ERROR : WARNING),
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -461,7 +461,7 @@ DefineIndex(RangeVar *heapRelation,
 		errmsg("access method \"%s\" does not support exclusion constraints",
 			   accessMethodName)));
 
-    if  (unique && (RelationIsAoRows(rel) || RelationIsAoCols(rel)))
+    if  (unique && RelationIsAppendOptimized(rel))
         ereport(ERROR,
                 (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
                  errmsg("append-only tables do not support unique indexes")));

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -409,7 +409,7 @@ CreateTrigger(CreateTrigStmt *stmt, const char *queryString,
 	}
 
 	/* Check GPDB limitations */
-	if ((RelationIsAoRows(rel) || RelationIsAoCols(rel)) &&
+	if (RelationIsAppendOptimized(rel) &&
 		TRIGGER_FOR_ROW(tgtype) &&
 		!stmt->isconstraint)
 	{
@@ -2635,7 +2635,7 @@ GetTupleForTrigger(EState *estate,
 	Buffer		buffer;
 
 	/* these should be rejected when you try to create such triggers, but let's check */
-	if (RelationIsAoRows(relation) || RelationIsAoCols(relation))
+	if (RelationIsAppendOptimized(relation))
 		elog(ERROR, "UPDATE and DELETE triggers are not supported on append-only tables");
 	if (RelationIsExternal(relation))
 		elog(ERROR, "UPDATE and DELETE triggers are not supported on external tables");

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -423,7 +423,7 @@ vacuum_assign_compaction_segno(Relation onerel,
 
 	Assert(Gp_role != GP_ROLE_EXECUTE);
 	Assert(RelationIsValid(onerel));
-	Assert(RelationIsAoRows(onerel) || RelationIsAoCols(onerel));
+	Assert(RelationIsAppendOptimized(onerel));
 
 	/*
 	 * Assign a compaction segment num and insert segment num
@@ -1969,7 +1969,7 @@ vacuum_rel(Relation onerel, Oid relid, VacuumStmt *vacstmt, LOCKMODE lmode,
 
 	if (!is_heap)
 	{
-		Assert(RelationIsAoRows(onerel) || RelationIsAoCols(onerel));
+		Assert(RelationIsAppendOptimized(onerel));
 		GetAppendOnlyEntryAuxOids(RelationGetRelid(onerel), SnapshotNow,
 								  &aoseg_relid,
 								  &aoblkdir_relid, NULL,
@@ -2105,7 +2105,7 @@ vacuum_rel(Relation onerel, Oid relid, VacuumStmt *vacstmt, LOCKMODE lmode,
 	 * after the drop.
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH && vacstmt->appendonly_compaction_segno &&
-		(RelationIsAoRows(onerel) || RelationIsAoCols(onerel)))
+		RelationIsAppendOptimized(onerel))
 	{
 		if (vacstmt->appendonly_phase == AOVAC_COMPACT)
 		{
@@ -2226,7 +2226,7 @@ static bool vacuum_appendonly_index_should_vacuum(Relation aoRelation,
 	int64 hidden_tupcount;
 	FileSegTotals *totals;
 
-	Assert(RelationIsAoRows(aoRelation) || RelationIsAoCols(aoRelation));
+	Assert(RelationIsAppendOptimized(aoRelation));
 
 	if(Gp_role == GP_ROLE_DISPATCH)
 	{
@@ -2284,7 +2284,7 @@ vacuum_appendonly_indexes(Relation aoRelation, VacuumStmt *vacstmt)
 	FileSegInfo **segmentFileInfo = NULL; /* Might be a casted AOCSFileSegInfo */
 	int totalSegfiles;
 
-	Assert(RelationIsAoRows(aoRelation) || RelationIsAoCols(aoRelation));
+	Assert(RelationIsAppendOptimized(aoRelation));
 	Assert(vacstmt);
 
 	memset(&vacuumIndexState, 0, sizeof(vacuumIndexState));

--- a/src/backend/commands/vacuumlazy.c
+++ b/src/backend/commands/vacuumlazy.c
@@ -228,7 +228,7 @@ lazy_vacuum_rel(Relation onerel, VacuumStmt *vacstmt,
 	 * Execute the various vacuum operations. Appendonly tables are treated
 	 * differently.
 	 */
-	if (RelationIsAoRows(onerel) || RelationIsAoCols(onerel))
+	if (RelationIsAppendOptimized(onerel))
 	{
 		lazy_vacuum_aorel(onerel, vacstmt);
 		return;
@@ -1375,7 +1375,7 @@ vacuum_appendonly_fill_stats(Relation aorel, Snapshot snapshot,
 	int64       hidden_tupcount;
 	AppendOnlyVisimap visimap;
 
-	Assert(RelationIsAoRows(aorel) || RelationIsAoCols(aorel));
+	Assert(RelationIsAppendOptimized(aorel));
 
 	relname = RelationGetRelationName(aorel);
 
@@ -1447,7 +1447,7 @@ vacuum_appendonly_rel(Relation aorel, VacuumStmt *vacstmt)
 {
 	char	   *relname;
 
-	Assert(RelationIsAoRows(aorel) || RelationIsAoCols(aorel));
+	Assert(RelationIsAppendOptimized(aorel));
 
 	relname = RelationGetRelationName(aorel);
 	ereport(elevel,

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1504,7 +1504,7 @@ ExecUpdateAOtupCount(ResultRelInfo *result_rels,
 
 	for (i = num_result_rels; i > 0; i--)
 	{
-		if(RelationIsAoRows(result_rels->ri_RelationDesc) || RelationIsAoCols(result_rels->ri_RelationDesc))
+		if(RelationIsAppendOptimized(result_rels->ri_RelationDesc))
 		{
 			Assert(result_rels->ri_aosegno != InvalidFileSegNumber);
 

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -921,7 +921,7 @@ CondUpgradeRelLock(Oid relid)
 
 	if (!rel)
 		elog(ERROR, "Relation open failed!");
-	else if (RelationIsAoRows(rel) || RelationIsAoCols(rel))
+	else if (RelationIsAppendOptimized(rel))
 		upgrade = true;
 	else
 		upgrade = false;

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -570,7 +570,7 @@ calculate_table_size(Oid relOid)
 	if (OidIsValid(rel->rd_rel->reltoastrelid))
 		size += calculate_toast_table_size(rel->rd_rel->reltoastrelid);
 
-	if (RelationIsAoRows(rel) || RelationIsAoCols(rel))
+	if (RelationIsAppendOptimized(rel))
 	{
 		Assert(OidIsValid(rel->rd_appendonly->segrelid));
 		size += calculate_total_relation_size(rel->rd_appendonly->segrelid);

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -332,6 +332,13 @@ typedef struct StdRdOptions
 	((bool)(((relation)->rd_rel->relstorage == RELSTORAGE_AOCOLS)))
 
 /*
+ * RelationIsAppendOptimized
+ * 		True iff relation has append only storage (can be row or column orientation)
+ */
+#define RelationIsAppendOptimized(relation) \
+	(RelationIsAoRows(relation) || RelationIsAoCols(relation))
+
+/*
  * RelationIsForeign
  * 		True iff relation has foreign storage
  */


### PR DESCRIPTION
Many places is code need to check if its row or column oriented storage table,
which means basically is it AppendOptimized table or not. Currently its done by
combination of two macros RelationIsAoRows() and RelationIsAoCols(). Simplify
the same with new macro RelationIsAppendOptimized().