### PR TITLE
Syncing python-dependencies with pythonsrc-ext

### DIFF
--- a/python-dependencies.txt
+++ b/python-dependencies.txt
@@ -1,6 +1,6 @@
+argparse=1.2.1
 behave==1.2.4
 ecdsa==0.13
-enum34==1.1.6
 epydoc==3.0.1
 lockfile==0.9.1
 logilab-astng==0.20.1
@@ -9,11 +9,8 @@ MarkupSafe==1.0
 mock==1.0.1
 paramiko==1.18.1
 parse==1.8.2
-parse-type==0.4.2
 psutil==4.0.0
-ptyprocess==0.5.2
 pycrypto==2.6.1
 pylint==0.21.0
 setuptools==36.6.0
-six==1.11.0
 unittest2==0.5.1

--- a/python-developer-dependencies.txt
+++ b/python-developer-dependencies.txt
@@ -1,5 +1,9 @@
+enum34==1.1.6
 Jinja2==2.10
+parse-type==0.4.2
 pexpect==4.4.0
 PSI==0.3b2
 pysql==0.16
 PyYAML==3.12
+ptyprocess==0.5.2
+six==1.11.0


### PR DESCRIPTION
In comparing https://github.com/greenplum-db/pythonsrc-ext
to python-dependencies.txt, there are several differences.

pythonsrc-ext is the vendored python repo, so it should be
in sync with pythonsrc-ext

argparse is in pythonsrc-ext, adding it to python-dependencies.txt

enum34, parse-type, ptyprocess, six are not in pythonsrc-ext,
so moving them to python-developer-dependencies.txt

Authored-by: Todd Sedano <tsedano@pivotal.io>