### PR TITLE
tuptoaster: gracefully handle changes to TOAST_MAX_CHUNK_SIZE

### DIFF
--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -1751,11 +1751,18 @@ toast_fetch_datum(struct varlena * attr)
 	char	   *chunkdata;
 	int32		chunksize;
 
+	/*
+	 * GPDB: start with the assumption that chunks max out at
+	 * TOAST_MAX_CHUNK_SIZE. This may later prove false (e.g. if we've upgraded
+	 * from GPDB 4.3), in which case we'll readjust numchunks later.
+	 */
+	int32		actual_max_chunk_size = TOAST_MAX_CHUNK_SIZE;
+
 	/* Must copy to access aligned fields */
 	VARATT_EXTERNAL_GET_POINTER(toast_pointer, attr);
 
 	ressize = toast_pointer.va_extsize;
-	numchunks = ((ressize - 1) / TOAST_MAX_CHUNK_SIZE) + 1;
+	numchunks = ((ressize - 1) / actual_max_chunk_size) + 1;
 
 	result = (struct varlena *) palloc(ressize + VARHDRSZ);
 
@@ -1830,21 +1837,42 @@ toast_fetch_datum(struct varlena * attr)
 				 residx, nextidx,
 				 toast_pointer.va_valueid,
 				 RelationGetRelationName(toastrel));
