### PR TITLE
Add more files to gitignore

### DIFF
--- a/gpAux/gpdemo/.gitignore
+++ b/gpAux/gpdemo/.gitignore
@@ -1,3 +1,4 @@
+clusterConfigPostgresAddonsFile
 clusterConfigFile
 hostfile
 datadirs

--- a/src/backend/catalog/.gitignore
+++ b/src/backend/catalog/.gitignore
@@ -3,3 +3,4 @@
 /postgres.shdescription
 /cdb_init.sql
 /schemapg.h
+/pg_proc_combined.h

--- a/src/backend/utils/.gitignore
+++ b/src/backend/utils/.gitignore
@@ -2,4 +2,5 @@
 /fmgroids.h
 /probes.h
 /errcodes.h
+/pg_proc_combined.h
 *.tmp


### PR DESCRIPTION
When cloning a fresh copy of GPDB, running through the documented make
process, and then running the make target for the demo cluster, there
are three files that get generated. This commit adds those files to the
.gitignore files in their respective directories.

Authored-by: Jim Doty <jdoty@pivotal.io>