### PR TITLE
Narrow race condition between pg_partitions view and altering partiti…

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -7922,7 +7922,20 @@ get_rule_def_common(Oid partid, int prettyFlags, int bLeafTablename)
 
 	ReleaseSysCache(tuple);
 
-	return partition_rule_def_worker(rule, rule->parrangestart, 
+	/*
+	 * Look up the child relation too, just to check if it has been dropped
+	 * concurrently. partition_rule_def_worker() calls flatten_reloptions(),
+	 * which errors out if it can't find the relation. This isn't 100% reliable,
+	 * it's possible that the relation gets dropped between here and
+	 * flatten_reloptions(), but it's better than nothing.
+	 */
+	if (rule->parchildrelid)
+	{
+		if (!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(rule->parchildrelid)))
+			return NULL;
+	}
+
+	return partition_rule_def_worker(rule, rule->parrangestart,
 									 rule->parrangeend, rule,
 									 rule->parrangeevery, part, 
 									 false, prettyFlags, bLeafTablename, 0);


### PR DESCRIPTION
…ons.

We have lately seen a lot of failures in test cases related to
partitioning, with errors like this:

select tablename, partitionlevel, partitiontablename, partitionname, partitionrank, partitionboundary from pg_partitions where tablename = 'mpp3079a';
ERROR:  cache lookup failed for relation 148532 (ruleutils.c:7172)

The culprit is that that the view passes a relation OID to the
pg_get_partition_rule_def() function, and the function tries to perform a
syscache lookup on the relation (in flatten_reloptions()), but the lookup
fails because the relation was dropped concurrently by another transaction.
This race is possible, because the query runs with an MVCC snapshot, but
the syscache lookups use SnapshotNow.

This commit doesn't eliminate the race completely, but at least it makes it
narrower. A more reliable solution would've been to acquire a lock on the
table, but then that might block, which isn't nice either.

Another solution would've been to modify flatten_reloptions() to return
NULL instead of erroring out, if the lookup fails. That approach is taken
on the other lookups, but I'm reluctant to modify flatten_reloptions()
because it's inherited from upstream. Let's see how well this works in
practice first, before we do more drastic measures.