### PR TITLE
Run unittests as part of Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ addons:
     packages:
     - libevent-dev
     - g++-6
+    - python-dev
+    - python-yaml
 
 ## ----------------------------------------------------------------------
 ## Build tools
@@ -98,6 +100,8 @@ script:
   - make install USE_PGXS=1
   - cd ${TRAVIS_BUILD_DIR}/gpAux/extensions/gpmapreduce
   - make install
+  - cd ${TRAVIS_BUILD_DIR}
+  - make unittest-check
   - postgres --version
   - initdb --version
   - createdb --version

--- a/src/Makefile.mock
+++ b/src/Makefile.mock
@@ -7,7 +7,7 @@ override CPPFLAGS+= -I$(CMOCKERY_DIR)
 
 $(MOCK_DIR)/%_mock.c: $(abs_top_srcdir)/src/%.c
 	@echo mocking $<
-	@(cd $(MOCK_DIR) && PYTHONPATH=$(python_libdir) $(PYTHON) mocker.py $<)
+	PYTHONPATH=$(python_libdir) $(MOCK_DIR)/mocker.py $<
 
 # For some reason, mock.o files are intermediate files sometimes.
 # Mark them as secondary in order not to be deleted automatically.


### PR DESCRIPTION
Running the full ICW under Travis was problematic, but the unittests doesn't require a running cluster so let's run them at least to boost coverage.