### PR TITLE
docs - enhance discussion of PXF API classes

### DIFF
--- a/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -63,8 +63,21 @@
             <li>
               <a href="/docs/600/pxf/sdk/dev_concepts.html" format="markdown">PXF Developer Concepts</a>
             </li>
-            <li>
+            <li class="has_submenu">
               <a href="/docs/600/pxf/sdk/pxfapi.html" format="markdown">Introducing the PXF API</a>
+              <ul>
+                <li><a href="/docs/600/pxf/sdk/api/fragment.html" format="markdown">Fragment Class</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/fragmenter.html" format="markdown">Fragmenter Class</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/inputdata.html" format="markdown">InputData Class</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/onefield.html" format="markdown">OneField Class</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/onerow.html" format="markdown">OneRow Class</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/plugin.html" format="markdown">Plugin Class</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/readaccessor.html" format="markdown">ReadAccessor Interface</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/readresolver.html" format="markdown">ReadResolver Interface</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/readvectresolver.html" format="markdown">ReadVectorizedResolver Interface</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/writeaccessor.html" format="markdown">WriteAccessor Interface</a></li>
+                <li><a href="/docs/600/pxf/sdk/api/writeresolver.html" format="markdown">WriteResolver Interface</a></li>
+              </ul>
             </li>
             <li>
               <a href="/docs/600/pxf/sdk/build_conn.html" format="markdown">Building a Connector</a>

--- a/gpdb-doc/markdown/pxf/sdk/api/fragment.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/fragment.html.md.erb
@@ -1,0 +1,145 @@
+---
+title: Fragment Class
+---
+
+The `org.apache.hawq.pxf.api.Fragment` class represents a subset of data the `Fragmenter` reads from the external data source. Each data `Fragment` describes some part of the requested data set and includes information such as the the data source name (for example, the file or table name, etc.) and the name(s) of the host(s) on which the data is located.
+
+`Fragment` metadata identifies specific information about the fragment, such as the start index and length of the fragment or a region location.
+
+
+Instance variables defined by the `Fragment` class include:
+
+| Data Type         | Variable Name       |  Description           |
+|-------------------|---------------------|------------------------|
+| String    | sourceName | Absolute path, table name, etc. identifying the external data source. |
+| int    | index | The index of this `Fragment` in the list of `Fragment`s returned by the `Fragmenter`. |
+| String[]    | replicas | One or more host locations from which the *ReadAccessor* can read this `Fragment`. |
+| byte[]    | metadata | Connector-specific metadata associated with the `Fragment`, such as start location and length, region name; PXF passes this data to the *ReadAccessor*. |
+| byte[]    | userData | Connector-specific data associated with the `Fragment`; PXF passes this data to the *ReadAccessor*. |
+| String    | profile | The name of the recommended read profile for the `Fragment`. |
+
+
+## <a id="classdef"></a>Class Definition
+
+``` java
+package org.apache.hawq.pxf.api;
+
+public class Fragment {
+    /**
+     * File path+name, table name, etc.
+     */
+    private String sourceName;
+
+    /**
+     * Fragment index (incremented per sourceName).
+     */
+    private int index;
+
+    /**
+     * Fragment replicas (1 or more).
+     */
+    private String[] replicas;
+
+    /**
+     * Fragment metadata information (starting point + length, region location, etc.).
+     */
+    private byte[] metadata;
+
+    /**
+     * ThirdParty data added to a fragment. Ignored if null.
+     */
+    private byte[] userData;
+
+    /**
+     * Profile name, recommended for reading given Fragment.
+     */
+    private String profile;
+
+    /**
+     * Constructs a Fragment.
+     *
+     * @param sourceName the resource uri (File path+name, table name, etc.)
+     * @param hosts the replicas
+     * @param metadata the meta data (Starting point + length, region location, etc.).
+     */
+    public Fragment(String sourceName,
+                    String[] hosts,
+                    byte[] metadata) {
+        this.sourceName = sourceName;
+        this.replicas = hosts;
+        this.metadata = metadata;
+    }
+
+    /**
+     * Constructs a Fragment.
+     *
+     * @param sourceName the resource uri (File path+name, table name, etc.)
+     * @param hosts the replicas
+     * @param metadata the meta data (Starting point + length, region location, etc.).
+     * @param userData third party data added to a fragment.
+     */
+    public Fragment(String sourceName,
+                    String[] hosts,
+                    byte[] metadata,
+                    byte[] userData) {
+        this.sourceName = sourceName;
+        this.replicas = hosts;
+        this.metadata = metadata;
+        this.userData = userData;
+    }
+
+    public Fragment(String sourceName,
+            String[] hosts,
+            byte[] metadata,
+            byte[] userData,
+            String profile) {
+        this(sourceName, hosts, metadata, userData);
+        this.profile = profile;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public String[] getReplicas() {
+        return replicas;
+    }
+
+    public void setReplicas(String[] replicas) {
+        this.replicas = replicas;
+    }
+
+    public byte[] getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(byte[] metadata) {
+        this.metadata = metadata;
+    }
+
+    public byte[] getUserData() {
+        return userData;
+    }
+
+    public void setUserData(byte[] userData) {
+        this.userData = userData;
+    }
+
+    public String getProfile() {
+        return profile;
+    }
+
+    public void setProfile(String profile) {
+        this.profile = profile;
+    }
+}
+```
+

