### PR TITLE
Fix querying stats for largest child

### DIFF
--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -4293,14 +4293,16 @@ examine_variable(PlannerInfo *root, Node *node, int varRelid,
 					child_rte = rt_fetch(childrel->relid, root->parse->rtable);
 
 					Assert(child_rte != NULL);
+					const char *attname = get_relid_attribute_name(rte->relid, var->varattno);
+					AttrNumber child_attno = get_attnum(child_rte->relid, attname);
 
 					/*
 					 * Get statistics from the child partition.
 					 */
 					vardata->statsTuple = SearchSysCache3(STATRELATTINH,
 														  ObjectIdGetDatum(child_rte->relid),
-														  Int16GetDatum(var->varattno),
-														  BoolGetDatum(rte->inh));
+														  Int16GetDatum(child_attno),
+														  BoolGetDatum(child_rte->inh));
 
 					if (vardata->statsTuple != NULL)
 					{

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -2066,3 +2066,57 @@ ALTER TABLE tt7 NOT OF;
  y      | numeric(8,2) | 
 Distributed by: (x)
 
+--
+-- Test for splitting after dropping a column
+--
+DROP TABLE IF EXISTS test_part;
+NOTICE:  table "test_part" does not exist, skipping
+CREATE TABLE test_part (
+    field_part timestamp without time zone,
+    field1 int,
+    field2 text,
+    field3 int
+) PARTITION BY RANGE(field_part)
+          (
+          PARTITION p2017 START ('2017-01-01'::date) END ('2018-01-01'::date) WITH (appendonly=false ),
+          DEFAULT PARTITION p_overflow  WITH (appendonly=false )
+          );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'field_part' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_part_1_prt_p_overflow" for table "test_part"
+NOTICE:  CREATE TABLE will create partition "test_part_1_prt_p2017" for table "test_part"
+DROP TABLE IF EXISTS test_ref;
+NOTICE:  table "test_ref" does not exist, skipping
+CREATE TABLE test_ref (
+    field1 text,
+    field2 text
+) DISTRIBUTED BY (field1);
+INSERT INTO test_part select '2017-01-01'::date + interval '1 days' * mod (id,1000) , mod(id,50), 'test ' || mod(id,5) ,mod(id,2) from generate_series(1,10000) id;
+INSERT INTO test_ref select 'test ' || id , 'values' from generate_series(1,10) id;
+ALTER TABLE test_part DROP COLUMN field1;
+ALTER TABLE test_part   SPLIT DEFAULT PARTITION
+START('2018-01-01'::date)
+       END( '2018-02-01'::date);
+NOTICE:  exchanged partition "p_overflow" of relation "test_part" with relation "pg_temp_32601"
+NOTICE:  dropped partition "p_overflow" for relation "test_part"
+NOTICE:  CREATE TABLE will create partition "test_part_1_prt_r28232684" for table "test_part"
+NOTICE:  CREATE TABLE will create partition "test_part_1_prt_p_overflow" for table "test_part"
+ANALYZE test_part;
+ANALYZE test_ref;
+SELECT * FROM test_part WHERE field2 IN (SELECT field1 FROM test_ref) ORDER BY 1 LIMIT 10;
+        field_part        | field2 | field3 
+--------------------------+--------+--------
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+ Mon Jan 02 00:00:00 2017 | test 1 |      1
+(10 rows)
+
+DROP TABLE test_ref;
+DROP TABLE test_part;

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -1016,40 +1016,40 @@ select * from t, pt where tid < ptid;
 -- cascading joins
 --
 explain select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=2.26..21.23 rows=6 width=69)
