### PR TITLE
Add gpaddmirrors workload test

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -2,8 +2,8 @@
 Feature: Tests for gpaddmirrors
 
     Scenario: gpaddmirrors with a default master data directory
-        Given a working directory of the test as '/tmp/gpexpand_behave'
-        And the user runs command "rm -rf /tmp/gpexpand_behave/*"
+        Given a working directory of the test as '/tmp/gpaddmirrors'
+        And the user runs command "rm -rf /tmp/gpaddmirrors/*"
         And the database is killed on hosts "mdw,sdw1"
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And gpaddmirrors adds mirrors
@@ -11,9 +11,28 @@ Feature: Tests for gpaddmirrors
 
     @gpaddmirrors_temp_directory
     Scenario: gpaddmirrors with a given master data directory [-d <master datadir>]
-        Given a working directory of the test as '/tmp/gpexpand_behave'
-        And the user runs command "rm -rf /tmp/gpexpand_behave/*"
+        Given a working directory of the test as '/tmp/gpaddmirrors'
+        And the user runs command "rm -rf /tmp/gpaddmirrors/*"
         And the database is killed on hosts "mdw,sdw1"
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And gpaddmirrors adds mirrors with temporary data dir
         Then verify the database has mirrors
+
+    @gpaddmirrors_workload
+    Scenario: gpaddmirrors when the primaries have data
+        Given a working directory of the test as '/tmp/gpaddmirrors'
+        And the user runs command "rm -rf /tmp/gpaddmirrors/*"
+        And the database is killed on hosts "mdw,sdw1"
+        And a cluster is created with no mirrors on "mdw" and "sdw1"
+        And database "gptest" exists
+        And there is a "heap" table "public.heap_table" in "gptest" with "100" rows
+        And there is a "ao" table "public.ao_table" in "gptest" with "100" rows
+        And there is a "co" table "public.co_table" in "gptest" with "100" rows
+        And gpaddmirrors adds mirrors with temporary data dir
+        And an FTS probe is triggered
+        And the segments are synchronized
+        When user kills all primary processes
+        And user can start transactions
+        Then verify that there is a "heap" table "public.heap_table" in "gptest" with "100" rows
+        Then verify that there is a "ao" table "public.ao_table" in "gptest" with "100" rows
+        Then verify that there is a "co" table "public.co_table" in "gptest" with "100" rows

--- a/gpMgmt/test/behave_utils/cluster_setup.py
+++ b/gpMgmt/test/behave_utils/cluster_setup.py
@@ -101,7 +101,7 @@ class TestCluster:
         # Whether to do gpinitsystem or not
         self.mirror_enabled = False
         self.number_of_segments = 2
-        self.number_of_hosts = 1
+        self.number_of_hosts = len(self.hosts)-1
         self.standby_enabled = False
 
         self.number_of_expansion_hosts = 0


### PR DESCRIPTION
This test explicitly creates some tables and verifies that they can be
read from after gpaddmirrors has been run on the cluster. The existing
TINC test that does this will be deleted after all the new gpaddmirrors
tests have been added.

We've also added some code to allow cluster creation on more than one
segment host.

Co-authored-by: Nadeem Ghani <nghani@pivotal.io>
Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>