### PR TITLE
Backport segfault fix with identify_system_timezone() to 5.8.X

### DIFF
--- a/src/timezone/pgtz.c
+++ b/src/timezone/pgtz.c
@@ -310,7 +310,7 @@ score_timezone(const char *tzname, struct tztry * tt)
 	 */
 	if (tzload(tzname, NULL, &tz.state, TRUE) != 0)
 	{
-		if (tzname[0] == ':' || tzparse(tzname, &tz.state, FALSE) != 0)
+		if (tzname[0] == ':' || !tzparse(tzname, &tz.state, FALSE))
 		{
 			return -1;			/* can't handle the TZ name at all */
 		}


### PR DESCRIPTION
This backports the changes from #5079 to the 5.8.X branch. These changes will prevent segfaults when trying to identify the system timezone on `gpinitsystem` and segment startup.