### PR TITLE
Fixed EXTERNAL WEB TABLE crashed when ON MASTER without LOG ERRORS

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -1249,7 +1249,7 @@ InitParseState(CopyState pstate, Relation relation,
 									  islimitinrows,
 									  uri,
 									  (char *) pstate->cur_relname,
-									  true);
+									  logerrors);
 
 		pstate->cdbsreh->relid = RelationGetRelid(relation);
 

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -64,6 +64,7 @@ DROP EXTERNAL TABLE IF EXISTS tableless_ext;
 DROP EXTERNAL TABLE IF EXISTS ret_too_many_uris;
 DROP EXTERNAL TABLE IF EXISTS wet_too_many_uris;
 DROP EXTERNAL TABLE IF EXISTS exttab_basic_1;
+DROP EXTERNAL TABLE IF EXISTS exttab_basic_error_1;
 DROP EXTERNAL TABLE IF EXISTS exttab_basic_2;
 DROP EXTERNAL TABLE IF EXISTS exttab_basic_3;
 DROP EXTERNAL TABLE IF EXISTS exttab_basic_4;
@@ -362,6 +363,13 @@ SELECT * FROM gp_read_error_log('exttab_basic_1');
 SELECT COUNT(*) FROM exttab_basic_1;
 -- Error log should still be empty
 SELECT * FROM gp_read_error_log('exttab_basic_1');
+
+-- test ON MASTER without LOG ERRORS, return empty results for all rows error out
+CREATE EXTERNAL WEB TABLE exttab_basic_error_1( i int )
+EXECUTE E'cat @abs_srcdir@/data/exttab.data' ON MASTER
+FORMAT 'TEXT' (DELIMITER '|')
+SEGMENT REJECT LIMIT 20;
+SELECT * FROM exttab_basic_error_1;
 
 -- Some errors without exceeding reject limit
 CREATE EXTERNAL TABLE exttab_basic_2( i int, j text )

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -559,6 +559,16 @@ SELECT * FROM gp_read_error_log('exttab_basic_1');
 ---------+---------+----------+---------+---------+--------+---------+----------
 (0 rows)
 
+-- test ON MASTER without LOG ERRORS, return empty results for all rows error out
+CREATE EXTERNAL WEB TABLE exttab_basic_error_1( i int )
+EXECUTE E'cat @abs_srcdir@/data/exttab.data' ON MASTER
+FORMAT 'TEXT' (DELIMITER '|')
+SEGMENT REJECT LIMIT 20;
+SELECT * FROM exttab_basic_error_1;
+ i 
+---
+(0 rows)
+
 -- Some errors without exceeding reject limit
 CREATE EXTERNAL TABLE exttab_basic_2( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') FORMAT 'TEXT' (DELIMITER '|')


### PR DESCRIPTION
This is for gpdb master branch.

The fix for gpdb 5X_STABLE branch is:
https://github.com/greenplum-db/gpdb/pull/5154