### PR TITLE
Efficient handing of AO/CO drop table

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -30,8 +30,8 @@
 #include <sys/file.h>
 
 #include "utils/guc.h"
-#include "access/appendonlytid.h"
 #include "cdb/cdbappendonlystorage.h"
+#include "access/appendonlytid.h"
 #include "access/appendonlywriter.h"
 #include "cdb/cdbappendonlyxlog.h"
 
@@ -195,6 +195,118 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 					    relname)));
 	if (RelationNeedsWAL(rel))
 		xlog_ao_truncate(rel->rd_node, segFileNum, offset);
+}
+
+/*
+ * Delete All segment file extensions, in case it was an AO or AOCS
+ * table. Ideally the logic works even for heap tables, but is only used
+ * currently for AO and AOCS tables to avoid merge conflicts.
+ *
+ * There are different rules for the naming of the files, depending on
+ * the type of table:
+ *
+ *   Heap Tables: contiguous extensions, no upper bound
+ *   AO Tables: non contiguous extensions [.1 - .127]
+ *   CO Tables: non contiguous extensions
+ *          [  .1 - .127] for first column
+ *          [.129 - .255] for second column
+ *          [.257 - .283] for third column
+ *          etc
+ *
+ *  Algorithm is coded with the assumption for CO tables that for a given
+ *  concurrency level either all columns have the file or none.
+ *
+ *  1) Finds for which concurrency levels the table has files. This is
+ *     calculated based off the first column. It performs 127
+ *     (MAX_AOREL_CONCURRENCY) unlink().
+ *  2) Iterates over the single column and deletes all concurrency level files.
+ *     For AO tables this will exit fast.
+ */
+void
+mdunlink_ao(const char *path)
+{
+	int path_size = strlen(path);
+	char *segpath = (char *) palloc(path_size + 12);
+	int segNumberArray[AOTupleId_MaxSegmentFileNum];
+	int segNumberArraySize;
+	char *segpath_suffix_position = segpath + path_size;
+
+	strncpy(segpath, path, path_size);
+
+	/*
+	 * The 0 based extensions such as .128, .256, ... for CO tables are
+	 * created by ALTER table or utility mode insert. These also need to be
+	 * deleted; however, they may not exist hence are treated separately
+	 * here. Column 0 concurrency level 0 file is always
+	 * present. MaxHeapAttributeNumber is used as a sanity check; we expect
+	 * the loop to terminate based on unlink return value.
+	 */
+	for(int colnum = 1; colnum <= MaxHeapAttributeNumber; colnum++)
+	{
+		sprintf(segpath_suffix_position, ".%u", colnum*AOTupleId_MultiplierSegmentFileNum);
+		if (unlink(segpath) != 0)
+		{
+			/* ENOENT is expected after the end of the extensions */
+			if (errno != ENOENT)
+				ereport(WARNING,
+						(errcode_for_file_access(),
+						 errmsg("could not remove file \"%s\": %m", segpath)));
+			else
+				break;
+		}
+	}
+
+	segNumberArraySize = 0;
+	/* Collect all the segmentNumbers in [1..127]. */
+	for (int concurrency_index = 1; concurrency_index < MAX_AOREL_CONCURRENCY;
+		 concurrency_index++)
+	{
+		sprintf(segpath_suffix_position, ".%u", concurrency_index);
+		if (unlink(segpath) != 0)
+		{
+			if (errno != ENOENT)
+				ereport(WARNING,
+						(errcode_for_file_access(),
+						 errmsg("could not remove file \"%s\": %m", segpath)));
+			continue;
+		}
+		segNumberArray[segNumberArraySize] = concurrency_index;
+		segNumberArraySize++;
+	}
+
+	if (segNumberArraySize == 0)
+	{
+		pfree(segpath);
+		return;
+	}
+
+	for (int colnum = 1; colnum <= MaxHeapAttributeNumber; colnum++)
+	{
+		bool finished = false;
+		for (int i = 0; i < segNumberArraySize; i++)
+		{
+			bool finished = false;
+			sprintf(segpath_suffix_position, ".%u",
+					colnum*AOTupleId_MultiplierSegmentFileNum + segNumberArray[i]);
+			if (unlink(segpath) != 0)
+			{
+				/* ENOENT is expected after the end of the extensions */
+				if (errno != ENOENT)
+					ereport(WARNING,
+							(errcode_for_file_access(),
+							 errmsg("could not remove file \"%s\": %m", segpath)));
+				else
+				{
+					finished = true;
+					break;
+				}
+			}
+		}
+		if (finished)
+			break;
+	}
+
+	pfree(segpath);
 }
 
 static void

