### PR TITLE
COPY: don't pfree() part_distData explicitly

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4265,7 +4265,6 @@ CopyFromDispatch(CopyState cstate)
 	pfree(cdbcopy_err.data);
 	pfree(line_buf_with_lineno.data);
 	pfree(cdbCopy);
-	pfree(part_distData);
 	pfree(getAttrContext);
 	FreePartitionData(partitionData);
 	FreeDistributionData(distData);


### PR DESCRIPTION
It might come from GetDistributionPolicyForPartition() and on the per
tuple memory context. Don't pfree() explicitly, let it drop with its
context.

Refer to: 
https://github.com/greenplum-db/gpdb/pull/5060