### PR TITLE
Add pg_log directory to basebackup static exclusion list

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1199,10 +1199,6 @@ def start_standbymaster(host, datadir, port, dbid, ncontents, era=None,
     if res:
         logger.warning("Unable to cleanup previously started standby: '%s'" % res)
 
-    #create a pg_log directory if necessary
-    CreateDirIfNecessary.remote('create standby logdir if needed', host, datadir + "/pg_log")
-
-
     cmd = GpStandbyStart.remote('start standby master',
                                 host, datadir, port, ncontents, dbid, era=era,
                                 wrapper=wrapper, wrapper_args=wrapper_args)

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -282,8 +282,6 @@ class PgBaseBackup(Command):
         # slow down the speed of gpinitstandby if containing a lot of data
         if excludePaths is None or len(excludePaths) == 0:
             cmd_tokens.append('-E')
-            cmd_tokens.append('./pg_log')
-            cmd_tokens.append('-E')
             cmd_tokens.append('./db_dumps')
             cmd_tokens.append('-E')
             cmd_tokens.append('./gpperfmon/data')

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -192,9 +192,6 @@ class GpStart:
         self._check_version()
         self._check_master_running()
 
-        if not os.path.exists(self.master_datadir + '/pg_log'):
-            os.mkdir(self.master_datadir + '/pg_log')
-
     ######
     def _basic_setup(self):
         self.gphome = gp.get_gphome()

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -139,7 +139,7 @@ PROCESS_QE () {
     if [ x"" != x"$COPY_FROM_PRIMARY_HOSTADDRESS" ]; then
         LOG_MSG "[INFO]:-Running pg_basebackup to init mirror on ${GP_HOSTADDRESS} using primary on ${COPY_FROM_PRIMARY_HOSTADDRESS} ..." 1
         RUN_COMMAND_REMOTE ${COPY_FROM_PRIMARY_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; echo 'host  replication ${GP_USER} samenet trust' >> ${COPY_FROM_PRIMARY_DIR}/pg_hba.conf; pg_ctl -D ${COPY_FROM_PRIMARY_DIR} reload"
-        RUN_COMMAND_REMOTE ${GP_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; rm -rf ${GP_DIR}; ${GPHOME}/bin/pg_basebackup -x -R -c fast -E ./pg_log -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D ${GP_DIR} -h ${COPY_FROM_PRIMARY_HOSTADDRESS} -p ${COPY_FROM_PRIMARY_PORT}; mkdir ${GP_DIR}/pg_log; mkdir ${GP_DIR}/pg_xlog/archive_status"
+        RUN_COMMAND_REMOTE ${GP_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; rm -rf ${GP_DIR}; ${GPHOME}/bin/pg_basebackup -x -R -c fast -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D ${GP_DIR} -h ${COPY_FROM_PRIMARY_HOSTADDRESS} -p ${COPY_FROM_PRIMARY_PORT}; mkdir ${GP_DIR}/pg_xlog/archive_status"
         REGISTER_MIRROR
         START_QE "-w"
         RETVAL=$?

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -209,10 +209,6 @@ class GpSegStart:
                 #
                 # segment datadir exists
                 #
-                pg_log = os.path.join(datadir, 'pg_log')
-                if not os.path.exists(pg_log):
-                    os.mkdir(pg_log)
-                    
                 postmaster_pid = os.path.join(datadir, 'postmaster.pid')
                 if os.path.exists(postmaster_pid):
                     self.logger.warning("postmaster.pid file exists, checking if recovery startup required")

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -797,6 +797,19 @@ sendDir(char *path, int basepathlen, bool sizeonly, List *tablespaces,
 			continue;			/* don't recurse into pg_xlog */
 		}
 
+		/*
+		 * We can skip pg_log because the segment logs should be unique to
+		 * each segment. However, include pg_log as an empty directory because
+		 * it is required to start the segment.
+		 */
+		if (strcmp(pathbuf, "./pg_log") == 0)
+		{
+			if (!sizeonly)
+				_tarWriteHeader(pathbuf + basepathlen + 1, NULL, &statbuf);
+
+			continue;
+		}
+
 		/* Skip if client does not want */
 		if (match_exclude_list(pathbuf, exclude))
 			continue;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/basebackup/test_basic.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/basebackup/test_basic.py
@@ -81,13 +81,3 @@ class simple(MPPTestCase):
              subprocess.check_call(['pg_basebackup', '-x', '-D', dest_dir])
         self.assertEqual(c.exception.returncode, 1)
         self.assertTrue(self.check_dir(dest_dir,'pg_xlog'))
-
-    def test_exclude_option(self):
-        """
-        @tags sanity
-        """
-
-        subprocess.check_call(['pg_basebackup', '-E', './pg_log', '-D',
-                               simple.DESTDIR])
-        pg_log = os.path.join(simple.DESTDIR, 'pg_log')
-        self.assertFalse(os.path.exists(pg_log))


### PR DESCRIPTION
The pg_log directory has always been excluded using the pg_basebackup
exclude option (-E ./pg_log). With this change, we add it to the
static list inside of basebackup. Because of this change, we are able
to remove all instances of mkdir pg_log in our management
utilities. Previously, the utilities would always have to create the
pg_log directory after running pg_basebackup because the postmaster
does a validation check on the pg_log path existing.

This also helps us align better with upstream Postgres since the
pg_basebackup exclude option is Greenplum-specific and really not
needed at all. Our dynamic exclusion list hasn't changed for a very
long time (so it's pretty much static anyways) and is not maintained
in the utilities very well. We may actually remove the pg_basebackup
exclude option in the near future.