### PR TITLE
docs - docs and updates for pgbouncer 1.8.1

### DIFF
--- a/gpdb-doc/dita/admin_guide/access_db/topics/pgbouncer.xml
+++ b/gpdb-doc/dita/admin_guide/access_db/topics/pgbouncer.xml
@@ -78,7 +78,7 @@ SHUTDOWN;</codeblock>
           file descriptors to the new process. If the transition fails for any reason, kill the new
           process and the old process will resume.</p>
         <p><b>If you are migrating to a Greenplum Database version 5.9.0 or later</b>, you must shut down the PgBouncer instance in your old installation and reconfigure and restart PgBouncer in your new installation.</p>
-        <p>If you used stunnel to secure PgBouncer connections in your old installation, you must configure SSL/TLS in your new installation using the built-in TLS capabilities of PgBouncer 1.8.1.</p>
+        <p>If you used stunnel to secure PgBouncer connections in your old installation, you must configure SSL/TLS in your new installation using the built-in TLS capabilities of PgBouncer 1.8.1 and later.</p>
       </body>
     </topic>
     <topic id="pgb_config">
@@ -100,10 +100,10 @@ logfile = pgbouncer.log
 pidfile = pgbouncer.pid
 admin_users = gpadmin</codeblock></p>
         <p>Refer to the <xref href="../../../utility_guide/admin_utilities/pgbouncer-ini.xml" format="dita"
-              scope="peer">pgbouncer-ini</xref> reference page for the
+              scope="peer">pgbouncer.ini</xref> reference page for the
           PgBouncer configuration file format and the list of configuration properties it supports.</p>
          <p>When a client connects to PgBouncer, the connection pooler looks up the
-           requested database (which may be an alias for the actual database) in the
+           the configuration for the requested database (which may be an alias for the actual database) that was specified in the
            <codeph>pgbouncer.ini</codeph> configuration file to find the host name, port, and
           database name for the database connection. The configuration file also identifies
           the authentication mode in effect for the database. </p>
@@ -119,14 +119,14 @@ admin_users = gpadmin</codeblock></p>
         <codeblock>"username1" "password" ...
 "username2" "md5abcdef012342345" ...</codeblock>
         <p><codeph>auth_file</codeph> contains one line per user. Each line must have at least two fields,
-          both of which are encloed in double quotes (<codeph>" "</codeph>). The first
+          both of which are enclosed in double quotes (<codeph>" "</codeph>). The first
           field identifies the Greenplum Database user name. The second field is
           either a plain-text or an MD5-encoded password. PgBouncer ignores the remainder of the line.</p>
         <p>(The format of <codeph>auth_file</codeph> is similar to that of the <codeph>pg_auth</codeph>
           text file that Greenplum Database uses for authentication information. PgBouncer
           can work directly with this Greenplum Database authentication file.)</p>
         <p>Use an MD5 encoded password. The format of an MD5 encoded password is: 
-        <codeblock>"md5" + md5(password + username)</codeblock></p>
+        <codeblock>"md5" + MD5_encoded(<varname>&lt;password>&lt;username></varname>)</codeblock></p>
         <p>You can also obtain the MD5-encoded passwords of all Greenplum Database users from the <codeph>pg_shadow</codeph> view.</p>
       </section>
       <section id="pgb_hba">
@@ -160,7 +160,7 @@ auth_hba_file = hba_bouncer.conf
         <p>Follow these steps to set up PgBouncer.</p>
         <ol id="ol_xyn_qwg_cs">
           <li>Create a PgBouncer configuration file. For example, add the following text
-           to a file named <codeph>pgbouncer.ini</codeph>::<codeblock>[databases]
+           to a file named <codeph>pgbouncer.ini</codeph>:<codeblock>[databases]
 postgres = host=127.0.0.1 port=5432 dbname=postgres
 pgb_mydb = host=127.0.0.1 port=5432 dbname=mydb
 
@@ -183,7 +183,7 @@ admin_users = gpadmin</codeblock><p>The file lists databases and their connectio
             example: <codeblock>"gpadmin" "gpadmin1234"</codeblock><p>If the <codeph>auth_type</codeph>
               in the following example is <codeph>md5</codeph>, the authentication field must be
               MD5-encoded. The format for an MD5-encoded password
-              is:<codeblock>"md5" + MD5(<varname>&lt;password>&lt;username></varname>)</codeblock></p>
+              is:<codeblock>"md5" + MD5_encoded(<varname>&lt;password>&lt;username></varname>)</codeblock></p>
             <p>To authenticate users against an LDAP or Active Directory server, the password
               field contains an LDAP lookup string. For
               example:</p><codeblock>"gpdbuser1" "ldap://10.0.0.11:10389/uid=gpdbuser1,ou=users,ou=system"</codeblock><p>For

--- a/gpdb-doc/dita/admin_guide/access_db/topics/pgbouncer.xml
+++ b/gpdb-doc/dita/admin_guide/access_db/topics/pgbouncer.xml
@@ -1,63 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE dita PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<dita>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
   <topic id="topic_fstrm">
     <title>Using the PgBouncer Connection Pooler </title>
-    <shortdesc>The PgBouncer utility manages connection pools for PostgreSQL and Greenplum Database
-      connections.</shortdesc>
     <body>
-      <p>The Greenplum Database installation includes the PgBouncer connection pooling software. The
-        following topics describe how to set up and use PgBouncer with Greenplum Database. See the
-          <xref href="https://pgbouncer.github.io" format="html" scope="external">PgBouncer Web
+      <p>The PgBouncer utility manages connection pools for PostgreSQL and Greenplum Database
+      connections.</p>
+      <p>The
+        following topics describe how to set up and use PgBouncer with Greenplum Database. Refer to the
+          <xref href="https://pgbouncer.github.io" format="html" scope="external">PgBouncer web
           site</xref> for information about using PgBouncer with PostgreSQL.</p>
       <ul id="ul_off_zqj_5s">
         <li>
           <xref href="#topic_nzk_nqg_cs" format="dita"/>
         </li>
         <li>
+          <xref href="#pgb_migrate" format="dita"/>
+        </li>
+        <li>
           <xref href="#pgb_config" format="dita"/>
         </li>
         <li>
-          <xref href="#topic_otc_snn_ts" format="dita"/>
+          <xref href="#pgb_start" format="dita"/>
         </li>
         <li>
-          <xref href="#topic_m2h_5dj_5s" format="dita"/>
-        </li>
-        <li>
-          <xref href="#topic_nfn_tvd_5s" format="dita"/>
+          <xref href="#topic_manage" format="dita"/>
         </li>
       </ul>
-      <p>Also, see reference information for PgBouncer in the <i>Greenplum Database Utility
-          Guide</i>. </p>
     </body>
     <topic id="topic_nzk_nqg_cs">
       <title>Overview</title>
       <body>
         <p>A database connection pool is a cache of database connections. Once a pool of connections
-          is established, connection pooling eliminates the overhead of creating database
+          is established, connection pooling eliminates the overhead of creating new database
           connections, so clients connect much faster and the server load is reduced.</p>
-        <p>The PgBouncer connection pooler, from the PostgreSQL community, is included with
-          Greenplum Database. PgBouncer can manage connection pools for multiple databases, and
-          databases may be on different Greenplum Database clusters or PostgreSQL backends.
-          PgBouncer creates a pool for each database user and database combination. A pooled
-          connection can only be reused for another connection request for the same user and
-          database. </p>
-        <p>The client application requires no software changes, but connects to the connection
-          pool's host and port instead of the Greenplum Database master host and port. PgBouncer
-          either creates a new database connection or reuses an existing connection. When the client
-          disconnects, the connection is returned to the pool for re-use. </p>
-        <p>PgBouncer supports the standard connection interface that PostgreSQL and Greenplum
-          Database share. A client requesting a database connection provides the host name and port
-          where PgBouncer is running, as well as the database name, username, and password.
-          PgBouncer looks up the requested database (which may be an alias for the actual database)
-          in its configuration file to find the host name, port, and database name for the database
-          connection. The configuration file entry also determines how to authenticate the user and
-          what database role will be used for the connection—a "forced user" can override the
-          username provided with the client's connection request. </p>
-        <p>PgBouncer requires an authentication file, a text file that contains a list of users and
-          passwords. Passwords may be either clear text, MD5-encoded, or an LDAP/AD lookup string.
-          You can also set up PgBouncer to query the destination database for users that are not in
-          the authentication file. </p>
+        <p>The PgBouncer connection pooler, from the PostgreSQL community, is included in
+          your Greenplum Database installation. PgBouncer is a light-weight connection pool
+          manager for Greenplum and PostgreSQL.
+          PgBouncer maintains a pool for connections for each database and user combination. PgBouncer either creates a new database connection for a client or reuses an
+          existing connection for the same user and database. When the client disconnects, PgBouncer
+          returns the connection to the pool for re-use.</p>
         <p>PgBouncer shares connections in one of three pool modes:<ul id="ul_jyx_rvg_cs">
             <li><i>Session pooling</i> – When a client connects, a connection is assigned to it as
               long as it remains connected. When the client disconnects, the connection is placed
@@ -70,33 +51,44 @@
               multi-statement transactions are not allowed. This mode is intended to enforce
               autocommit mode on the client and is targeted for PL/Proxy on PostgreSQL.</li>
           </ul></p>
-        <p>A default pool mode can be set for the PgBouncer instance and the mode can be overridden
-          for individual databases and users. </p>
-        <p>By connecting to a virtual <codeph>pgbouncer</codeph> database, you can monitor and
-          manage PgBouncer using SQL-like commands. Configuration parameters can be changed without
-          having to restart PgBouncer, and the configuration file can be reloaded to pick up
-          changes.</p>
-        <p>PgBouncer does not yet support SSL connections. If you want to encrypt traffic between
-          clients and PgBouncer, you can use <xref href="https://www.stunnel.org" format="html"
-            scope="external">stunnel</xref>, a free software utility that creates TLS-encrypted
-          tunnels using the OpenSSL cryptography library. See <xref href="#topic_nfn_tvd_5s"
-            format="dita"/> for directions.</p>
+        <p>You can set a default pool mode for the PgBouncer instance. You can override this
+          mode for individual databases and users. </p>
+        <p>PgBouncer supports the standard connection interface shared by PostgreSQL and Greenplum
+          Database. The Greenplum Database client application (for example, <codeph>psql</codeph>)
+          connects to the host and port on which PgBouncer is running rather than the Greenplum Database master host and port.</p>
+        <p>PgBouncer includes a <codeph>psql</codeph>-like administration console. Authorized users can connect to a virtual database to monitor and manage PgBouncer. You can manage a PgBouncer daemon process via the admin console. You can also use the console to update and reload PgBouncer configuration at runtime without stopping and restarting the process.</p>
+        <p>PgBouncer natively supports TLS.</p>
+      </body>
+    </topic>
+    <topic id="pgb_migrate">
+      <title>Migrating PgBouncer</title>
+      <body>
+        <p>When you migrate to a new Greenplum Database version, you must migrate your PgBouncer
+          instance to that in the new Greenplum Database installation.</p>
+        <p><b>If you are migrating to a Greenplum Database version 5.8.x or earlier</b>, you can migrate PgBouncer without dropping connections. Launch the new PgBouncer
+          process with the <codeph>-R</codeph> option and the configuration file that you started the process with:</p>
+        <codeblock>$ pgbouncer -R -d pgbouncer.ini</codeblock>
+        <p>The <codeph>-R</codeph> (reboot) option causes the new process to connect to the console
+          of the old process through a Unix socket and issue the following commands:</p>
+        <codeblock>SUSPEND;
+SHOW FDS;
+SHUTDOWN;</codeblock>
+        <p>When the new process detects that the old process is gone, it resumes the work with the old
+          connections. This is possible because the <codeph>SHOW FDS</codeph> command sends actual
+          file descriptors to the new process. If the transition fails for any reason, kill the new
+          process and the old process will resume.</p>
+        <p><b>If you are migrating to a Greenplum Database version 5.9.0 or later</b>, you must shut down the PgBouncer instance in your old installation and reconfigure and restart PgBouncer in your new installation.</p>
+        <p>If you used stunnel to secure PgBouncer connections in your old installation, you must configure SSL/TLS in your new installation using the built-in TLS capabilities of PgBouncer 1.8.1.</p>
       </body>
     </topic>
     <topic id="pgb_config">
-      <title>Configuring and Starting PgBouncer</title>
+      <title>Configuring PgBouncer</title>
       <body>
-        <p>PgBouncer can be run on the Greenplum Database master or on another server. If you
-          install PgBouncer on a separate server, you can easily switch clients to the standby
-          master by updating the PgBouncer configuration file and reloading the configuration using
-          the PgBouncer Administration Console. </p>
-        <p>Follow these steps to set up PgBouncer.</p>
-        <ol id="ol_xyn_qwg_cs">
-          <li>Create a PgBouncer configuration file, for example <codeph>pgbouncer.ini</codeph>.
-            Here is a simple configuration
-              file:<codeblock>[databases]
+        <p></p>
+        <p>You configure PgBouncer and its access to Greenplum Database via a configuration file. This configuration file, commonly named <codeph>pgbouncer.ini</codeph>, provides location information for Greenplum databases. The <codeph>pgbouncer.ini</codeph> file also specifies process, connection pool, authorized users, and authentication configuration for PgBouncer.</p>
+        <p>Sample <codeph>pgbouncer.ini</codeph> file contents:<codeblock>[databases]
 postgres = host=127.0.0.1 port=5432 dbname=postgres
-mydb = host=127.0.0.1 port=5432 dbname=mydb
+pgb_mydb = host=127.0.0.1 port=5432 dbname=mydb
 
 [pgbouncer]
 pool_mode = session
@@ -106,281 +98,162 @@ auth_type = md5
 auth_file = users.txt
 logfile = pgbouncer.log
 pidfile = pgbouncer.pid
