### PR TITLE
Undo accidental reversion of two commits

### DIFF
--- a/gpMgmt/bin/lib/gpenv.sh
+++ b/gpMgmt/bin/lib/gpenv.sh
@@ -21,7 +21,7 @@ export PYTHONPATH
 PYTHONHOME=$GPHOME/ext/python
 export PYTHONHOME
 
-# Add in library paths apropriate for this system
+# Add in library paths appropriate for this system
 case `uname` in
   Darwin) 
      if [ $DYLD_LIBRARY_PATH ]

--- a/python-dependencies.txt
+++ b/python-dependencies.txt
@@ -1,6 +1,6 @@
+argparse=1.2.1
 behave==1.2.4
 ecdsa==0.13
-enum34==1.1.6
 epydoc==3.0.1
 lockfile==0.9.1
 logilab-astng==0.20.1
@@ -9,11 +9,8 @@ MarkupSafe==1.0
 mock==1.0.1
 paramiko==1.18.1
 parse==1.8.2
-parse-type==0.4.2
 psutil==4.0.0
-ptyprocess==0.5.2
 pycrypto==2.6.1
 pylint==0.21.0
 setuptools==36.6.0
-six==1.11.0
 unittest2==0.5.1

--- a/python-developer-dependencies.txt
+++ b/python-developer-dependencies.txt
@@ -1,5 +1,9 @@
+enum34==1.1.6
 Jinja2==2.10
+parse-type==0.4.2
 pexpect==4.4.0
 PSI==0.3b2
 pysql==0.16
 PyYAML==3.12
+ptyprocess==0.5.2
+six==1.11.0


### PR DESCRIPTION
As part of the merge with PostgreSQL 9.1, two `gpdb/master` commits were incorrectly reverted. This change replays the following commits:

```
commit dd42f3d4411f23c5fae9f30b8d703c239e7b4c98
Author: Todd Sedano <tsedano@pivotal.io>
Date:   Thu May 17 10:47:30 2018 -0700

    Syncing python-dependencies with pythonsrc-ext

    In comparing https://github.com/greenplum-db/pythonsrc-ext
    to python-dependencies.txt, there are several differences.

    pythonsrc-ext is the vendored python repo, so it should be
    in sync with pythonsrc-ext

    argparse is in pythonsrc-ext, adding it to python-dependencies.txt

    enum34, parse-type, ptyprocess, six are not in pythonsrc-ext,
    so moving them to python-developer-dependencies.txt

    Authored-by: Todd Sedano <tsedano@pivotal.io>
```
```
commit 7f9f11d3c50abfbaeb2fe478ab5f9eead85f9c23
Author: Daniel Gustafsson <dgustafsson@pivotal.io>
Date:   Fri May 18 09:43:48 2018 +0200

    Fix typo in comment
```
@danielgustafsson @professor FYI