--- a/gpdb-doc/markdown/pxf/sdk/api/fragmenter.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/fragmenter.html.md.erb
@@ -1,0 +1,99 @@
+---
+title: Fragmenter Class
+---
+
+The `org.apache.hawq.pxf.api.Fragmenter` abstract class defines the splitting of data from an external data source into `Fragment`s that PXF can process in parallel. You implement a `Fragmenter` when your connector supports reading from an external data source.
+
+The `Fragmenter` generates data source-specific metadata for each data `Fragment`. This metadata may include location, indexes, table/file names, etc. For example, if the external data source is an HDFS file, the HDFS connector `Fragmenter` returns a list of data `Fragment`s each containing an HDFS block. Each `Fragment` includes the location of the block. If the external data source is an HBase table, the HBase connector `Fragmenter` returns information about the table regions, including their locations.
+
+## <a id="classdef"></a>Class Definition
+
+``` java
+package org.apache.hawq.pxf.api;
+
+public abstract class Fragmenter extends Plugin {
+    protected List<Fragment> fragments;
+
+    /**
+     * Constructs a Fragmenter.
+     *
+     * @param metaData the input data
+     */
+    public Fragmenter(InputData metaData) {
+        super(metaData);
+        fragments = new LinkedList<>();
+    }
+
+    /**
+     * Gets the fragments of a given path (source name and location of each
+     * fragment). Used to get fragments of data that could be read in parallel
+     * from the different segments.
+     *
+     * @return list of data fragments
+     * @throws Exception if fragment list could not be retrieved
+     */
+    public abstract List<Fragment> getFragments() throws Exception;
+
+    /**
+     * Default implementation of statistics for fragments. 
+     *   Note:  PXF in Greenplum Database does not support 
+     *          fragment statistics
+     *
+     * @return default statistics
+     * @throws Exception if statistics cannot be gathered
+     */
+    public FragmentsStats getFragmentsStats() throws Exception {
+        List<Fragment> fragments = getFragments();
+        long fragmentsNumber = fragments.size();
+        return new FragmentsStats(fragmentsNumber,
+                FragmentsStats.DEFAULT_FRAGMENT_SIZE, fragmentsNumber
+                        * FragmentsStats.DEFAULT_FRAGMENT_SIZE);
+    }
+}
+```
+
+*Note*: PXF for Greenplum Database does not currently support fragment statistics.
+
+## <a id="impls"></a>Fragmenter Implementations
+
+If your connector supports the read operation on an external data source, the *Fragmenter* class that you develop with the PXF API `extends org.apache.hawq.pxf.api.Fragmenter`.
+
+The PXF API includes these built-in `Fragmenter` implementations:
+
+<a id="fragmenter_table"></a>
+<table>
+<caption><span class="tablecap">Table 1. Built-in Fragmenter Implementations </span></caption>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><p>Fragmenter Class</p></th>
+<th><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hdfs.HdfsDataFragmenter</td>
+<td>Fragmenter for HDFS text, Avro, JSON, and SequenceFile format files.</td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hdfs.ParquetDataFragmenter</td>
+<td>Fragmenter for HDFS parquet format files.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hbase.HBaseDataFragmenter</td>
+<td>Fragmenter for HBase tables.</td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hive.HiveDataFragmenter</li>
+<td>All-purpose fragmenter for Hive tables. Auto-detects the file storage format and uses the optimal Fragmenter.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hive.HiveInputFormatFragmenter</td>
+<td>Fragmenter for Hive tables with RC, ORC, or text file formats.</td>
+</tr>
+</tbody>
+</table>
+

