### PR TITLE
Support RETURNING for replicated tables.

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1026,10 +1026,6 @@ focusPlan(Plan *plan, bool stable, bool rescannable)
 		plan->flow->locustype != CdbLocusType_SegmentGeneral)
 		return true;
 
-	/* TODO How specify deep-six? */
-	if (plan->flow->flotype == FLOW_REPLICATED)
-		return false;
-
 	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_FOCUS, NIL);
 }
 

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -744,7 +744,9 @@ ParallelizeSubplan(SubPlan *spExpr, PlanProfile *context)
 
 	Plan	   *origPlan = planner_subplan_get_plan(context->root, spExpr);
 
-	bool		containingPlanDistributed = (context->currentPlanFlow && context->currentPlanFlow->flotype == FLOW_PARTITIONED);
+	bool		containingPlanDistributed = (context->currentPlanFlow &&
+											 (context->currentPlanFlow->flotype == FLOW_PARTITIONED ||
+											  context->currentPlanFlow->flotype == FLOW_REPLICATED));
 	bool		subPlanDistributed = (origPlan->flow && origPlan->flow->flotype == FLOW_PARTITIONED);
 	bool		hasParParam = (list_length(spExpr->parParam) > 0);
 
@@ -783,7 +785,19 @@ ParallelizeSubplan(SubPlan *spExpr, PlanProfile *context)
 			focusPlan(newPlan, false /* stable */ , false /* rescannable */ );
 		}
 
-		newPlan = materialize_subplan(context->root, newPlan);
+		if (containingPlanDistributed &&
+			newPlan->flow->flotype == FLOW_SINGLETON &&
+			newPlan->flow->locustype == CdbLocusType_SegmentGeneral)
+		{
+			/*
+			 * Nothing to do, the data is already replicated on segments,
+			 * no need to add a motion or materialize.
+			 */
+		}
+		else
+		{
+			newPlan = materialize_subplan(context->root, newPlan);
+		}
 	}
 
 	/*
@@ -1021,7 +1035,10 @@ focusPlan(Plan *plan, bool stable, bool rescannable)
 {
 	Assert(plan->flow && plan->flow->flotype != FLOW_UNDEFINED);
 
-	/* Already focused and flow is not CdbLocusType_SegmentGeneral, Do nothing. */
+	/*
+	 * Already focused and flow is CdbLocusType_SingleQE, CdbLocusType_Entry,
+	 * do nothing.
+	 */
 	if (plan->flow->flotype == FLOW_SINGLETON &&
 		plan->flow->locustype != CdbLocusType_SegmentGeneral)
 		return true;
@@ -1036,6 +1053,11 @@ bool
 broadcastPlan(Plan *plan, bool stable, bool rescannable)
 {
 	Assert(plan->flow && plan->flow->flotype != FLOW_UNDEFINED);
+
+	/* Already focused and flow is CdbLocusType_SegmentGeneral, do nothing. */
+	if (plan->flow->flotype == FLOW_SINGLETON &&
+		plan->flow->locustype == CdbLocusType_SegmentGeneral)
+		return true;
 
 	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_BROADCAST, NIL);
 }

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -241,7 +241,6 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 	state.initPlans = NIL;
 
 	Assert(is_plan_node((Node *) plan) && IsA(query, Query));
-	Assert(plan->flow && plan->flow->flotype != FLOW_REPLICATED);
 
 	/* Does query have a target relation?  (INSERT/DELETE/UPDATE) */
 

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1105,6 +1105,13 @@ ExplainNode(Plan *plan, PlanState *planstate,
 							sname = "Broadcast Motion";
 							motion_recv = getgpsegmentCount();
 						}
+						else if (plan->lefttree &&
+								 plan->lefttree->flow &&
+								 plan->lefttree->flow->locustype == CdbLocusType_Replicated)
+						{
+							sname = "Explicit Gather Motion";
+							scaleFactor = 1;
+						}
 						else
 						{
 							sname = "Gather Motion";

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -12172,7 +12172,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			 errmsg("SET DISTRIBUTED BY not supported in utility mode")));
 
-	/* we only support partitioned tables */
+	/* we only support partitioned/replicated tables */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		if (GpPolicyIsEntry(rel->rd_cdbpolicy))
@@ -12321,20 +12321,25 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			}
 
 			policy = createRandomPartitionedPolicy(NULL);
-			rel->rd_cdbpolicy = GpPolicyCopy(GetMemoryChunkContext(rel), policy);
-			GpPolicyReplace(RelationGetRelid(rel), policy);
 
