### PR TITLE
Update master/standby replication status in gp_segment_configuration

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -679,6 +679,21 @@ def remove_standby_from_catalog(options, array):
         
 
 #-------------------------------------------------------------------------
+def force_fts_probe():
+    """Force an fts probe"""
+    try:
+        dburl = getDbUrlForInitStandby()
+        conn = dbconn.connect(dburl)
+        sql = "select gp_request_fts_probe_scan()"
+
+        logger.info('Forcing FTS probe.')
+        dbconn.execSQL(conn, sql)
+        conn.close()
+    except Exception, ex:
+        logger.error('Failed to force FTS probe.')
+        raise GpInitStandbyException(ex)
+
+#-------------------------------------------------------------------------
 def copy_master_datadir_to_standby(options, array, standby_datadir):
     """Copies the data directory from the master to the standby."""
 
@@ -811,6 +826,9 @@ try:
     else:
         create_standby(options)
         logger.info('Successfully created standby master on %s' % options.standby_host)
+
+    # Force an FTS probe after doing work
+    force_fts_probe()
 
 except KeyboardInterrupt:
     logger.error('User canceled')

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -541,6 +541,13 @@ void FtsLoop()
 			skipFtsProbe = true;
 #endif
 
+		if (!skipFtsProbe)
+		{
+			oldContext = MemoryContextSwitchTo(probeContext);
+			updateMasterStandbyStatus(cdbs->entry_db_info);
+			MemoryContextSwitchTo(oldContext);
+		}
+
 		if (skipFtsProbe || !has_mirrors)
 		{
 			elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -1321,7 +1321,7 @@ updateMasterStandbyStatus(CdbComponentDatabaseInfo *entry_db_info)
 	if (standby_master_mode == '\0')
 	{
 		/* standby master was deleted or did not exist */
-		if (master_mode == 's')
+		if (master_mode == GP_SEGMENT_CONFIGURATION_MODE_INSYNC)
 		{
 			ResourceOwner save = CurrentResourceOwner;
 			StartTransactionCommand();

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -23,4 +23,5 @@ ftsprobe.t: \
     $(MOCK_DIR)/backend/libpq/fe-exec_mock.o \
     $(MOCK_DIR)/backend/libpq/fe-connect_mock.o \
     $(MOCK_DIR)/backend/access/transam/xact_mock.o \
-    $(MOCK_DIR)/backend/utils/time/snapmgr_mock.o
+    $(MOCK_DIR)/backend/utils/time/snapmgr_mock.o \
+    $(MOCK_DIR)/backend/replication/gp_replication_mock.o

--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -1365,7 +1365,7 @@ test_updateMasterStandbyStatus_checkStandby_deleted(void **state)
 		sizeof(CdbComponentDatabaseInfo) * 2);
 	entry_db_info[0].dbid = 1;
 	entry_db_info[0].segindex = MASTER_CONTENT_ID;
-	entry_db_info[0].role = 'p';
+	entry_db_info[0].role = GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 	entry_db_info[0].mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
 	entry_db_info[0].status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 
@@ -1375,7 +1375,7 @@ test_updateMasterStandbyStatus_checkStandby_deleted(void **state)
 
 	expect_value(probeWalRepUpdateConfig, dbid, 1);
 	expect_value(probeWalRepUpdateConfig, segindex, MASTER_CONTENT_ID);
-	expect_value(probeWalRepUpdateConfig, role, 'p');
+	expect_value(probeWalRepUpdateConfig, role, GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY);
 	expect_value(probeWalRepUpdateConfig, IsSegmentAlive, true);
 	expect_value(probeWalRepUpdateConfig, IsInSync, false);
 	will_be_called(probeWalRepUpdateConfig);
@@ -1390,7 +1390,8 @@ test_updateMasterStandbyStatus_checkStandby_down_to_up(void **state)
 	FtsResponse mockresponse;
 	CdbComponentDatabaseInfo *entry_db_info;
 	LargestIntegralType dbids[2] = {1, 8};
-	LargestIntegralType roles[2] = {'p', 'm'};
+	LargestIntegralType roles[2] = {GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY,
+									GP_SEGMENT_CONFIGURATION_ROLE_MIRROR};
 
 	/* set up response to say standby is up */
 	mockresponse.IsMirrorUp = true;
@@ -1408,13 +1409,13 @@ test_updateMasterStandbyStatus_checkStandby_down_to_up(void **state)
 		sizeof(CdbComponentDatabaseInfo) * 2);
 	entry_db_info[0].dbid = 1;
 	entry_db_info[0].segindex = MASTER_CONTENT_ID;
-	entry_db_info[0].role = 'p';
+	entry_db_info[0].role = GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 	entry_db_info[0].mode = GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC;
 	entry_db_info[0].status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 
 	entry_db_info[1].dbid = 8;
 	entry_db_info[1].segindex = MASTER_CONTENT_ID;
-	entry_db_info[1].role = 'm';
+	entry_db_info[1].role = GP_SEGMENT_CONFIGURATION_ROLE_MIRROR;
 	entry_db_info[1].mode = GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC;
 	entry_db_info[1].status = GP_SEGMENT_CONFIGURATION_STATUS_DOWN;
 
@@ -1439,7 +1440,8 @@ test_updateMasterStandbyStatus_checkStandby_up_to_down(void **state)
 	FtsResponse mockresponse;
 	CdbComponentDatabaseInfo *entry_db_info;
 	LargestIntegralType dbids[2] = {1, 8};
-	LargestIntegralType roles[2] = {'p', 'm'};
+	LargestIntegralType roles[2] = {GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY,
+									GP_SEGMENT_CONFIGURATION_ROLE_MIRROR};
 	LargestIntegralType issegmentalive[2] = {true, false};
 
 	/* set up response to say standby is down */
@@ -1458,13 +1460,13 @@ test_updateMasterStandbyStatus_checkStandby_up_to_down(void **state)
 		sizeof(CdbComponentDatabaseInfo) * 2);
 	entry_db_info[0].dbid = 1;
 	entry_db_info[0].segindex = MASTER_CONTENT_ID;