-   ->  Hash Join  (cost=2.26..21.23 rows=2 width=69)
-         Hash Cond: t1.t2 = t.t2
-         ->  Hash Join  (cost=1.13..20.00 rows=2 width=50)
-               Hash Cond: dpe_single.pt.ptid = t1.tid
-               ->  Append  (cost=0.00..18.54 rows=18 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
-                           ->  Seq Scan on pt_1_prt_junk_data pt  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
-                           ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
-                           ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
-                           ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
-                           ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
-                           ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.09 rows=3 width=31)
-               ->  Hash  (cost=1.08..1.08 rows=2 width=19)
-                     ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..1.08 rows=2 width=19)
-                           Filter: t1.tid
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.08 rows=2 width=19)
-                                 ->  Seq Scan on t1  (cost=0.00..1.02 rows=1 width=19)
-         ->  Hash  (cost=1.08..1.08 rows=2 width=19)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.08 rows=2 width=19)
-                     ->  Seq Scan on t  (cost=0.00..1.02 rows=1 width=19)
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.43..22.45 rows=108 width=69)
+   ->  Hash Join  (cost=2.43..22.45 rows=36 width=69)
+         Hash Cond: dpe_single.pt.ptid = t1.tid
+         ->  Append  (cost=0.00..18.54 rows=18 width=31)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on pt_1_prt_junk_data pt  (cost=0.00..3.09 rows=3 width=31)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..3.09 rows=3 width=31)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..3.09 rows=3 width=31)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..3.09 rows=3 width=31)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..3.09 rows=3 width=31)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.09 rows=3 width=31)
+         ->  Hash  (cost=2.33..2.33 rows=3 width=38)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=1.13..2.33 rows=3 width=38)
+                     Filter: t1.tid
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.13..2.33 rows=3 width=38)
+                           ->  Hash Join  (cost=1.13..2.21 rows=2 width=38)
+                                 Hash Cond: t.t2 = t1.t2
+                                 ->  Seq Scan on t  (cost=0.00..1.02 rows=1 width=19)
+                                 ->  Hash  (cost=1.08..1.08 rows=2 width=19)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.08 rows=2 width=19)
+                                             ->  Seq Scan on t1  (cost=0.00..1.02 rows=1 width=19)
  Optimizer: legacy query optimizer
 (33 rows)
 
@@ -1098,120 +1098,81 @@ select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
 -- explain analyze
 --
 explain analyze select * from t, pt where tid = ptid;
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=1.13..20.61 rows=54 width=50)
-   Rows out:  18 rows at destination with 28 ms to first row, 45 ms to end, start offset by 1.635 ms.
-   ->  Hash Join  (cost=1.13..20.61 rows=18 width=50)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.13..20.48 rows=54 width=50) (actual time=3.847..4.038 rows=18 loops=1)
+   ->  Hash Join  (cost=1.13..20.48 rows=18 width=50) (actual time=1.234..3.222 rows=9 loops=1)
          Hash Cond: dpe_single.pt.ptid = t.tid
-         Rows out:  Avg 6.0 rows x 3 workers.  Max 9 rows (seg0) with 19 ms to first row, 29 ms to end, start offset by 2.635 ms.
-         Executor memory:  1K bytes avg, 1K bytes max (seg0).
-         Work_mem used:  1K bytes avg, 1K bytes max (seg0). Workfile: (0 spilling)
-         (seg0)   Hash chain length 1.0 avg, 1 max, using 2 of 1048576 buckets.
-         ->  Append  (cost=0.00..18.54 rows=18 width=31)
-               Rows out:  Avg 6.0 rows x 3 workers.  Max 9 rows (seg0) with 0.048 ms to first row, 0.089 ms to end, start offset by 21 ms.
-               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+         (seg0)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
+         ->  Append  (cost=0.00..18.54 rows=18 width=31) (actual time=0.031..0.059 rows=9 loops=1)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31) (never executed)
                      One-Time Filter: PartSelected
-                     Rows out:  0 rows (seg0) with 0.004 ms to end, start offset by 17 ms.
-                     ->  Seq Scan on pt_1_prt_junk_data pt  (cost=0.00..3.09 rows=3 width=31)
-                           Rows out:  (No row requested) 0 rows (seg0) with 0 ms to end.
-               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     ->  Seq Scan on pt_1_prt_junk_data pt  (cost=0.00..3.09 rows=3 width=31) (never executed)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31) (actual time=0.029..0.034 rows=4 loops=1)
                      One-Time Filter: PartSelected