-			/* only need to rebuild if have new storage options */
-			if (!(DatumGetPointer(newOptions) || force_reorg))
+			/* always need to rebuild if changed from replicated policy */
+			if (!GpPolicyIsReplicated(rel->rd_cdbpolicy))
 			{
-				/*
-				 * caller expects ATExecSetDistributedBy() to close rel
-				 * (see the non-random distribution case below for why.
-				 */
-				heap_close(rel, NoLock);
-				lsecond(lprime) = makeNode(SetDistributionCmd);
-				lprime = lappend(lprime, policy);
-				goto l_distro_fini;
+				rel->rd_cdbpolicy = GpPolicyCopy(GetMemoryChunkContext(rel), policy);
+				GpPolicyReplace(RelationGetRelid(rel), policy);
+
+				/* only need to rebuild if have new storage options */
+				if (!(DatumGetPointer(newOptions) || force_reorg))
+				{
+					/*
+					 * caller expects ATExecSetDistributedBy() to close rel
+					 * (see the non-random distribution case below for why.
+					 */
+					heap_close(rel, NoLock);
+					lsecond(lprime) = makeNode(SetDistributionCmd);
+					lprime = lappend(lprime, policy);
+					goto l_distro_fini;
+				}
 			}
 		}
 
@@ -12342,21 +12347,19 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		{
 			rep_pol = true;
 
-			if (!force_reorg)
-			{
-				if (GpPolicyIsReplicated(rel->rd_cdbpolicy))
-					ereport(WARNING,
-							(errcode(ERRCODE_DUPLICATE_OBJECT),
-							 errmsg("distribution policy of relation \"%s\" already set to DISTRIBUTED REPLICATED",
-									RelationGetRelationName(rel)),
-							 errhint("Use ALTER TABLE \"%s\" SET WITH (REORGANIZE=TRUE) DISTRIBUTED REPLICATED to force a replicated redistribution.",
-									 RelationGetRelationName(rel))));
-			}
+			if (GpPolicyIsReplicated(rel->rd_cdbpolicy))
+				ereport(WARNING,
+						(errcode(ERRCODE_DUPLICATE_OBJECT),
+						 errmsg("distribution policy of relation \"%s\" already set to DISTRIBUTED REPLICATED",
+								RelationGetRelationName(rel)),
+						 errhint("Use ALTER TABLE \"%s\" SET WITH (REORGANIZE=TRUE) DISTRIBUTED REPLICATED to force a replicated redistribution.",
+								 RelationGetRelationName(rel))));
 
 			policy = createReplicatedGpPolicy(NULL);
 
-			/* only need to rebuild if have new storage options */
-			if (!(DatumGetPointer(newOptions) || force_reorg))
+			/* rebuild if have new storage options or policy changed */
+			if (!DatumGetPointer(newOptions) &&
+				GpPolicyIsReplicated(rel->rd_cdbpolicy))
 			{
 				/*
 				 * caller expects ATExecSetDistributedBy() to close rel

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -304,6 +304,14 @@ execMotionSender(MotionState * node)
 			doSendEndOfStream(motion, node);
 			done = true;
 		}
+		else if (node->isExplictGatherMotion &&
+				 GpIdentity.segindex != gp_singleton_segindex)
+		{
+			/*
+			 * For explicit gather motion, receiver
+			 * get data from the singleton segment explictly.
+			 */
+		}
 		else
 		{
 			doSendTuple(motion, node, outerTupleSlot);
@@ -865,6 +873,7 @@ ExecInitMotion(Motion * node, EState *estate, int eflags)
 	motionstate->stopRequested = false;
 	motionstate->hashExpr = NULL;
 	motionstate->cdbhash = NULL;
+	motionstate->isExplictGatherMotion = false;
 
     /* Look up the sending gang's slice table entry. */
     sendSlice = (Slice *)list_nth(sliceTable->slices, node->motionID);
@@ -920,6 +929,21 @@ ExecInitMotion(Motion * node, EState *estate, int eflags)
 			motionstate->mstype = MOTIONSTATE_SEND;
         }
 		/* TODO: If neither sending nor receiving, don't bother to initialize. */
+	}
+
+	/*
+	 * If it's gather motion and subplan's locus is
+	 * CdbLocusType_Replicated, mark isExplictGatherMotion
+	 * to true
+	 */
+	if (motionstate->mstype == MOTIONSTATE_SEND &&
+		node->motionType == MOTIONTYPE_FIXED &&
+		node->numOutputSegs == 1 &&
+		outerPlan(node) &&
+		outerPlan(node)->flow &&
+		outerPlan(node)->flow->locustype == CdbLocusType_Replicated)
+	{
+		motionstate->isExplictGatherMotion = true;
 	}
 
     motionstate->tupleheapReady = false;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -5636,7 +5636,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 	 */
 	ListCell   *lcr,
 			   *lcp;