-	entry_db_info[0].role = 'p';
+	entry_db_info[0].role = GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 	entry_db_info[0].mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
 	entry_db_info[0].status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 
 	entry_db_info[1].dbid = 8;
 	entry_db_info[1].segindex = MASTER_CONTENT_ID;
-	entry_db_info[1].role = 'm';
+	entry_db_info[1].role = GP_SEGMENT_CONFIGURATION_ROLE_MIRROR;
 	entry_db_info[1].mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
 	entry_db_info[1].status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 
@@ -1489,7 +1491,8 @@ test_updateMasterStandbyStatus_checkStandby_no_update(void **state)
 	FtsResponse mockresponse;
 	CdbComponentDatabaseInfo *entry_db_info;
 	LargestIntegralType dbids[2] = {1, 8};
-	LargestIntegralType roles[2] = {'p', 'm'};
+	LargestIntegralType roles[2] = {GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY,
+									GP_SEGMENT_CONFIGURATION_ROLE_MIRROR};
 	LargestIntegralType issegmentalive[2] = {true, false};
 
 	/* set up response to say standby is up */
@@ -1508,13 +1511,13 @@ test_updateMasterStandbyStatus_checkStandby_no_update(void **state)
 		sizeof(CdbComponentDatabaseInfo) * 2);
 	entry_db_info[0].dbid = 1;
 	entry_db_info[0].segindex = MASTER_CONTENT_ID;
-	entry_db_info[0].role = 'p';
+	entry_db_info[0].role = GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 	entry_db_info[0].mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
 	entry_db_info[0].status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 
 	entry_db_info[1].dbid = 8;
 	entry_db_info[1].segindex = MASTER_CONTENT_ID;
-	entry_db_info[1].role = 'm';
+	entry_db_info[1].role = GP_SEGMENT_CONFIGURATION_ROLE_MIRROR;
 	entry_db_info[1].mode = GP_SEGMENT_CONFIGURATION_MODE_INSYNC;
 	entry_db_info[1].status = GP_SEGMENT_CONFIGURATION_STATUS_UP;
 

--- a/src/include/postmaster/ftsprobe.h
+++ b/src/include/postmaster/ftsprobe.h
@@ -93,4 +93,5 @@ typedef struct
 } fts_context;
 
 extern bool FtsWalRepMessageSegments(CdbComponentDatabases *context);
+extern void updateMasterStandbyStatus(CdbComponentDatabaseInfo *entry_db_info);
 #endif


### PR DESCRIPTION
The master/standby information in gp_segment_configuration does not
reflect the actual replication status between the two segments. The
FTS does not probe the master because the FTS belongs to the master
and setting up an FTS probe handler for master would be redundant
because the probe information should already be accessible by the
FTS. Since the information is already accessible, copy that
master/standby replication information into gp_segment_configuration
during every probe to make gp_segment_configuration complete.

Now that FTS properly records master/standby replication status, we
should also force an FTS probe at the end of gpinitstandby instead of
waiting for the FTS probe interval to update gp_segment_configuration.

This also fixes half of https://github.com/greenplum-db/gpdb/issues/5055.