### PR TITLE
Move gpaddmirrors' standby and recover TINC tests to behave

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -1,6 +1,34 @@
 @gpaddmirrors
 Feature: Tests for gpaddmirrors
 
+    Scenario: gprecoverseg works correctly on a newly added mirror
+        Given a working directory of the test as '/tmp/gpaddmirrors'
+        And the user runs command "rm -rf /tmp/gpaddmirrors/*"
+        And the database is killed on hosts "mdw,sdw1,sdw2"
+        And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2"
+        And gpaddmirrors adds mirrors
+        Then verify the database has mirrors
+        And the information of a "mirror" segment on a remote host is saved
+        When user kills a "mirror" process with the saved information
+        When the user runs "gprecoverseg -a"
+        Then gprecoverseg should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized
+
+    Scenario: gpaddmirrors puts mirrors on the same hosts when there is a standby configured
+        Given a working directory of the test as '/tmp/gpaddmirrors'
+        And the user runs command "rm -rf /tmp/gpaddmirrors/*"
+        And the database is killed on hosts "mdw,sdw1,sdw2,sdw3"
+        And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2, sdw3"
+        And gpaddmirrors adds mirrors
+        Then verify the database has mirrors
+        And save the gparray to context
+        Given the user runs command "rm -rf /tmp/gpaddmirrors/*"
+        And the database is killed on hosts "mdw,sdw1,sdw2,sdw3"
+        And a cluster is created with no mirrors and a standby on "mdw" and "sdw1, sdw2, sdw3"
+        And gpaddmirrors adds mirrors
+        Then mirror hostlist matches the one saved in context
+
     # This test requires a bigger cluster than the other gpaddmirrors tests.
     @gpaddmirrors_spread
     Scenario: gpaddmirrors puts mirrors on different host
@@ -46,4 +74,3 @@ Feature: Tests for gpaddmirrors
         Then verify that there is a "heap" table "public.heap_table" in "gptest" with "100" rows
         Then verify that there is a "ao" table "public.ao_table" in "gptest" with "100" rows
         Then verify that there is a "co" table "public.co_table" in "gptest" with "100" rows
-

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2434,8 +2434,7 @@ def step_impl(context, abbreviated_timezone):
 def impl(context, working_directory):
     context.working_directory = working_directory
 
-@given('a cluster is created with no mirrors on "{master_host}" and "{segment_host_list}"')
-def impl(context, master_host, segment_host_list):
+def _create_cluster(context, master_host, segment_host_list, standby_enabled):
     segment_host_list = segment_host_list.split(",")
     del os.environ['MASTER_DATA_DIRECTORY']
     os.environ['MASTER_DATA_DIRECTORY'] = os.path.join(context.working_directory,
@@ -2450,10 +2449,18 @@ def impl(context, master_host, segment_host_list):
     except:
         pass
 
-    testcluster = TestCluster(hosts=[master_host]+segment_host_list, base_dir=context.working_directory)
+    testcluster = TestCluster(hosts=[master_host]+segment_host_list, base_dir=context.working_directory, standby_enabled = standby_enabled)
     testcluster.reset_cluster()
     testcluster.create_cluster(with_mirrors=False)
     context.gpexpand_mirrors_enabled = False
+
+@given('a cluster is created with no mirrors and a standby on "{master_host}" and "{segment_host_list}"')
+def impl(context, master_host, segment_host_list):
+    _create_cluster(context, master_host, segment_host_list, standby_enabled=True)
+
+@given('a cluster is created with no mirrors on "{master_host}" and "{segment_host_list}"')
+def impl(context, master_host, segment_host_list):
+    _create_cluster(context, master_host, segment_host_list, standby_enabled=False)
 
 @given('a cluster is created with mirrors on "{master_host}" and "{segment_host}"')
 def impl(context, master_host, segment_host):

--- a/gpMgmt/test/behave_utils/cluster_setup.py
+++ b/gpMgmt/test/behave_utils/cluster_setup.py
@@ -64,7 +64,7 @@ class GpDeleteSystem(Command):
 
 
 class TestCluster:
-    def __init__(self, hosts = None, base_dir = '/tmp/default_gpinitsystem'):
+    def __init__(self, hosts = None, base_dir = '/tmp/default_gpinitsystem', standby_enabled = False):
         """
         hosts: lists of cluster hosts. master host will be assumed to be the first element.
         base_dir: cluster directory
@@ -102,7 +102,7 @@ class TestCluster:
         self.mirror_enabled = False
         self.number_of_segments = 2
         self.number_of_hosts = len(self.hosts)-1
-        self.standby_enabled = False
+        self.standby_enabled = standby_enabled
 
         self.number_of_expansion_hosts = 0
         self.number_of_expansion_segments = 0
@@ -151,7 +151,9 @@ class TestCluster:
 
         # run gpinitsystem
         clean_env = 'unset MASTER_DATA_DIRECTORY; unset PGPORT;'
-        gpinitsystem_cmd = clean_env + 'gpinitsystem -a -c  %s' % (self.init_file)
+        gpinitsystem_cmd = clean_env + 'gpinitsystem -a -c  %s ' % (self.init_file)
+        if self.standby_enabled:
+            gpinitsystem_cmd += ' -s {} -P {} '.format(self.hosts[0], int(self.master_port)+1)
         res = run_shell_command(gpinitsystem_cmd, 'run gpinitsystem', verbose=True)
         # initsystem returns 1 for warnings and 2 for errors
         if res['rc'] > 1:
@@ -241,4 +243,3 @@ if __name__ == '__main__':
     testcluster = TestCluster([])
     testcluster.reset_cluster()
     testcluster.create_cluster()
-


### PR DESCRIPTION
- Add mirrors with and without standby, and ensure that the host
  assignment is identical between the two.
- Add mirrors, then kill one, and ensure that gprecoverseg operates
  correctly on the newly added mirror.

Co-authored-by: Nadeem Ghani <nghani@pivotal.io>
Co-authored-by: Jacob Champion <pchampion@pivotal.io>