--- a/gpdb-doc/markdown/pxf/sdk/api/inputdata.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/inputdata.html.md.erb
@@ -1,0 +1,354 @@
+---
+title: InputData Class
+---
+
+The Greenplum Database user provides connector-specific information to PXF via the `CREATE EXTERNAL TABLE` `LOCATION` string. PXF passes this information to the connector plug-ins at runtime. The parameters in this string are available to a plug-in through methods in the `org.apache.hawq.pxf.api.utilities.InputData` class.
+
+The `InputData` class is an argument to the constructor of each connector plug-in. `InputData` includes the `CREATE EXTERNAL TABLE` table definintion and the data and the options that the user provides in the `LOCATION` string. The `Fragmenter` also writes fragment metadata to an instance of this class. 
+
+Instance variables defined by the `InputData` class include those identified in the table below. The values of these variables are derived from different sources - the SQL command issued by the user, from PXF, or from the Connector. 
+
+(Note: "LOCATION string", when specified in the table, refers to the string the Greenplum Database user provides in the `CREATE EXTERNAL TABLE` command `LOCATION` clause.)
+
+| Data Type      | Variable Name |  Source   | Description    |
+|----------------|---------------------|-------------|--------|
+| Map<String, String>    | requestParametersMap | LOCATION string  | The properties and values from the `LOCATION` string. |
+| ArrayList<ColumnDescriptor>  | tupleDescription | CREATE EXTERNAL TABLE table definition  | The external table column types, names, and other information. |
+|  int  | segmentId | PXF | The segment identifier.  |
+|  int  | totalSegments | PXF | The total number of Greenplum Database segments in the cluster. |
+|  byte[]  | fragmentMetadata | Fragmenter | Fragment identification information; Fragmenter-specific. For example, the start and end location. |
+|  byte[]  | userData | Fragmenter | Other Fragmenter-specific data for a fragment. Optional. |
+|  boolean  | filterStringValid | PXF | Identifies whether or not an external table query filter is provided. (Not implemented) |
+|  String  | filterString | PXF | External table query filter. (Not implemented) |
+|  String  | dataSource | LOCATION string | The external-data-source-specific data source identifier; for example, file path, table name, etc. |
+|  String  | profile | LOCATION string | The profile specified by the user. Optional. |
+|  String  | accessor | LOCATION string | The *Accessor* plug-in class name. The class name may be directly specified by the user or derived from the profile. |
+|  String  | resolver | LOCATION string | The *Resolver* plug-in class name. The class name may be directly specified by the user or derived from the profile. |
+|  String  | fragmenter | LOCATION string | The *Fragmenter* plug-in class name. The class name may be directly specified by the user or derived from the profile. Optional. |
+|  String  | metadata | LOCATION string | Metadata required by the connector. Connector-dependent. Optional. |
+|  boolean  | threadSafe | Connector plugin | Handle requests in single or multiple threads. Connector-dependent; for example, the HDFS connector turns this off when it must compress/uncompress a file. |
+|  ColumnDescriptor  | recordkeyColumn | CREATE EXTERNAL TABLE table definition | The recordkey column descriptor for the external table. Connector-dependent; for example, the HDFS connector supports SequenceFile format, which utilizes a recordkey for each row. Optional. |
+|  int  | numAttrsProjected | PXF | The number of columns projected. (Not implemented) |
+
+The `InputData` class includes getter and setter methods for most of these variables. Plug-ins can fetch the values of the plug-in-specific properties added to the `LOCATION` string with the `getUserProperty()` method.
+
+## <a id="classdef"></a>Class Definition
+
+``` java
+package org.apache.hawq.pxf.api.utilities;
+
+public class InputData {
+
+    /**
+     * Constructs an empty InputData
+     */
+    public InputData() {
+    }
+
+    /**
+     * Constructs an InputData from a copy. Used to create from an extending
+     * class.
+     *
+     * @param copy the input data to copy
+     */
+    public InputData(InputData copy) {
+
+        this.requestParametersMap = copy.requestParametersMap;
+        this.segmentId = copy.segmentId;
+        this.totalSegments = copy.totalSegments;
+        this.fragmentMetadata = copy.fragmentMetadata;
+        this.userData = copy.userData;
+        this.tupleDescription = copy.tupleDescription;
+        this.recordkeyColumn = copy.recordkeyColumn;
+        this.filterStringValid = copy.filterStringValid;
+        this.filterString = copy.filterString;
+        this.dataSource = copy.dataSource;
+        this.profile = copy.profile;
+        this.accessor = copy.accessor;
+        this.resolver = copy.resolver;
+        this.fragmenter = copy.fragmenter;
+        this.metadata = copy.metadata;
+        this.remoteLogin = copy.remoteLogin;
+        this.remoteSecret = copy.remoteSecret;
+        this.threadSafe = copy.threadSafe;
+    }
+
+    /**
+     * Returns a user defined property.
+     *
+     * @param userProp the lookup user property
+     * @return property value as a String
+     */
+    public String getUserProperty(String userProp) {
+        return requestParametersMap.get(USER_PROP_PREFIX + userProp.toUpperCase());
+    }
+
+    /**
+     * Sets the byte serialization of a fragment meta data.
+     *
+     * @param location start, len, and location of the fragment
+     */
+    public void setFragmentMetadata(byte[] location) {
+        this.fragmentMetadata = location;
+    }
+
+    /**
+     * The byte serialization of a data fragment.
+     *
+     * @return serialized fragment metadata
+     */
+    public byte[] getFragmentMetadata() {
+        return fragmentMetadata;
+    }
+
+    /**
+     * Gets any custom user data that may have been passed from the fragmenter.
+     * Will mostly be used by the accessor or resolver.
+     *
+     * @return fragment user data
+     */
+    public byte[] getFragmentUserData() {
+        return userData;
+    }
+
+    /**
+     * Sets any custom user data that needs to be shared across plugins. Will
+     * mostly be set by the fragmenter.
+     *
+     * @param userData user data
+     */
+    public void setFragmentUserData(byte[] userData) {
+        this.userData = userData;
+    }
+
+    /**
+     * Returns the number of segments in HAWQ.
+     *
+     * @return number of segments
+     */
+    public int getTotalSegments() {
+        return totalSegments;
+    }
+
+    /**
+     * Returns the current segment ID in HAWQ.
+     *
+     * @return current segment ID
+     */
+    public int getSegmentId() {
+        return segmentId;
+    }
+
+    /**
+     * Returns true if there is a filter string to parse.
+     *
+     * @return whether there is a filter string
+     */
+    public boolean hasFilter() {
+        return filterStringValid;
+    }
+
+    /**
+     * Returns the filter string, <tt>null</tt> if #hasFilter is <tt>false</tt>.
+     *
+     * @return the filter string or null
+     */
+    public String getFilterString() {
+        return filterString;
+    }
+
+    /**
+     * Returns tuple description.
+     *
+     * @return tuple description
+     */
+    public ArrayList<ColumnDescriptor> getTupleDescription() {
+        return tupleDescription;
+    }
+
+    /**
+     * Returns the number of columns in tuple description.
+     *
+     * @return number of columns
+     */
+    public int getColumns() {
+        return tupleDescription.size();
+    }
+
+    /**
+     * Returns column index from tuple description.
+     *
+     * @param index index of column
+     * @return column by index
+     */
+    public ColumnDescriptor getColumn(int index) {
+        return tupleDescription.get(index);
+    }
+
+    /**
+     * Returns the column descriptor of the recordkey column. If the recordkey
+     * column was not specified by the user in the create table statement will
+     * return null.
+     *
+     * @return column of record key or null
+     */
+    public ColumnDescriptor getRecordkeyColumn() {
+        return recordkeyColumn;
+    }
+
+    /**
+     * Returns the data source of the required resource (i.e a file path or a
+     * table name).
+     *
+     * @return data source
+     */
+    public String getDataSource() {
+        return dataSource;
+    }
+
+    /**
+     * Sets the data source for the required resource.
+     *
+     * @param dataSource data source to be set
+     */
+    public void setDataSource(String dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    /**
+     * Returns the profile name.
+     *
+     * @return name of profile
+     */
+    public String getProfile() {
+        return profile;
+    }
+
+    /**
+     * Returns the ClassName for the java class that was defined as Accessor.
+     *
+     * @return class name for Accessor
+     */
+    public String getAccessor() {
+        return accessor;
+    }
+
+    /**
+     * Returns the ClassName for the java class that was defined as Resolver.
+     *
+     * @return class name for Resolver
+     */
+    public String getResolver() {
+        return resolver;
+    }
+
+    /**
+     * Returns the ClassName for the java class that was defined as Fragmenter
+     * or null if no fragmenter was defined.
+     *
+     * @return class name for Fragmenter or null
+     */
+    public String getFragmenter() {
+        return fragmenter;
+    }
+
+    /**
+     * Returns the ClassName for the java class that was defined as Metadata
+     * or null if no metadata was defined.
+     *
+     * @return class name for METADATA or null
+     */
+    public String getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Returns the contents of pxf_remote_service_login set in Hawq. Should the
+     * user set it to an empty string this function will return null.
+     *
+     * @return remote login details if set, null otherwise
+     */
+    public String getLogin() {
+        return remoteLogin;
+    }
+
+    /**
+     * Returns the contents of pxf_remote_service_secret set in Hawq. Should the
+     * user set it to an empty string this function will return null.
+     *
+     * @return remote password if set, null otherwise
+     */
+    public String getSecret() {
+        return remoteSecret;
+    }
+
+    /**
+     * Returns whether this request is thread safe.
+     * If it is not, request will be handled consequentially and not in parallel.
+     *
+     * @return whether the request is thread safe
+     */
+    public boolean isThreadSafe() {
+        return threadSafe;
+    }
+
+    /**
+     * Returns a data fragment index. plan to deprecate it in favor of using
+     * getFragmentMetadata().
+     *
+     * @return data fragment index
+     */
+    public int getDataFragment() {
+        return dataFragment;
+    }
+
+    /**
+     * Returns aggregate type, i.e - count, min, max, etc
+     * @return aggregate type
+     */
+    public EnumAggregationType getAggType() {
+        return aggType;
+    }
+
+    /**
+     * Sets aggregate type, one of @see EnumAggregationType value
+     * @param aggType aggregate type
+     */
+    public void setAggType(EnumAggregationType aggType) {
+        this.aggType = aggType;
+    }
+
+    /**
+     * Returns index of a fragment in a file
+     * @return index of a fragment
+     */
+    public int getFragmentIndex() {
+        return fragmentIndex;
+    }
+
+    /**
+     * Sets index of a fragment in a file
+     * @param fragmentIndex index of a fragment
+     */
+    public void setFragmentIndex(int fragmentIndex) {
+        this.fragmentIndex = fragmentIndex;
+    }
+
+    /**
+     * Returns number of attributes projected in a query
+     * @return number of attributes projected
+     */
+    public int getNumAttrsProjected() {
+        return numAttrsProjected;
+    }
+
+    /**
+     * Sets number of attributes projected
+     * @param numAttrsProjected number of attrivutes projected
+     */
+    public void setNumAttrsProjected(int numAttrsProjected) {
+        this.numAttrsProjected = numAttrsProjected;
+    }
+}
+```
+

