### PR TITLE
ci: nightly-trigger only on AIX jobs

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -601,7 +601,7 @@ resources:
     versioned_file: {{deb_package_ubuntu16_versioned_file}}
 
 {% endif %}
-{% if 'CLI' in test_sections + os_types or 'aix7' in test_sections + os_types %}
+{% if "aix7" in os_types %}
 - name: nightly-trigger
   type: time
   source:


### PR DESCRIPTION
For a while there were several jobs that were behind the nightly
trigger.  This necessitated some logic about including the
nightly-trigger resource if any of a number of conditions were met.  At
the time of this commit, the only job that is using the resourse is an
AIX job.  Therefore the inclusion of the nightly-trigger resource will
match the conditions that include the only job that requires that
resource.  This elimnates the "resource not used" error that can be seen
when setting a development version of the pipeline that does not include
the AIX job.

Authored-by: Jim Doty <jdoty@pivotal.io>