### PR TITLE
Add ServerAliveInterval=60 option to ssh.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -648,7 +648,7 @@ class RemoteExecutionContext(LocalExecutionContext):
 
         # Escape " for remote execution otherwise it interferes with ssh
         cmd.cmdStr = cmd.cmdStr.replace('"', '\\"')
-        cmd.cmdStr = "ssh -o 'StrictHostKeyChecking no' " \
+        cmd.cmdStr = "ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 " \
                      "{targethost} \"{gphome} {cmdstr}\"".format(targethost=self.targetHost,
                                                                  gphome=". %s/greenplum_path.sh;" % self.gphome,
                                                                  cmdstr=cmd.cmdStr)

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
@@ -72,7 +72,7 @@ class WorkerPoolTestCase(unittest.TestCase):
         cmd.propagate_env_map['foo'] = 1
         cmd.propagate_env_map['bar'] = 1
         self.subject.execute(cmd)
-        self.assertEquals("bar=1 && foo=1 && ssh -o \'StrictHostKeyChecking no\' localhost "
+        self.assertEquals("bar=1 && foo=1 && ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 localhost "
                           "\". gphome/greenplum_path.sh; bar=1 && foo=1 && ls /tmp\"", cmd.cmdStr)
 
     def test_no_workders_in_WorkerPool(self):


### PR DESCRIPTION
For long running commands such as gpinitstandby with a large master data
directory, the server takes a long time. Therefore, there is no acitivity from
the client to the server. If the ClientAliveInterval is set, then the server
reports a timeout after ClientAliveInterval seconds.

Setting a ServerAliveInterval value less than the ClientAliveInterval interval
forces the client to send a Null message to the server.  Hence, avoiding the
timeout.

This PR is the second attempt, with https://github.com/greenplum-db/gpdb/pull/5091 as the first.  This code has been verified to work on the platforms that failed last time (15493596064bc8ed5ff86f2d1cbfa17f0b5244d8 was reverted by 32b5accb1384b975cd41914a2316411394c52a33)

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>
Co-authored-by: Shoaib Lari <slari@pivotal.io>