--- a/gpdb-doc/markdown/pxf/sdk/api/onefield.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/onefield.html.md.erb
@@ -1,0 +1,126 @@
+---
+title: OneField Class
+---
+
+The `org.apache.hawq.pxf.api.OneField` class represents one deserialized or serialized field in a `OneRow` object. PXF converts a `OneField` object to/from a Greenplum Database-readable `GPDBWritable` format.
+
+A class that implements the `ReadResolver` interface deserializes a `OneRow` record into a list of `OneField` objects. A class that implements the `ReadVectorizedResolver` interface deserializes a batch of `OneRow` records.
+
+A class that implements the `WriteResolver` interface serializes a list of `OneField` objects into a `OneRow` record.
+
+
+`OneField` objects are defined by a data type and a value. Instance variables in the `OneField` class include:
+
+| Data Type      | Variable Name |  Description    |
+|----------------|---------------------|--------------|
+| int    | type | The `DataType` OID identifying the type of field data. |
+| Object   | val | The field data.
+
+
+## <a id="classdef"></a>Class Definition
+
+``` java
+package org.apache.hawq.pxf.api;
+
+public class OneField {
+    /** OID value recognized by GPDBWritable. */
+    public int type;
+
+    /** Field value. */
+    public Object val;
+
+    public OneField() {
+    }
+
+    /**
+     * Constructs a OneField object.
+     *
+     * @param type the OID value recognized by GPDBWritable
+     * @param val the field value
+     */
+    public OneField(int type, Object val) {
+        this.type = type;
+        this.val = val;
+    }
+
+    @Override
+    public String toString() {
+        return val.toString();
+    }
+}
+```
+
+## <a id="datatypes"></a>Data Types Supported
+
+The `OneField.type` must be one of the `enums` defined in `org.apache.hawq.pxf.api.io.DataType`. The data type of the field value `val` is the appropriate Java class for the `OneField.type`. Supported types are:
+
+<a id="onefield_datatypes_table"></a>
+
+<table>
+<caption><span class="tablecap">Table 1. Resolver Supported Data Types</span></caption>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><p>PXF Type OID</p></th>
+<th><p>Data Value Java Type</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><p><code class="ph codeph">DataType.SMALLINT</code></p></td>
+<td><p><code class="ph codeph">Short</code></p></td>
+</tr>
+<tr class="even">
+<td><p><code class="ph codeph">DataType.INTEGER</code></p></td>
+<td><p><code class="ph codeph">Integer</code></p></td>
+</tr>
+<tr class="odd">
+<td><p><code class="ph codeph">DataType.BIGINT</code></p></td>
+<td><p><code class="ph codeph">Long</code></p></td>
+</tr>
+<tr class="even">
+<td><p><code class="ph codeph">DataType.REAL</code></p></td>
+<td><p><code class="ph codeph">Float</code></p></td>
+</tr>
+<tr class="odd">
+<td><p><code class="ph codeph">DataType.FLOAT8</code></p></td>
+<td><p><code class="ph codeph">Double</code></p></td>
+</tr>
+<tr class="even">
+<td><p><code class="ph codeph">DataType.NUMERIC</code></p></td>
+<td><p><code class="ph codeph">BigDecimal</code></p></td>
+</tr>
+<tr class="odd">
+<td><p><code class="ph codeph">DataType.BOOLEAN</code></p></td>
+<td><p><code class="ph codeph">Boolean</code></p></td>
+</tr>
+<tr class="even">
+<td><p><code class="ph codeph">DataType.VARCHAR</code></p></td>
+<td><p><code class="ph codeph">String</code></p></td>
+</tr>
+<tr class="odd">
+<td><p><code class="ph codeph">DataType.BPCHAR</code></p></td>
+<td><p><code class="ph codeph">String</code></p></td>
+</tr>
+<tr class="even">
+<td><p><code class="ph codeph">DataType.TEXT</code></p></td>
+<td><p><code class="ph codeph">String</code></p></td>
+</tr>
+<tr class="odd">
+<td><p><code class="ph codeph">DataType.BYTEA</code></p></td>
+<td><p><code class="ph codeph">byte []</code></p></td>
+</tr>
+<tr class="even">
+<td><p><code class="ph codeph">DataType.TIMESTAMP</code></p></td>
+<td><p><code class="ph codeph">Timestamp</code></p></td>
+</tr>
+<tr class="odd">
+<td><p><code class="ph codeph">DataType.Date</code></p></td>
+<td><p><code class="ph codeph">Date</code></p></td>
+</tr>
+</tbody>
+</table>
+