--- a/src/backend/access/appendonly/test/aomd_test.c
+++ b/src/backend/access/appendonly/test/aomd_test.c
@@ -3,9 +3,66 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
-#include "../aomd.c"
-
+#include "postgres.h"
+#include "access/appendonlywriter.h"
 #include "catalog/pg_tablespace.h"
+
+#define PATH_TO_DATA_FILE "/tmp/md_test/1234"
+/*
+ * file_present is a 1-based array used to determine return values for
+ * access/unlink.
+ */
+static bool file_present[MAX_AOREL_CONCURRENCY * MaxHeapAttributeNumber + 2];
+static int num_unlink_called = 0;
+static bool unlink_passing = true;
+
+static void
+setup_test_structures()
+{
+	num_unlink_called = 0;
+	memset(file_present, false, sizeof(file_present));
+	unlink_passing = true;
+}
+
+/*
+ *******************************************************************************
+ * Mocking access and unlink for unittesting
+ *******************************************************************************
+ */
+#undef unlink
+#define unlink mock_unlink
+
+int mock_unlink(const char * path)
+{
+	int ec = 0;
+	u_int segfile = 0; /* parse the path */
+	char *tmp_path = path + strlen(PATH_TO_DATA_FILE) + 1;
+	if (strcmp(tmp_path, "") != 0)
+	{
+		segfile = atoi(tmp_path);
+	}
+
+	if (!file_present[segfile])
+	{
+		ec = -1;
+		errno = ENOENT;
+	}
+	else
+	{
+		num_unlink_called++;
+	}
+
+#if 0
+	elog(WARNING, "UNLINK %s %d num_times_called=%d unlink_passing %d\n",
+		path, segfile, num_unlink_called, unlink_passing);
+#endif
+	return ec;
+}
+/*
+ *******************************************************************************
+ */
+
+#include "../aomd.c"
 
 void
 test__AOSegmentFilePathNameLen(void **state)
@@ -96,6 +153,104 @@ test__MakeAOSegmentFileName(void **state)
 	assert_int_equal(fileSegNo, 256);
 }
 
