### PR TITLE
 Fix external table with non-UTF8 encoding data

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -68,7 +68,7 @@ static void InitParseState(CopyState pstate, Relation relation,
 			   bool writable,
 			   char fmtType,
 			   char *uri, int rejectlimit,
-			   bool islimitinrows, bool logerrors, int encoding);
+			   bool islimitinrows, bool logerrors);
 
 static void FunctionCallPrepareFormatter(FunctionCallInfoData *fcinfo,
 							 int nArgs,
@@ -96,6 +96,8 @@ static void base16_encode(char *raw, int len, char *encoded);
 static char *get_eol_delimiter(List *params);
 static void external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape,
 				 char *quote, int eol_type, bool header, uint32 scancounter, List *params);
+
+static List *appendCopyEncodingOption(List *copyFmtOpts, int encoding);
 
 /* ----------------------------------------------------------------
 *				   external_ interface functions
@@ -283,6 +285,9 @@ external_beginscan(Relation relation, uint32 scancounter,
 	else
 		copyFmtOpts = parseCopyFormatString(fmtOptString, fmtType);
 
+	/* pass external table's encoding to copy's options */
+	copyFmtOpts = appendCopyEncodingOption(copyFmtOpts, encoding);
+
 	/*
 	 * Allocate and init our structure that keeps track of data parsing state
 	 */
@@ -295,7 +300,7 @@ external_beginscan(Relation relation, uint32 scancounter,
 
 	/* Initialize all the parsing and state variables */
 	InitParseState(scan->fs_pstate, relation, false, fmtType,
-				   scan->fs_uri, rejLimit, rejLimitInRows, logErrors, encoding);
+				   scan->fs_uri, rejLimit, rejLimitInRows, logErrors);
 
 	if (fmttype_is_custom(fmtType))
 	{
@@ -615,8 +620,10 @@ external_insert_init(Relation rel)
 	else
 		copyFmtOpts = parseCopyFormatString(extentry->fmtopts, extentry->fmtcode);
 
-	extInsertDesc->ext_pstate = BeginCopyToForExternalTable(rel,
-															copyFmtOpts);
+	/* pass external table's encoding to copy's options */
+	copyFmtOpts = appendCopyEncodingOption(copyFmtOpts, extentry->encoding);
+
+	extInsertDesc->ext_pstate = BeginCopyToForExternalTable(rel, copyFmtOpts);
 	InitParseState(extInsertDesc->ext_pstate,
 				   rel,
 				   true,
@@ -624,8 +631,7 @@ external_insert_init(Relation rel)
 				   extInsertDesc->ext_uri,
 				   extentry->rejectlimit,
 				   (extentry->rejectlimittype == 'r'),
-				   extentry->logerrors,
-				   extentry->encoding);
+				   extentry->logerrors);
 
 	if (fmttype_is_custom(extentry->fmtcode))
 	{
@@ -1206,14 +1212,14 @@ lookupCustomFormatter(char *formatter_name, bool iswritable)
  * Initialize the data parsing state.
  *
  * This includes format descriptions (delimiter, quote...), format type
- * (text, csv), encoding converstion information, etc...
+ * (text, csv), etc...
  */
 static void
 InitParseState(CopyState pstate, Relation relation,
 			   bool iswritable,
 			   char fmtType,
 			   char *uri, int rejectlimit,
-			   bool islimitinrows, bool logerrors, int encoding)
+			   bool islimitinrows, bool logerrors)
 {
 	/*
 	 * Error handling setup
@@ -1249,9 +1255,6 @@ InitParseState(CopyState pstate, Relation relation,
 
 		pstate->num_consec_csv_err = 0;
 	}
-
-	// GPDB_91_MERGE_FIXME: how do we get encoding to BeginCopyFrom?
-	//pstate->client_encoding = encoding;
 
 	/* Initialize 'out_functions', like CopyTo() would. */
 	CopyState cstate = pstate;
@@ -2334,4 +2337,10 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 	}
 	extvar->GP_LINE_DELIM_STR = pstrdup(encoded_delim);
 	sprintf(extvar->GP_LINE_DELIM_LENGTH, "%d", line_delim_len);
+}
+
+static List *
+appendCopyEncodingOption(List *copyFmtOpts, int encoding)
+{
+	return lappend(copyFmtOpts, makeDefElem("encoding", (Node *)makeString((char *)pg_encoding_to_char(encoding))));
 }

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1885,7 +1885,7 @@ BeginCopy(bool is_from,
 		  pg_database_encoding_max_length() > 1));
 	/* See Multibyte encoding comment above */
 	cstate->encoding_embeds_ascii = PG_ENCODING_IS_CLIENT_ONLY(cstate->file_encoding);
