### PR TITLE
Remove drop table from partition* test to cut-down wasted secs.

### DIFF
--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -1955,7 +1955,7 @@ from pg_class where relname like 'granttest%';
 drop table granttest;
 drop role part_role;
 -- deep inline + optional subpartition comma:
-CREATE TABLE partsupp (
+CREATE TABLE partsupp_1 (
     ps_partkey integer,
     ps_suppkey integer,
     ps_availqty integer,
@@ -2018,35 +2018,34 @@ CREATE TABLE partsupp (
                           )
                   )
           );
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1" for table "partsupp"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_1" for table "partsupp_1_prt_p1_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_1_3_prt_1" for table "partsupp_1_prt_p1_1_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_1_3_prt_2" for table "partsupp_1_prt_p1_1_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_2" for table "partsupp_1_prt_p1_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_2_3_prt_1" for table "partsupp_1_prt_p1_1_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_2_3_prt_2" for table "partsupp_1_prt_p1_1_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2" for table "partsupp"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_1" for table "partsupp_1_prt_p1_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_1_3_prt_1" for table "partsupp_1_prt_p1_2_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_1_3_prt_2" for table "partsupp_1_prt_p1_2_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_2" for table "partsupp_1_prt_p1_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_2_3_prt_1" for table "partsupp_1_prt_p1_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_2_3_prt_2" for table "partsupp_1_prt_p1_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3" for table "partsupp"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_1" for table "partsupp_1_prt_p1_3"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_1_3_prt_1" for table "partsupp_1_prt_p1_3_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_1_3_prt_2" for table "partsupp_1_prt_p1_3_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_2" for table "partsupp_1_prt_p1_3"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_2_3_prt_1" for table "partsupp_1_prt_p1_3_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_2_3_prt_2" for table "partsupp_1_prt_p1_3_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4" for table "partsupp"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_1" for table "partsupp_1_prt_p1_4"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_1_3_prt_1" for table "partsupp_1_prt_p1_4_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_1_3_prt_2" for table "partsupp_1_prt_p1_4_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_2" for table "partsupp_1_prt_p1_4"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_2_3_prt_1" for table "partsupp_1_prt_p1_4_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_2_3_prt_2" for table "partsupp_1_prt_p1_4_2_prt_2"
-drop table partsupp;
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1" for table "partsupp_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_1" for table "partsupp_1_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_1_3_prt_1" for table "partsupp_1_1_prt_p1_1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_1_3_prt_2" for table "partsupp_1_1_prt_p1_1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_2" for table "partsupp_1_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_2_3_prt_1" for table "partsupp_1_1_prt_p1_1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_2_3_prt_2" for table "partsupp_1_1_prt_p1_1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2" for table "partsupp_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_1" for table "partsupp_1_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_1_3_prt_1" for table "partsupp_1_1_prt_p1_2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_1_3_prt_2" for table "partsupp_1_1_prt_p1_2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_2" for table "partsupp_1_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_2_3_prt_1" for table "partsupp_1_1_prt_p1_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_2_3_prt_2" for table "partsupp_1_1_prt_p1_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3" for table "partsupp_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_1" for table "partsupp_1_1_prt_p1_3"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_1_3_prt_1" for table "partsupp_1_1_prt_p1_3_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_1_3_prt_2" for table "partsupp_1_1_prt_p1_3_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_2" for table "partsupp_1_1_prt_p1_3"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_2_3_prt_1" for table "partsupp_1_1_prt_p1_3_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_2_3_prt_2" for table "partsupp_1_1_prt_p1_3_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4" for table "partsupp_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_1" for table "partsupp_1_1_prt_p1_4"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_1_3_prt_1" for table "partsupp_1_1_prt_p1_4_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_1_3_prt_2" for table "partsupp_1_1_prt_p1_4_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_2" for table "partsupp_1_1_prt_p1_4"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_2_3_prt_1" for table "partsupp_1_1_prt_p1_4_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_2_3_prt_2" for table "partsupp_1_1_prt_p1_4_2_prt_2"
 -- Accept negative values trivially:
 create table partition_g (i int) partition by range(i) (start((-1)) end(10));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
@@ -2216,7 +2215,6 @@ NOTICE:  CREATE TABLE will create partition "orders_1_prt_p1_5_2_prt_sp2_3_prt_1
 NOTICE:  CREATE TABLE will create partition "orders_1_prt_p1_5_2_prt_sp2_3_prt_2" for table "orders_1_prt_p1_5_2_prt_sp2"
 NOTICE:  CREATE TABLE will create partition "orders_1_prt_p1_5_2_prt_sp2_3_prt_3" for table "orders_1_prt_p1_5_2_prt_sp2"
 NOTICE:  CREATE TABLE will create partition "orders_1_prt_p1_5_2_prt_sp2_3_prt_4" for table "orders_1_prt_p1_5_2_prt_sp2"
