### PR TITLE
Add start_ignore and end_ignore around all gp_inject_fault loads

### DIFF
--- a/src/test/regress/expected/cursor.out
+++ b/src/test/regress/expected/cursor.out
@@ -1,4 +1,6 @@
+--start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+--end_ignore
 DROP TABLE if exists lu_customer;
 NOTICE:  table "lu_customer" does not exist, skipping
 CREATE TABLE lu_customer (

--- a/src/test/regress/expected/errors-at-eox.out
+++ b/src/test/regress/expected/errors-at-eox.out
@@ -3,6 +3,10 @@
 -- or ABORT processing. This test uses the fault injection mechanism
 -- built in to the server, to induce an ERROR at strategic places.
 --
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
+
 -- Create a plain table that we can insert to, to verify after the
 -- transaction whether the transaction's effects are visible.
 CREATE TABLE dtm_testtab(id int4);

--- a/src/test/regress/expected/fts_error.out
+++ b/src/test/regress/expected/fts_error.out
@@ -1,4 +1,6 @@
-create extension if not exists gp_inject_fault;
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';
  in_sync 

--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -2,7 +2,9 @@
 -- 'fts_conn_startup_packet' is used to simulate the primary responding
 -- in-recovery to FTS, primary is not actually going through crash-recovery in
 -- test.
-create extension if not exists gp_inject_fault;
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 select role, preferred_role, mode from gp_segment_configuration where content = 0;
  role | preferred_role | mode 
 ------+----------------+------

--- a/src/test/regress/expected/gporca_faults.out
+++ b/src/test/regress/expected/gporca_faults.out
@@ -1,7 +1,9 @@
 --
 -- ORCA tests which require gp_fault_injector
 --
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 CREATE SCHEMA gporca_faults;
 SET search_path = gporca_faults, public;
 CREATE TABLE foo (a int, b int);

--- a/src/test/regress/expected/gporca_faults_optimizer.out
+++ b/src/test/regress/expected/gporca_faults_optimizer.out
@@ -1,7 +1,9 @@
 --
 -- ORCA tests which require gp_fault_injector
 --
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 CREATE SCHEMA gporca_faults;
 SET search_path = gporca_faults, public;
 CREATE TABLE foo (a int, b int);

--- a/src/test/regress/expected/ic.out
+++ b/src/test/regress/expected/ic.out
@@ -4,7 +4,9 @@
  * Parameter combination tests
  * Improve code coverage tests
  */
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 CREATE SCHEMA ic_udp_test;
 SET search_path = ic_udp_test;
 -- Prepare some tables

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -3,7 +3,9 @@
 --
 -- We just use gp_inject_fault as an example of an extension here. We don't
 -- inject any faults.
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 \dx gp_inject*
                            List of installed extensions
       Name       | Version | Schema |                 Description                  

--- a/src/test/regress/expected/python_processed64bit.out
+++ b/src/test/regress/expected/python_processed64bit.out
@@ -1,6 +1,6 @@
---start_ignore
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
---end_ignore
+-- end_ignore
 --start_ignore
 CREATE LANGUAGE plpythonu;
 --end_ignore

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -1,4 +1,6 @@
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 NOTICE:  extension "gp_inject_fault" already exists, skipping
 drop table if exists _tmp_table;
 NOTICE:  table "_tmp_table" does not exist, skipping

--- a/src/test/regress/expected/segspace.out
+++ b/src/test/regress/expected/segspace.out
@@ -1,7 +1,9 @@
 --
 -- Tests the spill files disk space accounting mechanism
 --
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 -- check segspace before test
 reset statement_mem;
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -1,4 +1,6 @@
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 DROP TABLE IF EXISTS test_zlib_hashjoin;
 NOTICE:  table "test_zlib_hashjoin" does not exist, skipping
 CREATE TABLE test_zlib_hashjoin (i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int) WITH (APPENDONLY=true) DISTRIBUTED BY (i1) ; 

--- a/src/test/regress/sql/cursor.sql
+++ b/src/test/regress/sql/cursor.sql
@@ -1,4 +1,6 @@
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 
 DROP TABLE if exists lu_customer;
 CREATE TABLE lu_customer (

--- a/src/test/regress/sql/errors-at-eox.sql
+++ b/src/test/regress/sql/errors-at-eox.sql
@@ -3,6 +3,9 @@
 -- or ABORT processing. This test uses the fault injection mechanism
 -- built in to the server, to induce an ERROR at strategic places.
 --
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 
 -- Create a plain table that we can insert to, to verify after the
 -- transaction whether the transaction's effects are visible.

--- a/src/test/regress/sql/fts_error.sql
+++ b/src/test/regress/sql/fts_error.sql
@@ -1,4 +1,6 @@
-create extension if not exists gp_inject_fault;
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';
 -- Once this fault is hit, FTS process should abort current

--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -2,7 +2,9 @@
 -- 'fts_conn_startup_packet' is used to simulate the primary responding
 -- in-recovery to FTS, primary is not actually going through crash-recovery in
 -- test.
-create extension if not exists gp_inject_fault;
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 select role, preferred_role, mode from gp_segment_configuration where content = 0;
 select gp_inject_fault_infinite('fts_conn_startup_packet', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';

--- a/src/test/regress/sql/gporca_faults.sql
+++ b/src/test/regress/sql/gporca_faults.sql
@@ -2,7 +2,9 @@
 -- ORCA tests which require gp_fault_injector
 --
 
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 
 CREATE SCHEMA gporca_faults;
 SET search_path = gporca_faults, public;

--- a/src/test/regress/sql/ic.sql
+++ b/src/test/regress/sql/ic.sql
@@ -4,7 +4,9 @@
  * Parameter combination tests
  * Improve code coverage tests
  */
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 
 CREATE SCHEMA ic_udp_test;
 SET search_path = ic_udp_test;

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -3,7 +3,9 @@
 --
 -- We just use gp_inject_fault as an example of an extension here. We don't
 -- inject any faults.
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 
 \dx gp_inject*
 \dx+ gp_inject*

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -1,5 +1,6 @@
-
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 
 drop table if exists _tmp_table;
 create table _tmp_table (i1 int, i2 int, i3 int, i4 int);

--- a/src/test/regress/sql/segspace.sql
+++ b/src/test/regress/sql/segspace.sql
@@ -2,7 +2,9 @@
 -- Tests the spill files disk space accounting mechanism
 --
 
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 
 -- check segspace before test
 reset statement_mem;

--- a/src/test/regress/sql/zlib.sql
+++ b/src/test/regress/sql/zlib.sql
@@ -1,4 +1,6 @@
+-- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 
 DROP TABLE IF EXISTS test_zlib_hashjoin;
 CREATE TABLE test_zlib_hashjoin (i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int) WITH (APPENDONLY=true) DISTRIBUTED BY (i1) ; 


### PR DESCRIPTION
This makes loading the extension more stable, as multiple tests will to load this extension.