-                     Rows out:  Avg 3.0 rows x 3 workers.  Max 4 rows (seg0) with 0.042 ms to first row, 0.049 ms to end, start offset by 21 ms.
-                     ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..3.09 rows=3 width=31)
-                           Rows out:  Avg 3.0 rows x 3 workers.  Max 4 rows (seg0) with 0.034 ms to first row, 0.039 ms to end, start offset by 21 ms.
-               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..3.09 rows=3 width=31) (actual time=0.026..0.029 rows=4 loops=1)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31) (actual time=0.011..0.017 rows=5 loops=1)
                      One-Time Filter: PartSelected
-                     Rows out:  Avg 3.0 rows x 3 workers.  Max 5 rows (seg0) with 0.019 ms to first row, 0.023 ms to end, start offset by 21 ms.
-                     ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..3.09 rows=3 width=31)
-                           Rows out:  Avg 3.0 rows x 3 workers.  Max 5 rows (seg0) with 0.013 ms to first row, 0.015 ms to end, start offset by 21 ms.
-               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..3.09 rows=3 width=31) (actual time=0.009..0.012 rows=5 loops=1)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31) (never executed)
                      One-Time Filter: PartSelected
-                     Rows out:  0 rows (seg0) with 0.002 ms to end, start offset by 17 ms.
-                     ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..3.09 rows=3 width=31)
-                           Rows out:  (No row requested) 0 rows (seg0) with 0 ms to end.
-               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..3.09 rows=3 width=31) (never executed)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31) (never executed)
                      One-Time Filter: PartSelected
-                     Rows out:  0 rows (seg0) with 0.002 ms to end, start offset by 17 ms.
-                     ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..3.09 rows=3 width=31)
-                           Rows out:  (No row requested) 0 rows (seg0) with 0 ms to end.
-               ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                     ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..3.09 rows=3 width=31) (never executed)
+               ->  Result  (cost=0.00..3.09 rows=3 width=31) (never executed)
                      One-Time Filter: PartSelected
-                     Rows out:  0 rows (seg0) with 0.002 ms to end, start offset by 21 ms.
-                     ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.09 rows=3 width=31)
-                           Rows out:  (No row requested) 0 rows (seg0) with 0 ms to end.
-         ->  Hash  (cost=1.08..1.08 rows=2 width=19)
-               Rows in:  Avg 2.0 rows x 3 workers.  Max 2 rows (seg0) with 0.137 ms to end, start offset by 21 ms.
-               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..1.08 rows=2 width=19)
+                     ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.09 rows=3 width=31) (never executed)
+         ->  Hash  (cost=1.08..1.08 rows=2 width=19) (actual time=0.715..0.715 rows=2 loops=1)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..1.08 rows=2 width=19) (actual time=0.072..0.707 rows=2 loops=1)
                      Filter: t.tid
