### PR TITLE
Upgrade pgbouncer to 1.8.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "gpAux/extensions/pgbouncer/source"]
 	path = gpAux/extensions/pgbouncer/source
 	url = https://github.com/greenplum-db/pgbouncer.git
-	branch = master
+	branch = pgbouncer_1_8_1
 [submodule "gpAux/extensions/postgis-2.0.3/source"]
 	path = gpAux/extensions/postgis-2.0.3/source
 	url = https://github.com/greenplum-db/postgis.git

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -897,7 +897,7 @@ ifeq "$(shell uname -s)" "Darwin"
 	echo "pgbouncer can't build on Mac"
 else
 	@if [ ! -f extensions/pgbouncer/source/configure ]; then cd extensions/pgbouncer/source && ./autogen.sh ;fi
-	@cd extensions/pgbouncer/source && ./configure --with-libevent=$(BLD_TOP)/ext/$(BLD_ARCH) --prefix=$(INSTLOC) --enable-evdns
+	@cd extensions/pgbouncer/source && ./configure --with-libevent=$(BLD_TOP)/ext/$(BLD_ARCH) --prefix=$(INSTLOC) --enable-evdns --with-pam
 	$(MAKE) -C extensions/pgbouncer/source install
 endif
 


### PR DESCRIPTION
* Change pgbouncer submodule branch to pgbouncer_1_8_1
* support PAM/HBA auth type in pgbouncer v1.8.1
* pgbouncer suports tls auth, but can not work with gpdb default configuration. We will fix it later.
* We have tested the pr manually, pgbouncer pipeline will be added in other prs.