+
+		if ((residx == 0) && (chunksize < ressize)
+			&& (chunksize != actual_max_chunk_size))
+		{
+			/*
+			 * GPDB: This toasted tuple is using a different max chunk size.
+			 * This can happen after an upgrade, for instance. Realign our
+			 * expectations.
+			 *
+			 * Only perform this check on the first chunk (the max size isn't
+			 * allowed to change partway through), and only if we expect more
+			 * chunks to come after this based on ressize.
+			 */
+			elog(DEBUG4, "readjusting max chunk size from %d to %d for toast value %u in %s",
+				 actual_max_chunk_size, chunksize, toast_pointer.va_valueid,
+				 RelationGetRelationName(toastrel));
+
+			actual_max_chunk_size = chunksize;
+			numchunks = ((ressize - 1) / actual_max_chunk_size) + 1;
+		}
+
 		if (residx < numchunks - 1)
 		{
-			if (chunksize != TOAST_MAX_CHUNK_SIZE)
+			if (chunksize != actual_max_chunk_size)
 				elog(ERROR, "unexpected chunk size %d (expected %d) in chunk %d of %d for toast value %u in %s",
-					 chunksize, (int) TOAST_MAX_CHUNK_SIZE,
+					 chunksize, (int) actual_max_chunk_size,
 					 residx, numchunks,
 					 toast_pointer.va_valueid,
 					 RelationGetRelationName(toastrel));
 		}
 		else if (residx == numchunks - 1)
 		{
-			if ((residx * TOAST_MAX_CHUNK_SIZE + chunksize) != ressize)
+			if ((residx * actual_max_chunk_size + chunksize) != ressize)
 				elog(ERROR, "unexpected chunk size %d (expected %d) in final chunk %d for toast value %u in %s",
 					 chunksize,
-					 (int) (ressize - residx * TOAST_MAX_CHUNK_SIZE),
+					 (int) (ressize - residx * actual_max_chunk_size),
 					 residx,
 					 toast_pointer.va_valueid,
 					 RelationGetRelationName(toastrel));
@@ -1859,7 +1887,7 @@ toast_fetch_datum(struct varlena * attr)
 		/*
 		 * Copy the data into proper place in our result
 		 */
-		memcpy(VARDATA(result) + residx * TOAST_MAX_CHUNK_SIZE,
+		memcpy(VARDATA(result) + residx * actual_max_chunk_size,
 			   chunkdata,
 			   chunksize);
 
@@ -1920,6 +1948,13 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 	int32		chcpystrt;
 	int32		chcpyend;
 
+	/*
+	 * GPDB: start with the assumption that chunks max out at
+	 * TOAST_MAX_CHUNK_SIZE. This may later prove false (e.g. if we've upgraded
+	 * from GPDB 4.3), in which case we'll readjust everything later.
+	 */
+	int32		actual_max_chunk_size = TOAST_MAX_CHUNK_SIZE;
+
 	Assert(VARATT_IS_EXTERNAL(attr));
 
 	/* Must copy to access aligned fields */
@@ -1932,7 +1967,6 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 	Assert(!VARATT_EXTERNAL_IS_COMPRESSED(toast_pointer));
 
 	attrsize = toast_pointer.va_extsize;
-	totalchunks = ((attrsize - 1) / TOAST_MAX_CHUNK_SIZE) + 1;
 
 	if (sliceoffset >= attrsize)
 	{
@@ -1953,13 +1987,6 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 	if (length == 0)
 		return (struct varlena *)result;			/* Can save a lot of work at this point! */
 
-	startchunk = sliceoffset / TOAST_MAX_CHUNK_SIZE;
-	endchunk = (sliceoffset + length - 1) / TOAST_MAX_CHUNK_SIZE;
-	numchunks = (endchunk - startchunk) + 1;
-
-	startoffset = sliceoffset % TOAST_MAX_CHUNK_SIZE;
-	endoffset = (sliceoffset + length - 1) % TOAST_MAX_CHUNK_SIZE;
-
 	/*
 	 * Open the toast relation and its index
 	 */
@@ -1968,6 +1995,74 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 	toastidx = index_open(toastrel->rd_rel->reltoastidxid, AccessShareLock);
 
 	check_toast_indisvalid(toastrel, toastidx);
+
+	{
+		/*
+		 * GPDB: because we allow upgrades from clusters with different
+		 * TOAST_MAX_CHUNK_SIZEs, we can't compute our chunk offsets yet. Open
+		 * the first chunk and check its size.
+		 */
+		ScanKeyInit(&toastkey[0],
+					(AttrNumber) 1,
+					BTEqualStrategyNumber, F_OIDEQ,
+					ObjectIdGetDatum(toast_pointer.va_valueid));
+		ScanKeyInit(&toastkey[1],
+					(AttrNumber) 2,
+					BTEqualStrategyNumber, F_INT4EQ,
+					Int32GetDatum(0));
+		nscankeys = 2;
+
+		toastscan = systable_beginscan_ordered(toastrel, toastidx,
+											   SnapshotToast, nscankeys, toastkey);
+
+		if ((ttup = systable_getnext_ordered(toastscan, ForwardScanDirection)) != NULL)
+		{
+			/*
+			 * Have a chunk, extract the sequence number and the data
+			 */
+			residx = DatumGetInt32(fastgetattr(ttup, 2, toasttupDesc, &isnull));
+			Assert(!isnull);
+			chunk = DatumGetPointer(fastgetattr(ttup, 3, toasttupDesc, &isnull));
+			Assert(!isnull);
+
+			if (!VARATT_IS_EXTENDED(chunk))
+			{
+				chunksize = VARSIZE(chunk) - VARHDRSZ;
+			}
+			else if (VARATT_IS_SHORT(chunk))
+			{
+				/* could happen due to heap_form_tuple doing its thing */
+				chunksize = VARSIZE_SHORT(chunk) - VARHDRSZ_SHORT;
+			}
+			else
+			{
+				/* should never happen */
+				elog(ERROR, "found toasted toast chunk for toast value %u in %s",
+					 toast_pointer.va_valueid,
+					 RelationGetRelationName(toastrel));
+				chunksize = 0;		/* keep compiler quiet */
+			}
+
+			if (chunksize < attrsize)
+			{
+				/*
+				 * Only adjust the max chunk size if this isn't the only chunk.
+				 */
+				actual_max_chunk_size = chunksize;
+			}
+		}
+
+		systable_endscan_ordered(toastscan);
+	}
+
+	totalchunks = ((attrsize - 1) / actual_max_chunk_size) + 1;
+
+	startchunk = sliceoffset / actual_max_chunk_size;
+	endchunk = (sliceoffset + length - 1) / actual_max_chunk_size;
+	numchunks = (endchunk - startchunk) + 1;
+
+	startoffset = sliceoffset % actual_max_chunk_size;
+	endoffset = (sliceoffset + length - 1) % actual_max_chunk_size;
 
 	/*
 	 * Setup a scan key to fetch from the index. This is either two keys or
@@ -2050,19 +2145,19 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 				 RelationGetRelationName(toastrel));
 		if (residx < totalchunks - 1)
 		{
-			if (chunksize != TOAST_MAX_CHUNK_SIZE)
+			if (chunksize != actual_max_chunk_size)
 				elog(ERROR, "unexpected chunk size %d (expected %d) in chunk %d of %d for toast value %u in %s when fetching slice",
-					 chunksize, (int) TOAST_MAX_CHUNK_SIZE,
+					 chunksize, (int) actual_max_chunk_size,
 					 residx, totalchunks,
 					 toast_pointer.va_valueid,
 					 RelationGetRelationName(toastrel));
 		}
 		else if (residx == totalchunks - 1)
 		{
-			if ((residx * TOAST_MAX_CHUNK_SIZE + chunksize) != attrsize)
+			if ((residx * actual_max_chunk_size + chunksize) != attrsize)
 				elog(ERROR, "unexpected chunk size %d (expected %d) in final chunk %d for toast value %u in %s when fetching slice",
 					 chunksize,
-					 (int) (attrsize - residx * TOAST_MAX_CHUNK_SIZE),
+					 (int) (attrsize - residx * actual_max_chunk_size),
 					 residx,
 					 toast_pointer.va_valueid,
 					 RelationGetRelationName(toastrel));
@@ -2085,7 +2180,7 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 			chcpyend = endoffset;
 
 		memcpy(VARDATA(result) +
-			   (residx * TOAST_MAX_CHUNK_SIZE - sliceoffset) + chcpystrt,
+			   (residx * actual_max_chunk_size - sliceoffset) + chcpystrt,
 			   chunkdata + chcpystrt,
 			   (chcpyend - chcpystrt) + 1);
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -20,6 +20,7 @@
 
 #include "access/reloptions.h"
 #include "access/transam.h"
+#include "access/tuptoaster.h"
 #include "access/url.h"
 #include "access/xlog_internal.h"
 #include "cdb/cdbappendonlyam.h"
@@ -161,6 +162,7 @@ bool		gp_create_table_random_default_distribution = true;
 bool		gp_allow_non_uniform_partitioning_ddl = true;
 bool		gp_enable_exchange_default_partition = false;
 int			dtx_phase2_retry_count = 0;
+int			gp_test_toast_max_chunk_size_override = 0;
 
 bool		log_dispatch_stats = false;
 
@@ -4418,6 +4420,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_max_slices,
 		0, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"gp_test_toast_max_chunk_size_override", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Testing support for TOAST_MAX_CHUNK_SIZE changes."),
+			NULL,
+			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+		},
+		&gp_test_toast_max_chunk_size_override,
+		0, 0, TOAST_MAX_CHUNK_SIZE, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -275,6 +275,7 @@ extern bool gp_create_table_random_default_distribution;
 extern bool gp_allow_non_uniform_partitioning_ddl;
 extern bool gp_enable_exchange_default_partition;
 extern int  dtx_phase2_retry_count;
+extern int	gp_test_toast_max_chunk_size_override;
 
 /* WAL replication debug gucs */
 extern bool debug_walrepl_snd;

--- a/src/test/regress/expected/toast.out
+++ b/src/test/regress/expected/toast.out
@@ -88,3 +88,25 @@ SELECT char_length(a), char_length(b), c, d FROM toastable_ao;
 DROP TABLE toastable_heap;
 DROP TABLE toastable_ao;
 -- TODO: figure out a way to verify that the toast tables are dropped
+-- Test TOAST_MAX_CHUNK_SIZE changes for upgrade.
+CREATE TABLE toast_chunk_test (a bytea);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE toast_chunk_test ALTER COLUMN a SET STORAGE EXTERNAL;
+-- Alter our TOAST_MAX_CHUNK_SIZE and insert a value we know will be toasted.
+SET gp_test_toast_max_chunk_size_override = 7993;
+INSERT INTO toast_chunk_test VALUES (repeat('abcdefghijklmnopqrstuvwxyz', 1000)::bytea);
+RESET gp_test_toast_max_chunk_size_override;
+-- The toasted value should still be read correctly.
+SELECT * FROM toast_chunk_test WHERE a <> repeat('abcdefghijklmnopqrstuvwxyz', 1000)::bytea;
+ a 
+---
+(0 rows)
+
+-- Random access into the toast table should work equally well.
+SELECT encode(substring(a from 521*26+1 for 26), 'escape') FROM toast_chunk_test;
+           encode           
+----------------------------
+ abcdefghijklmnopqrstuvwxyz
+(1 row)
+


### PR DESCRIPTION
GPDB 4.3 uses a slightly smaller `TOAST_MAX_CHUNK_SIZE`, and we claim to be able to upgrade those toast tables, but there's currently no support in tuptoaster:

	ERROR:  unexpected chunk size 8138 (expected 8140) in chunk 0 of 4 for toast value 16486 in pg_toast_16479 (tuptoaster.c:1840)

For the full `toast_fetch_datum()`, we can optimistically assume that the max chunk size is `TOAST_MAX_CHUNK_SIZE`, and then adjust if that turns out to be false. For the random access in `toast_fetch_datum_slice()`, though, I haven't tried a similar optimization -- if we don't know the
chunk size to begin with, it seems like there are too many corner cases to keep track of when jumping into the middle of a toast relation. So `toast_fetch_datum_slice()` will always open the first chunk, which may somewhat impact performance for some queries.

Test support introduces the `gp_test_toast_max_chunk_size_override` GUC, which allows a superuser to manually reduce the chunk size used by `toast_save_datum()`.