-                     Rows out:  Avg 2.0 rows x 3 workers.  Max 2 rows (seg0) with 0.111 ms to first row, 0.126 ms to end, start offset by 21 ms.
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.08 rows=2 width=19)
-                           Rows out:  Avg 2.0 rows x 3 workers at destination.  Max 2 rows (seg0) with 0.032 ms to first row, 0.038 ms to end, start offset by 21 ms.
-                           ->  Seq Scan on t  (cost=0.00..1.02 rows=1 width=19)
-                                 Rows out:  2 rows (seg0) with 0.132 ms to first row, 0.140 ms to end, start offset by 3.879 ms.
- Slice statistics:
-   (slice0)    Executor memory: 547K bytes.
-   (slice1)    Executor memory: 308K bytes avg x 3 workers, 318K bytes max (seg0).
-   (slice2)    Executor memory: 16726K bytes avg x 3 workers, 16726K bytes max (seg0).  Work_mem: 1K bytes max.
- Statement statistics:
-   Memory used: 128000K bytes
- Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_segments_for_planner=2; optimizer_segments=2
- Optimizer status: legacy query optimizer
- Total runtime: 48.954 ms
-(58 rows)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.08 rows=2 width=19) (actual time=0.038..0.668 rows=2 loops=1)
+                           ->  Seq Scan on t  (cost=0.00..1.02 rows=1 width=19) (actual time=0.056..0.062 rows=2 loops=1)
+   (slice0)    Executor memory: 544K bytes.
+   (slice1)    Executor memory: 60K bytes avg x 3 workers, 62K bytes max (seg0).
+   (slice2)    Executor memory: 4418K bytes avg x 3 workers, 4418K bytes max (seg0).  Work_mem: 1K bytes max.
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 5.970 ms
+(34 rows)
 
 --
 -- Partitioned table on both sides of the join. This will create a result node as Append node is
 -- not projection capable.
 --
 explain select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt1.dist;
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=56.05..56.86 rows=324 width=62)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=42.50..42.73 rows=93 width=62)
    Merge Key: dpe_single.pt1.dist
-   ->  Sort  (cost=56.05..56.86 rows=108 width=62)
+   ->  Sort  (cost=42.50..42.73 rows=31 width=62)
          Sort Key: dpe_single.pt1.dist
-         ->  Hash Join  (cost=19.00..42.54 rows=108 width=62)
-               Hash Cond: dpe_single.pt1.ptid = dpe_single.pt.ptid
-               ->  Append  (cost=0.00..18.54 rows=18 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
-                           ->  Seq Scan on pt1_1_prt_junk_data pt1  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
+         ->  Hash Join  (cost=19.43..39.47 rows=31 width=62)
+               Hash Cond: dpe_single.pt.ptid = dpe_single.pt1.ptid
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.86 rows=4 width=31)
+                     ->  Append  (cost=0.00..18.68 rows=2 width=31)
+                           ->  Seq Scan on pt_1_prt_junk_data pt  (cost=0.00..3.11 rows=1 width=31)
+                                 Filter: pt1 = 'hello0'::text
+                           ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..3.11 rows=1 width=31)
+                                 Filter: pt1 = 'hello0'::text
+                           ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..3.11 rows=1 width=31)
+                                 Filter: pt1 = 'hello0'::text
+                           ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..3.11 rows=1 width=31)
+                                 Filter: pt1 = 'hello0'::text
+                           ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..3.11 rows=1 width=31)
+                                 Filter: pt1 = 'hello0'::text
+                           ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.11 rows=1 width=31)
+                                 Filter: pt1 = 'hello0'::text
+               ->  Hash  (cost=18.08..18.08 rows=36 width=31)
+                     ->  Append  (cost=0.00..18.08 rows=36 width=31)
+                           ->  Seq Scan on pt1_1_prt_junk_data pt1  (cost=0.00..3.63 rows=21 width=31)
                            ->  Seq Scan on pt1_1_prt_2 pt1  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
                            ->  Seq Scan on pt1_1_prt_3 pt1  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
-                           ->  Seq Scan on pt1_1_prt_4 pt1  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
+                           ->  Seq Scan on pt1_1_prt_4 pt1  (cost=0.00..2.09 rows=3 width=31)
                            ->  Seq Scan on pt1_1_prt_5 pt1  (cost=0.00..3.09 rows=3 width=31)
-                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                           One-Time Filter: PartSelected
                            ->  Seq Scan on pt1_1_prt_6 pt1  (cost=0.00..3.09 rows=3 width=31)
