### PR TITLE
Refine the fault injector framework

### DIFF
--- a/contrib/gp_inject_fault/gp_inject_fault.c
+++ b/contrib/gp_inject_fault/gp_inject_fault.c
@@ -20,14 +20,14 @@ PG_MODULE_MAGIC;
 extern Datum gp_inject_fault(PG_FUNCTION_ARGS);
 
 static char *
-processTransitionRequest_faultInject(char *faultName, char *type, char *ddlStatement, char *databaseName, char *tableName, int numOccurrences, int sleepTimeSeconds)
+processTransitionRequest_faultInject(char *faultName, char *type, char *ddlStatement, char *databaseName, char *tableName, int startOccurrence, int endOccurrence, int extraArg)
 {
 	StringInfo buf = makeStringInfo();
 #ifdef FAULT_INJECTOR
 	FaultInjectorEntry_s    faultInjectorEntry;
 
-	elog(DEBUG1, "FAULT INJECTED: Name %s Type %s, DDL %s, DB %s, Table %s, NumOccurrences %d  SleepTime %d",
-		 faultName, type, ddlStatement, databaseName, tableName, numOccurrences, sleepTimeSeconds );
+	elog(DEBUG1, "FAULT INJECTED: Name %s Type %s, DDL %s, DB %s, Table %s, StartOccurrence %d, EndOccurrence %d, extraArg %d",
+		 faultName, type, ddlStatement, databaseName, tableName, startOccurrence, endOccurrence, extraArg );
 
 	strlcpy(faultInjectorEntry.faultName, faultName, sizeof(faultInjectorEntry.faultName));
 	faultInjectorEntry.faultInjectorIdentifier = FaultInjectorIdentifierStringToEnum(faultName);
@@ -51,14 +51,18 @@ processTransitionRequest_faultInject(char *faultName, char *type, char *ddlState
 		goto exit;
 	}
 
-	faultInjectorEntry.sleepTime = sleepTimeSeconds;
-	if (sleepTimeSeconds < 0 || sleepTimeSeconds > 7200) {
-		ereport(COMMERROR,
-				(errcode(ERRCODE_PROTOCOL_VIOLATION),
-				 errmsg("invalid sleep time, allowed range [0, 7200 sec]")));
+	faultInjectorEntry.extraArg = extraArg;
 
-		appendStringInfo(buf, "Failure: invalid sleep time, allowed range [0, 7200 sec]");
-		goto exit;
+	if (faultInjectorEntry.faultInjectorType == FaultInjectorTypeSleep)
+	{
+		if (extraArg < 0 || extraArg > 7200) {
+			ereport(COMMERROR,
+					(errcode(ERRCODE_PROTOCOL_VIOLATION),
+					 errmsg("invalid sleep time, allowed range [0, 7200 sec]")));
+
+			appendStringInfo(buf, "Failure: invalid sleep time, allowed range [0, 7200 sec]");
+			goto exit;
+		}
 	}
 
 	faultInjectorEntry.ddlStatement = FaultInjectorDDLStringToEnum(ddlStatement);
@@ -75,16 +79,29 @@ processTransitionRequest_faultInject(char *faultName, char *type, char *ddlState
 
 	snprintf(faultInjectorEntry.tableName, sizeof(faultInjectorEntry.tableName), "%s", tableName);
 
-	faultInjectorEntry.occurrence = numOccurrences;
-	if (numOccurrences > 1000)
+	if (startOccurrence < 1 || startOccurrence > 1000)
 	{
 		ereport(COMMERROR,
 				(errcode(ERRCODE_PROTOCOL_VIOLATION),
-				 errmsg("invalid occurrence number, allowed range [1, 1000]")));
+				 errmsg("invalid start occurrence number, allowed range [1, 1000]")));
 
 		appendStringInfo(buf, "Failure: invalid occurrence number, allowed range [1, 1000]");
 		goto exit;
 	}
+
+	if (endOccurrence != INFINITE_END_OCCURRENCE && endOccurrence < startOccurrence)
+	{
+		ereport(COMMERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("invalid end occurrence number, allowed range [startOccurrence, ] or -1")));
+
+		appendStringInfo(buf, "Failure: invalid end occurrence number, allowed range [startOccurrence, ] or -1");
+		goto exit;
+	}
+
+	faultInjectorEntry.startOccurrence = startOccurrence;
+	faultInjectorEntry.endOccurrence = endOccurrence;
+
 
 	if (FaultInjector_SetFaultInjection(&faultInjectorEntry) == STATUS_OK)
 	{
@@ -108,14 +125,15 @@ PG_FUNCTION_INFO_V1(gp_inject_fault);
 Datum
 gp_inject_fault(PG_FUNCTION_ARGS)
 {
-	char	   *faultName = TextDatumGetCString(PG_GETARG_DATUM(0));
-	char	   *type = TextDatumGetCString(PG_GETARG_DATUM(1));
-	char	   *ddlStatement = TextDatumGetCString(PG_GETARG_DATUM(2));
-	char	   *databaseName = TextDatumGetCString(PG_GETARG_DATUM(3));
-	char	   *tableName = TextDatumGetCString(PG_GETARG_DATUM(4));
-	int			numOccurrences = PG_GETARG_INT32(5);
-	int			sleepTimeSeconds = PG_GETARG_INT32(6);
-	int         dbid = PG_GETARG_INT32(7);
+	char	*faultName = TextDatumGetCString(PG_GETARG_DATUM(0));
+	char	*type = TextDatumGetCString(PG_GETARG_DATUM(1));
+	char	*ddlStatement = TextDatumGetCString(PG_GETARG_DATUM(2));
+	char	*databaseName = TextDatumGetCString(PG_GETARG_DATUM(3));
+	char	*tableName = TextDatumGetCString(PG_GETARG_DATUM(4));
+	int		startOccurrence = PG_GETARG_INT32(5);
+	int		endOccurrence = PG_GETARG_INT32(6);
+	int		extraArg = PG_GETARG_INT32(7);
+	int		dbid = PG_GETARG_INT32(8);
 
 	/* Fast path if injecting fault in our postmaster. */
 	if (GpIdentity.dbid == dbid)
@@ -124,7 +142,7 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 
 		response = processTransitionRequest_faultInject(
 			faultName, type, ddlStatement, databaseName,
-			tableName, numOccurrences, sleepTimeSeconds);
+			tableName, startOccurrence, endOccurrence, extraArg);
 		if (!response)
 			elog(ERROR, "failed to inject fault locally (dbid %d)", dbid);
 		if (strncmp(response, "Success:",  strlen("Success:")) != 0)
@@ -154,14 +172,15 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 		 */
 		char	   *sql;
 
-		sql = psprintf("select gp_inject_fault(%s, %s, %s, %s, %s, %d, %d, %d)",
+		sql = psprintf("select gp_inject_fault(%s, %s, %s, %s, %s, %d, %d, %d, %d)",
 					   quote_literal_cstr(faultName),
 					   quote_literal_cstr(type),
 					   quote_literal_cstr(ddlStatement),
 					   quote_literal_cstr(databaseName),
 					   quote_literal_cstr(tableName),
-					   numOccurrences,
-					   sleepTimeSeconds,
+					   startOccurrence,
+					   endOccurrence,
+					   extraArg,
 					   dbid);
 
 		CdbDispatchCommand(sql, DF_CANCEL_ON_ERROR, NULL);

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -74,7 +74,7 @@ static FaultInjectorEntry_s* FaultInjector_InsertHashEntry(
 static int FaultInjector_NewHashEntry(
 								FaultInjectorEntry_s	*entry);
 
-static int FaultInjector_UpdateHashEntry(
+static int FaultInjector_MarkEntryAsResume(
 								FaultInjectorEntry_s	*entry);
 
 static bool FaultInjector_RemoveHashEntry(
@@ -334,18 +334,21 @@ FaultInjector_InjectFaultNameIfSet(
 			break;
 		}
 
-		/* Update the injection fault entry in hash table */
-		if (entryShared->occurrence != OCCURRENCE_UNDEFINED)
+		entryShared->numTimesTriggered++;
+
+		if (entryShared->numTimesTriggered < entryShared->startOccurrence)
 		{
-			if (entryShared->occurrence > 1)
-			{
-				entryShared->occurrence--;
-				break;
-			}
+			break;
 		}
 
+		/* Update the injection fault entry in hash table */
 		entryShared->faultInjectorState = FaultInjectorStateTriggered;
-		entryShared->numTimesTriggered++;
+
+		/* Mark fault injector to completed */
+		if (entryShared->endOccurrence != INFINITE_END_OCCURRENCE &&
+			entryShared->numTimesTriggered >= entryShared->endOccurrence)
+			entryShared->faultInjectorState = FaultInjectorStateCompleted;
+
 		memcpy(entryLocal, entryShared, sizeof(FaultInjectorEntry_s));
 		retvalue = entryLocal->faultInjectorType;
 	} while (0);
@@ -356,7 +359,6 @@ FaultInjector_InjectFaultNameIfSet(
 		return FaultInjectorTypeNotSpecified;
 
 	/* Inject fault */
-	
 	switch (entryLocal->faultInjectorType) {
 		case FaultInjectorTypeNotSpecified:
 			
@@ -368,7 +370,7 @@ FaultInjector_InjectFaultNameIfSet(
 							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
 			
-			pg_usleep(entryLocal->sleepTime * 1000000L);
+			pg_usleep(entryLocal->extraArg * 1000000L);
 			break;
 		case FaultInjectorTypeFault:
 			ereport(ERROR,
@@ -379,18 +381,6 @@ FaultInjector_InjectFaultNameIfSet(
 			
 			break;
 		case FaultInjectorTypeFatal:
-			/*
-			 * If it's one time occurrence then disable the fault before it's
-			 * actually triggered because this fault errors out the transaction
-			 * and hence we wont get a chance to disable it or put it in completed
-			 * state.
-			 */
-			if (entryLocal->occurrence != OCCURRENCE_UNDEFINED)
-			{
-				entryLocal->faultInjectorState = FaultInjectorStateCompleted;
-				FaultInjector_UpdateHashEntry(entryLocal);
-			}
-			
 			ereport(FATAL, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
@@ -400,23 +390,11 @@ FaultInjector_InjectFaultNameIfSet(
 			break;
 		case FaultInjectorTypePanic:
 			/*
-			 * If it's one time occurrence then disable the fault before it's
-			 * actually triggered because this fault errors out the transaction
-			 * and hence we wont get a chance to disable it or put it in completed
-			 * state. For PANIC it may be unnecessary though.
-			 */
-			if (entryLocal->occurrence != OCCURRENCE_UNDEFINED)
-			{
-				entryLocal->faultInjectorState = FaultInjectorStateCompleted;
-				FaultInjector_UpdateHashEntry(entryLocal);
-			}
-
-			/*
 			 * Avoid core file generation for this PANIC. It helps to avoid
 			 * filling up disks during tests and also saves time.
 			 */
 #if defined(HAVE_GETRLIMIT) && defined(RLIMIT_CORE)
-			struct rlimit lim;
+			;struct rlimit lim;
 			getrlimit(RLIMIT_CORE, &lim);
 			lim.rlim_cur = 0;
 			if (setrlimit(RLIMIT_CORE, &lim) != 0)
@@ -432,18 +410,6 @@ FaultInjector_InjectFaultNameIfSet(
 
 			break;
 		case FaultInjectorTypeError:
-			/*
-			 * If it's one time occurrence then disable the fault before it's
-			 * actually triggered because this fault errors out the transaction
-			 * and hence we wont get a chance to disable it or put it in completed
-			 * state.
-			 */
-			if (entryLocal->occurrence != OCCURRENCE_UNDEFINED)
-			{
-				entryLocal->faultInjectorState = FaultInjectorStateCompleted;
-				FaultInjector_UpdateHashEntry(entryLocal);
-			}
-
 			ereport(ERROR, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
@@ -590,12 +556,6 @@ FaultInjector_InjectFaultNameIfSet(
 
 		case FaultInjectorTypeCheckpointAndPanic:
 		{
-			if (entryLocal->occurrence != OCCURRENCE_UNDEFINED)
-			{
-				entryLocal->faultInjectorState = FaultInjectorStateCompleted;
-				FaultInjector_UpdateHashEntry(entryLocal);
-			}
-
 			RequestCheckpoint(CHECKPOINT_WAIT | CHECKPOINT_IMMEDIATE);
 			ereport(PANIC,
 					(errcode(ERRCODE_FAULT_INJECT),
@@ -617,13 +577,6 @@ FaultInjector_InjectFaultNameIfSet(
 			break;
 	}
 		
-	if (entryLocal->occurrence != OCCURRENCE_UNDEFINED)
-	{
-		entryLocal->faultInjectorState = FaultInjectorStateCompleted;
-	}
-
-	FaultInjector_UpdateHashEntry(entryLocal);	
-	
 	return (entryLocal->faultInjectorType);
 }
 
@@ -783,17 +736,11 @@ FaultInjector_NewHashEntry(
 	entryLocal->faultInjectorIdentifier = entry->faultInjectorIdentifier;
 	strlcpy(entryLocal->faultName, entry->faultName, sizeof(entryLocal->faultName));
 
-	entryLocal->sleepTime = entry->sleepTime;
+	entryLocal->extraArg = entry->extraArg;
 	entryLocal->ddlStatement = entry->ddlStatement;
 	
-	if (entry->occurrence != 0)
-	{
-		entryLocal->occurrence = entry->occurrence;
-	}
-	else 
-	{
-		entryLocal->occurrence = OCCURRENCE_UNDEFINED;
-	}
+	entryLocal->startOccurrence = entry->startOccurrence;
+	entryLocal->endOccurrence = entry->endOccurrence;
 
 	entryLocal->numTimesTriggered = 0;
 	strcpy(entryLocal->databaseName, entry->databaseName);
@@ -817,12 +764,14 @@ exit:
  * update hash entry with state 
  */		
 static int 
-FaultInjector_UpdateHashEntry(
+FaultInjector_MarkEntryAsResume(
 							FaultInjectorEntry_s	*entry)
 {
 	
 	FaultInjectorEntry_s	*entryLocal;
 	int						status = STATUS_OK;
+
+	Assert(entry->faultInjectorType == FaultInjectorTypeResume);
 
 	FiLockAcquire();
 
@@ -840,25 +789,21 @@ FaultInjector_UpdateHashEntry(
 						FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 		goto exit;
 	}
-	
-	if (entry->faultInjectorType == FaultInjectorTypeResume)
-	{
-		entryLocal->faultInjectorType = FaultInjectorTypeResume;
-	}
-	else
-	{	
-		entryLocal->faultInjectorState = entry->faultInjectorState;
-		entryLocal->occurrence = entry->occurrence;
-	}
+
+	if (entryLocal->faultInjectorType != FaultInjectorTypeSuspend)
+		ereport(ERROR, 
+				(errcode(ERRCODE_FAULT_INJECT),
+				 errmsg("only suspend fault can be resumed")));	
+
+	entryLocal->faultInjectorType = FaultInjectorTypeResume;
 	
 	FiLockRelease();
 	
 	ereport(DEBUG1,
 			(errmsg("LOG(fault injector): update fault injection hash entry "
-					"identifier:'%s' state:'%s' occurrence:'%d' ",
+					"identifier:'%s' state:'%s'",
 					entry->faultName,
-					FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
-					entry->occurrence)));
+					FaultInjectorStateEnumToString[entryLocal->faultInjectorState])));
 	
 exit:	
 	
@@ -922,7 +867,8 @@ FaultInjector_SetFaultInjection(
 			int retry_count = 600; /* 10 minutes */
 
 			while ((entryLocal = FaultInjector_LookupHashEntry(entry->faultName)) != NULL &&
-				   entry->occurrence > entryLocal->numTimesTriggered)
+				   entryLocal->faultInjectorState != FaultInjectorStateCompleted &&
+				   entryLocal->numTimesTriggered - entryLocal->startOccurrence < entry->extraArg - 1)
 			{
 				pg_usleep(1000000L);  // 1 sec
 				retry_count--;
@@ -942,7 +888,7 @@ FaultInjector_SetFaultInjection(
 				ereport(LOG,
 						(errcode(ERRCODE_FAULT_INJECT),
 						 errmsg("fault triggered %d times, fault name:'%s' fault type:'%s' ",
-							entry->occurrence,
+							entryLocal->numTimesTriggered,
 							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entry->faultInjectorType])));
 				status = STATUS_OK;
@@ -980,8 +926,9 @@ FaultInjector_SetFaultInjection(
 							"ddl statement:'%s' "
 							"database name:'%s' "
 							"table name:'%s' "
-							"occurrence:'%d' "
-							"sleep time:'%d' "
+							"start occurrence:'%d' "
+							"end occurrence:'%d' "
+							"extra argument:'%d' "
 							"fault injection state:'%s' "
 							"num times hit:'%d' ",
 							entryLocal->faultName,
@@ -989,8 +936,9 @@ FaultInjector_SetFaultInjection(
 							FaultInjectorDDLEnumToString[entryLocal->ddlStatement],
 							entryLocal->databaseName,
 							entryLocal->tableName,
-							entryLocal->occurrence,
-							entryLocal->sleepTime,
+							entryLocal->startOccurrence,
+							entryLocal->endOccurrence,
+							entryLocal->extraArg,
 							FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
 						entryLocal->numTimesTriggered)));
 				
@@ -1003,8 +951,9 @@ FaultInjector_SetFaultInjection(
 									  "ddl statement:'%s' "
 									  "database name:'%s' "
 									  "table name:'%s' "
-									  "occurrence:'%d' "
-									  "sleep time:'%d' "
+									  "start occurrence:'%d' "
+									  "end occurrence:'%d' "
+									  "extra arg:'%d' "
 									  "fault injection state:'%s'  "
 									  "num times hit:'%d' \n",
 									  entryLocal->faultName,
@@ -1012,8 +961,9 @@ FaultInjector_SetFaultInjection(
 									  FaultInjectorDDLEnumToString[entryLocal->ddlStatement],
 									  entryLocal->databaseName,
 									  entryLocal->tableName,
-									  entryLocal->occurrence,
-									  entryLocal->sleepTime,
+									  entryLocal->startOccurrence,
+									  entryLocal->endOccurrence,
+									  entryLocal->extraArg,
 									  FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
 									  entryLocal->numTimesTriggered);
 						found = TRUE;
@@ -1027,15 +977,17 @@ FaultInjector_SetFaultInjection(
 			break;
 		}
 		case FaultInjectorTypeResume:
+		{
 			ereport(LOG, 
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
 							entry->faultName,
 							FaultInjectorTypeEnumToString[entry->faultInjectorType])));	
 			
-			FaultInjector_UpdateHashEntry(entry);	
+			FaultInjector_MarkEntryAsResume(entry);
 			
 			break;
+		}
 		default: 
 			
 			status = FaultInjector_NewHashEntry(entry);

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -15,7 +15,7 @@
 
 #define FAULT_NAME_MAX_LENGTH	256
 
-#define OCCURRENCE_UNDEFINED 0xFFFFFFFF
+#define INFINITE_END_OCCURRENCE -1
 
 /*
  *
@@ -66,7 +66,7 @@ typedef struct FaultInjectorEntry_s {
 	
 	FaultInjectorType_e		faultInjectorType;
 	
-	int						sleepTime;
+	int						extraArg;
 		/* in seconds, in use if fault injection type is sleep */
 		
 	DDLStatement_e			ddlStatement;
@@ -75,7 +75,8 @@ typedef struct FaultInjectorEntry_s {
 	
 	char					tableName[NAMEDATALEN];
 	
-	volatile	int			occurrence;
+	volatile	int			startOccurrence;
+	volatile	int			endOccurrence;
 	volatile	 int	numTimesTriggered;
 	volatile	FaultInjectorState_e	faultInjectorState;
 

--- a/src/test/fsync/expected/bgwriter_checkpoint.out
+++ b/src/test/fsync/expected/bgwriter_checkpoint.out
@@ -12,6 +12,12 @@
 --     corresponding to fsync_test1 and fsync_test2 tables.
 --   * Verify that at least two files were fsync'ed by checkpointer.
 --
+-- the hit times of fsync_counter is undetermined, both 5 or 6 are
+-- correct, so mark them out to make case stable.
+-- start_matchsubs
+-- m/num times hit:\'[5-6]\'/
+-- s/num times hit:\'[5-6]\'/num times hit:\'FIVE_OR_SIX\'/
+-- end_matchsubs
 begin;
 create function num_dirty(relid oid) returns bigint as
 $$
@@ -52,13 +58,21 @@ insert into fsync_test1 select i, i from generate_series(1,100)i;
 insert into fsync_test2 select -i, i from generate_series(1,100)i;
 end;
 -- Reset all faults.
-select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+-- 
+-- NOTICE: important.
+--
+-- we use gp_inject_fault_infinite here instead of
+-- gp_inject_fault so cache of pg_proc that contains
+-- gp_inject_fault_infinite is loaded before checkpoint and
+-- the following gp_inject_fault_infinite don't dirty the
+-- buffer again.
+select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
 NOTICE:  Success:
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
 NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
 NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t

--- a/src/test/fsync/expected/bgwriter_checkpoint.out
+++ b/src/test/fsync/expected/bgwriter_checkpoint.out
@@ -52,7 +52,7 @@ insert into fsync_test1 select i, i from generate_series(1,100)i;
 insert into fsync_test2 select -i, i from generate_series(1,100)i;
 end;
 -- Reset all faults.
-select gp_inject_fault('all', 'reset', '', '', '', 0, 0, dbid) from gp_segment_configuration;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 NOTICE:  Success:
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
 NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
@@ -72,26 +72,26 @@ NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
 -- Start with a clean slate (no dirty buffers).
 checkpoint;
 -- Skip checkpoints.
-select gp_inject_fault('checkpoint', 'skip', '', '', '', 0, 0, dbid)
+select gp_inject_fault_infinite('checkpoint', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
 NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
 NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
 (3 rows)
 
 -- Suspend bgwriter.
-select gp_inject_fault('fault_in_background_writer_main', 'suspend', '', '', '', 0, 0, dbid)
+select gp_inject_fault_infinite('fault_in_background_writer_main', 'suspend', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
 NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
 NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
@@ -130,20 +130,20 @@ select sum(num_dirty('fsync_test2'::regclass)) > 0 as passed
 (1 row)
 
 -- Flush all dirty pages by BgBufferSync()
-select gp_inject_fault('bg_buffer_sync_default_logic', 'skip', '', '', '', 0, 0, dbid)
+select gp_inject_fault_infinite('bg_buffer_sync_default_logic', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
 NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
 NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
 (3 rows)
 
 -- Resume bgwriter.
-select gp_inject_fault('fault_in_background_writer_main', 'resume', '', '', '', 0, 0, dbid)
+select gp_inject_fault('fault_in_background_writer_main', 'resume', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
 NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
@@ -172,20 +172,20 @@ select wait_for_bgwriter('fsync_test2'::regclass, 25) as passed;
 (1 row)
 
 -- Inject fault to count relfiles fsync'ed by checkpointer.
-select gp_inject_fault('fsync_counter', 'skip', '', '', '', 0, 0, dbid)
+select gp_inject_fault_infinite('fsync_counter', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
 NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
 NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
 (3 rows)
 
 -- Resume checkpoints.
-select gp_inject_fault('checkpoint', 'reset', '', '', '', 0, 0, dbid)
+select gp_inject_fault('checkpoint', 'reset', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
 NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
@@ -209,15 +209,15 @@ select dirty_buffers() from gp_dist_random('gp_id')
 -- least 2.  The two files fsync'ed should be corresponding to
 -- fsync_test1 and fsync_test2 tables. `num times hit` is corresponding
 -- to the number of files synced by `fsync_counter` fault type.
-select gp_inject_fault('fsync_counter', 'status', '', '', '', 0, 0, 2::smallint);
-NOTICE:  Success: fault name:'fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'0' fault injection state:'triggered'  num times hit:'5'  (seg0 127.0.1.1:25432 pid=24489)
+select gp_inject_fault('fsync_counter', 'status', 2::smallint);
+NOTICE:  Success: fault name:'fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'5'  (seg0 127.0.1.1:25432 pid=24489)
  gp_inject_fault 
 -----------------
  t
 (1 row)
 
 -- Reset all faults.
-select gp_inject_fault('all', 'reset', '', '', '', 0, 0, dbid) from gp_segment_configuration;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 NOTICE:  Success:
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
 NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)

--- a/src/test/fsync/sql/bgwriter_checkpoint.sql
+++ b/src/test/fsync/sql/bgwriter_checkpoint.sql
@@ -56,17 +56,17 @@ insert into fsync_test2 select -i, i from generate_series(1,100)i;
 end;
 
 -- Reset all faults.
-select gp_inject_fault('all', 'reset', '', '', '', 0, 0, dbid) from gp_segment_configuration;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 
 -- Start with a clean slate (no dirty buffers).
 checkpoint;
 
 -- Skip checkpoints.
-select gp_inject_fault('checkpoint', 'skip', '', '', '', 0, 0, dbid)
+select gp_inject_fault_infinite('checkpoint', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 
 -- Suspend bgwriter.
-select gp_inject_fault('fault_in_background_writer_main', 'suspend', '', '', '', 0, 0, dbid)
+select gp_inject_fault_infinite('fault_in_background_writer_main', 'suspend', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 
 -- Ensure no buffers are dirty before we start.
@@ -87,11 +87,11 @@ select sum(num_dirty('fsync_test2'::regclass)) > 0 as passed
  from gp_dist_random('gp_id');
 
 -- Flush all dirty pages by BgBufferSync()
-select gp_inject_fault('bg_buffer_sync_default_logic', 'skip', '', '', '', 0, 0, dbid)
+select gp_inject_fault_infinite('bg_buffer_sync_default_logic', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 
 -- Resume bgwriter.
-select gp_inject_fault('fault_in_background_writer_main', 'resume', '', '', '', 0, 0, dbid)
+select gp_inject_fault('fault_in_background_writer_main', 'resume', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 
 -- Wait until bgwriter sweeps through and writes out dirty buffers.
@@ -102,11 +102,11 @@ select wait_for_bgwriter('fsync_test1'::regclass, 25) as passed;
 select wait_for_bgwriter('fsync_test2'::regclass, 25) as passed;
 
 -- Inject fault to count relfiles fsync'ed by checkpointer.
-select gp_inject_fault('fsync_counter', 'skip', '', '', '', 0, 0, dbid)
+select gp_inject_fault_infinite('fsync_counter', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 
 -- Resume checkpoints.
-select gp_inject_fault('checkpoint', 'reset', '', '', '', 0, 0, dbid)
+select gp_inject_fault('checkpoint', 'reset', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
 
 checkpoint;
@@ -119,7 +119,7 @@ select dirty_buffers() from gp_dist_random('gp_id')
 -- least 2.  The two files fsync'ed should be corresponding to
 -- fsync_test1 and fsync_test2 tables. `num times hit` is corresponding
 -- to the number of files synced by `fsync_counter` fault type.
-select gp_inject_fault('fsync_counter', 'status', '', '', '', 0, 0, 2::smallint);
+select gp_inject_fault('fsync_counter', 'status', 2::smallint);
 
 -- Reset all faults.
-select gp_inject_fault('all', 'reset', '', '', '', 0, 0, dbid) from gp_segment_configuration;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;

--- a/src/test/heap_checksum/expected/heap_checksum_corruption.out
+++ b/src/test/heap_checksum/expected/heap_checksum_corruption.out
@@ -111,6 +111,19 @@ NOTICE:  Success:
  t
 (1 row)
 
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
+NOTICE:  Success:
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t
+(1 row)
+
 --  Corrupt a heap table
 create table corrupt_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/heap_checksum/expected/heap_checksum_corruption.out
+++ b/src/test/heap_checksum/expected/heap_checksum_corruption.out
@@ -104,10 +104,10 @@ SHOW data_checksums;
 (1 row)
 
 -- skip FTS probes always
-SELECT gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 
@@ -233,10 +233,10 @@ set gp_disable_tuple_hints=off;
 -- flush the data to disk
 checkpoint;
 -- skip all further checkpoint
-select gp_inject_fault('checkpoint', 'skip', '', '', '', 0, 0, dbid) from gp_segment_configuration where role = 'p';
+select gp_inject_fault_infinite('checkpoint', 'skip', dbid) from gp_segment_configuration where role = 'p';
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
@@ -278,10 +278,10 @@ WARNING:  page verification failed, calculated checksum 38937 but expected 15001
 WARNING:  page verification failed, calculated checksum 18239 but expected 58815  (seg2 slice1 127.0.0.1:25434 pid=27289)
 ERROR:  invalid page in block 0 of relation base/81967/81939  (seg0 slice1 127.0.0.1:25432 pid=27287)
 -- trigger recovery on primaries with multiple retries and ignore warning/notice messages
-select gp_inject_fault('finish_prepared_after_record_commit_prepared', 'panic', '', '', '', 0, 0, dbid) from gp_segment_configuration where role = 'p';
+select gp_inject_fault_infinite('finish_prepared_after_record_commit_prepared', 'panic', dbid) from gp_segment_configuration where role = 'p';
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
@@ -302,7 +302,7 @@ select count(*) from corrupt_heap_checksum.mark_buffer_dirty_hint;
 (1 row)
 
 -- reset the fault injector
-select gp_inject_fault('checkpoint', 'reset', '', '', '', 0, 0, dbid) from gp_segment_configuration where role = 'p';
+select gp_inject_fault('checkpoint', 'reset', dbid) from gp_segment_configuration where role = 'p';
 NOTICE:  Success:
  gp_inject_fault 
 -----------------
@@ -312,7 +312,7 @@ NOTICE:  Success:
  t
 (4 rows)
 
-select gp_inject_fault('finish_prepared_after_record_commit_prepared', 'reset', '', '', '', 0, 0, dbid) from gp_segment_configuration where role = 'p';
+select gp_inject_fault('finish_prepared_after_record_commit_prepared', 'reset', dbid) from gp_segment_configuration where role = 'p';
 NOTICE:  Success:
  gp_inject_fault 
 -----------------
@@ -327,7 +327,7 @@ reset search_path;
 DROP SCHEMA corrupt_heap_checksum CASCADE;
 NOTICE:  drop cascades to 13 other objects
 -- resume fts
-SELECT gp_inject_fault('fts_probe', 'reset', '', '', '', -1, 0, 1);
+SELECT gp_inject_fault('fts_probe', 'reset', 1);
 NOTICE:  Success:
  gp_inject_fault 
 -----------------

--- a/src/test/heap_checksum/sql/heap_checksum_corruption.sql
+++ b/src/test/heap_checksum/sql/heap_checksum_corruption.sql
@@ -113,6 +113,8 @@ SHOW data_checksums;
 
 -- skip FTS probes always
 SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
+SELECT gp_request_fts_probe_scan();
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 --  Corrupt a heap table
 create table corrupt_table(a int);

--- a/src/test/heap_checksum/sql/heap_checksum_corruption.sql
+++ b/src/test/heap_checksum/sql/heap_checksum_corruption.sql
@@ -112,7 +112,7 @@ $$ LANGUAGE plpgsql;
 SHOW data_checksums;
 
 -- skip FTS probes always
-SELECT gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
 
 --  Corrupt a heap table
 create table corrupt_table(a int);
@@ -160,7 +160,7 @@ set gp_disable_tuple_hints=off;
 -- flush the data to disk
 checkpoint;
 -- skip all further checkpoint
-select gp_inject_fault('checkpoint', 'skip', '', '', '', 0, 0, dbid) from gp_segment_configuration where role = 'p';
+select gp_inject_fault_infinite('checkpoint', 'skip', dbid) from gp_segment_configuration where role = 'p';
 -- set the hint bit on (the buffer will be marked dirty)
 select count(*) from mark_buffer_dirty_hint;
 -- using a DML to trigger the XLogFlush() to have the backup block written
@@ -171,7 +171,7 @@ select SUM(corrupt_file(get_relation_path('mark_buffer_dirty_hint'), -50)) from 
 select invalidate_buffers_for_rel('mark_buffer_dirty_hint') from gp_dist_random('gp_id');
 select count(*) from mark_buffer_dirty_hint;
 -- trigger recovery on primaries with multiple retries and ignore warning/notice messages
-select gp_inject_fault('finish_prepared_after_record_commit_prepared', 'panic', '', '', '', 0, 0, dbid) from gp_segment_configuration where role = 'p';
+select gp_inject_fault_infinite('finish_prepared_after_record_commit_prepared', 'panic', dbid) from gp_segment_configuration where role = 'p';
 set client_min_messages='ERROR';
 set dtx_phase2_retry_count=10;
 create table trigger_recovery_on_primaries(c int);
@@ -181,11 +181,11 @@ reset client_min_messages;
 -- EXPECT: Full Page Image (FPI) in XLOG should overwrite the corrupted page during recovery
 select count(*) from corrupt_heap_checksum.mark_buffer_dirty_hint;
 -- reset the fault injector
-select gp_inject_fault('checkpoint', 'reset', '', '', '', 0, 0, dbid) from gp_segment_configuration where role = 'p';
-select gp_inject_fault('finish_prepared_after_record_commit_prepared', 'reset', '', '', '', 0, 0, dbid) from gp_segment_configuration where role = 'p';
+select gp_inject_fault('checkpoint', 'reset', dbid) from gp_segment_configuration where role = 'p';
+select gp_inject_fault('finish_prepared_after_record_commit_prepared', 'reset', dbid) from gp_segment_configuration where role = 'p';
 
 -- Clean up. We don't want to leave the corrupt tables lying around!
 reset search_path;
 DROP SCHEMA corrupt_heap_checksum CASCADE;
 -- resume fts
-SELECT gp_inject_fault('fts_probe', 'reset', '', '', '', -1, 0, 1);
+SELECT gp_inject_fault('fts_probe', 'reset', 1);

--- a/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
+++ b/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
@@ -4,10 +4,10 @@ CREATE
 -- TEST 1: block checkpoint on segments
 
 -- pause the 2PC after setting inCommit flag
-select gp_inject_fault('twophase_transaction_commit_prepared', 'suspend', 3);
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('twophase_transaction_commit_prepared', 'suspend', 3);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 
 -- trigger a 2PC, and it will block at commit;
@@ -44,10 +44,10 @@ CHECKPOINT
 
 -- pause the CommitTransaction right before persistent table cleanup after
 -- notifyCommittedDtxTransaction()
-select gp_inject_fault('onephase_transaction_commit', 'suspend', 1);
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('onephase_transaction_commit', 'suspend', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 
 -- trigger a 2PC, and it will block at commit;

--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -3,6 +3,18 @@ CREATE
 1:CREATE TABLE crash_test_table(c1 int);
 CREATE
 
+1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+role|preferred_role|content|mode|status
+----+--------------+-------+----+------
+m   |m             |-1     |s   |u     
+m   |m             |0      |s   |u     
+m   |m             |1      |s   |u     
+m   |m             |2      |s   |u     
+p   |p             |-1     |n   |u     
+p   |p             |0      |s   |u     
+p   |p             |1      |s   |u     
+p   |p             |2      |s   |u     
+(8 rows)
 -- transaction of session 2 and session 3 inserted 'COMMIT' record before checkpoint
 1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
 gp_inject_fault_infinite

--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -4,10 +4,10 @@ CREATE
 CREATE
 
 -- transaction of session 2 and session 3 inserted 'COMMIT' record before checkpoint
-1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', 1);
-gp_inject_fault
----------------
-t              
+1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 2&:insert into crash_test_table values (1);  <waiting ...>
 3&:create table crash_test_ddl(c1 int);  <waiting ...>
@@ -32,10 +32,10 @@ t
 (1 row)
 
 -- transaction of session 5 didn't insert 'COMMIT' record
-1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'suspend', 1);
-gp_inject_fault
----------------
-t              
+1:select gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'suspend', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 5&:INSERT INTO crash_test_table VALUES (3);  <waiting ...>
 

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -194,6 +194,16 @@ gp_inject_fault_infinite
 ------------------------
 t                       
 (1 row)
+11: SELECT gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
+(1 row)
+11: select gp_wait_until_triggered_fault('fts_probe', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
 11: SET debug_abort_after_segment_prepared = true;
 SET
 11: DELETE FROM QE_panic_test_table;

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -16,6 +16,18 @@
 CREATE OR REPLACE FUNCTION wait_till_master_shutsdown() RETURNS void AS $$ BEGIN loop PERFORM pg_sleep(.5); /* in func */ end loop; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE
 
+1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+role|preferred_role|content|mode|status
+----+--------------+-------+----+------
+m   |m             |-1     |s   |u     
+m   |m             |0      |s   |u     
+m   |m             |1      |s   |u     
+m   |m             |2      |s   |u     
+p   |p             |-1     |n   |u     
+p   |p             |0      |s   |u     
+p   |p             |1      |s   |u     
+p   |p             |2      |s   |u     
+(8 rows)
 -- Scenario 1: Test to fail broadcasting of COMMIT PREPARED to one
 -- segment and hence trigger PANIC in master while after completing
 -- phase 2 of 2PC. Master's recovery cycle should correctly broadcast

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -30,10 +30,10 @@ CREATE
 1: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE
 -- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', -1, 0, 2);
-gp_inject_fault
----------------
-t              
+1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', 2);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 -- create utility session to segment which will be used to reset the fault
 0U: SELECT 1;
@@ -177,10 +177,10 @@ CHECKPOINT
 11: SET dtx_phase2_retry_count=9;
 SET
 -- skip FTS probes always
-11: SELECT gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
-gp_inject_fault
----------------
-t              
+11: SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 11: SET debug_abort_after_segment_prepared = true;
 SET
@@ -191,7 +191,7 @@ count
 -----
 10   
 (1 row)
-11: SELECT gp_inject_fault('fts_probe', 'reset', '', '', '', -1, 0, 1);
+11: SELECT gp_inject_fault('fts_probe', 'reset', 1);
 gp_inject_fault
 ---------------
 t              

--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -4,16 +4,16 @@ CREATE
 CREATE
 
 -- transaction of session 2 suspend after inserted 'COMMIT' record
-1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', 1);
-gp_inject_fault
----------------
-t              
+1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 -- checkpoint suspend before scanning proc array
-1:select gp_inject_fault('checkpoint_dtx_info', 'suspend', 1);
-gp_inject_fault
----------------
-t              
+1:select gp_inject_fault_infinite('checkpoint_dtx_info', 'suspend', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 1&:CHECKPOINT;  <waiting ...>
 

--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -3,6 +3,18 @@ CREATE
 1:CREATE TABLE crash_test_redundant(c1 int);
 CREATE
 
+1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+role|preferred_role|content|mode|status
+----+--------------+-------+----+------
+m   |m             |-1     |s   |u     
+m   |m             |0      |s   |u     
+m   |m             |1      |s   |u     
+m   |m             |2      |s   |u     
+p   |p             |-1     |n   |u     
+p   |p             |0      |s   |u     
+p   |p             |1      |s   |u     
+p   |p             |2      |s   |u     
+(8 rows)
 -- transaction of session 2 suspend after inserted 'COMMIT' record
 1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
 gp_inject_fault_infinite

--- a/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
+++ b/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
@@ -43,10 +43,10 @@ gp_inject_fault
 ---------------
 t              
 (1 row)
-select gp_inject_fault('transaction_start_under_entry_db_singleton', 'suspend', 1);
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('transaction_start_under_entry_db_singleton', 'suspend', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 
 -- The QD should already hold RowExclusiveLock and ExclusiveLock on

--- a/src/test/isolation2/expected/distributed_snapshot.out
+++ b/src/test/isolation2/expected/distributed_snapshot.out
@@ -32,7 +32,7 @@ INSERT 1
 
 -- Hold after walking over ProcArray in GetSnpashotData(), right at start of
 -- DistributedLog_AdvanceOldestXmin()
-1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend', '', 'postgres', '', 1, 5, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend', '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration where content = 0 and role = 'p';
 gp_inject_fault
 ---------------
 t              

--- a/src/test/isolation2/expected/gdd/avoid-qd-deadlock.out
+++ b/src/test/isolation2/expected/gdd/avoid-qd-deadlock.out
@@ -18,7 +18,7 @@ gp_inject_fault
 ---------------
 t              
 (1 row)
-SELECT gp_inject_fault('upgrade_row_lock', 'sleep', '', '', '', 1, 10, 1);
+SELECT gp_inject_fault('upgrade_row_lock', 'sleep', '', '', '', 1, -1, 10, 1);
 gp_inject_fault
 ---------------
 t              
@@ -38,3 +38,9 @@ func1
 (1 row)
 3q: ... <quitting>
 4q: ... <quitting>
+
+SELECT gp_inject_fault('upgrade_row_lock', 'reset', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)

--- a/src/test/isolation2/expected/reindex.out
+++ b/src/test/isolation2/expected/reindex.out
@@ -4,10 +4,10 @@ CREATE
 CREATE DATABASE reindexdb1 TEMPLATE template1;
 CREATE
 -- halt reindex after scanning the pg_class and getting the relids
-SELECT gp_inject_fault('reindex_db', 'suspend', '', '', '', 0, 0, 1);
-gp_inject_fault
----------------
-t              
+SELECT gp_inject_fault_infinite('reindex_db', 'suspend', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 1:@db_name reindexdb1: CREATE TABLE heap1(a INT, b INT);
 CREATE
@@ -19,7 +19,7 @@ t
 (1 row)
 2:@db_name reindexdb1:DROP TABLE heap1;
 DROP
-SELECT gp_inject_fault('reindex_db', 'reset', '', '', '', 0, 0, 1);
+SELECT gp_inject_fault('reindex_db', 'reset', 1);
 gp_inject_fault
 ---------------
 t              
@@ -42,10 +42,10 @@ insert into reindex_index1 select i,i+1 from generate_series(1, 10)i;
 INSERT 10
 COMMIT;
 COMMIT
-SELECT gp_inject_fault('reindex_relation', 'suspend', '', '', '', 0, 0, 1);
-gp_inject_fault
----------------
-t              
+SELECT gp_inject_fault_infinite('reindex_relation', 'suspend', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 3&: REINDEX TABLE reindex_index1;  <waiting ...>
 SELECT gp_wait_until_triggered_fault('reindex_relation', 1, 1);
@@ -56,7 +56,7 @@ t
 -- create one more index
 CREATE INDEX reindex_index1_idx2 on reindex_index1 (a);
 CREATE
-SELECT gp_inject_fault('reindex_relation', 'reset', '', '', '', 0, 0, 1);
+SELECT gp_inject_fault('reindex_relation', 'reset', 1);
 gp_inject_fault
 ---------------
 t              

--- a/src/test/isolation2/expected/reindex_gpfastsequence.out
+++ b/src/test/isolation2/expected/reindex_gpfastsequence.out
@@ -10,10 +10,10 @@ INSERT 100
 create extension if not exists gp_inject_fault;
 CREATE
 
-select gp_inject_fault('reindex_relation', 'suspend', 2);
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('reindex_relation', 'suspend', 2);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 
 -- The reindex_relation fault should be hit

--- a/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
+++ b/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
@@ -15,6 +15,18 @@ t
 create or replace function wait_for_replication(iterations int) returns bool as $$ begin /* in func */ for i in 1 .. iterations loop /* in func */ if exists (select waiting_reason from pg_stat_activity where sess_id in (select sess_id from store_session_id) and waiting_reason = 'replication') then /* in func */ return true; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ end loop; /* in func */ return false; /* in func */ end; /* in func */ $$ language plpgsql VOLATILE;
 CREATE
 
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+role|preferred_role|content|mode|status
+----+--------------+-------+----+------
+m   |m             |-1     |s   |u     
+m   |m             |0      |s   |u     
+m   |m             |1      |s   |u     
+m   |m             |2      |s   |u     
+p   |p             |-1     |n   |u     
+p   |p             |0      |s   |u     
+p   |p             |1      |s   |u     
+p   |p             |2      |s   |u     
+(8 rows)
 create table store_session_id(a int, sess_id int);
 CREATE
 -- adding `0` as first column as the distribution column and add this tuple to segment 0

--- a/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
+++ b/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
@@ -22,10 +22,10 @@ CREATE
 INSERT 1
 -- suspend to hit commit-prepared point on segment (as we are
 -- interested in testing Commit here and not really Prepare)
-select gp_inject_fault('finish_prepared_start_of_function', 'suspend', 2);
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', 2);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 -- Expect: `create table` should be blocked until reset
 -- `wal_sender_loop`. We also verify the `sync_rep_query_cancel` is
@@ -37,10 +37,10 @@ gp_wait_until_triggered_fault
 t                            
 (1 row)
 -- now pause the wal sender on primary for content 0
-select gp_inject_fault('wal_sender_loop', 'suspend', 2);
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('wal_sender_loop', 'suspend', 2);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 -- let the transaction move forward with the commit
 select gp_inject_fault('finish_prepared_start_of_function', 'reset', 2);
@@ -55,10 +55,10 @@ wait_for_replication
 t                   
 (1 row)
 -- hitting this fault, is checked for test validation
-select gp_inject_fault('sync_rep_query_cancel', 'skip', 2);
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('sync_rep_query_cancel', 'skip', 2);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 0U: select pg_cancel_backend(procpid) from pg_stat_activity where waiting_reason='replication' and sess_id in (select sess_id from store_session_id);
 pg_cancel_backend

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -9,12 +9,18 @@ create or replace function pg_ctl(datadir text, command text, port int, contenti
 CREATE
 
 -- make sure we are in-sync for the primary we will be testing with
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+select content, role, preferred_role, mode, status from gp_segment_configuration;
 content|role|preferred_role|mode|status
 -------+----+--------------+----+------
+-1     |p   |p             |n   |u     
+-1     |m   |m             |s   |u     
+2      |p   |p             |s   |u     
+2      |m   |m             |s   |u     
+1      |p   |p             |s   |u     
+1      |m   |m             |s   |u     
 0      |p   |p             |s   |u     
 0      |m   |m             |s   |u     
-(2 rows)
+(8 rows)
 
 -- print synchronous_standby_names should be set to '*' at start of test
 0U: show synchronous_standby_names;

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -55,10 +55,10 @@ gp_request_fts_probe_scan
 t                        
 (1 row)
 -- verify the failure should be triggered once
-select gp_inject_fault('fts_probe', 'status', 1);
-gp_inject_fault
----------------
-t              
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 
 -- stop a mirror and show commit on dbid 2 will block

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -37,10 +37,10 @@ gp_inject_fault
 ---------------
 t              
 (1 row)
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 -- force scan to trigger the fault
 select gp_request_fts_probe_scan();

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -65,10 +65,10 @@ gp_request_fts_probe_scan
 t                        
 (1 row)
 -- verify the failure should be triggered once
-select gp_inject_fault('fts_probe', 'status', 1);
-gp_inject_fault
----------------
-t              
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
 (1 row)
 
 -- stop a mirror

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -13,12 +13,18 @@ create or replace function pg_ctl(datadir text, command text, port int, contenti
 CREATE
 
 -- make sure we are in-sync for the primary we will be testing with
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
+select content, role, preferred_role, mode, status from gp_segment_configuration;
 content|role|preferred_role|mode|status
 -------+----+--------------+----+------
+-1     |p   |p             |n   |u     
+-1     |m   |m             |s   |u     
 2      |p   |p             |s   |u     
 2      |m   |m             |s   |u     
-(2 rows)
+1      |p   |p             |s   |u     
+1      |m   |m             |s   |u     
+0      |p   |p             |s   |u     
+0      |m   |m             |s   |u     
+(8 rows)
 
 -- synchronous_standby_names should be set to '*' by default on primary 2, since
 -- we have a working/sync'd mirror

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -47,10 +47,10 @@ gp_inject_fault
 ---------------
 t              
 (1 row)
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 -- force scan to trigger the fault
 select gp_request_fts_probe_scan();
@@ -147,10 +147,10 @@ synchronous_standby_names
 (1 row)
 
 --hold walsender in startup
-select gp_inject_fault('initialize_wal_sender', 'suspend', dbid) from gp_segment_configuration where role='p' and content=2;
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('initialize_wal_sender', 'suspend', dbid) from gp_segment_configuration where role='p' and content=2;
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 
 -- bring the mirror back up and see primary s/u and mirror s/u

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -23,6 +23,18 @@ cmd = 'pg_ctl -D %s ' % datadir if command in ('stop'): cmd = cmd + '-w -m immed
 return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
 CREATE
 
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+role|preferred_role|content|mode|status
+----+--------------+-------+----+------
+m   |m             |-1     |s   |u     
+m   |m             |0      |s   |u     
+m   |m             |1      |s   |u     
+m   |m             |2      |s   |u     
+p   |p             |-1     |n   |u     
+p   |p             |0      |s   |u     
+p   |p             |1      |s   |u     
+p   |p             |2      |s   |u     
+(8 rows)
 -- stop a primary in order to trigger a mirror promotion
 select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
 pg_ctl                                              

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -97,10 +97,10 @@ dbid
 (1 row)
 -- end_ignore
 
-select gp_inject_fault('fts_handle_message', 'infinite_loop', '', '', '', -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
-gp_inject_fault
----------------
-t              
+select gp_inject_fault_infinite('fts_handle_message', 'infinite_loop', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 
 -- trigger failover

--- a/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
@@ -64,6 +64,12 @@ gp_inject_fault_infinite
 ------------------------
 t                       
 (1 row)
+-- do fts probe request twice to guarantee the fault is triggered
+2:SELECT gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
+(1 row)
 2:SELECT gp_request_fts_probe_scan();
 gp_request_fts_probe_scan
 -------------------------
@@ -112,6 +118,12 @@ t
 gp_inject_fault_infinite
 ------------------------
 t                       
+(1 row)
+-- do fts probe request twice to guarantee the fault is triggered
+3:SELECT gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
 (1 row)
 3:SELECT gp_request_fts_probe_scan();
 gp_request_fts_probe_scan
@@ -162,6 +174,12 @@ t
 gp_inject_fault_infinite
 ------------------------
 t                       
+(1 row)
+-- do fts probe request twice to guarantee the fault is triggered
+4:SELECT gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
 (1 row)
 4:SELECT gp_request_fts_probe_scan();
 gp_request_fts_probe_scan

--- a/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
@@ -54,6 +54,11 @@ gp_inject_fault_infinite
 t                       
 (1 row)
 1&:CREATE TABLE tolerance_test_table(an_int int);  <waiting ...>
+2:SELECT gp_wait_until_triggered_fault('start_prepare', 1, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
 2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
 gp_inject_fault_infinite
 ------------------------
@@ -91,23 +96,29 @@ LINE 1: INSERT INTO tolerance_test_table VALUES(42);
 
 
 -- Scenario 2: Prepared but not committed
+-- NOTICE: Don't use session 2 again because it's cached gang is invalid
 1:SELECT gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
 gp_inject_fault_infinite
 ------------------------
 t                       
 (1 row)
 1&:CREATE TABLE tolerance_test_table(an_int int);  <waiting ...>
-2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+3:SELECT gp_wait_until_triggered_fault('transaction_abort_after_distributed_prepared', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
+3:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 gp_inject_fault_infinite
 ------------------------
 t                       
 (1 row)
-2:SELECT gp_request_fts_probe_scan();
+3:SELECT gp_request_fts_probe_scan();
 gp_request_fts_probe_scan
 -------------------------
 t                        
 (1 row)
-2:SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'resume', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+3:SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'resume', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
 gp_inject_fault
 ---------------
 t              
@@ -135,18 +146,24 @@ p   |m
 INSERT 1
 
 -- Scenario 3: Commit-Prepare received on primary but not acknowledged to master
+-- NOTICE: Don't use session 2 again because it's cached gang is invalid
 1:SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'infinite_loop', dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
 gp_inject_fault_infinite
 ------------------------
 t                       
 (1 row)
 1&:DROP TABLE tolerance_test_table;  <waiting ...>
-2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
+4:SELECT gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
+4:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
 gp_inject_fault_infinite
 ------------------------
 t                       
 (1 row)
-2:SELECT gp_request_fts_probe_scan();
+4:SELECT gp_request_fts_probe_scan();
 gp_request_fts_probe_scan
 -------------------------
 t                        

--- a/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
@@ -48,16 +48,16 @@ m   |m             |2
 (8 rows)
 
 -- Scenario 1: Not prepared
-1:SELECT gp_inject_fault('start_prepare', 'infinite_loop', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
-gp_inject_fault
----------------
-t              
+1:SELECT gp_inject_fault_infinite('start_prepare', 'infinite_loop', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 1&:CREATE TABLE tolerance_test_table(an_int int);  <waiting ...>
-2:SELECT gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
-gp_inject_fault
----------------
-t              
+2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 2:SELECT gp_request_fts_probe_scan();
 gp_request_fts_probe_scan
@@ -91,16 +91,16 @@ LINE 1: INSERT INTO tolerance_test_table VALUES(42);
 
 
 -- Scenario 2: Prepared but not committed
-1:SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
-gp_inject_fault
----------------
-t              
+1:SELECT gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 1&:CREATE TABLE tolerance_test_table(an_int int);  <waiting ...>
-2:SELECT gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-gp_inject_fault
----------------
-t              
+2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 2:SELECT gp_request_fts_probe_scan();
 gp_request_fts_probe_scan
@@ -135,16 +135,16 @@ p   |m
 INSERT 1
 
 -- Scenario 3: Commit-Prepare received on primary but not acknowledged to master
-1:SELECT gp_inject_fault('finish_prepared_start_of_function', 'infinite_loop', dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
-gp_inject_fault
----------------
-t              
+1:SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'infinite_loop', dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 1&:DROP TABLE tolerance_test_table;  <waiting ...>
-2:SELECT gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
-gp_inject_fault
----------------
-t              
+2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 2:SELECT gp_request_fts_probe_scan();
 gp_request_fts_probe_scan

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -53,7 +53,7 @@ INSERT 10
 UPDATE 10
 
 -- suspend at intended points.
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
+3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
 gp_inject_fault
 ---------------
 t              
@@ -64,7 +64,7 @@ gp_wait_until_triggered_fault
 -----------------------------
 t                            
 (1 row)
-3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 0, 0, 2);
+3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 1, -1, 0, 2);
 gp_inject_fault
 ---------------
 t              
@@ -75,7 +75,7 @@ t
 -- previous VACUUM on crash_before_segmentfile_drop is suspended in drop
 -- phase. This results in segment file 1 remaining in drop pending state which
 -- results in segment file 1 not being scheduled for any new inserts.
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
+3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 1, -1, 0, 2);
 gp_inject_fault
 ---------------
 t              
@@ -114,17 +114,17 @@ ERROR:  could not connect to segment: initialization of segworker group failed
 (1 row)
 
 -- reset faults as protection incase tests failed and panic didn't happen
-1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', '', '', '', 0, 0, 2);
+1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
 gp_inject_fault
 ---------------
 t              
 (1 row)
-1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', '', '', '', 0, 0, 2);
+1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
 gp_inject_fault
 ---------------
 t              
 (1 row)
-1:SELECT gp_inject_fault('appendonly_insert', 'reset', '', '', '', 0, 0, 2);
+1:SELECT gp_inject_fault('appendonly_insert', 'reset', 2);
 gp_inject_fault
 ---------------
 t              
@@ -352,7 +352,7 @@ INSERT 10
 DELETE 3
 
 -- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 0, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
 gp_inject_fault
 ---------------
 t              
@@ -367,7 +367,7 @@ t
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 0, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
 gp_inject_fault
 ---------------
 t              
@@ -383,12 +383,12 @@ server closed the connection unexpectedly
 	before or while processing the request.
 
 -- reset faults as protection incase tests failed and panic didn't happen
-4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', '', '', '', 0, 0, 1);
+4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
 gp_inject_fault
 ---------------
 t              
 (1 row)
-4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', '', '', '', 0, 0, 1);
+4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
 gp_inject_fault
 ---------------
 t              

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -7,6 +7,18 @@
 -- end_matchsubs
 3:CREATE extension if NOT EXISTS gp_inject_fault;
 CREATE
+3:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+role|preferred_role|content|mode|status
+----+--------------+-------+----+------
+m   |m             |-1     |s   |u     
+m   |m             |0      |s   |u     
+m   |m             |1      |s   |u     
+m   |m             |2      |s   |u     
+p   |p             |-1     |n   |u     
+p   |p             |0      |s   |u     
+p   |p             |1      |s   |u     
+p   |p             |2      |s   |u     
+(8 rows)
 --
 -- Test to validate crash at different points in AO/CO vacuum.
 --

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -55,7 +55,7 @@ UPDATE 10
 -- suspend at intended points. Only one AO table can be in drop phase in a
 -- system at a time hence we must wait for this table's VACUUM to reach cleanup
 -- phase before triggering another VACUUM.
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
+3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 1, -1, 0, 2);
 gp_inject_fault
 ---------------
 t              
@@ -67,7 +67,7 @@ gp_wait_until_triggered_fault
 t                            
 (1 row)
 
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
+3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
 gp_inject_fault
 ---------------
 t              
@@ -82,7 +82,7 @@ t
 -- we already waited for suspend faults to trigger and hence we can proceed to
 -- run next command which would trigger panic fault and help test
 -- crash_recovery
-3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 0, 0, 2);
+3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 1, -1, 0, 2);
 gp_inject_fault
 ---------------
 t              
@@ -111,17 +111,17 @@ ERROR:  could not connect to segment: initialization of segworker group failed
 (1 row)
 
 -- reset faults as protection incase tests failed and panic didn't happen
-1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', '', '', '', 0, 0, 2);
+1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
 gp_inject_fault
 ---------------
 t              
 (1 row)
-1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', '', '', '', 0, 0, 2);
+1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
 gp_inject_fault
 ---------------
 t              
 (1 row)
-1:SELECT gp_inject_fault('appendonly_insert', 'reset', '', '', '', 0, 0, 2);
+1:SELECT gp_inject_fault('appendonly_insert', 'reset', 2);
 gp_inject_fault
 ---------------
 t              
@@ -313,13 +313,13 @@ INSERT 10
 DELETE 3
 
 -- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 0, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
 gp_inject_fault
 ---------------
 t              
 (1 row)
 1&:VACUUM crash_master_before_cleanup_phase;  <waiting ...>
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 0, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
 gp_inject_fault
 ---------------
 t              
@@ -344,12 +344,12 @@ server closed the connection unexpectedly
 	before or while processing the request.
 
 -- reset faults as protection incase tests failed and panic didn't happen
-4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', '', '', '', 0, 0, 1);
+4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
 gp_inject_fault
 ---------------
 t              
 (1 row)
-4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', '', '', '', 0, 0, 1);
+4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
 gp_inject_fault
 ---------------
 t              

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -7,6 +7,18 @@
 -- end_matchsubs
 3:CREATE extension if NOT EXISTS gp_inject_fault;
 CREATE
+3:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+role|preferred_role|content|mode|status
+----+--------------+-------+----+------
+m   |m             |-1     |s   |u     
+m   |m             |0      |s   |u     
+m   |m             |1      |s   |u     
+m   |m             |2      |s   |u     
+p   |p             |-1     |n   |u     
+p   |p             |0      |s   |u     
+p   |p             |1      |s   |u     
+p   |p             |2      |s   |u     
+(8 rows)
 --
 -- Test to validate crash at different points in AO/CO vacuum.
 --

--- a/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
+++ b/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
@@ -44,7 +44,18 @@ CREATE
 
 CREATE OR REPLACE FUNCTION test_protocol_allseg(mid int, mshop int, mgender character) RETURNS VOID AS $$ DECLARE tfactor int default 0; /* in func */ BEGIN /* in func */ BEGIN /* in func */ CREATE TABLE employees(id int, shop_id int, gender character) DISTRIBUTED BY (id); /* in func */  INSERT INTO employees VALUES (0, 1, 'm'); /* in func */ END; /* in func */ BEGIN /* in func */ BEGIN /* in func */ IF EXISTS (select 1 from employees where id = mid) THEN /* in func */ RAISE EXCEPTION 'Duplicate employee id'; /* in func */ ELSE /* in func */ IF NOT (mshop between 1 AND 2) THEN /* in func */ RAISE EXCEPTION 'Invalid shop id' ; /* in func */ END IF; /* in func */ END IF; /* in func */ SELECT * INTO tfactor FROM test_excep(0); /* in func */ BEGIN /* in func */ INSERT INTO employees VALUES (mid, mshop, mgender); /* in func */ EXCEPTION /* in func */ WHEN OTHERS THEN /* in func */ BEGIN /* in func */ RAISE NOTICE 'catching the exception ...3'; /* in func */ END; /* in func */ END; /* in func */ EXCEPTION /* in func */ WHEN OTHERS THEN /* in func */ RAISE NOTICE 'catching the exception ...2'; /* in func */ END; /* in func */ EXCEPTION /* in func */ WHEN OTHERS THEN /* in func */ RAISE NOTICE 'catching the exception ...1'; /* in func */ END; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE
-
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+role|preferred_role|content|mode|status
+----+--------------+-------+----+------
+m   |m             |-1     |s   |u     
+m   |m             |0      |s   |u     
+m   |m             |1      |s   |u     
+m   |m             |2      |s   |u     
+p   |p             |-1     |n   |u     
+p   |p             |0      |s   |u     
+p   |p             |1      |s   |u     
+p   |p             |2      |s   |u     
+(8 rows)
 SET debug_dtm_action_segment=1;
 SET
 SET debug_dtm_action_target=protocol;

--- a/src/test/isolation2/input/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/input/uao/vacuum_cleanup.source
@@ -19,7 +19,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 2: update ao_@orientation@_vacuum_cleanup2 set b = b + 1;
 
 
-1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 2);
+1: select gp_inject_fault_infinite('vacuum_relation_open_relation_during_drop_phase', 'suspend', 2);
 
 2&: vacuum ao_@orientation@_vacuum_cleanup1;
 
@@ -49,7 +49,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- Check the age of the table before vacuum to make sure that clean phase gets
 -- performed
 1: select age(relfrozenxid) between 3 and 5, regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
-1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
+1: select gp_inject_fault_infinite('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
 1&: vacuum ao_@orientation@_vacuum_cleanup3;
 
 -- Wait till compaction phase is completed and only then start the serializable

--- a/src/test/isolation2/output/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/output/uao/vacuum_cleanup.source
@@ -30,10 +30,10 @@ UPDATE 100
 UPDATE 100
 
 
-1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 2);
-gp_inject_fault
----------------
-t              
+1: select gp_inject_fault_infinite('vacuum_relation_open_relation_during_drop_phase', 'suspend', 2);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 
 2&: vacuum ao_@orientation@_vacuum_cleanup1;  <waiting ...>
@@ -93,10 +93,10 @@ DELETE 100
 t       |pg_<seg>_<oid>    
 t       |pg_aovisimap_<oid>
 (2 rows)
-1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
-gp_inject_fault
----------------
-t              
+1: select gp_inject_fault_infinite('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
 (1 row)
 1&: vacuum ao_@orientation@_vacuum_cleanup3;  <waiting ...>
 

--- a/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
+++ b/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- TEST 1: block checkpoint on segments
 
 -- pause the 2PC after setting inCommit flag
-select gp_inject_fault('twophase_transaction_commit_prepared', 'suspend', 3);
+select gp_inject_fault_infinite('twophase_transaction_commit_prepared', 'suspend', 3);
 
 -- trigger a 2PC, and it will block at commit;
 2: checkpoint;
@@ -26,7 +26,7 @@ select gp_inject_fault('twophase_transaction_commit_prepared', 'reset', 3);
 
 -- pause the CommitTransaction right before persistent table cleanup after
 -- notifyCommittedDtxTransaction()
-select gp_inject_fault('onephase_transaction_commit', 'suspend', 1);
+select gp_inject_fault_infinite('onephase_transaction_commit', 'suspend', 1);
 
 -- trigger a 2PC, and it will block at commit;
 2: checkpoint;

--- a/src/test/isolation2/sql/crash_recovery.sql
+++ b/src/test/isolation2/sql/crash_recovery.sql
@@ -2,7 +2,7 @@
 1:CREATE TABLE crash_test_table(c1 int);
 
 -- transaction of session 2 and session 3 inserted 'COMMIT' record before checkpoint
-1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', 1);
+1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
 2&:insert into crash_test_table values (1);
 3&:create table crash_test_ddl(c1 int);
 
@@ -17,7 +17,7 @@
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 3, 1);
 
 -- transaction of session 5 didn't insert 'COMMIT' record
-1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'suspend', 1);
+1:select gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'suspend', 1);
 5&:INSERT INTO crash_test_table VALUES (3);
 
 -- wait session 5 hit inject point

--- a/src/test/isolation2/sql/crash_recovery.sql
+++ b/src/test/isolation2/sql/crash_recovery.sql
@@ -1,6 +1,7 @@
 1:CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 1:CREATE TABLE crash_test_table(c1 int);
 
+1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 -- transaction of session 2 and session 3 inserted 'COMMIT' record before checkpoint
 1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
 2&:insert into crash_test_table values (1);

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -102,6 +102,8 @@ $$ LANGUAGE plpgsql;
 11: SET dtx_phase2_retry_count=9;
 -- skip FTS probes always
 11: SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
+11: SELECT gp_request_fts_probe_scan();
+11: select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 11: SET debug_abort_after_segment_prepared = true;
 11: DELETE FROM QE_panic_test_table;
 11: SELECT count(*) from QE_panic_test_table;

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -23,6 +23,7 @@ $$
   END; /* in func */
 $$ LANGUAGE plpgsql;
 
+1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 -- Scenario 1: Test to fail broadcasting of COMMIT PREPARED to one
 -- segment and hence trigger PANIC in master while after completing
 -- phase 2 of 2PC. Master's recovery cycle should correctly broadcast

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -36,7 +36,7 @@ $$ LANGUAGE plpgsql;
 -- after querying in-doubt prepared transactions from segments.
 1: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', -1, 0, 2);
+1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', 2);
 -- create utility session to segment which will be used to reset the fault
 0U: SELECT 1;
 -- Start looping in background, till master panics and closes the session
@@ -100,8 +100,8 @@ $$ LANGUAGE plpgsql;
 -- Set to maximum number of 2PC retries to avoid any failures.
 11: SET dtx_phase2_retry_count=9;
 -- skip FTS probes always
-11: SELECT gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+11: SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
 11: SET debug_abort_after_segment_prepared = true;
 11: DELETE FROM QE_panic_test_table;
 11: SELECT count(*) from QE_panic_test_table;
-11: SELECT gp_inject_fault('fts_probe', 'reset', '', '', '', -1, 0, 1);
+11: SELECT gp_inject_fault('fts_probe', 'reset', 1);

--- a/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
+++ b/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
@@ -2,9 +2,9 @@
 1:CREATE TABLE crash_test_redundant(c1 int);
 
 -- transaction of session 2 suspend after inserted 'COMMIT' record 
-1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', 1);
+1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
 -- checkpoint suspend before scanning proc array
-1:select gp_inject_fault('checkpoint_dtx_info', 'suspend', 1);
+1:select gp_inject_fault_infinite('checkpoint_dtx_info', 'suspend', 1);
 1&:CHECKPOINT;
 
 -- wait till checkpoint reaches intended point

--- a/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
+++ b/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
@@ -1,6 +1,7 @@
 1:CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 1:CREATE TABLE crash_test_redundant(c1 int);
 
+1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 -- transaction of session 2 suspend after inserted 'COMMIT' record 
 1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
 -- checkpoint suspend before scanning proc array

--- a/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
+++ b/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
@@ -40,7 +40,7 @@ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
 
 -- inject fault on QD
 select gp_inject_fault('transaction_start_under_entry_db_singleton', 'reset', 1);
-select gp_inject_fault('transaction_start_under_entry_db_singleton', 'suspend', 1);
+select gp_inject_fault_infinite('transaction_start_under_entry_db_singleton', 'suspend', 1);
 
 -- The QD should already hold RowExclusiveLock and ExclusiveLock on
 -- deadlock_entry_db_singleton_table and the QE ENTRY_DB_SINGLETON

--- a/src/test/isolation2/sql/distributed_snapshot.sql
+++ b/src/test/isolation2/sql/distributed_snapshot.sql
@@ -23,7 +23,7 @@ CREATE TABLE distributed_snapshot_test1 (a int);
 -- Hold after walking over ProcArray in GetSnpashotData(), right at start of
 -- DistributedLog_AdvanceOldestXmin()
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend',
-   '', 'postgres', '', 1, 5, dbid) from gp_segment_configuration
+   '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration
    where content = 0 and role = 'p';
 3&:@db_name postgres: SELECT count(*) > 0 from gp_dist_random('gp_id');
 1: SELECT gp_wait_until_triggered_fault('distributedlog_advance_oldest_xmin', 1, dbid)

--- a/src/test/isolation2/sql/gdd/avoid-qd-deadlock.sql
+++ b/src/test/isolation2/sql/gdd/avoid-qd-deadlock.sql
@@ -15,7 +15,7 @@ LANGUAGE plpgsql;
 INSERT INTO tsudf select i, i+1 from generate_series(1,10) i;
 
 SELECT gp_inject_fault('upgrade_row_lock', 'reset', 1);
-SELECT gp_inject_fault('upgrade_row_lock', 'sleep', '', '', '', 1, 10, 1);
+SELECT gp_inject_fault('upgrade_row_lock', 'sleep', '', '', '', 1, -1, 10, 1);
 
 3&: SELECT * FROM func1(1);
 4: SELECT * FROM func1(2);
@@ -23,3 +23,5 @@ SELECT gp_inject_fault('upgrade_row_lock', 'sleep', '', '', '', 1, 10, 1);
 3<:
 3q:
 4q:
+
+SELECT gp_inject_fault('upgrade_row_lock', 'reset', 1);

--- a/src/test/isolation2/sql/reindex.sql
+++ b/src/test/isolation2/sql/reindex.sql
@@ -2,12 +2,12 @@
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE DATABASE reindexdb1 TEMPLATE template1;
 -- halt reindex after scanning the pg_class and getting the relids
-SELECT gp_inject_fault('reindex_db', 'suspend', '', '', '', 0, 0, 1);
+SELECT gp_inject_fault_infinite('reindex_db', 'suspend', 1);
 1:@db_name reindexdb1: CREATE TABLE heap1(a INT, b INT);
 1&:REINDEX DATABASE reindexdb1;
 SELECT gp_wait_until_triggered_fault('reindex_db', 1, 1);
 2:@db_name reindexdb1:DROP TABLE heap1;
-SELECT gp_inject_fault('reindex_db', 'reset', '', '', '', 0, 0, 1);
+SELECT gp_inject_fault('reindex_db', 'reset', 1);
 -- reindex should complete fine
 1<:
 1q:
@@ -20,12 +20,12 @@ CREATE TABLE reindex_index1(a int, b int);
 CREATE INDEX reindex_index1_idx1 on reindex_index1 (b);
 insert into reindex_index1 select i,i+1 from generate_series(1, 10)i;
 COMMIT;
-SELECT gp_inject_fault('reindex_relation', 'suspend', '', '', '', 0, 0, 1);
+SELECT gp_inject_fault_infinite('reindex_relation', 'suspend', 1);
 3&: REINDEX TABLE reindex_index1;
 SELECT gp_wait_until_triggered_fault('reindex_relation', 1, 1);
 -- create one more index
 CREATE INDEX reindex_index1_idx2 on reindex_index1 (a);
-SELECT gp_inject_fault('reindex_relation', 'reset', '', '', '', 0, 0, 1);
+SELECT gp_inject_fault('reindex_relation', 'reset', 1);
 3<:
 
 DROP DATABASE reindexdb1;

--- a/src/test/isolation2/sql/reindex_gpfastsequence.sql
+++ b/src/test/isolation2/sql/reindex_gpfastsequence.sql
@@ -6,7 +6,7 @@ insert into test_fastseqence select i , 'aa'||i from generate_series(1,100) i;
 
 create extension if not exists gp_inject_fault;
 
-select gp_inject_fault('reindex_relation', 'suspend', 2);
+select gp_inject_fault_infinite('reindex_relation', 'suspend', 2);
 
 -- The reindex_relation fault should be hit
 1&: reindex table gp_fastsequence;

--- a/src/test/isolation2/sql/segwalrep/cancel_commit_pending_replication.sql
+++ b/src/test/isolation2/sql/segwalrep/cancel_commit_pending_replication.sql
@@ -17,6 +17,7 @@ begin /* in func */
 end; /* in func */
 $$ language plpgsql VOLATILE;
 
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 create table store_session_id(a int, sess_id int);
 -- adding `0` as first column as the distribution column and add this tuple to segment 0
 1: insert into store_session_id select 0, sess_id from pg_stat_activity where procpid = pg_backend_pid();

--- a/src/test/isolation2/sql/segwalrep/cancel_commit_pending_replication.sql
+++ b/src/test/isolation2/sql/segwalrep/cancel_commit_pending_replication.sql
@@ -22,20 +22,20 @@ create table store_session_id(a int, sess_id int);
 1: insert into store_session_id select 0, sess_id from pg_stat_activity where procpid = pg_backend_pid();
 -- suspend to hit commit-prepared point on segment (as we are
 -- interested in testing Commit here and not really Prepare)
-select gp_inject_fault('finish_prepared_start_of_function', 'suspend', 2);
+select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', 2);
 -- Expect: `create table` should be blocked until reset
 -- `wal_sender_loop`. We also verify the `sync_rep_query_cancel` is
 -- triggered by query cancel request.
 1&: create table cancel_commit_pending_replication(a int, b int);
 select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, 2);
 -- now pause the wal sender on primary for content 0
-select gp_inject_fault('wal_sender_loop', 'suspend', 2);
+select gp_inject_fault_infinite('wal_sender_loop', 'suspend', 2);
 -- let the transaction move forward with the commit
 select gp_inject_fault('finish_prepared_start_of_function', 'reset', 2);
 -- loop to reach waiting_reason=replication
 0U: select wait_for_replication(200);
 -- hitting this fault, is checked for test validation
-select gp_inject_fault('sync_rep_query_cancel', 'skip', 2);
+select gp_inject_fault_infinite('sync_rep_query_cancel', 'skip', 2);
 0U: select pg_cancel_backend(procpid) from pg_stat_activity where waiting_reason='replication' and sess_id in (select sess_id from store_session_id);
 -- EXPECT: hit this fault for QueryCancelPending
 select gp_wait_until_triggered_fault('sync_rep_query_cancel', 1, 2);

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -31,7 +31,7 @@ insert into segwalrep_commit_blocking values (1);
 -- skip FTS probes always
 create extension if not exists gp_inject_fault;
 select gp_inject_fault('fts_probe', 'reset', 1);
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 -- force scan to trigger the fault
 select gp_request_fts_probe_scan();
 -- verify the failure should be triggered once

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -35,7 +35,7 @@ select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 -- force scan to trigger the fault
 select gp_request_fts_probe_scan();
 -- verify the failure should be triggered once
-select gp_inject_fault('fts_probe', 'status', 1);
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 -- stop a mirror and show commit on dbid 2 will block
 -1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop', NULL, NULL, NULL);

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -19,7 +19,7 @@ returns text as $$
 $$ language plpythonu;
 
 -- make sure we are in-sync for the primary we will be testing with
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=0;
+select content, role, preferred_role, mode, status from gp_segment_configuration;
 
 -- print synchronous_standby_names should be set to '*' at start of test
 0U: show synchronous_standby_names;

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -36,7 +36,7 @@ returns text as $$
 $$ language plpythonu;
 
 -- make sure we are in-sync for the primary we will be testing with
-select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
+select content, role, preferred_role, mode, status from gp_segment_configuration;
 
 -- synchronous_standby_names should be set to '*' by default on primary 2, since
 -- we have a working/sync'd mirror

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -50,7 +50,7 @@ insert into fts_unblock_primary values (1);
 -- skip FTS probes always
 create extension if not exists gp_inject_fault;
 select gp_inject_fault('fts_probe', 'reset', 1);
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 -- force scan to trigger the fault
 select gp_request_fts_probe_scan();
 -- verify the failure should be triggered once
@@ -92,7 +92,7 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
 2U: show synchronous_standby_names;
 
 --hold walsender in startup
-select gp_inject_fault('initialize_wal_sender', 'suspend', dbid)
+select gp_inject_fault_infinite('initialize_wal_sender', 'suspend', dbid)
 from gp_segment_configuration where role='p' and content=2;
 
 -- bring the mirror back up and see primary s/u and mirror s/u

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -54,7 +54,7 @@ select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 -- force scan to trigger the fault
 select gp_request_fts_probe_scan();
 -- verify the failure should be triggered once
-select gp_inject_fault('fts_probe', 'status', 1);
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 -- stop a mirror
 -1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), 'stop', NULL, NULL, NULL);

--- a/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
@@ -29,6 +29,7 @@ returns text as $$
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
 $$ language plpythonu;
 
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 -- stop a primary in order to trigger a mirror promotion
 select pg_ctl((select datadir from gp_segment_configuration c
 where c.role='p' and c.content=0), 'stop');

--- a/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
@@ -76,7 +76,7 @@ where content = 0;
 select dbid from gp_segment_configuration where content = 0 and role = 'p';
 -- end_ignore
 
-select gp_inject_fault('fts_handle_message', 'infinite_loop', '', '', '', -1, 0, dbid)
+select gp_inject_fault_infinite('fts_handle_message', 'infinite_loop', dbid)
 from gp_segment_configuration
 where content = 0 and role = 'p';
 

--- a/src/test/isolation2/sql/segwalrep/twophase_tolerance_with_mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/twophase_tolerance_with_mirror_promotion.sql
@@ -29,10 +29,10 @@ CREATE extension IF NOT EXISTS gp_inject_fault;
 1:SELECT role, preferred_role, content FROM gp_segment_configuration;
 
 -- Scenario 1: Not prepared
-1:SELECT gp_inject_fault('start_prepare', 'infinite_loop', dbid)
+1:SELECT gp_inject_fault_infinite('start_prepare', 'infinite_loop', dbid)
   FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
 1&:CREATE TABLE tolerance_test_table(an_int int);
-2:SELECT gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid)
+2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
   FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
 2:SELECT gp_request_fts_probe_scan();
 1<:
@@ -47,10 +47,10 @@ CREATE extension IF NOT EXISTS gp_inject_fault;
 
 
 -- Scenario 2: Prepared but not committed
-1:SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'suspend', dbid)
+1:SELECT gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'suspend', dbid)
   FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
 1&:CREATE TABLE tolerance_test_table(an_int int);
-2:SELECT gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid)
+2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
   FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 2:SELECT gp_request_fts_probe_scan();
 2:SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'resume', dbid)
@@ -65,10 +65,10 @@ CREATE extension IF NOT EXISTS gp_inject_fault;
 1:INSERT INTO tolerance_test_table VALUES(42);
 
 -- Scenario 3: Commit-Prepare received on primary but not acknowledged to master
-1:SELECT gp_inject_fault('finish_prepared_start_of_function', 'infinite_loop', dbid)
+1:SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'infinite_loop', dbid)
   FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
 1&:DROP TABLE tolerance_test_table;
-2:SELECT gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid)
+2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
   FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
 2:SELECT gp_request_fts_probe_scan();
 1<:

--- a/src/test/isolation2/sql/segwalrep/twophase_tolerance_with_mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/twophase_tolerance_with_mirror_promotion.sql
@@ -36,6 +36,8 @@ CREATE extension IF NOT EXISTS gp_inject_fault;
   FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
 2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
   FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+-- do fts probe request twice to guarantee the fault is triggered
+2:SELECT gp_request_fts_probe_scan();
 2:SELECT gp_request_fts_probe_scan();
 1<:
 
@@ -57,6 +59,8 @@ CREATE extension IF NOT EXISTS gp_inject_fault;
   FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
 3:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
   FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+-- do fts probe request twice to guarantee the fault is triggered
+3:SELECT gp_request_fts_probe_scan();
 3:SELECT gp_request_fts_probe_scan();
 3:SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'resume', dbid)
   FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
@@ -78,6 +82,8 @@ CREATE extension IF NOT EXISTS gp_inject_fault;
   FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
 4:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
   FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
+-- do fts probe request twice to guarantee the fault is triggered
+4:SELECT gp_request_fts_probe_scan();
 4:SELECT gp_request_fts_probe_scan();
 1<:
 

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -6,6 +6,7 @@
 -- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
 -- end_matchsubs
 3:CREATE extension if NOT EXISTS gp_inject_fault;
+3:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 --
 -- Test to validate crash at different points in AO/CO vacuum.
 --

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -32,17 +32,17 @@
 3:UPDATE crash_vacuum_in_appendonly_insert SET b = 2;
 
 -- suspend at intended points.
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
+3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
 2&:VACUUM crash_before_segmentfile_drop;
 3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
-3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 0, 0, 2);
+3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 1, -1, 0, 2);
 
 -- Only one AO table can be in drop phase at a time. VACUUM on
 -- crash_before_cleanup_phase will end up skipping the drop phase because
 -- previous VACUUM on crash_before_segmentfile_drop is suspended in drop
 -- phase. This results in segment file 1 remaining in drop pending state which
 -- results in segment file 1 not being scheduled for any new inserts.
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
+3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 1, -1, 0, 2);
 1&:VACUUM crash_before_cleanup_phase;
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
 
@@ -57,9 +57,9 @@
 0U: SELECT 1;
 
 -- reset faults as protection incase tests failed and panic didn't happen
-1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', '', '', '', 0, 0, 2);
-1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', '', '', '', 0, 0, 2);
-1:SELECT gp_inject_fault('appendonly_insert', 'reset', '', '', '', 0, 0, 2);
+1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
+1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
+1:SELECT gp_inject_fault('appendonly_insert', 'reset', 2);
 
 -- perform post crash validation checks
 -- for crash_before_cleanup_phase
@@ -113,20 +113,20 @@
 2:DELETE FROM crash_master_before_segmentfile_drop WHERE a < 4;
 
 -- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 0, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
 1&:VACUUM crash_master_before_cleanup_phase;
 SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
 -- crash_recovery
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 0, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
 2:VACUUM crash_master_before_segmentfile_drop;
 1<:
 
 -- reset faults as protection incase tests failed and panic didn't happen
-4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', '', '', '', 0, 0, 1);
-4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', '', '', '', 0, 0, 1);
+4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
+4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
 
 -- perform post crash validation checks
 -- for crash_master_before_cleanup_phase

--- a/src/test/isolation2/sql/uao_crash_compaction_row.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_row.sql
@@ -6,6 +6,7 @@
 -- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
 -- end_matchsubs
 3:CREATE extension if NOT EXISTS gp_inject_fault;
+3:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 --
 -- Test to validate crash at different points in AO/CO vacuum.
 --

--- a/src/test/isolation2/sql/uao_crash_compaction_row.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_row.sql
@@ -34,18 +34,18 @@
 -- suspend at intended points. Only one AO table can be in drop phase in a
 -- system at a time hence we must wait for this table's VACUUM to reach cleanup
 -- phase before triggering another VACUUM.
-3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 0, 0, 2);
+3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 1, -1, 0, 2);
 1&:VACUUM crash_before_cleanup_phase;
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
 
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 0, 0, 2);
+3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
 2&:VACUUM crash_before_segmentfile_drop;
 3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
 
 -- we already waited for suspend faults to trigger and hence we can proceed to
 -- run next command which would trigger panic fault and help test
 -- crash_recovery
-3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 0, 0, 2);
+3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 1, -1, 0, 2);
 3:VACUUM crash_vacuum_in_appendonly_insert;
 1<:
 2<:
@@ -54,9 +54,9 @@
 0U: SELECT 1;
 
 -- reset faults as protection incase tests failed and panic didn't happen
-1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', '', '', '', 0, 0, 2);
-1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', '', '', '', 0, 0, 2);
-1:SELECT gp_inject_fault('appendonly_insert', 'reset', '', '', '', 0, 0, 2);
+1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
+1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
+1:SELECT gp_inject_fault('appendonly_insert', 'reset', 2);
 
 -- perform post crash validation checks
 -- for crash_before_cleanup_phase
@@ -108,9 +108,9 @@
 2:DELETE FROM crash_master_before_segmentfile_drop WHERE a < 4;
 
 -- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 0, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
 1&:VACUUM crash_master_before_cleanup_phase;
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 0, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
 
 -- wait for suspend faults to trigger and then proceed to run next
 -- command which would trigger panic fault and help test
@@ -120,8 +120,8 @@ SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 1<:
 
 -- reset faults as protection incase tests failed and panic didn't happen
-4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', '', '', '', 0, 0, 1);
-4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', '', '', '', 0, 0, 1);
+4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
+4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
 
 -- perform post crash validation checks
 -- for crash_master_before_cleanup_phase

--- a/src/test/isolation2/sql/udf_exception_blocks_panic_scenarios.sql
+++ b/src/test/isolation2/sql/udf_exception_blocks_panic_scenarios.sql
@@ -90,7 +90,7 @@ BEGIN /* in func */
 END; /* in func */
 $$
 LANGUAGE plpgsql;
-
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=subtransaction_begin;

--- a/src/test/regress/expected/cursor.out
+++ b/src/test/regress/expected/cursor.out
@@ -78,10 +78,10 @@ abort;
 CREATE TABLE cursor_writer_reader (a int, b int) DISTRIBUTED BY (a);
 BEGIN;
 INSERT INTO cursor_writer_reader VALUES(1, 666);
-select gp_inject_fault('qe_got_snapshot_and_interconnect', 'suspend', 2);
+select gp_inject_fault_infinite('qe_got_snapshot_and_interconnect', 'suspend', 2);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 

--- a/src/test/regress/expected/errors-at-eox.out
+++ b/src/test/regress/expected/errors-at-eox.out
@@ -10,7 +10,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- throw an ERROR, just after we have broadcast the PREPARE of the
 -- transaction to segments.
-select gp_inject_fault('dtm_broadcast_prepare', 'error', '', '', '', 1, 0, 1::smallint);
+select gp_inject_fault('dtm_broadcast_prepare', 'error', 1::smallint);
  gp_inject_fault 
 -----------------
  t
@@ -25,7 +25,7 @@ select * from dtm_testtab;
 
 -- throw an ERROR, in master, just before we have broadcast the COMMIT
 -- PREPARED to segments.
-select gp_inject_fault('dtm_broadcast_commit_prepared', 'error', '', '', '', 1, 0, 1::smallint);
+select gp_inject_fault('dtm_broadcast_commit_prepared', 'error', 1::smallint);
  gp_inject_fault 
 -----------------
  t

--- a/src/test/regress/expected/fts_error.out
+++ b/src/test/regress/expected/fts_error.out
@@ -8,20 +8,20 @@ where content = 0 and mode = 's';
 
 -- Once this fault is hit, FTS process should abort current
 -- transaction and exit.
-select gp_inject_fault('fts_update_config', 'error', '', '', '', -1, 0, 1);
+select gp_inject_fault_infinite('fts_update_config', 'error', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 
 -- FTS probe connection should encounter an error due to this fault,
 -- injected on content 0 primary.
-select gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid)
+select gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15439)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 

--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -10,11 +10,11 @@ select role, preferred_role, mode from gp_segment_configuration where content = 
  m    | m              | s
 (2 rows)
 
-select gp_inject_fault('fts_conn_startup_packet', 'skip', '', '', '', -1, 0, dbid)
+select gp_inject_fault_infinite('fts_conn_startup_packet', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 
@@ -61,11 +61,11 @@ select role, preferred_role, mode from gp_segment_configuration where content = 
 -- test other scenario where recovery on primary is hung and hence FTS marks
 -- primary down and promotes mirror. When 'fts_recovery_in_progress' is set to
 -- skip it mimics the behavior of hung recovery on primary.
-select gp_inject_fault('fts_recovery_in_progress', 'skip', '', '', '', -1, 0, dbid)
+select gp_inject_fault_infinite('fts_recovery_in_progress', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 
@@ -142,7 +142,7 @@ select role, preferred_role, mode from gp_segment_configuration where content = 
 \!gpstop -u
 -- end_ignore
 -- cleanup steps
-select gp_inject_fault('fts_recovery_in_progress', 'reset', '', '', '', -1, 0, dbid)
+select gp_inject_fault('fts_recovery_in_progress', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=30929)
  gp_inject_fault 
@@ -150,7 +150,7 @@ NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=30929)
  t
 (1 row)
 
-select gp_inject_fault('fts_conn_startup_packet', 'reset', '', '', '', -1, 0, dbid)
+select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=27127)
  gp_inject_fault 

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -12,13 +12,14 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 (1 row)
 
 \dx+ gp_inject*
-                   Objects in extension "gp_inject_fault"
-                             Object Description                             
-----------------------------------------------------------------------------
+                       Objects in extension "gp_inject_fault"
+                                 Object Description                                 
+------------------------------------------------------------------------------------
+ function gp_inject_fault_infinite(text,text,integer)
  function gp_inject_fault(text,text,integer)
- function gp_inject_fault(text,text,text,text,text,integer,integer,integer)
+ function gp_inject_fault(text,text,text,text,text,integer,integer,integer,integer)
  function gp_wait_until_triggered_fault(text,integer,integer)
-(3 rows)
+(4 rows)
 
 --
 -- Test extended \du flags

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -33,7 +33,7 @@ select DISTINCT S from (select row_number() over(partition by i1 order by i2) AS
 (1 row)
 
 select gp_inject_fault('execsort_mksort_mergeruns', 'status', 2);
-NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'  (seg0 127.0.1.1:25432 pid=15470)
+NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -81,7 +81,7 @@ select * from cte c1, cte c2 limit 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'  (seg0 127.0.1.1:25432 pid=15470)
+NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -115,7 +115,7 @@ select * from cte c1, cte c2 limit 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'  (seg0 127.0.1.1:25432 pid=15470)
+NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -148,10 +148,10 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 -- with FTS probes.  Request a scan so that the skip fault is
 -- triggered immediately, rather that waiting until the next probe
 -- interval.
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 
@@ -169,7 +169,7 @@ NOTICE:  Success:
 (1 row)
 
 -- make one QE sleep before reading command
-select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 50, 2::smallint);
+select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, -1, 50, 2::smallint);
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------

--- a/src/test/regress/expected/segspace.out
+++ b/src/test/regress/expected/segspace.out
@@ -51,7 +51,7 @@ SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE 
 ERROR:  canceling MPP operation  (seg0 slice2 127.0.0.1:25432 pid=26876)
 rollback;
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -111,7 +111,7 @@ SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE 
 ERROR:  canceling MPP operation  (seg0 127.0.0.1:25432 pid=26876)
 rollback;
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -169,7 +169,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 ERROR:  canceling MPP operation  (seg0 127.0.0.1:25432 pid=26876)
 rollback;
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -239,7 +239,7 @@ update foo set j=m.cc1 from (
   where t1.i1 = t2.i2 ) as m;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice3 127.0.0.1:25432 pid=3175)
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -308,7 +308,7 @@ delete from testsisc using (
 ) src  where testsisc.i1 = src.i;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 127.0.0.1:25432 pid=3143)
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -372,7 +372,7 @@ select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used
 (1 row)
 
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -423,7 +423,7 @@ select * from
 where x.a = ctesisc.i1) y;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice1 127.0.0.1:25432 pid=3175)
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t

--- a/src/test/regress/expected/spi_processed64bit.out
+++ b/src/test/regress/expected/spi_processed64bit.out
@@ -13,7 +13,7 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "spi64bittest_pke
 -- Use type 'skip', because we don't want to throw an ERROR or worse. There
 -- is special handling at the code that checks for this fault, to bump up
 -- the row counter regardless of the fault type.
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 NOTICE:  Success:
@@ -29,15 +29,15 @@ NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
 (4 rows)
 
 -- insert enough rows to trigger the fault injector
-SELECT gp_inject_fault('executor_run_high_processed', 'skip', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 NOTICE:  Success:
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
 NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
 NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
@@ -58,7 +58,7 @@ begin
 end;
 $$;
 NOTICE:  Inserted 4294987269 rows
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 NOTICE:  Success:
@@ -81,15 +81,15 @@ SELECT COUNT(*) AS count
 (1 row)
 
 -- update all rows, and trigger the fault injector
-SELECT gp_inject_fault('executor_run_high_processed', 'skip', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 NOTICE:  Success:
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
 NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
 NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
@@ -109,7 +109,7 @@ begin
 end;
 $$;
 NOTICE:  Updated 4294987269 rows
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 NOTICE:  Success:
@@ -132,15 +132,15 @@ SELECT COUNT(*) AS count
 (1 row)
 
 -- delete all rows, and trigger the fault injector
-SELECT gp_inject_fault('executor_run_high_processed', 'skip', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 NOTICE:  Success:
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
 NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
 NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
@@ -159,7 +159,7 @@ begin
 end;
 $$;
 NOTICE:  Deleted 4294987269 rows
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 NOTICE:  Success:
@@ -217,15 +217,15 @@ SELECT sql_exec_stmt('INSERT INTO public.spi64bittest_2 (id) SELECT generate_ser
 (1 row)
 
 -- activate fault injector
-SELECT gp_inject_fault('executor_run_high_processed', 'skip', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 NOTICE:  Success:
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
 NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
 NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
  t
  t
@@ -257,7 +257,7 @@ SELECT sql_exec_stmt('INSERT INTO public.spi64bittest_2 (id) SELECT id FROM publ
    12884901855
 (1 row)
 
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 NOTICE:  Success:

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -26,7 +26,7 @@ NOTICE:  Success:
 SELECT COUNT(t1.*) FROM test_zlib_hashjoin AS t1, test_zlib_hashjoin AS t2 WHERE t1.i1=t2.i2;
 ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=2829)
 select gp_inject_fault('workfile_creation_failure', 'status', 2);
-NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -60,7 +60,7 @@ NOTICE:  Success:
 SELECT MAX(i1) FROM test_zlib_hagg GROUP BY i2;
 ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=2829)
 select gp_inject_fault('workfile_creation_failure', 'status', 2);
-NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -127,7 +127,7 @@ select * from t1;
 (0 rows)
 
 select gp_inject_fault('workfile_creation_failure', 'status', 2);
-NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -573,7 +573,7 @@ create extension if not exists gp_inject_fault;
 -- Inject fault on one primary segment that will cause compression to
 -- be considered not useful.
 select gp_inject_fault('appendonly_skip_compression', 'skip', '', '',
-'aocs_small_and_dense_content', -1, 0, dbid)
+'aocs_small_and_dense_content', 1, -1, 0, dbid)
 from gp_segment_configuration where role = 'p' and content = 0;
 
 insert into aocs_small_and_dense_content select i,i from

--- a/src/test/regress/input/autovacuum-template0.source
+++ b/src/test/regress/input/autovacuum-template0.source
@@ -12,7 +12,7 @@ set debug_burn_xids=on;
 select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
 
 -- track that we've updated the row in pg_database for template0
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', 1);
+SELECT gp_inject_fault_infinite('vacuum_update_dat_frozen_xid', 'skip', 1);
 
 select test_consume_xids(100 * 1000000);
 select test_consume_xids(100 * 1000000);

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -11,13 +11,9 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- end_matchsubs
 
 -- skip FTS probes always
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
-select gp_inject_fault('fts_probe', 'status', 1);
-
--- skip Gdd probes always
-select gp_inject_fault('gdd_probe', 'skip', '', '', '', -1, 0, 1);
-select gp_inject_fault('gdd_probe', 'wait_until_triggered', 1);
-select gp_inject_fault('gdd_probe', 'status', 1);
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
+select gp_request_fts_probe_scan();
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 -- Test quoting of GUC values and database names when they're sent to segments
 set client_min_messages='warning';
@@ -162,7 +158,7 @@ select cleanupAllGangs();
 
 -- trigger fault and put segment 0 into recovery mode
 select gp_inject_fault('process_startup_packet', 'segv', 2);
-select gp_inject_fault('quickdie', 'sleep', '', '', '', 1, 5, 2::smallint);
+select gp_inject_fault('quickdie', 'sleep', '', '', '', 1, 1, 5, 2::smallint);
 select cleanupAllGangs();
 --start_ignore
 select 'trigger fault' from gp_dist_random('gp_id');
@@ -175,6 +171,7 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 
 -- Wait for the quickdie() sleep to time out, and the server to restart.
 select pg_sleep(5);
+
 set gp_gang_creation_retry_count to 100;
 select gp_inject_fault('process_startup_packet', 'reset', 2);
 select gp_inject_fault('quickdie', 'reset', 2);
@@ -222,7 +219,7 @@ select cleanupAllGangs();
 
 select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 -- segment 0 report an error when get the second request (reader gang creation request)
-select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 0, 2::smallint);
+select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint);
 select cleanupAllGangs();
 
 -- expect failure
@@ -241,20 +238,24 @@ select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 -- Test createGang timeout.
 -- gp_segment_connect_timeout = 0 : wait forever
 -- gp_segment_connect_timeout = 1 : wait 1 second
-select cleanupAllGangs();
 
-select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 5, 2::smallint);
 set gp_segment_connect_timeout to 1;
+select gp_inject_fault('process_startup_packet', 'suspend', 2);
+
+select cleanupAllGangs();
 
 -- expect timeout failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 
-set gp_segment_connect_timeout to 0;
+select gp_inject_fault('process_startup_packet', 'resume', 2);
 select gp_inject_fault('process_startup_packet', 'reset', 2);
-select cleanupAllGangs();
 
-select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 1, 2::smallint);
+set gp_segment_connect_timeout to 0;
+
+select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 1, 2, 2::smallint);
+
+select cleanupAllGangs();
 
 -- expect success 
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
@@ -367,4 +368,3 @@ end;
 
 -- resume FTS probes
 select gp_inject_fault('fts_probe', 'reset', 1);
-select gp_inject_fault('gdd_probe', 'reset', 1);

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1157,7 +1157,7 @@ create extension if not exists gp_inject_fault;
 -- Inject fault on one primary segment that will cause compression to
 -- be considered not useful.
 select gp_inject_fault('appendonly_skip_compression', 'skip', '', '',
-'aocs_small_and_dense_content', -1, 0, dbid)
+'aocs_small_and_dense_content', 1, -1, 0, dbid)
 from gp_segment_configuration where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------

--- a/src/test/regress/output/autovacuum-template0.source
+++ b/src/test/regress/output/autovacuum-template0.source
@@ -13,10 +13,10 @@ select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='templat
 (1 row)
 
 -- track that we've updated the row in pg_database for template0
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', 1);
+SELECT gp_inject_fault_infinite('vacuum_update_dat_frozen_xid', 'skip', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -8,39 +8,23 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
 -- end_matchsubs
 -- skip FTS probes always
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 
-select gp_inject_fault('fts_probe', 'status', 1);
-NOTICE:  Success: fault name:'fts_probe' fault type:'skip' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'0' fault injection state:'set'  num times hit:'0'
- gp_inject_fault 
------------------
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
  t
 (1 row)
 
--- skip Gdd probes always
-select gp_inject_fault('gdd_probe', 'skip', '', '', '', -1, 0, 1);
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
- t
-(1 row)
-
-select gp_inject_fault('gdd_probe', 'wait_until_triggered', 1);
-NOTICE:  Success:
- gp_inject_fault 
------------------
- t
-(1 row)
-
-select gp_inject_fault('gdd_probe', 'status', 1);
-NOTICE:  Success: fault name:'gdd_probe' fault type:'skip' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'0' fault injection state:'triggered'  num times hit:'1'
- gp_inject_fault 
------------------
+ gp_wait_until_triggered_fault 
+-------------------------------
  t
 (1 row)
 
@@ -265,7 +249,7 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11116)
  t
 (1 row)
 
-select gp_inject_fault('quickdie', 'sleep', '', '', '', 1, 5, 2::smallint);
+select gp_inject_fault('quickdie', 'sleep', '', '', '', 1, 1, 5, 2::smallint);
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11116)
  gp_inject_fault 
 -----------------
@@ -414,7 +398,7 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11272)
 (1 row)
 
 -- segment 0 report an error when get the second request (reader gang creation request)
-select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 0, 2::smallint);
+select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint);
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11272)
  gp_inject_fault 
 -----------------
