### PR TITLE
Optimize and correct copy_append_only_data().

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -32,6 +32,7 @@
 #include "utils/guc.h"
 #include "access/appendonlytid.h"
 #include "cdb/cdbappendonlystorage.h"
+#include "access/appendonlywriter.h"
 #include "cdb/cdbappendonlyxlog.h"
 
 int
@@ -194,4 +195,186 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 					    relname)));
 	if (RelationNeedsWAL(rel))
 		xlog_ao_truncate(rel->rd_node, segFileNum, offset);
+}
+
+static void
+copy_file(char *srcsegpath, char* dstsegpath,
+		  RelFileNode dst, int segfilenum, bool use_wal)
+{
+	File		srcFile;
+	File		dstFile;
+	int64		left;
+	off_t		offset;
+	char       *buffer = palloc(BLCKSZ);
+	int dstflags;
+
+	srcFile = PathNameOpenFile(srcsegpath, O_RDONLY | PG_BINARY, 0600);
+	if (srcFile < 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 (errmsg("could not open file %s: %m", srcsegpath))));
+
+	dstflags = O_WRONLY | O_EXCL | PG_BINARY;
+	/*
+	 * .0 relfilenode is expected to exist before calling this
+	 * function. Caller calls RelationCreateStorage() which creates the base
+	 * file for the relation. Hence use different flag for the same.
+	 */
+	if (segfilenum)
+		dstflags |= O_CREAT;
+
+	dstFile = PathNameOpenFile(dstsegpath, dstflags, 0600);
+	if (dstFile < 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 (errmsg("could not create destination file %s: %m", dstsegpath))));
+
+	left = FileSeek(srcFile, 0, SEEK_END);
+	if (left < 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 (errmsg("could not seek to end of file %s: %m", srcsegpath))));
+
+	if (FileSeek(srcFile, 0, SEEK_SET) < 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 (errmsg("could not seek to beginning of file %s: %m", srcsegpath))));
+
+	offset = 0;
+	while(left > 0)
+	{
+		int			len;
+
+		CHECK_FOR_INTERRUPTS();
+
+		len = Min(left, BLCKSZ);
+		if (FileRead(srcFile, buffer, len) != len)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not read %d bytes from file \"%s\": %m",
+							len, srcsegpath)));
+
+		if (FileWrite(dstFile, buffer, len) != len)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not write %d bytes to file \"%s\": %m",
+							len, dstsegpath)));
+
+		if (use_wal)
+			xlog_ao_insert(dst, segfilenum, offset, buffer, len);
+
+		offset += len;
+		left -= len;
+	}
+
+	if (FileSync(dstFile) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not fsync file \"%s\": %m",
+						dstsegpath)));
+	FileClose(srcFile);
+	FileClose(dstFile);
+	pfree(buffer);
+}
+
+/*
+ * Like copy_relation_data(), but for AO tables.
+ *
+ * Currently, AO tables don't have any extra forks.
+ */
+void
+copy_append_only_data(RelFileNode src, RelFileNode dst, BackendId backendid, char relpersistence)
+{
+	char *srcpath;
+	char *dstpath;
+	char srcsegpath[MAXPGPATH + 12];
+	char dstsegpath[MAXPGPATH + 12];
+	int segNumberArray[AOTupleId_MaxSegmentFileNum];
+	int segNumberArraySize;
+	bool use_wal;
+
+	/*
+	 * We need to log the copied data in WAL iff WAL archiving/streaming is
+	 * enabled AND it's a permanent relation.
+	 */
+	use_wal = XLogIsNeeded() && relpersistence == RELPERSISTENCE_PERMANENT;
+
+	srcpath = relpathbackend(src, backendid, MAIN_FORKNUM);
+	dstpath = relpathbackend(dst, backendid, MAIN_FORKNUM);
+
+	/*
+	 * For CO table, ALTER table, or utility mode insert files .128.. .256 0
+	 * based extensions are created. These also need to be copied; however,
+	 * they may not exist hence are treated separately here. Column 0
+	 * concurrency level 0 file is always present. MaxHeapAttributeNumber is
+	 * used as a sanity check; we expect the loop to terminate based on
+	 * access()'s return value.
+	 */
+	copy_file(srcpath, dstpath, dst, 0, use_wal);
+	for(int colnum = 1; colnum <= MaxHeapAttributeNumber; colnum++)
+	{
+		int suffix = colnum*AOTupleId_MultiplierSegmentFileNum;
+		sprintf(srcsegpath, "%s.%u", srcpath, suffix);
+		if (access(srcsegpath, F_OK) != 0)
+		{
+			/* ENOENT is expected after the end of the extensions */
+			if (errno != ENOENT)
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						 errmsg("access failed for file \"%s\": %m", srcsegpath)));
+			break;
+		}
+		sprintf(dstsegpath, "%s.%u", dstpath, suffix);
+		copy_file(srcsegpath, dstsegpath, dst, suffix, use_wal);
+	}
+
+	segNumberArraySize=0;
+	/* Collect all the segmentNumbers in [1..127]. */
+	for (int concurrency_index = 1; concurrency_index < MAX_AOREL_CONCURRENCY;
+		 concurrency_index++)
+	{
+		sprintf(srcsegpath, "%s.%u", srcpath, concurrency_index);
+		if (access(srcsegpath, F_OK) != 0)
+		{
+			if (errno != ENOENT)
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						 errmsg("access failed for file \"%s\": %m", srcsegpath)));
+			continue;
+		}
+		sprintf(dstsegpath, "%s.%u", dstpath, concurrency_index);
+		copy_file(srcsegpath, dstsegpath, dst, concurrency_index, use_wal);
+
+		segNumberArray[segNumberArraySize] = concurrency_index;
+		segNumberArraySize++;
+	}
+
+	if (segNumberArraySize == 0)
+		return;
+
+	for (int colnum = 1; colnum <= MaxHeapAttributeNumber; colnum++)
+	{
+		bool finished = false;
+		for (int concurrency_index = 0; concurrency_index < segNumberArraySize;
+			 concurrency_index++)
+		{
+			int suffix =
+				colnum*AOTupleId_MultiplierSegmentFileNum + segNumberArray[concurrency_index];
+			sprintf(srcsegpath, "%s.%u", srcpath, suffix);
+			if (access(srcsegpath, F_OK) != 0)
+			{
+				/* ENOENT is expected after the end of the extensions */
+				if (errno != ENOENT)
+					ereport(ERROR,
+							(errcode_for_file_access(),
+							 errmsg("access failed for file \"%s\": %m", srcsegpath)));
+				finished = true;
+				break;
+			}
+			sprintf(dstsegpath, "%s.%u", dstpath, suffix);
+			copy_file(srcsegpath, dstsegpath, dst, suffix, use_wal);
+		}
+		if (finished)
+			break;
+	}
 }

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17,6 +17,7 @@
 #include "postgres.h"
 
 #include "access/aocs_compaction.h"