-               ->  Hash  (cost=18.86..18.86 rows=4 width=31)
-                     ->  Partition Selector for pt1 (dynamic scan id: 2)  (cost=0.00..18.86 rows=4 width=31)
-                           Filter: dpe_single.pt.ptid
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.86 rows=4 width=31)
-                                 ->  Append  (cost=0.00..18.68 rows=2 width=31)
-                                       ->  Seq Scan on pt_1_prt_junk_data pt  (cost=0.00..3.11 rows=1 width=31)
-                                             Filter: pt1 = 'hello0'::text
-                                       ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..3.11 rows=1 width=31)
-                                             Filter: pt1 = 'hello0'::text
-                                       ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..3.11 rows=1 width=31)
-                                             Filter: pt1 = 'hello0'::text
-                                       ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..3.11 rows=1 width=31)
-                                             Filter: pt1 = 'hello0'::text
-                                       ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..3.11 rows=1 width=31)
-                                             Filter: pt1 = 'hello0'::text
-                                       ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.11 rows=1 width=31)
-                                             Filter: pt1 = 'hello0'::text
- Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_segments_for_planner=2; optimizer_segments=2
- Optimizer status: legacy query optimizer
-(44 rows)
+ Optimizer: legacy query optimizer
+(29 rows)
 
 select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt1.dist;
  dist |  pt1   |  pt2  |    pt3    | ptid | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -1228,52 +1189,37 @@ select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt
 (9 rows)
 
 explain select count(*) from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0';
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=43.41..43.42 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=43.35..43.39 rows=1 width=8)
-         ->  Aggregate  (cost=43.35..43.36 rows=1 width=8)
-               ->  Hash Join  (cost=19.00..42.54 rows=108 width=0)
-                     Hash Cond: dpe_single.pt1.ptid = dpe_single.pt.ptid
-                     ->  Append  (cost=0.00..18.54 rows=18 width=4)
-                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
-                                 One-Time Filter: PartSelected
-                                 ->  Seq Scan on pt1_1_prt_junk_data pt1  (cost=0.00..3.09 rows=3 width=4)
-                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
-                                 One-Time Filter: PartSelected
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=39.76..39.77 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=39.70..39.74 rows=1 width=8)
+         ->  Aggregate  (cost=39.70..39.71 rows=1 width=8)
+               ->  Hash Join  (cost=19.43..39.47 rows=31 width=0)
+                     Hash Cond: dpe_single.pt.ptid = dpe_single.pt1.ptid
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.86 rows=4 width=4)
+                           ->  Append  (cost=0.00..18.68 rows=2 width=4)
+                                 ->  Seq Scan on pt_1_prt_junk_data pt  (cost=0.00..3.11 rows=1 width=4)
+                                       Filter: pt1 = 'hello0'::text
+                                 ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..3.11 rows=1 width=4)
+                                       Filter: pt1 = 'hello0'::text
+                                 ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..3.11 rows=1 width=4)
+                                       Filter: pt1 = 'hello0'::text
+                                 ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..3.11 rows=1 width=4)
+                                       Filter: pt1 = 'hello0'::text
+                                 ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..3.11 rows=1 width=4)
+                                       Filter: pt1 = 'hello0'::text
+                                 ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.11 rows=1 width=4)
+                                       Filter: pt1 = 'hello0'::text
+                     ->  Hash  (cost=18.08..18.08 rows=36 width=4)
+                           ->  Append  (cost=0.00..18.08 rows=36 width=4)
+                                 ->  Seq Scan on pt1_1_prt_junk_data pt1  (cost=0.00..3.63 rows=21 width=4)
                                  ->  Seq Scan on pt1_1_prt_2 pt1  (cost=0.00..3.09 rows=3 width=4)
-                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
-                                 One-Time Filter: PartSelected
                                  ->  Seq Scan on pt1_1_prt_3 pt1  (cost=0.00..3.09 rows=3 width=4)
-                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
-                                 One-Time Filter: PartSelected
-                                 ->  Seq Scan on pt1_1_prt_4 pt1  (cost=0.00..3.09 rows=3 width=4)
-                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
-                                 One-Time Filter: PartSelected
+                                 ->  Seq Scan on pt1_1_prt_4 pt1  (cost=0.00..2.09 rows=3 width=4)
                                  ->  Seq Scan on pt1_1_prt_5 pt1  (cost=0.00..3.09 rows=3 width=4)