+void
+test_mdunlink_co_no_file_exists(void **state)
+{
+	setup_test_structures();
+
+	mdunlink_ao(PATH_TO_DATA_FILE);
+
+	// called 1 time checking column
+	assert_true(num_unlink_called == 0);
+	return;
+}
+
+/* concurrency = 1 max_column = 4 */
+void
+test_mdunlink_co_4_columns_1_concurrency(void **state)
+{
+	setup_test_structures();
+
+	/* concurrency 1 exists */
+	file_present[1] = true;
+
+	/* max column exists */
+	file_present[(1*AOTupleId_MultiplierSegmentFileNum) + 1] = true;
+	file_present[(2*AOTupleId_MultiplierSegmentFileNum) + 1] = true;
+	file_present[(3*AOTupleId_MultiplierSegmentFileNum) + 1] = true;
+
+	mdunlink_ao(PATH_TO_DATA_FILE);
+
+	assert_true(num_unlink_called == 4);
+	assert_true(unlink_passing);
+	return;
+}
+
+/* concurrency = 1,5 max_column = 3 */
+void
+test_mdunlink_co_3_columns_2_concurrency(void **state)
+{
+	setup_test_structures();
+
+	/* concurrency 1,5 exists */
+	file_present[1] = true;
+	file_present[5] = true;
+
+	/* Concurrency 1 files */
+	file_present[(1*AOTupleId_MultiplierSegmentFileNum) + 1] = true;
+	file_present[(2*AOTupleId_MultiplierSegmentFileNum) + 1] = true;
+
+	/* Concurrency 5 files */
+	file_present[(1*AOTupleId_MultiplierSegmentFileNum) + 5] = true;
+	file_present[(2*AOTupleId_MultiplierSegmentFileNum) + 5] = true;
+
+	mdunlink_ao(PATH_TO_DATA_FILE);
+	assert_true(num_unlink_called == 6);
+	assert_true(unlink_passing);
+	return;
+}
+
+void
+test_mdunlink_co_all_columns_full_concurrency(void **state)
+{
+	setup_test_structures();
+
+	memset(file_present, true, sizeof(file_present));
+	file_present[MAX_AOREL_CONCURRENCY * MaxHeapAttributeNumber + 1] = false;
+
+	mdunlink_ao(PATH_TO_DATA_FILE);
+
+	assert_true(num_unlink_called == MaxHeapAttributeNumber * MAX_AOREL_CONCURRENCY);
+	assert_true(unlink_passing);
+	return;
+}
+
+void
+test_mdunlink_co_one_columns_one_concurrency(void **state)
+{
+	setup_test_structures();
+
+	file_present[1] = true;
+
+	mdunlink_ao(PATH_TO_DATA_FILE);
+	assert_true(num_unlink_called == 1);
+	assert_true(unlink_passing);
+	return;
+}
+
+void
+test_mdunlink_co_one_columns_full_concurrency(void **state)
+{
+	setup_test_structures();
+
+	for (int filenum=1; filenum < MAX_AOREL_CONCURRENCY; filenum++)
+		file_present[filenum] = true;
+
+	mdunlink_ao(PATH_TO_DATA_FILE);
+	assert_true(num_unlink_called == 127);
+	assert_true(unlink_passing);
+	return;
+}
 
 int
 main(int argc, char *argv[])
