### PR TITLE
Fix tzparse calls during initdb

### DIFF
--- a/src/bin/initdb/findtimezone.c
+++ b/src/bin/initdb/findtimezone.c
@@ -99,7 +99,7 @@ pg_load_tz(const char *name)
 	 */
 	if (strcmp(name, "GMT") == 0)
 	{
-		if (tzparse(name, &tz.state, TRUE) != 0)
+		if (!tzparse(name, &tz.state, TRUE))
 		{
 			/* This really, really should not happen ... */
 			return NULL;
@@ -107,7 +107,7 @@ pg_load_tz(const char *name)
 	}
 	else if (tzload(name, NULL, &tz.state, TRUE) != 0)
 	{
-		if (name[0] == ':' || tzparse(name, &tz.state, FALSE) != 0)
+		if (name[0] == ':' || !tzparse(name, &tz.state, FALSE))
 		{
 			return NULL;		/* unknown timezone */
 		}


### PR DESCRIPTION
The return value of tzparse() has changed as of commit b749790, but the corresponding change to the tzparse() function in pg_load_tz() was never made. As a result, under certain circumstances the server might pick a bogus timezone.