--- a/gpdb-doc/markdown/pxf/sdk/api/onerow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/onerow.html.md.erb
@@ -1,0 +1,77 @@
+---
+title: OneRow Class
+---
+
+The `org.apache.hawq.pxf.api.OneRow` class represents one record or row in the external data source. When reading, rows are extracted from a `Fragment`.
+
+A class that implements the `ReadAccessor` interface reads a `Fragment` from the external data source and generates `OneRow` records.
+
+A class that implements the `WriteAccessor` interface writes `OneRow` records directly to the external data source.
+
+Instance variables defined by the `OneRow` class include:
+
+| Data Type           | Variable Name |  Description  |
+|---------------------|----------------|----------------------|
+| Object   | key  | The key of the data record. (Optional) |
+| Object   | data | The record/row data. |
+
+In certain data formats such as SequenceFile, the data for a record is accompanied by a key. PXF reserves the Greenplum Database column name `recordkey` for representing such data formats.
+
+
+## <a id="classdef"></a>Class Definition
+
+
+``` java
+package org.apache.hawq.pxf.api;
+
+public class OneRow {
+    private Object key;
+    private Object data;
+
+    public OneRow(){
+    }
+
+    /**
+     * Constructs a OneRow
+     *
+     * @param key the key for the record
+     * @param data the actual record
+     */
+    public OneRow(Object key, Object data) {
+        this.key = key;
+        this.data = data;
+    }
+
+    /**
+     * Constructs a OneRow without a key value
+     *
+     * @param data the actual record
+     */
+    public OneRow(Object data) {
+        this.data = data;
+    }
+
+    public void setKey(Object key) {
+        this.key = key;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+
+    public Object getKey() {
+        return key;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    @Override
+    public String toString() {
+        return "OneRow:" + key + "->" + data;
+    }
+}
+
+```
+

--- a/gpdb-doc/markdown/pxf/sdk/api/plugin.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/plugin.html.md.erb
@@ -1,0 +1,32 @@
+---
+title: Plugin Class
+---
+
+The `Plugin` class is the base class for all PXF plug-in types. The *Accessor*, *Resolver*, and *Fragmenter* Java classes that you develop will extend the `org.apache.hawq.pxf.api.utilities.Plugin` class.
+
+The `Plugin` class provides access to the metadata associated with a specific user request (i.e. a `CREATE EXTERNAL TABLE`, or a `SELECT` from or `INSERT` into the external table). This information is available in the `InputData` class.
+
+## <a id="classdef"></a>Class Definition
+
+``` java
+package org.apache.hawq.pxf.api.utilities;
+
+public class Plugin {
+    protected InputData inputData;
+
+    /**
+     * Constructs a plugin.
+     *
+     * @param input the input data
+     */
+    public Plugin(InputData input);
+
+    /**
+     * Checks if the plugin is thread safe or not, based on inputData.
+     *
+     * @return true if plugin is thread safe
+     */
+    public boolean isThreadSafe();
+}
+```
+