@@ -105,7 +260,13 @@ main(int argc, char *argv[])
 	const		UnitTest tests[] = {
 		unit_test(test__AOSegmentFilePathNameLen),
 		unit_test(test__FormatAOSegmentFileName),
-		unit_test(test__MakeAOSegmentFileName)
+		unit_test(test__MakeAOSegmentFileName),
+		unit_test(test_mdunlink_co_one_columns_full_concurrency),
+		unit_test(test_mdunlink_co_one_columns_one_concurrency),
+		unit_test(test_mdunlink_co_all_columns_full_concurrency),
+		unit_test(test_mdunlink_co_3_columns_2_concurrency),
+		unit_test(test_mdunlink_co_4_columns_1_concurrency),
+		unit_test(test_mdunlink_co_no_file_exists)
 	};
 
 	MemoryContextInit();

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -376,7 +376,7 @@ heap_create(const char *relname,
 		isAppendOnly = (relstorage == RELSTORAGE_AOROWS || relstorage == RELSTORAGE_AOCOLS);
 
 		RelationOpenSmgr(rel);
-		RelationCreateStorage(rel->rd_node, relpersistence);
+		RelationCreateStorage(rel->rd_node, relpersistence, relstorage);
 
 		/*
 		 * AO tables don't use the buffer manager, better to not keep the

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -11531,7 +11531,8 @@ ATExecSetTableSpace(Oid tableOid, Oid newTableSpace, LOCKMODE lockmode)
 	 * NOTE: any conflict in relfilenode value will be caught in
 	 * RelationCreateStorage().
 	 */
-	RelationCreateStorage(newrnode, rel->rd_rel->relpersistence);
+	RelationCreateStorage(newrnode, rel->rd_rel->relpersistence,
+						  rel->rd_rel->relstorage);
 
 	if (RelationIsAppendOptimized(rel))
 	{

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -728,7 +728,6 @@ ProcArrayApplyRecoveryInfo(RunningTransactions running)
 	TransactionIdAdvance(nextXid);
 	if (TransactionIdFollows(nextXid, ShmemVariableCache->nextXid))
 		ShmemVariableCache->nextXid = nextXid;
-
 	Assert(TransactionIdIsNormal(ShmemVariableCache->latestCompletedXid));
 	Assert(TransactionIdIsValid(ShmemVariableCache->nextXid));
 

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -394,7 +394,7 @@ mdcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo)
  * we are usually not in a transaction anymore when this is called.
  */
 void
-mdunlink(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo)
+mdunlink(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo, char relstorage)
 {
 	char	   *path;
 	int			ret;
@@ -404,7 +404,8 @@ mdunlink(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo)
 	 * relation, else the next mdsync() will fail.  There can't be any such
 	 * requests for a temp relation, though.
 	 */
-	if (!RelFileNodeBackendIsTemp(rnode))
+	if (!RelFileNodeBackendIsTemp(rnode) &&
+		!relstorage_is_ao(relstorage))
 		ForgetRelationFsyncRequests(rnode.node, forkNum);
 
 	path = relpath(rnode, forkNum);

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -312,6 +312,10 @@ smgrdounlink(SMgrRelation reln, ForkNumber forknum, bool isRedo, char relstorage
 	/*
 	 * Get rid of any remaining buffers for the relation.  bufmgr will just
 	 * drop them without bothering to write the contents.
+	 *
+	 * Apart from relstorage == RELSTORAGE_HEAP do any other RELSTOARGE type
+	 * expected to have buffers in shared memory ? Can check only for
+	 * RELSTORAGE_HEAP below.
 	 */
 	if ((relstorage != RELSTORAGE_AOROWS) &&
 		(relstorage != RELSTORAGE_AOCOLS))

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -2833,7 +2833,8 @@ RelationSetNewRelfilenode(Relation relation, TransactionId freezeXid)
 	newrnode.node = relation->rd_node;
 	newrnode.node.relNode = newrelfilenode;
 	newrnode.backend = relation->rd_backend;
-	RelationCreateStorage(newrnode.node, relation->rd_rel->relpersistence);
+	RelationCreateStorage(newrnode.node, relation->rd_rel->relpersistence,
+						  relation->rd_rel->relstorage);
 	smgrclosenode(newrnode);
 
 	/*

--- a/src/include/access/aomd.h
+++ b/src/include/access/aomd.h
@@ -48,5 +48,7 @@ TruncateAOSegmentFile(File fd,
 					  int64 offset);
 
 extern void
+mdunlink_ao(const char *path);
+extern void
 copy_append_only_data(RelFileNode src, RelFileNode dst, BackendId backendid, char relpersistence);
 #endif							/* AOMD_H */

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -133,7 +133,7 @@ typedef struct xl_xact_commit
 	Oid			dbId;			/* MyDatabaseId */
 	Oid			tsId;			/* MyDatabaseTableSpace */
 	/* Array of RelFileNode(s) to drop at commit */
-	RelFileNode xnodes[1];		/* VARIABLE LENGTH ARRAY */
+	RelFileNodeWithStorageType xnodes[1];		/* VARIABLE LENGTH ARRAY */
 	/* ARRAY OF COMMITTED SUBTRANSACTION XIDs FOLLOWS */
 	/* ARRAY OF SHARED INVALIDATION MESSAGES FOLLOWS */
 	/* DISTRIBUTED XACT STUFF FOLLOWS */
@@ -163,7 +163,7 @@ typedef struct xl_xact_abort
 	int			nrels;			/* number of RelFileNodes */
 	int			nsubxacts;		/* number of subtransaction XIDs */
 	/* Array of RelFileNode(s) to drop at abort */
-	RelFileNode xnodes[1];		/* VARIABLE LENGTH ARRAY */
+	RelFileNodeWithStorageType xnodes[1];		/* VARIABLE LENGTH ARRAY */
 	/* ARRAY OF ABORTED SUBTRANSACTION XIDs FOLLOWS */
 } xl_xact_abort;
 

--- a/src/include/catalog/storage.h
+++ b/src/include/catalog/storage.h
@@ -20,7 +20,7 @@
 #include "storage/relfilenode.h"
 #include "utils/relcache.h"
 
-extern void RelationCreateStorage(RelFileNode rnode, char relpersistence);
+extern void RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage);
 extern void RelationDropStorage(Relation rel);
 extern void RelationPreserveStorage(RelFileNode rnode);
 extern void RelationTruncate(Relation rel, BlockNumber nblocks);
@@ -30,7 +30,7 @@ extern void RelationTruncate(Relation rel, BlockNumber nblocks);
  * naming
  */
 extern void smgrDoPendingDeletes(bool isCommit);
-extern int	smgrGetPendingDeletes(bool forCommit, RelFileNode **ptr);
+extern int	smgrGetPendingDeletes(bool forCommit, RelFileNodeWithStorageType **ptr);
 extern void AtSubCommit_smgr(void);
 extern void AtSubAbort_smgr(void);
 extern void PostPrepare_smgr(void);

--- a/src/include/storage/relfilenode.h
+++ b/src/include/storage/relfilenode.h
@@ -124,4 +124,16 @@ inline static bool RelFileNode_IsEmpty(
 		    relFileNode->relNode == 0);
 }
 
