### PR TITLE
Fix memory leak when copy into a partition table

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -8005,10 +8005,11 @@ GetDistributionPolicyForPartition(CopyState cstate, EState *estate,
 		values_for_partition = getAttrContext->values;
 	}
 
-	/* values_get_partition() calls palloc() */
-	MemoryContext save_cxt = MemoryContextSwitchTo(ctxt);
 	GpDistributionData *distData = palloc(sizeof(GpDistributionData));
 	distData->p_attr_types = p_attr_types;
+
+	/* values_get_partition() calls palloc() */
+	MemoryContext save_cxt = MemoryContextSwitchTo(ctxt);
 	resultRelInfo = values_get_partition(values_for_partition,
 	                                     getAttrContext->nulls,
 	                                     getAttrContext->tupDesc, estate);
@@ -8033,8 +8034,8 @@ GetDistributionPolicyForPartition(CopyState cstate, EState *estate,
 		}
 		else
 		{
-			Relation rel = heap_open(relid, NoLock);
 			MemoryContextSwitchTo(ctxt);
+			Relation rel = heap_open(relid, NoLock);
 
 			/*
 			 * Make sure this all persists the current


### PR DESCRIPTION
`part_distData` was allocated for every tuple but not allocated in the
per tuple memory context.

Fix #4986

Why only 5X_STABLE?
During the merge, this issue was fixed on master. The memory is allocated before memory context switch now.

Why no tests?
Quoted Zhanwei said in #4987
> No idea that how we test memory leak right now. It will not crash or return wrong answer. Even with limited memory in test case, we cannot tell the query fail due to memory leak or real need of such size of memory. It is also not possible to detect such memory leak in a memory context using tools like valgrind. 