### PR TITLE
docs - add resgroup links to best practices memory mgmt page

### DIFF
--- a/gpdb-doc/dita/best_practices/workloads.xml
+++ b/gpdb-doc/dita/best_practices/workloads.xml
@@ -4,6 +4,7 @@
   <title>Memory and Resource Management with Resource Queues</title>
   <shortdesc>Avoid memory errors and manage Greenplum Database resources.</shortdesc>
   <body>
+    <note>Resource groups are a newer resource management scheme that enforces memory, CPU, and concurrent transaction limits in Greenplum Database. The <xref href="../admin_guide/wlmgmt.xml" format="dita" type="topic" scope="peer" >Managing Resources</xref> topic provides a comparison of the resource queue and the resource group management schemes. Refer to <xref href="../admin_guide/workload_mgmt_resgroups.xml" format="dita" type="topic" scope="peer">Using Resource Groups</xref> for configuration and usage information for this resource management scheme.</note>
     <p>Memory management has a significant impact on performance in a Greenplum Database cluster.
       The default settings are suitable for most environments. Do not change the default settings
       until you understand the memory characteristics and usage on your system. </p>


### PR DESCRIPTION
add note to best practices RQ-focused memory/resource management page describing resource groups.  include links to RQ/RG comparison page and the RG "using" page.

doc review site link:
- http://docs-gpdb-review-staging.cfapps.io/review/best_practices/workloads.html