### PR TITLE
Fix incorrect modification of storageAttributes.compress.

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -946,17 +946,6 @@ aocs_insert_values(AOCSInsertDesc idesc, Datum *d, bool *null, AOTupleId *aoTupl
 			if (err < 0)
 			{
 				Assert(!null[i]);
-
-				/*
-				 * rle_type is running on a block stream, if an object spans
-				 * multiple blocks then data will not be compressed (if
-				 * rle_type is set).
-				 */
-				if ((idesc->compType != NULL) && (pg_strcasecmp(idesc->compType, "rle_type") == 0))
-				{
-					idesc->ds[i]->ao_write.storageAttributes.compress = FALSE;
-				}
-
 				err = datumstreamwrite_lob(idesc->ds[i],
 										   datum,
 										   &idesc->blockDirectory,
@@ -1998,16 +1987,6 @@ aocs_addcol_insert_datum(AOCSAddColumnDesc desc, Datum *d, bool *isnull)
 			if (err < 0)
 			{
 				Assert(!isnull[i]);
-
-				/*
-				 * rle_type is running on a block stream, if an object spans
-				 * multiple blocks then data will not be compressed (if
-				 * rle_type is set).
-				 */
-				if (desc->dsw[i]->rle_want_compression)
-				{
-					desc->dsw[i]->ao_write.storageAttributes.compress = FALSE;
-				}
 				err = datumstreamwrite_lob(desc->dsw[i],
 										   datum,
 										   &desc->blockDirectory,

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -2040,3 +2040,31 @@ SELECT count(*) from col_large_content_block;
 (1 row)
 
 SET enable_seqscan TO ON;
+------------------------------------------------------------------------------
+-- Test to validate insert into column oriented table works when in *single
+-- insert statement* first large content block is inserted followed by bulk
+-- dense content block.
+------------------------------------------------------------------------------
+-- dummy table to help create the scenario
+CREATE TABLE ao_from_table(a INT, arr DOUBLE PRECISION[]) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- insert data to create large content header for CO table
+INSERT INTO ao_from_table
+SELECT 1,
+       array_fill(1234567890.12, ARRAY[1100])
+       FROM generate_series(1, 1);
+-- Bulk dense content header with RLE compression, need 16k rows for the same
+INSERT INTO ao_from_table SELECT 1,'{0.1}' FROM generate_series(1, 17000)i;
+CREATE TABLE co_large_and_bulk_content(a INT,
+                     arr DOUBLE PRECISION[] ENCODING (compresstype=RLE_TYPE,compresslevel=3,blocksize=8192))
+                     WITH (appendonly=true, orientation=column, compresstype=RLE_TYPE);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO co_large_and_bulk_content SELECT * FROM ao_from_table;
+-- can't do count(*) as CO optimizes to read only first column
+SELECT * FROM co_large_and_bulk_content where a > 1;
+ a | arr 
+---+-----
+(0 rows)
+

--- a/src/test/regress/sql/column_compression.sql
+++ b/src/test/regress/sql/column_compression.sql
@@ -767,3 +767,24 @@ WHERE id=1;
 -- Lets validate above insert worked.
 SELECT count(*) from col_large_content_block;
 SET enable_seqscan TO ON;
+
+------------------------------------------------------------------------------
+-- Test to validate insert into column oriented table works when in *single
+-- insert statement* first large content block is inserted followed by bulk
+-- dense content block.
+------------------------------------------------------------------------------
+-- dummy table to help create the scenario
+CREATE TABLE ao_from_table(a INT, arr DOUBLE PRECISION[]) WITH (appendonly=true);
+-- insert data to create large content header for CO table
+INSERT INTO ao_from_table
+SELECT 1,
+       array_fill(1234567890.12, ARRAY[1100])
+       FROM generate_series(1, 1);
+-- Bulk dense content header with RLE compression, need 16k rows for the same
+INSERT INTO ao_from_table SELECT 1,'{0.1}' FROM generate_series(1, 17000)i;
+CREATE TABLE co_large_and_bulk_content(a INT,
+                     arr DOUBLE PRECISION[] ENCODING (compresstype=RLE_TYPE,compresslevel=3,blocksize=8192))
+                     WITH (appendonly=true, orientation=column, compresstype=RLE_TYPE);
+INSERT INTO co_large_and_bulk_content SELECT * FROM ao_from_table;
+-- can't do count(*) as CO optimizes to read only first column
+SELECT * FROM co_large_and_bulk_content where a > 1;


### PR DESCRIPTION
For CO table, storageAttributes.compress only conveys if should apply block
compression or not. RLE is performed as stream compression within the block and
hence storageAttributes.compress true or false doesn't relate to rle at all. So,
with rle_type compression storageAttributes.compress is true for compression
levels > 1 where along with stream compression, block compression is
performed. For compress level = 1 storageAttributes.compress is always false as
no block compression is applied. Now since rle doesn't relate to
storageAttributes.compress there is no reason to touch the same based on
rle_type compression.

Also, the problem manifests more due the fact in datumstream layer
AppendOnlyStorageAttributes in DatumStreamWrite (`acc->ao_attr.compress`) is
used to decide block type whereas in cdb storage layer functions
AppendOnlyStorageAttributes from AppendOnlyStorageWrite
(`idesc->ds[i]->ao_write->storageAttributes.compress`) is used. Due to this
difference changing just one that too unnecessarily is bound to cause issue
during insert.

So, removing the unnecessary and incorrect update to
AppendOnlyStorageAttributes.

Test case showcases the failing scenario without the patch.