### PR TITLE
Preserve persistence when reorganizing temp tables.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -12907,12 +12907,21 @@ make_temp_table_name(Relation rel, BackendId id)
 {
 	char	   *nspname;
 	char		tmpname[NAMEDATALEN];
+	RangeVar   *tmprel;
 
 	/* temporary enough */
 	snprintf(tmpname, NAMEDATALEN, "pg_temp_%u_%i", RelationGetRelid(rel), id);
 	nspname = get_namespace_name(RelationGetNamespace(rel));
 
-	return makeRangeVar(nspname, pstrdup(tmpname), -1);
+	tmprel = makeRangeVar(nspname, pstrdup(tmpname), -1);
+
+	/*
+	 * Ensure the temp relation has the same persistence setting with the
+	 * original relation.
+	 */
+	tmprel->relpersistence = rel->rd_rel->relpersistence;
+
+	return tmprel;
 }
 
 /*

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1426,3 +1426,22 @@ ALTER TABLE mpp6489_1_prt_1_2_prt_5 set distributed randomly;
 ALTER TABLE "mpp6489" ALTER PARTITION FOR('M'::bpchar) alter PARTITION
 FOR(RANK(5)) set distributed by (id, gender, year);
 NOTICE:  altering table "mpp6489_1_prt_1_2_prt_5" (partition for rank 5 of partition for value ('M'::bpchar) of relation "mpp6489")
+-- Altering distribution policy for temp tables
+create temp table atsdb (c1 int, c2 int) distributed randomly;
+select * from atsdb;
+ c1 | c2 
+----+----
+(0 rows)
+
+alter table atsdb set distributed by (c1);
+select * from atsdb;
+ c1 | c2 
+----+----
+(0 rows)
+
+alter table atsdb set distributed by (c2);
+select * from atsdb;
+ c1 | c2 
+----+----
+(0 rows)
+

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -475,3 +475,11 @@ subpartition template
 ALTER TABLE mpp6489_1_prt_1_2_prt_5 set distributed randomly;
 ALTER TABLE "mpp6489" ALTER PARTITION FOR('M'::bpchar) alter PARTITION
 FOR(RANK(5)) set distributed by (id, gender, year);
+
+-- Altering distribution policy for temp tables
+create temp table atsdb (c1 int, c2 int) distributed randomly;
+select * from atsdb;
+alter table atsdb set distributed by (c1);
+select * from atsdb;
+alter table atsdb set distributed by (c2);
+select * from atsdb;


### PR DESCRIPTION
When altering a table's distribution policy we might need to reorganize
the data by creating a __temp__ table, copying the data to it, then swap
the underlying relation files.  However we always create the __temp__
table as permanent, then when the original table is temp the underlying
files can not be found in later queries.

	CREATE TEMP TABLE t1 (c1 int, c2 int) DISTRIBUTED BY (c1);
	ALTER TABLE t1 SET DISTRIBUTED BY (c2);
	SELECT * FROM t1;