### PR TITLE
Exclude _mock.c files from make_etags.

### DIFF
--- a/src/tools/make_etags
+++ b/src/tools/make_etags
@@ -4,5 +4,5 @@
 
 rm -f ./TAGS
 
-find `pwd`/ -type f -name '*.[chyl]' -print |
+find `pwd`/ -type f -name '*.[chyl]' -not -name "*_mock.c" -print |
 	xargs etags --append -o TAGS


### PR DESCRIPTION
Unit tests generate mock version of the .c files and its very annoying as they
get in TAGS file and always first visit lands in mocked implementation.