### PR TITLE
Fix segfault with identify_system_timezone()

### DIFF
--- a/src/timezone/pgtz.c
+++ b/src/timezone/pgtz.c
@@ -310,7 +310,7 @@ score_timezone(const char *tzname, struct tztry * tt)
 	 */
 	if (tzload(tzname, NULL, &tz.state, TRUE) != 0)
 	{
-		if (tzname[0] == ':' || tzparse(tzname, &tz.state, FALSE) != 0)
+		if (tzname[0] == ':' || !tzparse(tzname, &tz.state, FALSE))
 		{
 			return -1;			/* can't handle the TZ name at all */
 		}


### PR DESCRIPTION
The return value of `tzparse()` has changed as of commit b749790a, but the corresponding change to `tzparse()` in `score_timezone()` was never made. As a result, under certain circumstances the server could produce a SIGSEGV while running `identify_system_timezone()`. 

This commit changes the `tzparse()` function call in `score_timezone()` to prevent these segfaults.