-drop table orders;
 -- grammar bug: MPP-3361
 create table i2 (i int) partition by range(i) (start(-2::int) end(20));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
@@ -3415,7 +3413,6 @@ select tablename, partitionboundary from pg_partitions where tablename like 'mpp
  mpp5878a  | VALUES( ('e', 'f'),  ('g', 'h'))
 (4 rows)
 
-drop table mpp5878, mpp5878a;
 -- MPP-5941: work with many levels of templates
 CREATE TABLE mpp5941 (a int, b date, c char, 
 	   		 		 d char(4), e varchar(20), f timestamp)
@@ -4396,7 +4393,6 @@ select pg_get_partition_def('mpp6589a'::regclass,true);
            )
 (1 row)
 
-drop table mpp6589a;
 CREATE TABLE mpp6589i(a int, b int) 
 partition by range (b) (start (1) end (3));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -4430,7 +4426,6 @@ select pg_get_partition_def('mpp6589i'::regclass,true);
            )
 (1 row)
 
-DROP TABLE mpp6589i;
 -- test open-ended SPLIT
 CREATE TABLE mpp6589b
 (
@@ -4470,7 +4465,6 @@ select pg_get_partition_def('mpp6589b'::regclass,true);
            )
 (1 row)
 
-drop table mpp6589b;
 -- MPP-7191, MPP-7193: partitioned tables - fully-qualify storage type
 -- if not specified (and not a template)
 CREATE TABLE mpp5992 (a int, b date, c char,
@@ -5286,7 +5280,6 @@ select pg_get_partition_def('mpp5992'::regclass,true, true);
            )
 (1 row)
 
-drop table mpp5992;
 -- MPP-10223: split subpartitions
 CREATE TABLE MPP10223pk
 (
@@ -5385,7 +5378,7 @@ ALTER TABLE MPP10223pk
  ALTER PARTITION min15part 
 SPLIT PARTITION  P_FUTURE AT ('2010-06-25') 
 INTO (PARTITION P20010101, PARTITION P_FUTURE);
-NOTICE:  exchanged partition "p_future" of partition "min15part" of relation "mpp10223pk" with relation "pg_temp_4049276"
+NOTICE:  exchanged partition "p_future" of partition "min15part" of relation "mpp10223pk" with relation "pg_temp_530246"
 NOTICE:  dropped partition "p_future" for partition "min15part" of relation "mpp10223pk"
 NOTICE:  CREATE TABLE will create partition "mpp10223pk_1_prt_min15part_2_prt_p20010101" for table "mpp10223pk_1_prt_min15part"
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "mpp10223pk_1_prt_min15part_2_prt_p20010101_pkey" for table "mpp10223pk_1_prt_min15part_2_prt_p20010101"
@@ -5505,7 +5498,6 @@ select pg_get_partition_def('mpp10223'::regclass,true);
            )
 (1 row)
 
-drop table mpp10223;
 -- simpler version
 create table mpp10223b (a int, b int , d int)
 partition by range (b)
@@ -5548,7 +5540,6 @@ select pg_get_partition_def('mpp10223b'::regclass,true);
            )
 (1 row)
 
