### PR TITLE
[Fix Build] gpAux/Makefile: generate errcodes.h on AIX

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -365,6 +365,7 @@ define BUILD_STEPS
 	rm -rf $(INSTLOC)
 	cd $(BUILDDIR)/gpMgmt/ && $(MAKE) generate_greenplum_path_file
 	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/parser/gram.h
+	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/utils/errcodes.h
 	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/utils/fmgroids.h
 	cd $(BUILDDIR)/src/include/ && $(MAKE) install
 	cd $(BUILDDIR)/src/interfaces/libpq/ && $(MAKE) install
@@ -395,6 +396,7 @@ define BUILD_STEPS
 	fi
 	cd $(BUILDDIR)/gpMgmt/ && $(MAKE) generate_greenplum_path_file
 	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/parser/gram.h
+	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/utils/errcodes.h
 	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/utils/fmgroids.h
 	cd $(BUILDDIR)/src/port/ && $(MAKE) install
 	cd $(BUILDDIR)/src/bin/scripts/ && $(MAKE) install


### PR DESCRIPTION
AIX builds are currently failing with the following error message:

    ../../config/install-sh: utils/errcodes.h does not exist.

There is currently a hardcoded list of headers that must be generated
before installing `src/include` on AIX. `errcodes.h` came in as part of the
9.1 merge, and it was missed in this list.

Co-authored-by: Asim Praveen <apraveen@pivotal.io>