### PR TITLE
User can see cpu usage on cpuset groups

### DIFF
--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -1148,21 +1148,17 @@ ResGroupOps_AssignGroup(Oid group, ResGroupCaps *caps, int pid)
 		)
 		return;
 
-	if (caps == NULL || !curViaCpuset)
+	writeInt64(group, NULL, "cpu", "cgroup.procs", pid);
+	writeInt64(group, NULL, "cpuacct", "cgroup.procs", pid);
+
+	if (gp_resource_group_enable_cgroup_cpuset)
 	{
-		writeInt64(group, NULL, "cpu", "cgroup.procs", pid);
-		writeInt64(group, NULL, "cpuacct", "cgroup.procs", pid);
-		if (gp_resource_group_enable_cgroup_cpuset)
+		if (caps == NULL || !curViaCpuset)
 		{
 			/* add pid to default group */
 			writeInt64(DEFAULT_CPUSET_GROUP_ID, NULL, "cpuset", "cgroup.procs", pid);
 		}
-	}
-	else
-	{
-		writeInt64(RESGROUP_ROOT_ID, NULL, "cpu", "cgroup.procs", pid);
-		writeInt64(RESGROUP_ROOT_ID, NULL, "cpuacct", "cgroup.procs", pid);
-		if (gp_resource_group_enable_cgroup_cpuset)
+		else
 		{
 			writeInt64(group, NULL, "cpuset", "cgroup.procs", pid);
 		}

--- a/src/test/isolation2/input/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpuset.source
@@ -238,6 +238,24 @@ select * from cancel_all;
 11q:
 -- end_ignore
 
+-- test cpu_usage
+10: SET ROLE TO role1_cpuset_test;
+10: BEGIN;
+10&: SELECT * FROM busy;
+
+select pg_sleep(2);
+
+11: BEGIN;
+11: select (cpu_usage::json->>'0')::float > 50 from gp_toolkit.gp_resgroup_status where rsgname='rg1_cpuset_test';
+-- cancel the transaction
+-- start_ignore
+select * from cancel_all;
+
+10<:
+10q:
+11q:
+-- end_ignore
+
 -- positive: cgroup cpuset must correspond to config cpuset
 -- default group value must be valid
 -- suppose the cores numbered 0 & 1 are available

--- a/src/test/isolation2/output/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpuset.source
@@ -155,6 +155,40 @@ ERROR:  canceling statement due to user request
 11q: ... <quitting>
 -- end_ignore
 
+-- test cpu_usage
+10: SET ROLE TO role1_cpuset_test;
+SET
+10: BEGIN;
+BEGIN
+10&: SELECT * FROM busy;  <waiting ...>
+
+select pg_sleep(2);
+pg_sleep
+--------
+        
+(1 row)
+
+11: BEGIN;
+BEGIN
+11: select (cpu_usage::json->>'0')::float > 50 from gp_toolkit.gp_resgroup_status where rsgname='rg1_cpuset_test';
+?column?
+--------
+t       
+(1 row)
+-- cancel the transaction
+-- start_ignore
+select * from cancel_all;
+pg_cancel_backend
+-----------------
+t                
+(1 row)
+
+10<:  <... completed>
+ERROR:  canceling statement due to user request
+10q: ... <quitting>
+11q: ... <quitting>
+-- end_ignore
+
 -- positive: cgroup cpuset must correspond to config cpuset
 -- default group value must be valid
 -- suppose the cores numbered 0 & 1 are available


### PR DESCRIPTION
Cpu usage of cpuset groups should also be displayed in
gp_toolkit.gp_resgroup_status.