+#include "access/aomd.h"
 #include "access/appendonlywriter.h"
 #include "access/bitmap.h"
 #include "access/genam.h"
@@ -396,8 +397,6 @@ static void copy_relation_data(SMgrRelation rel, SMgrRelation dst,
 				   ForkNumber forkNum, char relpersistence);
 static const char *storage_name(char c);
 
-
-static void copy_append_only_data(RelFileNode src, RelFileNode dst, BackendId backendid, char relpersistence);
 static void ATExecSetDistributedBy(Relation rel, Node *node,
 								   AlterTableCmd *cmd);
 static void ATPrepExchange(Relation rel, AlterPartitionCmd *pc);
@@ -11700,128 +11699,6 @@ copy_relation_data(SMgrRelation src, SMgrRelation dst,
 	 */
 	if (relpersistence == RELPERSISTENCE_PERMANENT)
 		smgrimmedsync(dst, forkNum);
-}
-
-/*
- * Like copy_relation_data(), but for AO tables.
- *
- * Currently, AO tables don't have any extra forks.
- */
-static void
-copy_append_only_data(RelFileNode src, RelFileNode dst, BackendId backendid, char relpersistence)
-{
-	DIR		   *dir;
-	struct dirent *de;
-	char	   *srcdir;
-	char	   *srcfilename;
-	char	   *srcfiledot;
-	char	   *dstpath;
-	char	   *buffer = palloc(BLCKSZ);
-
-	/*
-	 * Get the directory and base filename of the data file.
-	 */
-	reldir_and_filename(src, backendid, MAIN_FORKNUM, &srcdir, &srcfilename);
-	srcfiledot = psprintf("%s.", srcfilename);
-	dstpath = relpathbackend(dst, backendid, MAIN_FORKNUM);
-
-	/*
-	 * Scan the directory, looking for files belonging to this relation.
-	 * This is the same logic as in mdunlink(), see comments there.
-	 */
-	dir = AllocateDir(srcdir);
-	while ((de = ReadDir(dir, srcdir)) != NULL)
-	{
-		char	   *suffix;
-		char		srcsegpath[MAXPGPATH + 12];
-		char		dstsegpath[MAXPGPATH + 12];
-		File		srcFile;
-		File		dstFile;
-		int64		left;
-		off_t		offset;
-		int			segfilenum;
-
-		if (strcmp(de->d_name, ".") == 0 ||
-			strcmp(de->d_name, "..") == 0)
-			continue;
-
-		/* Does it begin with the relfilenode? */
-		if (strlen(de->d_name) <= strlen(srcfiledot) ||
-			strncmp(de->d_name, srcfiledot, strlen(srcfiledot)) != 0)
-			continue;
-
-		/*
-		 * Does it have a digits-only suffix? (This is not really
-		 * necessary to check, but better be conservative.)
-		 */
-		suffix = de->d_name + strlen(srcfiledot);
-		if (strspn(suffix, "0123456789") != strlen(suffix) ||
-			strlen(suffix) > 10)
-			continue;
-
-		/* Looks like a match. Go ahead and copy it. */
-		segfilenum = pg_atoi(suffix, 4, 0);
-
-		snprintf(srcsegpath, sizeof(srcsegpath), "%s/%s.%d", srcdir, srcfilename, segfilenum);
-		snprintf(dstsegpath, sizeof(dstsegpath), "%s.%d", dstpath, segfilenum);
-
-		srcFile = PathNameOpenFile(srcsegpath, O_RDONLY | PG_BINARY, 0600);
-		if (srcFile < 0)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 (errmsg("could not open file %s: %m", srcsegpath))));
-		dstFile = PathNameOpenFile(dstsegpath, O_WRONLY | O_CREAT | O_EXCL | PG_BINARY, 0600);
-		if (dstFile < 0)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 (errmsg("could not create destination file %s: %m", dstsegpath))));
-
-		left = FileSeek(srcFile, 0, SEEK_END);
-		if (left < 0)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 (errmsg("could not seek to end of file %s: %m", srcsegpath))));
-
-		if (FileSeek(srcFile, 0, SEEK_SET) < 0)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 (errmsg("could not seek to beginning of file %s: %m", srcsegpath))));
-
-		offset = 0;
-		while(left > 0)
-		{
-			int			len;
-
-			CHECK_FOR_INTERRUPTS();
-
-			len = Min(left, BLCKSZ);
-			if (FileRead(srcFile, buffer, len) != len)
-				ereport(ERROR,
-						(errcode_for_file_access(),
-						 errmsg("could not read %d bytes from file \"%s\": %m",
-								len, srcsegpath)));
-
-			if (FileWrite(dstFile, buffer, len) != len)
-				ereport(ERROR,
-						(errcode_for_file_access(),
-						 errmsg("could not write %d bytes to file \"%s\": %m",
-								len, dstsegpath)));
-
-			xlog_ao_insert(dst, segfilenum, offset, buffer, len);
-
-			offset += len;
-			left -= len;
-		}
-
-		if (FileSync(dstFile) != 0)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not fsync file \"%s\": %m",
-							dstsegpath)));
-		FileClose(srcFile);
-		FileClose(dstFile);
-	}
-	FreeDir(dir);
 }
 
 /*

--- a/src/include/access/aomd.h
+++ b/src/include/access/aomd.h
@@ -47,4 +47,6 @@ TruncateAOSegmentFile(File fd,
 					  int32 segmentFileNum,
 					  int64 offset);
 
+extern void
+copy_append_only_data(RelFileNode src, RelFileNode dst, BackendId backendid, char relpersistence);
 #endif							/* AOMD_H */