-                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
-                                 One-Time Filter: PartSelected
                                  ->  Seq Scan on pt1_1_prt_6 pt1  (cost=0.00..3.09 rows=3 width=4)
-                     ->  Hash  (cost=18.86..18.86 rows=4 width=4)
-                           ->  Partition Selector for pt1 (dynamic scan id: 2)  (cost=0.00..18.86 rows=4 width=4)
-                                 Filter: dpe_single.pt.ptid
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.86 rows=4 width=4)
-                                       ->  Append  (cost=0.00..18.68 rows=2 width=4)
-                                             ->  Seq Scan on pt_1_prt_junk_data pt  (cost=0.00..3.11 rows=1 width=4)
-                                                   Filter: pt1 = 'hello0'::text
-                                             ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..3.11 rows=1 width=4)
-                                                   Filter: pt1 = 'hello0'::text
-                                             ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..3.11 rows=1 width=4)
-                                                   Filter: pt1 = 'hello0'::text
-                                             ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..3.11 rows=1 width=4)
-                                                   Filter: pt1 = 'hello0'::text
-                                             ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..3.11 rows=1 width=4)
-                                                   Filter: pt1 = 'hello0'::text
-                                             ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.11 rows=1 width=4)
-                                                   Filter: pt1 = 'hello0'::text
- Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_segments_for_planner=2; optimizer_segments=2
- Optimizer status: legacy query optimizer
-(43 rows)
+ Optimizer: legacy query optimizer
+(28 rows)
 
 select count(*) from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0';
  count 

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -1423,3 +1423,39 @@ CREATE TYPE tt_t1 AS (x int, y numeric(8,2));
 ALTER TABLE tt7 OF tt_t1;			-- reassign an already-typed table
 ALTER TABLE tt7 NOT OF;
 \d tt7
+
+--
+-- Test for splitting after dropping a column
+--
+DROP TABLE IF EXISTS test_part;
+CREATE TABLE test_part (
+    field_part timestamp without time zone,
+    field1 int,
+    field2 text,
+    field3 int
+) PARTITION BY RANGE(field_part)
+          (
+          PARTITION p2017 START ('2017-01-01'::date) END ('2018-01-01'::date) WITH (appendonly=false ),
+          DEFAULT PARTITION p_overflow  WITH (appendonly=false )
+          );
+
+DROP TABLE IF EXISTS test_ref;
+CREATE TABLE test_ref (
+    field1 text,
+    field2 text
+) DISTRIBUTED BY (field1);
+
+INSERT INTO test_part select '2017-01-01'::date + interval '1 days' * mod (id,1000) , mod(id,50), 'test ' || mod(id,5) ,mod(id,2) from generate_series(1,10000) id;
+INSERT INTO test_ref select 'test ' || id , 'values' from generate_series(1,10) id;
+
+ALTER TABLE test_part DROP COLUMN field1;
+ALTER TABLE test_part   SPLIT DEFAULT PARTITION
+START('2018-01-01'::date)
+       END( '2018-02-01'::date);
+ANALYZE test_part;
+ANALYZE test_ref;
+
+SELECT * FROM test_part WHERE field2 IN (SELECT field1 FROM test_ref) ORDER BY 1 LIMIT 10;
+
+DROP TABLE test_ref;
+DROP TABLE test_part;


### PR DESCRIPTION
Previously, we would use the root table's information to acquire stats
from the `syscache` which return no result. The reason it does not
return any result is because we query syscache using `inh` field which
is set true for root table and false for the leaf tables.

Another issue which is not evident is the possibility of mismatching
`attnum`s for the root and leaf tables after running specific scenarios.
When we delete a column and then split a partition, unchanged partitions
and old partitions preserves the old attnums while newly created
partitions have increasing attnums with no gaps. If we query syscache
using the root's attnum for that column, we would be getting a wrong
stats for that specific column. Passing root's `inh` hide the issue of
having wrong stats.

This PR fixes the issue by getting the attribute name using the
root's attnume and use it to acquire correct attnum for the largest leaf
partition.