### PR TITLE
Make qp_derived_table faster with ORCA

### DIFF
--- a/src/test/regress/sql/qp_derived_table.sql
+++ b/src/test/regress/sql/qp_derived_table.sql
@@ -1,6 +1,11 @@
 -- start_ignore
 create schema qp_derived_table;
 set search_path to qp_derived_table;
+-- This test file contains join intensive queries and when run with ORCA; the
+-- optimization time is higher. Hence disable exhaustive join order search for
+-- faster run. Also catch any fallbacks to planner.
+set optimizer_join_order=query;
+set optimizer_trace_fallback=on;
 -- end_ignore
 
 create table T0(


### PR DESCRIPTION
Disable the exhaustive optimal join order search by setting
optimizer_join_order=query. qp_derived_table contains join intensive queries
and when run with ORCA; the optimization time is higher. Since there are no
EXPLAIN tests in qp_derived_table we can disable the exhaustive search and make
this test run faster with ORCA.

Also verified with set optimizer_trace_fallback=on, that after setting the
above GUC, ORCA does not fallback for any query.