### PR TITLE
Get `rm_desc` signature and code closer to upstream

### DIFF
--- a/src/backend/access/bitmap/bitmapxlog.c
+++ b/src/backend/access/bitmap/bitmapxlog.c
@@ -662,7 +662,7 @@ out_target(StringInfo buf, RelFileNode *node)
 }
 
 void
-bitmap_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+bitmap_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/access/gin/ginxlog.c
+++ b/src/backend/access/gin/ginxlog.c
@@ -705,7 +705,7 @@ desc_node(StringInfo buf, RelFileNode node, BlockNumber blkno)
 }
 
 void
-gin_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+gin_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/access/gist/gistxlog.c
+++ b/src/backend/access/gist/gistxlog.c
@@ -363,7 +363,7 @@ out_gistxlogPageSplit(StringInfo buf, gistxlogPageSplit *xlrec)
 }
 
 void
-gist_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+gist_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -719,6 +719,6 @@ hash_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribut
 }
 
 void
-hash_desc(StringInfo buf __attribute__((unused)), XLogRecPtr beginLoc, XLogRecord *record __attribute__((unused)))
+hash_desc(StringInfo buf __attribute__((unused)), XLogRecord *record __attribute__((unused)))
 {
 }

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -5506,7 +5506,7 @@ out_target(StringInfo buf, xl_heaptid *target)
 }
 
 void
-heap_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+heap_desc(StringInfo buf, XLogRecord *record)
 {
 	char	   *rec = XLogRecGetData(record);
 	uint8		xl_info = record->xl_info;
@@ -5647,7 +5647,7 @@ bool heap_getrelfilenode(
 }
 
 void
-heap2_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+heap2_desc(StringInfo buf, XLogRecord *record)
 {
 	char	   *rec = XLogRecGetData(record);
 	uint8		xl_info = record->xl_info;

--- a/src/backend/access/nbtree/nbtxlog.c
+++ b/src/backend/access/nbtree/nbtxlog.c
@@ -1144,7 +1144,7 @@ out_delete_page(StringInfo buf, uint8 info, XLogRecord *record)
 }
 
 void
-btree_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+btree_desc(StringInfo buf, XLogRecord *record)
 {
 	char	   *rec = XLogRecGetData(record);
 	uint8		xl_info = record->xl_info;

--- a/src/backend/access/transam/clog.c
+++ b/src/backend/access/transam/clog.c
@@ -831,7 +831,7 @@ clog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 }
 
 void
-clog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+clog_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -1010,7 +1010,7 @@ DistributedLog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 }
 
 void
-DistributedLog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+DistributedLog_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/access/transam/multixact.c
+++ b/src/backend/access/transam/multixact.c
@@ -2050,7 +2050,7 @@ multixact_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __att
 }
 
 void
-multixact_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+multixact_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -247,43 +247,6 @@ add_recover_post_checkpoint_prepared_transactions_map_entry(TransactionId xid, X
 }  /* end add_recover_post_checkpoint_prepared_transactions_map_entry */
 
 /*
- * Find a mapping in the recover post checkpoint prepared transactions hash table.
- */
-bool
-TwoPhaseFindRecoverPostCheckpointPreparedTransactionsMapEntry(TransactionId xid, XLogRecPtr *m, char *caller)
-{
-  prpt_map *entry = NULL;
-  bool      found = false;
-
-  MemSet(m, 0, sizeof(XLogRecPtr));
-
-  /*
-   * The table is lazily initialised.
-   */
-  if (crashRecoverPostCheckpointPreparedTransactions_map_ht == NULL)
-  {
-    crashRecoverPostCheckpointPreparedTransactions_map_ht
-                     = init_hash("two phase post checkpoint prepared transactions map",
-                                 sizeof(TransactionId), /* keysize */
-                                 sizeof(prpt_map),
-                                 10 /* initialize for 10 entries */);
-  }
-
-  entry = hash_search(crashRecoverPostCheckpointPreparedTransactions_map_ht,
-                      &xid,
-                      HASH_FIND,
-                      &found);
-  if (entry == NULL)
-  {
-          return false;
-  }
-
-  memcpy(m, &entry->xlogrecptr, sizeof(XLogRecPtr));
-
-  return true;
-}
-
-/*
  * Remove a mapping from the recover post checkpoint prepared transactions hash table.
  */
 static void

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -6174,7 +6174,7 @@ xact_desc_assignment(StringInfo buf, xl_xact_assignment *xlrec)
 }
 
 void
