### PR TITLE
Add -Werror=implicit-function-declaration in CFLAGS.

### DIFF
--- a/configure
+++ b/configure
@@ -19166,6 +19166,41 @@ if test x"$pgac_cv_prog_cc_cflags__Werror_uninitialized" = x"yes"; then
   CFLAGS="$CFLAGS -Werror=uninitialized"
 fi
 
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-function-declaration" >&5
+$as_echo_n "checking whether $CC supports -Werror=implicit-function-declaration... " >&6; }
+if ${pgac_cv_prog_cc_cflags__Werror_implicit_function_declaration+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -Werror=implicit-function-declaration"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__Werror_implicit_function_declaration=yes
+else
+  pgac_cv_prog_cc_cflags__Werror_implicit_function_declaration=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Werror_implicit_function_declaration" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__Werror_implicit_function_declaration" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__Werror_implicit_function_declaration" = x"yes"; then
+  CFLAGS="$CFLAGS -Werror=implicit-function-declaration"
+fi
+
 fi
 
 # Begin output steps

--- a/configure.in
+++ b/configure.in
@@ -2370,6 +2370,7 @@ fi
 # false side-effects happens.
 if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-Werror=uninitialized])
+  PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-function-declaration])
 fi
 
 # Begin output steps


### PR DESCRIPTION
This kind of error could lead to serious problems sometimes,
so let's check it during compiling.

This patch includes a PostgreSQL upstream patch (see below) since
without it some conftest.c code in configure could fail due to this cflag.

commit 1c0cf52b39ca3a9a79661129cff918dc000a55eb
Author: Peter Eisentraut <peter_e@gmx.net>
Date:   Tue Aug 30 12:00:00 2016 -0400

    Use return instead of exit() in configure

    Using exit() requires stdlib.h, which is not included.  Use return
    instead.  Also add return type for main().

    Reviewed-by: Heikki Linnakangas <hlinnaka@iki.fi>
    Reviewed-by: Thomas Munro <thomas.munro@enterprisedb.com>