--- a/gpdb-doc/markdown/pxf/sdk/api/readaccessor.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/readaccessor.html.md.erb
@@ -1,0 +1,116 @@
+---
+title: ReadAccessor Interface
+---
+
+The `org.apache.hawq.pxf.api.ReadAccessor` interface defines the read operation to an external data source. A class that implements this interface reads a `Fragment` and generates individual `OneRow` records.
+
+## <a id="classdef"></a>Interface Definition
+
+``` java
+package org.apache.hawq.pxf.api;
+
+public interface ReadAccessor {
+    /**
+     * Opens the resource for reading.
+     *
+     * @return true if the resource is successfully opened
+     * @throws Exception if opening the resource failed
+     */
+    boolean openForRead() throws Exception;
+
+    /**
+     * Reads the next object.
+     *
+     * @return the object which was read
+     * @throws Exception if reading from the resource failed
+     */
+    OneRow readNextObject() throws Exception;
+
+    /**
+     * Closes the resource.
+     *
+     * @throws Exception if closing the resource failed
+     */
+    void closeForRead() throws Exception;
+}
+```
+
+## <a id="impls"></a>ReadAccessor Implementations
+
+A *ReadAccessor* class that you develop with the PXF API `extends org.apache.hawq.pxf.api.utilities.Plugin` and `implements org.apache.hawq.pxf.api.ReadAccessor`.
+
+The PXF API includes the following `ReadAccessor` implementations:
+
+<a id="read_accessor_table"></a>
+<table>
+<caption><span class="tablecap">Table 1. Built-in ReadAccessor Implementations </span></caption>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><p>Accessor Class</p></th>
+<th><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hdfs.HdfsAtomicDataAccessor</td>
+<td>Base class for accessing HDFS data sources which cannot be split. These will be accessed by a single Greenplum Database segment.</td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hdfs.QuotedLineBreakAccessor</td>
+<td>Read accessor for HDFS text files that have records with embedded linebreaks.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hdfs.HdfsSplittableDataAccessor</td>
+<td><p>Base class for accessing HDFS files using the Hadoop <code class="ph codeph">RecordReader</code> class.</p></td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hdfs.LineBreakAccessor</td>
+<td>Read accessor for HDFS text files.</td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hdfs.ParquetFileAccessor</td>
+<td>Read accessor for HDFS parquet format files.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hdfs.AvroFileAccessor</td>
+<td>Read accessor for HDFS Avro format files.</td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hdfs.SequenceFileAccessor</td>
+<td>Read accessor for HDFS SequenceFile format files.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hbase.HBaseAccessor </td>
+<td>Read accessor for HBase tables.</td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hive.HiveAccessor</td>
+<td>Read accessor for Hive tables.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hive.HiveLineBreakAccessor</td>
+<td>Read accessor for Hive tables stored as text file format.</td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hive.HiveRCFileAccessor</td>
+<td>Read accessor for Hive tables stored as RC file format.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hive.HiveORCAccessor</td>
+<td>Read accessor for Hive tables stored as ORC format.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hive.HiveORCVectorizedAccessor</td>
+<td>Read accessor (batch) for Hive tables stored as ORC format.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.json.JsonAccessor</td>
+<td>Read accessor for HDFS JSON format files.</td>
+</tr>
+</tbody>
+</table>
+

--- a/gpdb-doc/markdown/pxf/sdk/api/readresolver.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/readresolver.html.md.erb
@@ -1,0 +1,109 @@
+---
+title: ReadResolver Interface
+---
+
+The `org.apache.hawq.pxf.api.ReadResolver` interface defines the deserialization of data read from an external data source into a form consumable by Greenplum Database. A class that implements this interface generates a list of `OneField` objects from a `OneRow` object.
+
+## <a id="intdef"></a>Interface Definition
+
+``` java
+package org.apache.hawq.pxf.api;
+
+public interface ReadResolver {
+    /**
+     * Gets the {@link OneField} list of one row.
+     *
+     * @param row the row to get the fields from
+     * @return the {@link OneField} list of one row.
+     * @throws Exception if decomposing the row into fields failed
+     */
+    List<OneField> getFields(OneRow row) throws Exception;
+}
+```
+
+## <a id="impls"></a>ReadResolver Implementations
+
+A *ReadResolver* class that you develop with the PXF API `extends org.apache.hawq.pxf.api.utilities.Plugin` and `implements org.apache.hawq.pxf.api.ReadResolver`.
+
+The PXF API includes the following `ReadResolver` implementations:
+
+<a id="read_resolver_table"></a>
+
+<table>
+<caption><span class="tablecap">Table 1. Built-in ReadResolver Implementations</span></caption>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><p>Resolver Class</p></th>
+<th><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><p>org.apache.hawq.pxf.plugins.hdfs.StringPassResolver</p></td>
+<td><p><code class="ph codeph">StringPassResolver</code> passes whole records (composed of any data types) as strings without parsing them</p></td>
+</tr>
+<tr class="even">
+<td><p>org.apache.hawq.pxf.plugins.hdfs.WritableResolver</p></td>
+<td><p>Resolver for custom Hadoop readable/writable implementations. A custom deserialization class can be specified with the `DATA-SCHEMA` option. Supports the following types:</p>
+<pre class="pre codeblock"><code>DataType.BOOLEAN
+DataType.INTEGER
+DataType.BIGINT
+DataType.REAL
+DataType.FLOAT8
+DataType.VARCHAR
+DataType.BYTEA</code></pre></td>
+</tr>
+<tr class="odd">
+<td><p>org.apache.hawq.pxf.plugins.hdfs.AvroResolver</p></td>
+<td><p>Supports the same field types as <code class="ph codeph">WritableResolver</code>. </p></td>
+</tr>
+<tr class="odd">
+<td><p>org.apache.hawq.pxf.plugins.hdfs.JsonResolver</p></td>
+<td><p>Resolver for HDFS JSON format files. Supports the same field types as <code class="ph codeph">WritableResolver</code> and also supports the following:</p>
+<pre class="pre codeblock"><code>DataType.SMALLINT
+DataType.BPCHAR
+DataType.TEXT</code></pre></td>
+</tr>
+<tr class="odd">
+<td><p>org.apache.hawq.pxf.plugins.hdfs.ParquetResolver</p></td>
+<td><p>Resolver for HDFS parquet format files. Supports the same field types as <code class="ph codeph">WritableResolver</code> and also supports the following:</p><pre class="pre codeblock"><code>DataType.SMALLINT
+DataType.NUMERIC
+DataType.TEXT
+DataType.DATE
+DataType.TIMESTAMP</code></pre></td>
+</tr>
+<tr class="even">
+<td><p>org.apache.hawq.pxf.plugins.hbase.HBaseResolver</p></td>
+<td><p>Supports the same field types as <code class="ph codeph">WritableResolver</code> and also supports the following:</p>
+<pre class="pre codeblock"><code>DataType.SMALLINT
+DataType.NUMERIC
+DataType.TEXT
+DataType.BPCHAR
+DataType.TIMESTAMP</code></pre></td>
+</tr>
+<tr class="odd">
+<td><p>org.apache.hawq.pxf.plugins.hive.HiveResolver</p></td>
+<td><p>Supports the same field objects as <code class="ph codeph">WritableResolver</code> and also supports the following:</p>
+<pre class="pre codeblock"><code>DataType.SMALLINT
+DataType.TEXT
+DataType.TIMESTAMP</code></pre></td>
+</tr>
+<tr class="even">
+<td><p>org.apache.hawq.pxf.plugins.hive.HiveStringPassResolver</p></td>
+<td>Specialized <code class="ph codeph">HiveResolver</code> for a Hive table stored as text file. Use together with the <code class="ph codeph">HiveInputFormatFragmenter</code>/<code class="ph codeph">HiveLineBreakAccessor</code> classes.</td>
+</tr>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hive.HiveColumnarSerdeResolver</td>
+<td>Specialized <code class="ph codeph">HiveResolver</code> for a Hive table stored as RC file. Use together with the <code class="ph codeph">HiveInputFormatFragmenter</code>/<code class="ph codeph">HiveRCFileAccessor</code> classes.</td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hive.HiveORCSerdeResolver</td>
+<td>Specialized <code class="ph codeph">HiveResolver</code> for a Hive table stored as ORC format. Use together with the <code class="ph codeph">HiveInputFormatFragmenter</code>/<code class="ph codeph">HiveORCAccessor</code> classes.</td>
+</tr>
+</tbody>
+</table>
+