-xact_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+xact_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -1271,7 +1271,7 @@ begin:;
 
 		contiguousCopy = XLogContiguousCopy(record, rdata);
 		appendStringInfo(&buf, " - ");
-		RmgrTable[record->xl_rmid].rm_desc(&buf, RecPtr, (XLogRecord*)contiguousCopy);
+		RmgrTable[record->xl_rmid].rm_desc(&buf, (XLogRecord*)contiguousCopy);
 		pfree(contiguousCopy);
 
 		elog(LOG, "%s", buf.data);
@@ -7308,7 +7308,6 @@ StartupXLOG(void)
 					xlog_outrec(&buf, record);
 					appendStringInfo(&buf, " - ");
 					RmgrTable[record->xl_rmid].rm_desc(&buf,
-													   record->xl_info,
 													 XLogRecGetData(record));
 					elog(LOG, "%s", buf.data);
 					pfree(buf.data);
@@ -10108,7 +10107,7 @@ xlog_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribut
 }
 
 void
-xlog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+xlog_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);
@@ -11460,7 +11459,6 @@ rm_redo_error_callback(void *arg)
 	initStringInfo(&buf);
 	RmgrTable[redoErrorCallBack->record->xl_rmid].rm_desc(
 												   &buf,
-												   redoErrorCallBack->location,
 												   redoErrorCallBack->record);
 
 	/* don't bother emitting empty description */

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6969,19 +6969,10 @@ StartupXLOG(void)
 
 	LastRec = RecPtr = checkPointLoc;
 
