### PR TITLE
resgroup: fallback to insert when updating caps.

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -1245,10 +1245,20 @@ updateResgroupCapabilityEntry(Relation rel,
 
 	oldTuple = systable_getnext(sscan);
 	if (!HeapTupleIsValid(oldTuple))
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("capabilities missing for resource group %d type %d",
-						groupId, limitType)));
+	{
+		/*
+		 * It's possible for a cap to be missing, e.g. a resgroup is created
+		 * with v5.0 which does not support cap=7 (cpuset), then we binary
+		 * switch to v5.10 and alter it, then we'll find cap=7 missing here.
+		 * Instead of raising an error we should fallback to insert a new cap.
+		 */
+
+		systable_endscan(sscan);
+
+		insertResgroupCapabilityEntry(rel, groupId, limitType, strValue);
+
+		return;
+	}
 
 	if (limitType == RESGROUP_LIMIT_TYPE_CPUSET)
 	{


### PR DESCRIPTION
Resource group capabilities could be missing in ALTER command, e.g.:

- create resgroup rg1 with v5.0 which does not support cpuset(cap=7);
- binary switch to v5.10 (suppose it supports cpuset);
- alter rg1's cpu_rate_limit, it will also `update` the cpuset cap;

Now as rg1 was created with v5.0 so there is no cap=7 row in the catalog
table pg_resgroupcapability, so the `update` operation will raise an
error as the expected tuple can not be found.

The proper behavior is to fallback to `insert` in such a case.

Test cases are not included as it is already covered by existing binary
swap test resgroup_current_3_queue.