### PR TITLE
Numeric short support for cdbHash

### DIFF
--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -303,11 +303,8 @@ hashDatum(Datum datum, Oid type, datumHashFunction hashFn, void *clientData)
 			else
 				/* not a nan */
 			{
-				/* GPDB_91_MERGE_FIXME: This doesn't know about the new
-				 * "short" representation of numerics. */
-#define NUMERIC_HDRSZ	(VARHDRSZ + sizeof(uint16) + sizeof(int16))
-				buf = VARDATA(num);
-				len = (VARSIZE(num) - NUMERIC_HDRSZ);
+				buf = numeric_digits(num);
+				len = numeric_len(num);
 			}
 
 			/*

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -596,6 +596,28 @@ numeric_is_nan(Numeric num)
 }
 
 /*
+ * numeric_digits() -
+ *
+ *	Output function for numeric's digits
+ */
+NumericDigit *
+numeric_digits(Numeric num)
+{
+	return NUMERIC_DIGITS(num);
+}
+
+/*
+ * numeric_len() -
+ *
+ *	Output size of digits in bytes
+ */
+int
+numeric_len(Numeric num)
+{
+	return NUMERIC_NDIGITS(num) * sizeof(NumericDigit);
+}
+
+/*
  * numeric_maximum_size() -
  *
  *	Maximum size of a numeric with given typmod, or -1 if unlimited/unknown.

--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -62,6 +62,8 @@ extern Numeric numeric_li_value(float8 f, Numeric y0, Numeric y1);
  * Utility functions in numeric.c
  */
 extern bool numeric_is_nan(Numeric num);
+extern int16 *numeric_digits(Numeric num);
+extern int numeric_len(Numeric num);
 int32		numeric_maximum_size(int32 typmod);
 extern char *numeric_out_sci(Numeric num, int scale);
 


### PR DESCRIPTION
No hash was created for the new numeric format when it is a
`NumericShort`. This is the first attempt to make it work and marked as
`FIXME` for 9.1 merge.