-	/*
-	 * Currently, standby mode (WAL based replication support) is not provided
-	 * to segments.
-	 * Hence it's okay to do the following only once on the segments as there
-	 * will be only one checkpoint to be analyzed.
-	 */
-	if (!IS_QUERY_DISPATCHER())
-	{
-		CheckpointExtendedRecord ckptExtended;
-		UnpackCheckPointRecord(record, &ckptExtended);
-		if (ckptExtended.ptas)
-			SetupCheckpointPreparedTransactionList(ckptExtended.ptas);
-	}
+	CheckpointExtendedRecord ckptExtended;
+	UnpackCheckPointRecord(record, &ckptExtended);
+	if (ckptExtended.ptas)
+		SetupCheckpointPreparedTransactionList(ckptExtended.ptas);
 
 	/*
 	 * Find Xacts that are distributed committed from the checkpoint record and

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -564,7 +564,7 @@ smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 }
 
 void
-smgr_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+smgr_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8           info = record->xl_info & ~XLR_INFO_MASK;
 	char            *rec = XLogRecGetData(record);

--- a/src/backend/cdb/cdbappendonlystorage.c
+++ b/src/backend/cdb/cdbappendonlystorage.c
@@ -48,7 +48,7 @@ appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 }
 
 void
-appendonly_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+appendonly_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		  xl_info = record->xl_info;
 	uint8		  info = xl_info & ~XLR_INFO_MASK;

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -2173,7 +2173,7 @@ dbase_redo(XLogRecPtr beginLoc  __attribute__((unused)), XLogRecPtr lsn  __attri
 }
 
 void
-dbase_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+dbase_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1758,7 +1758,7 @@ seq_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 }
 
 void
-seq_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+seq_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1695,7 +1695,7 @@ tblspc_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 }
 
 void
-tblspc_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+tblspc_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/storage/ipc/standby.c
+++ b/src/backend/storage/ipc/standby.c
@@ -747,7 +747,7 @@ standby_desc_running_xacts(StringInfo buf, xl_running_xacts *xlrec)
 }
 
 void
-standby_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+standby_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/utils/cache/relmapper.c
+++ b/src/backend/utils/cache/relmapper.c
@@ -896,7 +896,7 @@ relmap_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 }
 
 void
-relmap_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
+relmap_desc(StringInfo buf, XLogRecord *record)
 {
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
 	char		*rec = XLogRecGetData(record);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -147,7 +147,6 @@ bool		Debug_appendonly_rezero_quicklz_compress_scratch = false;
 bool		Debug_appendonly_rezero_quicklz_decompress_scratch = false;
 bool		Debug_appendonly_guard_end_quicklz_scratch = false;
 bool		gp_local_distributed_cache_stats = false;
-bool		Debug_xlog_insert_print = false;
 bool		debug_xlog_record_read = false;
 bool		Debug_cancel_print = false;
 bool		Debug_datumstream_write_print_small_varlena_info = false;
@@ -1604,17 +1603,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Debug_appendonly_print_datumstream,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"debug_xlog_insert_print", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Print XLOG Insert record debugging information."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_xlog_insert_print,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/access/bitmap.h
+++ b/src/include/access/bitmap.h
@@ -844,7 +844,7 @@ extern bool _bitmap_findvalue(Relation lovHeap, Relation lovIndex,
  * prototypes for functions in bitmapxlog.c
  */
 extern void bitmap_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void bitmap_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void bitmap_desc(StringInfo buf, XLogRecord *record);
 extern void bitmap_xlog_startup(void);
 extern void bitmap_xlog_cleanup(void);
 extern bool bitmap_safe_restartpoint(void);

--- a/src/include/access/clog.h
+++ b/src/include/access/clog.h
@@ -54,6 +54,6 @@ extern bool CLOGTransactionIsOld(TransactionId xid);
 #define CLOG_TRUNCATE		0x10
 
 extern void clog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void clog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void clog_desc(StringInfo buf, XLogRecord *record);
 
 #endif   /* CLOG_H */

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -81,6 +81,6 @@ extern bool DistributedLog_GetLowWaterXid(
 #define DISTRIBUTEDLOG_TRUNCATE		0x10
 
 extern void DistributedLog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void DistributedLog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void DistributedLog_desc(StringInfo buf, XLogRecord *record);
 
 #endif							/* DISTRIBUTEDLOG_H */

--- a/src/include/access/gin.h
+++ b/src/include/access/gin.h
@@ -63,7 +63,7 @@ extern void ginUpdateStats(Relation index, const GinStatsData *stats);
 
 /* ginxlog.c */
 extern void gin_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void gin_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void gin_desc(StringInfo buf, XLogRecord *record);
 extern void gin_xlog_startup(void);
 extern void gin_xlog_cleanup(void);
 extern bool gin_safe_restartpoint(void);

--- a/src/include/access/gist_private.h
+++ b/src/include/access/gist_private.h
@@ -297,7 +297,7 @@ extern GISTInsertStack *gistFindPath(Relation r, BlockNumber child);
 
 /* gistxlog.c */
 extern void gist_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void gist_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void gist_desc(StringInfo buf, XLogRecord *record);
 extern void gist_xlog_startup(void);
 extern void gist_xlog_cleanup(void);
 extern void gist_mask(char *pagedata, BlockNumber blkno);

--- a/src/include/access/hash.h
+++ b/src/include/access/hash.h
@@ -354,6 +354,6 @@ extern OffsetNumber _hash_binsearch_last(Page page, uint32 hash_value);
 
 /* hash.c */
 extern void hash_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void hash_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void hash_desc(StringInfo buf, XLogRecord *record);
 
 #endif   /* HASH_H */

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -147,12 +147,12 @@ extern void heap_restrpos(HeapScanDesc scan);
 extern void heap_sync(Relation relation);
 
 extern void heap_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *rptr);
