### PR TITLE
Always generate relfilenode for about to be created relations

### DIFF
--- a/src/include/storage/backendid.h
+++ b/src/include/storage/backendid.h
@@ -25,6 +25,20 @@ typedef int BackendId;			/* unique currently active backend identifier */
 /*
  * TempRelBackendId is used in GPDB in place of a real backend ID in some
  * places where we deal with a temporary tables.
+ *
+ * Future enhancement: To align closer with upstream, the TempRelBackendId
+ * constant should be replaced with gp_session_id.  In order for it to work,
+ * the BufferTag needs to be augmented with session ID so that we can get rid
+ * of two further GPDB-specific hacks: (1) BM_TEMP flag added to distinguish
+ * shared buffers belonging to temp relations from non-temp relations and (2)
+ * the additional check for collition in GetNewRelFileNode.
+ *
+ * Based on this discussion adding gp_session_id to BufferTag is considered a
+ * performance overhead:
+ * http://www.postgresql-archive.org/Keeping-temporary-tables-in-shared-buffers-td6022361.html
+ *
+ * The advantage we would get is BufferTag can never hash to the same value for
+ * a temp and a non-temp relation having the same RelFileNode.
  */
 #define TempRelBackendId		(-2)
 


### PR DESCRIPTION
We have found the culprit causing relfilenode collisions to be VACUUM
FULL on a mapped relation.  The code was reusing OID as relfilenode for
the temporary table created by vacuum full.  This happened without
bumping the relfilenode counter.  The patch fixes this such that
relfilenode is always generated, even in case of mapped relations.

With this, we believe that there is no 'race' condition, even with
sequence relations, that would cause a collision in shared buffers due
to OID being reused as relfilenode.  Therefore, demote the corresponding
fixme to 'future enhancement'.

Co-authored-by: David Kimura <dkimura@pivotal.io>