-drop table mpp10223b;
 -- MPP-10480: dump templates (but don't use "foo")
 create table MPP10480 (a int, b int, d int)
 partition by range (b)
@@ -5676,7 +5667,6 @@ select pg_get_partition_template_def('MPP10480'::regclass, true, true);
  
 (1 row)
 
-drop table MPP10480;
 -- MPP-10421: fix SPLIT of partitions with PRIMARY KEY constraint/indexes
 CREATE TABLE mpp10321a
 (
@@ -6957,8 +6947,6 @@ select * from parttest_t;
 reset optimizer_nestloop_factor;
 -- Sub-partition insertion with checking if the user provided correct leaf part
 set dml_ignore_target_partition_check=false;
-drop table if exists part_tab;
-NOTICE:  table "part_tab" does not exist, skipping
 create table part_tab ( i int, j int) distributed by (i) partition by range(j) (start(0) end(10) every(2));
 NOTICE:  CREATE TABLE will create partition "part_tab_1_prt_1" for table "part_tab"
 NOTICE:  CREATE TABLE will create partition "part_tab_1_prt_2" for table "part_tab"
@@ -7095,24 +7083,22 @@ insert into part_tab select i1.x, i2.y from input1 as i1 join input2 as i2 on i1
 select * from part_tab;
  i | j 
 ---+---
- 2 | 2
- 4 | 4
- 4 | 4
- 6 | 6
- 8 | 8
  1 | 1
+ 2 | 2
  3 | 3
  5 | 5
  5 | 5
+ 4 | 4
  5 | 5
+ 4 | 4
  5 | 5
+ 6 | 6
  7 | 7
+ 8 | 8
  9 | 9
 (13 rows)
 
 -- Multi-level partitioning
-drop table if exists deep_part;
-NOTICE:  table "deep_part" does not exist, skipping
 create table deep_part ( i int, j int, k int, s char(5)) 
 distributed by (i) 
 partition by list(s)
@@ -7631,22 +7617,20 @@ select * from deep_part_1_prt_female_2_prt_5_3_prt_5;
 
 -- Out of range partition
 insert into deep_part values (9, 9, 10, 'F');
-ERROR:  no partition for partitioning key  (seg0 slarimac:40000 pid=97899)
+ERROR:  no partition for partitioning key  (seg2 127.0.1.1:25434 pid=22690)
 select * from deep_part;
  i | j | k |   s   
 ---+---+---+-------
  1 | 1 | 1 | F    
  1 | 1 | 1 | F    
- 9 | 9 | 9 | F    
  1 | 1 | 1 | M    
  1 | 1 | 1 | M    
  5 | 5 | 5 | M    
+ 9 | 9 | 9 | F    
 (6 rows)
 
 drop table input2;
 drop table input1;
-drop table part_tab;
-drop table deep_part;
 -- Avoid TupleDesc leak when COPY partition table from files
 -- This also covers the bug reported in MPP-9548 where insertion
 -- into a dropped/added column yielded incorrect results

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -1955,7 +1955,7 @@ from pg_class where relname like 'granttest%';
 drop table granttest;
 drop role part_role;
 -- deep inline + optional subpartition comma:
-CREATE TABLE partsupp (
+CREATE TABLE partsupp_1 (
     ps_partkey integer,
     ps_suppkey integer,
     ps_availqty integer,
@@ -2018,35 +2018,34 @@ CREATE TABLE partsupp (
                           )
                   )
           );
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1" for table "partsupp"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_1" for table "partsupp_1_prt_p1_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_1_3_prt_1" for table "partsupp_1_prt_p1_1_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_1_3_prt_2" for table "partsupp_1_prt_p1_1_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_2" for table "partsupp_1_prt_p1_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_2_3_prt_1" for table "partsupp_1_prt_p1_1_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_1_2_prt_2_3_prt_2" for table "partsupp_1_prt_p1_1_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2" for table "partsupp"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_1" for table "partsupp_1_prt_p1_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_1_3_prt_1" for table "partsupp_1_prt_p1_2_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_1_3_prt_2" for table "partsupp_1_prt_p1_2_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_2" for table "partsupp_1_prt_p1_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_2_3_prt_1" for table "partsupp_1_prt_p1_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_2_2_prt_2_3_prt_2" for table "partsupp_1_prt_p1_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3" for table "partsupp"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_1" for table "partsupp_1_prt_p1_3"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_1_3_prt_1" for table "partsupp_1_prt_p1_3_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_1_3_prt_2" for table "partsupp_1_prt_p1_3_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_2" for table "partsupp_1_prt_p1_3"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_2_3_prt_1" for table "partsupp_1_prt_p1_3_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_3_2_prt_2_3_prt_2" for table "partsupp_1_prt_p1_3_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4" for table "partsupp"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_1" for table "partsupp_1_prt_p1_4"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_1_3_prt_1" for table "partsupp_1_prt_p1_4_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_1_3_prt_2" for table "partsupp_1_prt_p1_4_2_prt_1"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_2" for table "partsupp_1_prt_p1_4"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_2_3_prt_1" for table "partsupp_1_prt_p1_4_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "partsupp_1_prt_p1_4_2_prt_2_3_prt_2" for table "partsupp_1_prt_p1_4_2_prt_2"
-drop table partsupp;
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1" for table "partsupp_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_1" for table "partsupp_1_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_1_3_prt_1" for table "partsupp_1_1_prt_p1_1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_1_3_prt_2" for table "partsupp_1_1_prt_p1_1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_2" for table "partsupp_1_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_2_3_prt_1" for table "partsupp_1_1_prt_p1_1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_1_2_prt_2_3_prt_2" for table "partsupp_1_1_prt_p1_1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2" for table "partsupp_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_1" for table "partsupp_1_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_1_3_prt_1" for table "partsupp_1_1_prt_p1_2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_1_3_prt_2" for table "partsupp_1_1_prt_p1_2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_2" for table "partsupp_1_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_2_3_prt_1" for table "partsupp_1_1_prt_p1_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_2_2_prt_2_3_prt_2" for table "partsupp_1_1_prt_p1_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3" for table "partsupp_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_1" for table "partsupp_1_1_prt_p1_3"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_1_3_prt_1" for table "partsupp_1_1_prt_p1_3_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_1_3_prt_2" for table "partsupp_1_1_prt_p1_3_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_2" for table "partsupp_1_1_prt_p1_3"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_2_3_prt_1" for table "partsupp_1_1_prt_p1_3_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_3_2_prt_2_3_prt_2" for table "partsupp_1_1_prt_p1_3_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4" for table "partsupp_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_1" for table "partsupp_1_1_prt_p1_4"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_1_3_prt_1" for table "partsupp_1_1_prt_p1_4_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_1_3_prt_2" for table "partsupp_1_1_prt_p1_4_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_2" for table "partsupp_1_1_prt_p1_4"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_2_3_prt_1" for table "partsupp_1_1_prt_p1_4_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "partsupp_1_1_prt_p1_4_2_prt_2_3_prt_2" for table "partsupp_1_1_prt_p1_4_2_prt_2"
 -- Accept negative values trivially:
 create table partition_g (i int) partition by range(i) (start((-1)) end(10));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
@@ -2216,7 +2215,6 @@ NOTICE:  CREATE TABLE will create partition "orders_1_prt_p1_5_2_prt_sp2_3_prt_1
 NOTICE:  CREATE TABLE will create partition "orders_1_prt_p1_5_2_prt_sp2_3_prt_2" for table "orders_1_prt_p1_5_2_prt_sp2"
 NOTICE:  CREATE TABLE will create partition "orders_1_prt_p1_5_2_prt_sp2_3_prt_3" for table "orders_1_prt_p1_5_2_prt_sp2"
 NOTICE:  CREATE TABLE will create partition "orders_1_prt_p1_5_2_prt_sp2_3_prt_4" for table "orders_1_prt_p1_5_2_prt_sp2"
-drop table orders;
 -- grammar bug: MPP-3361
 create table i2 (i int) partition by range(i) (start(-2::int) end(20));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
@@ -3414,7 +3412,6 @@ select tablename, partitionboundary from pg_partitions where tablename like 'mpp
  mpp5878a  | VALUES( ('e', 'f'),  ('g', 'h'))
 (4 rows)
 
-drop table mpp5878, mpp5878a;
 -- MPP-5941: work with many levels of templates
 CREATE TABLE mpp5941 (a int, b date, c char, 
 	   		 		 d char(4), e varchar(20), f timestamp)
@@ -4395,7 +4392,6 @@ select pg_get_partition_def('mpp6589a'::regclass,true);
            )
 (1 row)
 
-drop table mpp6589a;
 CREATE TABLE mpp6589i(a int, b int) 
 partition by range (b) (start (1) end (3));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -4429,7 +4425,6 @@ select pg_get_partition_def('mpp6589i'::regclass,true);
            )
 (1 row)
 