-	setEncodingConversionProc(cstate, pg_get_client_encoding(), !is_from);
+	setEncodingConversionProc(cstate, cstate->file_encoding, !is_from);
   }
   else
   {
@@ -6543,20 +6543,18 @@ static void CopyInitDataParser(CopyState cstate)
  *
  * The code here mimics a part of SetClientEncoding() in mbutils.c
  */
-void setEncodingConversionProc(CopyState cstate, int client_encoding, bool iswritable)
+void setEncodingConversionProc(CopyState cstate, int encoding, bool iswritable)
 {
 	Oid		conversion_proc;
 	
 	/*
-	 * COPY FROM and RET: convert from client to server
-	 * COPY TO   and WET: convert from server to client
+	 * COPY FROM and RET: convert from file to server
+	 * COPY TO   and WET: convert from server to file
 	 */
 	if (iswritable)
-		conversion_proc = FindDefaultConversionProc(GetDatabaseEncoding(),
-													client_encoding);
+		conversion_proc = FindDefaultConversionProc(GetDatabaseEncoding(), encoding);
 	else		
-		conversion_proc = FindDefaultConversionProc(client_encoding,
-												    GetDatabaseEncoding());
+		conversion_proc = FindDefaultConversionProc(encoding, GetDatabaseEncoding());
 	
 	if (OidIsValid(conversion_proc))
 	{

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -314,7 +314,7 @@ extern void CopySendEndOfRow(CopyState cstate);
 extern char *limit_printout_length(const char *str);
 extern void truncateEol(StringInfo buf, EolType	eol_type);
 extern void truncateEolStr(char *str, EolType eol_type);
-extern void setEncodingConversionProc(CopyState cstate, int client_encoding, bool iswritable);
+extern void setEncodingConversionProc(CopyState cstate, int encoding, bool iswritable);
 extern void CopyEolStrToType(CopyState cstate);
 
 typedef struct GpDistributionData

--- a/src/interfaces/gppc/Makefile
+++ b/src/interfaces/gppc/Makefile
@@ -22,7 +22,7 @@ NAME = gppc
 SO_MAJOR_VERSION = 1
 SO_MINOR_VERSION = 2
 
-override CPPFLAGS := -I$(includedir_server) -I$(includedir_internal) $(CPPFLAGS)
+override CPPFLAGS := $(CPPFLAGS) -I$(includedir_server) -I$(includedir_internal)
 OBJS = gppc.o
 
 all: all-lib

--- a/src/test/regress/data/latin1_encoding.csv
+++ b/src/test/regress/data/latin1_encoding.csv
@@ -1,0 +1,3 @@
+3,d'automation
+4,tá sé seo le tástáil dea-
+5,minden amire szüksége van a szeret

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -1588,3 +1588,24 @@ SET gp_log_gang TO DEFAULT;
 
 DROP FUNCTION exttab_error_context_callback_func();
 DROP EXTERNAL TABLE exttab_error_context_callback;
+
+-- --------------------------------------
+-- Encoding
+-- --------------------------------------
+
+CREATE EXTERNAL TABLE encoding_issue (num int, word text)
+LOCATION ('file://@hostname@@abs_srcdir@/data/latin1_encoding.csv')
+FORMAT 'CSV' ENCODING 'LATIN1';
+
+SELECT * FROM encoding_issue WHERE num = 4;
+
+COPY (SELECT * FROM encoding_issue) TO '/tmp/latin1_encoding.csv' WITH (FORMAT 'csv', ENCODING 'LATIN1');
+
+CREATE EXTERNAL TABLE encoding_issue2 (num int, word text)
+LOCATION ('file://@hostname@/tmp/latin1_encoding.csv')
+FORMAT 'CSV' ENCODING 'LATIN1';
+
+SELECT * FROM encoding_issue2 WHERE num = 5;
+
+DROP EXTERNAL TABLE encoding_issue;
+DROP EXTERNAL TABLE encoding_issue2;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -2893,3 +2893,27 @@ PL/pgSQL function "exttab_error_context_callback_func" line 5 at FOR over SELECT
 SET gp_log_gang TO DEFAULT;
 DROP FUNCTION exttab_error_context_callback_func();
 DROP EXTERNAL TABLE exttab_error_context_callback;
+-- --------------------------------------
+-- Encoding
+-- --------------------------------------
+CREATE EXTERNAL TABLE encoding_issue (num int, word text)
+LOCATION ('file://@hostname@@abs_srcdir@/data/latin1_encoding.csv')
+FORMAT 'CSV' ENCODING 'LATIN1';
+SELECT * FROM encoding_issue WHERE num = 4;
+ num |           word            
+-----+---------------------------
+   4 | tá sé seo le tástáil dea-
+(1 row)
+
+COPY (SELECT * FROM encoding_issue) TO '/tmp/latin1_encoding.csv' WITH (FORMAT 'csv', ENCODING 'LATIN1');
+CREATE EXTERNAL TABLE encoding_issue2 (num int, word text)
+LOCATION ('file://@hostname@/tmp/latin1_encoding.csv')
+FORMAT 'CSV' ENCODING 'LATIN1';
+SELECT * FROM encoding_issue2 WHERE num = 5;
+ num |                word                
+-----+------------------------------------
+   5 | minden amire szüksége van a szeret
+(1 row)
+
+DROP EXTERNAL TABLE encoding_issue;
+DROP EXTERNAL TABLE encoding_issue2;


### PR DESCRIPTION
1, pass external table encoding to copy's options, then set
cstate->file_encoding to it, for reading and writing.

2, after the merge, copy state doesn't have a member of client encoding,
which used to set to the target encoding, get the converted data as a
client, now passes the file encoding (from copy options) to convert
directly.