-admin_users = gpadmin</codeblock><p>The
-              file is in the <codeph>.ini</codeph> file format and has three sections:
-                <i>databases</i>, <i>pgbouncer</i>, and <i>users</i>. The databases section lists
-              databases with their connection details. The pgbouncer section configures the
-              PgBouncer instance. </p></li>
-          <li>Create an authentication file. The name of the file must match the
-              <codeph>auth_file</codeph> parameter in the <codeph>pgbouncer.ini</codeph> file,
-              <codeph>users.txt</codeph> in this example. Each line contains a user name and
+admin_users = gpadmin</codeblock></p>
+        <p>Refer to the <xref href="../../../utility_guide/admin_utilities/pgbouncer-ini.xml" format="dita"
+              scope="peer">pgbouncer-ini</xref> reference page for the
+          PgBouncer configuration file format and the list of configuration properties it supports.</p>
+         <p>When a client connects to PgBouncer, the connection pooler looks up the
+           requested database (which may be an alias for the actual database) in the
+           <codeph>pgbouncer.ini</codeph> configuration file to find the host name, port, and
+          database name for the database connection. The configuration file also identifies
+          the authentication mode in effect for the database. </p>
+        <p>PgBouncer requires an authentication file, a text file that contains a list of
+          Greenplum Database users and passwords. The contents of the file are dependent on the <codeph>auth_type</codeph> you configure in the <codeph>pgbouncer.ini</codeph> file. Passwords may be either clear text, MD5-encoded, or an LDAP/AD lookup string.
+          You can also configure PgBouncer to query the destination database to obtain
+          password information for users that are not in the authentication file. </p>
+      <section id="pgb_auth">
+        <title>PgBouncer Authentication File Format</title>
+        <p>PgBouncer requires its own user authentication file. You specify the name of this file 
+          in the <codeph>auth_file</codeph> property of the <codeph>pgbouncer.ini</codeph> configuration
+           file. <codeph>auth_file</codeph> is a text file in the following format:</p>
+        <codeblock>"username1" "password" ...
+"username2" "md5abcdef012342345" ...</codeblock>
+        <p><codeph>auth_file</codeph> contains one line per user. Each line must have at least two fields,
+          both of which are encloed in double quotes (<codeph>" "</codeph>). The first
+          field identifies the Greenplum Database user name. The second field is
+          either a plain-text or an MD5-encoded password. PgBouncer ignores the remainder of the line.</p>
+        <p>(The format of <codeph>auth_file</codeph> is similar to that of the <codeph>pg_auth</codeph>
+          text file that Greenplum Database uses for authentication information. PgBouncer
+          can work directly with this Greenplum Database authentication file.)</p>
+        <p>Use an MD5 encoded password. The format of an MD5 encoded password is: 
+        <codeblock>"md5" + md5(password + username)</codeblock></p>
+        <p>You can also obtain the MD5-encoded passwords of all Greenplum Database users from the <codeph>pg_shadow</codeph> view.</p>
+      </section>
+      <section id="pgb_hba">
+        <title>Configuring HBA-based Authentication for PgBouncer</title>
+        <p>PgBouncer supports HBA-based authentication. To configure HBA-based authentication for PgBouncer, you set <codeph>auth_type=hba</codeph> in the <codeph>pgbouncer.ini</codeph> configuration file. You also provide the filename of the HBA-format file in the <codeph>auth_hba_file</codeph> parameter of the <codeph>pgbouncer.ini</codeph> file.</p>
+        <p>Contents of an example PgBouncer HBA file named <codeph>hba_bouncer.conf</codeph>:<codeblock>local       all     bouncer             trust
+host        all     bouncer      127.0.0.1/32       trust</codeblock></p>
+        <p>Example excerpt from the related <codeph>pgbouncer.ini</codeph> configuration file:</p><codeblock>[databases]
+p0 = port=15432 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2
+p1 = port=15432 host=127.0.0.1 dbname=p1 user=bouncer
+...
+
+[pgbouncer]
+...
+auth_type = hba
+auth_file = userlist.txt
+auth_hba_file = hba_bouncer.conf
+...</codeblock>
+         <p>Refer to the <xref href="https://pgbouncer.github.io/config.html#hba-file-format" format="html" scope="external">HBA file format
+          </xref> discussion in the PgBouncer documentation for information about PgBouncer support of the HBA authentication file format.</p>
+      </section>
+      </body>
+    </topic>
+    <topic id="pgb_start">
+      <title>Starting PgBouncer</title>
+      <body>
+        <p>You can run PgBouncer on the Greenplum Database master or on another server. If you
+          install PgBouncer on a separate server, you can easily switch clients to the standby
+          master by updating the PgBouncer configuration file and reloading the configuration using
+          the PgBouncer Administration Console. </p>
+        <p>Follow these steps to set up PgBouncer.</p>
+        <ol id="ol_xyn_qwg_cs">
+          <li>Create a PgBouncer configuration file. For example, add the following text
+           to a file named <codeph>pgbouncer.ini</codeph>::<codeblock>[databases]
+postgres = host=127.0.0.1 port=5432 dbname=postgres
+pgb_mydb = host=127.0.0.1 port=5432 dbname=mydb
+
+[pgbouncer]
+pool_mode = session
+listen_port = 6543
+listen_addr = 127.0.0.1
+auth_type = md5
+auth_file = users.txt
+logfile = pgbouncer.log
+pidfile = pgbouncer.pid
+admin_users = gpadmin</codeblock><p>The file lists databases and their connection details. The file also configures the PgBouncer instance. Refer to the <xref href="../../../utility_guide/admin_utilities/pgbouncer-ini.xml" format="dita"
+              scope="peer">pgbouncer.ini</xref> reference page for information about the
+              format and content of a PgBouncer configuration file.</p></li>
+          <li>Create an authentication file. The filename should be the name you specified for the <codeph>auth_file</codeph> parameter of the <codeph>pgbouncer.ini</codeph> file, <codeph>users.txt</codeph>.
+            Each line contains a user name and
             password. The format of the password string matches the <codeph>auth_type</codeph>
-            parameter in the PgBouncer configuration file. If the <codeph>auth_type</codeph>
+            you configured in the PgBouncer configuration file. If the <codeph>auth_type</codeph>
             parameter is <codeph>plain</codeph>, the password string is a clear text password, for
-            example: <codeblock>"gpadmin" "gpadmin1234"</codeblock><p>The <codeph>auth_type</codeph>
-              in the following example is <codeph>md5</codeph>, so the authentication field must be
+            example: <codeblock>"gpadmin" "gpadmin1234"</codeblock><p>If the <codeph>auth_type</codeph>
+              in the following example is <codeph>md5</codeph>, the authentication field must be
               MD5-encoded. The format for an MD5-encoded password
-              is:<codeblock>"md5" + MD5(<varname>&lt;password>&lt;username></varname>)</codeblock></p><p>You
-              can use the Linux <codeph>md5sum</codeph> command to calculate the MD5 string. For
-              example, if the <codeph>gpadmin</codeph> password is <codeph>admin1234</codeph> the
-              following command prints the string for the password
-              field:<codeblock>$ user=gpadmin; passwd=admin1234; echo -n md5; echo $passwd$user | md5sum
-md53ce96652dedd8226c498e09ae2d26220</codeblock></p><p>And
-              here is the MD5-encoded entry for the <codeph>gpadmin</codeph> user in the PgBouncer
-              authentication file:</p><p>
-              <codeblock>"gpadmin" "md53ce96652dedd8226c498e09ae2d26220"</codeblock>
-            </p><p>To authenticate users against an LDAP or Active Directory server, the password
+              is:<codeblock>"md5" + MD5(<varname>&lt;password>&lt;username></varname>)</codeblock></p>
+            <p>To authenticate users against an LDAP or Active Directory server, the password
               field contains an LDAP lookup string. For
               example:</p><codeblock>"gpdbuser1" "ldap://10.0.0.11:10389/uid=gpdbuser1,ou=users,ou=system"</codeblock><p>For
               Active Directory, a user entry looks like this
-              example:<codeblock>"gpdbuser2" "ldap://10.0.0.12:389/gpdbuser2"</codeblock>See <xref
-                href="#topic_m2h_5dj_5s" format="dita"/> for the steps to configure PgBouncer to
-              authenticate users with an LDAP server. </p><p>For details about the authentication
-              file, see the "Authentication File Format" section of the PgBouncer reference in the
-                <i>Greenplum Database Utility Guide</i>. </p></li>
+              example:<codeblock>"gpdbuser2" "ldap://10.0.0.12:389/gpdbuser2"</codeblock>
+              </p></li>
           <li>Launch
               <codeph>pgbouncer</codeph>:<codeblock>$ $GPHOME/bin/pgbouncer -d pgbouncer.ini</codeblock><p>The
-                <codeph>-d</codeph> or <codeph>--daemon</codeph> option runs PgBouncer as a
-              background process. See the PgBouncer reference in the <i>Greenplum Database Utility
-                Guide</i> for the <codeph>pgbouncer</codeph> command syntax and its
-            options.</p></li>
-          <li>Update client applications to connect to <codeph>pgbouncer</codeph> instead of
-            directly to Greenplum Database server. To start <codeph>psql</codeph>, for
-            example:<codeblock>$ psql -p 6543 -U <varname>someuser</varname> postgres</codeblock></li>
+                <codeph>-d</codeph> option runs PgBouncer as a
+              background (daemon) process. Refer to the <xref href="../../../utility_guide/admin_utilities/pgbouncer.xml" format="dita"
+              scope="peer">pgbouncer</xref> reference page for the
+              <codeph>pgbouncer</codeph> command syntax and options.</p></li>
+          <li>Update your client applications to connect to <codeph>pgbouncer</codeph> instead of
+            directly to Greenplum Database server. For example, to connect to the Greenplum
+            database named <codeph>mydb</codeph> configured above, run <codeph>psql</codeph> as follows:<codeblock>$ psql -p 6543 -U <varname>someuser</varname> pgb_mydb</codeblock><p>The <codeph>-p</codeph> option value is the <codeph>listen_port</codeph> that you configured for the PgBouncer instance.</p></li>
         </ol>
       </body>
     </topic>
-    <topic id="topic_lw4_rdm_g5">
-      <title>Server Reset Query</title>
-      <body>
-        <p>When a connection is returned to the pool, it must be reset to the state of a newly
-          created connection. PgBouncer accomplishes this by issuing a query before returning a
-          connection to the pool. PostgreSQL 8.3 and later have the <codeph>DISCARD ALL</codeph>
-          command for this purpose and it is the default reset query for the standard PgBouncer
-          distribution. Greenplum Database does not support <codeph>DISCARD ALL</codeph> and if it
-          is used an error is logged. </p>
-        <p>A reset query can be specified by setting the <codeph>server_reset_query</codeph>
-          parameter in the PgBouncer configuration file. For Greenplum Database with PgBouncer in
-          session pooling mode, the <codeph>server_reset_query</codeph> parameter can be set to this
-          query:<codeblock>RESET ALL; SET SESSION AUTHORIZATION DEFAULT</codeblock></p>
-        <p>This is the default server reset query in the modified version of PgBouncer included with
-          Greenplum Database 4.7.0 and later. Although the default differs from PgBouncer, it helps
-          to ensure that the connection pool is transparent to Greenplum Database users and client
-          applications do not have to be modified to use a connection pool. </p>
-        <p>For more information about the <codeph>server_reset_query</codeph> parameter and the
-          PgBouncer configuration file, see the PgBouncer reference in the <i>Greenplum Database
-            Utility Guide</i>.</p>
-      </body>
-    </topic>
-    <topic id="topic_otc_snn_ts">
+    <topic id="topic_manage">
       <title>Managing PgBouncer</title>
       <body>
-        <p>PgBouncer has an administrative console, which is accessed by logging into the
-            <codeph>pgbouncer</codeph> virtual database. The console accepts SQL-like commands that
-          allow you to monitor, reconfigure, and manage PgBouncer. </p>
-        <p>Follow these steps to get started with the PgBouncer administrative console.</p>
+        <p>PgBouncer provides a <codeph>psql</codeph>-like administration console. You
+          log in to the PgBouncer Administration Console by specifying the PgBouncer port
+           number and a virtual database named <codeph>pgbouncer</codeph>.
+          The console accepts SQL-like commands that you can use to monitor, reconfigure, and manage PgBouncer.</p>
+        <p>For complete documentation of PgBouncer Administration Console
+          commands, refer to the <xref href="../../../utility_guide/admin_utilities/pgbouncer-admin.xml" format="dita"
+              scope="peer">PgBouncer Administration Console</xref> command reference.</p>
+        <p>Follow these steps to get started with the PgBouncer Administration Console.</p>
         <ol id="ol_jwt_hyn_ts">
-          <li>Log in to the <codeph>pgbouncer</codeph> virtual database with
-              <codeph>psql</codeph>:<codeblock>$ psql -p 6543 -U <varname>username</varname> pgbouncer</codeblock><p>The
-              username must be set in the <codeph>admin_users</codeph> parameter in the
-                <codeph>pgbouncer.ini</codeph> configuration file. You can also log in with the
-              current Unix username if the <codeph>pgbouncer</codeph> process is running with that
+          <li>Use <codeph>psql</codeph> to log in to the <codeph>pgbouncer</codeph>
+            virtual database:<codeblock>$ psql -p 6543 -U <varname>username</varname> pgbouncer</codeblock><p>The
+              <varname>username</varname> that you specify must be listed in the <codeph>admin_users</codeph> parameter in the
+                <codeph>pgbouncer.ini</codeph> configuration file. You can also log in 
+              to the PgBouncer Administration Console with the
+              current Unix username if the <codeph>pgbouncer</codeph> process is running under that
               user's UID.</p></li>
-          <li>To see the available commands, run the <codeph>show help</codeph>
-            command:<codeblock>pgbouncer=# show help;
+          <li>To view the available PgBouncer Administration Console commands, run the <codeph>SHOW help</codeph>
+            command:<codeblock>pgbouncer=# SHOW help;
 NOTICE:  Console usage
 DETAIL:
-       SHOW HELP|CONFIG|DATABASES|POOLS|CLIENTS|SERVERS|VERSION
-	SHOW STATS|FDS|SOCKETS|ACTIVE_SOCKETS|LISTS|MEM
-	SHOW DNS_HOSTS|DNS_ZONES
-	SET key = arg
-	RELOAD
-	PAUSE [&lt;db>]
-	RESUME [&lt;db>]
-	DISABLE &lt;db>
-	ENABLE &lt;db>
-	KILL &lt;db>
-	SUSPEND
-	SHUTDOWN</codeblock></li>
-          <li>If you make changes to the <codeph>pgbouncer.ini</codeph> file, you can reload it with
-            the <codeph>RELOAD</codeph> command:<codeblock>pgbouncer=# RELOAD;</codeblock></li>
+    SHOW HELP|CONFIG|DATABASES|POOLS|CLIENTS|SERVERS|VERSION
+    SHOW FDS|SOCKETS|ACTIVE_SOCKETS|LISTS|MEM
+    SHOW DNS_HOSTS|DNS_ZONES
+    SHOW STATS|STATS_TOTALS|STATS_AVERAGES
+    SET key = arg
+    RELOAD
+    PAUSE [&lt;db>]
+    RESUME [&lt;db>]
+    DISABLE &lt;db>
+    ENABLE &lt;db>
+    KILL &lt;db>
+    SUSPEND
+    SHUTDOWN</codeblock></li>
+          <li>If you update PgBouncer configuration by editing the <codeph>pgbouncer.ini</codeph> configuration file, you use the <codeph>RELOAD</codeph> command to reload the file:<codeblock>pgbouncer=# RELOAD;</codeblock></li>
         </ol>
         <section>
-          <p>To map clients to server connections, use the <codeph>SHOW CLIENTS</codeph> and
-              <codeph>SHOW SERVERS</codeph> views:</p>
+          <title>Mapping PgBouncer Clients to Greenplum Database Server Connections</title>
+          <p>To map a PgBouncer client to a Greenplum Database server connection, use the 
+            PgBouncer Administration Console <codeph>SHOW CLIENTS</codeph> and
+              <codeph>SHOW SERVERS</codeph> commands:</p>
           <ol id="ol_xgn_qfq_bt">
             <li>Use <codeph>ptr</codeph> and <codeph>link</codeph> to map the local client
               connection to the server connection.</li>
-            <li>Use <codeph>addr</codeph> and <codeph>port</codeph> of the client connection to
+            <li>Use the <codeph>addr</codeph> and the <codeph>port</codeph> of the client connection to
               identify the TCP connection from the client.</li>
             <li>Use <codeph>local_addr</codeph> and <codeph>local_port</codeph> to identify the TCP
               connection to the server.</li>
           </ol>
         </section>
