### PR TITLE
Fix autovacuum test after fault injector refactor

### DIFF
--- a/src/test/regress/input/autovacuum-template0.source
+++ b/src/test/regress/input/autovacuum-template0.source
@@ -19,7 +19,7 @@ select test_consume_xids(100 * 1000000);
 select test_consume_xids(10 * 1000000);
 
 -- wait until autovacuum worker updates pg_database
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'wait_until_triggered', 1);
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
 SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
 
 -- Wait until autovacuum commits the pg_database change

--- a/src/test/regress/output/autovacuum-template0.source
+++ b/src/test/regress/output/autovacuum-template0.source
@@ -39,10 +39,10 @@ select test_consume_xids(10 * 1000000);
 (1 row)
 
 -- wait until autovacuum worker updates pg_database
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'wait_until_triggered', 1);
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_wait_until_triggered_fault 
+-------------------------------
  t
 (1 row)
 


### PR DESCRIPTION
There was a recent change to fault injector framework that made simple
form "gp_inject_fault(faultname, type, db_id)" not work with
wait_until_triggered fault type. To get around this, we should
properly use "gp_wait_until_triggered_fault()" instead.

Reference:
https://github.com/greenplum-db/gpdb/commit/723e58481ad706d4c8f4f7af1325be2dcd36c985