-DROP TABLE mpp6589i;
 -- test open-ended SPLIT
 CREATE TABLE mpp6589b
 (
@@ -4469,7 +4464,6 @@ select pg_get_partition_def('mpp6589b'::regclass,true);
            )
 (1 row)
 
-drop table mpp6589b;
 -- MPP-7191, MPP-7193: partitioned tables - fully-qualify storage type
 -- if not specified (and not a template)
 CREATE TABLE mpp5992 (a int, b date, c char,
@@ -5285,7 +5279,6 @@ select pg_get_partition_def('mpp5992'::regclass,true, true);
            )
 (1 row)
 
-drop table mpp5992;
 -- MPP-10223: split subpartitions
 CREATE TABLE MPP10223pk
 (
@@ -5504,7 +5497,6 @@ select pg_get_partition_def('mpp10223'::regclass,true);
            )
 (1 row)
 
-drop table mpp10223;
 -- simpler version
 create table mpp10223b (a int, b int , d int)
 partition by range (b)
@@ -5547,7 +5539,6 @@ select pg_get_partition_def('mpp10223b'::regclass,true);
            )
 (1 row)
 
-drop table mpp10223b;
 -- MPP-10480: dump templates (but don't use "foo")
 create table MPP10480 (a int, b int, d int)
 partition by range (b)
@@ -5675,7 +5666,6 @@ select pg_get_partition_template_def('MPP10480'::regclass, true, true);
  
 (1 row)
 
-drop table MPP10480;
 -- MPP-10421: fix SPLIT of partitions with PRIMARY KEY constraint/indexes
 CREATE TABLE mpp10321a
 (
@@ -6951,8 +6941,6 @@ select * from parttest_t;
 reset optimizer_nestloop_factor;
 -- Sub-partition insertion with checking if the user provided correct leaf part
 set dml_ignore_target_partition_check=false;
-drop table if exists part_tab;
-NOTICE:  table "part_tab" does not exist, skipping
 create table part_tab ( i int, j int) distributed by (i) partition by range(j) (start(0) end(10) every(2));
 NOTICE:  CREATE TABLE will create partition "part_tab_1_prt_1" for table "part_tab"
 NOTICE:  CREATE TABLE will create partition "part_tab_1_prt_2" for table "part_tab"
@@ -7105,8 +7093,6 @@ select * from part_tab;
 (13 rows)
 
 -- Multi-level partitioning
-drop table if exists deep_part;
-NOTICE:  table "deep_part" does not exist, skipping
 create table deep_part ( i int, j int, k int, s char(5)) 
 distributed by (i) 
 partition by list(s)
@@ -7639,8 +7625,6 @@ select * from deep_part;
 
 drop table input2;
 drop table input1;
-drop table part_tab;
-drop table deep_part;
 -- Avoid TupleDesc leak when COPY partition table from files
 -- This also covers the bug reported in MPP-9548 where insertion
 -- into a dropped/added column yielded incorrect results

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -25,8 +25,6 @@ SUBPARTITION TEMPLATE (start ('2000') end ('2006') every (interval '1'))
 drop table rank;
 set enable_partition_rules = off;
 
-drop table if exists ggg cascade;
-
 create table ggg (a char(1), b char(2), d char(3))
 distributed by (a)
 partition by LIST (b)
@@ -114,7 +112,6 @@ partition p1 start('1992-01-31') end('1998-11-01') every(interval '20 months')
 insert into mpp3285_lineitem values (18182,5794,3295,4,9,15298.11,0.04,0.01,'N','O','1995-07-04'::date,'1995-05-30'::date,'1995-08-03'::date,'DELIVER IN PERSON','RAIL','y special platelets.');
 select * from mpp3285_lineitem;
 drop table mpp3285_lineitem;
-drop table mpp3282_partsupp;
 CREATE TABLE mpp3282_PARTSUPP (
 PS_PARTKEY INTEGER,
 PS_SUPPKEY INTEGER,
@@ -134,8 +131,6 @@ copy mpp3282_partsupp from stdin delimiter '|';
 1|2|3325|771.64|, even theodolites. regular, final theodolites eat after the carefully pending foxes. furiously regular deposits sleep slyly. carefully bold realms above the ironic dependencies haggle careful
 \.
 select * from mpp3282_partsupp;
-drop table mpp3282_partsupp;
-drop table mpp3238_supplier;
 CREATE TABLE mpp3238_supplier(
                 S_SUPPKEY INTEGER,
                 S_NAME CHAR(25),
@@ -155,8 +150,6 @@ partition p5 start(22) end(25)
 );
 insert into mpp3238_supplier values(1,'Supplier#000000001',' N kD4on9OM Ipw3,gf0JBoQDd7tgrzrddZ',17,'27-918-335-1736',5755.94,'each slyly above the careful');
 select * from mpp3238_supplier;
-drop table mpp3238_supplier;
-drop table if exists mpp3219_customer;
 CREATE TABLE mpp3219_CUSTOMER (
 C_CUSTKEY INTEGER,
 C_NAME VARCHAR(25),
@@ -205,15 +198,12 @@ subpartition template (start('0') end('25') every(5))
 partition p1 start('1') end('150001') every(50000)
 );
 Alter table mpp3304_customer alter partition for (rank(2)) rename partition for (rank(1)) to newname;
-drop table mpp3304_customer;
-drop table if exists mpp3045_hhh;
 create table mpp3045_hhh (a char(1), b date, d char(3)) with (appendonly=true)
 distributed by (a) 
 partition by range (b) 
  (partition aa start (date '2007-01-01') end (date '2008-01-01'),
  partition bb start (date '2008-01-01') end (date '2009-01-01'));
 alter table mpp3045_hhh add partition aa;
-drop table mpp3045_hhh;
 drop table if exists mpp3287_nation;
 CREATE TABLE mpp3287_NATION (
             N_NATIONKEY INTEGER,
@@ -442,8 +432,6 @@ SUBPARTITION BY LIST (company_no) subpartition template
 
 \d mpp2564_transactions*
 
-DROP TABLE mpp2564_transactions;
-
 -- Check that DEFAULT can be used as partition's name with ALTER TABLE ADD PARTITION. (MPP-3363)
 CREATE TABLE mpp3363(a int, b int, c int)
 partition by range (a)
@@ -533,14 +521,6 @@ subpartition template (
 alter table mpp3059d rename partition pst to pacific;
 select tablename, partitionlevel, partitiontablename, partitionname, partitionrank, partitionboundary from pg_partitions where tablename = 'mpp3059d';
 
-drop table mpp3059;
-drop table mpp3059a_rename;
-drop table mpp3059b;
-drop table mpp3059c;
-drop table mpp3059d;
-drop table mpp3216a;
-drop table mpp3216_rename;
-
 create table test_khush (a integer, b date, c varchar(30))
 partition by range(b)
 ( start ('2008-01-01') end ('2008-04-01') );
@@ -570,9 +550,6 @@ insert into mpp3244 (a,b) values (10,1);
 
 select count(*) from mpp3244;
 select count(*) from mpp3244a;
-
-drop table mpp3244;
-drop table mpp3244a;
 
 CREATE TABLE mpp3256 (
         unique1         int4,
@@ -605,7 +582,6 @@ alter table mpp3256 drop partition default_part;
 alter table mpp3256 add default partition default_part;
 alter table mpp3256 drop partition default_part;
 
-drop table mpp3256;
 -- Examples from Documentation
 CREATE TABLE mpp3377_sales (trans_id int, date date, amount decimal(9,2), region text)
 DISTRIBUTED BY (trans_id)
@@ -640,7 +616,6 @@ ALTER TABLE mpp3377_sales ADD PARTITION START (date '2009-02-01') INCLUSIVE END 
 
 ALTER TABLE mpp3377_sales ADD PARTITION START (date '2009-02-01') INCLUSIVE END (date '2009-03-01') EXCLUSIVE;
 
-DROP TABLE mpp3377_sales;
 CREATE TABLE mpp3250 (
         unique1         int4,
         unique2         int4,
@@ -665,7 +640,6 @@ alter table mpp3250 add default partition default_part;
 
 copy mpp3250 from '@abs_srcdir@/data/onek.data';
 
-drop table mpp3250;
 CREATE TABLE mpp3375 (
         unique1         int4,
         unique2         int4,
@@ -713,9 +687,6 @@ insert into mpp3375a select * from mpp3375;
 alter table mpp3375a add default partition default_part;
 alter table mpp3375a drop partition;
 alter table mpp3375a drop partition default_part;
-
-drop table mpp3375a;
-drop table mpp3375;
 
 -- Check that a negative number can be used in START, without quotes.
 CREATE TABLE mpp3241(a int, b int, c int)
@@ -976,13 +947,6 @@ partition by range (val)
 select tablename, partitionlevel, partitiontablename, partitionname, partitionrank, partitionboundary 
   from pg_partitions where tablename like 'mpp3080%' order by tablename;
 
-drop table mpp3080_int8;
-drop table mpp3080_float4;
-drop table mpp3080_float8;
-drop table mpp3080_floatreal;
-drop table mpp3080_floatdouble;
-drop table mpp3080_numeric;
-drop table mpp3080_numericbig;
 create temp TABLE temp_hour_range (f1 time(2))
 partition by range (f1)
 (

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -23,7 +23,6 @@ LINE 4: SUBPARTITION TEMPLATE (start ('2000') end ('2006') every (in...
 HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
 drop table rank;
 set enable_partition_rules = off;
-drop table if exists ggg cascade;
 create table ggg (a char(1), b char(2), d char(3))
 distributed by (a)
 partition by LIST (b)
@@ -136,8 +135,6 @@ select * from mpp3285_lineitem;
 (1 row)
 
 drop table mpp3285_lineitem;
-drop table mpp3282_partsupp;
-ERROR:  table "mpp3282_partsupp" does not exist
 CREATE TABLE mpp3282_PARTSUPP (
 PS_PARTKEY INTEGER,
 PS_SUPPKEY INTEGER,
@@ -160,9 +157,6 @@ select * from mpp3282_partsupp;
           1 |          2 |        3325 |        771.64 | , even theodolites. regular, final theodolites eat after the carefully pending foxes. furiously regular deposits sleep slyly. carefully bold realms above the ironic dependencies haggle careful
 (1 row)
 
-drop table mpp3282_partsupp;
-drop table mpp3238_supplier;
-ERROR:  table "mpp3238_supplier" does not exist
 CREATE TABLE mpp3238_supplier(
                 S_SUPPKEY INTEGER,
                 S_NAME CHAR(25),
@@ -187,8 +181,6 @@ select * from mpp3238_supplier;
          1 | Supplier#000000001        |  N kD4on9OM Ipw3,gf0JBoQDd7tgrzrddZ |          17 | 27-918-335-1736 |   5755.94 | each slyly above the careful
 (1 row)
 
-drop table mpp3238_supplier;
-drop table if exists mpp3219_customer;
 CREATE TABLE mpp3219_CUSTOMER (
 C_CUSTKEY INTEGER,
 C_NAME VARCHAR(25),
@@ -241,8 +233,6 @@ subpartition template (start('0') end('25') every(5))
 partition p1 start('1') end('150001') every(50000)
 );
 Alter table mpp3304_customer alter partition for (rank(2)) rename partition for (rank(1)) to newname;
-drop table mpp3304_customer;
-drop table if exists mpp3045_hhh;
 create table mpp3045_hhh (a char(1), b date, d char(3)) with (appendonly=true)
 distributed by (a) 
 partition by range (b) 
@@ -250,7 +240,6 @@ partition by range (b)
  partition bb start (date '2008-01-01') end (date '2009-01-01'));
 alter table mpp3045_hhh add partition aa;
 ERROR:  partition "aa" of relation "mpp3045_hhh" already exists
-drop table mpp3045_hhh;
 drop table if exists mpp3287_nation;
 CREATE TABLE mpp3287_NATION (
             N_NATIONKEY INTEGER,
@@ -2036,7 +2025,6 @@ Check constraints:
 Inherits: mpp2564_transactions_1_prt_9
 Distributed randomly
 
-DROP TABLE mpp2564_transactions;
 -- Check that DEFAULT can be used as partition's name with ALTER TABLE ADD PARTITION. (MPP-3363)
 CREATE TABLE mpp3363(a int, b int, c int)
 partition by range (a)
@@ -2212,13 +2200,6 @@ select tablename, partitionlevel, partitiontablename, partitionname, partitionra
  mpp3059d  |              1 | mpp3059d_1_prt_pacific_2_prt_female | female        |               | SUBPARTITION female VALUES('Female', 'F')
 (6 rows)
 
-drop table mpp3059;
-drop table mpp3059a_rename;
-drop table mpp3059b;
-drop table mpp3059c;
-drop table mpp3059d;
-drop table mpp3216a;
-drop table mpp3216_rename;
 create table test_khush (a integer, b date, c varchar(30))
 partition by range(b)
 ( start ('2008-01-01') end ('2008-04-01') );
@@ -2251,8 +2232,6 @@ select count(*) from mpp3244a;
      1
 (1 row)
 
-drop table mpp3244;
-drop table mpp3244a;
 CREATE TABLE mpp3256 (
         unique1         int4,
         unique2         int4,
@@ -2283,7 +2262,6 @@ alter table mpp3256 add default partition default_part;
 alter table mpp3256 drop partition default_part;
 alter table mpp3256 add default partition default_part;
 alter table mpp3256 drop partition default_part;
-drop table mpp3256;
 -- Examples from Documentation
 CREATE TABLE mpp3377_sales (trans_id int, date date, amount decimal(9,2), region text)
 DISTRIBUTED BY (trans_id)
@@ -2316,7 +2294,6 @@ ERROR:  subpartition configuration conflicts with subpartition template
 ALTER TABLE mpp3377_sales ADD PARTITION START (date '2009-02-01') INCLUSIVE END (date '2009-03-01') EXCLUSIVE;
 ALTER TABLE mpp3377_sales ADD PARTITION START (date '2009-02-01') INCLUSIVE END (date '2009-03-01') EXCLUSIVE;
 ERROR:  new partition overlaps existing partition
-DROP TABLE mpp3377_sales;
 CREATE TABLE mpp3250 (
         unique1         int4,
         unique2         int4,
@@ -2339,7 +2316,6 @@ subpartition by range (unique2) subpartition template ( start (0) end (1000) eve
 ( start (0) end (1000) every (100));
 alter table mpp3250 add default partition default_part;
 copy mpp3250 from '@abs_srcdir@/data/onek.data';
-drop table mpp3250;
 CREATE TABLE mpp3375 (
         unique1         int4,
         unique2         int4,
@@ -2383,8 +2359,6 @@ insert into mpp3375a select * from mpp3375;
 alter table mpp3375a add default partition default_part;
 alter table mpp3375a drop partition;
 alter table mpp3375a drop partition default_part;
-drop table mpp3375a;
-drop table mpp3375;
 -- Check that a negative number can be used in START, without quotes.
 CREATE TABLE mpp3241(a int, b int, c int)
 partition by range (a)
@@ -2955,13 +2929,6 @@ select tablename, partitionlevel, partitiontablename, partitionname, partitionra
  mpp3080_numericbig  |              0 | mpp3080_numericbig_1_prt_1  |               |             1 | START (1.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000::numeric(1000,800)) END (2.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000::numeric(1000,800)) EVERY (1::numeric)
 (28 rows)
 
-drop table mpp3080_int8;
-drop table mpp3080_float4;
-drop table mpp3080_float8;
-drop table mpp3080_floatreal;
-drop table mpp3080_floatdouble;
-drop table mpp3080_numeric;
-drop table mpp3080_numericbig;
 create temp TABLE temp_hour_range (f1 time(2))
 partition by range (f1)
 (

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -1031,7 +1031,7 @@ drop table granttest;
 drop role part_role;
 
 -- deep inline + optional subpartition comma:
-CREATE TABLE partsupp (
+CREATE TABLE partsupp_1 (
     ps_partkey integer,
     ps_suppkey integer,
     ps_availqty integer,
@@ -1094,7 +1094,6 @@ CREATE TABLE partsupp (
                           )
                   )
           );
-drop table partsupp;
 
 -- Accept negative values trivially:
 create table partition_g (i int) partition by range(i) (start((-1)) end(10));
@@ -1203,7 +1202,6 @@ WITH (appendonly=true, checksum=true, blocksize=368640, compresslevel=9) PARTITI
                           )
                   )
           );
-drop table orders;
 
 -- grammar bug: MPP-3361
 create table i2 (i int) partition by range(i) (start(-2::int) end(20));
@@ -1778,8 +1776,6 @@ values (('e','f'),('g','h'))
 select tablename, partitionlistvalues from pg_partitions where tablename like 'mpp5878%';
 select tablename, partitionboundary from pg_partitions where tablename like 'mpp5878%';
 
-drop table mpp5878, mpp5878a;
-
 -- MPP-5941: work with many levels of templates
 
 CREATE TABLE mpp5941 (a int, b date, c char, 
@@ -2311,8 +2307,6 @@ INTO( PARTITION p20090309, PARTITION p20090312_tmp);
 
 select pg_get_partition_def('mpp6589a'::regclass,true);
 
-drop table mpp6589a;
-
 CREATE TABLE mpp6589i(a int, b int) 
 partition by range (b) (start (1) end (3));
 select pg_get_partition_def('mpp6589i'::regclass,true);
@@ -2325,8 +2319,6 @@ ALTER TABLE mpp6589i ADD PARTITION start (3) exclusive;
 -- should work - make sure can add an open-ended final partition
 ALTER TABLE mpp6589i ADD PARTITION start (3);
 select pg_get_partition_def('mpp6589i'::regclass,true);
-
-DROP TABLE mpp6589i;
 
 -- test open-ended SPLIT
 CREATE TABLE mpp6589b
@@ -2348,8 +2340,6 @@ SPLIT PARTITION p20090312 AT( '20090310' )
 INTO( PARTITION p20090309, PARTITION p20090312_tmp);
 
 select pg_get_partition_def('mpp6589b'::regclass,true);
-
-drop table mpp6589b;
 
 -- MPP-7191, MPP-7193: partitioned tables - fully-qualify storage type
 -- if not specified (and not a template)
@@ -2418,8 +2408,6 @@ start (date '2013-01-01') end (date '2014-01-01') WITH (appendonly=true);
 
 select pg_get_partition_def('mpp5992'::regclass,true, true);
 
-drop table mpp5992;
-
 -- MPP-10223: split subpartitions
 CREATE TABLE MPP10223pk
 (
@@ -2480,9 +2468,7 @@ ALTER TABLE MPP10223pk
  ALTER PARTITION min15part 
 SPLIT PARTITION  P_FUTURE AT ('2010-06-25') 
 INTO (PARTITION P20010101, PARTITION P_FUTURE);
-
 drop table mpp10223pk;
-
 -- rebuild the table without a primary key
 CREATE TABLE MPP10223
 (
@@ -2542,8 +2528,6 @@ INTO (PARTITION P20010101, PARTITION P_FUTURE2);
 
 select pg_get_partition_def('mpp10223'::regclass,true);
 
-drop table mpp10223;
-
 -- simpler version
 create table mpp10223b (a int, b int , d int)
 partition by range (b)
@@ -2562,8 +2546,6 @@ select partitiontablename,partitionposition,partitionrangestart,
 
 select pg_get_partition_def('mpp10223b'::regclass,true);
 
-drop table mpp10223b;
-
 -- MPP-10480: dump templates (but don't use "foo")
 create table MPP10480 (a int, b int, d int)
 partition by range (b)
@@ -2572,8 +2554,6 @@ subpartition template (start (1) end (10) every (1))
 (start (20) end (30) every (1));
 
 select pg_get_partition_template_def('MPP10480'::regclass, true, true);
-
-drop table MPP10480;
 
 -- MPP-10421: fix SPLIT of partitions with PRIMARY KEY constraint/indexes
 CREATE TABLE mpp10321a
@@ -3490,7 +3470,6 @@ reset optimizer_nestloop_factor;
 
 -- Sub-partition insertion with checking if the user provided correct leaf part
 set dml_ignore_target_partition_check=false;
-drop table if exists part_tab;
 create table part_tab ( i int, j int) distributed by (i) partition by range(j) (start(0) end(10) every(2));
 -- Wrong part
 insert into part_tab_1_prt_1 values(5,5);
@@ -3540,7 +3519,6 @@ insert into part_tab select i1.x, i2.y from input1 as i1 join input2 as i2 on i1
 select * from part_tab;
 
 -- Multi-level partitioning
-drop table if exists deep_part;
 create table deep_part ( i int, j int, k int, s char(5)) 
 distributed by (i) 
 partition by list(s)
@@ -3681,8 +3659,6 @@ select * from deep_part;
 
 drop table input2;
 drop table input1;
-drop table part_tab;
-drop table deep_part;
 
 -- Avoid TupleDesc leak when COPY partition table from files
 -- This also covers the bug reported in MPP-9548 where insertion


### PR DESCRIPTION
There are still lot of wasted cycles spent in creating partitions very deep and wide in these tests but that's for some other day to tackle and save time.