### PR TITLE
Drop role if exists in bfv_partition test.

### DIFF
--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1835,6 +1835,7 @@ ERROR:  value too long for type character(1)
 drop table mpp4582;
 -- Use a particular username in the tests below, so that the output of \di
 -- commands don't vary depending on current user.
+DROP USER IF EXISTS mpp3641_user;
 CREATE USER mpp3641_user;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 GRANT ALL ON SCHEMA bfv_partition TO mpp3641_user;
@@ -5406,7 +5407,9 @@ select 'pg_partition_templates', count(*) from pg_partition_templates where tabl
 --
 -- Check that dependencies to users are recorded correctly when operating on partitions.
 --
+DROP ROLE IF EXISTS part_acl_owner;
 CREATE ROLE part_acl_owner;
+DROP ROLE IF EXISTS part_acl_u1;
 CREATE ROLE part_acl_u1;
 GRANT ALL ON SCHEMA bfv_partition to part_acl_owner;
 SET ROLE part_acl_owner;

--- a/src/test/regress/expected/role.out
+++ b/src/test/regress/expected/role.out
@@ -7,14 +7,12 @@
 -- This also covers an old bug with dispatching GUCs with units in ALTER ROLE
 -- statement (MPP-15479).
 --
-set client_min_messages to warning; -- suppress 'role does not exist' notices
 DROP ROLE IF EXISTS role_setting_test_1;
 DROP ROLE IF EXISTS role_setting_test_2;
 DROP ROLE IF EXISTS role_setting_test_3;
 DROP ROLE IF EXISTS role_setting_test_4;
 DROP ROLE IF EXISTS role_setting_test_5;
 DROP ROLE IF EXISTS role_setting_test_6;
-reset client_min_messages;
 CREATE ROLE role_setting_test_1 NOLOGIN;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE role_setting_test_2 NOLOGIN;

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -705,6 +705,7 @@ drop table mpp4582;
 
 -- Use a particular username in the tests below, so that the output of \di
 -- commands don't vary depending on current user.
+DROP USER IF EXISTS mpp3641_user;
 CREATE USER mpp3641_user;
 GRANT ALL ON SCHEMA bfv_partition TO mpp3641_user;
 SET ROLE mpp3641_user;
@@ -1693,7 +1694,9 @@ select 'pg_partition_templates', count(*) from pg_partition_templates where tabl
 --
 -- Check that dependencies to users are recorded correctly when operating on partitions.
 --
+DROP ROLE IF EXISTS part_acl_owner;
 CREATE ROLE part_acl_owner;
+DROP ROLE IF EXISTS part_acl_u1;
 CREATE ROLE part_acl_u1;
 GRANT ALL ON SCHEMA bfv_partition to part_acl_owner;
 

--- a/src/test/regress/sql/role.sql
+++ b/src/test/regress/sql/role.sql
@@ -8,14 +8,13 @@
 -- This also covers an old bug with dispatching GUCs with units in ALTER ROLE
 -- statement (MPP-15479).
 --
-set client_min_messages to warning; -- suppress 'role does not exist' notices
 DROP ROLE IF EXISTS role_setting_test_1;
 DROP ROLE IF EXISTS role_setting_test_2;
 DROP ROLE IF EXISTS role_setting_test_3;
 DROP ROLE IF EXISTS role_setting_test_4;
 DROP ROLE IF EXISTS role_setting_test_5;
 DROP ROLE IF EXISTS role_setting_test_6;
-reset client_min_messages;
+
 CREATE ROLE role_setting_test_1 NOLOGIN;
 CREATE ROLE role_setting_test_2 NOLOGIN;
 CREATE ROLE role_setting_test_3 NOLOGIN;


### PR DESCRIPTION
bfv_partition tests fail if ICW is run n times after creating the cluster, as
the role is not dropped. With this commit now this test can be run n times
successfully without re-creating the cluster.

On the way also remove the suppression of warnings in role.sql.