### PR TITLE
Disable GDD scan for dispatch tests

### DIFF
--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -361,8 +361,6 @@ GlobalDeadLockDetectorLoop(void)
 
 	for (;;)
 	{
-		pg_usleep(gp_global_deadlock_detector_period * 1000000L);
-
 		CHECK_FOR_INTERRUPTS();
 
 		if (shutdown_requested)
@@ -389,6 +387,10 @@ GlobalDeadLockDetectorLoop(void)
 			CommitTransactionCommand();
 		else
 			AbortCurrentTransaction();
+
+		/* GUC gp_global_deadlock_detector_period may be changed, skip sleep */
+		if (!got_SIGHUP)
+			pg_usleep(gp_global_deadlock_detector_period * 1000000L);
 	}
 
 	return;

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -15,6 +15,15 @@ select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 select gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
+-- skip GDD scan always
+select gp_inject_fault_infinite('gdd_probe', 'skip', 1);
+-- acting like gp_request_fts_probe_scan() to wake up GDD backend so
+-- 'gdd_probe' can be triggered as soon as possible
+-- start_ignore
+\! gpstop -u
+-- end_ignore
+select gp_wait_until_triggered_fault('gdd_probe', 1, 1);
+
 -- Test quoting of GUC values and database names when they're sent to segments
 set client_min_messages='warning';
 DROP DATABASE IF EXISTS "funny""db'with\\quotes";
@@ -368,3 +377,5 @@ end;
 
 -- resume FTS probes
 select gp_inject_fault('fts_probe', 'reset', 1);
+-- resume GDD scan 
+select gp_inject_fault('gdd_probe', 'reset', 1);

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -28,6 +28,26 @@ NOTICE:  Success:
  t
 (1 row)
 
+-- skip GDD scan always
+select gp_inject_fault_infinite('gdd_probe', 'skip', 1);
+NOTICE:  Success:
+ gp_inject_fault_infinite 
+--------------------------
+ t
+(1 row)
+
+-- acting like gp_request_fts_probe_scan() to wake up GDD backend so
+-- 'gdd_probe' can be triggered as soon as possible
+-- start_ignore
+\! gpstop -u
+-- end_ignore
+select gp_wait_until_triggered_fault('gdd_probe', 1, 1);
+NOTICE:  Success:
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t
+(1 row)
+
 -- Test quoting of GUC values and database names when they're sent to segments
 set client_min_messages='warning';
 DROP DATABASE IF EXISTS "funny""db'with\\quotes";
@@ -670,6 +690,14 @@ begin isolation level read uncommitted;
 end;
 -- resume FTS probes
 select gp_inject_fault('fts_probe', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- resume GDD scan 
+select gp_inject_fault('gdd_probe', 'reset', 1);
 NOTICE:  Success:
  gp_inject_fault 
 -----------------


### PR DESCRIPTION
Dispatch tests don't expect backends created by other tests or auxiliary
processes like FTS and GDD, this commit disables GDD too to make dispatch
tests stable.