--- a/gpdb-doc/markdown/pxf/sdk/api/readvectresolver.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/readvectresolver.html.md.erb
@@ -1,0 +1,52 @@
+---
+title: ReadVectorizedResolver Interface
+---
+
+The `org.apache.hawq.pxf.api.ReadVectorizedResolver` interface defines the deserialization of data read from an external data source to Greenplum Database. A class that implements this interface generates a list of `OneField` objects from a batch of `OneRow` objects.
+
+## <a id="intdef"></a>Interface Definition
+
+``` java
+package org.apache.hawq.pxf.api;
+
+public interface ReadVectorizedResolver {
+
+    /**
+     * Returns resolved list of tuples
+     *
+     * @param batch unresolved batch
+     * @return list of tuples
+     */
+    public List<List<OneField>> getFieldsForBatch(OneRow batch);
+
+}
+```
+
+## <a id="impls"></a>ReadVectorizedResolver Implementations
+
+A *ReadVectorizedResolver* class that you develop with the PXF API `extends org.apache.hawq.pxf.api.utilities.Plugin` and `implements org.apache.hawq.pxf.api.ReadVectorizedResolver`.
+
+The PXF API includes the following `ReadVectorizedResolver` implementation:
+
+<a id="readvect_resolver_table"></a>
+
+<table>
+<caption><span class="tablecap">Table 1. Built-in ReadVectorizedResolver Implementations</span></caption>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><p>Resolver Class</p></th>
+<th><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>org.apache.hawq.pxf.plugins.hive.HiveORCVectorizedResolver</td>
+<td>Specialized <code class="ph codeph">HiveResolver</code> for a Hive table stored in ORC format. Use together with the <code class="ph codeph">HiveInputFormatFragmenter</code>/<code class="ph codeph">HiveORCVectorizedAccessor</code> classes.</td>
+</tr>
+</tbody>
+</table>
+

--- a/gpdb-doc/markdown/pxf/sdk/api/writeaccessor.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/writeaccessor.html.md.erb
@@ -1,0 +1,69 @@
+---
+title: WriteAccessor Interface
+---
+
+The `org.apache.hawq.pxf.api.WriteAccessor` interface defines the write operation to an external data source. A class that implements this interface writes `OneRow` records directly to the external data source.
+
+## <a id="intdef"></a>Interface Definition
+
+``` java
+package org.apache.hawq.pxf.api;
+
+public interface WriteAccessor {
+    /**
+     * Opens the resource for write.
+     *
+     * @return true if the resource is successfully opened
+     * @throws Exception if opening the resource failed
+     */
+    boolean openForWrite() throws Exception;
+
+    /**
+     * Writes the next object.
+     *
+     * @param onerow the object to be written
+     * @return true if the write succeeded
+     * @throws Exception writing to the resource failed
+     */
+    boolean writeNextObject(OneRow onerow) throws Exception;
+
+    /**
+     * Closes the resource for write.
+     *
+     * @throws Exception if closing the resource failed
+     */
+    void closeForWrite() throws Exception;
+}
+```
+
+## <a id="impls"></a>WriteAccessor Implementations
+
+A *WriteAccessor* class that you develop with the PXF API `extends org.apache.hawq.pxf.api.utilities.Plugin` and `implements org.apache.hawq.pxf.api.WriteAccessor`.
+
+The PXF API includes the following `WriteAccessor` implementations:
+
+<a id="write_accessor_table"></a>
+<table>
+<caption><span class="tablecap">Table 1. Built-in WriteAccessor Implementations </span></caption>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><p>Accessor Class</p></th>
+<th><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hdfs.LineBreakAccessor</td>
+<td>Write accessor for HDFS text format files.</td>
+</tr>
+<tr class="even">
+<td>org.apache.hawq.pxf.plugins.hdfs.SequenceFileAccessor</td>
+<td>Write accessor for HDFS SequenceFile format files.</td>
+</tr>
+</tbody>
+</table>
+

