### PR TITLE
docs - identify query to view RG memory auditor (5x)

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -695,6 +695,32 @@ gpstart
           <codeblock>=# SELECT * FROM gp_toolkit.gp_resgroup_config;
 </codeblock>
         </p>
+        <p>
+          The <codeph>gp_toolkit.gp_resgroup_config</codeph> view does not
+          display the resource group memory auditor attribute. To view the
+          memory auditor along with the resource group limits, run the
+          following query:<codeblock>=# SELECT g.oid AS groupid, g.rsgname AS groupname,
+     t1.value AS concurrency, t1.proposed AS proposed_concurrency,
+     t2.value AS cpu_rate_limit, t3.value AS memory_limit,
+     t3.proposed AS proposed_memory_limit,
+     t4.value AS memory_shared_quota,
+     t4.proposed AS proposed_memory_shared_quota,
+     t5.value AS memory_spill_ratio,
+     t5.proposed AS proposed_memory_spill_ratio,
+     CASE
+       WHEN t6.value IS NULL THEN 'vmtracker'::text
+       WHEN t6.value = '0'::text THEN 'vmtracker'::text
+       WHEN t6.value = '1'::text THEN 'cgroup'::text
+       ELSE 'unknown'::text
+     END AS memory_auditor
+   FROM pg_resgroup g
+     JOIN pg_resgroupcapability t1 ON g.oid = t1.resgroupid AND t1.reslimittype = 1
+     JOIN pg_resgroupcapability t2 ON g.oid = t2.resgroupid AND t2.reslimittype = 2
+     JOIN pg_resgroupcapability t3 ON g.oid = t3.resgroupid AND t3.reslimittype = 3
+     JOIN pg_resgroupcapability t4 ON g.oid = t4.resgroupid AND t4.reslimittype = 4
+     JOIN pg_resgroupcapability t5 ON g.oid = t5.resgroupid AND t5.reslimittype = 5
+     LEFT JOIN pg_resgroupcapability t6 ON g.oid = t6.resgroupid AND t6.reslimittype = 6;</codeblock>
+        </p>
       </body>
     </topic>
 


### PR DESCRIPTION
note the query that the user should run to view the memory_auditor resource group attribute.

link to doc review site:
- http://docs-gpdb-review-staging.cfapps.io/review/admin_guide/workload_mgmt_resgroups.html#topic22