### PR TITLE
Fix validation of SEQUENCE filepath

### DIFF
--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -799,6 +799,7 @@ GetNewSequenceRelationOid(Relation relation)
 		CHECK_FOR_INTERRUPTS();
 
 		newOid = GetNewSequenceRelationObjectId();
+		rnode.relNode = newOid;
 
 		ScanKeyInit(&key,
 					(AttrNumber) 1,


### PR DESCRIPTION
A check was added during the 9.1 merge to verify that the sequence
filepath to be created would not collide with an existing file. The
filepath that is constructed does not use the sequence OID value that
was just generated and uses whatever value is in that piece of memory
at the time. This would make the check go through usually, especially
in our CI testing, but occasionally a sequence would fail to be
created because the random filepath would exist. Fix the issue by
storing the generated OID in the RelFileNode var that will be passed
into the filepath construction.