### PR TITLE
Fix Cmockery unit test compilation

### DIFF
--- a/gpAux/extensions/pxf/test/libchurl_test.c
+++ b/gpAux/extensions/pxf/test/libchurl_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
 #define UNIT_TESTING
 

--- a/gpAux/extensions/pxf/test/pxfbridge_test.c
+++ b/gpAux/extensions/pxf/test/pxfbridge_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
 #define UNIT_TESTING
 

--- a/gpAux/extensions/pxf/test/pxffragment_test.c
+++ b/gpAux/extensions/pxf/test/pxffragment_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
 #define UNIT_TESTING
 

--- a/gpAux/extensions/pxf/test/pxfheaders_test.c
+++ b/gpAux/extensions/pxf/test/pxfheaders_test.c
@@ -22,6 +22,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
 #define UNIT_TESTING
 

--- a/gpAux/extensions/pxf/test/pxfprotocol_test.c
+++ b/gpAux/extensions/pxf/test/pxfprotocol_test.c
@@ -22,6 +22,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
 #define UNIT_TESTING
 

--- a/gpAux/extensions/pxf/test/pxfuriparser_test.c
+++ b/gpAux/extensions/pxf/test/pxfuriparser_test.c
@@ -22,6 +22,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
 #define UNIT_TESTING
 

--- a/gpAux/extensions/pxf/test/pxfutils_test.c
+++ b/gpAux/extensions/pxf/test/pxfutils_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
 #define UNIT_TESTING
 

--- a/src/backend/access/aocs/test/aocsam_test.c
+++ b/src/backend/access/aocs/test/aocsam_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 #include "../aocsam.c"
 
 /*

--- a/src/backend/access/appendonly/test/aomd_test.c
+++ b/src/backend/access/appendonly/test/aomd_test.c
@@ -4,6 +4,7 @@
 #include "cmockery.h"
 
 #include "postgres.h"
+#include "utils/memutils.h"
 #include "access/appendonlywriter.h"
 #include "catalog/pg_tablespace.h"
 

--- a/src/backend/access/appendonly/test/appendonly_visimap_entry_test.c
+++ b/src/backend/access/appendonly/test/appendonly_visimap_entry_test.c
@@ -2,6 +2,9 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include "cmockery.h"
+
+#include "postgres.h"
+#include "utils/memutils.h"
 #include "access/appendonlytid.h"
 
 #include "../appendonly_visimap_entry.c"

--- a/src/backend/cdb/test/cdbappendonlyxlog_test.c
+++ b/src/backend/cdb/test/cdbappendonlyxlog_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 #include "../cdbappendonlyxlog.c"
 
 #include "catalog/pg_tablespace.h"

--- a/src/backend/cdb/test/cdbdistributedsnapshot_test.c
+++ b/src/backend/cdb/test/cdbdistributedsnapshot_test.c
@@ -2,7 +2,9 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include "cmockery.h"
+
 #include "postgres.h"
+#include "utils/memutils.h"
 
 #include "../cdbdistributedsnapshot.c"
 

--- a/src/backend/cdb/test/cdbsrlz_test.c
+++ b/src/backend/cdb/test/cdbsrlz_test.c
@@ -6,6 +6,8 @@
 
 #include "c.h"
 
+#include "postgres.h"
+
 /* Ignore ereport */
 #include "utils/elog.h"
 #undef ereport

--- a/src/backend/executor/test/execAmi_test.c
+++ b/src/backend/executor/test/execAmi_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 #include "../execAmi.c"
 
 /* ==================== ExecEagerFree ==================== */

--- a/src/backend/executor/test/nodeShareInputScan_test.c
+++ b/src/backend/executor/test/nodeShareInputScan_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 #include "../nodeShareInputScan.c"
 
 #define FIXED_POINTER_VAL ((LargestIntegralType) 0x0000beef)

