### PR TITLE
Disallow (again) setting optimizer when we can't

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5280,7 +5280,10 @@ check_optimizer(bool *newval, void **extra, GucSource source)
 {
 #ifndef USE_ORCA
 	if (*newval)
+	{
 		GUC_check_errmsg("ORCA is not supported by this build");
+		return false;
+	}
 #endif
 
 	if (!optimizer_control)


### PR DESCRIPTION
When the server is built with `--disable-orca`, we shouldn't (and used
not to) allow setting the option `optimizer=on`. Upstream Postgres 9.1
commit 2594cf0e8c04406ffff19b1651c5a406d376657c introduced the check
hook in a GUC code refactoring, and it seems that we regressed in the
9.1 merge where we forgot to signal the calling code in
`call_bool_check_hook` to error out.

This commit fixes that by reintroducing the error.