--- a/src/test/regress/input/gp_tablespace.source
+++ b/src/test/regress/input/gp_tablespace.source
@@ -14,7 +14,22 @@ CREATE TABLE aoco_ts_table (id int4, t text) with (appendonly=true, orientation=
 insert into ao_ts_table select g, 'foo' || g from generate_series(1, 10000) g;
 insert into aoco_ts_table select g, 'bar' || g from generate_series(1, 10000) g;
 
+-- alter table to create scenario where .0 file also has data
+ALTER TABLE ao_ts_table ALTER COLUMN id TYPE bigint;
+-- to satisfy orca
+ANALYZE ao_ts_table;
+
+ALTER TABLE aoco_ts_table ALTER COLUMN id TYPE bigint;
+-- to satisfy orca
+ANALYZE aoco_ts_table;
+
+insert into ao_ts_table select g, 'foofoo' || g from generate_series(10000, 10100) g;
+insert into aoco_ts_table select g, 'barbar' || g from generate_series(10000, 10100) g;
+
 CREATE INDEX ao_ts_index ON ao_ts_table(id);
+
+SELECT COUNT(*) FROM ao_ts_table;
+SELECT COUNT(*) FROM aoco_ts_table;
 
 ALTER TABLE ao_ts_table SET TABLESPACE testspace;
 ALTER TABLE aoco_ts_table SET TABLESPACE testspace;
@@ -24,6 +39,9 @@ INSERT INTO ao_ts_table VALUES(-1);
 INSERT INTO aoco_ts_table VALUES(-1);
 SELECT COUNT(*) FROM ao_ts_table;
 SELECT COUNT(*) FROM aoco_ts_table;
+-- Since count(*) for CO doesn't actually read all the columns, this query will
+-- read all the columns and all the newly written files.
+SELECT * FROM aoco_ts_table where id > 9995 and id < 10005;
 
 -- Clean up. (It would be good to leave some extra tablespaces behind, so that
 -- they would go through the gpcheckcat, pg_upgrade, etc. passes that run

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -19,7 +19,28 @@ CREATE TABLE ao_ts_table (id int4, t text) with (appendonly=true, orientation=ro
 CREATE TABLE aoco_ts_table (id int4, t text) with (appendonly=true, orientation=column) distributed by (id);
 insert into ao_ts_table select g, 'foo' || g from generate_series(1, 10000) g;
 insert into aoco_ts_table select g, 'bar' || g from generate_series(1, 10000) g;
+-- alter table to create scenario where .0 file also has data
+ALTER TABLE ao_ts_table ALTER COLUMN id TYPE bigint;
+-- to satisfy orca
+ANALYZE ao_ts_table;
+ALTER TABLE aoco_ts_table ALTER COLUMN id TYPE bigint;
+-- to satisfy orca
+ANALYZE aoco_ts_table;
+insert into ao_ts_table select g, 'foofoo' || g from generate_series(10000, 10100) g;
+insert into aoco_ts_table select g, 'barbar' || g from generate_series(10000, 10100) g;
 CREATE INDEX ao_ts_index ON ao_ts_table(id);
+SELECT COUNT(*) FROM ao_ts_table;
+ count 
+-------
+ 10101
+(1 row)
+
+SELECT COUNT(*) FROM aoco_ts_table;
+ count 
+-------
+ 10101
+(1 row)
+
 ALTER TABLE ao_ts_table SET TABLESPACE testspace;
 ALTER TABLE aoco_ts_table SET TABLESPACE testspace;
 ALTER INDEX ao_ts_index SET TABLESPACE testspace;
@@ -28,14 +49,31 @@ INSERT INTO aoco_ts_table VALUES(-1);
 SELECT COUNT(*) FROM ao_ts_table;
  count 
 -------
- 10001
+ 10102
 (1 row)
 
 SELECT COUNT(*) FROM aoco_ts_table;
  count 
 -------
- 10001
+ 10102
 (1 row)
+
+-- Since count(*) for CO doesn't actually read all the columns, this query will
+-- read all the columns and all the newly written files.
+SELECT * FROM aoco_ts_table where id > 9995 and id < 10005;
+  id   |      t      
+-------+-------------
+  9997 | bar9997
+  9998 | bar9998
+ 10000 | bar10000
+ 10000 | barbar10000
+ 10001 | barbar10001
+ 10002 | barbar10002
+ 10003 | barbar10003
+ 10004 | barbar10004
+  9996 | bar9996
+  9999 | bar9999
+(10 rows)
 
 -- Clean up. (It would be good to leave some extra tablespaces behind, so that
 -- they would go through the gpcheckcat, pg_upgrade, etc. passes that run


### PR DESCRIPTION
Alter tablespace needs to copy all underlying files of table from one tablespace
to other. For AO/CO tables this was implemented using full directory scan to
find files and copy when persistent tables were removed. This gets very
inefficient and varies in performance based on number of files present in the
directory. Instead use the same optimization logic used for `mdunlink_ao()`
leveraging known file layout for AO/CO tables.

Also, old logic had couple of bugs:
- missed coping the base or .0 file. Which means data loss if table was altered in past.
- xlogging even for temp tables

These are fixed as well with this patch. Additional tests added to cover for
those missing scenaiors. Also, moved the AO specific code to aomd.c, out of
tablecmds.c file to reduce conflicts to upstream.