### PR TITLE
Make resource queues object addressable

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/COMMENT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/COMMENT.xml
@@ -17,6 +17,7 @@
   OPERATOR <varname>op</varname> (<varname>leftoperand_type</varname>, <varname>rightoperand_type</varname>) |
   OPERATOR CLASS <varname>object_name</varname> USING <varname>index_method</varname> |
   [PROCEDURAL] LANGUAGE <varname>object_name</varname> |
+  RESOURCE GROUP <varname>object_name</varname> |
   RESOURCE QUEUE <varname>object_name</varname> |
   ROLE <varname>object_name</varname> |
   RULE <varname>rule_name</varname> ON <varname>table_name</varname> |

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -908,7 +908,7 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		if (mask & (1 << type))
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					errmsg("Find duplicate resoure group resource type: %s",
+					errmsg("Find duplicate resource group resource type: %s",
 						   defel->defname)));
 		else
 			mask |= 1 << type;
@@ -1151,7 +1151,7 @@ validateCapabilities(Relation rel,
 
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_OBJECT),
-					errmsg("Find duplicate resoure group id:%d", groupid)));
+					errmsg("Find duplicate resource group id:%d", groupid)));
 		}
 
 		typeDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_reslimittype,

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -7385,6 +7385,7 @@ comment_type:
 			| SERVER							{ $$ = OBJECT_FOREIGN_SERVER; }
 			| FOREIGN DATA_P WRAPPER			{ $$ = OBJECT_FDW; }
 			| RESOURCE QUEUE                    { $$ = OBJECT_RESQUEUE; }
+			| RESOURCE GROUP_P					{ $$ = OBJECT_RESGROUP; }
 		;
 
 comment_text:

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1367,7 +1367,7 @@ PortalRunUtility(Portal portal, Node *utilityStmt, bool isTopLevel,
 	else
 		active_snapshot_set = false;
 
-	/* check if this utility statement need to be involved into resoure queue
+	/* check if this utility statement need to be involved into resource queue
 	 * mgmt */
 	ResHandleUtilityStmt(portal, utilityStmt);
 

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -1075,8 +1075,8 @@ AtAbort_ResScheduler(void)
 		portalId = 0;
 }
 
-/* This routine checks whether speficied utility stmt should be involved into
- * resourece queue mgmt; if yes, take the slot from the resource queue; if we
+/* This routine checks whether specified utility stmt should be involved into
+ * resource queue mgmt; if yes, take the slot from the resource queue; if we
  * want to track additional utility stmts, add it into the condition check */
 void
 ResHandleUtilityStmt(Portal portal, Node *stmt)

--- a/src/include/commands/queue.h
+++ b/src/include/commands/queue.h
@@ -25,5 +25,6 @@ extern void AlterQueue(AlterQueueStmt *stmt);
 extern void DropQueue(DropQueueStmt *stmt);
 extern char *GetResqueueName(Oid resqueueOid);
 extern char *GetResqueuePriority(Oid queueId);
+extern Oid get_resqueue_oid(const char *queuename, bool missing_ok);
 
 #endif   /* QUEUE_H */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1264,7 +1264,8 @@ typedef enum ObjectType
 	OBJECT_TSTEMPLATE,
 	OBJECT_TYPE,
 	OBJECT_VIEW,
-	OBJECT_RESQUEUE
+	OBJECT_RESQUEUE,
+	OBJECT_RESGROUP
 } ObjectType;
 
 /* ----------------------

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -109,13 +109,13 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
 ERROR:  must specify both memory_limit and cpu_rate_limit
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
-ERROR:  Find duplicate resoure group resource type: concurrency
+ERROR:  Find duplicate resource group resource type: concurrency
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, cpu_rate_limit=5);
-ERROR:  Find duplicate resoure group resource type: cpu_rate_limit
+ERROR:  Find duplicate resource group resource type: cpu_rate_limit
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, memory_limit=5);
-ERROR:  Find duplicate resoure group resource type: memory_limit
+ERROR:  Find duplicate resource group resource type: memory_limit
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, memory_shared_quota=70, memory_shared_quota=80);
-ERROR:  Find duplicate resoure group resource type: memory_shared_quota
+ERROR:  Find duplicate resource group resource type: memory_shared_quota
 -- can't drop non-exist resource group
 DROP RESOURCE GROUP non_exist_group;
 ERROR:  resource group "non_exist_group" does not exist

--- a/src/test/regress/expected/resource_queue.out
+++ b/src/test/regress/expected/resource_queue.out
@@ -27,6 +27,7 @@ SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  regressq |             2 |         4000 | f             |                  0
 (1 row)
 
+COMMENT ON RESOURCE QUEUE regressq IS 'regressq comment';
 DROP RESOURCE QUEUE regressq;
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
  rsqname | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 

--- a/src/test/regress/sql/resource_queue.sql
+++ b/src/test/regress/sql/resource_queue.sql
@@ -8,8 +8,10 @@ ALTER RESOURCE QUEUE regressq COST THRESHOLD 3000.00 OVERCOMMIT;
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
 ALTER RESOURCE QUEUE regressq COST THRESHOLD 4e+3 NOOVERCOMMIT;
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
+COMMENT ON RESOURCE QUEUE regressq IS 'regressq comment';
 DROP RESOURCE QUEUE regressq;
 SELECT * FROM pg_resqueue WHERE rsqname='regressq';
+
 
 -- more coverage
 CREATE RESOURCE QUEUE regressq ACTIVE THRESHOLD 1 WITH (max_cost=2000);


### PR DESCRIPTION
In order to be able to set comments on resource queues, they must be object addressable, so fix by implementing. Also add a small test for commenting on a resource queue.

This fixes #5027