### PR TITLE
Minimize the time sensitivity in autovacuum regression test

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1649,7 +1649,10 @@ vac_update_datfrozenxid(void)
 	}
 
 	if (dirty)
+	{
 		heap_inplace_update(relation, tuple);
+		SIMPLE_FAULT_INJECTOR(VacuumUpdateDatFrozenXid);
+	}
 
 	heap_freetuple(tuple);
 	heap_close(relation, RowExclusiveLock);

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -284,7 +284,8 @@ FaultInjector_InjectFaultNameIfSet(
 	 * using fault injector framework, this restriction needs to be lifted and
 	 * some other mechanism needs to be placed to avoid flaky failures.
 	 */
-	if (IsAutoVacuumLauncherProcess() || IsAutoVacuumWorkerProcess())
+	if (IsAutoVacuumLauncherProcess() ||
+		(IsAutoVacuumWorkerProcess() && 0 != strcmp("vacuum_update_dat_frozen_xid", faultName)))
 		return FaultInjectorTypeNotSpecified;
 
 	/*

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -235,6 +235,8 @@ FI_IDENT(FTSRecoveryInProgress, "fts_recovery_in_progress")
 FI_IDENT(UpgradeRowLock, "upgrade_row_lock")
 /* inject fault in Gdd loop */
 FI_IDENT(GddProbe, "gdd_probe")
+/* inject fault after updating pg_database.datfrozenxid (but before committing) */
+FI_IDENT(VacuumUpdateDatFrozenXid, "vacuum_update_dat_frozen_xid")
 #endif
 
 /*

--- a/src/test/regress/input/autovacuum-template0.source
+++ b/src/test/regress/input/autovacuum-template0.source
@@ -1,3 +1,5 @@
+create extension if not exists gp_inject_fault;
+
 create or replace function test_consume_xids(int4) returns void
 as '@abs_srcdir@/regress.so', 'test_consume_xids'
 language C;
@@ -9,23 +11,34 @@ set debug_burn_xids=on;
 -- autovacuum_freeze_max_age (we assume the default of 200 million here).
 select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
 
+-- track that we've updated the row in pg_database for template0
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', 1);
+
 select test_consume_xids(100 * 1000000);
 select test_consume_xids(100 * 1000000);
 select test_consume_xids(10 * 1000000);
 
--- Wait until autovacuum has processed template0. (But give up after 2 minutes)
+-- wait until autovacuum worker updates pg_database
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'wait_until_triggered', 1);
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
+
+-- Wait until autovacuum commits the pg_database change
+-- Or timeout after 30 seconds
 do $$
 begin
-  for i in 1..120 loop
+  for i in 1..300 loop
     if (select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0') then
       raise notice 'template0 is young again';
       return;
     end if;
-    perform pg_sleep(1);
+    perform pg_sleep(0.1);
   end loop;
   raise notice 'FAIL: template0 is not being frozen!';
 end;
 $$;
+
+-- template0 should be young
+select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
 
 -- But autovacuum should not touch other databases. Hence, our database
 -- should be well above the 200 million mark.

--- a/src/test/regress/output/autovacuum-template0.source
+++ b/src/test/regress/output/autovacuum-template0.source
@@ -1,3 +1,4 @@
+create extension if not exists gp_inject_fault;
 create or replace function test_consume_xids(int4) returns void
 as '@abs_srcdir@/regress.so', 'test_consume_xids'
 language C;
@@ -8,6 +9,14 @@ set debug_burn_xids=on;
 select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
  ?column? 
 ----------
+ t
+(1 row)
+
+-- track that we've updated the row in pg_database for template0
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
  t
 (1 row)
 
@@ -29,20 +38,43 @@ select test_consume_xids(10 * 1000000);
  
 (1 row)
 
--- Wait until autovacuum has processed template0. (But give up after 2 minutes)
+-- wait until autovacuum worker updates pg_database
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'wait_until_triggered', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- Wait until autovacuum commits the pg_database change
+-- Or timeout after 30 seconds
 do $$
 begin
-  for i in 1..120 loop
+  for i in 1..300 loop
     if (select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0') then
       raise notice 'template0 is young again';
       return;
     end if;
-    perform pg_sleep(1);
+    perform pg_sleep(0.1);
   end loop;
   raise notice 'FAIL: template0 is not being frozen!';
 end;
 $$;
 NOTICE:  template0 is young again
+-- template0 should be young
+select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
+ ?column? 
+----------
+ t
+(1 row)
+
 -- But autovacuum should not touch other databases. Hence, our database
 -- should be well above the 200 million mark.
 select age(datfrozenxid) > 200 * 1000000 from pg_database where datname=current_database();


### PR DESCRIPTION
To verify that autovacuum actually freezes template0, we used to just
busy wait for about two minutes, expecting to observe the change of
pg_database.datfrozenxid. While this "usually works", it's too sensitive
to the amount of time it takes to vacuum freeze template0. Specifically,
in some of our very I/O-deprived environments, this process sometimes
takes slightly longer than two minutes.

This patch introduces a fault injector to help us observe the expected
vacuuming. The wait-in-a-loop is still there, but the bulk of the
uncertain timing is now before the loop, not during the loop.

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>
Co-authored-by: Jimmy Yih <jyih@pivotal.io>