-	bool		all_subplans_entry = true;
+	bool		all_subplans_entry = true,
+				all_subplans_replicated = true;
 
 	if (node->operation == CMD_INSERT)
 	{
@@ -5657,6 +5658,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 			if (targetPolicyType == POLICYTYPE_PARTITIONED)
 			{
 				all_subplans_entry = false;
+				all_subplans_replicated = false;
 
 				if (gp_enable_fast_sri && IsA(subplan, Result))
 					sri_optimize_for_result(root, subplan, rte, &targetPolicy, &hashExpr);
@@ -5675,6 +5677,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 			{
 				/* Master-only table */
 
+				all_subplans_replicated = false;
+
 				/* All's well if query result is already on the QD. */
 				if (!(subplan->flow->flotype == FLOW_SINGLETON &&
 					  subplan->flow->segindex < 0))
@@ -5692,6 +5696,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 			else if (targetPolicyType == POLICYTYPE_REPLICATED)
 			{
 				Assert(subplan->flow->flotype != FLOW_REPLICATED);
+
+				all_subplans_entry = false;
 
 				/*
 				 * CdbLocusType_SegmentGeneral is only used by replicated table
@@ -5748,6 +5754,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 			if (targetPolicyType == POLICYTYPE_PARTITIONED)
 			{
 				all_subplans_entry = false;
+				all_subplans_replicated = false;
 
 				/*
 				 * The planner does not support updating any of the
@@ -5766,6 +5773,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 			}
 			else if (targetPolicyType == POLICYTYPE_ENTRY)
 			{
+				all_subplans_replicated = false;
+
 				/* Master-only table */
 				if (subplan->flow->flotype == FLOW_PARTITIONED ||
 					subplan->flow->flotype == FLOW_REPLICATED ||
@@ -5801,6 +5810,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 			else if (targetPolicyType == POLICYTYPE_REPLICATED)
 			{
 				/* Do nothing here, see main work in cdbpath_motion_for_join() */
+				all_subplans_entry = false;
 			}
 			else
 				elog(ERROR, "unrecognized policy type %u", targetPolicyType);
@@ -5821,6 +5831,10 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 	if (all_subplans_entry)
 	{
 		mark_plan_entry((Plan *) node);
+	}
+	else if (all_subplans_replicated)
+	{
+		mark_plan_replicated((Plan *) node);
 	}
 	else
 	{

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2821,6 +2821,7 @@ typedef struct MotionState
 	Oid		   *outputFunArray;	/* output functions for each column (debug only) */
 
 	int			numInputSegs;	/* the number of segments on the sending slice */
+	bool		isExplictGatherMotion;
 } MotionState;
 
 /*

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -271,16 +271,223 @@ alter table foo drop column x;
 alter table bar drop column x;
 NOTICE:  Dropping a column that is part of the distribution policy forces a NULL distribution policy
 drop table if exists foo;
+drop table if exists foo1;
+NOTICE:  table "foo1" does not exist, skipping
 drop table if exists bar;
+drop table if exists bar1;
+NOTICE:  table "bar1" does not exist, skipping
 -- Alter gp_distribution_policy
 create table foo(x int, y int) distributed replicated;
+create table foo1(x int, y int) distributed replicated;
 create table bar(x int, y int) distributed by (x);
+create table bar1(x int, y int) distributed randomly;
+insert into foo select i,i from generate_series(1,10) i;
+insert into foo1 select i,i from generate_series(1,10) i;
+insert into bar select i,i from generate_series(1,10) i;
+insert into bar1 select i,i from generate_series(1,10) i;
 -- alter distribution policy of replicated table
 alter table foo set distributed by (x);
+alter table foo1 set distributed randomly;
 -- alter a partitioned table to replicated table
 alter table bar set distributed replicated;
+alter table bar1 set distributed replicated;
+-- verify the new policies
+\d foo
+       Table "rpt.foo"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ x      | integer | 
+ y      | integer | 
+Distributed by: (x)
+
+\d foo1
+       Table "rpt.foo1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ x      | integer | 
+ y      | integer | 
+Distributed randomly
+
+\d bar
+       Table "rpt.bar"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ x      | integer | 
+ y      | integer | 
+Distributed Replicated
+
+\d bar1
+       Table "rpt.bar1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ x      | integer | 
+ y      | integer | 
+Distributed Replicated
+
+-- verify the reorganized data
+select * from foo;
+ x  | y  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+select * from foo1;
+ x  | y  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+select * from bar;
+ x  | y  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+select * from bar1;
+ x  | y  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+-- alter back
+alter table foo set distributed replicated;
+alter table foo1 set distributed replicated;
+alter table bar set distributed by (x);
+alter table bar1 set distributed randomly;
+-- verify the policies again
+\d foo
+       Table "rpt.foo"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ x      | integer | 
+ y      | integer | 
+Distributed Replicated
+
+\d foo1
+       Table "rpt.foo1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ x      | integer | 
+ y      | integer | 
+Distributed Replicated
+
+\d bar
+       Table "rpt.bar"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ x      | integer | 
+ y      | integer | 
+Distributed by: (x)
+
+\d bar1
+       Table "rpt.bar1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ x      | integer | 
+ y      | integer | 
+Distributed randomly
+
+-- verify the reorganized data again
+select * from foo;
+ x  | y  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+select * from foo1;
+ x  | y  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+select * from bar;
+ x  | y  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+select * from bar1;
+ x  | y  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
 drop table if exists foo;
+drop table if exists foo1;
 drop table if exists bar;
+drop table if exists bar1;
 ---------
 -- UPDATE / DELETE
 ---------

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -114,6 +114,23 @@ create unique index bar_idx on foo (y);
 drop table if exists foo;
 drop table if exists bar;
 --
+-- CREATE TABLE with both PRIMARY KEY and UNIQUE constraints
+--
+create table foo (id int primary key, name text unique) distributed replicated;
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "foo_pkey" for table "foo"
+NOTICE:  CREATE TABLE / UNIQUE will create implicit index "foo_name_key" for table "foo"
+-- success
+insert into foo values (1,'aaa');
+insert into foo values (2,'bbb');
+-- fail
+insert into foo values (1,'ccc');
+ERROR:  duplicate key value violates unique constraint "foo_pkey"  (seg0 192.168.99.102:25432 pid=22681)
+DETAIL:  Key (id)=(1) already exists.
+insert into foo values (3,'aaa');
+ERROR:  duplicate key value violates unique constraint "foo_name_key"  (seg2 192.168.99.102:25434 pid=22683)
+DETAIL:  Key (name)=(aaa) already exists.
+drop table if exists foo;
+--
 -- CREATE TABLE
 --
 --

--- a/src/test/regress/expected/rpt_returning.out
+++ b/src/test/regress/expected/rpt_returning.out
@@ -54,6 +54,36 @@ SELECT * FROM foo;
   2 | more | 42
 (2 rows)
 
+-- Subplans and initplans in the RETURNING list
+INSERT INTO foo SELECT f1+10, f2, f3+99 FROM foo
+  RETURNING *, f1+112 IN (SELECT q1 FROM int8_tbl) AS subplan,
+    EXISTS(SELECT * FROM int4_tbl) AS initplan;
+ f1 |  f2  | f3  | subplan | initplan 
+----+------+-----+---------+----------
+ 11 | test | 141 | t       | t
+ 12 | more | 141 | f       | t
+(2 rows)
+
+UPDATE foo SET f3 = f3 * 2
+  WHERE f1 > 10
+  RETURNING *, f1+112 IN (SELECT q1 FROM int8_tbl) AS subplan,
+    EXISTS(SELECT * FROM int4_tbl) AS initplan;
+ f1 |  f2  | f3  | subplan | initplan 
+----+------+-----+---------+----------
+ 11 | test | 282 | t       | t
+ 12 | more | 282 | f       | t
+(2 rows)
+
+DELETE FROM foo
+  WHERE f1 > 10
+  RETURNING *, f1+112 IN (SELECT q1 FROM int8_tbl) AS subplan,
+    EXISTS(SELECT * FROM int4_tbl) AS initplan;
+ f1 |  f2  | f3  | subplan | initplan 
+----+------+-----+---------+----------
+ 11 | test | 282 | t       | t
+ 12 | more | 282 | f       | t
+(2 rows)
+
 -- Joins
 UPDATE foo SET f3 = f3*2
   FROM int4_tbl i

--- a/src/test/regress/expected/rpt_returning.out
+++ b/src/test/regress/expected/rpt_returning.out
@@ -1,0 +1,283 @@
+--
+-- Test INSERT/UPDATE/DELETE RETURNING on REPLICATED table
+--
+-- Simple cases
+CREATE TEMP TABLE foo (f1 serial, f2 text, f3 int default 42);
+NOTICE:  CREATE TABLE will create implicit sequence "foo_f1_seq" for serial column "foo.f1"
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE foo SET DISTRIBUTED REPLICATED;
+INSERT INTO foo (f2,f3)
+  VALUES ('test', DEFAULT), ('More', 11), (upper('more'), 7+9)
+  RETURNING *, f1+f3 AS sum;
+ f1 |  f2  | f3 | sum 
+----+------+----+-----
+  1 | test | 42 |  43
+  2 | More | 11 |  13
+  3 | MORE | 16 |  19
+(3 rows)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 
+----+------+----
+  1 | test | 42
+  2 | More | 11
+  3 | MORE | 16
+(3 rows)
+
+UPDATE foo SET f2 = lower(f2), f3 = DEFAULT RETURNING foo.*, f1+f3 AS sum13;
+ f1 |  f2  | f3 | sum13 
+----+------+----+-------
+  1 | test | 42 |    43
+  2 | more | 42 |    44
+  3 | more | 42 |    45
+(3 rows)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 
+----+------+----
+  1 | test | 42
+  2 | more | 42
+  3 | more | 42
+(3 rows)
+
+DELETE FROM foo WHERE f1 > 2 RETURNING f3, f2, f1, least(f1,f3);
+ f3 |  f2  | f1 | least 
+----+------+----+-------
+ 42 | more |  3 |     3
+(1 row)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 
+----+------+----
+  1 | test | 42
+  2 | more | 42
+(2 rows)
+
+-- Joins
+UPDATE foo SET f3 = f3*2
+  FROM int4_tbl i
+  WHERE foo.f1 + 123455 = i.f1
+  RETURNING foo.*, i.f1 as "i.f1";
+ f1 |  f2  | f3 |  i.f1  
+----+------+----+--------
+  1 | test | 84 | 123456
+(1 row)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 
+----+------+----
+  2 | more | 42
+  1 | test | 84
+(2 rows)
+
+DELETE FROM foo
+  USING int4_tbl i
+  WHERE foo.f1 + 123455 = i.f1
+  RETURNING foo.*, i.f1 as "i.f1";
+ f1 |  f2  | f3 |  i.f1  
+----+------+----+--------
+  1 | test | 84 | 123456
+(1 row)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 
+----+------+----
+  2 | more | 42
+(1 row)
+
+-- TODO: inheritance is not supported on replicated table yet
+-- Check inheritance cases
+--CREATE TEMP TABLE foochild (fc int) INHERITS (foo);
+--INSERT INTO foochild VALUES(123,'child',999,-123);
+ALTER TABLE foo ADD COLUMN f4 int8 DEFAULT 99;
+SELECT * FROM foo;
+ f1 |  f2  | f3 | f4 
+----+------+----+----
+  2 | more | 42 | 99
+(1 row)
+
+--SELECT * FROM foochild;
+UPDATE foo SET f4 = f4 + f3 WHERE f4 = 99 RETURNING *;
+ f1 |  f2  | f3 | f4  
+----+------+----+-----
+  2 | more | 42 | 141
+(1 row)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 | f4  
+----+------+----+-----
+  2 | more | 42 | 141
+(1 row)
+
+--SELECT * FROM foochild;
+UPDATE foo SET f3 = f3*2
+  FROM int8_tbl i
+  WHERE foo.f1 = i.q2
+  RETURNING *;
+ f1 | f2 | f3 | f4 | q1 | q2 
+----+----+----+----+----+----
+(0 rows)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 | f4  
+----+------+----+-----
+  2 | more | 42 | 141
+(1 row)
+
+--SELECT * FROM foochild;
+DELETE FROM foo
+  USING int8_tbl i
+  WHERE foo.f1 = i.q2
+  RETURNING *;
+ f1 | f2 | f3 | f4 | q1 | q2 
+----+----+----+----+----+----
+(0 rows)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 | f4  
+----+------+----+-----
+  2 | more | 42 | 141
+(1 row)
+
+--SELECT * FROM foochild;
+--DROP TABLE foochild;
+-- Rules and views
+CREATE TEMP VIEW voo AS SELECT f1, f2 FROM foo;
+CREATE RULE voo_i AS ON INSERT TO voo DO INSTEAD
+  INSERT INTO foo VALUES(new.*, 57);
+INSERT INTO voo VALUES(11,'zit');
+-- fails:
+INSERT INTO voo VALUES(12,'zoo') RETURNING *, f1*2;
+ERROR:  cannot perform INSERT RETURNING on relation "voo"
+HINT:  You need an unconditional ON INSERT DO INSTEAD rule with a RETURNING clause.
+-- fails, incompatible list:
+CREATE OR REPLACE RULE voo_i AS ON INSERT TO voo DO INSTEAD
+  INSERT INTO foo VALUES(new.*, 57) RETURNING *;
+ERROR:  RETURNING list has too many entries
+CREATE OR REPLACE RULE voo_i AS ON INSERT TO voo DO INSTEAD
+  INSERT INTO foo VALUES(new.*, 57) RETURNING f1, f2;
+-- should still work
+INSERT INTO voo VALUES(13,'zit2');
+-- works now
+INSERT INTO voo VALUES(14,'zoo2') RETURNING *;
+ f1 |  f2  
+----+------
+ 14 | zoo2
+(1 row)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 | f4  
+----+------+----+-----
+  2 | more | 42 | 141
+ 11 | zit  | 57 |  99
+ 13 | zit2 | 57 |  99
+ 14 | zoo2 | 57 |  99
+(4 rows)
+
+SELECT * FROM voo;
+ f1 |  f2  
+----+------
+  2 | more
+ 11 | zit
+ 13 | zit2
+ 14 | zoo2
+(4 rows)
+
+CREATE OR REPLACE RULE voo_u AS ON UPDATE TO voo DO INSTEAD
+  UPDATE foo SET f1 = new.f1, f2 = new.f2 WHERE f1 = old.f1
+  RETURNING f1, f2;
+update voo set f1 = f1 + 1 where f2 = 'zoo2';
+update voo set f1 = f1 + 1 where f2 = 'zoo2' RETURNING *, f1*2;
+ f1 |  f2  | ?column? 
+----+------+----------
+ 16 | zoo2 |       32
+(1 row)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 | f4  
+----+------+----+-----
+  2 | more | 42 | 141
+ 11 | zit  | 57 |  99
+ 13 | zit2 | 57 |  99
+ 16 | zoo2 | 57 |  99
+(4 rows)
+
+SELECT * FROM voo;
+ f1 |  f2  
+----+------
+  2 | more
+ 11 | zit
+ 13 | zit2
+ 16 | zoo2
+(4 rows)
+
+CREATE OR REPLACE RULE voo_d AS ON DELETE TO voo DO INSTEAD
+  DELETE FROM foo WHERE f1 = old.f1
+  RETURNING f1, f2;
+DELETE FROM foo WHERE f1 = 13;
+DELETE FROM foo WHERE f2 = 'zit' RETURNING *;
+ f1 | f2  | f3 | f4 
+----+-----+----+----
+ 11 | zit | 57 | 99
+(1 row)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 | f4  
+----+------+----+-----
+  2 | more | 42 | 141
+ 16 | zoo2 | 57 |  99
+(2 rows)
+
+SELECT * FROM voo;
+ f1 |  f2  
+----+------
+  2 | more
+ 16 | zoo2
+(2 rows)
+
+-- Try a join case
+CREATE TEMP TABLE joinme (f2j text, other int);
+ALTER TABLE joinme SET DISTRIBUTED REPLICATED;
+INSERT INTO joinme VALUES('more', 12345);
+INSERT INTO joinme VALUES('zoo2', 54321);
+INSERT INTO joinme VALUES('other', 0);
+CREATE TEMP VIEW joinview AS
+  SELECT foo.*, other FROM foo JOIN joinme ON (f2 = f2j);
+SELECT * FROM joinview;
+ f1 |  f2  | f3 | f4  | other 
+----+------+----+-----+-------
+  2 | more | 42 | 141 | 12345
+ 16 | zoo2 | 57 |  99 | 54321
+(2 rows)
+
+-- GPDB_90_MERGE_FIXME: This CREATE RULE fails in GPDB. Why?
+CREATE RULE joinview_u AS ON UPDATE TO joinview DO INSTEAD
+  UPDATE foo SET f1 = new.f1, f3 = new.f3
+    FROM joinme WHERE f2 = f2j AND f2 = old.f2
+    RETURNING foo.*, other;
+ERROR:  column "f2j" does not exist
+UPDATE joinview SET f1 = f1 + 1 WHERE f3 = 57 RETURNING *, other + 1;
+ERROR:  cannot update a view
+HINT:  You need an unconditional ON UPDATE DO INSTEAD rule.
+SELECT * FROM joinview;
+ f1 |  f2  | f3 | f4  | other 
+----+------+----+-----+-------
+  2 | more | 42 | 141 | 12345
+ 16 | zoo2 | 57 |  99 | 54321
+(2 rows)
+
+SELECT * FROM foo;
+ f1 |  f2  | f3 | f4  
+----+------+----+-----
+  2 | more | 42 | 141
+ 16 | zoo2 | 57 |  99
+(2 rows)
+
+SELECT * FROM voo;
+ f1 |  f2  
+----+------
+  2 | more
+ 16 | zoo2
+(2 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -122,7 +122,7 @@ test: bb_memory_quota memconsumption
 
 test: tuple_serialization
 # Tests for replicated table
-test: rpt rpt_joins rpt_tpch
+test: rpt rpt_joins rpt_tpch rpt_returning
 
 # NOTE: The bfv_temp test assumes that there are no temporary tables in
 # other sessions. Therefore the other tests in this group mustn't create

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -181,19 +181,62 @@ alter table foo drop column x;
 alter table bar drop column x;
 
 drop table if exists foo;
+drop table if exists foo1;
 drop table if exists bar;
+drop table if exists bar1;
 
 -- Alter gp_distribution_policy
 create table foo(x int, y int) distributed replicated;
+create table foo1(x int, y int) distributed replicated;
 create table bar(x int, y int) distributed by (x);
+create table bar1(x int, y int) distributed randomly;
+
+insert into foo select i,i from generate_series(1,10) i;
+insert into foo1 select i,i from generate_series(1,10) i;
+insert into bar select i,i from generate_series(1,10) i;
+insert into bar1 select i,i from generate_series(1,10) i;
 
 -- alter distribution policy of replicated table
 alter table foo set distributed by (x);
+alter table foo1 set distributed randomly;
 -- alter a partitioned table to replicated table
 alter table bar set distributed replicated;
+alter table bar1 set distributed replicated;
+
+-- verify the new policies
+\d foo
+\d foo1
+\d bar
+\d bar1
+
+-- verify the reorganized data
+select * from foo;
+select * from foo1;
+select * from bar;
+select * from bar1;
+
+-- alter back
+alter table foo set distributed replicated;
+alter table foo1 set distributed replicated;
+alter table bar set distributed by (x);
+alter table bar1 set distributed randomly;
+
+-- verify the policies again
+\d foo
+\d foo1
+\d bar
+\d bar1
+
+-- verify the reorganized data again
+select * from foo;
+select * from foo1;
+select * from bar;
+select * from bar1;
 
 drop table if exists foo;
+drop table if exists foo1;
 drop table if exists bar;
+drop table if exists bar1;
 
 ---------
 -- UPDATE / DELETE

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -65,6 +65,21 @@ drop table if exists foo;
 drop table if exists bar;
 
 --
+-- CREATE TABLE with both PRIMARY KEY and UNIQUE constraints
+--
+create table foo (id int primary key, name text unique) distributed replicated;
+
+-- success
+insert into foo values (1,'aaa');
+insert into foo values (2,'bbb');
+
+-- fail
+insert into foo values (1,'ccc');
+insert into foo values (3,'aaa');
+
+drop table if exists foo;
+
+--
 -- CREATE TABLE
 --
 --

--- a/src/test/regress/sql/rpt_returning.sql
+++ b/src/test/regress/sql/rpt_returning.sql
@@ -1,0 +1,144 @@
+--
+-- Test INSERT/UPDATE/DELETE RETURNING on REPLICATED table
+--
+
+-- Simple cases
+
+CREATE TEMP TABLE foo (f1 serial, f2 text, f3 int default 42);
+ALTER TABLE foo SET DISTRIBUTED REPLICATED;
+
+INSERT INTO foo (f2,f3)
+  VALUES ('test', DEFAULT), ('More', 11), (upper('more'), 7+9)
+  RETURNING *, f1+f3 AS sum;
+
+SELECT * FROM foo;
+
+UPDATE foo SET f2 = lower(f2), f3 = DEFAULT RETURNING foo.*, f1+f3 AS sum13;
+
+SELECT * FROM foo;
+
+DELETE FROM foo WHERE f1 > 2 RETURNING f3, f2, f1, least(f1,f3);
+
+SELECT * FROM foo;
+
+-- Joins
+
+UPDATE foo SET f3 = f3*2
+  FROM int4_tbl i
+  WHERE foo.f1 + 123455 = i.f1
+  RETURNING foo.*, i.f1 as "i.f1";
+
+SELECT * FROM foo;
+
+DELETE FROM foo
+  USING int4_tbl i
+  WHERE foo.f1 + 123455 = i.f1
+  RETURNING foo.*, i.f1 as "i.f1";
+
+SELECT * FROM foo;
+
+-- TODO: inheritance is not supported on replicated table yet
+-- Check inheritance cases
+
+--CREATE TEMP TABLE foochild (fc int) INHERITS (foo);
+
+--INSERT INTO foochild VALUES(123,'child',999,-123);
+
+ALTER TABLE foo ADD COLUMN f4 int8 DEFAULT 99;
+
+SELECT * FROM foo;
+--SELECT * FROM foochild;
+
+UPDATE foo SET f4 = f4 + f3 WHERE f4 = 99 RETURNING *;
+
+SELECT * FROM foo;
+--SELECT * FROM foochild;
+
+UPDATE foo SET f3 = f3*2
+  FROM int8_tbl i
+  WHERE foo.f1 = i.q2
+  RETURNING *;
+
+SELECT * FROM foo;
+--SELECT * FROM foochild;
+
+DELETE FROM foo
+  USING int8_tbl i
+  WHERE foo.f1 = i.q2
+  RETURNING *;
+
+SELECT * FROM foo;
+--SELECT * FROM foochild;
+
+--DROP TABLE foochild;
+
+-- Rules and views
+
+CREATE TEMP VIEW voo AS SELECT f1, f2 FROM foo;
+
+CREATE RULE voo_i AS ON INSERT TO voo DO INSTEAD
+  INSERT INTO foo VALUES(new.*, 57);
+
+INSERT INTO voo VALUES(11,'zit');
+-- fails:
+INSERT INTO voo VALUES(12,'zoo') RETURNING *, f1*2;
+
+-- fails, incompatible list:
+CREATE OR REPLACE RULE voo_i AS ON INSERT TO voo DO INSTEAD
+  INSERT INTO foo VALUES(new.*, 57) RETURNING *;
+
+CREATE OR REPLACE RULE voo_i AS ON INSERT TO voo DO INSTEAD
+  INSERT INTO foo VALUES(new.*, 57) RETURNING f1, f2;
+
+-- should still work
+INSERT INTO voo VALUES(13,'zit2');
+-- works now
+INSERT INTO voo VALUES(14,'zoo2') RETURNING *;
+
+SELECT * FROM foo;
+SELECT * FROM voo;
+
+CREATE OR REPLACE RULE voo_u AS ON UPDATE TO voo DO INSTEAD
+  UPDATE foo SET f1 = new.f1, f2 = new.f2 WHERE f1 = old.f1
+  RETURNING f1, f2;
+
+update voo set f1 = f1 + 1 where f2 = 'zoo2';
+update voo set f1 = f1 + 1 where f2 = 'zoo2' RETURNING *, f1*2;
+
+SELECT * FROM foo;
+SELECT * FROM voo;
+
+CREATE OR REPLACE RULE voo_d AS ON DELETE TO voo DO INSTEAD
+  DELETE FROM foo WHERE f1 = old.f1
+  RETURNING f1, f2;
+
+DELETE FROM foo WHERE f1 = 13;
+DELETE FROM foo WHERE f2 = 'zit' RETURNING *;
+
+SELECT * FROM foo;
+SELECT * FROM voo;
+
+-- Try a join case
+
+CREATE TEMP TABLE joinme (f2j text, other int);
+ALTER TABLE joinme SET DISTRIBUTED REPLICATED;
+INSERT INTO joinme VALUES('more', 12345);
+INSERT INTO joinme VALUES('zoo2', 54321);
+INSERT INTO joinme VALUES('other', 0);
+
+CREATE TEMP VIEW joinview AS
+  SELECT foo.*, other FROM foo JOIN joinme ON (f2 = f2j);
+
+SELECT * FROM joinview;
+
+-- GPDB_90_MERGE_FIXME: This CREATE RULE fails in GPDB. Why?
+CREATE RULE joinview_u AS ON UPDATE TO joinview DO INSTEAD
+  UPDATE foo SET f1 = new.f1, f3 = new.f3
+    FROM joinme WHERE f2 = f2j AND f2 = old.f2
+    RETURNING foo.*, other;
+
+UPDATE joinview SET f1 = f1 + 1 WHERE f3 = 57 RETURNING *, other + 1;
+
+SELECT * FROM joinview;
+SELECT * FROM foo;
+SELECT * FROM voo;

--- a/src/test/regress/sql/rpt_returning.sql
+++ b/src/test/regress/sql/rpt_returning.sql
@@ -21,6 +21,22 @@ DELETE FROM foo WHERE f1 > 2 RETURNING f3, f2, f1, least(f1,f3);
 
 SELECT * FROM foo;
 
+-- Subplans and initplans in the RETURNING list
+
+INSERT INTO foo SELECT f1+10, f2, f3+99 FROM foo
+  RETURNING *, f1+112 IN (SELECT q1 FROM int8_tbl) AS subplan,
+    EXISTS(SELECT * FROM int4_tbl) AS initplan;
+
+UPDATE foo SET f3 = f3 * 2
+  WHERE f1 > 10
+  RETURNING *, f1+112 IN (SELECT q1 FROM int8_tbl) AS subplan,
+    EXISTS(SELECT * FROM int4_tbl) AS initplan;
+
+DELETE FROM foo
+  WHERE f1 > 10
+  RETURNING *, f1+112 IN (SELECT q1 FROM int8_tbl) AS subplan,
+    EXISTS(SELECT * FROM int4_tbl) AS initplan;
+
 -- Joins
 
 UPDATE foo SET f3 = f3*2


### PR DESCRIPTION
The main purpose for this PR is to support the `RETURNING` syntax for replicated tables, we also fixed the reorganization issue when altering from/to replicated tables. Also added some tests to ensure that `PRIMARY` and `UNIQUE` can be both set on replicated tables.