### PR TITLE
Upgrade pgbouncer to 1.8.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "gpAux/extensions/pgbouncer/source"]
 	path = gpAux/extensions/pgbouncer/source
 	url = https://github.com/greenplum-db/pgbouncer.git
-	branch = master
+	branch = pgbouncer_1_8_1
 [submodule "gpAux/extensions/postgis-2.0.3/source"]
 	path = gpAux/extensions/postgis-2.0.3/source
 	url = https://github.com/greenplum-db/postgis.git

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -891,7 +891,7 @@ ifeq "$(shell uname -s)" "Darwin"
 	echo "pgbouncer can't build on Mac"
 else
 	@if [ ! -f extensions/pgbouncer/source/configure ]; then cd extensions/pgbouncer/source && ./autogen.sh ;fi
-	@cd extensions/pgbouncer/source && ./configure --with-libevent=$(BLD_TOP)/ext/$(BLD_ARCH) --prefix=$(INSTLOC) --enable-evdns
+	@cd extensions/pgbouncer/source && ./configure --with-libevent=$(BLD_TOP)/ext/$(BLD_ARCH) --prefix=$(INSTLOC) --enable-evdns --with-pam
 	$(MAKE) -C extensions/pgbouncer/source install
 endif
 


### PR DESCRIPTION
- support PAM/HBA auth type
- update submodule pgbouncer commit
- update pgbouncer's commit to support SSL connection
- change pgbouncer server_tls_ciphers default value
- run pgbouncer test cases manually.