--- a/gpdb-doc/markdown/pxf/sdk/api/writeresolver.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/api/writeresolver.html.md.erb
@@ -1,0 +1,62 @@
+---
+title: WriteResolver Interface
+---
+
+The `org.apache.hawq.pxf.api.WriteResolver` interface defines the serialization of data read from Greenplum Database. A class that implements this interface generates a `OneRow` object from a list of `OneField` objects.
+
+## <a id="intdef"></a>Interface Definition
+
+``` java
+package org.apache.hawq.pxf.api;
+
+public interface WriteResolver {
+    /**
+     * Constructs and sets the fields of a {@link OneRow}.
+     *
+     * @param record list of {@link OneField}
+     * @return the constructed {@link OneRow}
+     * @throws Exception if constructing a row from the fields failed
+     */
+    OneRow setFields(List<OneField> record) throws Exception;
+}
+```
+
+## <a id="impls"></a>WriteResolver Implementations
+
+A *WriteResolver* class that you develop with the PXF API `extends org.apache.hawq.pxf.api.utilities.Plugin` and `implements org.apache.hawq.pxf.api.WriteResolver`.
+
+The PXF API includes the following `WriteResolver` implementations:
+
+<a id="write_resolver_table"></a>
+
+<table>
+<caption><span class="tablecap">Table 1. Built-in WriteResolver Implementations</span></caption>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><p>Resolver Class</p></th>
+<th><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><p>org.apache.hawq.pxf.plugins.hdfs.StringPassResolver</p></td>
+<td><p><code class="ph codeph">StringPassResolver</code> passes whole records (composed of any data types) as strings without parsing them</p></td>
+</tr>
+<tr class="even">
+<td><p>org.apache.hawq.pxf.plugins.hdfs.WritableResolver</p></td>
+<td><p>Resolver for custom Hadoop readable/writable implementations. A custom serialization class can be specified with the `DATA-SCHEMA` option. Supports the following types:</p>
+<pre class="pre codeblock"><code>DataType.BOOLEAN
+DataType.INTEGER
+DataType.BIGINT
+DataType.REAL
+DataType.FLOAT8
+DataType.VARCHAR
+DataType.BYTEA</code></pre></td>
+</tr>
+</tbody>
+</table>
+

--- a/gpdb-doc/markdown/pxf/sdk/pxfapi.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/pxfapi.html.md.erb
@@ -4,29 +4,29 @@ title: Introducing the PXF API
 
 You use the PXF API to add support for a new external data store, data format, or data access API to Greenplum Database. You can also use the PXF API to extend existing external data stores, formats, and APIs. The PXF API defines the data structures, classes, and interfaces that you need to map external data into a tabular form suitable for Greenplum Database, and vice-versa.
 
-The PXF API interfaces that you will implement or extend depend upon the external data store/API, data types, and operations (read, write) that your connector or plug-in will support, as well as the specific features you want to provide. 
+The PXF API interfaces that you will implement or extend depend upon the external data store/API, data types, and operations (read, write) that your connector or plug-in will support, as well as the specific features that you want to provide. 
 
 The PXF API defines classes including the following:
 
 | Class Name       | Description                                |
 |------------------|--------------------------------------------|
-| `Plugin`       | The base class for all PXF plug-in types.    |
-| `Fragmenter`       | The abstract class that defines how to split data from an external source into fragments.    |
-| `Fragment`       | A subset of data that can be read in parallel.    |
-| `OneRow`       | One record or row in a `Fragment`.  |
-| `OneField`       | One deserialized or serialized field in a `OneRow` record.    |
-| `InputData`       | Input data from Greenplum Database and common configuration information available to all plug-ins, and the helper methods to access this information.    |
+| [`Plugin`](api/plugin.html)       | The base class for all PXF plug-in types.    |
+| [`Fragmenter`](api/fragmenter.html)      | The abstract class that defines how to split data read from an external source into fragments.    |
+| [`Fragment`](api/fragment.html)       | A subset of data that can be read in parallel.    |
+| [`OneRow`](api/onerow.html)      | One record or row of data; extracted from a `Fragment` when reading from the external data source.  |
+| [`OneField`](api/onefield.html)       | One deserialized or serialized field in a `OneRow` record.    |
+| [`InputData`](api/inputdata.html)       | Input data from Greenplum Database and common configuration information available to all plug-ins, and the helper methods to access this information.    |
 
 
 The PXF API exposes the following interfaces:
 
 | Interface Name  | Description                                |
 |------------------|--------------------------------------------|
-| `ReadAccessor` |  Reads a `Fragment` and generates a list of `OneRow` records.  |
-| `ReadResolver` |  Deserializes a single `OneRow` record into a list of `OneField` objects.  |
-| `ReadVectorizedResolver` |  Deserializes a batch of `OneRow` records into tuples of `OneField` objects.  |
-| `WriteResolver` |  Serializes a list of `OneField` objects into a single `OneRow` record. |
-| `WriteAccessor` |  Writes `OneRow` records to the external data source. |
+| [`ReadAccessor`](api/readaccessor.html) |  Reads a `Fragment` and generates a list of `OneRow` records.  |
+| [`ReadResolver`](api/readresolver.html) |  Deserializes a single `OneRow` record into a list of `OneField` objects.  |
+| [`ReadVectorizedResolver`](api/readvectresolver.html) |  Deserializes a batch of `OneRow` records into tuples of `OneField` objects.  |
+| [`WriteResolver`](api/writeresolver.html) |  Serializes a list of `OneField` objects into a single `OneRow` record. |
+| [`WriteAccessor`](api/writeaccessor.html) |  Writes a `OneRow` record to the external data source. |
 
 
 Refer to the [PXF API JavaDocs](http://hawq.incubator.apache.org/docs/pxf/javadoc/) for detailed information about the classes and interfaces exposed by the API.


### PR DESCRIPTION
people are developing pxf connectors.  enhance the pxf api class and interface content so it is equivalent to what currently exists in the hawq docs.

created a new page for some of the important classes/interfaces:
- include the class/interface definition
- identify the built-in implementations, if relevant

i created a table in which i try to identify the source of the data for each of the InputData class instance variables.  could use some extra eyes on this content.  

note:  there are no new examples/exercises in this PR.

doc review site main link (class name in the table is a link to specific page):
- http://docs-gpdb-review-staging.cfapps.io/review/pxf/sdk/pxfapi.html - (not sure why the Class Name column width is so narrow on this page.  working on that ...)
