### PR TITLE
Add unit test for gpaddmirrors with interview.

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -381,7 +381,7 @@ class GpAddMirrorsProgram:
             #
             while len(dirs) < maxPrimariesPerHost:
                 print 'Enter mirror segment data directory location %d of %d >' % (len(dirs) + 1, maxPrimariesPerHost)
-                line = sys.stdin.readline().strip()
+                line = raw_input().strip()
                 if len(line) > 0:
                     try:
                         dirs.append(normalizeAndValidateInputPath(line))

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
@@ -21,6 +21,7 @@ class GpAddMirrorsTest(GpTestCase):
         self.gparrayMock = self._createGpArrayWith2Primary2Mirrors()
         self.gparray_get_segments_by_hostname = dict(sdw1=[self.primary0])
         self.apply_patches([
+            patch('__builtin__.raw_input'),
             patch('gppylib.programs.clsAddMirrors.base.WorkerPool'),
             patch('gppylib.programs.clsAddMirrors.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error'])),
             patch('gppylib.programs.clsAddMirrors.log_to_file_only', return_value=Mock()),
@@ -31,6 +32,7 @@ class GpAddMirrorsTest(GpTestCase):
             patch('gppylib.gparray.GpArray.getSegmentsByHostName', return_value=self.gparray_get_segments_by_hostname),
 
         ])
+        self.raw_input_mock = self.get_mock_from_apply_patch("raw_input")
         self.mock_logger = self.get_mock_from_apply_patch('logger')
         self.gpMasterEnvironmentMock = self.get_mock_from_apply_patch("GpMasterEnvironment")
         self.gpMasterEnvironmentMock.return_value.getMasterPort.return_value = 123456
@@ -97,8 +99,8 @@ class GpAddMirrorsTest(GpTestCase):
         sys.argv = ['gpaddmirrors', '-o', mirror_config_output_file, '-m', datadir_config]
         self.config_provider_mock.loadSystemConfig.return_value = GpArray([self.master, self.primary0, self.primary1])
         options, _ = self.parser.parse_args()
-        subject = GpAddMirrorsProgram(options)
-        subject.run()
+        self.subject = GpAddMirrorsProgram(options)
+        self.subject.run()
 
         with open(mirror_config_output_file, 'r') as fp:
             result = fp.readlines()
@@ -115,8 +117,8 @@ class GpAddMirrorsTest(GpTestCase):
         sys.argv = ['gpaddmirrors', '-p', '5000', '-o', mirror_config_output_file, '-m', datadir_config]
         options, _ = self.parser.parse_args()
         self.config_provider_mock.loadSystemConfig.return_value = GpArray([self.master, self.primary0, self.primary1])
-        subject = GpAddMirrorsProgram(options)
-        subject.run()
+        self.subject = GpAddMirrorsProgram(options)
+        self.subject.run()
 
         with open(mirror_config_output_file, 'r') as fp:
             result = fp.readlines()
@@ -131,8 +133,8 @@ class GpAddMirrorsTest(GpTestCase):
     def test_pghbaconf_updated_successfully(self, mock):
         sys.argv = ['gpaddmirrors', '-i', '/tmp/nonexistent/file']
         options, _ = self.parser.parse_args()
-        subject = GpAddMirrorsProgram(options)
-        subject.config_primaries_for_replication(self.gparrayMock)
+        self.subject = GpAddMirrorsProgram(options)
+        self.subject.config_primaries_for_replication(self.gparrayMock)
         self.mock_logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
         self.mock_logger.info.assert_any_call("Successfully modified pg_hba.conf on primary segments to allow replication connections")
 
@@ -140,11 +142,20 @@ class GpAddMirrorsTest(GpTestCase):
     def test_pghbaconf_updated_fails(self, mock):
         sys.argv = ['gpaddmirrors', '-i', '/tmp/nonexistent/file']
         options, _ = self.parser.parse_args()
-        subject = GpAddMirrorsProgram(options)
+        self.subject = GpAddMirrorsProgram(options)
         with self.assertRaisesRegexp(Exception, "boom"):
-            subject.config_primaries_for_replication(self.gparrayMock)
+            self.subject.config_primaries_for_replication(self.gparrayMock)
         self.mock_logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
         self.mock_logger.error.assert_any_call("Failed while modifying pg_hba.conf on primary segments to allow replication connections: boom")
+
+    def test_datadir_interview(self):
+        self.raw_input_mock.side_effect = ["/tmp/datadirs/mirror1", "/tmp/datadirs/mirror2", "/tmp/datadirs/mirror3"]
+        sys.argv = ['gpaddmirrors', '-p', '5000']
+        options, _ = self.parser.parse_args()
+        self.config_provider_mock.loadSystemConfig.return_value = GpArray([self.master, self.primary0, self.primary1])
+        self.subject = GpAddMirrorsProgram(options)
+        directories = self.subject._GpAddMirrorsProgram__getDataDirectoriesForMirrors(3, None)
+        self.assertEqual(len(directories), 3)
 
     def _createGpArrayWith2Primary2Mirrors(self):
         self.master = Segment.initFromString(


### PR DESCRIPTION
We have added a unit test for gpaddmirrors when the mirror data directories are
provided interactively.

We've changed `sys.stdin.readline()` to `raw_input()` for testability.

Co-authored-by: Nadeem Ghani <nghani@pivotal.io>
Co-authored-by: Shoaib Lari <slari@pivotal.io>