### PR TITLE
Remove reference to ability to use port/username

### DIFF
--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpssh.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpssh.xml
@@ -83,10 +83,7 @@
                     <pt>-f <varname>hostfile_gpssh</varname></pt>
                     <pd>Specifies the name of a file that contains a list of hosts that will
                         participate in this SSH session.The syntax of the host file is one host
-                        per line as follows:</pd>
-                    <pd>
-                        <codeblock><varname>hostname</varname></codeblock>
-                    </pd>
+                        per line.</pd>
                 </plentry>
                 <plentry>
                     <pt>-h <varname>hostname</varname></pt>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpssh.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpssh.xml
@@ -82,11 +82,10 @@
                 <plentry>
                     <pt>-f <varname>hostfile_gpssh</varname></pt>
                     <pd>Specifies the name of a file that contains a list of hosts that will
-                        participate in this SSH session. The host name is required, and you can
-                        optionally specify an alternate user name and/or SSH port number per host.
-                        The syntax of the host file is one host per line as follows:</pd>
+                        participate in this SSH session.The syntax of the host file is one host
+                        per line as follows:</pd>
                     <pd>
-                        <codeblock>[<varname>username</varname>@]<varname>hostname</varname>[:<varname>ssh_port</varname>]</codeblock>
+                        <codeblock><varname>hostname</varname></codeblock>
                     </pd>
                 </plentry>
                 <plentry>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpssh.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpssh.xml
@@ -82,7 +82,7 @@
                 <plentry>
                     <pt>-f <varname>hostfile_gpssh</varname></pt>
                     <pd>Specifies the name of a file that contains a list of hosts that will
-                        participate in this SSH session.The syntax of the host file is one host
+                        participate in this SSH session. The syntax of the host file is one host
                         per line.</pd>
                 </plentry>
                 <plentry>


### PR DESCRIPTION
Port and username options do not work in current gpssh release.