-        <p>For complete documentation for all of the administration console commands, see the
-          "PgBouncer Administration Console Commands" section of the PgBouncer reference in the
-            <i>Greenplum Database Utility Guide</i>.</p>
-      </body>
-    </topic>
-    <topic id="id_mpv_d2q_bt">
-      <title>Upgrading PgBouncer</title>
-      <body>
-        <p>You can upgrade PgBouncer without dropping connections. Just launch the new PgBouncer
-          process with the <codeph>-R</codeph> option and the same configuration file:</p>
-        <codeblock>$ pgbouncer -R -d config.ini</codeblock>
-        <p>The <codeph>-R</codeph> (reboot) option causes the new process to connect to the console
-          of the old process through a Unix socket and issue the following commands:</p>
-        <codeblock>SUSPEND;
-SHOW FDS;
-SHUTDOWN;</codeblock>
-        <p>When the new process sees that the old process is gone, it resumes the work with the old
-          connections. This is possible because the <codeph>SHOW FDS</codeph> command sends actual
-          file descriptors to the new process. If the transition fails for any reason, kill the new
-          process and the old process will resume.</p>
-      </body>
-    </topic>
-    <topic id="topic_m2h_5dj_5s">
-      <title>Setting up LDAP Authentication with PgBouncer</title>
-      <body>
-        <p>You can authenticate Greenplum Database users against your LDAP or Active Directory
-          service when using the PgBouncer connection pooler. When you have LDAP authentication
-          working, you can secure client connections to PgBouncer by setting up stunnel, as
-          described in <xref href="#topic_nfn_tvd_5s" format="dita"/>. </p>
-        <p>Before you begin, you must have an LDAP or Active Directory server and a Greenplum
-          Database cluster. <ol id="ol_c3q_g3j_5s">
-            <li>Create Greenplum Database users in the LDAP/AD server, for example
-                <codeph>gpdbuser1</codeph> and <codeph>gpdbuser2</codeph>.</li>
-            <li>Create the corresponding Greenplum Database users in the
-              database:<codeblock>createuser gpdbuser1
-createuser gpdbuser2</codeblock></li>
-            <li>Add the users to the Greenplum Database <codeph>pg_hba.conf</codeph>
-              file:<codeblock>host     all         gpdbuser1              0.0.0.0/0     trust
-host     all         gpdbuser2              0.0.0.0/0     trust
-</codeblock></li>
-            <li>Create a PgBouncer <filepath>config.ini</filepath> file with the following
-              contents:<codeblock>[databases]
-* = host=<varname>GPDB_host_addr</varname> port=<varname>GPDB_port</varname>
-
-[pgbouncer]
-listen_port = 6432
-listen_addr = 0.0.0.0
-auth_type = plain
-auth_file = users.txt
-logfile = pgbouncer.log
-pidfile = pgbouncer.pid
-ignore_startup_parameters=options
-</codeblock></li>
-            <li>Create the <codeph>users.txt</codeph> PgBouncer authentication file. The first field
-              is the user name and the second is the LDAP or Active Directory lookup string for the
-              user. For OpenLDAP or ApacheDS, for example, a user entry in the
-                <filepath>users.txt</filepath> looks like
-                this:<codeblock>"gpdbuser1" "ldap://10.0.0.11:10389/uid=gpdbuser1,ou=users,ou=system"</codeblock><p>For
-                Active Directory, a user entry looks like this
-                example:<codeblock>"gpdbuser1" "ldap://10.0.0.12:389/gpdbuser1"</codeblock></p></li>
-            <li>Start PgBouncer with the <codeph>config.ini</codeph> file you
-              created:<codeblock>$ pgbouncer -d config.ini</codeblock></li>
-          </ol></p>
-      </body>
-    </topic>
-    <topic id="topic_nfn_tvd_5s">
-      <title>Securing PgBouncer Connections with stunnel</title>
-      <body>
-        <p>PgBouncer does not have SSL support, so connections between database clients and
-          PgBouncer are not encrypted. To encrypt these connections, you can use <xref
-            href="https://www.stunnel.org/index.html" format="html" scope="external">stunnel</xref>, a free
-          software utility. stunnel is a proxy that uses the OpenSSL cryptographic library to add
-          TLS encryption to network services. Newer versions of stunnel support the PostgreSQL libpq
-          protocol, so Greenplum and PostgreSQL clients can use libpq SSL support to connect
-          securely over the network to a stunnel instance set up as a proxy for PgBouncer. If you
-          use a version of stunnel without libpq support, you need to set up a stunnel instance on
-          both the client and PgBouncer host to create a secure tunnel over the network.</p>
-        <p>On most platforms, you can install stunnel using the system package manager. For Windows,
-          you can download an installer from <xref href="https://www.stunnel.org/index.html" format="html"
-            scope="external">https://www.stunnel.org/index.html</xref>. You can also download and install stunnel
-          from source if a packaged version is unavailable, if you want to upgrade to a newer
-          version, or if you want to upgrade to a newer OpenSSL version. The next section provides
-          steps to download, compile, and install OpenSSL and stunnel. </p>
-        <p>For complete stunnel documentation, visit the <xref
-            href="https://www.stunnel.org/docs.html" format="html" scope="external">stunnel
-            documentation</xref> web site.</p>
-        <section>
-          <title>Installing stunnel From Source</title>
-          <p>stunnel requires a version of the OpenSSL development package greater than 1.0. The
-            following instructions download and build OpenSSL and stunnel for Red Hat or CentOS. Be
-            sure to check <xref
-              href="https://www.postgresql.org/docs/9.4/static/auth-pg-hba-conf.html" format="html"
-              scope="external">https://www.stunnel.org/index.html</xref> and <xref
-              href="https://www.postgresql.org/docs/9.4/static/auth-pg-hba-conf.html" format="html"
-              scope="external">http://openssl.org</xref> for the latest versions. </p>
-          <ol id="ol_flk_5y3_bt">
-            <li>Set the <codeph>PREFIX</codeph> environment variable to the directory where you want
-              to install stunnel, for example <filepath>/usr/local/stunnel</filepath> or
-                <filepath>/home/gpadmin/stunnel</filepath>. If you choose to install stunnel in a
-              system directory, you may need to run the <codeph>make install</codeph> commands as
-              root.
-              <codeblock>export PREFIX=<varname>/path/to/install_stunnel</varname></codeblock></li>
-            <li>The following commands download, build, and install OpenSSL version
-              1.0.2c:<codeblock>wget ftp://ftp.openssl.org/source/openssl-1.0.2c.tar.gz
-tar xzf openssl-1.0.2c.tar.gz
-cd openssl-1.0.2c
-./Configure linux-x86_64 --prefix=$PREFIX shared no-asm
-make
-make install_sw
-cd ..</codeblock></li>
-            <li>Download, build, and install stunnel with the following
-              commands:<codeblock>wget --no-check-certificate https://www.stunnel.org/downloads/stunnel-5.22.tar.gz
-tar xzf stunnel-5.22.tar.gz
-cd stunnel-5.22
-LDFLAGS="-Wl,-rpath,'"'$$'"ORIGIN/../lib'"
-./configure --prefix=$PREFIX --with-ssl=$PREFIX
-make
-make install</codeblock></li>
-          </ol>
-        </section>
-        <section>
-          <title>Setting up Stunnel for PgBouncer</title>
-          <p>Set up a stunnel instance as a proxy for PgBouncer. The stunnel instance accepts secure
-            connections from database clients on its own port, decrypts the packets and forwards
-            them to the PgBouncer instance on the same host (or on another host in a protected local
-            network). PgBouncer results, including database results from connections managed by
-            PgBouncer, are encrypted and returned over the network to the client. </p>
-          <ol id="ol_gls_zwd_5s">
-            <li>On the server running PgBouncer, create a directory for stunnel configuration files,
-              for example <filepath>/home/gpadmin/stunnel</filepath>.</li>
-            <li>Create a certificate and key file to use for authenticating. You can also use an
-              existing certificate and key, or create a new pair with the following
-                <codeph>openssl</codeph>
-                command:<codeblock>$ openssl req -new -x509 -days 3650 -nodes -out stunnel.pem -keyout stunnel.key</codeblock><p>Move
-                the <codeph>stunnel.key</codeph> and <codeph>stunnel.pem</codeph> files into your
-                stunnel configuration directory. </p></li>
-            <li>Create a stunnel configuration file, for example, <filepath>stunnel.conf</filepath>,
-              with the following
-                contents:<codeblock>
-debug = info
-socket = l:TCP_NODELAY=1
-socket = r:TCP_NODELAY=1
-
-debug = 7
-
-cert = <varname>/PATH/TO/</varname>stunnel.pem
-key = <varname>/PATH/TO/</varname>stunnel.key
-
-[pg-server]
-client=no
-accept = 0.0.0.0:5433             # This is the SSL listening port
-connect = <varname>PGHOST</varname>:<varname>PGPORT</varname>   # This is the PgBouncer listen port
-protocol = pgsql
-</codeblock><p>See
-                the <xref href="https://www.stunnel.org/static/stunnel.html#CONFIGURATION-FILE"
-                  format="html" scope="external">stunnel configuration file reference</xref> for
-                additional configuration options. </p></li>
-            <li>Run <codeph>stunnel</codeph> on the
-              server:<codeblock>stunnel <varname>/path/to/stunnel-srv.conf</varname></codeblock></li>
-            <li>On the client, connect to stunnel on its host and accept port. For
-              example:<codeblock>psql -h <varname>pgbouncer-host</varname> -p <varname>stunnel-accept-port</varname> <varname>database-name</varname></codeblock></li>
-          </ol>
-        </section>
       </body>
     </topic>
   </topic>
-</dita>

--- a/gpdb-doc/dita/admin_guide/access_db/topics/pgbouncer.xml
+++ b/gpdb-doc/dita/admin_guide/access_db/topics/pgbouncer.xml
@@ -65,8 +65,8 @@
       <body>
         <p>When you migrate to a new Greenplum Database version, you must migrate your PgBouncer
           instance to that in the new Greenplum Database installation.</p>
-        <p><b>If you are migrating to a Greenplum Database version 5.8.x or earlier</b>, you can migrate PgBouncer without dropping connections. Launch the new PgBouncer
-          process with the <codeph>-R</codeph> option and the configuration file that you started the process with:</p>
+        <ul><li><b>If you are migrating to a Greenplum Database version 5.8.x or earlier</b>, you can migrate PgBouncer without dropping connections. Launch the new PgBouncer
+          process with the <codeph>-R</codeph> option and the configuration file that you started the process with:
         <codeblock>$ pgbouncer -R -d pgbouncer.ini</codeblock>
         <p>The <codeph>-R</codeph> (reboot) option causes the new process to connect to the console
           of the old process through a Unix socket and issue the following commands:</p>
@@ -76,9 +76,10 @@ SHUTDOWN;</codeblock>
         <p>When the new process detects that the old process is gone, it resumes the work with the old
           connections. This is possible because the <codeph>SHOW FDS</codeph> command sends actual
           file descriptors to the new process. If the transition fails for any reason, kill the new
-          process and the old process will resume.</p>
-        <p><b>If you are migrating to a Greenplum Database version 5.9.0 or later</b>, you must shut down the PgBouncer instance in your old installation and reconfigure and restart PgBouncer in your new installation.</p>
-        <p>If you used stunnel to secure PgBouncer connections in your old installation, you must configure SSL/TLS in your new installation using the built-in TLS capabilities of PgBouncer 1.8.1 and later.</p>
+          process and the old process will resume.</p></li>
+        <li><b>If you are migrating to a Greenplum Database version 5.9.0 or later</b>, you must shut down the PgBouncer instance in your old installation and reconfigure and restart PgBouncer in your new installation.</li>
+        <li>If you used stunnel to secure PgBouncer connections in your old installation, you must configure SSL/TLS in your new installation using the built-in TLS capabilities of PgBouncer 1.8.1 and later.</li>
+        <li>If you used LDAP authentication in your old installation, you must configure LDAP in your new installation using the built-in PAM integration capabilities of PgBouncer 1.8.1 and later. You must also remove or replace any <codeph>ldap://</codeph>-prefixed password strings in the <codeph>auth_file</codeph>.</li></ul>
       </body>
     </topic>
     <topic id="pgb_config">
@@ -108,7 +109,7 @@ admin_users = gpadmin</codeblock></p>
           database name for the database connection. The configuration file also identifies
           the authentication mode in effect for the database. </p>
         <p>PgBouncer requires an authentication file, a text file that contains a list of
-          Greenplum Database users and passwords. The contents of the file are dependent on the <codeph>auth_type</codeph> you configure in the <codeph>pgbouncer.ini</codeph> file. Passwords may be either clear text, MD5-encoded, or an LDAP/AD lookup string.
+          Greenplum Database users and passwords. The contents of the file are dependent on the <codeph>auth_type</codeph> you configure in the <codeph>pgbouncer.ini</codeph> file. Passwords may be either clear text or MD5-encoded strings.
           You can also configure PgBouncer to query the destination database to obtain
           password information for users that are not in the authentication file. </p>
       <section id="pgb_auth">
@@ -183,13 +184,7 @@ admin_users = gpadmin</codeblock><p>The file lists databases and their connectio
             example: <codeblock>"gpadmin" "gpadmin1234"</codeblock><p>If the <codeph>auth_type</codeph>
               in the following example is <codeph>md5</codeph>, the authentication field must be
               MD5-encoded. The format for an MD5-encoded password
-              is:<codeblock>"md5" + MD5_encoded(<varname>&lt;password>&lt;username></varname>)</codeblock></p>
-            <p>To authenticate users against an LDAP or Active Directory server, the password
-              field contains an LDAP lookup string. For
-              example:</p><codeblock>"gpdbuser1" "ldap://10.0.0.11:10389/uid=gpdbuser1,ou=users,ou=system"</codeblock><p>For
-              Active Directory, a user entry looks like this
-              example:<codeblock>"gpdbuser2" "ldap://10.0.0.12:389/gpdbuser2"</codeblock>
-              </p></li>
+              is:<codeblock>"md5" + MD5_encoded(<varname>&lt;password>&lt;username></varname>)</codeblock></p></li>
           <li>Launch
               <codeph>pgbouncer</codeph>:<codeblock>$ $GPHOME/bin/pgbouncer -d pgbouncer.ini</codeblock><p>The
                 <codeph>-d</codeph> option runs PgBouncer as a

--- a/gpdb-doc/dita/admin_guide/client_auth.xml
+++ b/gpdb-doc/dita/admin_guide/client_auth.xml
@@ -14,10 +14,6 @@
       other roles to connect, or if you want to allow connections from remote hosts, you have to
       configure Greenplum Database to allow such connections. This section explains how to configure
       client connections and authentication to Greenplum Database.</p>
-    <note>The PgBouncer connection pooler is bundled with Greenplum Database. PgBouncer can be
-      configured to support LDAP or Active Directory authentication for users connecting to
-      Greenplum Database through the connection pooler client connections to Greenplum Database. See
-        <xref href="access_db/topics/pgbouncer.xml#topic_fstrm"/>. </note>
   </body>
   <topic id="topic2" xml:lang="en">
     <title id="ip142171">Allowing Connections to Greenplum Database</title>

--- a/gpdb-doc/dita/admin_guide/ldap.xml
+++ b/gpdb-doc/dita/admin_guide/ldap.xml
@@ -19,10 +19,6 @@
       clear text connection.</p>
     <p>To use LDAP authentication, the Greenplum Database master host must be configured as an LDAP
       client. See your LDAP documentation for information about configuring LDAP clients.</p>
-    <note type="note">The PgBouncer connection pooler bundled with Greenplum Database is modified to
-      support LDAP or Active Directory authentication for users connecting to Greenplum Database
-      through the connection pooler. See <xref
-        href="access_db/topics/pgbouncer.xml#topic_m2h_5dj_5s"/> for instructions. </note>
     <section>
       <title>Enabing LDAP Authentication with STARTTLS and TLS</title>
       <p>To enable STARTTLS with the TLS protocol, in the pg_hba.conf file, add an

--- a/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
+++ b/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
@@ -206,16 +206,6 @@ MIRROR_REPLICATION_PORT_BASE = 9000</codeblock></note>
               connection port and the Greenplum master host address and port in the
                 <filepath>pgbouncer.ini</filepath> configuration file. </entry>
           </row>
-          <row>
-            <entry>stunnel SSL proxy</entry>
-            <entry>TCP, ssh, libpq</entry>
-            <entry>A stunnel SSL proxy can be used to add SSL support for database clients accessing
-              the database through a pgbouncer connection pool. A secure tunnel can be set up by
-              setting up stunnel on the client and the pgbouncer host. Newer versions of stunnel
-              that support encrypted libpq connections only require stunnel on the pgbouncer host.
-              The stunnel proxy's connection ports and the pgbouncer host and port are specified in
-              the <filepath>stunnel.conf</filepath> configuration file.</entry>
-          </row>
         </tbody>
       </tgroup>
     </table>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-admin.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-admin.xml
