### PR TITLE
ProcDie: Avoid replying without syncing to mirror for commit-prepared.

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1331,6 +1331,23 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
 	gxact = LockGXact(gid, GetUserId(), raiseErrorIfNotFound);
 	if (!raiseErrorIfNotFound && gxact == NULL)
 	{
+		/*
+		 * We can be here for commit-prepared and abort-prepared. Incase of
+		 * commit-prepared not able to find the gxact clearly means we already
+		 * processed the same and committed it. For abort-prepared either
+		 * prepare was never performed on this segment hence gxact doesn't
+		 * exists or it was performed but failed to respond back to QD. So,
+		 * only for commit-prepared validate if it made to mirror before
+		 * returning success to master, as for abort can't detect between
+		 * those 2 cases, plus abort anyways doesn't result in inconsistent
+		 * result. Though yes can potentially have dangling prepared
+		 * transaction on mirror for extremely thin window as any transaction
+		 * performed on primary will make sure to sync the abort prepared
+		 * record.
+		 */
+		if (isCommit)
+			wait_for_mirror();
+
 		return false;
 	}
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -12527,3 +12527,17 @@ last_xlog_replay_location()
 
 	return recptr;
 }
+
+void
+wait_for_mirror()
+{
+	XLogwrtResult tmpLogwrtResult;
+	/* use volatile pointer to prevent code rearrangement */
+	volatile XLogCtlData *xlogctl = XLogCtl;
+
+	SpinLockAcquire(&xlogctl->info_lck);
+	tmpLogwrtResult = xlogctl->LogwrtResult;
+	SpinLockRelease(&xlogctl->info_lck);
+
+	SyncRepWaitForLSN(tmpLogwrtResult.Flush);
+}

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -294,7 +294,11 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 		 */
 		if (ProcDiePending)
 		{
-			ereport(WARNING,
+			/*
+			 * FATAL only for QE's which use 2PC and hence can handle the
+			 * FATAL and retry.
+			 */
+			ereport(IS_QUERY_DISPATCHER() ? WARNING:FATAL,
 					(errcode(ERRCODE_ADMIN_SHUTDOWN),
 					 errmsg("canceling the wait for synchronous replication and terminating connection due to administrator command"),
 					 errdetail("The transaction has already committed locally, but might not have been replicated to the standby.")));

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -402,4 +402,5 @@ extern bool IsBkpBlockApplied(XLogRecord *record, uint8 block_id);
 extern XLogRecPtr
 last_xlog_replay_location(void);
 
+extern void wait_for_mirror(void);
 #endif   /* XLOG_H */


### PR DESCRIPTION
Upstream and for greenplum master if procdie is received while waiting for
replication, just WARNING is issued and transaction moves forward without
waiting for mirror. But that would cause inconsistency for QE if failover
happens to such mirror missing the commit-prepared record.

If only prepare is performed and primary is yet to process the commit-prepared,
gxact is present in memory. If commit-prepared processing is complete on primary
gxact is removed from memory. If gxact is found then we will flow through
regular commit-prepared flow, emit the xlog record and sync the same to
mirror. But if gxact is not found on primary, we used to return blindly success
to QD. Hence, modified the code to always call `SyncRepWaitForLSN()` before
replying to QD incase gxact is not found on primary.

It calls `SyncRepWaitForLSN()` with the lsn value of `flush` from
`xlogctl->LogwrtResult`, as there is no way to find-out the actual lsn value of
commit-prepared record for primary. Usage of that lsn is based on following
assumptions
	- WAL always is written serially forward
	- Synchronous mirror if has xlog record xyz must have xlog records before xyz
	- Not finding gxact entry in-memory on primary for commit-prepared retry
  	  from QD means it was for sure committed (completed) on primary

(writing automated test for same is very tricky as many things need to be controlled to effectively validate the scenario, still thinking on it but wish to open the code change. Manually verified the same using log messages and all to confidently open PR.)