### PR TITLE
Add pg_basebackup flag to force overwrite of destination data directory

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -915,7 +915,8 @@ class ConfigureNewSegment(Command):
     """
 
     def __init__(self, name, confinfo, newSegments=False, tarFile=None,
-                 batchSize=None, verbose=False,ctxt=LOCAL, remoteHost=None, validationOnly=False, writeGpIdFileOnly=False):
+                 batchSize=None, verbose=False,ctxt=LOCAL, remoteHost=None, validationOnly=False, writeGpIdFileOnly=False,
+                 forceoverwrite=False):
         cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\"' % (confinfo)
         if newSegments:
             cmdStr += ' -n'
@@ -929,6 +930,8 @@ class ConfigureNewSegment(Command):
             cmdStr += " --validation-only"
         if writeGpIdFileOnly:
             cmdStr += " --write-gpid-file-only"
+        if forceoverwrite:
+            cmdStr += " --force-overwrite"
 
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -268,7 +268,7 @@ class PgControlData(Command):
         return self.datadir
 
 class PgBaseBackup(Command):
-    def __init__(self, pgdata, host, port, excludePaths=[], ctxt=LOCAL, remoteHost=None):
+    def __init__(self, pgdata, host, port, excludePaths=[], ctxt=LOCAL, remoteHost=None, forceoverwrite=False):
         cmd_tokens = ['pg_basebackup',
                            '-x', '-R',
                            '-c', 'fast']
@@ -278,6 +278,10 @@ class PgBaseBackup(Command):
         cmd_tokens.append(host)
         cmd_tokens.append('-p')
         cmd_tokens.append(port)
+
+        if forceoverwrite:
+            cmd_tokens.append('--force-overwrite')
+
         # We exclude certain unnecessary directories from being copied as they will greatly
         # slow down the speed of gpinitstandby if containing a lot of data
         if excludePaths is None or len(excludePaths) == 0:
@@ -289,6 +293,8 @@ class PgBaseBackup(Command):
             cmd_tokens.append('./gpperfmon/logs')
             cmd_tokens.append('-E')
             cmd_tokens.append('./promote')
+            cmd_tokens.append('-E')
+            cmd_tokens.append('./gp_dbid')
         else:
             for path in excludePaths:
                 cmd_tokens.append('-E')

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -169,11 +169,12 @@ class GpMirrorToBuild:
 
 
 class GpMirrorListToBuild:
-    def __init__(self, toBuild, pool, quiet, parallelDegree, additionalWarnings=None, logger=logger):
+    def __init__(self, toBuild, pool, quiet, parallelDegree, additionalWarnings=None, logger=logger, forceoverwrite=False):
         self.__mirrorsToBuild = toBuild
         self.__pool = pool
         self.__quiet = quiet
         self.__parallelDegree = parallelDegree
+        self.__forceoverwrite = forceoverwrite
         self.__additionalWarnings = additionalWarnings or []
         if not logger:
             raise Exception('logger argument cannot be None')
@@ -247,7 +248,8 @@ class GpMirrorListToBuild:
         self.__ensureStopped(gpEnv, toStopDirectives)
         self.__ensureSharedMemCleaned(gpEnv, toStopDirectives)
         self.__ensureMarkedDown(gpEnv, toEnsureMarkedDown)
-        self.__cleanUpSegmentDirectories(cleanupDirectives)
+        if not self.__forceoverwrite:
+            self.__cleanUpSegmentDirectories(cleanupDirectives)
         self.__copySegmentDirectories(gpEnv, gpArray, copyDirectives)
 
         # update and save metadata in memory
@@ -398,7 +400,8 @@ class GpMirrorListToBuild:
                                           batchSize=self.__parallelDegree,
                                           ctxt=gp.REMOTE,
                                           remoteHost=hostName,
-                                          validationOnly=validationOnly)
+                                          validationOnly=validationOnly,
+                                          forceoverwrite=self.__forceoverwrite)
 
         #
         # validate directories for target segments

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -252,7 +252,7 @@ class GpRecoverSegmentProgram:
         self._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
 
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
-                                   self.__options.parallelDegree)
+                                   self.__options.parallelDegree, forceoverwrite=True)
 
     def findAndValidatePeersForFailedSegments(self, gpArray, failedSegments):
         dbIdToPeerMap = gpArray.getDbIdToPeerMap()
@@ -387,7 +387,8 @@ class GpRecoverSegmentProgram:
 
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
                                    self.__options.parallelDegree,
-                                   interfaceHostnameWarnings)
+                                   interfaceHostnameWarnings,
+                                   forceoverwrite=True)
 
     def _output_segments_with_persistent_mirroring_disabled(self, segs_persistent_mirroring_disabled=None):
         if segs_persistent_mirroring_disabled:

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -40,7 +40,7 @@ class ValidationException(Exception):
 
 class ConfExpSegCmd(Command):
     def __init__(self, name, cmdstr, datadir, port, dbid, newseg, tarfile, useLighterDirectoryValidation, isPrimary,
-                     syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, writeGpDbidFileOnly):
+                     syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, writeGpDbidFileOnly, forceoverwrite):
         """
         @param useLighterDirectoryValidation if True then we don't require an empty directory; we just require that
                                              database stuff is not there.