@@ -1,0 +1,1023 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1">
+  <title>pgbouncer-admin</title>
+  <body>
+    <p>PgBouncer Administration Console.</p>
+    <section>
+      <title>Synopsis</title>
+      <codeblock>psql -p <varname>port</varname> pgbouncer</codeblock>
+    </section>
+    <section>
+      <title>Description</title>
+        <p>The PgBouncer Adminstration Console is available via <codeph>psql</codeph>. Connect to the PgBouncer <codeph><varname>port</varname></codeph> and the virtual database named <codeph>pgbouncer</codeph> to log in to the console.</p>
+        <p>Users listed in the <codeph>pgbouncer.ini</codeph> configuration parameters <codeph>admin_users</codeph> and <codeph>stats_users</codeph> have privileges to log in to the PgBouncer Administration Console.</p>
+        <p>You can control connections between PgBouncer and Greenplum Database from the console. You can also set PgBouncer configuration parameters. </p>
+    </section>
+    <section>
+        <title>Options</title>
+        <parml>
+          <plentry>
+            <pt>-p <varname>port</varname> </pt>
+            <pd>The PgBouncer port number.</pd>
+          </plentry>
+        </parml>
+    </section>
+  </body>
+
+  <topic id="topic_bk3_3jc_dt">
+    <title>Command Syntax</title>
+    <body>
+      <codeblock>pgbouncer=# SHOW help;
+NOTICE:  Console usage
+DETAIL:  
+    SHOW HELP|CONFIG|DATABASES|POOLS|CLIENTS|SERVERS|VERSION
+    SHOW FDS|SOCKETS|ACTIVE_SOCKETS|LISTS|MEM
+    SHOW DNS_HOSTS|DNS_ZONES
+    SHOW STATS|STATS_TOTALS|STATS_AVERAGES
+    SET key = arg
+    RELOAD
+    PAUSE [&lt;db>]
+    RESUME [&lt;db>]
+    DISABLE &lt;db>
+    ENABLE &lt;db>
+    KILL &lt;db>
+    SUSPEND
+    SHUTDOWN</codeblock>
+    </body>
+  </topic>
+
+  <topic id="topic_bf5_jcl_gs">
+    <title>Administration Commands</title>
+    <body>
+      <p>The following PgBouncer administration commands control the running <codeph>pgbouncer</codeph> process.</p>
+      <parml>
+        <plentry>
+          <pt>PAUSE [<varname>db</varname>]</pt>
+          <pd>If no database is specified, PgBouncer tries to disconnect from all servers, first
+            waiting for all queries to complete. The command will not return before all queries
+            are finished. This command is to be used to prepare to restart the database.</pd>
+          <pd>If a database name is specified, PgBouncer pauses only that database.</pd>
+          <pd>If you run a <codeph>PAUSE <varname>db</varname></codeph> command, and then
+            a <codeph>PAUSE</codeph> command to pause all databases, you must execute two
+              <codeph>RESUME</codeph> commands, one for all databases, and one for the named
+            database.</pd>
+        </plentry>
+        <plentry>
+          <pt>SUSPEND</pt>
+          <pd>All socket buffers are flushed and PgBouncer stops listening for data on them. The
+            command will not return before all buffers are empty. To be used when rebooting
+            PgBouncer online.</pd>
+        </plentry>
+        <plentry>
+          <pt>RESUME [ <varname>db</varname> ]</pt>
+          <pd>Resume work from a previous <codeph>PAUSE</codeph> or <codeph>SUSPEND</codeph>
+            command.</pd>
+          <pd>If a database was specified for the <codeph>PAUSE</codeph> command, the database
+            must also be specified with the <codeph>RESUME</codeph> command.</pd>
+          <pd>After pausing all databases with the <codeph>PAUSE</codeph> command, resuming a
+            single database with <codeph>RESUME <varname>db</varname></codeph> is not
+            supported.</pd>
+        </plentry>
+        <plentry>
+          <pt>DISABLE <varname>db</varname></pt>
+          <pd>Reject all new client connections on the database.</pd>
+        </plentry>
+        <plentry>
+          <pt>ENABLE <varname>db</varname></pt>
+          <pd>Allow new client connections on the database.</pd>
+        </plentry>
+        <plentry>
+          <pt>KILL <varname>db</varname></pt>
+          <pd>Immediately drop all client and server connections to the named database.</pd>
+        </plentry>
+        <plentry>
+          <pt>SHUTDOWN</pt>
+          <pd>Stop PgBouncer process. To exit from the <codeph>psql</codeph> command line
+            session, enter <codeph>\q</codeph>.</pd>
+        </plentry>
+        <plentry>
+          <pt>RELOAD</pt>
+          <pd>The PgBouncer process reloads the current configuration file and updates the
+            changeable settings.</pd>
+        </plentry>
+        <plentry>
+          <pt>SET <varname>key</varname> = <varname>value</varname></pt>
+          <pd>Override specified configuration setting. See the <xref href="#CONFIG"
+              format="dita"><codeph>SHOW CONFIG;</codeph></xref> command.</pd>
+        </plentry>
+      </parml>
+    </body>
+  </topic>
+  <topic id="topic_zfh_2dl_gs">
+    <title>SHOW Command</title>
+    <body>
+      <p>The <codeph>SHOW <varname>category</varname></codeph> command displays different types
+        of PgBouncer information. You can specify one of the following categories:<ul
+          id="ul_ims_tgl_gs">
+          <li><xref href="#ACTIVE_SOCKETS" format="dita">ACTIVE_SOCKETS</xref></li>
+          <li><xref href="#CLIENTS" format="dita">CLIENTS</xref></li>
+          <li><xref href="#CONFIG" format="dita">CONFIG</xref></li>
+          <li><xref href="#DATABASES" format="dita">DATABASES</xref></li>
+          <li><xref href="#DNS_HOSTS" format="dita">DNS_HOSTS</xref></li>
+          <li><xref href="#DNS_ZONES" format="dita">DNS_ZONES</xref></li>
+          <li><xref href="#FDS" format="dita">FDS</xref></li>
+          <li><xref href="#POOLS" format="dita">POOLS</xref></li>
+          <li><xref href="#SERVERS" format="dita">SERVERS</xref></li>
+          <li><xref href="#SOCKETS" format="dita">SOCKETS</xref></li>
+          <li><xref href="#STATS" format="dita">STATS</xref></li>
+          <li><xref href="#STATS_TOTALS" format="dita">STATS_TOTALS</xref></li>
+          <li><xref href="#STATS_AVERAGES" format="dita">STATS_AVERAGES</xref></li>
+          <li>
+            <xref href="#LISTS" format="dita">LISTS</xref></li>
+          <li>
+            <xref href="#MEM" format="dita">MEM</xref></li>
+          <li><xref href="#USERS" format="dita">USERS</xref></li>
+          <li><xref href="#VERSION" format="dita">VERSION</xref></li>
+        </ul></p>
+    </body>
+    <topic id="ACTIVE_SOCKETS">
+      <title>ACTIVE_SOCKETS</title>
+      <body>
+        <table frame="all" id="table_smh_1hl_gs">
+          <title>Active Socket Information</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>type</entry>
+                <entry>S, for server, C for client.</entry>
+              </row>
+              <row>
+                <entry>user</entry>
+                <entry>Username <codeph>pgbouncer</codeph> uses to connect to server.</entry>
+              </row>
+              <row>
+                <entry>database</entry>
+                <entry>Database name.</entry>
+              </row>
+              <row>
+                <entry>state</entry>
+                <entry>State of the server connection, one of <codeph>active</codeph>,
+                    <codeph>used</codeph> or <codeph>idle</codeph>.</entry>
+              </row>
+              <row>
+                <entry>addr</entry>
+                <entry>IP address of PostgreSQL server.</entry>
+              </row>
+              <row>
+                <entry>port</entry>
+                <entry>Port of PostgreSQL server.</entry>
+              </row>
+              <row>
+                <entry>local_addr</entry>
+                <entry>Connection start address on local machine.</entry>
+              </row>
+              <row>
+                <entry>local_port</entry>
+                <entry>Connection start port on local machine.</entry>
+              </row>
+              <row>
+                <entry>connect_time</entry>
+                <entry>When the connection was made.</entry>
+              </row>
+              <row>
+                <entry>request_time</entry>
+                <entry>When last request was issued.</entry>
+              </row>
+              <row>
+                <entry>wait</entry>
+                <entry>Time waiting.</entry>
+              </row>
+              <row>
+                <entry>wait_us</entry>
+                <entry>Time waiting (microseconds).</entry>
+              </row>
+              <row>
+                <entry>ptr</entry>
+                <entry>Address of internal object for this connection. Used as unique
+                  ID.</entry>
+              </row>
+              <row>
+                <entry>link</entry>
+                <entry>Address of client connection the server is paired with.</entry>
+              </row>
+              <row>
+                <entry>remote_pid</entry>
+                <entry>Process identifier of backend server process.</entry>
+              </row>
+              <row>
+                <entry>tls</entry>
+                <entry>TLS context.</entry>
+              </row>
+              <row>
+                <entry>recv_pos</entry>
+                <entry>Receive position in the I/O buffer.</entry>
+              </row>
+              <row>
+                <entry>pkt_pos</entry>
+                <entry>Parse position in the I/O buffer.</entry>
+              </row>
+              <row>
+                <entry>pkt_remain</entry>
+                <entry>Number of packets remaining on the socket.</entry>
+              </row>
+              <row>
+                <entry>send_pos</entry>
+                <entry>Send position in the packet.</entry>
+              </row>
+              <row>
+                <entry>send_remain</entry>
+                <entry>Total packet length remaining to send.</entry>
+              </row>
+              <row>
+                <entry>pkt_avail</entry>
+                <entry>Amount of I/O buffer left to parse.</entry>
+              </row>
+              <row>
+                <entry>send_avail</entry>
+                <entry>Amount of I/O buffer left to send.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="CLIENTS">
+      <title>CLIENTS</title>
+      <body>
+        <table frame="all" id="table_dkj_2dl_gs">
+          <title>Clients</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>type</entry>
+                <entry>C, for client.</entry>
+              </row>
+              <row>
+                <entry>user</entry>
+                <entry>Client connected user.</entry>
+              </row>
+              <row>
+                <entry>database</entry>
+                <entry>Database name.</entry>
+              </row>
+              <row>
+                <entry>state</entry>
+                <entry>State of the client connection, one of <codeph>active</codeph>,
+                    <codeph>used</codeph>, <codeph>waiting</codeph> or
+                  <codeph>idle</codeph>.</entry>
+              </row>
+              <row>
+                <entry>addr</entry>
+                <entry>IP address of client, or <codeph>unix</codeph> for a socket
+                  connection.</entry>
+              </row>
+              <row>
+                <entry>port</entry>
+                <entry>Port client is connected to.</entry>
+              </row>
+              <row>
+                <entry>local_addr</entry>
+                <entry>Connection end address on local machine.</entry>
+              </row>
+              <row>
+                <entry>local_port</entry>
+                <entry>Connection end port on local machine.</entry>
+              </row>
+              <row>
+                <entry>connect_time</entry>
+                <entry>Timestamp of connect time.</entry>
+              </row>
+              <row>
+                <entry>request_time</entry>
+                <entry>Timestamp of latest client request.</entry>
+              </row>
+              <row>
+                <entry>wait</entry>
+                <entry>Time waiting.</entry>
+              </row>
+              <row>
+                <entry>wait_us</entry>
+                <entry>Time waiting (microseconds).</entry>
+              </row>
+              <row>
+                <entry>ptr</entry>
+                <entry>Address of internal object for this connection. Used as unique
+                  ID.</entry>
+              </row>
+              <row>
+                <entry>link</entry>
+                <entry>Address of server connection the client is paired with.</entry>
+              </row>
+              <row>
+                <entry>remote_pid</entry>
+                <entry>Process ID, if client connects with Unix socket and the OS supports
+                  getting it.</entry>
+              </row>
+              <row>
+                <entry>tls</entry>
+                <entry>Client TLS context.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="CONFIG">
+      <title>CONFIG</title>
+      <body>
+        <p>List of current PgBouncer parameter settings</p>
+        <table frame="all" id="table_d2j_2dl_gs">
+          <title>Config</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>key</entry>
+                <entry> Configuration variable name</entry>
+              </row>
+              <row>
+                <entry>value</entry>
+                <entry> Configuration value</entry>
+              </row>
+              <row>
+                <entry>changeable</entry>
+                <entry>Either <codeph>yes</codeph> or <codeph>no</codeph>. Shows whether the
+                  variable can be changed while running. If <codeph>no</codeph>, the variable
+                  can be changed only at boot time.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="DATABASES">
+      <title>DATABASES</title>
+      <body>
+        <table frame="all" id="table_gfj_2dl_gs">
+          <title>Databases</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>name</entry>
+                <entry>Name of configured database entry.</entry>
+              </row>
+              <row>
+                <entry>host</entry>
+                <entry>Host pgbouncer connects to.</entry>
+              </row>
+              <row>
+                <entry>port</entry>
+                <entry>Port pgbouncer connects to.</entry>
+              </row>
+              <row>
+                <entry>database</entry>
+                <entry>Actual database name pgbouncer connects to.</entry>
+              </row>
+              <row>
+                <entry>force_user </entry>
+                <entry>When user is part of the connection string, the connection between
+                  pgbouncer and the database server is forced to the given user, whatever the
+                  client user.</entry>
+              </row>
+              <row>
+                <entry>pool_size</entry>
+                <entry>Maximum number of server connections.</entry>
+              </row>
+              <row>
+                <entry>reserve_pool</entry>
+                <entry>The number of additional connections that can be created if the pool
+                  reaches <codeph>pool_size</codeph>.</entry>
+              </row>
+              <row>
+                <entry>pool_mode</entry>
+                <entry>The database's override <codeph>pool_mode</codeph> or NULL if the default
+                  will be used instead.</entry>
+              </row>
+              <row>
+                <entry>max_connections</entry>
+                <entry>Maximum number of connections for all pools for this database.</entry>
+              </row>
+              <row>
+                <entry>current_connections</entry>
+                <entry>The total count of connections for all pools for this database.</entry>
+              </row>
+              <row>
+                <entry>paused</entry>
+                <entry>Paused/unpaused state of the database.</entry>
+              </row>
+              <row>
+                <entry>disabled</entry>
+                <entry>Enabled/disabled state of the database.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+        <p/>
+      </body>
+    </topic>
+    <topic id="DNS_HOSTS">
+      <title>DNS_HOSTS</title>
+      <body>
+        <table frame="all" id="table_r4k_2dl_gs">
+          <title>DNS Zones in Cache</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>hostname</entry>
+                <entry>Host name</entry>
+              </row>
+              <row>
+                <entry>ttl</entry>
+                <entry>How many seconds until next lookup.</entry>
+              </row>
+              <row>
+                <entry>addrs</entry>
+                <entry>Comma-separated list of addresses.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="DNS_ZONES">
+      <title>DNS_ZONES</title>
+      <body>
+        <table frame="all" id="table_r4k_2dl_gs">
+          <title>DNS Zones in Cache</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>zonename</entry>
+                <entry>Zone name</entry>
+              </row>
+              <row>
+                <entry>serial</entry>
+                <entry>Current DNS serial number</entry>
+              </row>
+              <row>
+                <entry>count</entry>
+                <entry>Hostnames belonging to this zone</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="FDS">
+      <title>FDS</title>
+      <body>
+        <p><codeph>SHOW FDS</codeph> is an internal command used for an online restart, for
+          example when upgrading to a new PgBouncer version. It displays a list of file descriptors
+          in use with the internal state attached to them. This command blocks the internal
+          event loop, so it should not be used while PgBouncer is in use.</p>
+        <p>When the connected user has username "pgbouncer", connects through a Unix socket, and
+          has the same UID as the running process, the actual file descriptors are passed over
+          the connection.</p>
+        <table frame="all" id="table_ugj_2dl_gs">
+          <title>FDS</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>fd</entry>
+                <entry>File descriptor numeric value.</entry>
+              </row>
+              <row>
+                <entry>task</entry>
+                <entry>One of <codeph>pooler</codeph>, <codeph>client</codeph>, or
+                    <codeph>server</codeph>.</entry>
+              </row>
+              <row>
+                <entry>user</entry>
+                <entry>User of the connection using the file descriptor.</entry>
+              </row>
+              <row>
+                <entry>database</entry>
+                <entry>Database of the connection using the file descriptor.</entry>
+              </row>
+              <row>
+                <entry>addr</entry>
+                <entry>IP address of the connection using the file descriptor, "unix" if a Unix
+                  socket is used.</entry>
+              </row>
+              <row>
+                <entry>port</entry>
+                <entry>Port used by the connection using the file descriptor.</entry>
+              </row>
+              <row>
+                <entry>cancel</entry>
+                <entry>Cancel key for this connection.</entry>
+              </row>
+              <row>
+                <entry>link</entry>
+                <entry>File descriptor for corresponding server/client. NULL if idle.</entry>
+              </row>
+              <row>
+                <entry>client_encoding</entry>
+                <entry>Character set used for the database.</entry>
+              </row>
+              <row>
+                <entry>std_strings</entry>
+                <entry>This controls whether ordinary string literals ('...') treat backslashes
+                  literally, as specified in the SQL standard. </entry>
+              </row>
+              <row>
+                <entry>datestyle</entry>
+                <entry>Display format for date and time values. </entry>
+              </row>
+              <row>
+                <entry>timezone</entry>
+                <entry>The timezone for interpreting and displaying time stamps. </entry>
+              </row>
+              <row>
+                <entry>password</entry>
+                <entry><codeph>auth_user</codeph>'s password.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="LISTS">
+      <title>LISTS</title>
+      <body>
+        <p>Shows the following PgBouncer statistcs in two columns: the item label and value.</p>
+        <table frame="all" id="table_sqj_2dl_gs">
+          <title>Count of PgBouncer Items</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Item</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>databases</entry>
+                <entry>Count of databases.</entry>
+              </row>
+              <row>
+                <entry>users</entry>
+                <entry>Count of users.</entry>
+              </row>
+              <row>
+                <entry>pools</entry>
+                <entry>Count of pools.</entry>
+              </row>
+              <row>
+                <entry>free_clients</entry>
+                <entry>Count of free clients.</entry>
+              </row>
+              <row>
+                <entry>used_clients</entry>
+                <entry>Count of used clients.</entry>
+              </row>
+              <row>
+                <entry>login_clients</entry>
+                <entry>Count of clients in <codeph>login</codeph> state.</entry>
+              </row>
+              <row>
+                <entry>free_servers</entry>
+                <entry>Count of free servers.</entry>
+              </row>
+              <row>
+                <entry>used_servers</entry>
+                <entry>Count of used servers.</entry>
+              </row>
+              <row>
+                <entry>dns_names</entry>
+                <entry>Count of DNS names.</entry>
+              </row>
+              <row>
+                <entry>dns_zones </entry>
+                <entry>Count of DNS zones.</entry>
+              </row>
+              <row>
+                <entry>dns_queries</entry>
+                <entry>Count of DNS queries.</entry>
+              </row>
+              <row>
+                <entry>dns_pending</entry>
+                <entry>Count of in-flight DNS queries.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="MEM">
+      <title>MEM</title>
+      <body>
+        <p>Shows cache memory information for these PgBouncer caches:<ul id="ul_uzj_2dl_gs">
+            <li>user_cache</li>
+            <li>db_cache </li>
+            <li>pool_cache </li>
+            <li>server_cache </li>
+            <li>client_cache </li>
+            <li>iobuf_cache </li>
+          </ul></p>
+        <table frame="all" id="table_ghk_2dl_gs">
+          <title>In Memory Cache</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>name</entry>
+                <entry>Name of cache.</entry>
+              </row>
+              <row>
+                <entry>size</entry>
+                <entry>The size of a single slot in the cache. </entry>
+              </row>
+              <row>
+                <entry>used</entry>
+                <entry>Number of used slots in the cache. </entry>
+              </row>
+              <row>
+                <entry>free</entry>
+                <entry>The number of available slots in the cache.</entry>
+              </row>
+              <row>
+                <entry>memtotal</entry>
+                <entry>Total bytes used by the cache.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="POOLS">
+      <title>POOLS</title>
+      <body>
+        <p>A new pool entry is made for each pair of (database, user).</p>
+        <table frame="all" id="table_n3j_2dl_gs">
+          <title>Pools</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>database</entry>
+                <entry>Database name.</entry>
+              </row>
+              <row>
+                <entry>user</entry>
+                <entry>User name.</entry>
+              </row>
+              <row>
+                <entry>cl_active</entry>
+                <entry>Client connections that are linked to server connection and can process
+                  queries.</entry>
+              </row>
+              <row>
+                <entry>cl_waiting</entry>
+                <entry>Client connections have sent queries but have not yet got a server
+                  connection.</entry>
+              </row>
+              <row>
+                <entry>sv_active</entry>
+                <entry>Server connections that linked to client.</entry>
+              </row>
+              <row>
+                <entry>sv_idle</entry>
+                <entry>Server connections that are unused and immediately usable for client
+                  queries.</entry>
+              </row>
+              <row>
+                <entry>sv_used</entry>
+                <entry>Server connections that have been idle more than
+                    <codeph>server_check_delay</codeph>. The <codeph>server_check_query</codeph>
+                  query must be run on them before they can be used.</entry>
+              </row>
+              <row>
+                <entry>sv_tested</entry>
+                <entry>Server connections that are currently running either
+                    <codeph>server_reset_query</codeph> or
+                  <codeph>server_check_query</codeph>.</entry>
+              </row>
+              <row>
+                <entry>sv_login</entry>
+                <entry>Server connections currently in process of logging in.</entry>
+              </row>
+              <row>
+                <entry>maxwait</entry>
+                <entry>How long the first (oldest) client in the queue has waited, in seconds.
+                  If this begins to increase, the current pool of servers does not handle
+                  requests fast enough. The cause may be either an overloaded server or the
+                    <codeph>pool_size</codeph> setting is too small.</entry>
+              </row>
+              <row>
+                <entry>maxwait_us</entry>
+                <entry><codeph>max_wait</codeph> (microseconds).</entry>
+              </row>
+              <row>
+                <entry>pool_mode</entry>
+                <entry>The pooling mode in use.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="SERVERS">
+      <title>SERVERS</title>
+      <body>
+        <table frame="all" id="table_imj_2dl_gs">
+          <title>Servers</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.78*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>type</entry>
+                <entry>S, for server.</entry>
+              </row>
+              <row>
+                <entry>user</entry>
+                <entry>User ID that <codeph>pgbouncer</codeph> uses to connect to
+                  server.</entry>
+              </row>
+              <row>
+                <entry>database</entry>
+                <entry>Database name.</entry>
+              </row>
+              <row>
+                <entry>state</entry>
+                <entry>State of the pgbouncer server connection, one of <codeph>active</codeph>,
+                    <codeph>used</codeph>, or <codeph>idle</codeph>.</entry>
+              </row>
+              <row>
+                <entry>addr</entry>
+                <entry>IP address of the Greenplum or PostgreSQL server.</entry>
+              </row>
+              <row>
+                <entry>port</entry>
+                <entry>Port of the Greenplum or PostgreSQL server.</entry>
+              </row>
+              <row>
+                <entry>local_addr</entry>
+                <entry>Connection start address on local machine.</entry>
+              </row>
+              <row>
+                <entry>local_port</entry>
+                <entry>Connection start port on local machine.</entry>
+              </row>
+              <row>
+                <entry>connect_time</entry>
+                <entry>When the connection was made.</entry>
+              </row>
+              <row>
+                <entry>request_time</entry>
+                <entry>When the last request was issued.</entry>
+              </row>
+              <row>
+                <entry>wait</entry>
+                <entry>Time waiting.</entry>
+              </row>
+              <row>
+                <entry>wait_us</entry>
+                <entry>Time waiting (microseconds).</entry>
+              </row>
+              <row>
+                <entry>ptr</entry>
+                <entry>Address of the internal object for this connection. Used as unique
+                  ID.</entry>
+              </row>
+              <row>
+                <entry>link</entry>
+                <entry>Address of gthe client connection the server is paired with.</entry>
+              </row>
+              <row>
+                <entry>remote_pid</entry>
+                <entry>Pid of backend server process. If the connection is made over Unix socket
+                  and the OS supports getting process ID info, it is the OS pid. Otherwise it is
+                  extracted from the cancel packet the server sent, which should be PID in case
+                  server is PostgreSQL, but it is a random number in case server is another
+                  PgBouncer.</entry>
+              </row>
+              <row>
+                <entry>tls</entry>
+                <entry>TLS context.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="STATS">
+      <title>STATS</title>
+      <body>
+        <p>Shows statistics.</p>
+        <table frame="all" id="table_ubj_2dl_gs">
+          <title>Stats</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>database</entry>
+                <entry>Statistics are presented per database.</entry>
+              </row>
+              <row>
+                <entry>total_xact_count</entry>
+                <entry>Total number of SQL transactions pooled by PgBouncer.</entry>
+              </row>
+              <row>
+                <entry>total_query_count</entry>
+                <entry>Total number of SQL queries pooled by PgBouncer.</entry>
+              </row>
+              <row>
+                <entry>total_received</entry>
+                <entry>Total volume in bytes of network traffic received by
+                    <codeph>pgbouncer</codeph>.</entry>
+              </row>
+              <row>
+                <entry>total_sent</entry>
+                <entry>Total volume in bytes of network traffic sent by
+                    <codeph>pgbouncer</codeph>.</entry>
+              </row>
+              <row>
+                <entry>total_xact_time</entry>
+                <entry>Total number of microseconds spent by PgBouncer when connected to Greenplum Database in a transaction, either idle in transaction or executing queries.</entry>
+              </row>
+              <row>
+                <entry>total_query_time</entry>
+                <entry>Total number of microseconds spent by <codeph>pgbouncer</codeph> when
+                  actively connected to the database server.</entry>
+              </row>
+              <row>
+                <entry>total_wait_time</entry>
+                <entry>Time spent (in microseconds) by clients waiting for a server.</entry>
+              </row>
+              <row>
+                <entry>avg_xact_count</entry>
+                <entry>Average number of SQL transactions pooled by PgBouncer.</entry>
+              </row>
+              <row>
+                <entry>avg_query_count</entry>
+                <entry>Average queries per second in last stats period.</entry>
+              </row>
+              <row>
+                <entry>avg_recv</entry>
+                <entry>Average received (from clients) bytes per second.</entry>
+              </row>
+              <row>
+                <entry>avg_sent</entry>
+                <entry>Average sent (to clients) bytes per second.</entry>
+              </row>
+              <row>
+                <entry>avg_xact_time</entry>
+                <entry>Average transaction duration in microseconds.</entry>
+              </row>
+              <row>
+                <entry>avg_query_time</entry>
+                <entry>Average query duration in microseconds.</entry>
+              </row>
+              <row>
+                <entry>avg_wait_time</entry>
+                <entry>Time spent by clients waiting for a server in microseconds (average per second).</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="STATS_AVERAGES">
+      <title>STATS_AVERAGES</title>
+      <body>
+        <p>Subset of <codeph>SHOW STATS</codeph> showing the average values for selected statistics.</p>
+      </body>
+    </topic>
+    <topic id="STATS_TOTALS">
+      <title>STATS_TOTALS</title>
+      <body>
+        <p>Subset of <codeph>SHOW STATS</codeph> showing the total values for selected statistics.</p>
+      </body>
+    </topic>
+    <topic id="USERS">
+      <title>USERS</title>
+      <body>
+        <table frame="all" id="table_fyj_2dl_gs">
+          <title>Users</title>
+          <tgroup cols="2">
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.7*"/>
+            <thead>
+              <row>
+                <entry>Column</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>name</entry>
+                <entry>The user name</entry>
+              </row>
+              <row>
+                <entry>pool_mode</entry>
+                <entry>The user's override pool_mode, or NULL if the default will be used
+                  instead.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="VERSION">
+      <title>VERSION</title>
+      <body>
+        <p>Display PgBouncer version information.</p>
+        <note>This reference documentation is based on the PgBouncer 1.8.1 documentation.</note>
+      </body>
+    </topic>
+  </topic>
+  <topic id="seealso">
+    <title>See Also</title>
+    <body>
+      <p><codeph><xref href="pgbouncer.xml#topic1" type="topic" format="dita"/></codeph>,
+          <codeph><xref href="pgbouncer-ini.xml#topic1" type="topic" format="dita"/></codeph></p>
+      </body>
+  </topic>
+</topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ini.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ini.xml
@@ -1,0 +1,747 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1">
+  <title>pgbouncer.ini</title>
+  <body>
+    <p>PgBouncer configuration file</p>
+    <section>
+      <title>Synopsys</title>
+      <codeblock>[databases]
+db = ...
+
+[pgbouncer]
+...
+
+[users]
+...</codeblock>
+    </section>
+    <section>
+      <title>Description</title>
+      <p>You specify Greenplum Database and PgBouncer configuration parameters and identify user-specific configuration parameters in the PgBouncer <codeph>pgbouncer.ini</codeph> configuration file.</p>
+      <p>The PgBouncer configuration file (typically named <codeph>pgbouncer.ini</codeph>)
+        is specified in <codeph>.ini</codeph> format. Files in <codeph>.ini</codeph> format are composed of
+        sections, parameters, and values. Section names are enclosed in square brackets,
+        for example, <codeph>[<varname>section_name</varname>]</codeph>. Parameters and values are
+        specified in <codeph><varname>key</varname>=<varname>value</varname></codeph>
+        format. Lines beginning with a semicolon (<codeph>;</codeph>) or pound sign
+        (<codeph>#</codeph>) are considered comment lines in <codeph>.ini</codeph>-format files
+        and are ignored.</p>
+      <p>The PgBouncer configuration file includes the following sections, described in detail below:<ul id="ul_kwg_vll_gs">
+        <li><xref href="#topic_fmd_ckd_gs" format="dita"/></li>
+        <li><xref href="#topic_orc_gkd_gs" format="dita"/></li>
+        <li><xref href="#topic_lzk_zjd_gs" format="dita"/></li>
+      </ul></p>
+    </section>
+  </body>
+
+  <topic id="topic_fmd_ckd_gs">
+    <title>[databases] Section</title>
+    <body>
+      <p>The <codeph>[databases]</codeph> section contains <codeph><varname>key</varname>=<varname>value</varname></codeph> pairs, where the <codeph><varname>key</varname></codeph> is a database name and
+        the <codeph><varname>value</varname></codeph> is a <codeph>libpq</codeph> connect-string list of <codeph><varname>key</varname></codeph>=<codeph><varname>value</varname></codeph> pairs. </p>
+      <p>A database name can contain characters <codeph>[0-9A-Za-z_.-]</codeph> without quoting.
+        Names that contain other characters must be quoted with standard SQL identifier quoting:<ul
+          id="ul_wzm_b4p_ts">
+          <li>Enclose names in double quotes (<codeph>" "</codeph>).</li>
+          <li>Represent a double-quote within an identifier with two consecutive double quote
+            characters.</li>
+        </ul></p>
+      <p>The database name <codeph>*</codeph> is the fallback database. PgBouncer uses the
+        value for this key as a connect string for the requested database. Automatically-created database entries
+        such as these are cleaned up if they remain idle longer than the time specified in
+          <codeph>autodb_idle_timeout</codeph> parameter.</p>
+      <section>
+        <title>Location Parameters</title>
+        <p>The following parameters may be included in the <codeph><varname>value</varname></codeph> to specify the location of the
+          database. </p>
+        <parml>
+          <plentry>
+            <pt>dbname</pt>
+            <pd>The destination database name.<p>Default: the client-specified database
+                name</p></pd>
+          </plentry>
+          <plentry>
+            <pt>host</pt>
+            <pd>The name or IP address of the Greenplum master host. Host names are resolved at
+              connect time. If DNS returns several results, they are used in a round-robin
+              manner. The DNS result is cached and the <codeph>dns_max_ttl</codeph> parameter
+              determines when the cache entry expires. </pd>
+            <pd>
+              <p>Default: not set; the connection is made through a Unix socket</p>
+            </pd>
+          </plentry>
+          <plentry>
+            <pt>port</pt>
+            <pd>The Greenplum Database master port.</pd>
+            <pd><p>Default: 5432</p></pd>
+          </plentry>
+          <plentry>
+            <pt>user, password</pt>
+            <pd>If <codeph>user=</codeph> is set, all connections to the destination database
+              are initiated as the specified user, resulting in a single connection pool for
+               the database.<p>If the <codeph>user=</codeph> parameter is not set, PgBouncer
+                attempts to log in to the destination database with the user name passed by the
+                client. In this situation, there will be one pool for each user who connects to the
+                database.</p></pd>
+          </plentry>
+          <plentry>
+            <pt>auth_user</pt>
+            <pd>If <codeph>auth_user</codeph> is set, any user who is not specified in
+                <codeph>auth_file</codeph> is authenticated by querying the
+                <codeph>pg_shadow</codeph> database view. PgBouncer performs this
+                query as the
+                <codeph>auth_user</codeph> Greenplum Database user. <codeph>auth_user</codeph>'s password must be set
+              in the <codeph>auth_file</codeph>.</pd>
+          </plentry>
+        </parml>
+      </section>
+      <section>
+        <title>Pool Configuration</title>
+        <p>You can use the following parameters for database-specific pool configuration.</p>
+        <parml>
+          <plentry>
+            <pt>pool_size</pt>
+            <pd>Set the maximum size of pools for this database. If not set, the
+                <codeph>default_pool_size</codeph> is used.</pd>
+          </plentry>
+          <plentry>
+            <pt>connect_query</pt>
+            <pd>Query to be executed after a connection is established, but before allowing the
+              connection to be used by any clients. If the query raises errors, they are logged
+              but ignored otherwise.</pd>
+          </plentry>
+          <plentry>
+            <pt>pool_mode</pt>
+            <pd>Set the pool mode for this database. If not set, the default
+                <codeph>pool_mode</codeph> is used.</pd>
+          </plentry>
+          <plentry>
+            <pt>max_db_connections</pt>
+            <pd>Set a database-wide maximum number of PgBouncer connections for this
+              database. The total number of connections for all pools for this database
+              will not exceed this value.
+            </pd>
+          </plentry>
+        </parml>
+      </section>
+      <section>
+        <title>Extra Parameters</title>
+        <p>The following parameters allow setting default parameters on server connections.</p>
+        <p>Note that since version 1.1 PgBouncer tracks client changes for their values, so
+          their use in <codeph>pgbouncer.ini</codeph> is deprecated now.</p>
+        <parml>
+          <plentry>
+            <pt>client_encoding</pt>
+            <pd>Ask for specific <codeph>client_encoding</codeph> from server.</pd>
+          </plentry>
+          <plentry>
+            <pt>datestyle</pt>
+            <pd>Ask for specific <codeph>datestyle</codeph> from server.</pd>
+          </plentry>
+          <plentry>
+            <pt>timezone</pt>
+            <pd>Ask for specific <codeph>timezone</codeph> from server.</pd>
+          </plentry>
+        </parml>
+      </section>
+    </body>
+  </topic>
+
+  <topic id="topic_orc_gkd_gs">
+    <title>[pgbouncer] Section</title>
+    <body>
+      <section>
+        <title>Generic Settings</title>
+        <parml>
+          <plentry>
+            <pt>logfile</pt>
+            <pd>The location of the log file. The log file is kept open. After log
+              rotation, execute <codeph>kill -HUP pgbouncer</codeph> or run the <codeph>RELOAD;</codeph>
+              command in the PgBouncer Administration Console. <p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
+            <pt>pidfile</pt>
+            <pd>The name of the pid file. Without a pidfile, you cannot run PgBouncer as a
+              background (daemon) process.<p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
+            <pt>listen_addr</pt>
+            <pd>A list of interface addresses where PgBouncer listens for TCP connections. You
+              may also use <codeph>*</codeph>, which means to listen on all interfaces. If not
+              set, only Unix socket connections are allowed.<p>Specify addresses
+                numerically (IPv4/IPv6) or by name.</p><p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
+            <pt>listen_port</pt>
+            <pd>The port PgBouncer listens on. Applies to both TCP and Unix sockets.<p>Default:
+                6432</p></pd>
+          </plentry>
+          <plentry>
+            <pt>unix_socket_dir</pt>
+            <pd>Specifies the location for the Unix sockets. Applies to both listening socket and server
+              connections. If set to an empty string, Unix sockets are disabled. Required for
+              online restart (<codeph>-R</codeph> option) to work.
+              <p>Default: <codeph>/tmp</codeph></p></pd>
+          </plentry>
+          <plentry>
+            <pt>unix_socket_mode</pt>
+            <pd>Filesystem mode for the Unix socket.<p>Default: 0777</p></pd>
+          </plentry>
+          <plentry>
+            <pt>unix_socket_group</pt>
+            <pd>Group name to use for Unix socket.<p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
+            <pt>user</pt>
+            <pd>If set, specifies the Unix user to change to after startup. This works only if
+              PgBouncer is started as root or if <codeph>user</codeph> is the same as the
+              current user.<p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
+            <pt>auth_file</pt>
+            <pd>The name of the file containing the user names and passwords to load. The file
+              format is the same as the Greenplum Database <filepath>pg_auth</filepath>
+              file.<p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
+            <pt>auth_type</pt>
+            <pd>How to authenticate users.<parml>
+                <plentry>
+                  <pt>pam</pt>
+                  <pd>Use PAM to authenticate users. <codeph>auth_file</codeph> is ignored.
+                    This method is not compatible with databases using the <codeph>auth_user</codeph> option. The service name reported to PAM is “pgbouncer”. PAM is not supported in the HBA configuration file.
+                    </pd>
+                </plentry>
+                <plentry>
+                  <pt>hba</pt>
+                  <pd>The actual authentication type is loaded from the <codeph>auth_hba_file</codeph>. This setting allows different authentication methods different access paths.
+                    </pd>
+                </plentry>
+                <plentry>
+                  <pt>cert</pt>
+                  <pd>Clients must connect with TLS using a valid client certificate. The
+                    client's username is taken from CommonName field in the certificate.</pd>
+                </plentry>
+                <plentry>
+                  <pt>md5</pt>
+                  <pd>Use MD5-based password check. <codeph>auth_file</codeph> may contain both
+                    MD5-encrypted or plain-text passwords. This is the default authentication
+                    method.</pd>
+                </plentry>
+                <plentry>
+                  <pt>plain</pt>
+                  <pd>Clear-text password is sent over wire. <i>Deprecated</i>.</pd>
+                </plentry>
+                <plentry>
+                  <pt>trust</pt>
+                  <pd>No authentication is performed. The username must still exist in the
+                      <codeph>auth_file</codeph>.</pd>
+                </plentry>
+                <plentry>
+                  <pt>any</pt>
+                  <pd>Like the <codeph>trust</codeph> method, but the username supplied is
+                    ignored. Requires that all databases are configured to log in with a
+                    specific user. Additionally, the console database allows any user to log in
+                    as admin.</pd>
+                </plentry>
+              </parml></pd>
+          </plentry>
+          <plentry>
+            <pt>auth_query</pt>
+            <pd>Query to load a user's password from the database. If a user does not exist in the
+                <codeph>auth_file</codeph> and the database entry includes an
+                <codeph>auth_user</codeph>, this query is run in the database as
+                <codeph>auth_user</codeph> to lookup up the user.<p>Note that the query is run inside target database, so if a function is used it needs to be installed into each database.</p><p>Default: <codeph>SELECT
+                  usename, passwd FROM pg_shadow WHERE usename=$1</codeph></p></pd>
+          </plentry>
+          <plentry>
+            <pt>auth_user</pt>
+            <pd>If <codeph>auth_user</codeph> is set, any user who is not specified in
+                <codeph>auth_file</codeph> is authenticated through the 
+                <codeph>auth_query</codeph> query from the <codeph>pg_shadow</codeph> database view. PgBouncer performs this
+                query as the
+                <codeph>auth_user</codeph> Greenplum Database user. <codeph>auth_user</codeph>'s password must be set
+              in the <codeph>auth_file</codeph>.<p>Direct access to <codeph>pg_shadow</codeph> requires Greenplum Database administrative privileges. It is preferable to use a non-admin user that calls <codeph>SECURITY DEFINER</codeph> function instead.</p></pd>
+          </plentry>
+          <plentry>
+            <pt>pool_mode</pt>
+            <pd>Specifies when a server connection can be reused by other clients.<parml>
+                <plentry>
+                  <pt>session</pt>
+                  <pd>Connection is returned to the pool when the client disconnects.
+                    Default.</pd>
+                </plentry>
+                <plentry>
+                  <pt>transaction</pt>
+                  <pd>Connection is returned to the pool when the transaction finishes.</pd>
+                </plentry>
+                <plentry>
+                  <pt>statement</pt>
+                  <pd>Connection is returned to the pool when the current query finishes. Long
+                    transactions with multiple statements are disallowed in this mode.</pd>
+                </plentry>
+              </parml></pd>
+          </plentry>
+          <plentry>
+            <pt>max_client_conn</pt>
+            <pd>Maximum number of client connections allowed. When increased, you should also increase the file
+              descriptor limits. The actual number of file descriptors
+              used is more than <codeph>max_client_conn</codeph>. The theoretical maximum used,
+              when each user connects with its own username to the server
+                is:<codeblock>max_client_conn + (max_pool_size * total_databases * total_users)</codeblock><p>
+                If a database user is specified in the connect string, all users connect using
+                the same username. Then the theoretical maximum connections
+                is:</p><codeblock>max_client_conn + (max_pool_size * total_databases)</codeblock><p>(The
+                theoretical maximum should be never reached, unless someone deliberately crafts a
+                load for it. Still, it means you should set the number of file descriptors to a
+                safely high number. Search for <codeph>ulimit</codeph> in your operating system
+                documentation.)</p><p>Default: 100</p></pd>
+          </plentry>
+          <plentry>
+            <pt>default_pool_size</pt>
+            <pd>The number of server connections to allow per user/database pair. This can be
+              overridden in the per-database configuration.<p>Default: 20</p></pd>
+          </plentry>
+          <plentry>
+            <pt>min_pool_size</pt>
+            <pd>Add more server connections to the pool when it is lower than this number. This
+              improves behavior when the usual load drops and then returns suddenly after a
+              period of total inactivity.<p>Default: 0 (disabled)</p></pd>
+          </plentry>
+          <plentry>
+            <pt>reserve_pool_size</pt>
+            <pd>The number of additional connections to allow for a pool. 0 disables.<p>Default:
+                0 (disabled)</p></pd>
+          </plentry>
+          <plentry>
+            <pt>reserve_pool_timeout</pt>
+            <pd>If a client has not been serviced in this many seconds, PgBouncer enables use of
+              additional connections from the reserve pool. 0 disables.<p>Default: 5.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>max_db_connections</pt>
+            <pd>The maximum number of connections per database. If you hit the limit, closing a
+              client connection to one pool does not immediately allow a server connection to be
+              established for another pool, because the server connection for the first pool is
+              still open. Once the server connection closes (due to idle timeout), a new server
+              connection will be opened for the waiting pool.<p>Default: unlimited</p></pd>
+          </plentry>
+          <plentry>
+            <pt>max_user_connections</pt>
+            <pd>The maximum number of connections per-user. When you hit the limit, closing a
+              client connection to one pool does not immediately allow a connection to be
+              established for another pool, because the connection for the first pool is still
+              open. After the connection for the first pool has closed (due to idle timeout), a
+              new server connection is opened for the waiting pool.</pd>
+          </plentry>
+          <plentry>
+            <pt>server_round_robin</pt>
+            <pd>By default, PgBouncer reuses server connections in LIFO (last-in, first-out)
+              order, so that a few connections get the most load. This provides the best
+              performance when a single server serves a database. But if there is TCP
+              round-robin behind a database IP, then it is better if PgBouncer also uses
+              connections in that manner to achieve uniform load.<p>Default: 0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>ignore_startup_parameters</pt>
+            <pd>By default, PgBouncer allows only parameters it can keep track of in startup
+              packets: <codeph>client_encoding</codeph>, <codeph>datestyle</codeph>,
+                <codeph>timezone</codeph>, and
+                <codeph>standard_conforming_strings</codeph>.<p>All others parameters raise an
+                error. To allow other parameters, specify them here so that PgBouncer can ignore
+                them.</p><p>Default: empty</p></pd>
+          </plentry>
+          <plentry>
+            <pt>disable_pqexec</pt>
+            <pd>Disable Simple Query protocol (PQexec). Unlike Extended Query protocol, Simple
+              Query protocol allows multiple queries in one packet, which allows some classes of
+              SQL-injection attacks. Disabling it can improve security. This means that only
+              clients that exclusively use Extended Query protocol will work.<p>Default:
+              0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>application_name_add_host</pt>
+            <pd>Add the client host address and port to the application name setting set on
+              connection start. This helps in identifying the source of bad queries. The setting
+              is overwritten without detection if the application executes <codeph>SET
+                application_name</codeph> after connecting. <p>Default: 0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>conffile</pt>
+            <pd>Show location of the current configuration file. Changing this parameter will result in PgBouncer using another config file for next RELOAD / SIGHUP.
+                <p>Default: file from command line</p></pd>
+          </plentry>
+          <plentry>
+            <pt>service_name</pt>
+            <pd>Used during win32 service registration.
+                <p>Default: pgbouncer</p></pd>
+          </plentry>
+          <plentry>
+            <pt>job_name</pt>
+            <pd>Alias for <codeph>service_name</codeph>.</pd>
+          </plentry>
+        </parml>
+      </section>
+      <section>
+        <title>Log Settings</title>
+        <parml>
+          <plentry>
+            <pt>syslog</pt>
+            <pd>Toggles syslog on and off.<p>Default:
+                0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>syslog_ident</pt>
+            <pd>Under what name to send logs to syslog.<p>Default:
+                <codeph>pgbouncer</codeph></p></pd>
+          </plentry>
+          <plentry>
+            <pt>syslog_facility</pt>
+            <pd>Under what facility to send logs to syslog. Some possibilities are:
+                <codeph>auth</codeph>, <codeph>authpriv</codeph>, <codeph>daemon</codeph>,
+                <codeph>user</codeph>, <codeph>local0-7</codeph><p>Default:
+                  <codeph>daemon</codeph></p></pd>
+          </plentry>
+          <plentry>
+            <pt>log_connections</pt>
+            <pd>Log successful logins.<p>Default: 1</p></pd>
+          </plentry>
+          <plentry>
+            <pt>log_disconnections</pt>
+            <pd>Log disconnections, with reasons.<p>Default: 1</p></pd>
+          </plentry>
+          <plentry>
+            <pt>log_pooler_errors</pt>
+            <pd>Log error messages that the pooler sends to clients.<p>Default: 1</p></pd>
+          </plentry>
+          <plentry>
+            <pt>stats_period</pt>
+            <pd>How often to write aggregated statistics to the log. <p>Default: 60</p></pd>
+          </plentry>
+        </parml>
+      </section>
+      <section>
+        <title>Console Access Control</title>
+        <parml>
+          <plentry>
+            <pt>admin_users</pt>
+            <pd>Comma-separated list of database users that are allowed to connect and run all
+              commands on the PgBouncer Administration Console. Ignored when <codeph>auth_type=any</codeph>, in which case
+              any username is allowed in as admin.<p>Default: empty</p></pd>
+          </plentry>
+          <plentry>
+            <pt>stats_users</pt>
+            <pd>Comma-separated list of database users that are allowed to connect and run
+              read-only queries on the console. This includes all <codeph>SHOW</codeph> commands except <codeph>SHOW
+                FDS</codeph>.<p>Default: empty</p></pd>
+          </plentry>
+        </parml>
+      </section>
+      <section>
+        <title>Connection Sanity Checks, Timeouts</title>
+        <parml>
+          <plentry>
+            <pt>server_reset_query</pt>
+            <pd>Query sent to server on connection release, before making it available to other
+              clients. At that moment no transaction is in progress so it should not include
+                <codeph>ABORT</codeph> or <codeph>ROLLBACK</codeph>.<p>The query should clean any changes made to a database session so that the next client gets a connection in a well-defined state. Default is <codeph>DISCARD ALL</codeph> which cleans everything, but that leaves the next client no pre-cached state.</p> <p>When
+                transaction pooling is used, the <codeph>server_reset_query</codeph> should be
+                empty, as clients should not use any session features. If clients do use session
+                features, they will be broken because transaction pooling does not guarantee
+                that the next query will run on the same connection.</p><p>Default:
+                  <codeph>DISCARD ALL;</codeph></p></pd>
+          </plentry>
+          <plentry>
+            <pt>server_reset_query_always</pt>
+            <pd>
+              <p>Whether <codeph>server_reset_query</codeph> should be run in all pooling modes.
+                When this setting is off (default), the <codeph>server_reset_query</codeph> will
+                be run only in pools that are in sessions pooling mode. Connections in
+                transaction pooling mode should not have any need for reset query.</p>
+              <p>Default: 0</p>
+            </pd>
+          </plentry>
+          <plentry>
+            <pt>server_check_delay</pt>
+            <pd>How long to keep released connections available for re-use without running
+              sanity-check queries on it. If 0, then the query is run always.<p>Default:
+              30.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>server_check_query</pt>
+            <pd>A simple do-nothing query to test the server connection.<p>If an empty string,
+                then sanity checking is disabled.</p><p>Default: SELECT 1;</p></pd>
+          </plentry>
+          <plentry>
+            <pt>server_lifetime</pt>
+            <pd>The pooler tries to close server connections that have been connected longer
+              than this number of seconds. Setting it to 0 means the connection is to be used
+              only once, then closed.<p>Default: 3600.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>server_idle_timeout</pt>
+            <pd>If a server connection has been idle more than this many seconds it is dropped.
+              If this parameter is set to 0, timeout is disabled. [seconds]<p>Default:
+              600.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>server_connect_timeout</pt>
+            <pd>If connection and login will not finish in this number of seconds, the
+              connection will be closed. <p>Default: 15.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>server_login_retry</pt>
+            <pd>If a login fails due to failure from <codeph>connect()</codeph> or
+              authentication, the pooler waits this many seconds before retrying to connect.
+                <p>Default: 15.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>client_login_timeout</pt>
+            <pd>If a client connects but does not manage to login in this number of seconds, it
+              is disconnected. This is needed to avoid dead connections stalling
+                <codeph>SUSPEND</codeph> and thus online restart.<p>Default: 60.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>autodb_idle_timeout</pt>
+            <pd>If database pools created automatically (via <codeph>*</codeph>) have been unused this many
+              seconds, they are freed. Their statistics are also forgotten. <p>Default:
+                3600.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>dns_max_ttl</pt>
+            <pd>How long to cache DNS lookups, in seconds. If a DNS lookup returns several
+              answers, PgBouncer round-robins between them in the meantime. The actual DNS TTL
+              is ignored. <p>Default: 15.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>dns_nxdomain_ttl</pt>
+            <pd>How long error and NXDOMAIN DNS lookups can be cached, in seconds.<p>Default:
+                15.0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>dns_zone_check_period</pt>
+            <pd>Period to check if zone serial numbers have changed.<p>PgBouncer can collect DNS
+                zones from hostnames (everything after first dot) and then periodically check if
+                the zone serial numbers change. If changes are detected, all hostnames in that
+                zone are looked up again. If any host IP changes, its connections are
+                invalidated.</p><p>Works only with UDNS and c-ares backend (<codeph>--with-udns</codeph> or <codeph>--with-cares</codeph> to
+                configure).</p><p>Default: 0.0 (disabled)</p></pd>
+          </plentry>
+        </parml>
+      </section>
+      <section>
+        <title>TLS settings</title>
+        <parml>
+          <plentry><pt>client_tls_sslmode</pt><pd>TLS mode to use for connections from clients. TLS connections are disabled by default. When enabled, <codeph>client_tls_key_file</codeph> and <codeph>client_tls_cert_file</codeph> must be also configured to set up the key and certificate PgBouncer uses to accept client connections.<ul id="ul_dgn_drd_bt">
+            <li><codeph>disable</codeph>: Plain TCP. If client requests TLS, it’s ignored. Default.</li>
+            <li><codeph>allow</codeph>: If client requests TLS, it is used. If not, plain TCP is used. If client uses client-certificate, it is not validated.</li>
+            <li><codeph>prefer</codeph>: Same as <codeph>allow</codeph>.</li>
+            <li><codeph>require</codeph>: Client must use TLS. If not, client connection is rejected. If client uses client-certificate, it is not validated.</li>
+            <li><codeph>verify-ca</codeph>: Client must use TLS with valid client certificate.</li>
+            <li><codeph>verify-full</codeph>: Same as <codeph>verify-ca</codeph>.</li></ul></pd>
+          </plentry>
+          <plentry><pt>client_tls_key_file</pt><pd>Private key for PgBouncer to accept client connections.</pd><pd><p>Default: not set</p></pd>
+          </plentry>
+          <plentry><pt>client_tls_cert_file</pt><pd>Root certificate file to validate client certificates.</pd><pd><p>Default: unset</p></pd>
+          </plentry>
+          <plentry><pt>client_tls_ca_file</pt><pd>Root certificate to validate client certificates.</pd><pd><p>Default: unset</p></pd></plentry>
+          <plentry><pt>client_tls_protocols</pt><pd>Which TLS protocol versions are allowed. </pd><pd>Valid values: are <codeph>tlsv1.0</codeph>, <codeph>tlsv1.1</codeph>, <codeph>tlsv1.2</codeph>. </pd><pd>Shortcuts: <codeph>all</codeph> (<codeph>tlsv1.0</codeph>,<codeph>tlsv1.1</codeph>,<codeph>tlsv1.2</codeph>), <codeph>secure</codeph> (<codeph>tlsv1.2</codeph>), <codeph>legacy</codeph> (<codeph>all</codeph>).</pd><pd><p>Default: <codeph>all</codeph></p></pd>
+          </plentry>
+          <plentry><pt>client_tls_ciphers</pt><pd><p>Default: <codeph>fast</codeph></p></pd>
+          </plentry>
+          <plentry><pt>client_tls_ecdhcurve</pt><pd>Elliptic Curve name to use for ECDH key exchanges.</pd><pd>Allowed values: <codeph>none</codeph> (DH is disabled), <codeph>auto</codeph> (256-bit ECDH), curve name.</pd><pd><p>Default: <codeph>auto</codeph></p></pd>
+          </plentry>
+          <plentry><pt>client_tls_dheparams</pt><pd>DHE key exchange type.</pd><pd>Allowed values: <codeph>none</codeph> (DH is disabled), <codeph>auto</codeph> (2048-bit DH), <codeph>legacy</codeph> (1024-bit DH).</pd><pd><p>Default: <codeph>auto</codeph></p></pd>
+          </plentry>
+          <plentry><pt>server_tls_sslmode</pt><pd>TLS mode to use for connections to Greenplum Database and PostgreSQL servers. TLS connections are disabled by default.<ul id="ul_hyh_1td_bt">
+            <li><codeph>disabled</codeph>: Plain TCP. TLS is not requested from the server. Default.</li>
+            <li><codeph>allow</codeph>: If server rejects plain, try TLS. (<i>PgBouncer Documentation is speculative on this..</i>)</li>
+            <li><codeph>prefer</codeph>: TLS connection is always requested first. When connection is refused, plain TPC is used. Server certificate is not validated.</li>
+            <li><codeph>require</codeph>: Connection must use TLS. If server rejects it, plain TCP is not attempted. Server certificate is not validated.</li>
+            <li><codeph>verify-ca</codeph>: Connection must use TLS and server certificate must be valid according to <codeph>server_tls_ca_file</codeph>. The server hostname is not verfied against the certificate.</li>
+            <li><codeph>verify-full</codeph>: Connection must use TLS and the server certificate must be valid according to <codeph>server_tls_ca_file</codeph>. The server hostname must match the hostname in the certificate.</li></ul></pd>
+          </plentry>
+          <plentry><pt>server_tls_ca_file</pt><pd>Path to the root certificate file used to validate Greenplum Database and PostgreSQL server certificates.</pd><pd><p>Default: unset</p></pd>
+          </plentry>
+          <plentry><pt>server_tls_key_file</pt><pd>The private key for PgBouncer to authenticate against Greenplum Database or PostgreSQL server.</pd><pd><p>Default: not set</p></pd>
+          </plentry>
+          <plentry><pt>server_tls_cert_file</pt><pd>Certificate for private key. Greenplum Database or PostgreSQL servers can validate it.</pd><pd><p>Default: not set</p></pd>
+          </plentry>
+          <plentry><pt>server_tls_protocols</pt><pd>Which TLS protocol versions are allowed. </pd><pd>Valid values are: <codeph>tlsv1.0</codeph>, <codeph>tlsv1.1</codeph>, <codeph>tlsv1.2</codeph>. </pd><pd>Shortcuts: <codeph>all</codeph> (<codeph>tlsv1.0</codeph>, <codeph>tlsv1.1</codeph>, <codeph>tlsv1.2</codeph>); <codeph>secure</codeph> (<codeph>tlsv1.2</codeph>); <codeph>legacy</codeph> (<codeph>all</codeph>).</pd><pd><p>Default: <codeph>all</codeph></p></pd>
+          </plentry>
+          <plentry><pt>server_tls_ciphers</pt><pd><p>Default: <codeph>fast</codeph></p></pd>
+          </plentry>
+        </parml>
+      </section>
+      <section>
+        <title>Dangerous Timeouts</title>
+        <p>Setting the following timeouts can cause unexpected errors.</p>
+        <parml>
+          <plentry>
+            <pt>query_timeout</pt>
+            <pd>Queries running longer than this (seconds) are canceled. This parameter should
+              be used only with a slightly smaller server-side
+                <codeph>statement_timeout</codeph>, to trap queries with network problems.
+                [seconds]<p>Default: 0.0 (disabled)</p></pd>
+          </plentry>
+          <plentry>
+            <pt>query_wait_timeout</pt>
+            <pd>The maximum time, in seconds, queries are allowed to wait for execution. If the
+              query is not assigned a connection during that time, the client is disconnected.
+              This is used to prevent unresponsive servers from grabbing up
+                connections.<p>Default: 120</p></pd>
+          </plentry>
+          <plentry>
+            <pt>client_idle_timeout</pt>
+            <pd>Client connections idling longer than this many seconds are closed. This should
+              be larger than the client-side connection lifetime settings, and only used for
+              network problems.<p>Default: 0.0 (disabled)</p></pd>
+          </plentry>
+          <plentry>
+            <pt>idle_transaction_timeout</pt>
+            <pd>If client has been in "idle in transaction" state longer than this (seconds), it
+              is disconnected. <p>Default: 0.0 (disabled)</p></pd>
+          </plentry>
+        </parml>
+      </section>
+      <section>
+        <title>Low-level Network Settings</title>
+        <parml>
+          <plentry>
+            <pt>pkt_buf</pt>
+            <pd>Internal buffer size for packets. Affects the size of TCP packets sent and
+              general memory usage. Actual <codeph>libpq</codeph> packets can be larger than this so there is no
+              need to set it large.<p>Default: 4096</p></pd>
+              </plentry>
+          <plentry>
+            <pt>max_packet_size</pt>
+            <pd>Maximum size for packets that PgBouncer accepts. One packet is either one query
+              or one result set row. A full result set can be larger.<p>Default:
+              2147483647</p></pd>
+          </plentry>
+          <plentry>
+            <pt>listen_backlog</pt>
+            <pd>Backlog argument for the <codeph>listen(2)</codeph> system call. It determines how many new
+              unanswered connection attempts are kept in queue. When the queue is full, further
+              new connection attemps are dropped.<p>Default: 128</p></pd>
+          </plentry>
+          <plentry>
+            <pt>sbuf_loopcnt</pt>
+            <pd>How many times to process data on one connection, before proceeding. Without
+              this limit, one connection with a big result set can stall PgBouncer for a long
+              time. One loop processes one <codeph>pkt_buf</codeph> amount of data. 0 means no
+                limit.<p>Default: 5</p></pd>
+          </plentry>
+          <plentry>
+            <pt>suspend_timeout</pt>
+            <pd>How many seconds to wait for buffer flush during <codeph>SUSPEND</codeph> or
+              restart (<codeph>-R</codeph>). Connection is dropped if flush does not
+                succeed.<p>Default: 10</p></pd>
+          </plentry>
+          <plentry>
+            <pt>tcp_defer_accept</pt>
+            <pd>For details on this and other TCP options, please see the tcp(7) man
+                page.<p>Default: 45 on Linux, otherwise 0</p></pd>
+          </plentry>
+          <plentry>
+            <pt>tcp_socket_buffer</pt>
+            <pd><p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
+            <pt>tcp_keepalive</pt>
+            <pd>Turns on basic keepalive with OS defaults.<p>On Linux, the system defaults are
+                  <codeph>tcp_keepidle=7200</codeph>, <codeph>tcp_keepintvl=75</codeph>,
+                  <codeph>tcp_keepcnt=9</codeph>. </p><p>Default: 1</p></pd>
+          </plentry>
+          <plentry>
+            <pt>tcp_keepcnt</pt>
+            <pd><p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
+            <pt>tcp_keepidle</pt>
+            <pd><p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
+            <pt>tcp_keepintvl</pt>
+            <pd><p>Default: not set</p></pd>
+          </plentry>
+        </parml>
+      </section>
+    </body>
+  </topic>
+
+  <topic id="topic_lzk_zjd_gs">
+    <title>[users] Section</title>
+    <body>
+      <p>This section contains <codeph><varname>key</varname></codeph>=<codeph><varname>value</varname></codeph> pairs, where the <codeph><varname>key</varname></codeph> is a user name and the
+        <codeph><varname>value</varname></codeph> is a <codeph>libpq</codeph> connect-string list of <codeph><varname>key</varname></codeph>=<codeph><varname>value</varname></codeph> pairs. </p>
+      <p>
+        <b>Pool configuration</b>
+      </p>
+      <parml>
+        <plentry>
+          <pt>pool_mode</pt>
+          <pd>Set the pool mode for all connections from this user. If not set, the
+            database or default <codeph>pool_mode</codeph> is used.</pd>
+        </plentry>
+      </parml>
+    </body>
+  </topic>
+
+  <topic id="topic_xw4_dtc_gs">
+    <title>Example Configuration Files</title>
+    <body>
+      <p>
+        <b>Minimal Configuration</b>
+      </p>
+      <codeblock>[databases]
+postgres = host=127.0.0.1 dbname=postgres auth_user=gpadmin
+
+[pgbouncer]
+pool_mode = session
+listen_port = 6543
+listen_addr = 127.0.0.1
+auth_type = md5
+auth_file = users.txt
+logfile = pgbouncer.log
+pidfile = pgbouncer.pid
+admin_users = someuser
+stats_users = stat_collector
+</codeblock>
+        <p>Use connection parameters passed by the client:</p>
+        <codeblock>[databases]
+* =
+
+[pgbouncer]
+listen_port = 6543
+listen_addr = 0.0.0.0
+auth_type = trust
+auth_file = bouncer/users.txt
+logfile = pgbouncer.log
+pidfile = pgbouncer.pid
+ignore_startup_parameters=options</codeblock>
+        <p>
+          <b>Database Defaults</b>
+        </p>
+        <codeblock>[databases]
+
+; foodb over unix socket
+foodb =
+
+; redirect bardb to bazdb on localhost
+bardb = host=127.0.0.1 dbname=bazdb
+
+; access to destination database will go with single user
+forcedb = host=127.0.0.1 port=300 user=baz password=foo client_encoding=UNICODE datestyle=ISO
+</codeblock>
+    </body>
+  </topic>
+  <topic id="seealso">
+    <title>See Also</title>
+    <body>
+      <p><codeph><xref href="pgbouncer.xml#topic1" type="topic" format="dita"/></codeph>,
+          <codeph><xref href="pgbouncer-admin.xml#topic1" type="topic" format="dita"/></codeph></p>
+      </body>
+  </topic>
+
+</topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ini.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ini.xml
@@ -199,6 +199,11 @@ db = ...
               file.<p>Default: not set</p></pd>
           </plentry>
           <plentry>
+            <pt>auth_hba_file</pt>
+            <pd>HBA configuration file to use when <codeph>auth_type</codeph> is <codeph>hba</codeph>. Refer to the <xref href="https://pgbouncer.github.io/config.html#hba-file-format" format="html" scope="external">HBA file format
+          </xref> discussion in the PgBouncer documentation for information about PgBouncer support of the HBA authentication file format.<p>Default: not set</p></pd>
+          </plentry>
+          <plentry>
             <pt>auth_type</pt>
             <pd>How to authenticate users.<parml>
                 <plentry>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ini.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ini.xml
@@ -3,7 +3,7 @@
 <topic id="topic1">
   <title>pgbouncer.ini</title>
   <body>
-    <p>PgBouncer configuration file</p>
+    <p>PgBouncer configuration file.</p>
     <section>
       <title>Synopsys</title>
       <codeblock>[databases]
@@ -17,14 +17,14 @@ db = ...
     </section>
     <section>
       <title>Description</title>
-      <p>You specify Greenplum Database and PgBouncer configuration parameters and identify user-specific configuration parameters in the PgBouncer <codeph>pgbouncer.ini</codeph> configuration file.</p>
+      <p>You specify PgBouncer configuration parameters and identify user-specific configuration parameters in the <codeph>pgbouncer.ini</codeph> configuration file.</p>
       <p>The PgBouncer configuration file (typically named <codeph>pgbouncer.ini</codeph>)
         is specified in <codeph>.ini</codeph> format. Files in <codeph>.ini</codeph> format are composed of
         sections, parameters, and values. Section names are enclosed in square brackets,
         for example, <codeph>[<varname>section_name</varname>]</codeph>. Parameters and values are
         specified in <codeph><varname>key</varname>=<varname>value</varname></codeph>
         format. Lines beginning with a semicolon (<codeph>;</codeph>) or pound sign
-        (<codeph>#</codeph>) are considered comment lines in <codeph>.ini</codeph>-format files
+        (<codeph>#</codeph>) are considered comment lines
         and are ignored.</p>
       <p>The PgBouncer configuration file includes the following sections, described in detail below:<ul id="ul_kwg_vll_gs">
         <li><xref href="#topic_fmd_ckd_gs" format="dita"/></li>
@@ -51,7 +51,7 @@ db = ...
         such as these are cleaned up if they remain idle longer than the time specified in
           <codeph>autodb_idle_timeout</codeph> parameter.</p>
       <section>
-        <title>Location Parameters</title>
+        <title>Database Connection Parameters</title>
         <p>The following parameters may be included in the <codeph><varname>value</varname></codeph> to specify the location of the
           database. </p>
         <parml>
@@ -93,6 +93,18 @@ db = ...
                 <codeph>auth_user</codeph> Greenplum Database user. <codeph>auth_user</codeph>'s password must be set
               in the <codeph>auth_file</codeph>.</pd>
           </plentry>
+          <plentry>
+            <pt>client_encoding</pt>
+            <pd>Ask for specific <codeph>client_encoding</codeph> from server.</pd>
+          </plentry>
+          <plentry>
+            <pt>datestyle</pt>
+            <pd>Ask for specific <codeph>datestyle</codeph> from server.</pd>
+          </plentry>
+          <plentry>
+            <pt>timezone</pt>
+            <pd>Ask for specific <codeph>timezone</codeph> from server.</pd>
+          </plentry>
         </parml>
       </section>
       <section>
@@ -121,26 +133,6 @@ db = ...
               database. The total number of connections for all pools for this database
               will not exceed this value.
             </pd>
-          </plentry>
-        </parml>
-      </section>
-      <section>
-        <title>Extra Parameters</title>
-        <p>The following parameters allow setting default parameters on server connections.</p>
-        <p>Note that since version 1.1 PgBouncer tracks client changes for their values, so
-          their use in <codeph>pgbouncer.ini</codeph> is deprecated now.</p>
-        <parml>
-          <plentry>
-            <pt>client_encoding</pt>
-            <pd>Ask for specific <codeph>client_encoding</codeph> from server.</pd>
-          </plentry>
-          <plentry>
-            <pt>datestyle</pt>
-            <pd>Ask for specific <codeph>datestyle</codeph> from server.</pd>
-          </plentry>
-          <plentry>
-            <pt>timezone</pt>
-            <pd>Ask for specific <codeph>timezone</codeph> from server.</pd>
           </plentry>
         </parml>
       </section>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ini.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ini.xml
@@ -26,6 +26,9 @@ db = ...
         format. Lines beginning with a semicolon (<codeph>;</codeph>) or pound sign
         (<codeph>#</codeph>) are considered comment lines
         and are ignored.</p>
+      <p>The PgBouncer configuration file can contain <codeph>%include</codeph> directives,
+        which specify another file to read and process. This enables you to split the configuration
+        file into separate parts. For example:<codeblock>%include filename</codeblock></p><p>If the filename provided is not an absolute path, the file system location is taken as relative to the current working directory.</p>
       <p>The PgBouncer configuration file includes the following sections, described in detail below:<ul id="ul_kwg_vll_gs">
         <li><xref href="#topic_fmd_ckd_gs" format="dita"/></li>
         <li><xref href="#topic_orc_gkd_gs" format="dita"/></li>
@@ -732,7 +735,7 @@ forcedb = host=127.0.0.1 port=300 user=baz password=foo client_encoding=UNICODE 
     <title>See Also</title>
     <body>
       <p><codeph><xref href="pgbouncer.xml#topic1" type="topic" format="dita"/></codeph>,
-          <codeph><xref href="pgbouncer-admin.xml#topic1" type="topic" format="dita"/></codeph></p>
+          <codeph><xref href="pgbouncer-admin.xml#topic1" type="topic" format="dita"/></codeph>, <xref href="https://pgbouncer.github.io/config.html" format="html" scope="external">PgBouncer Configuration Page</xref></p>
       </body>
   </topic>
 

--- a/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ref.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer-ref.xml
@@ -270,7 +270,7 @@ db = ...
                 <pt>logfile</pt>
                 <pd>Specifies the location of the log file. The log file is kept open. After log
                   rotation execute <codeph>kill -HUP</codeph> or run the <codeph>RELOAD;</codeph>
-                  command in the PgBouncer Administrative Console. <p>Default: not set.</p><note> On
+                  command in the PgBouncer Administration Console. <p>Default: not set.</p><note> On
                     Windows machines, the service must be stopped and started</note>.</pd>
               </plentry>
               <plentry>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+  <topic id="topic1">
+    <title>pgbouncer</title>
+    <body>
+      <p>Manages database connection pools.</p>
+      <section>
+        <title>Synopsis</title>
+        <codeblock>pgbouncer [OPTION ...] pgbouncer.ini
+
+  OPTION
+   [ -d | --daemon ]
+   [ -R | --restart ]
+   [ -q | --quiet ]
+   [ -v | --verbose ]
+   [ {-u | --user}=<varname>username</varname> ]
+
+pgbouncer [ -V | --version ] | [ -h | --help ]</codeblock>
+      </section>
+      <section>
+        <title>Description</title>
+        <p>PgBouncer is a light-weight connection pool manager for Greenplum and
+          PostgreSQL databases. PgBouncer maintains a pool of connections for each
+          database user and database combination. PgBouncer either creates a new
+          database connection for the client or reuses an existing pooled connection
+          for the same user and database. When the client disconnects, PgBouncer
+          returns the connection to the pool for re-use. </p>
+        <p>PgBouncer supports the standard connection interface shared by PostgreSQL
+          and Greenplum Database. The Greenplum Database client application (for example,
+          <codeph>psql</codeph>) connects to the host and port on which PgBouncer
+          is running rather than the Greenplum Database master host and port.</p>
+         <p>You configure PgBouncer and its access to Greenplum Database via a
+           configuration file. You provide the configuration file name, usually <codeph>pgbouncer.ini</codeph>,
+           when you run the <codeph>pgbouncer</codeph> command. This file provides location information
+           for Greenplum databases. The <codeph>pgbouncer.ini</codeph> file also specifies
+           process, connection pool, authorized users, and authentication configuration
+           for PgBouncer, among other configuration options.</p>
+        <p>By default, the <codeph>pgbouncer</codeph> process runs as a foreground
+          process. You can optionally start <codeph>pgbouncer</codeph> as a
+          background (daemon) process.</p>
+ 
+        <p>The <codeph>pgbouncer</codeph> process is owned by the operating system
+          user that starts the process. You can optionally specify a different
+          user name under which to start <codeph>pgbouncer</codeph>.</p>
+        <p>PgBouncer includes a <codeph>psql</codeph>-like administration console.
+          Authorized users can connect to a virtual database to monitor and
+          manage PgBouncer. You can manage a PgBouncer daemon process via the admin
+          console. You can also use the console to update and reload PgBouncer 
+          configuration at runtime without stopping and restarting the process.</p>
+        <p>For additional information about PgBouncer, refer to the
+          <xref href="https://pgbouncer.github.io/faq.html" format="html" scope="external"
+            >PgBouncer FAQ</xref>.</p>
+      </section>
+      <section>
+        <title>Options</title>
+        <parml>
+          <plentry>
+            <pt>-d | --daemon</pt>
+            <pd>Run PgBouncer as a daemon (a background process). The default start-up
+              mode is to run as a foreground process.</pd>
+            <pd>When run as a daemon, PgBouncer displays start-up messages to
+              <codeph>stdout</codeph>. To suppress the display of these messages,
+              include the <codeph>-q</codeph> option when you start PgBouncer.</pd>
+            <pd>To stop a PgBouncer process that was started as a daemon, issue the
+                <codeph>SHUTDOWN</codeph> command from the PgBouncer administration
+                console.</pd>
+          </plentry>
+          <plentry>
+            <pt>-R | --restart </pt>
+            <pd>Restart PgBouncer using the specified command line arguments. Non-TLS connections to
+              databases are maintained during restart; TLS connections are dropped.</pd>
+            <pd>To restart PgBouncer as a daemon, specify the options
+              <codeph>-Rd</codeph>.<note>Restart is available only if the operating
+               system supports Unix sockets and the PgBouncer <codeph>unix_socket_dir</codeph>
+               configuration is not disabled.</note></pd>
+          </plentry>
+          <plentry>
+            <pt>-q | --quiet </pt>
+            <pd>Run quietly. Do not display messages to <codeph>stdout</codeph>.</pd>
+          </plentry>
+          <plentry>
+            <pt>-v | --verbose</pt>
+            <pd>Increase message verbosity. Can be specified multiple times.</pd>
+          </plentry>
+          <plentry>
+            <pt>{-u | --user}=<varname>username</varname></pt>
+            <pd>Assume the identity of <varname>username</varname> on PgBouncer process start-up.</pd>
+          </plentry>
+          <plentry>
+            <pt>-V | --version</pt>
+            <pd>Show the version and exit.</pd>
+          </plentry>
+          <plentry>
+            <pt>-h | --help</pt>
+            <pd>Show the command help message and exit.</pd>
+          </plentry>
+        </parml>
+      </section>
+      <section id="section7">
+      <title>See Also</title>
+      <p><codeph><xref href="pgbouncer-ini.xml#topic1" type="topic" format="dita"/></codeph>,
+            <codeph><xref href="pgbouncer-admin.xml#topic1" type="topic" format="dita"/></codeph></p>
+    </section>
+    </body>
+  </topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/pgbouncer.xml
@@ -27,8 +27,8 @@ pgbouncer [ -V | --version ] | [ -h | --help ]</codeblock>
           returns the connection to the pool for re-use. </p>
         <p>PgBouncer supports the standard connection interface shared by PostgreSQL
           and Greenplum Database. The Greenplum Database client application (for example,
-          <codeph>psql</codeph>) connects to the host and port on which PgBouncer
-          is running rather than the Greenplum Database master host and port.</p>
+          <codeph>psql</codeph>) should connect to the host and port on which PgBouncer
+          is running rather than directly to the Greenplum Database master host and port.</p>
          <p>You configure PgBouncer and its access to Greenplum Database via a
            configuration file. You provide the configuration file name, usually <codeph>pgbouncer.ini</codeph>,
            when you run the <codeph>pgbouncer</codeph> command. This file provides location information
@@ -37,7 +37,7 @@ pgbouncer [ -V | --version ] | [ -h | --help ]</codeblock>
            for PgBouncer, among other configuration options.</p>
         <p>By default, the <codeph>pgbouncer</codeph> process runs as a foreground
           process. You can optionally start <codeph>pgbouncer</codeph> as a
-          background (daemon) process.</p>
+          background (daemon) process with the <codeph>-d</codeph> option.</p>
  
         <p>The <codeph>pgbouncer</codeph> process is owned by the operating system
           user that starts the process. You can optionally specify a different
@@ -45,7 +45,7 @@ pgbouncer [ -V | --version ] | [ -h | --help ]</codeblock>
         <p>PgBouncer includes a <codeph>psql</codeph>-like administration console.
           Authorized users can connect to a virtual database to monitor and
           manage PgBouncer. You can manage a PgBouncer daemon process via the admin
-          console. You can also use the console to update and reload PgBouncer 
+          console. You can also use the console to update and reload the PgBouncer 
           configuration at runtime without stopping and restarting the process.</p>
         <p>For additional information about PgBouncer, refer to the
           <xref href="https://pgbouncer.github.io/faq.html" format="html" scope="external"

--- a/gpdb-doc/dita/utility_guide/admin_utilities/util_ref.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/util_ref.xml
@@ -64,8 +64,6 @@
           <p>
             <xref href="gplogfilter.xml#topic1" type="topic" format="dita"/>
           </p>
-        </stentry>
-        <stentry>
           <p>
             <xref href="gpmapreduce.xml#topic1" type="topic" format="dita"/>
           </p>
@@ -73,6 +71,8 @@
             <p>
             <xref href="gpmovemirrors.xml#topic1"/>
           </p>-->
+        </stentry>
+        <stentry>
           <p>
             <xref href="gpperfmon_install.xml#topic1"/>
           </p>
@@ -118,7 +118,13 @@
             <xref href="gptransfer.xml#topic1"/>
           </p>
           <p>
-            <xref href="pgbouncer-ref.xml#topic1"/>
+            <xref href="pgbouncer.xml#topic1"/>
+          </p>
+          <p>
+            <xref href="pgbouncer-ini.xml#topic1"/>
+          </p>
+          <p>
+            <xref href="pgbouncer-admin.xml#topic1"/>
           </p>
         </stentry>
       </strow>

--- a/gpdb-doc/dita/utility_guide/utility_guide.ditamap
+++ b/gpdb-doc/dita/utility_guide/utility_guide.ditamap
@@ -38,7 +38,9 @@
             <topicref href="admin_utilities/gpstop.xml"/>
             <topicref href="admin_utilities/gpsys.xml"/>
             <topicref href="admin_utilities/gptransfer.xml"/>
-            <topicref href="admin_utilities/pgbouncer-ref.xml"/>
+            <topicref href="admin_utilities/pgbouncer.xml"/>
+            <topicref href="admin_utilities/pgbouncer-ini.xml"/>
+            <topicref href="admin_utilities/pgbouncer-admin.xml"/>
         </topicref>
         <topicref href="cli_ref.xml">
             <topicref href="client_utilities/ClientUtilitySummary.xml" linking="targetonly">


### PR DESCRIPTION
update pgbouncer docs for version 1.8.1:

- the pgbouncer ref page had a lot of information.  now have 3 reference pages, all in the utility guide:
     - pgbouncer command
     - pgbouncer.ini configuration file
     - pgbouncer administrative console
- retained original doc content for most of the info in the original reference page
- verified the info with pgbouncer 1.8.1 docs
- added TLS config to the pgbouncer.ini page
- moved authentication file format info from reference page to the "using" page
- "using page" updates:
     - renamed upgrade section to "migrating pgbouncer" and moved the section under the overview. add migration info for greenplum version 5.9 and later
     - split "configuring and starting" pgbouncer section into two sections
     - added section on authentication file format
     - added section on configuring hba-based authentication
     - removed section on server_reset_query
     - removed content related to stunnel configuration, setting up ldap
- removed a few notes/links to ldap/stunnel from other docs pages
- (overall) misc edits, removed windows references, expanded the content in some areas

review site links:
- http://docs-gpdb-review-staging.cfapps.io/review/utility_guide/admin_utilities/pgbouncer.html#topic1
- http://docs-gpdb-review-staging.cfapps.io/review/utility_guide/admin_utilities/pgbouncer-ini.html
- http://docs-gpdb-review-staging.cfapps.io/review/utility_guide/admin_utilities/pgbouncer-admin.html#topic1
- http://docs-gpdb-review-staging.cfapps.io/review/admin_guide/access_db/topics/pgbouncer.html
   