+/*
+ * Augmenting a relfilenode with a storeage type provides a way to make optimal
+ * decisions in smgr and md layer. This is purposefully kept out of RelFileNode
+ * for performance concerns where RelFileNode used in a hotpath for BufferTag
+ * hashing.
+ */
+typedef struct RelFileNodeWithStorageType
+{
+	RelFileNode node;
+	char relstorage;
+} RelFileNodeWithStorageType;
+
 #endif   /* RELFILENODE_H */

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -86,7 +86,7 @@ extern void smgrclosenode(RelFileNodeBackend rnode);
 extern void smgrcreate(SMgrRelation reln, ForkNumber forknum, bool isRedo);
 extern void smgrcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo);
 extern void smgrdounlink(SMgrRelation reln, ForkNumber forknum,
-			 bool isRedo);
+						 bool isRedo, char relstorage);
 extern void smgrextend(SMgrRelation reln, ForkNumber forknum,
 		   BlockNumber blocknum, char *buffer, bool skipFsync);
 extern void smgrprefetch(SMgrRelation reln, ForkNumber forknum,
@@ -112,7 +112,7 @@ extern void mdclose(SMgrRelation reln, ForkNumber forknum);
 extern void mdcreate(SMgrRelation reln, ForkNumber forknum, bool isRedo);
 extern void mdcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo);
 extern bool mdexists(SMgrRelation reln, ForkNumber forknum);
-extern void mdunlink(RelFileNodeBackend rnode, ForkNumber forknum, bool isRedo);
+extern void mdunlink(RelFileNodeBackend rnode, ForkNumber forknum, bool isRedo, char relstorage);
 extern void mdextend(SMgrRelation reln, ForkNumber forknum,
 		 BlockNumber blocknum, char *buffer, bool skipFsync);
 extern void mdprefetch(SMgrRelation reln, ForkNumber forknum,


### PR DESCRIPTION
Previous algorithm scans entire directory to find specific relfilenode
extensions to be deleted. This is not optimal for large directory sizes. This
patch introduces extra logic based on the table extension pattern which helps
to avoid directory scan.

Algorithm is coded based on assumption that for CO tables a given concurrency
level either all columns have the file or none as well as the following file
table extension pattern:

  Heap Tables: contiguous extensions, no upper bound
  AO Tables: non contiguous extensions [.0 - .127]
  CO Tables: non contiguous extensions
         [  .0 - .127] for first column
         [.128 - .255] for second column
         [.256 - .283] for third column
         etc

  AO file format can be treated as a special case of CO tables with 1 column.

High level logic:
 1) Finds for which concurrency levels the table has files. This is
    calculated based off the first column. It performs 127
    (MAX_AOREL_CONCURRENCY) unlink().
 2) Iterates over the single column and deletes all concurrency level files.
    For AO tables this will exit fast.

This algorithm can be used for heap tables as well, however to prevent merge
conflicts it currently is only used for CO/AO tables.

---

Without this patch the strorage layout is not known in md and smgr layer. Due
to lack of this info sub-optimal operations need to be performed generically
for all table types. For example Heap specific functions like
ForgetRelationFsyncRequests(), DropRelFileNodeBuffers() gets called even for AO
and CO tables.

Adding new RelFileNodeWithStorageType struct to carry pass storage type to md
and smgr layer. XLOG_XACT_COMMIT and XLOG_XACT_ABORT wal records use the new
structure which has RelFileNode and storage type