### PR TITLE
Fix gpperfmon queries_history is showing 0 values for rows_out column

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -1044,7 +1044,7 @@ static void extract_segments_exec(gpmon_packet_t* pkt)
 	{
 		rec->u.queryseg.sum_cpu_elapsed += pidrec->cpu_elapsed;
 		rec->u.queryseg.sum_measures_rows_in += p->rowsin;
-		if (p->key.hash_key.segid == -1 && p->key.hash_key.nid == 1)
+		if (p->key.hash_key.segid == -1 && p->key.hash_key.nid == 1 && (int64)(p->rowsout) > rec->u.queryseg.final_rowsout)
 		{
 			rec->u.queryseg.final_rowsout = p->rowsout;
 		}


### PR DESCRIPTION
Gpperfmon table rows_out queries_history shows zero values under column "rows_out",
even though they returned several rows as output.

This fix will decrease the possibility of occurance of this bug.
But it is still possible due to gpperfmon harvest mode.

This backports from master.