-extern void heap_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void heap_desc(StringInfo buf, XLogRecord *record);
 extern bool heap_getrelfilenode(
 	XLogRecord 		*record,
 	RelFileNode		*relFileNode);
 extern void heap2_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *rptr);
-extern void heap2_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void heap2_desc(StringInfo buf, XLogRecord *record);
 extern void heap_mask(char *pagedata, BlockNumber blkno);
 
 extern void log_heap_newpage(Relation rel, 

--- a/src/include/access/multixact.h
+++ b/src/include/access/multixact.h
@@ -78,6 +78,6 @@ extern void multixact_twophase_postabort(TransactionId xid, uint16 info,
 
 extern void multixact_redo(XLogRecPtr beginLoc __attribute__((unused)),
 						   XLogRecPtr lsn __attribute__((unused)), XLogRecord *record);
-extern void multixact_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void multixact_desc(StringInfo buf, XLogRecord *record);
 
 #endif   /* MULTIXACT_H */

--- a/src/include/access/nbtree.h
+++ b/src/include/access/nbtree.h
@@ -646,7 +646,7 @@ extern void _bt_leafbuild(BTSpool *btspool, BTSpool *spool2);
  * prototypes for functions in nbtxlog.c
  */
 extern void btree_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void btree_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void btree_desc(StringInfo buf, XLogRecord *record);
 extern void btree_xlog_startup(void);
 extern void btree_xlog_cleanup(void);
 extern bool btree_safe_restartpoint(void);

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -105,6 +105,4 @@ extern void getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **
 
 extern void SetupCheckpointPreparedTransactionList(prepared_transaction_agg_state *ptas);
 
-extern bool TwoPhaseFindRecoverPostCheckpointPreparedTransactionsMapEntry(TransactionId xid, XLogRecPtr *m, char *caller);
-
 #endif   /* TWOPHASE_H */

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -274,7 +274,7 @@ extern void RecordDistributedForgetCommitted(struct TMGXACT_LOG *gxact_log);
 extern int	xactGetCommittedChildren(TransactionId **ptr);
 
 extern void xact_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void xact_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void xact_desc(StringInfo buf, XLogRecord *record);
 extern const char *IsoLevelAsUpperString(int IsoLevel);
 
 #endif   /* XACT_H */

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -314,7 +314,7 @@ extern XLogRecPtr XLogSaveBufferForHint(Buffer buffer);
 extern void RestoreBkpBlocks(XLogRecPtr lsn, XLogRecord *record, bool cleanup);
 
 extern void xlog_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribute__((unused)), XLogRecord *record);
-extern void xlog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void xlog_desc(StringInfo buf, XLogRecord *record);
 
 extern void issue_xlog_fsync(int fd, uint32 log, uint32 seg);
 

--- a/src/include/access/xlog_internal.h
+++ b/src/include/access/xlog_internal.h
@@ -254,7 +254,7 @@ typedef struct RmgrData
 {
 	const char *rm_name;
 	void		(*rm_redo) (XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *rptr);
-	void		(*rm_desc) (StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+	void		(*rm_desc) (StringInfo buf, XLogRecord *record);
 	void		(*rm_startup) (void);
 	void		(*rm_cleanup) (void);
 	bool		(*rm_safe_restartpoint) (void);

--- a/src/include/catalog/storage.h
+++ b/src/include/catalog/storage.h
@@ -38,6 +38,6 @@ extern void PostPrepare_smgr(void);
 extern void log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum);
 
 extern void smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void smgr_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void smgr_desc(StringInfo buf, XLogRecord *record);
 
 #endif   /* STORAGE_H */

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -400,7 +400,7 @@ typedef struct
 } xl_ao_truncate;
 
 extern void appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void appendonly_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void appendonly_desc(StringInfo buf, XLogRecord *record);
 
 extern void appendonly_update_finish(AppendOnlyUpdateDesc aoUpdateDesc);
 

--- a/src/include/commands/dbcommands.h
+++ b/src/include/commands/dbcommands.h
@@ -63,7 +63,7 @@ extern Oid	get_database_oid(const char *dbname, bool missingok);
 extern char *get_database_name(Oid dbid);
 
 extern void dbase_redo(XLogRecPtr beginLoc  __attribute__((unused)), XLogRecPtr lsn  __attribute__((unused)), XLogRecord *rptr);
-extern void dbase_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void dbase_desc(StringInfo buf, XLogRecord *record);
 
 extern void check_encoding_locale_matches(int encoding, const char *collate, const char *ctype);
 

--- a/src/include/commands/sequence.h
+++ b/src/include/commands/sequence.h
@@ -80,7 +80,7 @@ extern void AlterSequence(AlterSeqStmt *stmt);
 extern void ResetSequence(Oid seq_relid);
 
 extern void seq_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *rptr);
