### PR TITLE
ProcDie: Reply only after syncing to mirror for commit-prepared.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -12527,3 +12527,17 @@ last_xlog_replay_location()
 
 	return recptr;
 }
+
+void
+wait_for_mirror()
+{
+	XLogwrtResult tmpLogwrtResult;
+	/* use volatile pointer to prevent code rearrangement */
+	volatile XLogCtlData *xlogctl = XLogCtl;
+
+	SpinLockAcquire(&xlogctl->info_lck);
+	tmpLogwrtResult = xlogctl->LogwrtResult;
+	SpinLockRelease(&xlogctl->info_lck);
+
+	SyncRepWaitForLSN(tmpLogwrtResult.Flush);
+}

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -402,4 +402,5 @@ extern bool IsBkpBlockApplied(XLogRecord *record, uint8 block_id);
 extern XLogRecPtr
 last_xlog_replay_location(void);
 
+extern void wait_for_mirror(void);
 #endif   /* XLOG_H */


### PR DESCRIPTION
Upstream and for greenplum master if procdie is received while waiting for
replication, just WARNING is issued and transaction moves forward without
waiting for mirror. But that would cause inconsistency for QE if failover
happens to such mirror missing the commit-prepared record.

If only prepare is performed and primary is yet to process the commit-prepared,
gxact is present in memory. If commit-prepared processing is complete on primary
gxact is removed from memory. If gxact is found then we will flow through
regular commit-prepared flow, emit the xlog record and sync the same to
mirror. But if gxact is not found on primary, we used to return blindly success
to QD. Hence, modified the code to always call `SyncRepWaitForLSN()` before
replying to QD incase gxact is not found on primary.

It calls `SyncRepWaitForLSN()` with the lsn value of `flush` from
`xlogctl->LogwrtResult`, as there is no way to find-out the actual lsn value of
commit-prepared record for primary. Usage of that lsn is based on following
assumptions
	- WAL always is written serially forward
	- Synchronous mirror if has xlog record xyz must have xlog records before xyz
	- Not finding gxact entry in-memory on primary for commit-prepared retry
  	  from QD means it was for sure committed (completed) on primary

Since, the commit-prepared retry can be received if everything is done on
segment but failed on some other segment, under concurrency we may call
`SyncRepWaitForLSN()` with same lsn value multiple times given we are using
latest flush point. Hence in GPDB check in `SyncRepQueueIsOrderedByLSN()`
doesn't validate for unique entries but just validates the queue is sorted which
is required for correctness. Without the same during ICW tests can hit assertion
"!(SyncRepQueueIsOrderedByLSN(mode))".

**Note:**
main change in this PR compared to previous one is change in `SyncRepQueueIsOrderedByLSN()` to address assertion failures.