### PR TITLE
Fix compilation error "implicit declaration of function 'getpeereid'" on AIX

### DIFF
--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -87,6 +87,10 @@ static int ldapServiceLookup(const char *purl, PQconninfoOption *options,
 #include "libpq/ip.h"
 #include "mb/pg_wchar.h"
 
+#if defined(_AIX)
+int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
+#endif
+
 #ifndef FD_CLOEXEC
 #define FD_CLOEXEC 1
 #endif


### PR DESCRIPTION
This seems to be related to AIX system issue or old compiler. Not long ago
there is a similar complaint on the pg community also.
http://www.postgresql-archive.org/pgsql-Improve-performance-of-SendRowDescriptionMessage-td5987721.html

Do not want to waste too much time on this. Instead, I just
work around this issue following what we did on auth.c, i.e.

+#if defined(_AIX)
+int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
+#endif