--- a/src/backend/fts/test/.gitignore
+++ b/src/backend/fts/test/.gitignore
@@ -1,0 +1,1 @@
+fts_probe_file.bak

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -4,6 +4,7 @@
 #include "cmockery.h"
 
 #include "postgres.h"
+#include "utils/memutils.h"
 
 /* Actual function body */
 #include "../ftsmessagehandler.c"

--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 #include <poll.h>
 
 static int poll_expected_return_value;

--- a/src/backend/libpq/test/auth_test.c
+++ b/src/backend/libpq/test/auth_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 #include "../auth.c"
 
 #ifdef ENABLE_GSS

--- a/src/backend/postmaster/test/syslogger_test.c
+++ b/src/backend/postmaster/test/syslogger_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 #include "../syslogger.c"
 
 time_t

--- a/src/backend/storage/file/test/compress_zlib_test.c
+++ b/src/backend/storage/file/test/compress_zlib_test.c
@@ -4,6 +4,8 @@
 #include <zconf.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+
 #include "c.h"
 
 /* Ignore ereport */

--- a/src/backend/utils/misc/test/bitmap_compression_test.c
+++ b/src/backend/utils/misc/test/bitmap_compression_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 #include "../bitmap_compression.c"
 
 void 

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -24,6 +24,7 @@ int elevel;
 
 static void elog_mock(int elevel, const char *fmt,...);
 static void write_stderr_mock(const char *fmt,...);
+int fwrite_mock(const char *data, Size size, Size count, FILE *file);
 
 /* We will capture write_stderr output using write_stderr_mock */
 #define write_stderr write_stderr_mock

--- a/src/backend/utils/resource_manager/test/memquota_test.c
+++ b/src/backend/utils/resource_manager/test/memquota_test.c
@@ -3,6 +3,9 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
+#include "postgres.h"
+#include "utils/memutils.h"
+
 #include "../memquota.c"
 
 /* ==================== ComputeMemLimitForChildGroups ==================== */

--- a/src/backend/utils/sort/test/string_wrapper_test.c
+++ b/src/backend/utils/sort/test/string_wrapper_test.c
@@ -5,6 +5,7 @@
 #include "cmockery.h"
 
 #include "postgres.h"
+#include "utils/memutils.h"
 #include "utils/string_wrapper.h"
 
 #define STRXFRM_INPUT_LENGTH_LIMIT (50)

--- a/src/include/utils/string_wrapper.h
+++ b/src/include/utils/string_wrapper.h
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <errno.h>
 #include <utils/elog.h>
+#include "utils/guc.h"
 
 #define NULL_TO_DUMMY_STR(s) ((s) == NULL ? "<<null>>" : (s))
 #define SAFE_STR_LENGTH(s) ((s) == NULL ? 0 : strlen(s))

--- a/src/test/unit/cmockery/cmockery.c
+++ b/src/test/unit/cmockery/cmockery.c
@@ -22,6 +22,7 @@
 #include <setjmp.h>
 #ifndef _WIN32
 #include <signal.h>
+#include <unistd.h>
 #endif // !_WIN32
 #include <stdarg.h>
 #include <stddef.h>
@@ -986,6 +987,7 @@ static void expect_set(
 	assert_true(number_of_values);
 	memcpy(set, values, number_of_values * sizeof(values[0]));
 	check_integer_set->set = set;
+	check_integer_set->size_of_set = number_of_values;
 	_expect_check(
 			function, parameter, file, line, check_function,
 			check_data.value, &check_integer_set->event, count);


### PR DESCRIPTION
After -Werror=implicit-function-declaration was introduced in our
configure file, Cmockery unit tests do not seem to compile on OSX. I
am not sure how these compile on Linux, but this patch should fix the
issue for any OS hitting the same.

Reference to -Werror=implicit-function-declaration addition:
https://github.com/greenplum-db/gpdb/commit/a3104caa3b0619361f77f3d36ec6563e6c397545