@@ -458,27 +442,33 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11284)
 -- Test createGang timeout.
 -- gp_segment_connect_timeout = 0 : wait forever
 -- gp_segment_connect_timeout = 1 : wait 1 second
+set gp_segment_connect_timeout to 1;
+select gp_inject_fault('process_startup_packet', 'suspend', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 select cleanupAllGangs();
  cleanupallgangs 
 -----------------
  t
 (1 row)
 
-select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 5, 2::smallint);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
- gp_inject_fault 
------------------
- t
-(1 row)
-
-set gp_segment_connect_timeout to 1;
 -- expect timeout failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 ERROR:  failed to acquire resources on one or more segments
 DETAIL:  timeout expired
  (seg0 127.0.0.1:40000)
-set gp_segment_connect_timeout to 0;
+select gp_inject_fault('process_startup_packet', 'resume', 2);
+NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 select gp_inject_fault('process_startup_packet', 'reset', 2);
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
  gp_inject_fault 
@@ -486,15 +476,16 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
  t
 (1 row)
 
-select cleanupAllGangs();
- cleanupallgangs 
+set gp_segment_connect_timeout to 0;
+select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 1, 2, 2::smallint);
+NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11337)
+ gp_inject_fault 
 -----------------
  t
 (1 row)
 
-select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 1, 2::smallint);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11337)
- gp_inject_fault 
+select cleanupAllGangs();
+ cleanupallgangs 
 -----------------
  t
 (1 row)