@@ -63,6 +63,7 @@ class ConfExpSegCmd(Command):
         self.validationOnly = validationOnly
 
         self.writeGpDbidFileOnly = writeGpDbidFileOnly
+        self.forceoverwrite = forceoverwrite
         Command.__init__(self, name, cmdstr)
 
     def validatePath(self, path):
@@ -110,7 +111,8 @@ class ConfExpSegCmd(Command):
                     # make directories, extract template update postgresql.conf
                     logger.info("Validate data directories for new segment")
                     try:
-                        self.validatePath(self.datadir)
+                        if not self.forceoverwrite:
+                            self.validatePath(self.datadir)
                     except ValidationException, e:
                         msg = "for segment with port %s: %s" %  (self.port, e.getMessage())
                         self.set_results(CommandResult(1, '', msg, True, False))
@@ -127,7 +129,8 @@ class ConfExpSegCmd(Command):
                         # Create a mirror based on the primary
                         cmd = PgBaseBackup(pgdata=self.datadir,
                                            host=self.syncWithSegmentHostname,
-                                           port=str(self.syncWithSegmentPort))
+                                           port=str(self.syncWithSegmentPort),
+                                           forceoverwrite=self.forceoverwrite)
                         try:
                             cmd.run(validateAfter=True)
                             self.set_results(CommandResult(0, '', '', True, False))
@@ -220,6 +223,7 @@ def parseargs():
     parser.add_option('-B', '--batch-size', type='int', default=DEFAULT_BATCH_SIZE, metavar='<batch_size>')
     parser.add_option("-V", "--validation-only", dest="validationOnly", action='store_true', default=False)
     parser.add_option("-W", "--write-gpid-file-only", dest="writeGpidFileOnly", action='store_true', default=False)
+    parser.add_option('-f', '--force-overwrite', dest='forceoverwrite', action='store_true', default=False)
 
     parser.set_defaults(verbose=False, filters=[], slice=(None, None))
 
@@ -300,6 +304,7 @@ try:
                            , verbose = options.verbose
                            , validationOnly = options.validationOnly
                            , writeGpDbidFileOnly = options.writeGpidFileOnly
+                           , forceoverwrite = options.forceoverwrite
                            )
         pool.addCommand(cmd)
 


### PR DESCRIPTION
Add pg_basebackup flag to force overwrite of destination data directory

Currently, pg_basebackup has a hard restriction where the destination
data directory must be empty or nonexistant. It is expected that
anything of interest should be moved somewhere temporarily and then
copied back in. To reduce the complexity, we introduce a new flag
--force-overwrite which will delete the directories or files that are
being copied from the source data directory before doing the actual
copy. Combined with the Greenplum-specific exclusion flag (-E), we are
now able to preserve files of interest.

Our main example would be gprecoverseg full recovery and pg_log
files. There have been times when a mirror fails and a full recovery
would run which would drop the entire mirror directory before running
pg_basebackup which would result in the mirror log files before the
crash to be erased. This is substantially worse when we think of
gprecoverseg rebalancing scenario where we currently do not have
pg_rewind and must run full recovery to bring the old primary back
up... which would result in vast amounts of old primary log files to
be erased. Then during rebalance, the acting primary which would
return to being a mirror also goes through a full recovery so its logs
as a primary are also removed. The obvious solution would be to tar
these logs out and untar them back in afterwards, but what if there
are other files that must be preserved. Creating a copy may be costly
in environments where disk space is valued highly.