-extern void seq_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void seq_desc(StringInfo buf, XLogRecord *record);
 
 /*
  * CDB: nextval entry point called by sequence server

--- a/src/include/commands/tablespace.h
+++ b/src/include/commands/tablespace.h
@@ -59,7 +59,7 @@ extern char *get_tablespace_name(Oid spc_oid);
 extern bool directory_is_empty(const char *path);
 
 extern void tblspc_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *rptr);
-extern void tblspc_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void tblspc_desc(StringInfo buf, XLogRecord *record);
 extern void set_short_version(const char *path);
 
 #endif   /* TABLESPACE_H */

--- a/src/include/storage/standby.h
+++ b/src/include/storage/standby.h
@@ -81,7 +81,7 @@ typedef struct xl_running_xacts
 
 /* Recovery handlers for the Standby Rmgr (RM_STANDBY_ID) */
 extern void standby_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void standby_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void standby_desc(StringInfo buf, XLogRecord *record);
 
 /*
  * Declarations for GetRunningTransactionData(). Similar to Snapshots, but

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -257,7 +257,6 @@ extern bool gp_heap_require_relhasoids_match;
 extern bool	Debug_appendonly_rezero_quicklz_compress_scratch;
 extern bool	Debug_appendonly_rezero_quicklz_decompress_scratch;
 extern bool	Debug_appendonly_guard_end_quicklz_scratch;
-extern bool	Debug_xlog_insert_print;
 extern bool	debug_xlog_record_read;
 extern bool Debug_cancel_print;
 extern bool Debug_datumstream_write_print_small_varlena_info;

--- a/src/include/utils/relmapper.h
+++ b/src/include/utils/relmapper.h
@@ -57,6 +57,6 @@ extern void RelationMapInitializePhase2(void);
 extern void RelationMapInitializePhase3(void);
 
 extern void relmap_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
-extern void relmap_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record);
+extern void relmap_desc(StringInfo buf, XLogRecord *record);
 
 #endif   /* RELMAPPER_H */


### PR DESCRIPTION
Code cleanup around `rm_desc()` to match upstream. Still doesn't get us matching upstream. As upstream in 9.1 has
``` C
void            (*rm_desc) (StringInfo buf, uint8 xl_info, char *rec);
```
GPDB after this commit now has
``` C
void        (*rm_desc) (StringInfo buf, XLogRecord *record);
```
Aligning the full interface with upstream doesn't seem worth mainly because what GPDB has seems better as
- its consistent with rm_redo() routines
- gives all the rm related info to that layer, instead of just passing info and data part
This goes away with new xlog structure in upstream and when we catch-up, that time we can make it consistent till that time lets live with the diff as its better and can't change upstream in history.

Also, fix the problem of calling `UnpackCheckPointRecord()` only once on mirror (still thinking of what problem will happen without the same but based on code comment seems definitely something which should be enabled)