### PR TITLE
resgroup: load resgroup settings even for bypassed queries.

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_set_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_set_memory_spill_ratio.out
@@ -1,3 +1,13 @@
+-- This query must be the first one in this case.
+-- SHOW command will be bypassed in resgroup, when it's the first command
+-- in a connection it needs special handling to show memory_spill_ratio
+-- correctly.  Verify that it shows the correct value 10 instead of default 20.
+SHOW memory_spill_ratio;
+memory_spill_ratio
+------------------
+10                
+(1 row)
+
 --start_ignore
 DROP ROLE role1_spill_test;
 ERROR:  role "role1_spill_test" does not exist

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -83,7 +83,7 @@ SELECT * FROM gp_toolkit.gp_resgroup_config;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
 6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
-6438   |admin_group  |2          |2                   |10            |10          |10                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+6438   |admin_group  |2          |2                   |10            |10          |10                   |50                 |50                          |10                |10                         |vmtracker     |-1    
 (2 rows)
 
 -- negative

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -36,3 +36,6 @@ SELECT * FROM gp_toolkit.gp_resq_priority_backend;
 -- by default admin_group has concurrency set to -1 which leads to
 -- very small memory quota for each resgroup slot, correct it.
 ALTER RESOURCE GROUP admin_group SET concurrency 2;
+-- in later cases we will SHOW memory_spill_ratio as first command
+-- to verify that it can be correctly loaded even for bypassed commands
+ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;

--- a/src/test/isolation2/output/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup.source
@@ -73,3 +73,7 @@ rqpsession|rqpcommand|rqppriority|rqpweight
 -- very small memory quota for each resgroup slot, correct it.
 ALTER RESOURCE GROUP admin_group SET concurrency 2;
 ALTER
+-- in later cases we will SHOW memory_spill_ratio as first command
+-- to verify that it can be correctly loaded even for bypassed commands
+ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
+ALTER

--- a/src/test/isolation2/sql/resgroup/resgroup_set_memory_spill_ratio.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_set_memory_spill_ratio.sql
@@ -1,3 +1,9 @@
+-- This query must be the first one in this case.
+-- SHOW command will be bypassed in resgroup, when it's the first command
+-- in a connection it needs special handling to show memory_spill_ratio
+-- correctly.  Verify that it shows the correct value 10 instead of default 20.
+SHOW memory_spill_ratio;
+
 --start_ignore
 DROP ROLE role1_spill_test;
 DROP ROLE role2_spill_test;


### PR DESCRIPTION
`SHOW memory_spill_ratio` will always display 20 when it's the first
query in a connection (if you run this query in psql and pressed TAB
when entering the command then the implicit queries ran by the tab
completion function will be the first), the root cause is that SHOW
command will be bypassed in resgroup, so the bound resgroup will not be
assigned, and the resgroup's settings will not be loaded.

To display the proper value in this case we will also load the resgroup
settings even for bypassed queries.