### PR TITLE
Oops

### DIFF
--- a/src/backend/utils/resgroup/resgroup-ops-dummy.c
+++ b/src/backend/utils/resgroup/resgroup-ops-dummy.c
@@ -14,6 +14,7 @@
 
 #include "postgres.h"
 
+#include "utils/resgroup.h"
 #include "utils/resgroup-ops.h"
 
 /*


### PR DESCRIPTION
Commit 0c0782fe89933f29d34ede3bd12d4cc61e17c9a6 broke compilation when
we use the trivial / dummy implementation of resource group. The fix for
that is trivial (this commit). But it begs the question: should we make
the build system less magical (switching the implementation based on the
platform), and instead just always exercise the dummy implementation (or
at least the building of it).