### PR TITLE
Improve query_finish_pending test, cut down 100 secs.

### DIFF
--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -169,17 +169,15 @@ NOTICE:  Success:
 (1 row)
 
 -- make one QE sleep before reading command
-select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, -1, 50, 2::smallint);
+select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 1, 50, 2::smallint);
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
  t
 (1 row)
 
-begin;
 select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;
 ERROR:  division by zero  (seg0 slice1 127.0.1.1:25432 pid=15478)
-end;
 select gp_inject_fault('before_read_command', 'reset', 2);
 NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -1,3 +1,4 @@
+
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 
 drop table if exists _tmp_table;
@@ -76,11 +77,9 @@ select gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 -- make one QE sleep before reading command
-select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, -1, 50, 2::smallint);
+select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 1, 50, 2::smallint);
 
-begin;
 select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;
-end;
 
 select gp_inject_fault('before_read_command', 'reset', 2);
 -- Resume FTS probes starting from the next probe interval.


### PR DESCRIPTION
Commit 07ee8008a1298418d6b361c8666043cd3d2c7d00 added test section in
query_finish_pending.sql to validate case where if a query can be canceled when
cancel signal arrives fast than the query dispatched. For the same uses sleep
fault.

But the test was incorrect due to usage of "begin", as begin sleeps for 50 secs
instead of actual select query sleeping. Also, since the fault always trigger
the reset fault sleeps for additional 50 secs. Instead remove begin and just set
endoccurence to 1. Verified modified test fails/hangs without the fix and
passes/completes in couple secs with the fix.