### PR TITLE
CREATE DATABASE using a template db copies relation extensions

### DIFF
--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -327,7 +327,7 @@ static void copy_buffer_pool_files(
 		// -------- MirroredLock ----------
 		LWLockAcquire(MirroredLock, LW_SHARED);
 
-		smgrwrite(dstrel, blkno, buffer, false);
+		smgrextend(dstrel, blkno, buffer, false);
 
 		LWLockRelease(MirroredLock);
 		// -------- MirroredLock ----------

--- a/src/test/regress/expected/createdb_large_table.out
+++ b/src/test/regress/expected/createdb_large_table.out
@@ -1,0 +1,18 @@
+-- Create database using a template database containing a heap relation that
+-- has been extended. The create database operation will read the heap relation
+-- and write out to the destination file. That destination file must also be
+-- extended as the copying of data happens.
+DROP DATABASE IF EXISTS db_with_large_table;
+DROP DATABASE IF EXISTS copy_of_db_with_large_table;
+CREATE DATABASE db_with_large_table;
+\c db_with_large_table
+CREATE TABLE large_table(a) WITH (fillfactor=10) AS SELECT 1 FROM generate_series(1, 3100000)i DISTRIBUTED BY (a);
+-- When table size is greater than 1G we expect the heap relation to extend.
+SELECT pg_relation_size('large_table') > 1073741824;
+ ?column? 
+----------
+ t
+(1 row)
+
+\c regression
+CREATE DATABASE copy_of_db_with_large_table TEMPLATE db_with_large_table;

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -3328,20 +3328,6 @@ group by 1, 2;
 drop table qp_misc_jiras.foo_6325;
 drop table qp_misc_jiras.bar_6325;
 -- end_ignore
--- Test for an old bug in extending a heap relation beyond RELSEG_SIZE (1 GB).
--- The insert failed with an error:
---   could not open segment 1 of relation ...: No such file or directory
-create table qp_misc_jiras.heap_tbl8621 (a int) with (fillfactor=10) distributed by (a);
-insert into qp_misc_jiras.heap_tbl8621 select 1 from generate_series(1, 3100000);
--- Verify that the table really was larger than 1 GB. Otherwise we wouldn't
--- test the segment boundary.
-select pg_relation_size('qp_misc_jiras.heap_tbl8621') > 1100000000 as over_1gb;
- over_1gb 
-----------
- t
-(1 row)
-
-DROP TABLE qp_misc_jiras.heap_tbl8621;
 CREATE TABLE qp_misc_jiras.tbl8860_1 (
      id INTEGER NOT NULL,
      key TEXT NOT NULL

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -3351,20 +3351,6 @@ group by 1, 2;
 drop table qp_misc_jiras.foo_6325;
 drop table qp_misc_jiras.bar_6325;
 -- end_ignore
--- Test for an old bug in extending a heap relation beyond RELSEG_SIZE (1 GB).
--- The insert failed with an error:
---   could not open segment 1 of relation ...: No such file or directory
-create table qp_misc_jiras.heap_tbl8621 (a int) with (fillfactor=10) distributed by (a);
-insert into qp_misc_jiras.heap_tbl8621 select 1 from generate_series(1, 3100000);
--- Verify that the table really was larger than 1 GB. Otherwise we wouldn't
--- test the segment boundary.
-select pg_relation_size('qp_misc_jiras.heap_tbl8621') > 1100000000 as over_1gb;
- over_1gb 
-----------
- t
-(1 row)
-
-DROP TABLE qp_misc_jiras.heap_tbl8621;
 CREATE TABLE qp_misc_jiras.tbl8860_1 (
      id INTEGER NOT NULL,
      key TEXT NOT NULL

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -115,7 +115,7 @@ test: gporca_faults
  
 test: aggregate_with_groupingsets 
 
-test: nested_case_null sort bb_mpph
+test: nested_case_null sort bb_mpph createdb_large_table
 test: bb_memory_quota memconsumption
 
 test: tuple_serialization

--- a/src/test/regress/sql/createdb_large_table.sql
+++ b/src/test/regress/sql/createdb_large_table.sql
@@ -1,0 +1,16 @@
+-- Create database using a template database containing a heap relation that
+-- has been extended. The create database operation will read the heap relation
+-- and write out to the destination file. That destination file must also be
+-- extended as the copying of data happens.
+
+DROP DATABASE IF EXISTS db_with_large_table;
+DROP DATABASE IF EXISTS copy_of_db_with_large_table;
+CREATE DATABASE db_with_large_table;
+\c db_with_large_table
+
+CREATE TABLE large_table(a) WITH (fillfactor=10) AS SELECT 1 FROM generate_series(1, 3100000)i DISTRIBUTED BY (a);
+-- When table size is greater than 1G we expect the heap relation to extend.
+SELECT pg_relation_size('large_table') > 1073741824;
+\c regression
+
+CREATE DATABASE copy_of_db_with_large_table TEMPLATE db_with_large_table;

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -2020,19 +2020,6 @@ drop table qp_misc_jiras.foo_6325;
 drop table qp_misc_jiras.bar_6325;
 -- end_ignore
 
--- Test for an old bug in extending a heap relation beyond RELSEG_SIZE (1 GB).
--- The insert failed with an error:
---   could not open segment 1 of relation ...: No such file or directory
-create table qp_misc_jiras.heap_tbl8621 (a int) with (fillfactor=10) distributed by (a);
-insert into qp_misc_jiras.heap_tbl8621 select 1 from generate_series(1, 3100000);
-
--- Verify that the table really was larger than 1 GB. Otherwise we wouldn't
--- test the segment boundary.
-select pg_relation_size('qp_misc_jiras.heap_tbl8621') > 1100000000 as over_1gb;
-
-DROP TABLE qp_misc_jiras.heap_tbl8621;
-
-
 CREATE TABLE qp_misc_jiras.tbl8860_1 (
      id INTEGER NOT NULL,
      key TEXT NOT NULL


### PR DESCRIPTION
The CREATE DATABASE operation when using a template database was not copying
over extended heap relations properly. The regression was introduced during the
8.3 merge which included commit ef07221997eee08bbe6e541934a9e0d5a62e13ff that
refactored mdwrite and introduced mdextend. The copy_buffer_pool_files function
was not changed to use mdextend. Fixed the issue by using smgrextend instead of
smgrwrite so that the file will be extended properly.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>