@@ -679,13 +670,6 @@ begin isolation level read uncommitted;
 end;
 -- resume FTS probes
 select gp_inject_fault('fts_probe', 'reset', 1);
-NOTICE:  Success:
- gp_inject_fault 
------------------
- t
-(1 row)
-
-select gp_inject_fault('gdd_probe', 'reset', 1);
 NOTICE:  Success:
  gp_inject_fault 
 -----------------

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -1113,8 +1113,6 @@ PG_FUNCTION_INFO_V1(hasBackendsExist);
 Datum
 hasBackendsExist(PG_FUNCTION_ARGS)
 {
-	const char *walreceiver = "walreceiver";
-
 	int beid;
 	int32 result;
 	int timeout = PG_GETARG_INT32(0);
@@ -1132,9 +1130,8 @@ hasBackendsExist(PG_FUNCTION_ARGS)
 		for (beid = 1; beid <= tot_backends; beid++)
 		{
 			PgBackendStatus *beentry = pgstat_fetch_stat_beentry(beid);
-			if (beentry && beentry->st_procpid >0 && beentry->st_procpid != pid
-					&& strncmp(walreceiver, beentry->st_appname, strlen(walreceiver)) /* exclude the WALREP process*/
-				)
+			if (beentry && beentry->st_procpid >0 && beentry->st_procpid != pid &&
+				beentry->st_session_id == gp_session_id)
 				result++;
 		}
 		if (result == 0 || timeout == 0)

--- a/src/test/regress/sql/cursor.sql
+++ b/src/test/regress/sql/cursor.sql
@@ -53,7 +53,7 @@ abort;
 CREATE TABLE cursor_writer_reader (a int, b int) DISTRIBUTED BY (a);
 BEGIN;
 INSERT INTO cursor_writer_reader VALUES(1, 666);
-select gp_inject_fault('qe_got_snapshot_and_interconnect', 'suspend', 2);
+select gp_inject_fault_infinite('qe_got_snapshot_and_interconnect', 'suspend', 2);
 DECLARE cursor_c2 CURSOR FOR SELECT * FROM cursor_writer_reader WHERE b=666 ORDER BY 1;
 SAVEPOINT x;
 UPDATE cursor_writer_reader SET b=333 WHERE b=666;

--- a/src/test/regress/sql/errors-at-eox.sql
+++ b/src/test/regress/sql/errors-at-eox.sql
@@ -10,7 +10,7 @@ CREATE TABLE dtm_testtab(id int4);
 
 -- throw an ERROR, just after we have broadcast the PREPARE of the
 -- transaction to segments.
-select gp_inject_fault('dtm_broadcast_prepare', 'error', '', '', '', 1, 0, 1::smallint);
+select gp_inject_fault('dtm_broadcast_prepare', 'error', 1::smallint);
 
 insert into dtm_testtab values (1), (2);
 
@@ -18,7 +18,7 @@ select * from dtm_testtab;
 
 -- throw an ERROR, in master, just before we have broadcast the COMMIT
 -- PREPARED to segments.
-select gp_inject_fault('dtm_broadcast_commit_prepared', 'error', '', '', '', 1, 0, 1::smallint);
+select gp_inject_fault('dtm_broadcast_commit_prepared', 'error', 1::smallint);
 
 insert into dtm_testtab values (3), (4);
 
@@ -26,7 +26,7 @@ select * from dtm_testtab;
 
 -- throw an ERROR, after we have flushed the (two-phase) commit record
 -- to disk in master.
-select gp_inject_fault('dtm_xlog_distributed_commit', 'error', '', '', '', 1, 0, 1::smallint);
+select gp_inject_fault('dtm_xlog_distributed_commit', 'error', 1::smallint);
 
 insert into dtm_testtab values (3), (4);
 

--- a/src/test/regress/sql/fts_error.sql
+++ b/src/test/regress/sql/fts_error.sql
@@ -3,10 +3,10 @@ select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';
 -- Once this fault is hit, FTS process should abort current
 -- transaction and exit.
-select gp_inject_fault('fts_update_config', 'error', '', '', '', -1, 0, 1);
+select gp_inject_fault_infinite('fts_update_config', 'error', 1);
 -- FTS probe connection should encounter an error due to this fault,
 -- injected on content 0 primary.
-select gp_inject_fault('fts_handle_message', 'error', '', '', '', -1, 0, dbid)
+select gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 -- Upon failure to probe content 0 primary, FTS will try to update the
 -- configuration.  The update to configuration will hit error due to

--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -4,7 +4,7 @@
 -- test.
 create extension if not exists gp_inject_fault;
 select role, preferred_role, mode from gp_segment_configuration where content = 0;
-select gp_inject_fault('fts_conn_startup_packet', 'skip', '', '', '', -1, 0, dbid)
+select gp_inject_fault_infinite('fts_conn_startup_packet', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 -- to make test deterministic and fast
 -- start_ignore
@@ -29,8 +29,7 @@ select role, preferred_role, mode from gp_segment_configuration where content = 
 -- test other scenario where recovery on primary is hung and hence FTS marks
 -- primary down and promotes mirror. When 'fts_recovery_in_progress' is set to
 -- skip it mimics the behavior of hung recovery on primary.
-
-select gp_inject_fault('fts_recovery_in_progress', 'skip', '', '', '', -1, 0, dbid)
+select gp_inject_fault_infinite('fts_recovery_in_progress', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 -- We call gp_request_fts_probe_scan twice to guarantee that the scan happens
 -- after the fts_recovery_in_progress fault has been injected. If periodic fts
@@ -83,7 +82,7 @@ select role, preferred_role, mode from gp_segment_configuration where content = 
 -- end_ignore
 
 -- cleanup steps
-select gp_inject_fault('fts_recovery_in_progress', 'reset', '', '', '', -1, 0, dbid)
+select gp_inject_fault('fts_recovery_in_progress', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
-select gp_inject_fault('fts_conn_startup_packet', 'reset', '', '', '', -1, 0, dbid)
+select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -71,12 +71,12 @@ create table _tmp_table2 as select i as c1, 0 as c2 from generate_series(0, 10) 
 -- with FTS probes.  Request a scan so that the skip fault is
 -- triggered immediately, rather that waiting until the next probe
 -- interval.
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 select gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 -- make one QE sleep before reading command
-select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 50, 2::smallint);
+select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, -1, 50, 2::smallint);
 
 begin;
 select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;

--- a/src/test/regress/sql/spi_processed64bit.sql
+++ b/src/test/regress/sql/spi_processed64bit.sql
@@ -15,13 +15,13 @@ CREATE TABLE public.spi64bittest (id BIGSERIAL PRIMARY KEY, data BIGINT);
 -- is special handling at the code that checks for this fault, to bump up
 -- the row counter regardless of the fault type.
 
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 
 
 -- insert enough rows to trigger the fault injector
-SELECT gp_inject_fault('executor_run_high_processed', 'skip', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 DO $$
@@ -37,7 +37,7 @@ begin
   RAISE NOTICE 'Inserted % rows', num_rows;
 end;
 $$;
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 SELECT COUNT(*) AS count
@@ -45,7 +45,7 @@ SELECT COUNT(*) AS count
 
 
 -- update all rows, and trigger the fault injector
-SELECT gp_inject_fault('executor_run_high_processed', 'skip', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 DO $$
@@ -60,7 +60,7 @@ begin
   RAISE NOTICE 'Updated % rows', num_rows;
 end;
 $$;
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 SELECT COUNT(*) AS count
@@ -68,7 +68,7 @@ SELECT COUNT(*) AS count
 
 
 -- delete all rows, and trigger the fault injector
-SELECT gp_inject_fault('executor_run_high_processed', 'skip', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 DO $$
@@ -82,7 +82,7 @@ begin
   RAISE NOTICE 'Deleted % rows', num_rows;
 end;
 $$;
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 SELECT COUNT(*) AS count
@@ -120,7 +120,7 @@ CREATE TABLE public.spi64bittest_2 (id BIGINT);
 SELECT sql_exec_stmt('INSERT INTO public.spi64bittest_2 (id) SELECT generate_series(1,5000)');
 
 -- activate fault injector
-SELECT gp_inject_fault('executor_run_high_processed', 'skip', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 
@@ -130,7 +130,7 @@ SELECT sql_exec_stmt('INSERT INTO public.spi64bittest_2 (id) SELECT id FROM publ
 SELECT sql_exec_stmt('INSERT INTO public.spi64bittest_2 (id) SELECT id FROM public.spi64bittest_2');
 SELECT sql_exec_stmt('INSERT INTO public.spi64bittest_2 (id) SELECT id FROM public.spi64bittest_2');
 
-SELECT gp_inject_fault('executor_run_high_processed', 'reset', '', '', '', 0, 0, dbid)
+SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
 SELECT COUNT(*) AS count

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/GPDBStorageBaseTestCase.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/GPDBStorageBaseTestCase.py
@@ -55,11 +55,11 @@ class GPDBStorageBaseTestCase():
         self.dbstate = DbStateClass('run_validation', self.config)
         self.port = os.getenv('PGPORT')
 
-    def invoke_fault(self, fault_name, type, role='mirror', port=None, occurence=None, sleeptime=None, seg_id=None):
+    def invoke_fault(self, fault_name, type, role='mirror', port=None, s_occurence=None, e_occurrence=None, extra_arg=None, seg_id=None):
         ''' Reset the fault and then issue the fault with the given type'''
-        self.filereputil.inject_fault(f=fault_name, y='reset', r=role , o=occurence, sleeptime=sleeptime, seg_id=seg_id)
-        self.filereputil.inject_fault(f=fault_name, y=type, r=role , o=occurence, sleeptime=sleeptime, seg_id=seg_id)
-        tinctest.logger.info('Successfully injected fault_name : %s fault_type : %s  occurence : %s ' % (fault_name, type, occurence))
+        self.filereputil.inject_fault(f=fault_name, y='reset', r=role , s_o=s_occurence, e_o=e_occurrence, extra_arg=extra_arg, seg_id=seg_id)
+        self.filereputil.inject_fault(f=fault_name, y=type, r=role , s_o=s_occurence, e_o=e_occurrence, extra_arg=extra_arg, seg_id=seg_id)
+        tinctest.logger.info('Successfully injected fault_name : %s fault_type : %s  s_occurence : %s  e_occurence : %s' % (fault_name, type, s_occurence, e_occurrence))
 
     def start_db(self):
         '''Gpstart '''

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/lib/base.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/lib/base.py
@@ -36,15 +36,15 @@ class BaseClass(MPPTestCase):
         super(BaseClass,self).__init__(methodName)
         
 
-    def inject_fault(self, fault_name, type, role='mirror', occurence=0, sleeptime=0, seg_id=None):
+    def inject_fault(self, fault_name, type, role='mirror', s_occurence=1, e_occurrence=1, extra_arg=0, seg_id=None):
         ''' Reset the fault and then issue the fault with the given type'''
-        self.filereputil.inject_fault(f=fault_name, y='reset', r=role, o=occurence, sleeptime=sleeptime, seg_id=seg_id)
-        self.filereputil.inject_fault(f=fault_name, y=type, r=role, o=occurence, sleeptime=sleeptime, seg_id=seg_id)
+        self.filereputil.inject_fault(f=fault_name, y='reset', r=role, s_o=s_occurence, e_o=e_occurrence, extra_arg=extra_arg, seg_id=seg_id)
+        self.filereputil.inject_fault(f=fault_name, y=type, r=role, s_o=s_occurence, e_o=e_occurrence, extra_arg=extra_arg, seg_id=seg_id)
         tinctest.logger.info('Successfully injected fault_name : %s fault_type : %s  occurence : %s ' % (fault_name, type, occurence))
    
-    def reset_fault(self, fault_name, role='mirror', port=None, occurence=0, sleeptime=0, seg_id=None):
+    def reset_fault(self, fault_name, role='mirror', port=None, s_occurence=1, e_occurrence=1, extra_arg=0, seg_id=None):
         ''' Reset the fault '''
-        self.filereputil.inject_fault(f=fault_name, y='reset', r=role, o=occurence, sleeptime=sleeptime, seg_id=seg_id)
+        self.filereputil.inject_fault(f=fault_name, y='reset', r=role, s_o=s_occurence, e_o=e_occurrence, extra_arg=extra_arg, seg_id=seg_id)
         tinctest.logger.info('Successfully reset fault_name : %s fault_type : %s  occurence : %s ' % (fault_name, type, occurence))
 
     def check_fault_status(self, fault_name, seg_id=None, role=None):

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/basebackup/test_xlog_cleanup.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/basebackup/test_xlog_cleanup.py
@@ -37,15 +37,15 @@ class basebackup_cases(mpp.gpdb.tests.storage.walrepl.run.StandbyRunMixin, MPPTe
         super(basebackup_cases, self).tearDown()
         self.reset_fault('base_backup_post_create_checkpoint')
 
-    def run_gp_inject_fault(self, fault_type, fault_name):
+    def run_gp_inject_fault(self, fault_type, fault_name, s_occurrence=1, e_occurrence=1):
         fault_injector = Filerepe2e_Util()
-        fault_injector.inject_fault(f=fault_name, y=fault_type, seg_id=1)
+        fault_injector.inject_fault(f=fault_name, y=fault_type, seg_id=1, s_o=s_occurrence, e_o=e_occurrence)
 
     def resume(self, fault_name):
         self.run_gp_inject_fault('resume', fault_name)
 
     def suspend_at(self, fault_name):
-        self.run_gp_inject_fault('suspend', fault_name)
+        self.run_gp_inject_fault('suspend', fault_name, 1, -1)
 
     def reset_fault(self, fault_name):
         self.run_gp_inject_fault('reset', fault_name)

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/xact/test_basic.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/xact/test_basic.py
@@ -92,7 +92,7 @@ class xansrep(mpp.gpdb.tests.storage.walrepl.run.StandbyRunMixin, MPPTestCase):
 
         fault_injector = Filerepe2e_Util()
         # 2. Inject fault at commit prepared state
-        fault_injector.inject_fault(f='dtm_broadcast_commit_prepared', y='suspend', seg_id=1)
+        fault_injector.inject_fault(f='dtm_broadcast_commit_prepared', y='suspend', seg_id=1, s_o=1, e_o=-1)
 
         # 3. Now execute a transaction and commit it. The backend is expected
         #    to be blocked.
@@ -111,7 +111,7 @@ class xansrep(mpp.gpdb.tests.storage.walrepl.run.StandbyRunMixin, MPPTestCase):
         self.assertTrue(triggered, 'Fault was not triggered')
 
         # 4. Inject fault at prepared state
-        fault_injector.inject_fault(f='transaction_abort_after_distributed_prepared', y='suspend', seg_id=1)
+        fault_injector.inject_fault(f='transaction_abort_after_distributed_prepared', y='suspend', seg_id=1, s_o=1, e_o=-1)
 
         # 5. Now execute a transaction and commit it. The backend is expected
         #    to be blocked.

--- a/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
+++ b/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
@@ -59,8 +59,8 @@ class Filerepe2e_Util():
                raise Exception("Timed out: cluster not in change tracking")
         return (True,num_cl)
 
-    def inject_fault(self, y = None, f = None, r ='mirror', seg_id = None, H='ALL', m ='async', sleeptime=0,
-                     o=0, table = '', database = ''):
+    def inject_fault(self, y = None, f = None, r ='mirror', seg_id = None, H='ALL', m ='async', extra_arg=0,
+                     s_o=1, e_o=1, table = '', database = ''):
         '''
         PURPOSE : 
             Inject the fault using gpfaultinjector
@@ -76,20 +76,23 @@ class Filerepe2e_Util():
              raise Exception('MASTER_DATA_DIRECTORY environment variable is not set.')
         
         fault_cmd = ("select gp_inject_fault('{fault}', '{type}', '{ddl}', '{database}',"
-                     " '{table}', {occurrences}, {sleeptime}, {dbid})")
+                     " '{table}', {s_occurrences}, {e_occurrence}, {extra_arg}, {dbid})")
         if seg_id is None:
             fault_cmd = fault_cmd + " from gp_segment_configuration where role = '{role}'"
             if r == 'mirror':
                 fault_sql = fault_cmd.format(fault=f, type=y, ddl='', database=database, table=table,
-                                             occurrences=o, sleeptime=sleeptime, dbid='dbid', role='m')
+                                             s_occurrences=s_o, e_occurrence=e_o, extra_arg=extra_arg,
+                                             dbid='dbid', role='m')
             elif r == 'primary':
                 fault_sql = fault_cmd.format(fault=f, type=y, ddl='', database=database, table=table,
-                                             occurrences=o, sleeptime=sleeptime, dbid='dbid', role='p')
+                                             s_occurrences=s_o, e_occurrence=e_o, extra_arg=extra_arg,
+                                             dbid='dbid', role='p')
             else:
                 assert False
         else:
             fault_sql = fault_cmd.format(fault=f, type=y, ddl='', database=database, table=table,
-                                         occurrences=o, sleeptime=sleeptime, dbid=seg_id)
+                                         s_occurrences=s_o, e_occurrence=e_o, extra_arg=extra_arg,
+                                         dbid=seg_id)
 
         results = {'rc':-1, 'stdout':'', 'stderr':''}
         PSQL.run_sql_command(fault_sql, results=results)

--- a/src/test/walrep/expected/missing_xlog.out
+++ b/src/test/walrep/expected/missing_xlog.out
@@ -120,10 +120,10 @@ create extension if not exists gp_inject_fault;
 -- temporarily in the test.  Request a scan so that the skip fault is
 -- triggered immediately, rather that waiting until the next probe
 -- interval.
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_infinite 
+--------------------------
  t
 (1 row)
 

--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -121,7 +121,7 @@ create extension if not exists gp_inject_fault;
 -- temporarily in the test.  Request a scan so that the skip fault is
 -- triggered immediately, rather that waiting until the next probe
 -- interval.
-select gp_inject_fault('fts_probe', 'skip', '', '', '', -1, 0, 1);
+select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 select gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 


### PR DESCRIPTION
* Add counting feature so a fault can be triggered N times.
* Add a simpler version named gp_inject_fault_infinite.
* Refine and make code cleaner include renaming sleepTimes
  to extraArg so it can be used by other fault types.

Now 3 functions provided:

1. gp_inject_fault(faultname, type, ddl, database, tablename,
					start_occurrence, end_occurrence, extra_arg, db_id)
startOccurrence: nth occurrence that a fault starts triggering
endOccurrence: nth occurrence that a fault stops triggering,
-1 means the fault is always triggered until it is reset.

2. gp_inject_fault(faultname, type, db_id)
simpler version for fault triggered only once.

3. gp_inject_fault_infinite(faultname, type, db_id)
simpler version for fault always triggered until it's reset.