### PR TITLE
Fixed EXTERNAL WEB TABLE crashed when ON MASTER without LOG ERRORS

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -1312,6 +1312,8 @@ InitParseState(CopyState pstate, Relation relation,
 	}
 	else
 	{
+		bool		log_to_file = false;
+
 		/* select the SREH mode */
 		if (fmterrtbl == InvalidOid)
 		{
@@ -1322,6 +1324,7 @@ InitParseState(CopyState pstate, Relation relation,
 		{
 			/* errors into file */
 			pstate->errMode = SREH_LOG;
+			log_to_file = true;
 		}
 
 		/* Single row error handling */
@@ -1329,7 +1332,7 @@ InitParseState(CopyState pstate, Relation relation,
 									  islimitinrows,
 									  pstate->filename,
 									  (char *) pstate->cur_relname,
-									  true);
+									  log_to_file);
 
 		pstate->cdbsreh->relid = RelationGetRelid(relation);
 

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -423,7 +423,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	 * In the case of error log file, set fmtErrorTblOid to the external table
 	 * itself.
 	 */
-	if (issreh)
+	if (issreh && singlerowerrorDesc->into_file)
 		fmtErrTblOid = reloid;
 
 	/*

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -319,6 +319,13 @@ SELECT COUNT(*) FROM exttab_basic_1;
 -- Error log should still be empty
 SELECT * FROM gp_read_error_log('exttab_basic_1');
 
+-- test ON MASTER without LOG ERRORS, return empty results for all rows error out
+CREATE EXTERNAL WEB TABLE exttab_basic_error_1( i int )
+EXECUTE E'cat @abs_srcdir@/data/exttab.data' ON MASTER
+FORMAT 'TEXT' (DELIMITER '|')
+SEGMENT REJECT LIMIT 20;
+SELECT * FROM exttab_basic_error_1;
+
 -- Some errors without exceeding reject limit
 CREATE EXTERNAL TABLE exttab_basic_2( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') FORMAT 'TEXT' (DELIMITER '|')

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -556,6 +556,16 @@ SELECT * FROM gp_read_error_log('exttab_basic_1');
 ---------+---------+----------+---------+---------+--------+---------+----------
 (0 rows)
 
+-- test ON MASTER without LOG ERRORS, return empty results for all rows error out
+CREATE EXTERNAL WEB TABLE exttab_basic_error_1( i int )
+EXECUTE E'cat @abs_srcdir@/data/exttab.data' ON MASTER
+FORMAT 'TEXT' (DELIMITER '|')
+SEGMENT REJECT LIMIT 20;
+SELECT * FROM exttab_basic_error_1;
+ i 
+---
+(0 rows)
+
 -- Some errors without exceeding reject limit
 CREATE EXTERNAL TABLE exttab_basic_2( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') FORMAT 'TEXT' (DELIMITER '|')


### PR DESCRIPTION
This is for gpdb 5X_STABLE branch, which is different from master fix.

Because the bug, previous external table catalog stored the wrong info
about 'LOG ERRORS', which will still cause crash of this bug(this fix
only correct the wrong info when storing, but can not fix the info
already wrongly stored), in this case user need to re-create the
external table.