### PR TITLE
skip wal sender for ProcessStartupPacket fault

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2313,7 +2313,7 @@ retry1:
 			break;
 	}
 
-	if (!am_ftshandler)
+	if (!am_ftshandler && !am_walsender)
 	{
 		SIMPLE_FAULT_INJECTOR(ProcessStartupPacketFault);
 	}


### PR DESCRIPTION
This is a quick fix to make dispatch test pass, for a long term,
we need to redesign the dispatch test or make it a unit test.