### PR TITLE
Naucrates-specific Hungarian notation removal

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.68.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.69.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.68.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.69.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13405,7 +13405,7 @@ int
 main ()
 {
 
-return strncmp("2.68.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.69.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13415,7 +13415,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.68.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.69.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/contrib/orca_debug/orca_debug.cpp
+++ b/contrib/orca_debug/orca_debug.cpp
@@ -276,7 +276,7 @@ static int translateQueryToFile
 	Assert(pquery);
 
 	char *szXmlString = COptTasks::SzDXL(pquery);
-	int iLen = (int) gpos::clib::UlStrLen(szXmlString);
+	int iLen = (int) gpos::clib::Strlen(szXmlString);
 
 	CFileWriter fw;
 	fw.Open(szFilename, S_IRUSR | S_IWUSR);
@@ -668,14 +668,14 @@ DumpMDObjDXL(PG_FUNCTION_ARGS)
 {
 	Oid oid = gpdb::OidFromDatum(PG_GETARG_DATUM(0));
 
-	char *szDXL = COptTasks::SzMDObjs(ListMake1Oid(oid));
+	char *dxl_string = COptTasks::SzMDObjs(ListMake1Oid(oid));
 
-	if (NULL == szDXL)
+	if (NULL == dxl_string)
 	{
 		elog(ERROR, "Error dumping MD object");
 	}
 
-	PG_RETURN_TEXT_P(cstring_to_text(szDXL));
+	PG_RETURN_TEXT_P(cstring_to_text(dxl_string));
 }
 }
 
@@ -696,9 +696,9 @@ DumpRelStatsDXL(PG_FUNCTION_ARGS)
 {
 	Oid oid = gpdb::OidFromDatum(PG_GETARG_DATUM(0));
 
-	char *szDXL = COptTasks::SzRelStats(ListMake1Oid(oid));
+	char *dxl_string = COptTasks::SzRelStats(ListMake1Oid(oid));
 
-	PG_RETURN_TEXT_P(cstring_to_text(szDXL));
+	PG_RETURN_TEXT_P(cstring_to_text(dxl_string));
 }
 }
 
@@ -720,9 +720,9 @@ DumpMDCastDXL(PG_FUNCTION_ARGS)
 	Oid oidSrc = gpdb::OidFromDatum(PG_GETARG_DATUM(0));
 	Oid oidDest = gpdb::OidFromDatum(PG_GETARG_DATUM(1));
 
-	char *szDXL = COptTasks::SzMDCast(ListMake2Oid(oidSrc, oidDest));
+	char *dxl_string = COptTasks::SzMDCast(ListMake2Oid(oidSrc, oidDest));
 
-	PG_RETURN_TEXT_P(cstring_to_text(szDXL));
+	PG_RETURN_TEXT_P(cstring_to_text(dxl_string));
 }
 }
 
@@ -745,9 +745,9 @@ DumpMDScCmpDXL(PG_FUNCTION_ARGS)
 	Oid oidRight = gpdb::OidFromDatum(PG_GETARG_DATUM(1));
 	char *szCmpType = text_to_cstring(PG_GETARG_TEXT_P(2));
 	
-	char *szDXL = COptTasks::SzMDScCmp(ListMake2Oid(oidLeft, oidRight), szCmpType);
+	char *dxl_string = COptTasks::SzMDScCmp(ListMake2Oid(oidLeft, oidRight), szCmpType);
 
-	PG_RETURN_TEXT_P(cstring_to_text(szDXL));
+	PG_RETURN_TEXT_P(cstring_to_text(dxl_string));
 }
 }
 

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.68.0@gpdb/stable
+orca/v2.69.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.68.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.69.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -40,7 +40,7 @@
 #include "cdb/cdbgang.h"
 
 #ifdef USE_ORCA
-extern char *SzDXLPlan(Query *parse);
+extern char *SerializeDXLPlan(Query *parse);
 extern const char *OptVersion();
 #endif
 
@@ -335,7 +335,7 @@ ExplainDXL(Query *query, ExplainState *es, const char *queryString,
 	optimizer_enumerate_plans = true;
 
 	/* optimize query using optimizer and get generated plan in DXL format */
-	dxl = SzDXLPlan(query);
+	dxl = SerializeDXLPlan(query);
 
 	/* restore old value of enumerate plans GUC */
 	optimizer_enumerate_plans = save_enumerate;

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -36,26 +36,26 @@ extern MemoryContext MessageContext;
 //
 //---------------------------------------------------------------------------
 PlannedStmt *
-CGPOptimizer::PplstmtOptimize
+CGPOptimizer::GPOPTOptimizedPlan
 	(
-	Query *pquery,
-	bool *pfUnexpectedFailure // output : set to true if optimizer unexpectedly failed to produce plan
+	Query *query,
+	bool *had_unexpected_failure // output : set to true if optimizer unexpectedly failed to produce plan
 	)
 {
-	SOptContext octx;
+	SOptContext gpopt_context;
 	PlannedStmt* plStmt = NULL;
 	GPOS_TRY
 	{
-		plStmt = COptTasks::PplstmtOptimize(pquery, &octx, pfUnexpectedFailure);
+		plStmt = COptTasks::GPOPTOptimizedPlan(query, &gpopt_context, had_unexpected_failure);
 		// clean up context
-		octx.Free(octx.epinQuery, octx.epinPlStmt);
+		gpopt_context.Free(gpopt_context.epinQuery, gpopt_context.epinPlStmt);
 	}
 	GPOS_CATCH_EX(ex)
 	{
 		// clone the error message before context free.
-		CHAR* szErrorMsg = octx.CloneErrorMsg(MessageContext);
+		CHAR* serialized_error_msg = gpopt_context.CloneErrorMsg(MessageContext);
 		// clean up context
-		octx.Free(octx.epinQuery, octx.epinPlStmt);
+		gpopt_context.Free(gpopt_context.epinQuery, gpopt_context.epinPlStmt);
 
 		// Special handler for a few common user-facing errors. In particular,
 		// we want to use the correct error code for these, in case an application
@@ -64,18 +64,18 @@ CGPOptimizer::PplstmtOptimize
 		// application errors.
 		if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLNotNullViolation))
 		{
-			errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
 			errfinish(errcode(ERRCODE_NOT_NULL_VIOLATION),
-				  errmsg("%s", szErrorMsg));
+				  errmsg("%s", serialized_error_msg));
 		}
 
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiOptimizerError) ||
-			NULL != szErrorMsg)
+			NULL != serialized_error_msg)
 		{
-			Assert(NULL != szErrorMsg);
-			errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+			Assert(NULL != serialized_error_msg);
+			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
 			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
-					errmsg("%s", szErrorMsg));
+					errmsg("%s", serialized_error_msg));
 		}
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
 		{
@@ -83,13 +83,13 @@ CGPOptimizer::PplstmtOptimize
 		}
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiNoAvailableMemory))
 		{
-			errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
 			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
 					errmsg("No available memory to allocate string buffer."));
 		}
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiInvalidComparisonTypeCode))
 		{
-			errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
 			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
 					errmsg("Invalid comparison type code. Valid values are Eq, NEq, LT, LEq, GT, GEq."));
 		}
@@ -108,18 +108,18 @@ CGPOptimizer::PplstmtOptimize
 //
 //---------------------------------------------------------------------------
 char *
-CGPOptimizer::SzDXLPlan
+CGPOptimizer::SerializeDXLPlan
 	(
-	Query *pquery
+	Query *query
 	)
 {
 	GPOS_TRY;
 	{
-		return COptTasks::SzOptimize(pquery);
+		return COptTasks::Optimize(query);
 	}
 	GPOS_CATCH_EX(ex);
 	{
-		errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+		errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
 		errfinish(errcode(ERRCODE_INTERNAL_ERROR),
 				errmsg("Optimizer failed to produce plan"));
 	}
@@ -147,7 +147,7 @@ CGPOptimizer::InitGPOPT ()
 	gpos_free = gpdb::OptimizerFree;
   }
   struct gpos_init_params params =
-	{gpos_alloc, gpos_free, gpdb::FAbortRequested};
+	{gpos_alloc, gpos_free, gpdb::IsAbortRequested};
   gpos_init(&params);
   gpdxl_init();
   gpopt_init();
@@ -171,7 +171,7 @@ CGPOptimizer::TerminateGPOPT ()
 
 //---------------------------------------------------------------------------
 //	@function:
-//		PplstmtOptimize
+//		GPOPTOptimizedPlan
 //
 //	@doc:
 //		Expose GP optimizer API to C files
@@ -179,19 +179,19 @@ CGPOptimizer::TerminateGPOPT ()
 //---------------------------------------------------------------------------
 extern "C"
 {
-PlannedStmt *PplstmtOptimize
+PlannedStmt *GPOPTOptimizedPlan
 	(
-	Query *pquery,
-	bool *pfUnexpectedFailure
+	Query *query,
+	bool *had_unexpected_failure
 	)
 {
-	return CGPOptimizer::PplstmtOptimize(pquery, pfUnexpectedFailure);
+	return CGPOptimizer::GPOPTOptimizedPlan(query, had_unexpected_failure);
 }
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		SzDXLPlan
+//		SerializeDXLPlan
 //
 //	@doc:
 //		Serialize planned statement to DXL
@@ -199,12 +199,12 @@ PlannedStmt *PplstmtOptimize
 //---------------------------------------------------------------------------
 extern "C"
 {
-char *SzDXLPlan
+char *SerializeDXLPlan
 	(
-	Query *pquery
+	Query *query
 	)
 {
-	return CGPOptimizer::SzDXLPlan(pquery);
+	return CGPOptimizer::SerializeDXLPlan(query);
 }
 }
 

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -25,89 +25,89 @@ using namespace gpdxl;
 using namespace gpopt;
 
 // array mapping GUCs to traceflags
-CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elem[] =
+CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] =
 {
 		{
 		EopttracePrintQuery,
 		&optimizer_print_query,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints the optimizer's input query expression tree.")
 		},
 
 		{
 		EopttracePrintPlan,
 		&optimizer_print_plan,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints the plan expression tree produced by the optimizer.")
 		},
 
 		{
 		EopttracePrintXform,
 		&optimizer_print_xform,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints the input and output expression trees of the optimizer transformations.")
 		},
 
 		{
 		EopttracePrintXformResults,
 		&optimizer_print_xform_results,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Print input and output of xforms.")
 		},
 
 		{
 		EopttracePrintMemoAfterExploration,
 		&optimizer_print_memo_after_exploration,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints MEMO after exploration.")
 		},
 
 		{
 		EopttracePrintMemoAfterImplementation,
 		&optimizer_print_memo_after_implementation,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints MEMO after implementation.")
 		},
 
 		{
 		EopttracePrintMemoAfterOptimization,
 		&optimizer_print_memo_after_optimization,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints MEMO after optimization.")
 		},
 
 		{
 		EopttracePrintJobScheduler,
 		&optimizer_print_job_scheduler,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints jobs in scheduler on each job completion.")
 		},
 
 		{
 		EopttracePrintExpressionProperties,
 		&optimizer_print_expression_properties,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints expression properties.")
 		},
 
 		{
 		EopttracePrintGroupProperties,
 		&optimizer_print_group_properties,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints group properties.")
 		},
 
 		{
 		EopttracePrintOptimizationContext,
 		&optimizer_print_optimization_context,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints optimization context.")
 		},
 
 		{
 		EopttracePrintOptimizationStatistics,
 		&optimizer_print_optimization_stats,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints optimization stats.")
 		},
 
@@ -116,397 +116,397 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elem[] =
 		// GPDB_91_MERGE_FIXME: I turned optimizer_minidump from bool into
 		// an enum-type GUC. It's a bit dirty to cast it like this..
 		(bool *) &optimizer_minidump,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Generate optimizer minidump.")
 		},
              	
 		{
 		EopttraceDisableMotions,
 		&optimizer_enable_motions,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionBroadcast,
 		&optimizer_enable_motion_broadcast,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion broadcast nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionGather,
 		&optimizer_enable_motion_gather,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion gather nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionHashDistribute,
 		&optimizer_enable_motion_redistribute,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion hash-distribute nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionRandom,
 		&optimizer_enable_motion_redistribute,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion random nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionRountedDistribute,
 		&optimizer_enable_motion_redistribute,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion routed-distribute nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableSort,
 		&optimizer_enable_sort,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable sort nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableSpool,
 		&optimizer_enable_materialize,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable spool nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisablePartPropagation,
 		&optimizer_enable_partition_propagation,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable partition propagation nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisablePartSelection,
 		&optimizer_enable_partition_selection,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable partition selection in optimizer.")
 		},
 
 		{
 		EopttraceDisableOuterJoin2InnerJoinRewrite,
 		&optimizer_enable_outerjoin_rewrite,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable outer join to inner join rewrite in optimizer.")
 		},
 
 		{
 		EopttraceDonotDeriveStatsForAllGroups,
 		&optimizer_enable_derive_stats_all_groups,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable deriving stats for all groups after exploration.")
 		},
 
 		{
 		EopttraceEnableSpacePruning,
 		&optimizer_enable_space_pruning,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable space pruning in optimizer.")
 		},
 
 		{
 		EopttraceForceMultiStageAgg,
 		&optimizer_force_multistage_agg,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Force optimizer to always pick multistage aggregates when such a plan alternative is generated.")
 		},
 
 		{
 		EopttracePrintColsWithMissingStats,
 		&optimizer_print_missing_stats,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Print columns with missing statistics.")
 		},
 
 		{
 		EopttraceEnableRedistributeBroadcastHashJoin,
 		&optimizer_enable_hashjoin_redistribute_broadcast_children,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable generating hash join plan where outer child is Redistribute and inner child is Broadcast.")
 		},
 
 		{
 		EopttraceExtractDXLStats,
 		&optimizer_extract_dxl_stats,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Extract plan stats in dxl.")
 		},
 
 		{
 		EopttraceExtractDXLStatsAllNodes,
 		&optimizer_extract_dxl_stats_all_nodes,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Extract plan stats for all physical dxl nodes.")
 		},
 
 		{
 		EopttraceDeriveStatsForDPE,
 		&optimizer_dpe_stats,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable stats derivation of partitioned tables with dynamic partition elimination.")
 		},
 
 		{
 		EopttraceEnumeratePlans,
 		&optimizer_enumerate_plans,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable plan enumeration.")
 		},
 
 		{
 		EopttraceSamplePlans,
 		&optimizer_sample_plans,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable plan sampling.")
 		},
 
 		{
 		EopttraceEnableCTEInlining,
 		&optimizer_cte_inlining,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable CTE inlining.")
 		},
 
 		{
 		EopttraceEnableConstantExpressionEvaluation,
 		&optimizer_enable_constant_expression_evaluation,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Enable constant expression evaluation in the optimizer")
 		},
 
 		{
 		EopttraceUseExternalConstantExpressionEvaluationForInts,
 		&optimizer_use_external_constant_expression_evaluation_for_ints,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Enable constant expression evaluation for integers in the optimizer")
 		},
 
 		{
 		EopttraceApplyLeftOuter2InnerUnionAllLeftAntiSemiJoinDisregardingStats,
 		&optimizer_apply_left_outer_to_union_all_disregarding_stats,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Always apply Left Outer Join to Inner Join UnionAll Left Anti Semi Join without looking at stats")
 		},
 
 		{
 		EopttraceRemoveOrderBelowDML,
 		&optimizer_remove_order_below_dml,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Remove OrderBy below a DML operation")
 		},
 
 		{
 		EopttraceDisableReplicateInnerNLJOuterChild,
 		&optimizer_enable_broadcast_nestloop_outer_child,
-		true,  // m_fNegate
+		true,  // m_negate_param
 		GPOS_WSZ_LIT("Enable plan alternatives where NLJ's outer child is replicated")
 		},
 
 		{
 		EopttraceEnforceCorrelatedExecution,
 		&optimizer_enforce_subplans,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Enforce correlated execution in the optimizer")
 		},
 
 		{
 		EopttraceForceExpandedMDQAs,
 		&optimizer_force_expanded_distinct_aggs,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Always pick plans that expand multiple distinct aggregates into join of single distinct aggregate in the optimizer")
 		},
 
 		{
 		EopttraceDisablePushingCTEConsumerReqsToCTEProducer,
 		&optimizer_push_requirements_from_consumer_to_producer,
-		true,  // m_fNegate
+		true,  // m_negate_param
 		GPOS_WSZ_LIT("Optimize CTE producer plan on requirements enforced on top of CTE consumer")
 		},
 
 		{
 		EopttraceDisablePruneUnusedComputedColumns,
 		&optimizer_prune_computed_columns,
-		true,  // m_fNegate
+		true,  // m_negate_param
 		GPOS_WSZ_LIT("Prune unused computed columns when pre-processing query")
 		},
 
 		{
 		EopttraceForceThreeStageScalarDQA,
 		&optimizer_force_three_stage_scalar_dqa,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Force optimizer to always pick 3 stage aggregate plan for scalar distinct qualified aggregate.")
 		},
 
 		{
 		EopttraceEnableParallelAppend,
 		&optimizer_parallel_union,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable parallel execution for UNION/UNION ALL queries.")
 		},
 
 		{
 		EopttraceArrayConstraints,
 		&optimizer_array_constraints,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Allows the constraint framework to derive array constraints in the optimizer.")
 		}
 };
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CConfigParamMapping::PbsPack
+//		CConfigParamMapping::PackConfigParamInBitset
 //
 //	@doc:
 //		Pack the GPDB config params into a bitset
 //
 //---------------------------------------------------------------------------
 CBitSet *
-CConfigParamMapping::PbsPack
+CConfigParamMapping::PackConfigParamInBitset
 	(
-	IMemoryPool *pmp,
-	ULONG ulXforms // number of available xforms
+	IMemoryPool *mp,
+	ULONG xform_id // number of available xforms
 	)
 {
-	CBitSet *pbs = GPOS_NEW(pmp) CBitSet(pmp, EopttraceSentinel);
+	CBitSet *traceflag_bitset = GPOS_NEW(mp) CBitSet(mp, EopttraceSentinel);
 
-	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(m_elem); ul++)
+	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(m_elements); ul++)
 	{
-		SConfigMappingElem elem = m_elem[ul];
-		GPOS_ASSERT(!pbs->FBit((ULONG) elem.m_etf) &&
+		SConfigMappingElem elem = m_elements[ul];
+		GPOS_ASSERT(!traceflag_bitset->Get((ULONG) elem.m_trace_flag) &&
 					"trace flag already set");
 
-		BOOL fVal = *elem.m_pfParam;
-		if (elem.m_fNegate)
+		BOOL value = *elem.m_is_param;
+		if (elem.m_negate_param)
 		{
 			// negate the value of config param
-			fVal = !fVal;
+			value = !value;
 		}
 
-		if (fVal)
+		if (value)
 		{
 #ifdef GPOS_DEBUG
-			BOOL fSet =
+			BOOL is_traceflag_set =
 #endif // GPOS_DEBUG
-				pbs->FExchangeSet((ULONG) elem.m_etf);
-			GPOS_ASSERT(!fSet);
+				traceflag_bitset->ExchangeSet((ULONG) elem.m_trace_flag);
+			GPOS_ASSERT(!is_traceflag_set);
 		}
 	}
 
 	// pack disable flags of xforms
-	for (ULONG ul = 0; ul < ulXforms; ul++)
+	for (ULONG ul = 0; ul < xform_id; ul++)
 	{
-		GPOS_ASSERT(!pbs->FBit(EopttraceDisableXformBase + ul) &&
+		GPOS_ASSERT(!traceflag_bitset->Get(EopttraceDisableXformBase + ul) &&
 					"xform trace flag already set");
 
 		if (optimizer_xforms[ul])
 		{
 #ifdef GPOS_DEBUG
-			BOOL fSet =
+			BOOL is_traceflag_set =
 #endif // GPOS_DEBUG
-				pbs->FExchangeSet(EopttraceDisableXformBase + ul);
-			GPOS_ASSERT(!fSet);
+				traceflag_bitset->ExchangeSet(EopttraceDisableXformBase + ul);
+			GPOS_ASSERT(!is_traceflag_set);
 		}
 	}
 
 	if (!optimizer_enable_indexjoin)
 	{
-		CBitSet *pbsIndexJoin = CXform::PbsIndexJoinXforms(pmp);
-		pbs->Union(pbsIndexJoin);
-		pbsIndexJoin->Release();
+		CBitSet *index_join_bitset = CXform::PbsIndexJoinXforms(mp);
+		traceflag_bitset->Union(index_join_bitset);
+		index_join_bitset->Release();
 	}
 
 	// disable bitmap scan if the corresponding GUC is turned off
 	if (!optimizer_enable_bitmapscan)
 	{
-		CBitSet *pbsBitmapScan = CXform::PbsBitmapIndexXforms(pmp);
-		pbs->Union(pbsBitmapScan);
-		pbsBitmapScan->Release();
+		CBitSet *bitmap_index_bitset = CXform::PbsBitmapIndexXforms(mp);
+		traceflag_bitset->Union(bitmap_index_bitset);
+		bitmap_index_bitset->Release();
 	}
 
 	// disable outerjoin to unionall transformation if GUC is turned off
 	if (!optimizer_enable_outerjoin_to_unionall_rewrite)
 	{
-		 pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftOuter2InnerUnionAllLeftAntiSemiJoin));
+		 traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftOuter2InnerUnionAllLeftAntiSemiJoin));
 	}
 
 	// disable Assert MaxOneRow plans if GUC is turned off
 	if (!optimizer_enable_assert_maxonerow)
 	{
-		 pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfMaxOneRow2Assert));
+		 traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfMaxOneRow2Assert));
 	}
 
 	if (!optimizer_enable_partial_index)
 	{
-		CBitSet *pbsHeterogeneousIndex = CXform::PbsHeterogeneousIndexXforms(pmp);
-		pbs->Union(pbsHeterogeneousIndex);
-		pbsHeterogeneousIndex->Release();
+		CBitSet *heterogeneous_index_bitset = CXform::PbsHeterogeneousIndexXforms(mp);
+		traceflag_bitset->Union(heterogeneous_index_bitset);
+		heterogeneous_index_bitset->Release();
 	}
 
 	if (!optimizer_enable_hashjoin)
 	{
 		// disable hash-join if the corresponding GUC is turned off
-		CBitSet *pbsHashJoin = CXform::PbsHashJoinXforms(pmp);
-		pbs->Union(pbsHashJoin);
-		pbsHashJoin->Release();
+		CBitSet *hash_join_bitste = CXform::PbsHashJoinXforms(mp);
+		traceflag_bitset->Union(hash_join_bitste);
+		hash_join_bitste->Release();
 	}
 
 	if (!optimizer_enable_dynamictablescan)
 	{
 		// disable dynamic table scan if the corresponding GUC is turned off
-		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfDynamicGet2DynamicTableScan));
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfDynamicGet2DynamicTableScan));
 	}
 
 	if (!optimizer_enable_tablescan)
 	{
 		// disable table scan if the corresponding GUC is turned off
-		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfGet2TableScan));
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfGet2TableScan));
 	}
 
 	if (!optimizer_enable_indexscan)
 	{
 		// disable index scan if the corresponding GUC is turned off
-		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexScan));
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexScan));
 	}
 
-	CBitSet *pbsJoinHeuristic = NULL;
+	CBitSet *join_heuristic_bitset = NULL;
 	switch (optimizer_join_order)
 	{
 		case JOIN_ORDER_IN_QUERY:
-			pbsJoinHeuristic = CXform::PbsJoinOrderInQueryXforms(pmp);
+			join_heuristic_bitset = CXform::PbsJoinOrderInQueryXforms(mp);
 			break;
 		case JOIN_ORDER_GREEDY_SEARCH:
-			pbsJoinHeuristic = CXform::PbsJoinOrderOnGreedyXforms(pmp);
+			join_heuristic_bitset = CXform::PbsJoinOrderOnGreedyXforms(mp);
 			break;
 		case JOIN_ORDER_EXHAUSTIVE_SEARCH:
-			pbsJoinHeuristic = GPOS_NEW(pmp) CBitSet(pmp, EopttraceSentinel);
+			join_heuristic_bitset = GPOS_NEW(mp) CBitSet(mp, EopttraceSentinel);
 			break;
 		default:
 			elog(ERROR, "Invalid value for optimizer_join_order, must \
 				 not come here");
 			break;
 	}
-	pbs->Union(pbsJoinHeuristic);
-	pbsJoinHeuristic->Release();
+	traceflag_bitset->Union(join_heuristic_bitset);
+	join_heuristic_bitset->Release();
 
 	// disable join associativity transform if the corresponding GUC
 	// is turned off independent of the join order algorithm chosen
 	if (!optimizer_enable_associativity)
 	{
-		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfJoinAssociativity));
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfJoinAssociativity));
 	}
 
 	// enable nested loop index plans using nest params
 	// instead of outer reference as in the case with GPDB 4/5
-	pbs->FExchangeSet(EopttraceIndexedNLJOuterRefAsParams);
+	traceflag_bitset->ExchangeSet(EopttraceIndexedNLJOuterRefAsParams);
 
-	return pbs;
+	return traceflag_bitset;
 }
 
 // EOF

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -52,7 +52,7 @@
 using namespace gpos;
 
 bool
-gpdb::FBoolFromDatum
+gpdb::BoolFromDatum
 	(
 	Datum d
 	)
@@ -66,7 +66,7 @@ gpdb::FBoolFromDatum
 }
 
 Datum
-gpdb::DDatumFromBool
+gpdb::DatumFromBool
 	(
 	bool b
 	)
@@ -80,7 +80,7 @@ gpdb::DDatumFromBool
 }
 
 char
-gpdb::CCharFromDatum
+gpdb::CharFromDatum
 	(
 	Datum d
 	)
@@ -94,7 +94,7 @@ gpdb::CCharFromDatum
 }
 
 Datum
-gpdb::DDatumFromChar
+gpdb::DatumFromChar
 	(
 	char c
 	)
@@ -108,7 +108,7 @@ gpdb::DDatumFromChar
 }
 
 int8
-gpdb::CInt8FromDatum
+gpdb::Int8FromDatum
 	(
 	Datum d
 	)
@@ -122,7 +122,7 @@ gpdb::CInt8FromDatum
 }
 
 Datum
-gpdb::DDatumFromInt8
+gpdb::DatumFromInt8
 	(
 	int8 i8
 	)
@@ -136,7 +136,7 @@ gpdb::DDatumFromInt8
 }
 
 uint8
-gpdb::UcUint8FromDatum
+gpdb::Uint8FromDatum
 	(
 	Datum d
 	)
@@ -150,7 +150,7 @@ gpdb::UcUint8FromDatum
 }
 
 Datum
-gpdb::DDatumFromUint8
+gpdb::DatumFromUint8
 	(
 	uint8 ui8
 	)
@@ -164,7 +164,7 @@ gpdb::DDatumFromUint8
 }
 
 int16
-gpdb::SInt16FromDatum
+gpdb::Int16FromDatum
 	(
 	Datum d
 	)
@@ -178,7 +178,7 @@ gpdb::SInt16FromDatum
 }
 
 Datum
-gpdb::DDatumFromInt16
+gpdb::DatumFromInt16
 	(
 	int16 i16
 	)
@@ -192,7 +192,7 @@ gpdb::DDatumFromInt16
 }
 
 uint16
-gpdb::UsUint16FromDatum
+gpdb::Uint16FromDatum
 	(
 	Datum d
 	)
@@ -206,7 +206,7 @@ gpdb::UsUint16FromDatum
 }
 
 Datum
-gpdb::DDatumFromUint16
+gpdb::DatumFromUint16
 	(
 	uint16 ui16
 	)
@@ -220,7 +220,7 @@ gpdb::DDatumFromUint16
 }
 
 int32
-gpdb::IInt32FromDatum
+gpdb::Int32FromDatum
 	(
 	Datum d
 	)
@@ -234,7 +234,7 @@ gpdb::IInt32FromDatum
 }
 
 Datum
-gpdb::DDatumFromInt32
+gpdb::DatumFromInt32
 	(
 	int32 i32
 	)
@@ -248,7 +248,7 @@ gpdb::DDatumFromInt32
 }
 
 uint32
-gpdb::UlUint32FromDatum
+gpdb::lUint32FromDatum
 	(
 	Datum d
 	)
@@ -262,7 +262,7 @@ gpdb::UlUint32FromDatum
 }
 
 Datum
-gpdb::DDatumFromUint32
+gpdb::DatumFromUint32
 	(
 	uint32 ui32
 	)
@@ -276,7 +276,7 @@ gpdb::DDatumFromUint32
 }
 
 int64
-gpdb::LlInt64FromDatum
+gpdb::Int64FromDatum
 	(
 	Datum d
 	)
@@ -291,7 +291,7 @@ gpdb::LlInt64FromDatum
 }
 
 Datum
-gpdb::DDatumFromInt64
+gpdb::DatumFromInt64
 	(
 	int64 i64
 	)
@@ -306,7 +306,7 @@ gpdb::DDatumFromInt64
 }
 
 uint64
-gpdb::UllUint64FromDatum
+gpdb::Uint64FromDatum
 	(
 	Datum d
 	)
@@ -320,7 +320,7 @@ gpdb::UllUint64FromDatum
 }
 
 Datum
-gpdb::DDatumFromUint64
+gpdb::DatumFromUint64
 	(
 	uint64 ui64
 	)
@@ -348,7 +348,7 @@ gpdb::OidFromDatum
 }
 
 void *
-gpdb::PvPointerFromDatum
+gpdb::PointerFromDatum
 	(
 	Datum d
 	)
@@ -362,7 +362,7 @@ gpdb::PvPointerFromDatum
 }
 
 float4
-gpdb::FpFloat4FromDatum
+gpdb::Float4FromDatum
 	(
 	Datum d
 	)
@@ -376,7 +376,7 @@ gpdb::FpFloat4FromDatum
 }
 
 float8
-gpdb::DFloat8FromDatum
+gpdb::Float8FromDatum
 	(
 	Datum d
 	)
@@ -390,7 +390,7 @@ gpdb::DFloat8FromDatum
 }
 
 Datum
-gpdb::DDatumFromPointer
+gpdb::DatumFromPointer
 	(
 	const void *p
 	)
@@ -404,7 +404,7 @@ gpdb::DDatumFromPointer
 }
 
 bool
-gpdb::FAggregateExists
+gpdb::AggregateExists
 	(
 	Oid oid
 	)
@@ -418,7 +418,7 @@ gpdb::FAggregateExists
 }
 
 Bitmapset *
-gpdb::PbmsAddMember
+gpdb::BmsAddMember
 	(
 	Bitmapset *a,
 	int x
@@ -433,7 +433,7 @@ gpdb::PbmsAddMember
 }
 
 void *
-gpdb::PvCopyObject
+gpdb::CopyObject
 	(
 	void *from
 	)
@@ -447,16 +447,16 @@ gpdb::PvCopyObject
 }
 
 Size
-gpdb::SDatumSize
+gpdb::DatumSize
 	(
 	Datum value,
-	bool typByVal,
+	bool type_by_val,
 	int iTypLen
 	)
 {
 	GP_WRAP_START;
 	{
-		return datumGetSize(value, typByVal, iTypLen);
+		return datumGetSize(value, type_by_val, iTypLen);
 	}
 	GP_WRAP_END;
 	return 0;
@@ -465,112 +465,112 @@ gpdb::SDatumSize
 void
 gpdb::DeconstructArray
 	(
-	struct ArrayType *parray,
+	struct ArrayType *array,
 	Oid elmtype,
-	int iElmlen,
+	int elmlen,
 	bool elmbyval,
-	char cElmalign,
-	Datum **ppElemSP,
+	char elmalign,
+	Datum **elemsp,
 	bool **nullsp,
-	int *piElemSP
+	int *nelemsp
 	)
 {
 	GP_WRAP_START;
 	{
-		deconstruct_array(parray, elmtype, iElmlen, elmbyval, cElmalign, ppElemSP, nullsp, piElemSP);
+		deconstruct_array(array, elmtype, elmlen, elmbyval, elmalign, elemsp, nullsp, nelemsp);
 		return;
 	}
 	GP_WRAP_END;
 }
 
 Node *
-gpdb::PnodeMutateExpressionTree
+gpdb::MutateExpressionTree
 	(
-	Node *pnode,
+	Node *node,
 	Node *(*mutator) (),
 	void *context
 	)
 {
 	GP_WRAP_START;
 	{
-		return expression_tree_mutator(pnode, mutator, context);
+		return expression_tree_mutator(node, mutator, context);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 bool
-gpdb::FWalkExpressionTree
+gpdb::WalkExpressionTree
 	(
-	Node *pnode,
+	Node *node,
 	bool (*walker) (),
 	void *context
 	)
 {
 	GP_WRAP_START;
 	{
-		return expression_tree_walker(pnode, walker, context);
+		return expression_tree_walker(node, walker, context);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 Oid
-gpdb::OidExprType
+gpdb::ExprType
 	(
-	Node *pnodeExpr
+	Node *expr
 	)
 {
 	GP_WRAP_START;
 	{
-		return exprType(pnodeExpr);
+		return exprType(expr);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 int32
-gpdb::IExprTypeMod
+gpdb::ExprTypeMod
 	(
-	Node *pnodeExpr
+	Node *expr
 	)
 {
 	GP_WRAP_START;
 	{
-		return exprTypmod(pnodeExpr);
+		return exprTypmod(expr);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 Oid
-gpdb::OidExprCollation
+gpdb::ExprCollation
 	(
-	Node *pnodeExpr
+	Node *expr
 	)
 {
 	GP_WRAP_START;
 	{
-		if (pnodeExpr && IsA(pnodeExpr, List))
+		if (expr && IsA(expr, List))
 		{
-			// GPORCA currently does not support collations, so infer them using type defaults
-			List *exprlist = (List *) pnodeExpr;
+			// GDPB_91_MERGE_FIXME: collation
+			List *exprlist = (List *) expr;
 			ListCell   *lc;
 
-			Oid oidCollation = InvalidOid;
+			Oid collation = InvalidOid;
 			foreach(lc, exprlist)
 			{
 				Node *expr = (Node *) lfirst(lc);
-				if ((oidCollation = exprCollation(expr)) != InvalidOid)
+				if ((collation = exprCollation(expr)) != InvalidOid)
 				{
 					break;
 				}
 			}
-			return oidCollation;
+			return collation;
 		}
 		else
 		{
-			return exprCollation(pnodeExpr);
+			return exprCollation(expr);
 		}
 	}
 	GP_WRAP_END;
@@ -578,7 +578,7 @@ gpdb::OidExprCollation
 }
 
 Oid
-gpdb::OidTypeCollation
+gpdb::TypeCollation
 (
  Oid type
  )
@@ -598,32 +598,32 @@ gpdb::OidTypeCollation
 
 
 List *
-gpdb::PlExtractNodesPlan
+gpdb::ExtractNodesPlan
 	(
 	Plan *pl,
-	int iNodeTag,
-	bool descendIntoSubqueries
+	int node_tag,
+	bool descend_into_subqueries
 	)
 {
 	GP_WRAP_START;
 	{
-		return extract_nodes_plan(pl, iNodeTag, descendIntoSubqueries);
+		return extract_nodes_plan(pl, node_tag, descend_into_subqueries);
 	}
 	GP_WRAP_END;
 	return NIL;
 }
 
 List *
-gpdb::PlExtractNodesExpression
+gpdb::ExtractNodesExpression
 	(
 	Node *node,
-	int iNodeTag,
-	bool descendIntoSubqueries
+	int node_tag,
+	bool descend_into_subqueries
 	)
 {
 	GP_WRAP_START;
 	{
-		return extract_nodes_expression(node, iNodeTag, descendIntoSubqueries);
+		return extract_nodes_expression(node, node_tag, descend_into_subqueries);
 	}
 	GP_WRAP_END;
 	return NIL;
@@ -644,7 +644,7 @@ gpdb::FreeAttrStatsSlot
 }
 
 bool
-gpdb::FFuncStrict
+gpdb::FuncStrict
 	(
 	Oid funcid
 	)
@@ -659,7 +659,7 @@ gpdb::FFuncStrict
 }
 
 char
-gpdb::CFuncStability
+gpdb::FuncStability
 	(
 	Oid funcid
 	)
@@ -674,7 +674,7 @@ gpdb::CFuncStability
 }
 
 char
-gpdb::CFuncDataAccess
+gpdb::FuncDataAccess
 	(
 	Oid funcid
 	)
@@ -689,7 +689,7 @@ gpdb::CFuncDataAccess
 }
 
 char
-gpdb::CFuncExecLocation
+gpdb::FuncExecLocation
 	(
 	Oid funcid
 	)
@@ -704,7 +704,7 @@ gpdb::CFuncExecLocation
 }
 
 bool
-gpdb::FFunctionExists
+gpdb::FunctionExists
 	(
 	Oid oid
 	)
@@ -719,7 +719,7 @@ gpdb::FFunctionExists
 }
 
 List *
-gpdb::PlFunctionOids(void)
+gpdb::FunctionOids(void)
 {
 	GP_WRAP_START;
 	{
@@ -731,7 +731,7 @@ gpdb::PlFunctionOids(void)
 }
 
 Oid
-gpdb::OidAggIntermediateResultType
+gpdb::GetAggIntermediateResultType
 	(
 	Oid aggid
 	)
@@ -746,15 +746,15 @@ gpdb::OidAggIntermediateResultType
 }
 
 Query *
-gpdb::PqueryFlattenJoinAliasVar
+gpdb::FlattenJoinAliasVar
 	(
-	Query *pquery,
-	gpos::ULONG ulQueryLevel
+	Query *query,
+	gpos::ULONG query_level
 	)
 {
 	GP_WRAP_START;
 	{
-		return flatten_join_alias_var_optimizer(pquery, ulQueryLevel);
+		return flatten_join_alias_var_optimizer(query, query_level);
 	}
 	GP_WRAP_END;
 
@@ -762,7 +762,7 @@ gpdb::PqueryFlattenJoinAliasVar
 }
 
 bool
-gpdb::FOrderedAgg
+gpdb::IsOrderedAgg
 	(
 	Oid aggid
 	)
@@ -777,7 +777,7 @@ gpdb::FOrderedAgg
 }
 
 bool
-gpdb::FAggHasPrelimFunc
+gpdb::AggHasPrelimFunc
 	(
 	Oid aggid
 	)
@@ -792,7 +792,7 @@ gpdb::FAggHasPrelimFunc
 }
 
 bool
-gpdb::FAggHasPrelimOrInvPrelimFunc
+gpdb::AggHasPrelimOrInvPrelimFunc
 	(
 	Oid aggid
 	)
@@ -807,23 +807,23 @@ gpdb::FAggHasPrelimOrInvPrelimFunc
 }
 
 Oid
-gpdb::OidAggregate
+gpdb::GetAggregate
 	(
-	const char *szAgg,
-	Oid oidType
+	const char *agg,
+	Oid type_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_aggregate */
-		return get_aggregate(szAgg, oidType);
+		return get_aggregate(agg, type_oid);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 Oid
-gpdb::OidArrayType
+gpdb::GetArrayType
 	(
 	Oid typid
 	)
@@ -838,25 +838,25 @@ gpdb::OidArrayType
 }
 
 bool
-gpdb::FGetAttrStatsSlot
+gpdb::GetAttrStatsSlot
 	(
 	AttStatsSlot *sslot,
 	HeapTuple statstuple,
-	int iReqKind,
+	int reqkind,
 	Oid reqop,
 	int flags
 	)
 {
 	GP_WRAP_START;
 	{
-		return get_attstatsslot(sslot, statstuple, iReqKind, reqop, flags);
+		return get_attstatsslot(sslot, statstuple, reqkind, reqop, flags);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 HeapTuple
-gpdb::HtAttrStats
+gpdb::GetAttStats
 	(
 	Oid relid,
 	AttrNumber attnum
@@ -872,7 +872,7 @@ gpdb::HtAttrStats
 }
 
 Oid
-gpdb::OidCommutatorOp
+gpdb::GetCommutatorOp
 	(
 	Oid opno
 	)
@@ -887,7 +887,7 @@ gpdb::OidCommutatorOp
 }
 
 char *
-gpdb::SzTriggerName
+gpdb::GetTriggerName
 	(
 	Oid triggerid
 	)
@@ -902,7 +902,7 @@ gpdb::SzTriggerName
 }
 
 Oid
-gpdb::OidTriggerRelid
+gpdb::GetTriggerRelid
 	(
 	Oid triggerid
 	)
@@ -917,7 +917,7 @@ gpdb::OidTriggerRelid
 }
 
 Oid
-gpdb::OidTriggerFuncid
+gpdb::GetTriggerFuncid
 	(
 	Oid triggerid
 	)
@@ -932,7 +932,7 @@ gpdb::OidTriggerFuncid
 }
 
 int32
-gpdb::ITriggerType
+gpdb::GetTriggerType
 	(
 	Oid triggerid
 	)
@@ -947,7 +947,7 @@ gpdb::ITriggerType
 }
 
 bool
-gpdb::FTriggerEnabled
+gpdb::IsTriggerEnabled
 	(
 	Oid triggerid
 	)
@@ -962,7 +962,7 @@ gpdb::FTriggerEnabled
 }
 
 bool
-gpdb::FTriggerExists
+gpdb::TriggerExists
 	(
 	Oid oid
 	)
@@ -977,45 +977,45 @@ gpdb::FTriggerExists
 }
 
 bool
-gpdb::FCheckConstraintExists
+gpdb::CheckConstraintExists
 	(
-	Oid oidCheckConstraint
+	Oid check_constraint_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return check_constraint_exists(oidCheckConstraint);
+		return check_constraint_exists(check_constraint_oid);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 char *
-gpdb::SzCheckConstraintName
+gpdb::GetCheckConstraintName
 	(
-	Oid oidCheckConstraint
+	Oid check_constraint_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return get_check_constraint_name(oidCheckConstraint);
+		return get_check_constraint_name(check_constraint_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Oid
-gpdb::OidCheckConstraintRelid
+gpdb::GetCheckConstraintRelid
 	(
-	Oid oidCheckConstraint
+	Oid check_constraint_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return get_check_constraint_relid(oidCheckConstraint);
+		return get_check_constraint_relid(check_constraint_oid);
 	}
 	GP_WRAP_END;
 	return 0;
@@ -1024,51 +1024,51 @@ gpdb::OidCheckConstraintRelid
 Node *
 gpdb::PnodeCheckConstraint
 	(
-	Oid oidCheckConstraint
+	Oid check_constraint_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return get_check_constraint_expr_tree(oidCheckConstraint);
+		return get_check_constraint_expr_tree(check_constraint_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 List *
-gpdb::PlCheckConstraint
+gpdb::GetCheckConstraintOids
 	(
-	Oid oidRel
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return get_check_constraint_oids(oidRel);
+		return get_check_constraint_oids(rel_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Node *
-gpdb::PnodePartConstraintRel
+gpdb::GetRelationPartContraints
 	(
-	Oid oidRel,
-	List **pplDefaultLevels
+	Oid rel_oid,
+	List **default_levels
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_partition, pg_partition_rule, pg_constraint */
-		return get_relation_part_constraints(oidRel, pplDefaultLevels);
+		return get_relation_part_constraints(rel_oid, default_levels);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 bool
-gpdb::FHasExternalPartition
+gpdb::HasExternalPartition
 	(
 	Oid oid
 	)
@@ -1084,7 +1084,7 @@ gpdb::FHasExternalPartition
 
 
 bool
-gpdb::FLeafPartition
+gpdb::IsLeafPartition
 	(
 	Oid oid
 	)
@@ -1099,7 +1099,7 @@ gpdb::FLeafPartition
 }
 
 Oid
-gpdb::OidRootPartition
+gpdb::GetRootPartition
 	(
 	Oid oid
 	)
@@ -1114,62 +1114,62 @@ gpdb::OidRootPartition
 }
 
 bool
-gpdb::FCastFunc
+gpdb::GetCastFunc
 	(
-	Oid oidSrc,
-	Oid oidDest, 
+	Oid src_oid,
+	Oid dest_oid,
 	bool *is_binary_coercible,
-	Oid *oidCastFunc,
+	Oid *cast_fn_oid,
 	CoercionPathType *pathtype
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_cast */
-		return get_cast_func(oidSrc, oidDest, is_binary_coercible, oidCastFunc, pathtype);
+		return get_cast_func(src_oid, dest_oid, is_binary_coercible, cast_fn_oid, pathtype);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 unsigned int
-gpdb::UlCmpt
+gpdb::GetComparisonType
 	(
-	Oid oidOp,
-	Oid oidLeft, 
-	Oid oidRight
+	Oid op_oid,
+	Oid left_oid,
+	Oid right_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_amop */
-		return get_comparison_type(oidOp, oidLeft, oidRight);
+		return get_comparison_type(op_oid, left_oid, right_oid);
 	}
 	GP_WRAP_END;
 	return CmptOther;
 }
 
 Oid
-gpdb::OidScCmp
+gpdb::GetComparisonOperator
 	(
-	Oid oidLeft, 
-	Oid oidRight,
-	unsigned int ulCmpt
+	Oid left_oid,
+	Oid right_oid,
+	unsigned int cmpt
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_amop */
-		return get_comparison_operator(oidLeft, oidRight, (CmpType) ulCmpt);
+		return get_comparison_operator(left_oid, right_oid, (CmpType) cmpt);
 	}
 	GP_WRAP_END;
 	return InvalidOid;
 }
 
 Oid
-gpdb::OidEqualityOp
+gpdb::GetEqualityOp
 	(
-	Oid oidType
+	Oid type_oid
 	)
 {
 	GP_WRAP_START;
@@ -1177,7 +1177,7 @@ gpdb::OidEqualityOp
 		/* catalog tables: pg_type */
 		Oid eq_opr;
 
-		get_sort_group_operators(oidType,
+		get_sort_group_operators(type_oid,
 					 false, true, false,
 					 NULL, &eq_opr, NULL, NULL);
 
@@ -1188,7 +1188,7 @@ gpdb::OidEqualityOp
 }
 
 Oid
-gpdb::OidEqualityOpForOrderingOp
+gpdb::GetEqualityOpForOrderingOp
 	(
 	Oid opno,
 	bool *reverse
@@ -1204,7 +1204,7 @@ gpdb::OidEqualityOpForOrderingOp
 }
 
 Oid
-gpdb::OidOrderingOpForEqualityOp
+gpdb::GetOrderingOpForEqualityOp
 (
 	Oid opno,
 	bool *reverse
@@ -1220,7 +1220,7 @@ gpdb::OidOrderingOpForEqualityOp
 }
 
 char *
-gpdb::SzFuncName
+gpdb::GetFuncName
 	(
 	Oid funcid
 	)
@@ -1235,7 +1235,7 @@ gpdb::SzFuncName
 }
 
 List *
-gpdb::PlFuncOutputArgTypes
+gpdb::GetFuncOutputArgTypes
 	(
 	Oid funcid
 	)
@@ -1250,7 +1250,7 @@ gpdb::PlFuncOutputArgTypes
 }
 
 List *
-gpdb::PlFuncArgTypes
+gpdb::GetFuncArgTypes
 	(
 	Oid funcid
 	)
@@ -1265,7 +1265,7 @@ gpdb::PlFuncArgTypes
 }
 
 bool
-gpdb::FFuncRetset
+gpdb::GetFuncRetset
 	(
 	Oid funcid
 	)
@@ -1280,7 +1280,7 @@ gpdb::FFuncRetset
 }
 
 Oid
-gpdb::OidFuncRetType
+gpdb::GetFuncRetType
 	(
 	Oid funcid
 	)
@@ -1295,7 +1295,7 @@ gpdb::OidFuncRetType
 }
 
 Oid
-gpdb::OidInverseOp
+gpdb::GetInverseOp
 	(
 	Oid opno
 	)
@@ -1310,7 +1310,7 @@ gpdb::OidInverseOp
 }
 
 RegProcedure
-gpdb::OidOpFunc
+gpdb::GetOpFunc
 	(
 	Oid opno
 	)
@@ -1325,7 +1325,7 @@ gpdb::OidOpFunc
 }
 
 char *
-gpdb::SzOpName
+gpdb::GetOpName
 	(
 	Oid opno
 	)
@@ -1340,7 +1340,7 @@ gpdb::SzOpName
 }
 
 List *
-gpdb::PlPartitionAttrs
+gpdb::GetPartitionAttrs
 	(
 	Oid oid
 	)
@@ -1372,7 +1372,7 @@ gpdb::GetOrderedPartKeysAndKinds
 }
 
 PartitionNode *
-gpdb::PpnParts
+gpdb::GetParts
 	(
 	Oid relid,
 	int2 level,
@@ -1391,7 +1391,7 @@ gpdb::PpnParts
 }
 
 List *
-gpdb::PlRelationKeys
+gpdb::GetRelationKeys
 	(
 	Oid relid
 	)
@@ -1406,7 +1406,7 @@ gpdb::PlRelationKeys
 }
 
 Oid
-gpdb::OidTypeRelid
+gpdb::GetTypeRelid
 	(
 	Oid typid
 	)
@@ -1421,7 +1421,7 @@ gpdb::OidTypeRelid
 }
 
 char *
-gpdb::SzTypeName
+gpdb::GetTypeName
 	(
 	Oid typid
 	)
@@ -1436,7 +1436,7 @@ gpdb::SzTypeName
 }
 
 int
-gpdb::UlSegmentCountGP(void)
+gpdb::GetGPSegmentCount(void)
 {
 	GP_WRAP_START;
 	{
@@ -1447,15 +1447,15 @@ gpdb::UlSegmentCountGP(void)
 }
 
 bool
-gpdb::FHeapAttIsNull
+gpdb::HeapAttIsNull
 	(
 	HeapTuple tup,
-	int iAttNum
+	int attno
 	)
 {
 	GP_WRAP_START;
 	{
-		return heap_attisnull(tup, iAttNum);
+		return heap_attisnull(tup, attno);
 	}
 	GP_WRAP_END;
 	return false;
@@ -1476,7 +1476,7 @@ gpdb::FreeHeapTuple
 }
 
 bool
-gpdb::FIndexExists
+gpdb::IndexExists
 	(
 	Oid oid
 	)
@@ -1491,7 +1491,7 @@ gpdb::FIndexExists
 }
 
 bool
-gpdb::FGreenplumDbHashable
+gpdb::IsGreenplumDbHashable
 	(
 	Oid typid
 	)
@@ -1506,52 +1506,52 @@ gpdb::FGreenplumDbHashable
 }
 
 List *
-gpdb::PlAppendElement
+gpdb::LAppend
 	(
-	List *plist,
+	List *list,
 	void *datum
 	)
 {
 	GP_WRAP_START;
 	{
-		return lappend(plist, datum);
+		return lappend(list, datum);
 	}
 	GP_WRAP_END;
 	return NIL;
 }
 
 List *
-gpdb::PlAppendInt
+gpdb::LAppendInt
 	(
-	List *plist,
+	List *list,
 	int iDatum
 	)
 {
 	GP_WRAP_START;
 	{
-		return lappend_int(plist, iDatum);
+		return lappend_int(list, iDatum);
 	}
 	GP_WRAP_END;
 	return NIL;
 }
 
 List *
-gpdb::PlAppendOid
+gpdb::LAppendOid
 	(
-	List *plist,
+	List *list,
 	Oid datum
 	)
 {
 	GP_WRAP_START;
 	{
-		return lappend_oid(plist, datum);
+		return lappend_oid(list, datum);
 	}
 	GP_WRAP_END;
 	return NIL;
 }
 
 List *
-gpdb::PlPrependElement
+gpdb::LPrepend
 	(
 	void *datum,
 	List *list
@@ -1566,7 +1566,7 @@ gpdb::PlPrependElement
 }
 
 List *
-gpdb::PlPrependInt
+gpdb::LPrependInt
 	(
 	int datum,
 	List *list
@@ -1581,7 +1581,7 @@ gpdb::PlPrependInt
 }
 
 List *
-gpdb::PlPrependOid
+gpdb::LPrependOid
 	(
 	Oid datum,
 	List *list
@@ -1596,7 +1596,7 @@ gpdb::PlPrependOid
 }
 
 List *
-gpdb::PlConcat
+gpdb::ListConcat
 	(
 	List *list1,
 	List *list2
@@ -1611,7 +1611,7 @@ gpdb::PlConcat
 }
 
 List *
-gpdb::PlCopy
+gpdb::ListCopy
 	(
 	List *list
 	)
@@ -1625,7 +1625,7 @@ gpdb::PlCopy
 }
 
 ListCell *
-gpdb::PlcListHead
+gpdb::ListHead
 	(
 	List *l
 	)
@@ -1639,7 +1639,7 @@ gpdb::PlcListHead
 }
 
 ListCell *
-gpdb::PlcListTail
+gpdb::ListTail
 	(
 	List *l
 	)
@@ -1653,7 +1653,7 @@ gpdb::PlcListTail
 }
 
 uint32
-gpdb::UlListLength
+gpdb::ListLength
 	(
 	List *l
 	)
@@ -1667,7 +1667,7 @@ gpdb::UlListLength
 }
 
 void *
-gpdb::PvListNth
+gpdb::ListNth
 	(
 	List *list,
 	int n
@@ -1682,7 +1682,7 @@ gpdb::PvListNth
 }
 
 int
-gpdb::IListNth
+gpdb::ListNthInt
 	(
 	List *list,
 	int n
@@ -1697,7 +1697,7 @@ gpdb::IListNth
 }
 
 Oid
-gpdb::OidListNth
+gpdb::ListNthOid
 	(
 	List *list,
 	int n
@@ -1712,7 +1712,7 @@ gpdb::OidListNth
 }
 
 bool
-gpdb::FMemberOid
+gpdb::ListMemberOid
 	(
 	List *list,
 	Oid oid
@@ -1727,78 +1727,78 @@ gpdb::FMemberOid
 }
 
 void
-gpdb::FreeList
+gpdb::ListFree
 	(
-	List *plist
+	List *list
 	)
 {
 	GP_WRAP_START;
 	{
-		list_free(plist);
+		list_free(list);
 		return;
 	}
 	GP_WRAP_END;
 }
 
 void
-gpdb::FreeListDeep
+gpdb::ListFreeDeep
 	(
-	List *plist
+	List *list
 	)
 {
 	GP_WRAP_START;
 	{
-		list_free_deep(plist);
+		list_free_deep(list);
 		return;
 	}
 	GP_WRAP_END;
 }
 
 bool
-gpdb::FMotionGather
+gpdb::IsMotionGather
 	(
-	const Motion *pmotion
+	const Motion *motion
 	)
 {
 	GP_WRAP_START;
 	{
-		return isMotionGather(pmotion);
+		return isMotionGather(motion);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 bool
-gpdb::FAppendOnlyPartitionTable
+gpdb::IsAppendOnlyPartitionTable
 	(
-	Oid rootOid
+	Oid root_oid
 	)
 {
 	GP_WRAP_START;
 	{
-		return rel_has_appendonly_partition(rootOid);
+		return rel_has_appendonly_partition(root_oid);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 bool
-gpdb::FMultilevelPartitionUniform
+gpdb::IsMultilevelPartitionUniform
 	(
-	Oid rootOid
+	Oid root_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_partition, pg_partition_rule, pg_constraint */
-		return rel_partitioning_is_uniform(rootOid);
+		return rel_partitioning_is_uniform(root_oid);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 TypeCacheEntry *
-gpdb::PtceLookup
+gpdb::LookupTypeCache
 	(
 	Oid type_id,
 	int flags
@@ -1814,7 +1814,7 @@ gpdb::PtceLookup
 }
 
 Value *
-gpdb::PvalMakeString
+gpdb::MakeStringValue
 	(
 	char *str
 	)
@@ -1828,7 +1828,7 @@ gpdb::PvalMakeString
 }
 
 Value *
-gpdb::PvalMakeInteger
+gpdb::MakeIntegerValue
 	(
 	long i
 	)
@@ -1842,7 +1842,7 @@ gpdb::PvalMakeInteger
 }
 
 Node *
-gpdb::PnodeMakeBoolConst
+gpdb::MakeBoolConst
 	(
 	bool value,
 	bool isnull
@@ -1857,23 +1857,23 @@ gpdb::PnodeMakeBoolConst
 }
 
 Node *
-gpdb::PnodeMakeNULLConst
+gpdb::MakeNULLConst
 	(
-	Oid oidType
+	Oid type_oid
 	)
 {
 	GP_WRAP_START;
 	{
-		return (Node *) makeNullConst(oidType, -1 /*consttypmod*/, InvalidOid);
+		return (Node *) makeNullConst(type_oid, -1 /*consttypmod*/, InvalidOid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 TargetEntry *
-gpdb::PteMakeTargetEntry
+gpdb::MakeTargetEntry
 	(
-	Expr *pnodeExpr,
+	Expr *expr,
 	AttrNumber resno,
 	char *resname,
 	bool resjunk
@@ -1881,14 +1881,14 @@ gpdb::PteMakeTargetEntry
 {
 	GP_WRAP_START;
 	{
-		return makeTargetEntry(pnodeExpr, resno, resname, resjunk);
+		return makeTargetEntry(expr, resno, resname, resjunk);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Var *
-gpdb::PvarMakeVar
+gpdb::MakeVar
 	(
 	Index varno,
 	AttrNumber varattno,
@@ -1899,8 +1899,8 @@ gpdb::PvarMakeVar
 {
 	GP_WRAP_START;
 	{
-		// GPORCA currently does not support collations, so infer them using type defaults
-		Oid collation = OidTypeCollation(vartype);
+		// GPDB_91_MERGE_FIXME: collation
+		Oid collation = TypeCollation(vartype);
 		return makeVar(varno, varattno, vartype, vartypmod, collation, varlevelsup);
 	}
 	GP_WRAP_END;
@@ -1908,7 +1908,7 @@ gpdb::PvarMakeVar
 }
 
 void *
-gpdb::PvMemoryContextAllocImpl
+gpdb::MemCtxtAllocImpl
 	(
 	MemoryContext context,
 	Size size,
@@ -1926,7 +1926,7 @@ gpdb::PvMemoryContextAllocImpl
 }
 
 void *
-gpdb::PvMemoryContextAllocZeroAlignedImpl
+gpdb::MemCtxtAllocZeroAlignedImpl
 	(
 	MemoryContext context,
 	Size size,
@@ -1944,7 +1944,7 @@ gpdb::PvMemoryContextAllocZeroAlignedImpl
 }
 
 void *
-gpdb::PvMemoryContextAllocZeroImpl
+gpdb::MemCtxtAllocZeroImpl
 	(
 	MemoryContext context,
 	Size size,
@@ -1962,7 +1962,7 @@ gpdb::PvMemoryContextAllocZeroImpl
 }
 
 void *
-gpdb::PvMemoryContextReallocImpl
+gpdb::MemCtxtReallocImpl
 	(
 	void *pointer,
 	Size size,
@@ -1980,7 +1980,7 @@ gpdb::PvMemoryContextReallocImpl
 }
 
 char *
-gpdb::SzMemoryContextStrdup
+gpdb::MemCtxtStrdup
 	(
 	MemoryContext context,
 	const char *string
@@ -2025,7 +2025,7 @@ gpdb::GpdbEreportImpl
 }
 
 char *
-gpdb::SzNodeToString
+gpdb::NodeToString
 	(
 	void *obj
 	)
@@ -2039,7 +2039,7 @@ gpdb::SzNodeToString
 }
 
 Node *
-gpdb::Pnode
+gpdb::StringToNode
 	(
 	char *string
 	)
@@ -2054,7 +2054,7 @@ gpdb::Pnode
 
 
 Node *
-gpdb::PnodeTypeDefault
+gpdb::GetTypeDefault
 	(
 	Oid typid
 	)
@@ -2070,7 +2070,7 @@ gpdb::PnodeTypeDefault
 
 
 double
-gpdb::DNumericToDoubleNoOverflow
+gpdb::NumericToDoubleNoOverflow
 	(
 	Numeric num
 	)
@@ -2084,7 +2084,7 @@ gpdb::DNumericToDoubleNoOverflow
 }
 
 double
-gpdb::DConvertTimeValueToScalar
+gpdb::ConvertTimeValueToScalar
 	(
 	Datum datum,
 	Oid typid
@@ -2099,7 +2099,7 @@ gpdb::DConvertTimeValueToScalar
 }
 
 double
-gpdb::DConvertNetworkToScalar
+gpdb::ConvertNetworkToScalar
 	(
 	Datum datum,
 	Oid typid
@@ -2114,7 +2114,7 @@ gpdb::DConvertNetworkToScalar
 }
 
 bool
-gpdb::FOpHashJoinable
+gpdb::IsOpHashJoinable
 	(
 	Oid opno,
 	Oid inputtype
@@ -2130,7 +2130,7 @@ gpdb::FOpHashJoinable
 }
 
 bool
-gpdb::FOpStrict
+gpdb::IsOpStrict
 	(
 	Oid opno
 	)
@@ -2162,7 +2162,7 @@ gpdb::GetOpInputTypes
 }
 
 bool
-gpdb::FOperatorExists
+gpdb::OperatorExists
 	(
 	Oid oid
 	)
@@ -2205,7 +2205,7 @@ gpdb::GPDBFree
 }
 
 struct varlena *
-gpdb::PvlenDetoastDatum
+gpdb::DetoastDatum
 	(
 	struct varlena * datum
 	)
@@ -2219,9 +2219,9 @@ gpdb::PvlenDetoastDatum
 }
 
 bool
-gpdb::FWalkQueryOrExpressionTree
+gpdb::WalkQueryOrExpressionTree
 	(
-	Node *pnode,
+	Node *node,
 	bool (*walker) (),
 	void *context,
 	int flags
@@ -2229,16 +2229,16 @@ gpdb::FWalkQueryOrExpressionTree
 {
 	GP_WRAP_START;
 	{
-		return query_or_expression_tree_walker(pnode, walker, context, flags);
+		return query_or_expression_tree_walker(node, walker, context, flags);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 Node *
-gpdb::PnodeMutateQueryOrExpressionTree
+gpdb::MutateQueryOrExpressionTree
 	(
-	Node *pnode,
+	Node *node,
 	Node *(*mutator) (),
 	void *context,
 	int flags
@@ -2246,14 +2246,14 @@ gpdb::PnodeMutateQueryOrExpressionTree
 {
 	GP_WRAP_START;
 	{
-		return query_or_expression_tree_mutator(pnode, mutator, context, flags);
+		return query_or_expression_tree_mutator(node, mutator, context, flags);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Query *
-gpdb::PqueryMutateQueryTree
+gpdb::MutateQueryTree
 	(
 	Query *query,
 	Node *(*mutator) (),
@@ -2270,7 +2270,7 @@ gpdb::PqueryMutateQueryTree
 }
 
 List *
-gpdb::PlMutateRangeTable
+gpdb::MutateRangeTable
 	(
 	List *rtable,
 	Node *(*mutator) (),
@@ -2287,7 +2287,7 @@ gpdb::PlMutateRangeTable
 }
 
 bool
-gpdb::FRelPartIsRoot
+gpdb::RelPartIsRoot
 	(
 	Oid relid
 	)
@@ -2301,7 +2301,7 @@ gpdb::FRelPartIsRoot
 }
 
 bool
-gpdb::FRelPartIsInterior
+gpdb::RelPartIsInterior
 	(
 	Oid relid
 	)
@@ -2315,7 +2315,7 @@ gpdb::FRelPartIsInterior
 }
 
 bool
-gpdb::FRelPartIsNone
+gpdb::RelPartIsNone
 	(
 	Oid relid
 	)
@@ -2329,15 +2329,15 @@ gpdb::FRelPartIsNone
 }
 
 bool
-gpdb::FHasSubclassSlow
+gpdb::HasSubclassSlow
 	(
-	Oid oidRel
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_inherits */
-		return has_subclass_slow(oidRel);
+		return has_subclass_slow(rel_oid);
 	}
 	GP_WRAP_END;
 	return false;
@@ -2345,22 +2345,22 @@ gpdb::FHasSubclassSlow
 
 
 bool
-gpdb::FHasParquetChildren
+gpdb::HasParquetChildren
 	(
-	Oid oidRel
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_inherits, pg_class */
-		return has_parquet_children(oidRel);
+		return has_parquet_children(rel_oid);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 GpPolicy *
-gpdb::Pdistrpolicy
+gpdb::GetDistributionPolicy
 	(
 	Relation rel
 	)
@@ -2375,7 +2375,7 @@ gpdb::Pdistrpolicy
 }
 
 gpos::BOOL
-gpdb::FChildPartDistributionMismatch
+gpdb::IsChildPartDistributionMismatched
 	(
 	Relation rel
 	)
@@ -2390,23 +2390,23 @@ gpdb::FChildPartDistributionMismatch
 }
 
 gpos::BOOL
-gpdb::FChildTriggers
+gpdb::ChildPartHasTriggers
 	(
 	Oid oid,
-	int triggerType
+	int trigger_type
 	)
 {
     GP_WRAP_START;
     {
 		/* catalog tables: pg_inherits, pg_trigger */
-    	return child_triggers(oid, triggerType);
+    	return child_triggers(oid, trigger_type);
     }
     GP_WRAP_END;
     return false;
 }
 
 bool
-gpdb::FRelationExists
+gpdb::RelationExists
 	(
 	Oid oid
 	)
@@ -2421,7 +2421,7 @@ gpdb::FRelationExists
 }
 
 List *
-gpdb::PlRelationOids(void)
+gpdb::GetAllRelationOids(void)
 {
 	GP_WRAP_START;
 	{
@@ -2484,7 +2484,7 @@ gpdb::CloseRelation
 }
 
 List *
-gpdb::PlRelationIndexes
+gpdb::GetRelationIndexes
 	(
 	Relation relation
 	)
@@ -2499,7 +2499,7 @@ gpdb::PlRelationIndexes
 }
 
 LogicalIndexes *
-gpdb::Plgidx
+gpdb::GetLogicalPartIndexes
 	(
 	Oid oid
 	)
@@ -2514,16 +2514,16 @@ gpdb::Plgidx
 }
 
 LogicalIndexInfo *
-gpdb::Plgidxinfo
+gpdb::GetLogicalIndexInfo
 	(
-	Oid rootOid, 
-	Oid indexOid
+	Oid root_oid,
+	Oid index_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_index */
-		return logicalIndexInfoForIndexOid(rootOid, indexOid);
+		return logicalIndexInfoForIndexOid(root_oid, index_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
@@ -2545,37 +2545,37 @@ gpdb::BuildRelationTriggers
 }
 
 Relation
-gpdb::RelGetRelation
+gpdb::GetRelation
 	(
-	Oid relationId
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: relcache */
-		return RelationIdGetRelation(relationId);
+		return RelationIdGetRelation(rel_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 ExtTableEntry *
-gpdb::Pexttable
+gpdb::GetExternalTableEntry
 	(
-	Oid relationId
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_exttable */
-		return GetExtTableEntry(relationId);
+		return GetExtTableEntry(rel_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 List *
-gpdb::PlExternalScanUriList
+gpdb::GetExternalScanUriList
 	(
 	ExtTableEntry *ext,
 	bool *ismasteronlyp
@@ -2590,30 +2590,30 @@ gpdb::PlExternalScanUriList
 }
 
 TargetEntry *
-gpdb::PteMember
+gpdb::FindFirstMatchingMemberInTargetList
 	(
-	Node *pnode,
+	Node *node,
 	List *targetlist
 	)
 {
 	GP_WRAP_START;
 	{
-		return tlist_member(pnode, targetlist);
+		return tlist_member(node, targetlist);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 List *
-gpdb::PteMembers
+gpdb::FindMatchingMembersInTargetList
 	(
-	Node *pnode,
+	Node *node,
 	List *targetlist
 	)
 {
 	GP_WRAP_START;
 	{
-		return tlist_members(pnode, targetlist);
+		return tlist_members(node, targetlist);
 	}
 	GP_WRAP_END;
 
@@ -2621,7 +2621,7 @@ gpdb::PteMembers
 }
 
 bool
-gpdb::FEqual
+gpdb::Equals
 	(
 	void *p1,
 	void *p2
@@ -2636,7 +2636,7 @@ gpdb::FEqual
 }
 
 bool
-gpdb::FTypeExists
+gpdb::TypeExists
 	(
 	Oid oid
 	)
@@ -2651,7 +2651,7 @@ gpdb::FTypeExists
 }
 
 bool
-gpdb::FCompositeType
+gpdb::IsCompositeType
 	(
 	Oid typid
 	)
@@ -2666,35 +2666,35 @@ gpdb::FCompositeType
 }
 
 int
-gpdb::IValue
+gpdb::GetIntFromValue
 	(
-	Node *pnode
+	Node *node
 	)
 {
 	GP_WRAP_START;
 	{
-		return intVal(pnode);
+		return intVal(node);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 Uri *
-gpdb::PuriParseExternalTable
+gpdb::ParseExternalTableUri
 	(
-	const char *szUri
+	const char *uri
 	)
 {
 	GP_WRAP_START;
 	{
-		return ParseExternalTableUri(szUri);
+		return ParseExternalTableUri(uri);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 CdbComponentDatabases *
-gpdb::PcdbComponentDatabases(void)
+gpdb::GetComponentDatabases(void)
 {
 	GP_WRAP_START;
 	{
@@ -2706,22 +2706,22 @@ gpdb::PcdbComponentDatabases(void)
 }
 
 int
-gpdb::IStrCmpIgnoreCase
+gpdb::StrCmpIgnoreCase
 	(
-	const char *sz1,
-	const char *sz2
+	const char *s1,
+	const char *s2
 	)
 {
 	GP_WRAP_START;
 	{
-		return pg_strcasecmp(sz1, sz2);
+		return pg_strcasecmp(s1, s2);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 bool *
-gpdb::RgfRandomSegMap
+gpdb::ConstructRandomSegMap
 	(
 	int total_primaries,
 	int total_to_skip
@@ -2736,7 +2736,7 @@ gpdb::RgfRandomSegMap
 }
 
 StringInfo
-gpdb::SiMakeStringInfo(void)
+gpdb::MakeStringInfo(void)
 {
 	GP_WRAP_START;
 	{
@@ -2763,7 +2763,7 @@ gpdb::AppendStringInfo
 }
 
 int
-gpdb::IFindNodes
+gpdb::FindNodes
 	(
 	Node *node,
 	List *nodeTags
@@ -2778,7 +2778,7 @@ gpdb::IFindNodes
 }
 
 int
-gpdb::ICheckCollation
+gpdb::CheckCollation
 	(
 	Node *node
 	)
@@ -2792,11 +2792,11 @@ gpdb::ICheckCollation
 }
 
 Node *
-gpdb::PnodeCoerceToCommonType
+gpdb::CoerceToCommonType
 	(
 	ParseState *pstate,
-	Node *pnode,
-	Oid oidTargetType,
+	Node *node,
+	Oid target_type,
 	const char *context
 	)
 {
@@ -2806,8 +2806,8 @@ gpdb::PnodeCoerceToCommonType
 		return coerce_to_common_type
 					(
 					pstate,
-					pnode,
-					oidTargetType,
+					node,
+					target_type,
 					context
 					);
 	}
@@ -2816,7 +2816,7 @@ gpdb::PnodeCoerceToCommonType
 }
 
 bool
-gpdb::FResolvePolymorphicType
+gpdb::ResolvePolymorphicArgType
 	(
 	int numargs,
 	Oid *argtypes,
@@ -2835,15 +2835,15 @@ gpdb::FResolvePolymorphicType
 
 // hash a const value with GPDB's hash function
 int32 
-gpdb::ICdbHash
+gpdb::CdbHashConst
 	(
-	Const *pconst,
-	int iSegments
+	Const *constant,
+	int num_segments
 	)
 {
 	GP_WRAP_START;
 	{
-		return cdbhash_const(pconst, iSegments);	
+		return cdbhash_const(constant, num_segments);
 	}
 	GP_WRAP_END;
 	return 0;
@@ -2851,15 +2851,15 @@ gpdb::ICdbHash
 
 // hash a list of const values with GPDB's hash function
 int32 
-gpdb::ICdbHashList
+gpdb::CdbHashConstList
 	(
-	List *plConsts,
-	int iSegments
+	List *constants,
+	int num_segments
 	)
 {
 	GP_WRAP_START;
 	{
-		return cdbhash_const_list(plConsts, iSegments);	
+		return cdbhash_const_list(constants, num_segments);
 	}
 	GP_WRAP_END;
 	return 0;
@@ -2869,12 +2869,12 @@ gpdb::ICdbHashList
 void
 gpdb::CheckRTPermissions
 	(
-	List *plRangeTable
+	List *rtable
 	)
 {
 	GP_WRAP_START;
 	{
-		ExecCheckRTPerms(plRangeTable, true);
+		ExecCheckRTPerms(rtable, true);
 		return;
 	}
 	GP_WRAP_END;
@@ -2906,9 +2906,9 @@ gpdb::IndexOpProperties
 
 // get oids of opfamilies for the index keys
 List *
-gpdb::PlIndexOpFamilies
+gpdb::GetIndexOpFamilies
 	(
-	Oid oidIndex
+	Oid index_oid
 	)
 {
 	GP_WRAP_START;
@@ -2916,7 +2916,7 @@ gpdb::PlIndexOpFamilies
 		/* catalog tables: pg_index */
 
 		// We return the operator families of the index keys.
-		return get_index_opfamilies(oidIndex);
+		return get_index_opfamilies(index_oid);
 	}
 	GP_WRAP_END;
 	
@@ -2925,7 +2925,7 @@ gpdb::PlIndexOpFamilies
 
 // get oids of families this operator belongs to
 List *
-gpdb::PlScOpOpFamilies
+gpdb::GetOpFamiliesForScOp
 	(
 	Oid opno
 	)
@@ -2945,20 +2945,20 @@ gpdb::PlScOpOpFamilies
 
 
 
-// Evaluates 'pexpr' and returns the result as an Expr.
-// Caller keeps ownership of 'pexpr' and takes ownership of the result
+// Evaluates 'expr' and returns the result as an Expr.
+// Caller keeps ownership of 'expr' and takes ownership of the result
 Expr *
-gpdb::PexprEvaluate
+gpdb::EvaluateExpr
 	(
-	Expr *pexpr,
-	Oid oidResultType,
-	int32 iTypeMod
+	Expr *expr,
+	Oid result_type,
+	int32 typmod
 	)
 {
 	GP_WRAP_START;
 	{
-		// GPORCA currently does not support collations, so infer them using type defaults
-		return evaluate_expr(pexpr, oidResultType, iTypeMod, InvalidOid);
+		// GPDB_91_MERGE_FIXME: collation
+		return evaluate_expr(expr, result_type, typmod, InvalidOid);
 	}
 	GP_WRAP_END;
 	return NULL;
@@ -2966,35 +2966,35 @@ gpdb::PexprEvaluate
 
 // interpret the value of "With oids" option from a list of defelems
 bool
-gpdb::FInterpretOidsOption
+gpdb::InterpretOidsOption
 	(
-	List *plOptions
+	List *options
 	)
 {
 	GP_WRAP_START;
 	{
-		return interpretOidsOption(plOptions);
+		return interpretOidsOption(options);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 char *
-gpdb::SzDefGetString
+gpdb::DefGetString
 	(
-	DefElem *pdefelem
+	DefElem *defelem
 	)
 {
 	GP_WRAP_START;
 	{
-		return defGetString(pdefelem);
+		return defGetString(defelem);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Expr *
-gpdb::PexprTransformArrayConstToArrayExpr
+gpdb::TransformArrayConstToArrayExpr
 	(
 	Const *c
 	)
@@ -3008,7 +3008,7 @@ gpdb::PexprTransformArrayConstToArrayExpr
 }
 
 Node *
-gpdb::PnodeEvalConstExpressions
+gpdb::EvalConstExpressions
 	(
 	Node *node
 	)
@@ -3022,7 +3022,7 @@ gpdb::PnodeEvalConstExpressions
 }
 
 SelectedParts *
-gpdb::SpStaticPartitionSelection
+gpdb::RunStaticPartitionSelection
 	(
 	PartitionSelector *ps
 	)
@@ -3036,7 +3036,7 @@ gpdb::SpStaticPartitionSelection
 }
 
 FaultInjectorType_e
-gpdb::OptTasksFaultInjector
+gpdb::InjectFaultInOptTasks
 	(
 	FaultInjectorIdentifier_e identifier
 	)
@@ -3053,15 +3053,15 @@ gpdb::OptTasksFaultInjector
 }
 
 gpos::ULONG
-gpdb::UlLeafPartitions
+gpdb::CountLeafPartTables
        (
-       Oid oidRelation
+       Oid rel_oid
        )
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_partition, pg_partition_rules */
-		return countLeafPartTables(oidRelation);
+		return countLeafPartTables(rel_oid);
 	}
 	GP_WRAP_END;
 
@@ -3173,7 +3173,7 @@ register_mdcache_invalidation_callbacks(void)
 
 // Has there been any catalog changes since last call?
 bool
-gpdb::FMDCacheNeedsReset
+gpdb::MDCacheNeedsReset
 		(
 			void
 		)
@@ -3229,7 +3229,7 @@ gpdb::OptimizerFree
 
 // returns true if a query cancel is requested in GPDB
 bool
-gpdb::FAbortRequested
+gpdb::IsAbortRequested
 	(
 	void
 	)
@@ -3238,7 +3238,7 @@ gpdb::FAbortRequested
 }
 
 GpPolicy *
-gpdb::PMakeGpPolicy
+gpdb::MakeGpPolicy
        (
                MemoryContext mcxt,
                GpPolicyType ptype,

--- a/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
+++ b/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
@@ -37,41 +37,41 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CMDProviderRelcache::CMDProviderRelcache
 	(
-	IMemoryPool *pmp
+	IMemoryPool *mp
 	)
 	:
-	m_pmp(pmp)
+	m_mp(mp)
 {
-	GPOS_ASSERT(NULL != m_pmp);
+	GPOS_ASSERT(NULL != m_mp);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMDProviderRelcache::PstrObject
+//		CMDProviderRelcache::GetMDObjDXLStr
 //
 //	@doc:
 //		Returns the DXL of the requested object in the provided memory pool
 //
 //---------------------------------------------------------------------------
 CWStringBase *
-CMDProviderRelcache::PstrObject
+CMDProviderRelcache::GetMDObjDXLStr
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *md_id
 	)
 	const
 {
-	IMDCacheObject *pimdobj = CTranslatorRelcacheToDXL::Pimdobj(pmp, pmda, pmdid);
+	IMDCacheObject *md_obj = CTranslatorRelcacheToDXL::RetrieveObject(mp, md_accessor, md_id);
 
-	GPOS_ASSERT(NULL != pimdobj);
+	GPOS_ASSERT(NULL != md_obj);
 
-	CWStringDynamic *pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, pimdobj, true /*fSerializeHeaders*/, false /*findent*/);
+	CWStringDynamic *str = CDXLUtils::SerializeMDObj(m_mp, md_obj, true /*fSerializeHeaders*/, false /*findent*/);
 
 	// cleanup DXL object
-	pimdobj->Release();
+	md_obj->Release();
 
-	return pstr;
+	return str;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -35,28 +35,28 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CContextDXLToPlStmt::CContextDXLToPlStmt
 	(
-	IMemoryPool *pmp,
-	CIdGenerator *pidgtorPlan,
-	CIdGenerator *pidgtorMotion,
-	CIdGenerator *pidgtorParam,
-	List **plRTable,
-	List **plSubPlan
+	IMemoryPool *mp,
+	CIdGenerator *plan_id_counter,
+	CIdGenerator *motion_id_counter,
+	CIdGenerator *param_id_counter,
+	List **rtable_entries_list,
+	List **subplan_entries_list
 	)
 	:
-	m_pmp(pmp),
-	m_pidgtorPlan(pidgtorPlan),
-	m_pidgtorMotion(pidgtorMotion),
-	m_pidgtorParam(pidgtorParam),
-	m_pplRTable(plRTable),
-	m_plPartitionTables(NULL),
-	m_pdrgpulNumSelectors(NULL),
-	m_pplSubPlan(plSubPlan),
-	m_ulResultRelation(0),
-	m_pintocl(NULL),
-	m_pdistrpolicy(NULL)
+	m_mp(mp),
+	m_plan_id_counter(plan_id_counter),
+	m_motion_id_counter(motion_id_counter),
+	m_param_id_counter(param_id_counter),
+	m_rtable_entries_list(rtable_entries_list),
+	m_partitioned_tables_list(NULL),
+	m_num_partition_selectors_array(NULL),
+	m_subplan_entries_list(subplan_entries_list),
+	m_result_relation_index(0),
+	m_into_clause(NULL),
+	m_distribution_policy(NULL)
 {
-	m_phmulcteconsumerinfo = GPOS_NEW(m_pmp) HMUlCTEConsumerInfo(m_pmp);
-	m_pdrgpulNumSelectors = GPOS_NEW(m_pmp) DrgPul(m_pmp);
+	m_cte_consumer_info = GPOS_NEW(m_mp) HMUlCTEConsumerInfo(m_mp);
+	m_num_partition_selectors_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 }
 
 //---------------------------------------------------------------------------
@@ -69,78 +69,78 @@ CContextDXLToPlStmt::CContextDXLToPlStmt
 //---------------------------------------------------------------------------
 CContextDXLToPlStmt::~CContextDXLToPlStmt()
 {
-	m_phmulcteconsumerinfo->Release();
-	m_pdrgpulNumSelectors->Release();
+	m_cte_consumer_info->Release();
+	m_num_partition_selectors_array->Release();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlNextPlanId
+//		CContextDXLToPlStmt::GetNextPlanId
 //
 //	@doc:
 //		Get the next plan id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlNextPlanId()
+CContextDXLToPlStmt::GetNextPlanId()
 {
-	return m_pidgtorPlan->UlNextId();
+	return m_plan_id_counter->next_id();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlCurrentMotionId
+//		CContextDXLToPlStmt::GetCurrentMotionId
 //
 //	@doc:
 //		Get the current motion id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlCurrentMotionId()
+CContextDXLToPlStmt::GetCurrentMotionId()
 {
-	return m_pidgtorMotion->UlCurrentId();
+	return m_motion_id_counter->current_id();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlNextMotionId
+//		CContextDXLToPlStmt::GetNextMotionId
 //
 //	@doc:
 //		Get the next motion id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlNextMotionId()
+CContextDXLToPlStmt::GetNextMotionId()
 {
-	return m_pidgtorMotion->UlNextId();
+	return m_motion_id_counter->next_id();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlNextParamId
+//		CContextDXLToPlStmt::GetNextParamId
 //
 //	@doc:
 //		Get the next plan id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlNextParamId()
+CContextDXLToPlStmt::GetNextParamId()
 {
-	return m_pidgtorParam->UlNextId();
+	return m_param_id_counter->next_id();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlCurrentParamId
+//		CContextDXLToPlStmt::GetCurrentParamId
 //
 //	@doc:
 //		Get the current param id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlCurrentParamId()
+CContextDXLToPlStmt::GetCurrentParamId()
 {
-	return m_pidgtorParam->UlCurrentId();
+	return m_param_id_counter->current_id();
 }
 
 //---------------------------------------------------------------------------
@@ -154,49 +154,49 @@ CContextDXLToPlStmt::UlCurrentParamId()
 void
 CContextDXLToPlStmt::AddCTEConsumerInfo
 	(
-	ULONG ulCteId,
-	ShareInputScan *pshscan
+	ULONG cte_id,
+	ShareInputScan *share_input_scan
 	)
 {
-	GPOS_ASSERT(NULL != pshscan);
+	GPOS_ASSERT(NULL != share_input_scan);
 
-	SCTEConsumerInfo *pcteinfo = m_phmulcteconsumerinfo->PtLookup(&ulCteId);
-	if (NULL != pcteinfo)
+	SCTEConsumerInfo *cte_info = m_cte_consumer_info->Find(&cte_id);
+	if (NULL != cte_info)
 	{
-		pcteinfo->AddCTEPlan(pshscan);
+		cte_info->AddCTEPlan(share_input_scan);
 		return;
 	}
 
-	List *plPlanCTE = ListMake1(pshscan);
+	List *cte_plan = ListMake1(share_input_scan);
 
-	ULONG *pulKey = GPOS_NEW(m_pmp) ULONG(ulCteId);
+	ULONG *key = GPOS_NEW(m_mp) ULONG(cte_id);
 #ifdef GPOS_DEBUG
-	BOOL fResult =
+	BOOL result =
 #endif
-			m_phmulcteconsumerinfo->FInsert(pulKey, GPOS_NEW(m_pmp) SCTEConsumerInfo(plPlanCTE));
+			m_cte_consumer_info->Insert(key, GPOS_NEW(m_mp) SCTEConsumerInfo(cte_plan));
 
-	GPOS_ASSERT(fResult);
+	GPOS_ASSERT(result);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::PplanCTEProducer
+//		CContextDXLToPlStmt::GetCTEConsumerList
 //
 //	@doc:
 //		Return the list of GPDB plan nodes representing the CTE consumers
 //		with the given CTE identifier
 //---------------------------------------------------------------------------
 List *
-CContextDXLToPlStmt::PshscanCTEConsumer
+CContextDXLToPlStmt::GetCTEConsumerList
 	(
-	ULONG ulCteId
+	ULONG cte_id
 	)
 	const
 {
-	SCTEConsumerInfo *pcteinfo = m_phmulcteconsumerinfo->PtLookup(&ulCteId);
-	if (NULL != pcteinfo)
+	SCTEConsumerInfo *cte_info = m_cte_consumer_info->Find(&cte_id);
+	if (NULL != cte_info)
 	{
-		return pcteinfo->m_plSis;
+		return cte_info->m_cte_consumer_list;
 	}
 
 	return NULL;
@@ -204,30 +204,30 @@ CContextDXLToPlStmt::PshscanCTEConsumer
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::PlPrte
+//		CContextDXLToPlStmt::GetRTableEntriesList
 //
 //	@doc:
 //		Return the list of RangeTableEntries
 //
 //---------------------------------------------------------------------------
 List *
-CContextDXLToPlStmt::PlPrte()
+CContextDXLToPlStmt::GetRTableEntriesList()
 {
-	return (*(m_pplRTable));
+	return (*(m_rtable_entries_list));
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::PlPplanSubplan
+//		CContextDXLToPlStmt::GetSubplanEntriesList
 //
 //	@doc:
 //		Return the list of subplans generated so far
 //
 //---------------------------------------------------------------------------
 List *
-CContextDXLToPlStmt::PlPplanSubplan()
+CContextDXLToPlStmt::GetSubplanEntriesList()
 {
-	return (*(m_pplSubPlan));
+	return (*(m_subplan_entries_list));
 }
 
 //---------------------------------------------------------------------------
@@ -241,19 +241,19 @@ CContextDXLToPlStmt::PlPplanSubplan()
 void
 CContextDXLToPlStmt::AddRTE
 	(
-	RangeTblEntry *prte,
-	BOOL fResultRelation
+	RangeTblEntry *rte,
+	BOOL is_result_relation
 	)
 {
-	(* (m_pplRTable)) = gpdb::PlAppendElement((*(m_pplRTable)), prte);
+	(* (m_rtable_entries_list)) = gpdb::LAppend((*(m_rtable_entries_list)), rte);
 
-	prte->inFromCl = true;
+	rte->inFromCl = true;
 
-	if (fResultRelation)
+	if (is_result_relation)
 	{
-		GPOS_ASSERT(0 == m_ulResultRelation && "Only one result relation supported");
-		prte->inFromCl = false;
-		m_ulResultRelation = gpdb::UlListLength(*(m_pplRTable));
+		GPOS_ASSERT(0 == m_result_relation_index && "Only one result relation supported");
+		rte->inFromCl = false;
+		m_result_relation_index = gpdb::ListLength(*(m_rtable_entries_list));
 	}
 }
 
@@ -271,9 +271,9 @@ CContextDXLToPlStmt::AddPartitionedTable
 	OID oid
 	)
 {
-	if (!gpdb::FMemberOid(m_plPartitionTables, oid))
+	if (!gpdb::ListMemberOid(m_partitioned_tables_list, oid))
 	{
-		m_plPartitionTables = gpdb::PlAppendOid(m_plPartitionTables, oid);
+		m_partitioned_tables_list = gpdb::LAppendOid(m_partitioned_tables_list, oid);
 	}
 }
 
@@ -288,41 +288,41 @@ CContextDXLToPlStmt::AddPartitionedTable
 void
 CContextDXLToPlStmt::IncrementPartitionSelectors
 	(
-	ULONG ulScanId
+	ULONG scan_id
 	)
 {
 	// add extra elements to the array if necessary
-	const ULONG ulLen = m_pdrgpulNumSelectors->UlLength();
-	for (ULONG ul = ulLen; ul <= ulScanId; ul++)
+	const ULONG len = m_num_partition_selectors_array->Size();
+	for (ULONG ul = len; ul <= scan_id; ul++)
 	{
-		ULONG *pul = GPOS_NEW(m_pmp) ULONG(0);
-		m_pdrgpulNumSelectors->Append(pul);
+		ULONG *pul = GPOS_NEW(m_mp) ULONG(0);
+		m_num_partition_selectors_array->Append(pul);
 	}
 
-	ULONG *pul = (*m_pdrgpulNumSelectors)[ulScanId];
-	(*pul) ++;
+	ULONG *ul = (*m_num_partition_selectors_array)[scan_id];
+	(*ul) ++;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::PlNumPartitionSelectors
+//		CContextDXLToPlStmt::GetNumPartitionSelectorsList
 //
 //	@doc:
 //		Return list containing number of partition selectors for every scan id
 //
 //---------------------------------------------------------------------------
 List *
-CContextDXLToPlStmt::PlNumPartitionSelectors() const
+CContextDXLToPlStmt::GetNumPartitionSelectorsList() const
 {
-	List *pl = NIL;
-	const ULONG ulLen = m_pdrgpulNumSelectors->UlLength();
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	List *partition_selectors_list = NIL;
+	const ULONG len = m_num_partition_selectors_array->Size();
+	for (ULONG ul = 0; ul < len; ul++)
 	{
-		ULONG *pul = (*m_pdrgpulNumSelectors)[ul];
-		pl = gpdb::PlAppendInt(pl, *pul);
+		ULONG *num_partition_selectors = (*m_num_partition_selectors_array)[ul];
+		partition_selectors_list = gpdb::LAppendInt(partition_selectors_list, *num_partition_selectors);
 	}
 
-	return pl;
+	return partition_selectors_list;
 }
 
 //---------------------------------------------------------------------------
@@ -334,9 +334,9 @@ CContextDXLToPlStmt::PlNumPartitionSelectors() const
 //
 //---------------------------------------------------------------------------
 void
-CContextDXLToPlStmt::AddSubplan(Plan *pplan)
+CContextDXLToPlStmt::AddSubplan(Plan *plan)
 {
-	(* (m_pplSubPlan)) = gpdb::PlAppendElement((*(m_pplSubPlan)), pplan);
+	(* (m_subplan_entries_list)) = gpdb::LAppend((*(m_subplan_entries_list)), plan);
 }
 
 //---------------------------------------------------------------------------
@@ -352,15 +352,15 @@ CContextDXLToPlStmt::AddSubplan(Plan *pplan)
 void
 CContextDXLToPlStmt::AddCtasInfo
 	(
-	IntoClause *pintocl,
-	GpPolicy *pdistrpolicy
+	IntoClause *into_clause,
+	GpPolicy *distribution_policy
 	)
 {
-//	GPOS_ASSERT(NULL != pintocl);
-	GPOS_ASSERT(NULL != pdistrpolicy);
+//	GPOS_ASSERT(NULL != into_clause);
+	GPOS_ASSERT(NULL != distribution_policy);
 	
-	m_pintocl = pintocl;
-	m_pdistrpolicy = pdistrpolicy;
+	m_into_clause = into_clause;
+	m_distribution_policy = distribution_policy;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CMappingColIdVar.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVar.cpp
@@ -27,10 +27,10 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CMappingColIdVar::CMappingColIdVar
 	(
-	IMemoryPool *pmp
+	IMemoryPool *mp
 	)
 	:
-	m_pmp(pmp)
+	m_mp(mp)
 {
 }
 

--- a/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
+++ b/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
@@ -33,16 +33,16 @@ using namespace gpos;
 //---------------------------------------------------------------------------
 CMappingElementColIdParamId::CMappingElementColIdParamId
 	(
-	ULONG ulColId,
-	ULONG ulParamId,
-	IMDId *pmdid,
-	INT iTypeModifier
+	ULONG colid,
+	ULONG paramid,
+	IMDId *mdid,
+	INT type_modifier
 	)
 	:
-	m_ulColId(ulColId),
-	m_ulParamId(ulParamId),
-	m_pmdid(pmdid),
-	m_iTypeModifier(iTypeModifier)
+	m_colid(colid),
+	m_paramid(paramid),
+	m_mdid(mdid),
+	m_type_modifier(type_modifier)
 {
 }
 

--- a/src/backend/gpopt/translate/CMappingElementColIdTE.cpp
+++ b/src/backend/gpopt/translate/CMappingElementColIdTE.cpp
@@ -33,14 +33,14 @@ using namespace gpos;
 //---------------------------------------------------------------------------
 CMappingElementColIdTE::CMappingElementColIdTE
 	(
-	ULONG ulColId,
-	ULONG ulQueryLevel,
-	TargetEntry *pte
+	ULONG colid,
+	ULONG query_level,
+	TargetEntry *target_entry
 	)
 	:
-	m_ulColId(ulColId),
-	m_ulQueryLevel(ulQueryLevel),
-	m_pte(pte)
+	m_colid(colid),
+	m_query_level(query_level),
+	m_target_entry(target_entry)
 {
 }
 

--- a/src/backend/gpopt/translate/CMappingVarColId.cpp
+++ b/src/backend/gpopt/translate/CMappingVarColId.cpp
@@ -40,97 +40,97 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CMappingVarColId::CMappingVarColId
 	(
-	IMemoryPool *pmp
+	IMemoryPool *mp
 	)
 	:
-	m_pmp(pmp)
+	m_mp(mp)
 {
-	m_pmvcmap = GPOS_NEW(m_pmp) CMVCMap(m_pmp);
+	m_gpdb_att_opt_col_mapping = GPOS_NEW(m_mp) GPDBAttOptColHashMap(m_mp);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::Pgpdbattoptcol
+//		CMappingVarColId::GetGPDBAttOptColMapping
 //
 //	@doc:
 //		Given a gpdb attribute, return the mapping info to opt col
 //
 //---------------------------------------------------------------------------
 const CGPDBAttOptCol *
-CMappingVarColId::Pgpdbattoptcol
+CMappingVarColId::GetGPDBAttOptColMapping
 	(
-	ULONG ulCurrentQueryLevel,
-	const Var *pvar,
-	EPlStmtPhysicalOpType eplsphoptype
+	ULONG current_query_level,
+	const Var *var,
+	EPlStmtPhysicalOpType plstmt_physical_op_type
 	)
 	const
 {
-	GPOS_ASSERT(NULL != pvar);
-	GPOS_ASSERT(ulCurrentQueryLevel >= pvar->varlevelsup);
+	GPOS_ASSERT(NULL != var);
+	GPOS_ASSERT(current_query_level >= var->varlevelsup);
 
 	// absolute query level of var
-	ULONG ulAbsQueryLevel = ulCurrentQueryLevel - pvar->varlevelsup;
+	ULONG abs_query_level = current_query_level - var->varlevelsup;
 
 	// extract varno
-	ULONG ulVarNo = pvar->varno;
-	if (EpspotWindow == eplsphoptype || EpspotAgg == eplsphoptype || EpspotMaterialize == eplsphoptype)
+	ULONG var_no = var->varno;
+	if (EpspotWindow == plstmt_physical_op_type || EpspotAgg == plstmt_physical_op_type || EpspotMaterialize == plstmt_physical_op_type)
 	{
 		// Agg and Materialize need to employ OUTER, since they have other
 		// values in GPDB world
-		ulVarNo = OUTER_VAR;
+		var_no = OUTER_VAR;
 	}
 
-	CGPDBAttInfo *pgpdbattinfo = GPOS_NEW(m_pmp) CGPDBAttInfo(ulAbsQueryLevel, ulVarNo, pvar->varattno);
-	CGPDBAttOptCol *pgpdbattoptcol = m_pmvcmap->PtLookup(pgpdbattinfo);
+	CGPDBAttInfo *gpdb_att_info = GPOS_NEW(m_mp) CGPDBAttInfo(abs_query_level, var_no, var->varattno);
+	CGPDBAttOptCol *gpdb_att_opt_col_info = m_gpdb_att_opt_col_mapping->Find(gpdb_att_info);
 	
-	if (NULL == pgpdbattoptcol)
+	if (NULL == gpdb_att_opt_col_info)
 	{
 		// TODO: Sept 09 2013, remove temporary fix (revert exception to assert) to avoid crash during algebrization
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("No variable"));
 	}
 
-	pgpdbattinfo->Release();
-	return pgpdbattoptcol;
+	gpdb_att_info->Release();
+	return gpdb_att_opt_col_info;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::PstrColName
+//		CMappingVarColId::GetOptColName
 //
 //	@doc:
 //		Given a gpdb attribute, return a column name in optimizer world
 //
 //---------------------------------------------------------------------------
 const CWStringBase *
-CMappingVarColId::PstrColName
+CMappingVarColId::GetOptColName
 	(
-	ULONG ulCurrentQueryLevel,
-	const Var *pvar,
-	EPlStmtPhysicalOpType eplsphoptype
+	ULONG current_query_level,
+	const Var *var,
+	EPlStmtPhysicalOpType plstmt_physical_op_type
 	)
 	const
 {
-	return Pgpdbattoptcol(ulCurrentQueryLevel, pvar, eplsphoptype)->Poptcolinfo()->PstrColName();
+	return GetGPDBAttOptColMapping(current_query_level, var, plstmt_physical_op_type)->GetOptColInfo()->GetOptColName();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::UlColId
+//		CMappingVarColId::GetColId
 //
 //	@doc:
 //		given a gpdb attribute, return a column id in optimizer world
 //
 //---------------------------------------------------------------------------
 ULONG
-CMappingVarColId::UlColId
+CMappingVarColId::GetColId
 	(
-	ULONG ulCurrentQueryLevel,
-	const Var *pvar,
-	EPlStmtPhysicalOpType eplsphoptype
+	ULONG current_query_level,
+	const Var *var,
+	EPlStmtPhysicalOpType plstmt_physical_op_type
 	)
 	const
 {
-	return Pgpdbattoptcol(ulCurrentQueryLevel, pvar, eplsphoptype)->Poptcolinfo()->UlColId();
+	return GetGPDBAttOptColMapping(current_query_level, var, plstmt_physical_op_type)->GetOptColInfo()->GetColId();
 }
 
 //---------------------------------------------------------------------------
@@ -144,33 +144,33 @@ CMappingVarColId::UlColId
 void
 CMappingVarColId::Insert
 	(
-	ULONG ulQueryLevel,
-	ULONG ulVarNo,
-	INT iAttNo,
-	ULONG ulColId,
-	CWStringBase *pstrColName
+	ULONG query_level,
+	ULONG var_no,
+	INT attrnum,
+	ULONG colid,
+	CWStringBase *column_name
 	)
 {
 	// GPDB agg node uses 0 in Var, but that should've been taken care of
 	// by translator
-	GPOS_ASSERT(ulVarNo > 0);
+	GPOS_ASSERT(var_no > 0);
 
 	// create key
-	CGPDBAttInfo *pgpdbattinfo = GPOS_NEW(m_pmp) CGPDBAttInfo(ulQueryLevel, ulVarNo, iAttNo);
+	CGPDBAttInfo *gpdb_att_info = GPOS_NEW(m_mp) CGPDBAttInfo(query_level, var_no, attrnum);
 
 	// create value
-	COptColInfo *poptcolinfo = GPOS_NEW(m_pmp) COptColInfo(ulColId, pstrColName);
+	COptColInfo *opt_col_info = GPOS_NEW(m_mp) COptColInfo(colid, column_name);
 
 	// key is part of value, bump up refcount
-	pgpdbattinfo->AddRef();
-	CGPDBAttOptCol *pgpdbattoptcol = GPOS_NEW(m_pmp) CGPDBAttOptCol(pgpdbattinfo, poptcolinfo);
+	gpdb_att_info->AddRef();
+	CGPDBAttOptCol *gpdb_att_opt_col_info = GPOS_NEW(m_mp) CGPDBAttOptCol(gpdb_att_info, opt_col_info);
 
 #ifdef GPOS_DEBUG
-	BOOL fResult =
+	BOOL result =
 #endif // GPOS_DEBUG
-			m_pmvcmap->FInsert(pgpdbattinfo, pgpdbattoptcol);
+			m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info, gpdb_att_opt_col_info);
 
-	GPOS_ASSERT(fResult);
+	GPOS_ASSERT(result);
 }
 
 //---------------------------------------------------------------------------
@@ -185,25 +185,25 @@ CMappingVarColId::Insert
 void
 CMappingVarColId::LoadTblColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const CDXLTableDescr *pdxltabdesc
+	ULONG query_level,
+	ULONG RTE_index,
+	const CDXLTableDescr *table_descr
 	)
 {
-	GPOS_ASSERT(NULL != pdxltabdesc);
-	const ULONG ulSize = pdxltabdesc->UlArity();
+	GPOS_ASSERT(NULL != table_descr);
+	const ULONG size = table_descr->Arity();
 
 	// add mapping information for columns
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG i = 0; i < size; i++)
 	{
-		const CDXLColDescr *pdxlcd = pdxltabdesc->Pdxlcd(ul);
+		const CDXLColDescr *dxl_col_descr = table_descr->GetColumnDescrAt(i);
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				pdxlcd->IAttno(),
-				pdxlcd->UlID(),
-				pdxlcd->Pmdname()->Pstr()->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				dxl_col_descr->AttrNum(),
+				dxl_col_descr->Id(),
+				dxl_col_descr->MdName()->GetMDName()->Copy(m_mp)
 				);
 	}
 
@@ -221,28 +221,28 @@ CMappingVarColId::LoadTblColumns
 void
 CMappingVarColId::LoadIndexColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const IMDIndex *pmdindex,
-	const CDXLTableDescr *pdxltabdesc
+	ULONG query_level,
+	ULONG RTE_index,
+	const IMDIndex *index,
+	const CDXLTableDescr *table_descr
 	)
 {
-	GPOS_ASSERT(NULL != pdxltabdesc);
+	GPOS_ASSERT(NULL != table_descr);
 
-	const ULONG ulSize = pmdindex->UlKeys();
+	const ULONG size = index->Keys();
 
 	// add mapping information for columns
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG i = 0; i < size; i++)
 	{
-		ULONG ulPos = pmdindex->UlKey(ul);
-		const CDXLColDescr *pdxlcd = pdxltabdesc->Pdxlcd(ulPos);
+		ULONG pos = index->KeyAt(i);
+		const CDXLColDescr *dxl_col_descr = table_descr->GetColumnDescrAt(pos);
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				INT(ul + 1),
-				pdxlcd->UlID(),
-				pdxlcd->Pmdname()->Pstr()->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				INT(i + 1),
+				dxl_col_descr->Id(),
+				dxl_col_descr->MdName()->GetMDName()->Copy(m_mp)
 				);
 	}
 
@@ -259,34 +259,34 @@ CMappingVarColId::LoadIndexColumns
 void
 CMappingVarColId::Load
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	CIdGenerator *pidgtor,
-	List *plColNames
+	ULONG query_level,
+	ULONG RTE_index,
+	CIdGenerator *id_generator,
+	List *col_names
 	)
 {
-	ListCell *plcCol = NULL;
-	ULONG ul = 0;
+	ListCell *col_name = NULL;
+	ULONG i = 0;
 
 	// add mapping information for columns
-	ForEach(plcCol, plColNames)
+	ForEach(col_name, col_names)
 	{
-		Value *pvalue = (Value *) lfirst(plcCol);
-		CHAR *szColName = strVal(pvalue);
+		Value *value = (Value *) lfirst(col_name);
+		CHAR *col_name_char_array = strVal(value);
 
-		CWStringDynamic *pstrColName = CDXLUtils::PstrFromSz(m_pmp, szColName);
+		CWStringDynamic *column_name = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, col_name_char_array);
 
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				INT(ul + 1),
-				pidgtor->UlNextId(),
-				pstrColName->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				INT(i + 1),
+				id_generator->next_id(),
+				column_name->Copy(m_mp)
 				);
 
-		ul ++;
-		GPOS_DELETE(pstrColName);
+		i ++;
+		GPOS_DELETE(column_name);
 	}
 }
 
@@ -301,25 +301,25 @@ CMappingVarColId::Load
 void
 CMappingVarColId::LoadColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const DrgPdxlcd *pdrgdxlcd
+	ULONG query_level,
+	ULONG RTE_index,
+	const CDXLColDescrArray *column_descrs
 	)
 {
-	GPOS_ASSERT(NULL != pdrgdxlcd);
-	const ULONG ulSize = pdrgdxlcd->UlLength();
+	GPOS_ASSERT(NULL != column_descrs);
+	const ULONG size = column_descrs->Size();
 
 	// add mapping information for columns
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG i = 0; i < size; i++)
 	{
-		const CDXLColDescr *pdxlcd = (*pdrgdxlcd)[ul];
+		const CDXLColDescr *dxl_col_descr = (*column_descrs)[i];
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				pdxlcd->IAttno(),
-				pdxlcd->UlID(),
-				pdxlcd->Pmdname()->Pstr()->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				dxl_col_descr->AttrNum(),
+				dxl_col_descr->Id(),
+				dxl_col_descr->MdName()->GetMDName()->Copy(m_mp)
 				);
 	}
 
@@ -336,36 +336,36 @@ CMappingVarColId::LoadColumns
 void
 CMappingVarColId::LoadDerivedTblColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const DrgPdxln *pdrgpdxlnDerivedColumns,
-	List *plTargetList
+	ULONG query_level,
+	ULONG RTE_index,
+	const CDXLNodeArray *derived_columns_dxl,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpdxlnDerivedColumns);
-	GPOS_ASSERT( (ULONG) gpdb::UlListLength(plTargetList) >= pdrgpdxlnDerivedColumns->UlLength());
+	GPOS_ASSERT(NULL != derived_columns_dxl);
+	GPOS_ASSERT( (ULONG) gpdb::ListLength(target_list) >= derived_columns_dxl->Size());
 
-	ULONG ulDrvdTblColCounter = 0; // counter for the dynamic array of DXL nodes
-	ListCell *plc = NULL;
-	ForEach (plc, plTargetList)
+	ULONG drvd_tbl_col_counter = 0; // counter for the dynamic array of DXL nodes
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		if (!pte->resjunk)
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		if (!target_entry->resjunk)
 		{
-			GPOS_ASSERT(0 < pte->resno);
-			CDXLNode *pdxln = (*pdrgpdxlnDerivedColumns)[ulDrvdTblColCounter];
-			GPOS_ASSERT(NULL != pdxln);
-			CDXLScalarIdent *pdxlnIdent = CDXLScalarIdent::PdxlopConvert(pdxln->Pdxlop());
-			const CDXLColRef *pdxlcr = pdxlnIdent->Pdxlcr();
+			GPOS_ASSERT(0 < target_entry->resno);
+			CDXLNode *dxlnode = (*derived_columns_dxl)[drvd_tbl_col_counter];
+			GPOS_ASSERT(NULL != dxlnode);
+			CDXLScalarIdent *dxl_sc_ident = CDXLScalarIdent::Cast(dxlnode->GetOperator());
+			const CDXLColRef *dxl_colref = dxl_sc_ident->GetDXLColRef();
 			this->Insert
 					(
-					ulQueryLevel,
-					ulRTEIndex,
-					INT(pte->resno),
-					pdxlcr->UlID(),
-					pdxlcr->Pmdname()->Pstr()->PStrCopy(m_pmp)
+					query_level,
+					RTE_index,
+					INT(target_entry->resno),
+					dxl_colref->Id(),
+					dxl_colref->MdName()->GetMDName()->Copy(m_mp)
 					);
-			ulDrvdTblColCounter++;
+			drvd_tbl_col_counter++;
 		}
 	}
 }
@@ -381,35 +381,35 @@ CMappingVarColId::LoadDerivedTblColumns
 void
 CMappingVarColId::LoadCTEColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const DrgPul *pdrgpulCTEColumns,
-	List *plTargetList
+	ULONG query_level,
+	ULONG RTE_index,
+	const ULongPtrArray *CTE_columns,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpulCTEColumns);
-	GPOS_ASSERT( (ULONG) gpdb::UlListLength(plTargetList) >= pdrgpulCTEColumns->UlLength());
+	GPOS_ASSERT(NULL != CTE_columns);
+	GPOS_ASSERT( (ULONG) gpdb::ListLength(target_list) >= CTE_columns->Size());
 
-	ULONG ulCTE = 0;
-	ListCell *plc = NULL;
-	ForEach (plc, plTargetList)
+	ULONG idx = 0;
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		if (!pte->resjunk)
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		if (!target_entry->resjunk)
 		{
-			GPOS_ASSERT(0 < pte->resno);
-			ULONG ulCTEColId = *((*pdrgpulCTEColumns)[ulCTE]);
+			GPOS_ASSERT(0 < target_entry->resno);
+			ULONG CTE_colid = *((*CTE_columns)[idx]);
 			
-			CWStringDynamic *pstrColName = CDXLUtils::PstrFromSz(m_pmp, pte->resname);
+			CWStringDynamic *column_name = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, target_entry->resname);
 			this->Insert
 					(
-					ulQueryLevel,
-					ulRTEIndex,
-					INT(pte->resno),
-					ulCTEColId,
-					pstrColName
+					query_level,
+					RTE_index,
+					INT(target_entry->resno),
+					CTE_colid,
+					column_name
 					);
-			ulCTE++;
+			idx++;
 		}
 	}
 }
@@ -425,170 +425,170 @@ CMappingVarColId::LoadCTEColumns
 void
 CMappingVarColId::LoadProjectElements
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const CDXLNode *pdxlnPrL
+	ULONG query_level,
+	ULONG RTE_index,
+	const CDXLNode *project_list_dxlnode
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnPrL);
-	const ULONG ulSize = pdxlnPrL->UlArity();
+	GPOS_ASSERT(NULL != project_list_dxlnode);
+	const ULONG size = project_list_dxlnode->Arity();
 	// add mapping information for columns
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG i = 0; i < size; i++)
 	{
-		CDXLNode *pdxln = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrEl = CDXLScalarProjElem::PdxlopConvert(pdxln->Pdxlop());
+		CDXLNode *dxlnode = (*project_list_dxlnode)[i];
+		CDXLScalarProjElem *dxl_proj_elem = CDXLScalarProjElem::Cast(dxlnode->GetOperator());
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				INT(ul + 1),
-				pdxlopPrEl->UlId(),
-				pdxlopPrEl->PmdnameAlias()->Pstr()->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				INT(i + 1),
+				dxl_proj_elem->Id(),
+				dxl_proj_elem->GetMdNameAlias()->GetMDName()->Copy(m_mp)
 				);
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::PmapvarcolidCopy
+//		CMappingVarColId::CopyMapColId
 //
 //	@doc:
 //		Create a deep copy
 //
 //---------------------------------------------------------------------------
 CMappingVarColId *
-CMappingVarColId::PmapvarcolidCopy
+CMappingVarColId::CopyMapColId
 	(
-	ULONG ulQueryLevel
+	ULONG query_level
 	)
 	const
 {
-	CMappingVarColId *pmapvarcolid = GPOS_NEW(m_pmp) CMappingVarColId(m_pmp);
+	CMappingVarColId *var_colid_mapping = GPOS_NEW(m_mp) CMappingVarColId(m_mp);
 
 	// iterate over full map
-	CMVCMapIter mvcmi(this->m_pmvcmap);
-	while (mvcmi.FAdvance())
+	GPDBAttOptColHashMapIter col_map_iterator(this->m_gpdb_att_opt_col_mapping);
+	while (col_map_iterator.Advance())
 	{
-		const CGPDBAttOptCol *pgpdbattoptcol = mvcmi.Pt();
-		const CGPDBAttInfo *pgpdbattinfo = pgpdbattoptcol->Pgpdbattinfo();
-		const COptColInfo *poptcolinfo = pgpdbattoptcol->Poptcolinfo();
+		const CGPDBAttOptCol *gpdb_att_opt_col_info = col_map_iterator.Value();
+		const CGPDBAttInfo *gpdb_att_info = gpdb_att_opt_col_info->GetGPDBAttInfo();
+		const COptColInfo *opt_col_info = gpdb_att_opt_col_info->GetOptColInfo();
 
-		if (pgpdbattinfo->UlQueryLevel() <= ulQueryLevel)
+		if (gpdb_att_info->GetQueryLevel() <= query_level)
 		{
 			// include all variables defined at same query level or before
-			CGPDBAttInfo *pgpdbattinfoNew = GPOS_NEW(m_pmp) CGPDBAttInfo(pgpdbattinfo->UlQueryLevel(), pgpdbattinfo->UlVarNo(), pgpdbattinfo->IAttNo());
-			COptColInfo *poptcolinfoNew = GPOS_NEW(m_pmp) COptColInfo(poptcolinfo->UlColId(), GPOS_NEW(m_pmp) CWStringConst(m_pmp, poptcolinfo->PstrColName()->Wsz()));
-			pgpdbattinfoNew->AddRef();
-			CGPDBAttOptCol *pgpdbattoptcolNew = GPOS_NEW(m_pmp) CGPDBAttOptCol(pgpdbattinfoNew, poptcolinfoNew);
+			CGPDBAttInfo *gpdb_att_info_new = GPOS_NEW(m_mp) CGPDBAttInfo(gpdb_att_info->GetQueryLevel(), gpdb_att_info->GetVarNo(), gpdb_att_info->GetAttNo());
+			COptColInfo *opt_col_info_new = GPOS_NEW(m_mp) COptColInfo(opt_col_info->GetColId(), GPOS_NEW(m_mp) CWStringConst(m_mp, opt_col_info->GetOptColName()->GetBuffer()));
+			gpdb_att_info_new->AddRef();
+			CGPDBAttOptCol *gpdb_att_opt_col_new = GPOS_NEW(m_mp) CGPDBAttOptCol(gpdb_att_info_new, opt_col_info_new);
 
 			// insert into hashmap
 #ifdef GPOS_DEBUG
-			BOOL fResult =
+			BOOL result =
 #endif // GPOS_DEBUG
-					pmapvarcolid->m_pmvcmap->FInsert(pgpdbattinfoNew, pgpdbattoptcolNew);
-			GPOS_ASSERT(fResult);
+					var_colid_mapping->m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info_new, gpdb_att_opt_col_new);
+			GPOS_ASSERT(result);
 		}
 	}
 
-	return pmapvarcolid;
+	return var_colid_mapping;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::PmapvarcolidCopy
+//		CMappingVarColId::CopyMapColId
 //
 //	@doc:
 //		Create a deep copy
 //
 //---------------------------------------------------------------------------
 CMappingVarColId *
-CMappingVarColId::PmapvarcolidCopy
+CMappingVarColId::CopyMapColId
 	(
-	IMemoryPool *pmp
+	IMemoryPool *mp
 	)
 	const
 {
-	CMappingVarColId *pmapvarcolid = GPOS_NEW(pmp) CMappingVarColId(pmp);
+	CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
 
 	// iterate over full map
-	CMVCMapIter mvcmi(this->m_pmvcmap);
-	while (mvcmi.FAdvance())
+	GPDBAttOptColHashMapIter col_map_iterator(this->m_gpdb_att_opt_col_mapping);
+	while (col_map_iterator.Advance())
 	{
-		const CGPDBAttOptCol *pgpdbattoptcol = mvcmi.Pt();
-		const CGPDBAttInfo *pgpdbattinfo = pgpdbattoptcol->Pgpdbattinfo();
-		const COptColInfo *poptcolinfo = pgpdbattoptcol->Poptcolinfo();
+		const CGPDBAttOptCol *gpdb_att_opt_col_info = col_map_iterator.Value();
+		const CGPDBAttInfo *gpdb_att_info = gpdb_att_opt_col_info->GetGPDBAttInfo();
+		const COptColInfo *opt_col_info = gpdb_att_opt_col_info->GetOptColInfo();
 
-		CGPDBAttInfo *pgpdbattinfoNew = GPOS_NEW(pmp) CGPDBAttInfo(pgpdbattinfo->UlQueryLevel(), pgpdbattinfo->UlVarNo(), pgpdbattinfo->IAttNo());
-		COptColInfo *poptcolinfoNew = GPOS_NEW(pmp) COptColInfo(poptcolinfo->UlColId(), GPOS_NEW(pmp) CWStringConst(pmp, poptcolinfo->PstrColName()->Wsz()));
-		pgpdbattinfoNew->AddRef();
-		CGPDBAttOptCol *pgpdbattoptcolNew = GPOS_NEW(pmp) CGPDBAttOptCol(pgpdbattinfoNew, poptcolinfoNew);
+		CGPDBAttInfo *gpdb_att_info_new = GPOS_NEW(mp) CGPDBAttInfo(gpdb_att_info->GetQueryLevel(), gpdb_att_info->GetVarNo(), gpdb_att_info->GetAttNo());
+		COptColInfo *opt_col_info_new = GPOS_NEW(mp) COptColInfo(opt_col_info->GetColId(), GPOS_NEW(mp) CWStringConst(mp, opt_col_info->GetOptColName()->GetBuffer()));
+		gpdb_att_info_new->AddRef();
+		CGPDBAttOptCol *gpdb_att_opt_col_new = GPOS_NEW(mp) CGPDBAttOptCol(gpdb_att_info_new, opt_col_info_new);
 
 		// insert into hashmap
 #ifdef GPOS_DEBUG
-	BOOL fResult =
+	BOOL result =
 #endif // GPOS_DEBUG
-		pmapvarcolid->m_pmvcmap->FInsert(pgpdbattinfoNew, pgpdbattoptcolNew);
-		GPOS_ASSERT(fResult);
+		var_colid_mapping->m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info_new, gpdb_att_opt_col_new);
+		GPOS_ASSERT(result);
 	}
 
-	return pmapvarcolid;
+	return var_colid_mapping;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::PmapvarcolidRemap
+//		CMappingVarColId::CopyRemapColId
 //
 //	@doc:
 //		Create a copy of the mapping replacing the old column ids by new ones
 //
 //---------------------------------------------------------------------------
 CMappingVarColId *
-CMappingVarColId::PmapvarcolidRemap
+CMappingVarColId::CopyRemapColId
 	(
-	IMemoryPool *pmp,
-	DrgPul *pdrgpulOld,
-	DrgPul *pdrgpulNew
+	IMemoryPool *mp,
+	ULongPtrArray *old_colids,
+	ULongPtrArray *new_colids
 	)
 	const
 {
-	GPOS_ASSERT(NULL != pdrgpulOld);
-	GPOS_ASSERT(NULL != pdrgpulNew);
-	GPOS_ASSERT(pdrgpulNew->UlLength() == pdrgpulOld->UlLength());
+	GPOS_ASSERT(NULL != old_colids);
+	GPOS_ASSERT(NULL != new_colids);
+	GPOS_ASSERT(new_colids->Size() == old_colids->Size());
 	
 	// construct a mapping old cols -> new cols
-	HMUlUl *phmulul = CTranslatorUtils::PhmululMap(pmp, pdrgpulOld, pdrgpulNew);
+	UlongToUlongMap *old_new_col_mapping = CTranslatorUtils::MakeNewToOldColMapping(mp, old_colids, new_colids);
 		
-	CMappingVarColId *pmapvarcolid = GPOS_NEW(pmp) CMappingVarColId(pmp);
+	CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
 
-	CMVCMapIter mvcmi(this->m_pmvcmap);
-	while (mvcmi.FAdvance())
+	GPDBAttOptColHashMapIter col_map_iterator(this->m_gpdb_att_opt_col_mapping);
+	while (col_map_iterator.Advance())
 	{
-		const CGPDBAttOptCol *pgpdbattoptcol = mvcmi.Pt();
-		const CGPDBAttInfo *pgpdbattinfo = pgpdbattoptcol->Pgpdbattinfo();
-		const COptColInfo *poptcolinfo = pgpdbattoptcol->Poptcolinfo();
+		const CGPDBAttOptCol *gpdb_att_opt_col_info = col_map_iterator.Value();
+		const CGPDBAttInfo *gpdb_att_info = gpdb_att_opt_col_info->GetGPDBAttInfo();
+		const COptColInfo *opt_col_info = gpdb_att_opt_col_info->GetOptColInfo();
 
-		CGPDBAttInfo *pgpdbattinfoNew = GPOS_NEW(pmp) CGPDBAttInfo(pgpdbattinfo->UlQueryLevel(), pgpdbattinfo->UlVarNo(), pgpdbattinfo->IAttNo());
-		ULONG ulColId = poptcolinfo->UlColId();
-		ULONG *pulColIdNew = phmulul->PtLookup(&ulColId);
-		if (NULL != pulColIdNew)
+		CGPDBAttInfo *gpdb_att_info_new = GPOS_NEW(mp) CGPDBAttInfo(gpdb_att_info->GetQueryLevel(), gpdb_att_info->GetVarNo(), gpdb_att_info->GetAttNo());
+		ULONG colid = opt_col_info->GetColId();
+		ULONG *new_colid = old_new_col_mapping->Find(&colid);
+		if (NULL != new_colid)
 		{
-			ulColId = *pulColIdNew;
+			colid = *new_colid;
 		}
 		
-		COptColInfo *poptcolinfoNew = GPOS_NEW(pmp) COptColInfo(ulColId, GPOS_NEW(pmp) CWStringConst(pmp, poptcolinfo->PstrColName()->Wsz()));
-		pgpdbattinfoNew->AddRef();
-		CGPDBAttOptCol *pgpdbattoptcolNew = GPOS_NEW(pmp) CGPDBAttOptCol(pgpdbattinfoNew, poptcolinfoNew);
+		COptColInfo *opt_col_info_new = GPOS_NEW(mp) COptColInfo(colid, GPOS_NEW(mp) CWStringConst(mp, opt_col_info->GetOptColName()->GetBuffer()));
+		gpdb_att_info_new->AddRef();
+		CGPDBAttOptCol *gpdb_att_opt_col_new = GPOS_NEW(mp) CGPDBAttOptCol(gpdb_att_info_new, opt_col_info_new);
 
 #ifdef GPOS_DEBUG
-		BOOL fResult =
+		BOOL result =
 #endif // GPOS_DEBUG
-		pmapvarcolid->m_pmvcmap->FInsert(pgpdbattinfoNew, pgpdbattoptcolNew);
-		GPOS_ASSERT(fResult);
+		var_colid_mapping->m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info_new, gpdb_att_opt_col_new);
+		GPOS_ASSERT(result);
 	}
 	
-	phmulul->Release();
+	old_new_col_mapping->Release();
 
-	return pmapvarcolid;
+	return var_colid_mapping;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -37,31 +37,31 @@ using namespace gpmd;
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::FNeedsPrLNormalization
+//		CQueryMutators::NeedsProjListNormalization
 //
 //	@doc:
 //		Is the group by project list flat (contains only aggregates
 //		and grouping columns)
 //---------------------------------------------------------------------------
 BOOL
-CQueryMutators::FNeedsPrLNormalization
+CQueryMutators::NeedsProjListNormalization
 	(
-	const Query *pquery
+	const Query *query
 	)
 {
-	if (!pquery->hasAggs && NULL == pquery->groupClause)
+	if (!query->hasAggs && NULL == query->groupClause)
 	{
 		return false;
 	}
 
-	SContextTLWalker ctxTLWalker(pquery->targetList, pquery->groupClause);
+	SContextTLWalker context(query->targetList, query->groupClause);
 
-	ListCell *plc = NULL;
-	ForEach (plc, pquery->targetList)
+	ListCell *lc = NULL;
+	ForEach (lc, query->targetList)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
 
-		if (FNeedsToFallback((Node *) pte->expr, &ctxTLWalker))
+		if (ShouldFallback((Node *) target_entry->expr, &context))
 		{
 			// TODO: remove temporary fix (revert exception to assert) to avoid crash during algebrization
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("No attribute"));
@@ -69,7 +69,7 @@ CQueryMutators::FNeedsPrLNormalization
 
 		// Normalize when there is an expression that is neither used for grouping
 		// nor is an aggregate function
-		if (!IsA(pte->expr, Aggref) && !IsA(pte->expr, GroupingFunc) && !CTranslatorUtils::FGroupingColumn( (Node*) pte->expr, pquery->groupClause, pquery->targetList))
+		if (!IsA(target_entry->expr, Aggref) && !IsA(target_entry->expr, GroupingFunc) && !CTranslatorUtils::IsGroupingColumn( (Node*) target_entry->expr, query->groupClause, query->targetList))
 		{
 			return true;
 		}
@@ -81,46 +81,44 @@ CQueryMutators::FNeedsPrLNormalization
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::FNeedsToFallback
+//		CQueryMutators::ShouldFallback
 //
 //	@doc:
 //		Fall back when the target list refers to a attribute which algebrizer
 //		at this point cannot resolve
 //---------------------------------------------------------------------------
 BOOL
-CQueryMutators::FNeedsToFallback
+CQueryMutators::ShouldFallback
 	(
-	Node *pnode,
-	void *pvCtx
+	Node *node,
+	SContextTLWalker *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return false;
 	}
 
-	if (IsA(pnode, Const) || IsA(pnode, Aggref) || IsA(pnode, GroupingFunc) || IsA(pnode, SubLink))
+	if (IsA(node, Const) || IsA(node, Aggref) || IsA(node, GroupingFunc) || IsA(node, SubLink))
 	{
 		return false;
 	}
 
-	SContextTLWalker *pctx = (SContextTLWalker *) pvCtx;
-
-	TargetEntry *pteFound = gpdb::PteMember(pnode, pctx->m_plTE);
-	if (NULL != pteFound && CTranslatorUtils::FGroupingColumn( (Node *) pteFound->expr, pctx->m_groupClause, pctx->m_plTE))
+	TargetEntry *entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_target_entries);
+	if (NULL != entry && CTranslatorUtils::IsGroupingColumn( (Node *) entry->expr, context->m_group_clause, context->m_target_entries))
 	{
 		return false;
 	}
 
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
 		return false;
 	}
 
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvar = (Var *) pnode;
-		if (0 == pvar->varlevelsup)
+		Var *var = (Var *) node;
+		if (0 == var->varlevelsup)
 		{
 			// if we reach a Var that was not a grouping column then there is an equivalent column
 			// which the algebrizer at this point cannot resolve
@@ -136,13 +134,13 @@ CQueryMutators::FNeedsToFallback
 		return false;
 	}
 
-	return gpdb::FWalkExpressionTree(pnode, (PfFallback) CQueryMutators::FNeedsToFallback, pvCtx);
+	return gpdb::WalkExpressionTree(node, (FallbackWalkerFn) CQueryMutators::ShouldFallback, context);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryNormalizeGrpByPrL
+//		CQueryMutators::NormalizeGroupByProjList
 //
 //	@doc:
 // 		Flatten expressions in project list to contain only aggregates and
@@ -155,92 +153,90 @@ CQueryMutators::FNeedsToFallback
 //											   FROM t where r.b = t.e) t2)
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryNormalizeGrpByPrL
+CQueryMutators::NormalizeGroupByProjList
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const Query *pquery
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const Query *query
 	)
 {
-	Query *pqueryCopy = (Query *) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+	Query *query_copy = (Query *) gpdb::CopyObject(const_cast<Query*>(query));
 
-	if (!FNeedsPrLNormalization(pqueryCopy))
+	if (!NeedsProjListNormalization(query_copy))
 	{
-		return pqueryCopy;
+		return query_copy;
 	}
 
-	Query *pqueryNew = PqueryConvertToDerivedTable(pqueryCopy, false /*fFixTargetList*/, true /*fFixHavingQual*/);
-	gpdb::GPDBFree(pqueryCopy);
+	Query *new_query = ConvertToDerivedTable(query_copy, false /*should_fix_target_list*/, true /*should_fix_having_qual*/);
+	gpdb::GPDBFree(query_copy);
 
-	GPOS_ASSERT(1 == gpdb::UlListLength(pqueryNew->rtable));
-	Query *pqueryDrdTbl = (Query *) ((RangeTblEntry *) gpdb::PvListNth(pqueryNew->rtable, 0))->subquery;
-	SContextGrpbyPlMutator ctxGbPrLMutator(pmp, pmda, pqueryDrdTbl, NULL);
-	List *plTEcopy = (List*) gpdb::PvCopyObject(pqueryDrdTbl->targetList);
-	ListCell *plc = NULL;
+	GPOS_ASSERT(1 == gpdb::ListLength(new_query->rtable));
+	Query *derived_table_query = (Query *) ((RangeTblEntry *) gpdb::ListNth(new_query->rtable, 0))->subquery;
+	SContextGrpbyPlMutator context(mp, md_accessor, derived_table_query, NULL);
+	List *target_list_copy = (List*) gpdb::CopyObject(derived_table_query->targetList);
+	ListCell *lc = NULL;
 
 	// first normalize grouping columns
-	ForEach (plc, plTEcopy)
+	ForEach (lc, target_list_copy)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		GPOS_ASSERT(NULL != pte);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		GPOS_ASSERT(NULL != target_entry);
 
-		if (CTranslatorUtils::FGroupingColumn(pte, pqueryDrdTbl->groupClause))
+		if (CTranslatorUtils::IsGroupingColumn(target_entry, derived_table_query->groupClause))
 		{
-			pte->expr = (Expr*) PnodeFixGrpCol( (Node*) pte->expr, pte, &ctxGbPrLMutator);
+			target_entry->expr = (Expr*) FixGroupingCols( (Node*) target_entry->expr, target_entry, &context);
 		}
 	}
 
-	plc = NULL;
+	lc = NULL;
 	// normalize remaining project elements
-	ForEach (plc, plTEcopy)
+	ForEach (lc, target_list_copy)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		GPOS_ASSERT(NULL != pte);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		GPOS_ASSERT(NULL != target_entry);
 
-		BOOL fGroupingCol = CTranslatorUtils::FGroupingColumn(pte, pqueryDrdTbl->groupClause);
-		if (!fGroupingCol)
+		BOOL is_grouping_col = CTranslatorUtils::IsGroupingColumn(target_entry, derived_table_query->groupClause);
+		if (!is_grouping_col)
 		{
-			pte->expr = (Expr*) PnodeGrpbyPrLMutator( (Node*) pte->expr, &ctxGbPrLMutator);
+			target_entry->expr = (Expr*) RunGroupByProjListMutator( (Node*) target_entry->expr, &context);
 			GPOS_ASSERT
 				(
-				!IsA(pte->expr, Aggref) && !IsA(pte->expr, GroupingFunc) &&
+				!IsA(target_entry->expr, Aggref) && !IsA(target_entry->expr, GroupingFunc) &&
 				"New target list entry should not contain any Aggrefs"
 				);
 		}
 	}
 
-	pqueryDrdTbl->targetList = ctxGbPrLMutator.m_plTENewGroupByQuery;
-	pqueryNew->targetList = plTEcopy;
+	derived_table_query->targetList = context.m_groupby_target_list;
+	new_query->targetList = target_list_copy;
 
-	ReassignSortClause(pqueryNew, pqueryDrdTbl);
+	ReassignSortClause(new_query, derived_table_query);
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeIncrementLevelsupMutator
+//		CQueryMutators::RunIncrLevelsUpMutator
 //
 //	@doc:
 //		Increment any the query levels up of any outer reference by one
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeIncrementLevelsupMutator
+CQueryMutators::RunIncrLevelsUpMutator
 	(
-	Node *pnode,
-	void *pvCtx
+	Node *node,
+	SContextIncLevelsupMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	SContextIncLevelsupMutator *pctxIncLvlMutator = (SContextIncLevelsupMutator *) pvCtx;
-
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvar = (Var *) gpdb::PvCopyObject(pnode);
+		Var *var = (Var *) gpdb::CopyObject(node);
 
 		// Consider the following use case:
 		//	ORGINAL QUERY:
@@ -254,180 +250,178 @@ CQueryMutators::PnodeIncrementLevelsupMutator
 		// In such a scenario, we need increment the levels up for the
 		// correlation variable r.b in the subquery by 1.
 
-		if (pvar->varlevelsup > pctxIncLvlMutator->m_ulCurrLevelsUp)
+		if (var->varlevelsup > context->m_current_query_level)
 		{
-			pvar->varlevelsup++;
-			return (Node *) pvar;
+			var->varlevelsup++;
+			return (Node *) var;
 		}
-		return (Node *) pvar;
+		return (Node *) var;
 	}
 
-	if (IsA(pnode, CommonTableExpr))
+	if (IsA(node, CommonTableExpr))
 	{
-		CommonTableExpr *pcte = (CommonTableExpr *) gpdb::PvCopyObject(pnode);
-		GPOS_ASSERT(IsA(pcte->ctequery, Query));
+		CommonTableExpr *cte = (CommonTableExpr *) gpdb::CopyObject(node);
+		GPOS_ASSERT(IsA(cte->ctequery, Query));
 
-		Query *pqueryCte = (Query *) pcte->ctequery;
+		Query *cte_query = (Query *) cte->ctequery;
 
-		pctxIncLvlMutator->m_ulCurrLevelsUp++;
-		pcte->ctequery = PnodeIncrementLevelsupMutator((Node *) pqueryCte, pctxIncLvlMutator);
-		pctxIncLvlMutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level++;
+		cte->ctequery = RunIncrLevelsUpMutator((Node *) cte_query, context);
+		context->m_current_query_level--;
 
-		gpdb::GPDBFree(pqueryCte);
+		gpdb::GPDBFree(cte_query);
 
-		return (Node *) pcte;
+		return (Node *) cte;
 	}
 
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		SubLink *psublink = (SubLink *) gpdb::PvCopyObject(pnode);
-		GPOS_ASSERT(IsA(psublink->subselect, Query));
+		SubLink *sublink = (SubLink *) gpdb::CopyObject(node);
+		GPOS_ASSERT(IsA(sublink->subselect, Query));
 
-		Query *pquerySublink = (Query *) psublink->subselect;
+		Query *sublink_query = (Query *) sublink->subselect;
 
-		pctxIncLvlMutator->m_ulCurrLevelsUp++;
-		psublink->subselect = PnodeIncrementLevelsupMutator( (Node *) pquerySublink, pctxIncLvlMutator);
-		pctxIncLvlMutator->m_ulCurrLevelsUp--;
-		gpdb::GPDBFree(pquerySublink);
+		context->m_current_query_level++;
+		sublink->subselect = RunIncrLevelsUpMutator( (Node *) sublink_query, context);
+		context->m_current_query_level--;
+		gpdb::GPDBFree(sublink_query);
 
-		return (Node *) psublink;
+		return (Node *) sublink;
 	}
 
-	if (IsA(pnode, TargetEntry) && 0 == pctxIncLvlMutator->m_ulCurrLevelsUp && !pctxIncLvlMutator->m_fFixTargetListTopLevel)
+	if (IsA(node, TargetEntry) && 0 == context->m_current_query_level && !context->m_should_fix_top_level_target_list)
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
 	// recurse into query structure
-	if (IsA(pnode, Query))
+	if (IsA(node, Query))
 	{
-		Query *pquery = gpdb::PqueryMutateQueryTree
+		Query *query = gpdb::MutateQueryTree
 								(
-								(Query *) pnode,
-								(Pfnode) CQueryMutators::PnodeIncrementLevelsupMutator,
-								pctxIncLvlMutator,
+								(Query *) node,
+								(MutatorWalkerFn) CQueryMutators::RunIncrLevelsUpMutator,
+								context,
 								1 // flag -- do not mutate range table entries
 								);
 
 		// fix the outer reference in derived table entries
-		List *plRtable = pquery->rtable;
-		ListCell *plc = NULL;
-		ForEach (plc, plRtable)
+		List *rtable = query->rtable;
+		ListCell *lc = NULL;
+		ForEach (lc, rtable)
 		{
-			RangeTblEntry *prte = (RangeTblEntry *) lfirst(plc);
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 
-			if (RTE_SUBQUERY == prte->rtekind)
+			if (RTE_SUBQUERY == rte->rtekind)
 			{
-				Query *pquerySubquery = prte->subquery;
+				Query *subquery = rte->subquery;
 				// since we did not walk inside derived tables
-				pctxIncLvlMutator->m_ulCurrLevelsUp++;
-				prte->subquery = (Query *) PnodeIncrementLevelsupMutator( (Node *) pquerySubquery, pctxIncLvlMutator);
-				pctxIncLvlMutator->m_ulCurrLevelsUp--;
-				gpdb::GPDBFree(pquerySubquery);
+				context->m_current_query_level++;
+				rte->subquery = (Query *) RunIncrLevelsUpMutator( (Node *) subquery, context);
+				context->m_current_query_level--;
+				gpdb::GPDBFree(subquery);
 			}
 		}
 
-		return (Node *) pquery;
+		return (Node *) query;
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeIncrementLevelsupMutator, pvCtx);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunIncrLevelsUpMutator, context);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeFixCTELevelsupMutator
+//		CQueryMutators::RunFixCTELevelsUpMutator
 //
 //	@doc:
 //		Increment any the query levels up of any CTE range table reference by one
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeFixCTELevelsupMutator
+CQueryMutators::RunFixCTELevelsUpMutator
 	(
-	Node *pnode,
-	void *pvCtx
+	Node *node,
+	SContextIncLevelsupMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	SContextIncLevelsupMutator *pctxinclvlmutator = (SContextIncLevelsupMutator *) pvCtx;
-
 	// recurse into query structure
-	if (IsA(pnode, Query))
+	if (IsA(node, Query))
 	{
-		Query *pquery = gpdb::PqueryMutateQueryTree
+		Query *query = gpdb::MutateQueryTree
 								(
-								(Query *) pnode,
-								(Pfnode) CQueryMutators::PnodeFixCTELevelsupMutator,
-								pvCtx,
+								(Query *) node,
+								(MutatorWalkerFn) CQueryMutators::RunFixCTELevelsUpMutator,
+								context,
 								1 // flag -- do not mutate range table entries
 								);
 
-		List *plRtable = pquery->rtable;
-		ListCell *plc = NULL;
-		ForEach (plc, plRtable)
+		List *rtable = query->rtable;
+		ListCell *lc = NULL;
+		ForEach (lc, rtable)
 		{
-			RangeTblEntry *prte = (RangeTblEntry *) lfirst(plc);
-			if (RTE_CTE == prte->rtekind  && FNeedsLevelsUpCorrection(pctxinclvlmutator, prte->ctelevelsup))
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+			if (RTE_CTE == rte->rtekind  && NeedsLevelsUpCorrection(context, rte->ctelevelsup))
 			{
 				// fix the levels up for CTE range table entry when needed
 				// the walker in GPDB does not walk range table entries of type CTE
-				prte->ctelevelsup++;
+				rte->ctelevelsup++;
 			}
 
-			if (RTE_SUBQUERY == prte->rtekind)
+			if (RTE_SUBQUERY == rte->rtekind)
 			{
-				Query *pquerySubquery = prte->subquery;
+				Query *subquery = rte->subquery;
 				// since we did not walk inside derived tables
-				pctxinclvlmutator->m_ulCurrLevelsUp++;
-				prte->subquery = (Query *) PnodeFixCTELevelsupMutator( (Node *) pquerySubquery, pctxinclvlmutator);
-				pctxinclvlmutator->m_ulCurrLevelsUp--;
-				gpdb::GPDBFree(pquerySubquery);
+				context->m_current_query_level++;
+				rte->subquery = (Query *) RunFixCTELevelsUpMutator( (Node *) subquery, context);
+				context->m_current_query_level--;
+				gpdb::GPDBFree(subquery);
 			}
 		}
 
-		return (Node *) pquery;
+		return (Node *) query;
 	}
 
-	if (IsA(pnode, CommonTableExpr))
+	if (IsA(node, CommonTableExpr))
 	{
-		CommonTableExpr *pcte = (CommonTableExpr *) gpdb::PvCopyObject(pnode);
-		GPOS_ASSERT(IsA(pcte->ctequery, Query));
+		CommonTableExpr *cte = (CommonTableExpr *) gpdb::CopyObject(node);
+		GPOS_ASSERT(IsA(cte->ctequery, Query));
 
-		Query *pqueryCte = (Query *) pcte->ctequery;
-		pcte->ctequery = NULL;
+		Query *cte_query = (Query *) cte->ctequery;
+		cte->ctequery = NULL;
 
-		pctxinclvlmutator->m_ulCurrLevelsUp++;
-		pcte->ctequery = PnodeFixCTELevelsupMutator((Node *) pqueryCte, pctxinclvlmutator);
-		pctxinclvlmutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level++;
+		cte->ctequery = RunFixCTELevelsUpMutator((Node *) cte_query, context);
+		context->m_current_query_level--;
 
-		gpdb::GPDBFree(pqueryCte);
+		gpdb::GPDBFree(cte_query);
 
-		return (Node *) pcte;
+		return (Node *) cte;
 	}
 
 	// recurse into a query attached to sublink
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		SubLink *psublink = (SubLink *) gpdb::PvCopyObject(pnode);
-		GPOS_ASSERT(IsA(psublink->subselect, Query));
+		SubLink *sublink = (SubLink *) gpdb::CopyObject(node);
+		GPOS_ASSERT(IsA(sublink->subselect, Query));
 
-		Query *pquerySublink = (Query *) psublink->subselect;
-		psublink->subselect = NULL;
+		Query *sublink_query = (Query *) sublink->subselect;
+		sublink->subselect = NULL;
 
-		pctxinclvlmutator->m_ulCurrLevelsUp++;
-		psublink->subselect = PnodeFixCTELevelsupMutator((Node *) pquerySublink, pctxinclvlmutator);
-		pctxinclvlmutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level++;
+		sublink->subselect = RunFixCTELevelsUpMutator((Node *) sublink_query, context);
+		context->m_current_query_level--;
 
-		gpdb::GPDBFree(pquerySublink);
+		gpdb::GPDBFree(sublink_query);
 
-		return (Node *) psublink;
+		return (Node *) sublink;
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeFixCTELevelsupMutator, pctxinclvlmutator);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunFixCTELevelsUpMutator, context);
 }
 
 //---------------------------------------------------------------------------
@@ -438,428 +432,425 @@ CQueryMutators::PnodeFixCTELevelsupMutator
 //		Check if the cte levels up is the expected query level
 //---------------------------------------------------------------------------
 BOOL
-CQueryMutators::FNeedsLevelsUpCorrection
+CQueryMutators::NeedsLevelsUpCorrection
 	(
-	SContextIncLevelsupMutator *pctxinclvlmutator,
-	Index idxCtelevelsup
+	SContextIncLevelsupMutator *context,
+	Index cte_levels_up
 	)
 {
 	// when converting the query to derived table, all references to cte defined at the current level
 	// or above needs to be incremented
-	return idxCtelevelsup >= pctxinclvlmutator->m_ulCurrLevelsUp;
+	return cte_levels_up >= context->m_current_query_level;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeGrpbyPrLMutator
+//		CQueryMutators::RunGroupByProjListMutator
 //
 //	@doc:
 // 		Traverse the project list of a groupby operator and extract all aggregate
 //		functions in an arbitrarily complex project element
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeGrpbyPrLMutator
+CQueryMutators::RunGroupByProjListMutator
 	(
-	Node *pnode,
-	void *pctx
+	Node *node,
+	SContextGrpbyPlMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	if (IsA(pnode, Const))
+	if (IsA(node, Const))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	SContextGrpbyPlMutator *pctxGrpByMutator = (SContextGrpbyPlMutator *) pctx;
 
-	if (IsA(pnode, Var) && pctxGrpByMutator->m_fAggregateArg)
+	if (IsA(node, Var) && context->m_is_mutating_agg_arg)
 	{
 		// if we are mutating an aggregate argument do nothing since the aggregate will be place in the derived table's target list
 		// fix any outer references in the grouping column expression or arguments of an aggregate
-		return (Node *) PvarOuterReferenceIncrLevelsUp((Var*) pnode);
+		return (Node *) IncrLevelsUpInVar((Var*) node);
 	}
 	
 	// if we find an aggregate or precentile expression then insert into the new derived table
 	// and refer to it in the top-level query
 
-	if (IsA(pnode, Aggref))
+	if (IsA(node, Aggref))
 	{
-		Aggref *paggrefOld = (Aggref*) pnode;
-		Aggref *paggref = PaggrefFlatCopy(paggrefOld);
-		paggref->agglevelsup = paggrefOld->agglevelsup;
+		Aggref *old_aggref = (Aggref*) node;
+		Aggref *aggref = FlatCopyAggref(old_aggref);
+		aggref->agglevelsup = old_aggref->agglevelsup;
 
-		List *plArgsNew = NIL;
-		ListCell *plc = NULL;
+		List *new_args = NIL;
+		ListCell *lc = NULL;
 
-		BOOL fAggregate = pctxGrpByMutator->m_fAggregateArg;
-		pctxGrpByMutator->m_fAggregateArg = true;
+		BOOL fAggregate = context->m_is_mutating_agg_arg;
+		context->m_is_mutating_agg_arg = true;
 
-		ForEach (plc, paggrefOld->args)
+		ForEach (lc, old_aggref->args)
 		{
-			Node *pnodeArg = (Node *) gpdb::PvCopyObject((Node*) lfirst(plc));
-			GPOS_ASSERT(NULL != pnodeArg);
+			Node *arg = (Node *) gpdb::CopyObject((Node*) lfirst(lc));
+			GPOS_ASSERT(NULL != arg);
 			// traverse each argument and fix levels up when needed
-			plArgsNew = gpdb::PlAppendElement
+			new_args = gpdb::LAppend
 						(
-						plArgsNew,
-						gpdb::PnodeMutateQueryOrExpressionTree
+						new_args,
+						gpdb::MutateQueryOrExpressionTree
 							(
-							pnodeArg,
-							(Pfnode) CQueryMutators::PnodeGrpbyPrLMutator,
-							(void *) pctx,
+							arg,
+							(MutatorWalkerFn) CQueryMutators::RunGroupByProjListMutator,
+							(void *) context,
 							0 // flags -- mutate into cte-lists
 							)
 						);
 		}
-		pctxGrpByMutator->m_fAggregateArg = fAggregate;
-		paggref->args = plArgsNew;
+		context->m_is_mutating_agg_arg = fAggregate;
+		aggref->args = new_args;
 
-		const ULONG ulAttno = gpdb::UlListLength(pctxGrpByMutator->m_plTENewGroupByQuery) + 1;
-		TargetEntry *pte = PteAggregateExpr(pctxGrpByMutator->m_pmp, pctxGrpByMutator->m_pmda, (Node *) paggref, ulAttno);
+		const ULONG attno = gpdb::ListLength(context->m_groupby_target_list) + 1;
+		TargetEntry *target_entry = GetTargetEntryForAggExpr(context->m_mp, context->m_md_accessor, (Node *) aggref, attno);
 
 		// Add a new target entry to the query
-		pctxGrpByMutator->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctxGrpByMutator->m_plTENewGroupByQuery, pte);
+		context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
-		Var *pvarNew = gpdb::PvarMakeVar
+		Var *new_var = gpdb::MakeVar
 						(
 						1, // varno
-						(AttrNumber) ulAttno,
-						gpdb::OidExprType(pnode),
-						gpdb::IExprTypeMod(pnode),
+						(AttrNumber) attno,
+						gpdb::ExprType(node),
+						gpdb::ExprTypeMod(node),
 						0 // query levelsup
 						);
 
-		return (Node*) pvarNew;
+		return (Node*) new_var;
 	}
 
-	if (IsA(pnode, GroupingFunc))
+	if (IsA(node, GroupingFunc))
 	{
-		Node *pnodeCopy = (Node *) gpdb::PvCopyObject(pnode);
+		Node *pnodeCopy = (Node *) gpdb::CopyObject(node);
 
-		const ULONG ulAttno = gpdb::UlListLength(pctxGrpByMutator->m_plTENewGroupByQuery) + 1;
-		TargetEntry *pte = PteAggregateExpr(pctxGrpByMutator->m_pmp, pctxGrpByMutator->m_pmda, pnodeCopy, ulAttno);
+		const ULONG attno = gpdb::ListLength(context->m_groupby_target_list) + 1;
+		TargetEntry *target_entry = GetTargetEntryForAggExpr(context->m_mp, context->m_md_accessor, pnodeCopy, attno);
 
 		// Add a new target entry to the query
-		pctxGrpByMutator->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctxGrpByMutator->m_plTENewGroupByQuery, pte);
+		context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
-		Var *pvarNew = gpdb::PvarMakeVar
+		Var *new_var = gpdb::MakeVar
 								(
 								1, // varno
-								(AttrNumber) ulAttno,
-								gpdb::OidExprType(pnode),
-								gpdb::IExprTypeMod(pnode),
+								(AttrNumber) attno,
+								gpdb::ExprType(node),
+								gpdb::ExprTypeMod(node),
 								0 // query levelsup
 								);
 
-		return (Node*) pvarNew;
+		return (Node*) new_var;
 	}
 
-	if (!pctxGrpByMutator->m_fAggregateArg)
+	if (!context->m_is_mutating_agg_arg)
 	{
 		// if we find a target entry in the new derived table then return the appropriate var
 		// else investigate it to see if it needs to be added to the new derived table
 
-		TargetEntry *pteFound = gpdb::PteMember(pnode, pctxGrpByMutator->m_plTENewGroupByQuery);
+		TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
 
-		if (NULL != pteFound)
+		if (NULL != found_target_entry)
 		{
-			pteFound->resjunk = false;
-			Var *pvarNew = gpdb::PvarMakeVar
+			found_target_entry->resjunk = false;
+			Var *new_var = gpdb::MakeVar
 					(
 							1, // varno
-							pteFound->resno,
-							gpdb::OidExprType((Node*) pteFound->expr),
-							gpdb::IExprTypeMod( (Node*) pteFound->expr),
+							found_target_entry->resno,
+							gpdb::ExprType((Node*) found_target_entry->expr),
+							gpdb::ExprTypeMod( (Node*) found_target_entry->expr),
 							0 // query levelsup
 					);
 
-			return (Node*) pvarNew;
+			return (Node*) new_var;
 		}
 
 		// if it is grouping column then we have already added it to the derived table
 		// so merely refer to it in the top-level query
-		TargetEntry *pteFoundNewDrvdTable = gpdb::PteMember(pnode, pctxGrpByMutator->m_plTENewGroupByQuery);
-		if (NULL != pteFoundNewDrvdTable)
+		TargetEntry *new_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
+		if (NULL != new_target_entry)
 		{
-			return (Node *) gpdb::PvarMakeVar
+			return (Node *) gpdb::MakeVar
 							(
 							1, // varno
-							(AttrNumber) pteFoundNewDrvdTable->resno,
-							gpdb::OidExprType( (Node*) pteFoundNewDrvdTable->expr),
-							gpdb::IExprTypeMod( (Node*) pteFoundNewDrvdTable->expr),
+							(AttrNumber) new_target_entry->resno,
+							gpdb::ExprType( (Node*) new_target_entry->expr),
+							gpdb::ExprTypeMod( (Node*) new_target_entry->expr),
 							0 // query levelsup
 							);
 		}
 	}
 
 	// do not traverse into sub queries as they will be inserted into top-level query as is
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeGrpbyPrLMutator, pctx);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunGroupByProjListMutator, context);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeGrpColMutator
+//		CQueryMutators::RunGroupingColMutator
 //
 //	@doc:
 // 		Mutate the grouping columns, fix levels up when necessary
 //
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeGrpColMutator
+CQueryMutators::RunGroupingColMutator
 	(
-	Node *pnode,
-	void *pctx
+	Node *node,
+	SContextGrpbyPlMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	if (IsA(pnode, Const))
+	if (IsA(node, Const))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	SContextGrpbyPlMutator *pctxGrpByMutator = (SContextGrpbyPlMutator *) pctx;
-
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvarCopy = (Var *) gpdb::PvCopyObject(pnode);
+		Var *var_copy = (Var *) gpdb::CopyObject(node);
 
-		if (pvarCopy->varlevelsup > pctxGrpByMutator->m_ulCurrLevelsUp)
+		if (var_copy->varlevelsup > context->m_current_query_level)
 		{
-			pvarCopy->varlevelsup++;
+			var_copy->varlevelsup++;
 		}
 
-		return (Node *) pvarCopy;
+		return (Node *) var_copy;
 	}
 
-	if (IsA(pnode, Aggref))
+	if (IsA(node, Aggref))
 	{
 		// merely fix the arguments of an aggregate
-		Aggref *paggrefOld = (Aggref*) pnode;
-		Aggref *paggref = PaggrefFlatCopy(paggrefOld);
-		paggref->agglevelsup = paggrefOld->agglevelsup;
+		Aggref *old_aggref = (Aggref*) node;
+		Aggref *aggref = FlatCopyAggref(old_aggref);
+		aggref->agglevelsup = old_aggref->agglevelsup;
 
-		List *plArgsNew = NIL;
-		ListCell *plc = NULL;
+		List *new_args = NIL;
+		ListCell *lc = NULL;
 
-		BOOL fAggregate = pctxGrpByMutator->m_fAggregateArg;
-		pctxGrpByMutator->m_fAggregateArg = true;
+		BOOL is_agg = context->m_is_mutating_agg_arg;
+		context->m_is_mutating_agg_arg = true;
 
-		ForEach (plc, paggrefOld->args)
+		ForEach (lc, old_aggref->args)
 		{
-			Node *pnodeArg = (Node *) gpdb::PvCopyObject((Node*) lfirst(plc));
-			GPOS_ASSERT(NULL != pnodeArg);
+			Node *arg = (Node *) gpdb::CopyObject((Node*) lfirst(lc));
+			GPOS_ASSERT(NULL != arg);
 			// traverse each argument and fix levels up when needed
-			plArgsNew = gpdb::PlAppendElement
+			new_args = gpdb::LAppend
 						(
-						plArgsNew,
-						gpdb::PnodeMutateQueryOrExpressionTree
+						new_args,
+						gpdb::MutateQueryOrExpressionTree
 							(
-							pnodeArg,
-							(Pfnode) CQueryMutators::PnodeGrpColMutator,
-							(void *) pctxGrpByMutator,
+							arg,
+							(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+							(void *) context,
 							0 // flags -- mutate into cte-lists
 							)
 						);
 		}
-		pctxGrpByMutator->m_fAggregateArg = fAggregate;
-		paggref->args = plArgsNew;
+		context->m_is_mutating_agg_arg = is_agg;
+		aggref->args = new_args;
 
-		return (Node*) paggref;
+		return (Node*) aggref;
 	}
 
-	if (IsA(pnode, GroupingFunc))
+	if (IsA(node, GroupingFunc))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		SubLink *psublinkOld = (SubLink *) pnode;
+		SubLink *old_sublink = (SubLink *) node;
 
-		SubLink *psublinkNew = MakeNode(SubLink);
-		psublinkNew->subLinkType = psublinkOld->subLinkType;
-		psublinkNew->location = psublinkOld->location;
-		psublinkNew->operName = (List *) gpdb::PvCopyObject(psublinkOld->operName);
+		SubLink *new_sublink = MakeNode(SubLink);
+		new_sublink->subLinkType = old_sublink->subLinkType;
+		new_sublink->location = old_sublink->location;
+		new_sublink->operName = (List *) gpdb::CopyObject(old_sublink->operName);
 
-		psublinkNew->testexpr =	gpdb::PnodeMutateQueryOrExpressionTree
+		new_sublink->testexpr =	gpdb::MutateQueryOrExpressionTree
 										(
-										psublinkOld->testexpr,
-										(Pfnode) CQueryMutators::PnodeGrpColMutator,
-										(void *) pctxGrpByMutator,
+										old_sublink->testexpr,
+										(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+										(void *) context,
 										0 // flags -- mutate into cte-lists
 										);
-		pctxGrpByMutator->m_ulCurrLevelsUp++;
+		context->m_current_query_level++;
 
-		GPOS_ASSERT(IsA(psublinkOld->subselect, Query));
+		GPOS_ASSERT(IsA(old_sublink->subselect, Query));
 
-		psublinkNew->subselect = gpdb::PnodeMutateQueryOrExpressionTree
+		new_sublink->subselect = gpdb::MutateQueryOrExpressionTree
 										(
-										psublinkOld->subselect,
-										(Pfnode) CQueryMutators::PnodeGrpColMutator,
-										(void *) pctxGrpByMutator,
+										old_sublink->subselect,
+										(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+										context,
 										0 // flags -- mutate into cte-lists
 										);
 
-		pctxGrpByMutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level--;
 
-		return (Node *) psublinkNew;
+		return (Node *) new_sublink;
 	}
 
-	if (IsA(pnode, CommonTableExpr))
+	if (IsA(node, CommonTableExpr))
 	{
-		CommonTableExpr *pcte = (CommonTableExpr *) gpdb::PvCopyObject(pnode);
-		pctxGrpByMutator->m_ulCurrLevelsUp++;
+		CommonTableExpr *cte = (CommonTableExpr *) gpdb::CopyObject(node);
+		context->m_current_query_level++;
 
-		GPOS_ASSERT(IsA(pcte->ctequery, Query));
+		GPOS_ASSERT(IsA(cte->ctequery, Query));
 
-		pcte->ctequery = gpdb::PnodeMutateQueryOrExpressionTree
+		cte->ctequery = gpdb::MutateQueryOrExpressionTree
 									(
-									pcte->ctequery,
-									(Pfnode) CQueryMutators::PnodeGrpColMutator,
-									(void *) pctxGrpByMutator,
+									cte->ctequery,
+									(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+									(void *) context,
 									0 // flags --- mutate into cte-lists
 									);
 
-		pctxGrpByMutator->m_ulCurrLevelsUp--;
-		return (Node *) pcte;
+		context->m_current_query_level--;
+		return (Node *) cte;
 	}
 
 	// recurse into query structure
-	if (IsA(pnode, Query))
+	if (IsA(node, Query))
 	{
-		Query *pquery = gpdb::PqueryMutateQueryTree
+		Query *query = gpdb::MutateQueryTree
 								(
-								(Query *) pnode,
-								(Pfnode) CQueryMutators::PnodeGrpColMutator,
-								pctxGrpByMutator,
+								(Query *) node,
+								(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+								context,
 								1 // flag -- do not mutate range table entries
 								);
 
 		// fix the outer reference in derived table entries
-		List *plRtable = pquery->rtable;
-		ListCell *plc = NULL;
-		ForEach (plc, plRtable)
+		List *rtable = query->rtable;
+		ListCell *lc = NULL;
+		ForEach (lc, rtable)
 		{
-			RangeTblEntry *prte = (RangeTblEntry *) lfirst(plc);
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 
-			if (RTE_SUBQUERY == prte->rtekind)
+			if (RTE_SUBQUERY == rte->rtekind)
 			{
-				Query *pquerySubquery = prte->subquery;
+				Query *subquery = rte->subquery;
 				// since we did not walk inside derived tables
-				pctxGrpByMutator->m_ulCurrLevelsUp++;
-				prte->subquery = (Query *) PnodeGrpColMutator( (Node *) pquerySubquery, pctxGrpByMutator);
-				pctxGrpByMutator->m_ulCurrLevelsUp--;
-				gpdb::GPDBFree(pquerySubquery);
+				context->m_current_query_level++;
+				rte->subquery = (Query *) RunGroupingColMutator( (Node *) subquery, context);
+				context->m_current_query_level--;
+				gpdb::GPDBFree(subquery);
 			}
 		}
 
-		return (Node *) pquery;
+		return (Node *) query;
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeGrpColMutator, pctx);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunGroupingColMutator, context);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeFixGrpCol
+//		CQueryMutators::FixGroupingCols
 //
 //	@doc:
 // 		Mutate the grouping columns, fix levels up when necessary
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeFixGrpCol
+CQueryMutators::FixGroupingCols
 	(
-	Node *pnode,
-	TargetEntry *pteOriginal,
-	SContextGrpbyPlMutator *pctx
+	Node *node,
+	TargetEntry *orginal_target_entry,
+	SContextGrpbyPlMutator *context
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 
-	ULONG ulArity = gpdb::UlListLength(pctx->m_plTENewGroupByQuery) + 1;
+	ULONG arity = gpdb::ListLength(context->m_groupby_target_list) + 1;
 
 	// fix any outer references in the grouping column expression
-	Node *pnodeExpr = (Node *) PnodeGrpColMutator( pnode, pctx);
+	Node *expr = (Node *) RunGroupingColMutator(node, context);
 
-	CHAR* szName = CQueryMutators::SzTEName(pteOriginal,pctx->m_pquery);
-	TargetEntry *pteNew = gpdb::PteMakeTargetEntry((Expr*) pnodeExpr, (AttrNumber) ulArity, szName, false /*resjunk */);
+	CHAR* name = CQueryMutators::GetTargetEntryColName(orginal_target_entry,context->m_query);
+	TargetEntry *new_target_entry = gpdb::MakeTargetEntry((Expr*) expr, (AttrNumber) arity, name, false /*resjunk */);
 
-	pteNew->ressortgroupref = pteOriginal->ressortgroupref;
-	pteNew->resjunk = false;
+	new_target_entry->ressortgroupref = orginal_target_entry->ressortgroupref;
+	new_target_entry->resjunk = false;
 
-	pctx->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctx->m_plTENewGroupByQuery, pteNew);
+	context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, new_target_entry);
 
-	Var *pvarNew = gpdb::PvarMakeVar
+	Var *new_var = gpdb::MakeVar
 			(
 					1, // varno
-					(AttrNumber) ulArity,
-					gpdb::OidExprType( (Node*) pteOriginal->expr),
-					gpdb::IExprTypeMod( (Node*) pteOriginal->expr),
+					(AttrNumber) arity,
+					gpdb::ExprType( (Node*) orginal_target_entry->expr),
+					gpdb::ExprTypeMod( (Node*) orginal_target_entry->expr),
 					0 // query levelsup
 			);
 
-	return (Node*) pvarNew;
+	return (Node*) new_var;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PteAggregateExpr
+//		CQueryMutators::GetTargetEntryForAggExpr
 //
 //	@doc:
 // 		Return a target entry for an aggregate expression
 //---------------------------------------------------------------------------
 TargetEntry *
-CQueryMutators::PteAggregateExpr
+CQueryMutators::GetTargetEntryForAggExpr
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	Node *pnode,
-	ULONG ulAttno
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	Node *node,
+	ULONG attno
 	)
 {
-	GPOS_ASSERT(IsA(pnode, Aggref) || IsA(pnode, GroupingFunc));
+	GPOS_ASSERT(IsA(node, Aggref) || IsA(node, GroupingFunc));
 
 	// get the function/aggregate name
-	CHAR *szName = NULL;
-	if (IsA(pnode, GroupingFunc))
+	CHAR *name = NULL;
+	if (IsA(node, GroupingFunc))
 	{
-		szName = CTranslatorUtils::SzFromWsz(GPOS_WSZ_LIT("grouping"));
+		name = CTranslatorUtils::CreateMultiByteCharStringFromWCString(GPOS_WSZ_LIT("grouping"));
 	}
 	else
 	{
-		Aggref *paggref = (Aggref*) pnode;
+		Aggref *aggref = (Aggref*) node;
 
-		CMDIdGPDB *pmdidAgg = GPOS_NEW(pmp) CMDIdGPDB(paggref->aggfnoid);
-		const IMDAggregate *pmdagg = pmda->Pmdagg(pmdidAgg);
-		pmdidAgg->Release();
+		CMDIdGPDB *agg_mdid = GPOS_NEW(mp) CMDIdGPDB(aggref->aggfnoid);
+		const IMDAggregate *md_agg = md_accessor->RetrieveAgg(agg_mdid);
+		agg_mdid->Release();
 
-		const CWStringConst *pstr = pmdagg->Mdname().Pstr();
-		szName = CTranslatorUtils::SzFromWsz(pstr->Wsz());
+		const CWStringConst *str = md_agg->Mdname().GetMDName();
+		name = CTranslatorUtils::CreateMultiByteCharStringFromWCString(str->GetBuffer());
 	}
-	GPOS_ASSERT(NULL != szName);
+	GPOS_ASSERT(NULL != name);
 
-	return gpdb::PteMakeTargetEntry((Expr*) pnode, (AttrNumber) ulAttno, szName, false);
+	return gpdb::MakeTargetEntry((Expr*) node, (AttrNumber) attno, name, false);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeHavingQualMutator
+//		CQueryMutators::RunHavingQualMutator
 //
 //	@doc:
 // 		This mutator function checks to see if the current node is an AggRef
@@ -870,260 +861,258 @@ CQueryMutators::PteAggregateExpr
 //			Then replaces it with a attribute from the top-level query.
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeHavingQualMutator
+CQueryMutators::RunHavingQualMutator
 	(
-	Node *pnode,
-	void *pctx
+	Node *node,
+	SContextHavingQualMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	if (IsA(pnode, Const))
+	if (IsA(node, Const))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	SContextHavingQualMutator *pctxHavingQualMutator = (SContextHavingQualMutator *) pctx;
-
 	// check to see if the node is in the target list of the derived table.
-	// check if we have the corresponding pte entry in derived tables target list
-	if (0 == pctxHavingQualMutator->m_ulCurrLevelsUp)
+	// check if we have the corresponding target_entry entry in derived tables target list
+	if (0 == context->m_current_query_level)
 	{
-		if (IsA(pnode, Var) && pctxHavingQualMutator->m_fAggregateArg)
+		if (IsA(node, Var) && context->m_is_mutating_agg_arg)
 		{
 			// fix outer references used in the aggregates
-			return (Node *) PvarOuterReferenceIncrLevelsUp((Var*) pnode);
+			return (Node *) IncrLevelsUpInVar((Var*) node);
 		}
 
 		// check if an entry already exists, if so no need for duplicate
-		Node *pnodeFound = PnodeFind(pnode, pctxHavingQualMutator);
-		if (NULL != pnodeFound)
+		Node *found_node = FindNodeInTargetEntries(node, context);
+		if (NULL != found_node)
 		{
-			return pnodeFound;
+			return found_node;
 		}
 
-		if (IsA(pnode, GroupingFunc))
+		if (IsA(node, GroupingFunc))
 		{
 			// create a new entry in the derived table and return its corresponding var
-			Node *pnodeCopy = (Node*) gpdb::PvCopyObject(pnode);
-			return (Node *) PvarInsertIntoDerivedTable(pnodeCopy, pctxHavingQualMutator);
+			Node *node_copy = (Node*) gpdb::CopyObject(node);
+			return (Node *) MakeVarInDerivedTable(node_copy, context);
 		}
 	}
 
-	if (IsA(pnode, Aggref))
+	if (IsA(node, Aggref))
 	{
-		Aggref *paggrefOld = (Aggref *) pnode;
-		if (paggrefOld->agglevelsup == pctxHavingQualMutator->m_ulCurrLevelsUp)
+		Aggref *old_aggref = (Aggref *) node;
+		if (old_aggref->agglevelsup == context->m_current_query_level)
 		{
-			Aggref *paggrefNew = PaggrefFlatCopy(paggrefOld);
+			Aggref *new_aggref = FlatCopyAggref(old_aggref);
 			
-			BOOL fAggregateOld = pctxHavingQualMutator->m_fAggregateArg;
-			ULONG ulAggregateLevelUp = pctxHavingQualMutator->m_ulAggregateLevelUp;
+			BOOL is_agg_old = context->m_is_mutating_agg_arg;
+			ULONG agg_levels_up = context->m_agg_levels_up;
 
-			pctxHavingQualMutator->m_fAggregateArg = true;
-			pctxHavingQualMutator->m_ulAggregateLevelUp = paggrefOld->agglevelsup;
+			context->m_is_mutating_agg_arg = true;
+			context->m_agg_levels_up = old_aggref->agglevelsup;
 
-			List *plargsNew = NIL;
-			ListCell *plc = NULL;
+			List *new_args = NIL;
+			ListCell *lc = NULL;
 
-			ForEach (plc, paggrefOld->args)
+			ForEach (lc, old_aggref->args)
 			{
-				Node *pnodeArg = (Node*) lfirst(plc);
-				GPOS_ASSERT(NULL != pnodeArg);
+				Node *arg = (Node*) lfirst(lc);
+				GPOS_ASSERT(NULL != arg);
 				// traverse each argument and fix levels up when needed
-				plargsNew = gpdb::PlAppendElement
+				new_args = gpdb::LAppend
 									(
-									plargsNew,
-									gpdb::PnodeMutateQueryOrExpressionTree
+									new_args,
+									gpdb::MutateQueryOrExpressionTree
 											(
-											pnodeArg,
-											(Pfnode) CQueryMutators::PnodeHavingQualMutator,
-											(void *) pctxHavingQualMutator,
+											arg,
+											(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+											(void *) context,
 											0 // mutate into cte-lists
 											)
 									);
 			}
-			paggrefNew->args = plargsNew;
-			pctxHavingQualMutator->m_fAggregateArg = fAggregateOld;
-			pctxHavingQualMutator->m_ulAggregateLevelUp = ulAggregateLevelUp;
+			new_aggref->args = new_args;
+			context->m_is_mutating_agg_arg = is_agg_old;
+			context->m_agg_levels_up = agg_levels_up;
 
 			// check if an entry already exists, if so no need for duplicate
-			Node *pnodeFound = PnodeFind((Node*) paggrefNew, pctxHavingQualMutator);
-			if (NULL != pnodeFound)
+			Node *found_node = FindNodeInTargetEntries((Node*) new_aggref, context);
+			if (NULL != found_node)
 			{
-				return pnodeFound;
+				return found_node;
 			}
 
 			// create a new entry in the derived table and return its corresponding var
-			return (Node *) PvarInsertIntoDerivedTable((Node *) paggrefNew, pctxHavingQualMutator);
+			return (Node *) MakeVarInDerivedTable((Node *) new_aggref, context);
 		}
 	}
 
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvar = (Var *) gpdb::PvCopyObject(pnode);
-		if (pvar->varlevelsup == pctxHavingQualMutator->m_ulCurrLevelsUp)
+		Var *var = (Var *) gpdb::CopyObject(node);
+		if (var->varlevelsup == context->m_current_query_level)
 		{
 			// process outer references
-			if (pvar->varlevelsup == pctxHavingQualMutator->m_ulAggregateLevelUp)
+			if (var->varlevelsup == context->m_agg_levels_up)
 			{
 				// an argument of an outer aggregate
-				pvar->varlevelsup = 0;
+				var->varlevelsup = 0;
 
-				return (Node *) pvar;
+				return (Node *) var;
 			}
 
-			pvar->varlevelsup = 0;
-			TargetEntry *pteFound = gpdb::PteMember( (Node*) pvar, pctxHavingQualMutator->m_plTENewGroupByQuery);
+			var->varlevelsup = 0;
+			TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList( (Node*) var, context->m_groupby_target_list);
 
-			if (NULL == pteFound)
+			if (NULL == found_target_entry)
 			{
 				// Consider two table r(a,b) and s(c,d) and the following query
 				// SELECT 1 from r LEFT JOIN s on (r.a = s.c) group by r.a having count(*) > a
 				// The having clause refers to the output of the left outer join while the
 				// grouping column refers to the base table column.
 				// While r.a and a are equivalent, the algebrizer at this point cannot detect this.
-				// Therefore, pteFound will be NULL and we fall back.
+				// Therefore, found_target_entry will be NULL and we fall back.
 
-				pctxHavingQualMutator->m_fFallbackToPlanner = true;
+				context->m_should_fallback = true;
 				return NULL;
 			}
 
-			pvar->varlevelsup = pctxHavingQualMutator->m_ulCurrLevelsUp;
-			pvar->varno = 1;
-			pvar->varattno = pteFound->resno;
-			pteFound->resjunk = false;
+			var->varlevelsup = context->m_current_query_level;
+			var->varno = 1;
+			var->varattno = found_target_entry->resno;
+			found_target_entry->resjunk = false;
 
-			return (Node*) pvar;
+			return (Node*) var;
 		}
-		return (Node *) pvar;
+		return (Node *) var;
 	}
 
-	if (IsA(pnode, CommonTableExpr))
+	if (IsA(node, CommonTableExpr))
 	{
-		CommonTableExpr *pcte = (CommonTableExpr *) gpdb::PvCopyObject(pnode);
-		pctxHavingQualMutator->m_ulCurrLevelsUp++;
+		CommonTableExpr *cte = (CommonTableExpr *) gpdb::CopyObject(node);
+		context->m_current_query_level++;
 
-		GPOS_ASSERT(IsA(pcte->ctequery, Query));
+		GPOS_ASSERT(IsA(cte->ctequery, Query));
 
-		pcte->ctequery = gpdb::PnodeMutateQueryOrExpressionTree
+		cte->ctequery = gpdb::MutateQueryOrExpressionTree
 									(
-									pcte->ctequery,
-									(Pfnode) CQueryMutators::PnodeHavingQualMutator,
-									(void *) pctxHavingQualMutator,
+									cte->ctequery,
+									(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+									(void *) context,
 									0 // flags --- mutate into cte-lists
 									);
 
-		pctxHavingQualMutator->m_ulCurrLevelsUp--;
-		return (Node *) pcte;
+		context->m_current_query_level--;
+		return (Node *) cte;
 	}
 
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		SubLink *psublinkOld = (SubLink *) pnode;
+		SubLink *old_sublink = (SubLink *) node;
 
-		SubLink *psublinkNew = MakeNode(SubLink);
-		psublinkNew->subLinkType = psublinkOld->subLinkType;
-		psublinkNew->location = psublinkOld->location;
-		psublinkNew->operName = (List *) gpdb::PvCopyObject(psublinkOld->operName);
+		SubLink *new_sublink = MakeNode(SubLink);
+		new_sublink->subLinkType = old_sublink->subLinkType;
+		new_sublink->location = old_sublink->location;
+		new_sublink->operName = (List *) gpdb::CopyObject(old_sublink->operName);
 
-		psublinkNew->testexpr =	gpdb::PnodeMutateQueryOrExpressionTree
+		new_sublink->testexpr =	gpdb::MutateQueryOrExpressionTree
 										(
-										psublinkOld->testexpr,
-										(Pfnode) CQueryMutators::PnodeHavingQualMutator,
-										(void *) pctxHavingQualMutator,
+										old_sublink->testexpr,
+										(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+										(void *) context,
 										0 // flags -- mutate into cte-lists
 										);
-		pctxHavingQualMutator->m_ulCurrLevelsUp++;
+		context->m_current_query_level++;
 
-		GPOS_ASSERT(IsA(psublinkOld->subselect, Query));
+		GPOS_ASSERT(IsA(old_sublink->subselect, Query));
 
-		psublinkNew->subselect = gpdb::PnodeMutateQueryOrExpressionTree
+		new_sublink->subselect = gpdb::MutateQueryOrExpressionTree
 										(
-										psublinkOld->subselect,
-										(Pfnode) CQueryMutators::PnodeHavingQualMutator,
-										(void *) pctxHavingQualMutator,
+										old_sublink->subselect,
+										(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+										(void *) context,
 										0 // flags -- mutate into cte-lists
 										);
 
-		pctxHavingQualMutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level--;
 
-		return (Node *) psublinkNew;
+		return (Node *) new_sublink;
 	}
 	
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeHavingQualMutator, pctxHavingQualMutator);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunHavingQualMutator, context);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PvarInsertIntoDerivedTable
+//		CQueryMutators::MakeVarInDerivedTable
 //
 //	@doc:
 //		Create a new entry in the derived table and return its corresponding var
 //---------------------------------------------------------------------------
 Var *
-CQueryMutators::PvarInsertIntoDerivedTable
+CQueryMutators::MakeVarInDerivedTable
 	(
-	Node *pnode,
+	Node *node,
 	SContextHavingQualMutator *context
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 	GPOS_ASSERT(NULL != context);
-	GPOS_ASSERT(IsA(pnode, Aggref) || IsA(pnode, GroupingFunc));
+	GPOS_ASSERT(IsA(node, Aggref) || IsA(node, GroupingFunc));
 
-	const ULONG ulAttno = gpdb::UlListLength(context->m_plTENewGroupByQuery) + 1;
-	TargetEntry *pte = PteAggregateExpr(context->m_pmp, context->m_pmda, (Node *) pnode, ulAttno);
-	context->m_plTENewGroupByQuery = gpdb::PlAppendElement(context->m_plTENewGroupByQuery, pte);
+	const ULONG attno = gpdb::ListLength(context->m_groupby_target_list) + 1;
+	TargetEntry *target_entry = GetTargetEntryForAggExpr(context->m_mp, context->m_md_accessor, (Node *) node, attno);
+	context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
-	Var *pvarNew = gpdb::PvarMakeVar
+	Var *new_var = gpdb::MakeVar
 					(
 					1, // varno
-					ulAttno,
-					gpdb::OidExprType((Node*) pnode),
-					gpdb::IExprTypeMod((Node*) pnode),
-					context->m_ulCurrLevelsUp
+					attno,
+					gpdb::ExprType((Node*) node),
+					gpdb::ExprTypeMod((Node*) node),
+					context->m_current_query_level
 					);
 
-	return pvarNew;
+	return new_var;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeFind
+//		CQueryMutators::FindNodeInTargetEntries
 //
 //	@doc:
 //		Check if a matching entry already exists in the list of target
 //		entries, if yes return its corresponding var, otherwise return NULL
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeFind
+CQueryMutators::FindNodeInTargetEntries
 	(
-	Node *pnode,
+	Node *node,
 	SContextHavingQualMutator *context
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 	GPOS_ASSERT(NULL != context);
 	
-	TargetEntry *pteFound = gpdb::PteMember(pnode, context->m_plTENewGroupByQuery);
-	if (NULL != pteFound)
+	TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
+	if (NULL != found_target_entry)
 	{
-		gpdb::GPDBFree(pnode);
-		Var *pvarNew = gpdb::PvarMakeVar
+		gpdb::GPDBFree(node);
+		Var *new_var = gpdb::MakeVar
 						(
 						1, // varno
-						pteFound->resno,
-						gpdb::OidExprType( (Node*) pteFound->expr),
-						gpdb::IExprTypeMod( (Node*) pteFound->expr),
-						context->m_ulCurrLevelsUp
+						found_target_entry->resno,
+						gpdb::ExprType( (Node*) found_target_entry->expr),
+						gpdb::ExprTypeMod( (Node*) found_target_entry->expr),
+						context->m_current_query_level
 						);
 
-		pteFound->resjunk = false;
-		return (Node*) pvarNew;
+		found_target_entry->resjunk = false;
+		return (Node*) new_var;
 	}
 
 	return NULL;
@@ -1131,211 +1120,211 @@ CQueryMutators::PnodeFind
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PaggrefFlatCopy
+//		CQueryMutators::FlatCopyAggref
 //
 //	@doc:
 //		Make a copy of the aggref (minus the arguments)
 //---------------------------------------------------------------------------
 Aggref *
-CQueryMutators::PaggrefFlatCopy
+CQueryMutators::FlatCopyAggref
 	(
-	Aggref *paggrefOld
+	Aggref *old_aggref
 	)
 {
-	Aggref *paggrefNew = MakeNode(Aggref);
+	Aggref *new_aggref = MakeNode(Aggref);
 
-	*paggrefNew = *paggrefOld;
+	*new_aggref = *old_aggref;
 
-	paggrefNew->agglevelsup = 0;
+	new_aggref->agglevelsup = 0;
 	// This is not strictly necessary: we seem to ALWAYS assgin to args from
 	// the callers
 	// Explicitly setting this both to be safe and to be clear that we are
 	// intentionally NOT copying the args
-	paggrefNew->args = NIL;
+	new_aggref->args = NIL;
 
-	return paggrefNew;
+	return new_aggref;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PvarOuterReferenceIncrLevelsUp
+//		CQueryMutators::IncrLevelsUpInVar
 //
 //	@doc:
 //		Increment the levels up of outer references
 //---------------------------------------------------------------------------
 Var *
-CQueryMutators::PvarOuterReferenceIncrLevelsUp
+CQueryMutators::IncrLevelsUpInVar
 	(
-	Var *pvar
+	Var *var
 	)
 {
-	GPOS_ASSERT(NULL != pvar);
+	GPOS_ASSERT(NULL != var);
 
-	Var *pvarCopy = (Var *) gpdb::PvCopyObject(pvar);
-	if (0 != pvarCopy->varlevelsup)
+	Var *var_copy = (Var *) gpdb::CopyObject(var);
+	if (0 != var_copy->varlevelsup)
 	{
-		pvarCopy->varlevelsup++;
+		var_copy->varlevelsup++;
 	}
 
-	return pvarCopy;
+	return var_copy;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryNormalizeHaving
+//		CQueryMutators::NormalizeHaving
 //
 //	@doc:
 //		Pull up having qual into a select and fix correlated references
 //		to the top-level query
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryNormalizeHaving
+CQueryMutators::NormalizeHaving
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const Query *pquery
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const Query *query
 	)
 {
-	Query *pqueryCopy = (Query *) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+	Query *query_copy = (Query *) gpdb::CopyObject(const_cast<Query*>(query));
 
-	if (NULL == pquery->havingQual)
+	if (NULL == query->havingQual)
 	{
-		return pqueryCopy;
+		return query_copy;
 	}
 
-	Query *pqueryNew = PqueryConvertToDerivedTable(pqueryCopy, true /*fFixTargetList*/, false /*fFixHavingQual*/);
-	gpdb::GPDBFree(pqueryCopy);
+	Query *new_query = ConvertToDerivedTable(query_copy, true /*should_fix_target_list*/, false /*should_fix_having_qual*/);
+	gpdb::GPDBFree(query_copy);
 
-	RangeTblEntry *prte = ((RangeTblEntry *) gpdb::PvListNth(pqueryNew->rtable, 0));
-	Query *pqueryDrdTbl = (Query *) prte->subquery;
+	RangeTblEntry *rte = ((RangeTblEntry *) gpdb::ListNth(new_query->rtable, 0));
+	Query *derived_table_query = (Query *) rte->subquery;
 
 	// Add all necessary target list entries of subquery
 	// into the target list of the RTE as well as the new top most query
-	ListCell *plc = NULL;
-	ULONG ulTECount = 1;
-	ForEach (plc, pqueryDrdTbl->targetList)
+	ListCell *lc = NULL;
+	ULONG num_target_entries = 1;
+	ForEach (lc, derived_table_query->targetList)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		GPOS_ASSERT(NULL != pte);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		GPOS_ASSERT(NULL != target_entry);
 
 		// Add to the target lists:
 		// 	(1) All grouping / sorting columns even if they do not appear in the subquery output (resjunked)
 		//	(2) All non-resjunked target list entries
-		if (CTranslatorUtils::FGroupingColumn(pte, pqueryDrdTbl->groupClause) ||
-			CTranslatorUtils::FSortingColumn(pte, pqueryDrdTbl->sortClause) || !pte->resjunk)
+		if (CTranslatorUtils::IsGroupingColumn(target_entry, derived_table_query->groupClause) ||
+			CTranslatorUtils::IsSortingColumn(target_entry, derived_table_query->sortClause) || !target_entry->resjunk)
 		{
-			TargetEntry *pteNew = Pte(pte, ulTECount);
-			pqueryNew->targetList = gpdb::PlAppendElement(pqueryNew->targetList, pteNew);
+			TargetEntry *new_target_entry = MakeTopLevelTargetEntry(target_entry, num_target_entries);
+			new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry);
 			// Ensure that such target entries is not suppressed in the target list of the RTE
 			// and has a name
-			pte->resname = SzTEName(pte, pqueryDrdTbl);
-			pte->resjunk = false;
-			pteNew->ressortgroupref = pte->ressortgroupref;
+			target_entry->resname = GetTargetEntryColName(target_entry, derived_table_query);
+			target_entry->resjunk = false;
+			new_target_entry->ressortgroupref = target_entry->ressortgroupref;
 
-			ulTECount++;
+			num_target_entries++;
 		}
 	}
 
-	SContextHavingQualMutator ctxHavingQualMutator(pmp, pmda, ulTECount, pqueryDrdTbl->targetList);
+	SContextHavingQualMutator context(mp, md_accessor, num_target_entries, derived_table_query->targetList);
 
 	// fix outer references in the qual
-	pqueryNew->jointree->quals = PnodeHavingQualMutator(pqueryDrdTbl->havingQual, &ctxHavingQualMutator);
+	new_query->jointree->quals = RunHavingQualMutator(derived_table_query->havingQual, &context);
 
-	if (ctxHavingQualMutator.m_fFallbackToPlanner)
+	if (context.m_should_fallback)
 	{
 		// TODO: Oct 14 2013, remove temporary fix (revert exception to assert) to avoid crash during algebrization
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("No attribute"));
 	}
 
-	pqueryDrdTbl->havingQual = NULL;
+	derived_table_query->havingQual = NULL;
 
-	ReassignSortClause(pqueryNew, prte->subquery);
+	ReassignSortClause(new_query, rte->subquery);
 
-	if (!prte->subquery->hasAggs && NIL == prte->subquery->groupClause)
+	if (!rte->subquery->hasAggs && NIL == rte->subquery->groupClause)
 	{
 		// if the derived table has no grouping columns or aggregates then the
 		// subquery is equivalent to select XXXX FROM CONST-TABLE 
 		// (where XXXX is the original subquery's target list)
 
-		Query *pqueryNewSubquery = MakeNode(Query);
+		Query *new_subquery = MakeNode(Query);
 
-		pqueryNewSubquery->commandType = CMD_SELECT;
-		pqueryNewSubquery->targetList = NIL;
+		new_subquery->commandType = CMD_SELECT;
+		new_subquery->targetList = NIL;
 
-		pqueryNewSubquery->hasAggs = false;
-		pqueryNewSubquery->hasWindowFuncs = false;
-		pqueryNewSubquery->hasSubLinks = false;
+		new_subquery->hasAggs = false;
+		new_subquery->hasWindowFuncs = false;
+		new_subquery->hasSubLinks = false;
 
-		ListCell *plc = NULL;
-		ForEach (plc, prte->subquery->targetList)
+		ListCell *lc = NULL;
+		ForEach (lc, rte->subquery->targetList)
 		{
-			TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-			GPOS_ASSERT(NULL != pte);
+			TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+			GPOS_ASSERT(NULL != target_entry);
 
-			GPOS_ASSERT(!pte->resjunk);
+			GPOS_ASSERT(!target_entry->resjunk);
 			
-			pqueryNewSubquery->targetList =  gpdb::PlAppendElement
+			new_subquery->targetList =  gpdb::LAppend
 													(
-													pqueryNewSubquery->targetList,
-													(TargetEntry *) gpdb::PvCopyObject(const_cast<TargetEntry*>(pte))
+													new_subquery->targetList,
+													(TargetEntry *) gpdb::CopyObject(const_cast<TargetEntry*>(target_entry))
 													);
 		}
 
-		gpdb::GPDBFree(prte->subquery);
+		gpdb::GPDBFree(rte->subquery);
 
-		prte->subquery = pqueryNewSubquery;
-		prte->subquery->jointree = MakeNode(FromExpr);
-		prte->subquery->groupClause = NIL;
-		prte->subquery->sortClause = NIL;
-		prte->subquery->windowClause = NIL;
+		rte->subquery = new_subquery;
+		rte->subquery->jointree = MakeNode(FromExpr);
+		rte->subquery->groupClause = NIL;
+		rte->subquery->sortClause = NIL;
+		rte->subquery->windowClause = NIL;
 	}
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryNormalize
+//		CQueryMutators::NormalizeQuery
 //
 //	@doc:
 //		Normalize queries with having and group by clauses
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryNormalize
+CQueryMutators::NormalizeQuery
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const Query *pquery,
-	ULONG ulQueryLevel
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const Query *query,
+	ULONG query_level
 	)
 {
 	// flatten join alias vars defined at the current level of the query
-	Query *pqueryResolveJoinVarReferences = gpdb::PqueryFlattenJoinAliasVar(const_cast<Query*>(pquery), ulQueryLevel);
+	Query *pqueryResolveJoinVarReferences = gpdb::FlattenJoinAliasVar(const_cast<Query*>(query), query_level);
 
 	// eliminate distinct clause
-	Query *pqueryEliminateDistinct = CQueryMutators::PqueryEliminateDistinctClause(pqueryResolveJoinVarReferences);
+	Query *pqueryEliminateDistinct = CQueryMutators::EliminateDistinctClause(pqueryResolveJoinVarReferences);
 	GPOS_ASSERT(NULL == pqueryEliminateDistinct->distinctClause);
 	gpdb::GPDBFree(pqueryResolveJoinVarReferences);
 
 	// normalize window operator's project list
-	Query *pqueryWindowPlNormalized = CQueryMutators::PqueryNormalizeWindowPrL(pmp, pmda, pqueryEliminateDistinct);
+	Query *pqueryWindowPlNormalized = CQueryMutators::NormalizeWindowProjList(mp, md_accessor, pqueryEliminateDistinct);
 	gpdb::GPDBFree(pqueryEliminateDistinct);
 
 	// pull-up having quals into a select
-	Query *pqueryHavingNormalized = CQueryMutators::PqueryNormalizeHaving(pmp, pmda, pqueryWindowPlNormalized);
+	Query *pqueryHavingNormalized = CQueryMutators::NormalizeHaving(mp, md_accessor, pqueryWindowPlNormalized);
 	GPOS_ASSERT(NULL == pqueryHavingNormalized->havingQual);
 	gpdb::GPDBFree(pqueryWindowPlNormalized);
 
 	// normalize the group by project list
-	Query *pqueryNew = CQueryMutators::PqueryNormalizeGrpByPrL(pmp, pmda, pqueryHavingNormalized);
+	Query *new_query = CQueryMutators::NormalizeGroupByProjList(mp, md_accessor, pqueryHavingNormalized);
 	gpdb::GPDBFree(pqueryHavingNormalized);
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::Pte
+//		CQueryMutators::GetTargetEntry
 //
 //	@doc:
 //		Given an Target list entry in the derived table, create a new
@@ -1343,111 +1332,114 @@ CQueryMutators::PqueryNormalize
 //		memory
 //---------------------------------------------------------------------------
 TargetEntry *
-CQueryMutators::Pte
+CQueryMutators::MakeTopLevelTargetEntry
 	(
-	TargetEntry *pteOld,
-	ULONG ulVarAttno
+	TargetEntry *old_target_entry,
+	ULONG attno
 	)
 {
-	Var *pvarNew = gpdb::PvarMakeVar
+	Var *new_var = gpdb::MakeVar
 							(
 							1,
-							(AttrNumber) ulVarAttno,
-							gpdb::OidExprType( (Node*) pteOld->expr),
-							gpdb::IExprTypeMod( (Node*) pteOld->expr),
+							(AttrNumber) attno,
+							gpdb::ExprType( (Node*) old_target_entry->expr),
+							gpdb::ExprTypeMod( (Node*) old_target_entry->expr),
 							0 // query levelsup
 							);
 
-	TargetEntry *pteNew = gpdb::PteMakeTargetEntry((Expr*) pvarNew, (AttrNumber) ulVarAttno, pteOld->resname, pteOld->resjunk);
+	TargetEntry *new_target_entry = gpdb::MakeTargetEntry((Expr*) new_var, (AttrNumber) attno, old_target_entry->resname, old_target_entry->resjunk);
 
-	return pteNew;
+	return new_target_entry;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::SzTEName
+//		CQueryMutators::GetTargetEntryColName
 //
 //	@doc:
 //		Return the column name of the target list entry
 //---------------------------------------------------------------------------
 CHAR *
-CQueryMutators::SzTEName
+CQueryMutators::GetTargetEntryColName
 	(
-	TargetEntry *pte,
-	Query *pquery
+	TargetEntry *target_entry,
+	Query *query
 	)
 {
-	if (NULL != pte->resname)
+	if (NULL != target_entry->resname)
 	{
-		return pte->resname;
+		return target_entry->resname;
 	}
 
 	// Since a resjunked target list entry will not have a column name create a dummy column name
-	CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
+	CWStringConst dummy_colname(GPOS_WSZ_LIT("?column?"));
 
-	return CTranslatorUtils::SzFromWsz(strUnnamedCol.Wsz());
+	return CTranslatorUtils::CreateMultiByteCharStringFromWCString(dummy_colname.GetBuffer());
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryConvertToDerivedTable
+//		CQueryMutators::ConvertToDerivedTable
 //
 //	@doc:
 //		Converts query into a derived table and return the new top-level query
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryConvertToDerivedTable
+CQueryMutators::ConvertToDerivedTable
 	(
-	const Query *pquery,
-	BOOL fFixTargetList,
-	BOOL fFixHavingQual
+	const Query *query,
+	BOOL should_fix_target_list,
+	BOOL should_fix_having_qual
 	)
 {
-	Query *pqueryCopy = (Query *) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+	Query *query_copy = (Query *) gpdb::CopyObject(const_cast<Query*>(query));
 
-	// fix any outer references
-	SContextIncLevelsupMutator ctxIncLvlMutator(0, fFixTargetList);
-
-	Node *pnodeHavingQual = NULL;
-	if (!fFixHavingQual)
+	Node *having_qual = NULL;
+	if (!should_fix_having_qual)
 	{
-		pnodeHavingQual = pqueryCopy->havingQual;
-		pqueryCopy->havingQual = NULL;
+		having_qual = query_copy->havingQual;
+		query_copy->havingQual = NULL;
 	}
 
 	// fix outer references
-	Query *pqueryDrvd = (Query *) PnodeIncrementLevelsupMutator((Node*) pqueryCopy, &ctxIncLvlMutator);
-	gpdb::GPDBFree(pqueryCopy);
+	Query *derived_table_query;
+	{
+		SContextIncLevelsupMutator context(0, should_fix_target_list);
+		derived_table_query = (Query *) RunIncrLevelsUpMutator((Node*) query_copy, &context);
+	}
+	gpdb::GPDBFree(query_copy);
 
 	// fix the CTE levels up -- while the old query is converted into a derived table, its cte list
 	// is re-assigned to the new top-level query. The references to the ctes listed in the old query
 	// as well as those listed before the current query level are accordingly adjusted in the new
 	// derived table.
-	List *plCteOriginal = pqueryDrvd->cteList;
-	pqueryDrvd->cteList = NIL;
+	List *original_cte_list = derived_table_query->cteList;
+	derived_table_query->cteList = NIL;
 
-	SContextIncLevelsupMutator ctxinclvlmutator(0 /*starting level */, fFixTargetList);
-
-	Query *pqueryDrvdNew  = (Query *) PnodeFixCTELevelsupMutator( (Node *) pqueryDrvd, &ctxinclvlmutator);
-	gpdb::GPDBFree(pqueryDrvd);
-	pqueryDrvd = pqueryDrvdNew;
+	Query *new_derived_table_query;
+	{
+		SContextIncLevelsupMutator context(0 /*starting level */, should_fix_target_list);
+		new_derived_table_query  = (Query *) RunFixCTELevelsUpMutator( (Node *) derived_table_query, &context);
+	}
+	gpdb::GPDBFree(derived_table_query);
+	derived_table_query = new_derived_table_query;
 
 	// create a range table entry for the query node
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
-	prte->rtekind = RTE_SUBQUERY;
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
+	rte->rtekind = RTE_SUBQUERY;
 
-	prte->subquery = pqueryDrvd;
-	prte->inFromCl = true;
-	prte->subquery->cteList = NIL;
+	rte->subquery = derived_table_query;
+	rte->inFromCl = true;
+	rte->subquery->cteList = NIL;
 
-	if (NULL != pnodeHavingQual)
+	if (NULL != having_qual)
 	{
-		pqueryDrvd->havingQual = pnodeHavingQual;
+		derived_table_query->havingQual = having_qual;
 	}
 
 	// create a new range table reference for the new RTE
-	RangeTblRef *prtref = MakeNode(RangeTblRef);
-	prtref->rtindex = 1;
+	RangeTblRef *rtref = MakeNode(RangeTblRef);
+	rtref->rtindex = 1;
 
 	// GPDB_92_MERGE_FIXME: other than holding the intoClause and intoPolicy,
 	// what purpose does this normalization step do? Upstream commit 9dbf2b7d
@@ -1456,142 +1448,143 @@ CQueryMutators::PqueryConvertToDerivedTable
 //	// intoClause, if not null, must be set on the top query, not on the derived table
 //	IntoClause *origIntoClause = pqueryDrvd->intoClause;
 //	pqueryDrvd->intoClause = NULL;
-	struct GpPolicy* origIntoPolicy = pqueryDrvd->intoPolicy;
-	pqueryDrvd->intoPolicy = NULL;
+	// intoClause, if not null, must be set on the top query, not on the derived table
+	struct GpPolicy* into_policy = derived_table_query->intoPolicy;
+	derived_table_query->intoPolicy = NULL;
 
 	// create a new top-level query with the new RTE in its from clause
-	Query *pqueryNew = MakeNode(Query);
-	pqueryNew->cteList = plCteOriginal;
-	pqueryNew->hasAggs = false;
-	pqueryNew->rtable = gpdb::PlAppendElement(pqueryNew->rtable, prte);
-//	pqueryNew->intoClause = origIntoClause;
-	pqueryNew->intoPolicy = origIntoPolicy;
-	pqueryNew->isCTAS = pqueryDrvd->isCTAS;
-	pqueryDrvd->isCTAS = false;
+	Query *new_query = MakeNode(Query);
+	new_query->cteList = original_cte_list;
+	new_query->hasAggs = false;
+	new_query->rtable = gpdb::LAppend(new_query->rtable, rte);
+//	new_query->intoClause = origIntoClause;
+	new_query->intoPolicy = into_policy;
+	new_query->isCTAS = derived_table_query->isCTAS;
+	derived_table_query->isCTAS = false;
 
-	FromExpr *pfromexpr = MakeNode(FromExpr);
-	pfromexpr->quals = NULL;
-	pfromexpr->fromlist = gpdb::PlAppendElement(pfromexpr->fromlist, prtref);
+	FromExpr *fromexpr = MakeNode(FromExpr);
+	fromexpr->quals = NULL;
+	fromexpr->fromlist = gpdb::LAppend(fromexpr->fromlist, rtref);
 
-	pqueryNew->jointree = pfromexpr;
-	pqueryNew->commandType = CMD_SELECT;
+	new_query->jointree = fromexpr;
+	new_query->commandType = CMD_SELECT;
 
-	GPOS_ASSERT(1 == gpdb::UlListLength(pqueryNew->rtable));
-	return pqueryNew;
+	GPOS_ASSERT(1 == gpdb::ListLength(new_query->rtable));
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryEliminateDistinctClause
+//		CQueryMutators::EliminateDistinctClause
 //
 //	@doc:
 //		Eliminate distinct columns by translating it into a grouping columns
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryEliminateDistinctClause
+CQueryMutators::EliminateDistinctClause
 	(
-	const Query *pquery
+	const Query *query
 	)
 {
-	if (0 == gpdb::UlListLength(pquery->distinctClause))
+	if (0 == gpdb::ListLength(query->distinctClause))
 	{
-		return (Query*) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+		return (Query*) gpdb::CopyObject(const_cast<Query*>(query));
 	}
 
 	// create a derived table out of the previous query
-	Query *pqueryNew = PqueryConvertToDerivedTable(pquery, true /*fFixTargetList*/, true /*fFixHavingQual*/);
+	Query *new_query = ConvertToDerivedTable(query, true /*should_fix_target_list*/, true /*should_fix_having_qual*/);
 
-	GPOS_ASSERT(1 == gpdb::UlListLength(pqueryNew->rtable));
-	Query *pqueryDrdTbl = (Query *) ((RangeTblEntry *) gpdb::PvListNth(pqueryNew->rtable, 0))->subquery;
+	GPOS_ASSERT(1 == gpdb::ListLength(new_query->rtable));
+	Query *derived_table_query = (Query *) ((RangeTblEntry *) gpdb::ListNth(new_query->rtable, 0))->subquery;
 
-	ReassignSortClause(pqueryNew, pqueryDrdTbl);
+	ReassignSortClause(new_query, derived_table_query);
 
-	pqueryNew->targetList = NIL;
-	List *plTE = pqueryDrdTbl->targetList;
-	ListCell *plc = NULL;
+	new_query->targetList = NIL;
+	List *target_entries = derived_table_query->targetList;
+	ListCell *lc = NULL;
 
 	// build the project list of the new top-level query
-	ForEach (plc, plTE)
+	ForEach (lc, target_entries)
 	{
-		ULONG ulResNo = gpdb::UlListLength(pqueryNew->targetList) + 1;
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		GPOS_ASSERT(NULL != pte);
+		ULONG resno = gpdb::ListLength(new_query->targetList) + 1;
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		GPOS_ASSERT(NULL != target_entry);
 
-		if (!pte->resjunk)
+		if (!target_entry->resjunk)
 		{
 			// create a new target entry that points to the corresponding entry in the derived table
-			Var *pvarNew = gpdb::PvarMakeVar
+			Var *new_var = gpdb::MakeVar
 									(
 									1,
-									pte->resno,
-									gpdb::OidExprType((Node*) pte->expr),
-									gpdb::IExprTypeMod((Node*) pte->expr),
+									target_entry->resno,
+									gpdb::ExprType((Node*) target_entry->expr),
+									gpdb::ExprTypeMod((Node*) target_entry->expr),
 									0 // query levels up
 									);
-			TargetEntry *pteNew= gpdb::PteMakeTargetEntry((Expr*) pvarNew, (AttrNumber) ulResNo, pte->resname, false);
+			TargetEntry *new_target_entry= gpdb::MakeTargetEntry((Expr*) new_var, (AttrNumber) resno, target_entry->resname, false);
 
-			pteNew->ressortgroupref =  pte->ressortgroupref;
-			pqueryNew->targetList = gpdb::PlAppendElement(pqueryNew->targetList, pteNew);
+			new_target_entry->ressortgroupref =  target_entry->ressortgroupref;
+			new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry);
 		}
 
-		if (0 < pte->ressortgroupref &&
-			!CTranslatorUtils::FGroupingColumn(pte, pqueryDrdTbl->groupClause) &&
-			!CTranslatorUtils::FWindowSpec(pte, pqueryDrdTbl->windowClause))
+		if (0 < target_entry->ressortgroupref &&
+			!CTranslatorUtils::IsGroupingColumn(target_entry, derived_table_query->groupClause) &&
+			!CTranslatorUtils::IsWindowSpec(target_entry, derived_table_query->windowClause))
 		{
 			// initialize the ressortgroupref of target entries not used in the grouping clause
-			 pte->ressortgroupref = 0;
+			 target_entry->ressortgroupref = 0;
 		}
 	}
 
-	if (gpdb::UlListLength(pqueryNew->targetList) != gpdb::UlListLength(pquery->distinctClause))
+	if (gpdb::ListLength(new_query->targetList) != gpdb::ListLength(query->distinctClause))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("DISTINCT operation on a subset of target list columns"));
 	}
 
-	ListCell *plcDistinctCl = NULL;
-	ForEach (plcDistinctCl, pquery->distinctClause)
+	ListCell *pl = NULL;
+	ForEach (pl, query->distinctClause)
 	{
-		SortGroupClause *psortcl  = (SortGroupClause*) lfirst(plcDistinctCl);
-		GPOS_ASSERT(NULL != psortcl);
+		SortGroupClause *sort_group_clause  = (SortGroupClause*) lfirst(pl);
+		GPOS_ASSERT(NULL != sort_group_clause);
 
-		SortGroupClause *pgrpcl = MakeNode(SortGroupClause);
-		pgrpcl->tleSortGroupRef = psortcl->tleSortGroupRef;
-		pgrpcl->eqop = psortcl->eqop;
-		pgrpcl->sortop = psortcl->sortop;
-		pgrpcl->nulls_first = psortcl->nulls_first;
-		pqueryNew->groupClause = gpdb::PlAppendElement(pqueryNew->groupClause, pgrpcl);
+		SortGroupClause *new_sort_group_clause = MakeNode(SortGroupClause);
+		new_sort_group_clause->tleSortGroupRef = sort_group_clause->tleSortGroupRef;
+		new_sort_group_clause->eqop = sort_group_clause->eqop;
+		new_sort_group_clause->sortop = sort_group_clause->sortop;
+		new_sort_group_clause->nulls_first = sort_group_clause->nulls_first;
+		new_query->groupClause = gpdb::LAppend(new_query->groupClause, new_sort_group_clause);
 	}
-	pqueryNew->distinctClause = NIL;
-	pqueryDrdTbl->distinctClause = NIL;
+	new_query->distinctClause = NIL;
+	derived_table_query->distinctClause = NIL;
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::FNeedsWindowPrLNormalization
+//		CQueryMutators::NeedsProjListWindowNormalization
 //
 //	@doc:
 //		Check whether the window operator's project list only contains
 //		window functions and columns used in the window specification
 //---------------------------------------------------------------------------
 BOOL
-CQueryMutators::FNeedsWindowPrLNormalization
+CQueryMutators::NeedsProjListWindowNormalization
 	(
-	const Query *pquery
+	const Query *query
 	)
 {
-	if (!pquery->hasWindowFuncs)
+	if (!query->hasWindowFuncs)
 	{
 		return false;
 	}
 
-	ListCell *plc = NULL;
-	ForEach (plc, pquery->targetList)
+	ListCell *lc = NULL;
+	ForEach (lc, query->targetList)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
 
-		if (!CTranslatorUtils::FWindowSpec( (Node *) pte->expr, pquery->windowClause, pquery->targetList) && !IsA(pte->expr, WindowFunc) && !IsA(pte->expr, Var))
+		if (!CTranslatorUtils::IsWindowSpec( (Node *) target_entry->expr, query->windowClause, query->targetList) && !IsA(target_entry->expr, WindowFunc) && !IsA(target_entry->expr, Var))
 		{
 			// computed columns in the target list that is not
 			// used in the order by or partition by of the window specification(s)
@@ -1604,7 +1597,7 @@ CQueryMutators::FNeedsWindowPrLNormalization
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryNormalizeWindowPrL
+//		CQueryMutators::NormalizeWindowProjList
 //
 //	@doc:
 // 		Flatten expressions in project list to contain only window functions and
@@ -1617,193 +1610,192 @@ CQueryMutators::FNeedsWindowPrLNormalization
 //			SELECT rn+rk from (SELECT row_number() over() as rn rank() over(partition by a+b order by a-b) as rk FROM foo) foo_new
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryNormalizeWindowPrL
+CQueryMutators::NormalizeWindowProjList
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const Query *pquery
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const Query *query
 	)
 {
-	Query *pqueryCopy = (Query *) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+	Query *query_copy = (Query *) gpdb::CopyObject(const_cast<Query*>(query));
 
-	if (!FNeedsWindowPrLNormalization(pquery))
+	if (!NeedsProjListWindowNormalization(query))
 	{
-		return pqueryCopy;
+		return query_copy;
 	}
 
 	// we do not fix target list of the derived table since we will be mutating it below
 	// to ensure that it does not have operations with window function
-	Query *pqueryNew = PqueryConvertToDerivedTable(pqueryCopy, false /*fFixTargetList*/, true /*fFixHavingQual*/);
-	gpdb::GPDBFree(pqueryCopy);
+	Query *new_query = ConvertToDerivedTable(query_copy, false /*should_fix_target_list*/, true /*should_fix_having_qual*/);
+	gpdb::GPDBFree(query_copy);
 
-	GPOS_ASSERT(1 == gpdb::UlListLength(pqueryNew->rtable));
-	Query *pqueryDrdTbl = (Query *) ((RangeTblEntry *) gpdb::PvListNth(pqueryNew->rtable, 0))->subquery;
+	GPOS_ASSERT(1 == gpdb::ListLength(new_query->rtable));
+	Query *derived_table_query = (Query *) ((RangeTblEntry *) gpdb::ListNth(new_query->rtable, 0))->subquery;
 
-	SContextGrpbyPlMutator ctxWindowPrLMutator(pmp, pmda, pqueryDrdTbl, NULL);
-	ListCell *plc = NULL;
-	List *plTE = pqueryDrdTbl->targetList;
-	ForEach (plc, plTE)
+	SContextGrpbyPlMutator context(mp, md_accessor, derived_table_query, NULL);
+	ListCell *lc = NULL;
+	List *target_entries = derived_table_query->targetList;
+	ForEach (lc, target_entries)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		const ULONG ulResNoNew = gpdb::UlListLength(pqueryNew->targetList) + 1;
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		const ULONG ulResNoNew = gpdb::ListLength(new_query->targetList) + 1;
 
-		if (CTranslatorUtils::FWindowSpec(pte, pquery->windowClause))
+		if (CTranslatorUtils::IsWindowSpec(target_entry, query->windowClause))
 		{
 			// insert the target list entry used in the window specification as is
-			TargetEntry *pteNew = (TargetEntry *) gpdb::PvCopyObject(pte);
-			pteNew->resno = gpdb::UlListLength(ctxWindowPrLMutator.m_plTENewGroupByQuery) + 1;
-			ctxWindowPrLMutator.m_plTENewGroupByQuery = gpdb::PlAppendElement(ctxWindowPrLMutator.m_plTENewGroupByQuery, pteNew);
+			TargetEntry *new_target_entry = (TargetEntry *) gpdb::CopyObject(target_entry);
+			new_target_entry->resno = gpdb::ListLength(context.m_groupby_target_list) + 1;
+			context.m_groupby_target_list = gpdb::LAppend(context.m_groupby_target_list, new_target_entry);
 
-			if (!pte->resjunk || CTranslatorUtils::FSortingColumn(pte, pquery->sortClause))
+			if (!target_entry->resjunk || CTranslatorUtils::IsSortingColumn(target_entry, query->sortClause))
 			{
 				// if the target list entry used in the window specification is present
 				// in the query output then add it to the target list of the new top level query
-				Var *pvarNew = gpdb::PvarMakeVar
+				Var *new_var = gpdb::MakeVar
 										(
 										1,
-										pteNew->resno,
-										gpdb::OidExprType((Node*) pte->expr),
-										gpdb::IExprTypeMod((Node*) pte->expr),
+										new_target_entry->resno,
+										gpdb::ExprType((Node*) target_entry->expr),
+										gpdb::ExprTypeMod((Node*) target_entry->expr),
 										0 // query levels up
 										);
-				TargetEntry *pteNewCopy = gpdb::PteMakeTargetEntry((Expr*) pvarNew, ulResNoNew, pte->resname, pte->resjunk);
+				TargetEntry *new_target_entry_copy = gpdb::MakeTargetEntry((Expr*) new_var, ulResNoNew, target_entry->resname, target_entry->resjunk);
 
 				// Copy the resortgroupref and resjunk information for the top-level target list entry
 				// Set target list entry of the derived table to be non-resjunked
-				pteNewCopy->resjunk = pteNew->resjunk;
-				pteNewCopy->ressortgroupref = pteNew->ressortgroupref;
-				pteNew->resjunk = false;
+				new_target_entry_copy->resjunk = new_target_entry->resjunk;
+				new_target_entry_copy->ressortgroupref = new_target_entry->ressortgroupref;
+				new_target_entry->resjunk = false;
 
-				pqueryNew->targetList = gpdb::PlAppendElement(pqueryNew->targetList, pteNewCopy);
+				new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry_copy);
 			}
 		}
 		else
 		{
 			// normalize target list entry
-			ctxWindowPrLMutator.m_ulRessortgroupref = pte->ressortgroupref;
-			Expr *pexprNew = (Expr*) PnodeWindowPrLMutator( (Node*) pte->expr, &ctxWindowPrLMutator);
-			TargetEntry *pteNew = gpdb::PteMakeTargetEntry(pexprNew, ulResNoNew, pte->resname, pte->resjunk);
-			pteNew->ressortgroupref = pte->ressortgroupref;
-			pqueryNew->targetList = gpdb::PlAppendElement(pqueryNew->targetList, pteNew);
+			context.m_sort_group_ref = target_entry->ressortgroupref;
+			Expr *pexprNew = (Expr*) RunWindowProjListMutator( (Node*) target_entry->expr, &context);
+			TargetEntry *new_target_entry = gpdb::MakeTargetEntry(pexprNew, ulResNoNew, target_entry->resname, target_entry->resjunk);
+			new_target_entry->ressortgroupref = target_entry->ressortgroupref;
+			new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry);
 		}
 	}
-	pqueryDrdTbl->targetList = ctxWindowPrLMutator.m_plTENewGroupByQuery;
+	derived_table_query->targetList = context.m_groupby_target_list;
 
-	GPOS_ASSERT(gpdb::UlListLength(pqueryNew->targetList) <= gpdb::UlListLength(pquery->targetList));
+	GPOS_ASSERT(gpdb::ListLength(new_query->targetList) <= gpdb::ListLength(query->targetList));
 
-	pqueryNew->hasWindowFuncs = false;
-	ReassignSortClause(pqueryNew, pqueryDrdTbl);
+	new_query->hasWindowFuncs = false;
+	ReassignSortClause(new_query, derived_table_query);
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeWindowPrLMutator
+//		CQueryMutators::RunWindowProjListMutator
 //
 //	@doc:
 // 		Traverse the project list of extract all window functions in an
 //		arbitrarily complex project element
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeWindowPrLMutator
+CQueryMutators::RunWindowProjListMutator
 	(
-	Node *pnode,
-	void *pctx
+	Node *node,
+	SContextGrpbyPlMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
 	// do not traverse into sub queries as they will be inserted are inserted into
 	// top-level query as is
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	SContextGrpbyPlMutator *pctxWindowPrLMutator = (SContextGrpbyPlMutator *) pctx;
-	const ULONG ulResNo = gpdb::UlListLength(pctxWindowPrLMutator->m_plTENewGroupByQuery) + 1;
+	const ULONG resno = gpdb::ListLength(context->m_groupby_target_list) + 1;
 
-	if (IsA(pnode, WindowFunc))
+	if (IsA(node, WindowFunc))
 	{
 		// insert window operator into the derived table
         // and refer to it in the top-level query's target list
-		WindowFunc *pwindowfunc = (WindowFunc *) gpdb::PvCopyObject(pnode);
+		WindowFunc *window_func = (WindowFunc *) gpdb::CopyObject(node);
 
 		// get the function name and add it to the target list
-		CMDIdGPDB *pmdidFunc = GPOS_NEW(pctxWindowPrLMutator->m_pmp) CMDIdGPDB(pwindowfunc->winfnoid);
-		const CWStringConst *pstr = CMDAccessorUtils::PstrWindowFuncName(pctxWindowPrLMutator->m_pmda, pmdidFunc);
-		pmdidFunc->Release();
+		CMDIdGPDB *mdid_func = GPOS_NEW(context->m_mp) CMDIdGPDB(window_func->winfnoid);
+		const CWStringConst *str = CMDAccessorUtils::PstrWindowFuncName(context->m_md_accessor, mdid_func);
+		mdid_func->Release();
 
-		TargetEntry *pte = gpdb::PteMakeTargetEntry
+		TargetEntry *target_entry = gpdb::MakeTargetEntry
 								(
-								(Expr*) gpdb::PvCopyObject(pnode),
-								(AttrNumber) ulResNo,
-								CTranslatorUtils::SzFromWsz(pstr->Wsz()),
+								(Expr*) gpdb::CopyObject(node),
+								(AttrNumber) resno,
+								CTranslatorUtils::CreateMultiByteCharStringFromWCString(str->GetBuffer()),
 								false /* resjunk */
 								);
-		pctxWindowPrLMutator->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctxWindowPrLMutator->m_plTENewGroupByQuery, pte);
+		context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
 		// return a variable referring to the new derived table's corresponding target list entry
-		Var *pvarNew = gpdb::PvarMakeVar
+		Var *new_var = gpdb::MakeVar
 								(
 								1,
-								(AttrNumber) ulResNo,
-								gpdb::OidExprType(pnode),
-								gpdb::IExprTypeMod(pnode),
+								(AttrNumber) resno,
+								gpdb::ExprType(node),
+								gpdb::ExprTypeMod(node),
 								0 // query levelsup
 								);
 
-		return (Node*) pvarNew;
+		return (Node*) new_var;
 	}
 
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvarNew = NULL;
+		Var *new_var = NULL;
 
-		TargetEntry *pteFound = gpdb::PteMember(pnode, pctxWindowPrLMutator->m_plTENewGroupByQuery);
-		if (NULL == pteFound)
+		TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
+		if (NULL == found_target_entry)
 		{
 			// insert target entry into the target list of the derived table
-			CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
-			TargetEntry *pte = gpdb::PteMakeTargetEntry
+			CWStringConst str_unnamed_col(GPOS_WSZ_LIT("?column?"));
+			TargetEntry *target_entry = gpdb::MakeTargetEntry
 									(
-									(Expr*) gpdb::PvCopyObject(pnode),
-									(AttrNumber) ulResNo,
-									CTranslatorUtils::SzFromWsz(strUnnamedCol.Wsz()),
+									(Expr*) gpdb::CopyObject(node),
+									(AttrNumber) resno,
+									CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_unnamed_col.GetBuffer()),
 									false /* resjunk */
 									);
-			pctxWindowPrLMutator->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctxWindowPrLMutator->m_plTENewGroupByQuery, pte);
+			context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
-			pvarNew = gpdb::PvarMakeVar
+			new_var = gpdb::MakeVar
 								(
 								1,
-								(AttrNumber) ulResNo,
-								gpdb::OidExprType(pnode),
-								gpdb::IExprTypeMod(pnode),
+								(AttrNumber) resno,
+								gpdb::ExprType(node),
+								gpdb::ExprTypeMod(node),
 								0 // query levelsup
 								);
 		}
 		else
 		{
-			pteFound->resjunk = false; // ensure that the derived target list is not resjunked
-			pvarNew = gpdb::PvarMakeVar
+			found_target_entry->resjunk = false; // ensure that the derived target list is not resjunked
+			new_var = gpdb::MakeVar
 								(
 								1,
-								pteFound->resno,
-								gpdb::OidExprType(pnode),
-								gpdb::IExprTypeMod(pnode),
+								found_target_entry->resno,
+								gpdb::ExprType(node),
+								gpdb::ExprTypeMod(node),
 								0 // query levelsup
 								);
 		}
 
-		return (Node*) pvarNew;
+		return (Node*) new_var;
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeWindowPrLMutator, pctx);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunWindowProjListMutator, context);
 }
 
 //---------------------------------------------------------------------------
@@ -1816,16 +1808,16 @@ CQueryMutators::PnodeWindowPrLMutator
 void
 CQueryMutators::ReassignSortClause
 	(
-	Query *pqueryNew,
-	Query *pqueryDrdTbl
+	Query *top_level_query,
+	Query *derived_table_query
 	)
 {
-	pqueryNew->sortClause = pqueryDrdTbl->sortClause;
-	pqueryNew->limitOffset = pqueryDrdTbl->limitOffset;
-	pqueryNew->limitCount = pqueryDrdTbl->limitCount;
-	pqueryDrdTbl->sortClause = NULL;
-	pqueryDrdTbl->limitOffset = NULL;
-	pqueryDrdTbl->limitCount = NULL;
+	top_level_query->sortClause = derived_table_query->sortClause;
+	top_level_query->limitOffset = derived_table_query->limitOffset;
+	top_level_query->limitCount = derived_table_query->limitCount;
+	derived_table_query->sortClause = NULL;
+	derived_table_query->limitOffset = NULL;
+	derived_table_query->limitCount = NULL;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -69,23 +69,23 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	CContextDXLToPlStmt* pctxdxltoplstmt,
-	ULONG ulSegments
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	CContextDXLToPlStmt* dxl_to_plstmt_context,
+	ULONG num_of_segments
 	)
 	:
-	m_pmp(pmp),
-	m_pmda(pmda),
-	m_pctxdxltoplstmt(pctxdxltoplstmt),
-	m_cmdtype(CMD_SELECT),
-	m_fTargetTableDistributed(false),
-	m_plResultRelations(NULL),
-	m_ulExternalScanCounter(0),
-	m_ulSegments(ulSegments),
-	m_ulPartitionSelectorCounter(0)
+	m_mp(mp),
+	m_md_accessor(md_accessor),
+	m_dxl_to_plstmt_context(dxl_to_plstmt_context),
+	m_cmd_type(CMD_SELECT),
+	m_is_tgt_tbl_distributed(false),
+	m_result_rel_list(NULL),
+	m_external_scan_counter(0),
+	m_num_of_segments(num_of_segments),
+	m_partition_selector_counter(0)
 {
-	m_pdxlsctranslator = GPOS_NEW(m_pmp) CTranslatorDXLToScalar(m_pmp, m_pmda, m_ulSegments);
+	m_translator_dxl_to_scalar = GPOS_NEW(m_mp) CTranslatorDXLToScalar(m_mp, m_md_accessor, m_num_of_segments);
 	InitTranslators();
 }
 
@@ -99,7 +99,7 @@ CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt
 //---------------------------------------------------------------------------
 CTranslatorDXLToPlStmt::~CTranslatorDXLToPlStmt()
 {
-	GPOS_DELETE(m_pdxlsctranslator);
+	GPOS_DELETE(m_translator_dxl_to_scalar);
 }
 
 //---------------------------------------------------------------------------
@@ -113,192 +113,192 @@ CTranslatorDXLToPlStmt::~CTranslatorDXLToPlStmt()
 void
 CTranslatorDXLToPlStmt::InitTranslators()
 {
-	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(m_rgpfTranslators); ul++)
+	for (ULONG idx = 0; idx < GPOS_ARRAY_SIZE(m_dxlop_translator_func_mapping_array); idx++)
 	{
-		m_rgpfTranslators[ul] = NULL;
+		m_dxlop_translator_func_mapping_array[idx] = NULL;
 	}
 
 	// array mapping operator type to translator function
-	static const STranslatorMapping rgTranslators[] =
+	static const STranslatorMapping dxlop_translator_func_mapping_array[] =
 	{
-			{EdxlopPhysicalTableScan,				&gpopt::CTranslatorDXLToPlStmt::PtsFromDXLTblScan},
-			{EdxlopPhysicalExternalScan,			&gpopt::CTranslatorDXLToPlStmt::PtsFromDXLTblScan},
-			{EdxlopPhysicalIndexScan,				&gpopt::CTranslatorDXLToPlStmt::PisFromDXLIndexScan},
-			{EdxlopPhysicalHashJoin, 				&gpopt::CTranslatorDXLToPlStmt::PhjFromDXLHJ},
-			{EdxlopPhysicalNLJoin, 					&gpopt::CTranslatorDXLToPlStmt::PnljFromDXLNLJ},
-			{EdxlopPhysicalMergeJoin,				&gpopt::CTranslatorDXLToPlStmt::PmjFromDXLMJ},
-			{EdxlopPhysicalMotionGather,			&gpopt::CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion},
-			{EdxlopPhysicalMotionBroadcast,			&gpopt::CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion},
-			{EdxlopPhysicalMotionRedistribute,		&gpopt::CTranslatorDXLToPlStmt::PplanTranslateDXLMotion},
-			{EdxlopPhysicalMotionRandom,			&gpopt::CTranslatorDXLToPlStmt::PplanTranslateDXLMotion},
-			{EdxlopPhysicalMotionRoutedDistribute,	&gpopt::CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion},
-			{EdxlopPhysicalLimit, 					&gpopt::CTranslatorDXLToPlStmt::PlimitFromDXLLimit},
-			{EdxlopPhysicalAgg, 					&gpopt::CTranslatorDXLToPlStmt::PaggFromDXLAgg},
-			{EdxlopPhysicalWindow, 					&gpopt::CTranslatorDXLToPlStmt::PwindowFromDXLWindow},
-			{EdxlopPhysicalSort,					&gpopt::CTranslatorDXLToPlStmt::PsortFromDXLSort},
-			{EdxlopPhysicalSubqueryScan,			&gpopt::CTranslatorDXLToPlStmt::PsubqscanFromDXLSubqScan},
-			{EdxlopPhysicalResult, 					&gpopt::CTranslatorDXLToPlStmt::PresultFromDXLResult},
-			{EdxlopPhysicalAppend, 					&gpopt::CTranslatorDXLToPlStmt::PappendFromDXLAppend},
-			{EdxlopPhysicalMaterialize, 			&gpopt::CTranslatorDXLToPlStmt::PmatFromDXLMaterialize},
-			{EdxlopPhysicalSequence, 				&gpopt::CTranslatorDXLToPlStmt::PplanSequence},
-			{EdxlopPhysicalDynamicTableScan,		&gpopt::CTranslatorDXLToPlStmt::PplanDTS},
-			{EdxlopPhysicalDynamicIndexScan,		&gpopt::CTranslatorDXLToPlStmt::PplanDIS},
-			{EdxlopPhysicalTVF,						&gpopt::CTranslatorDXLToPlStmt::PplanFunctionScanFromDXLTVF},
-			{EdxlopPhysicalDML,						&gpopt::CTranslatorDXLToPlStmt::PplanDML},
-			{EdxlopPhysicalSplit,					&gpopt::CTranslatorDXLToPlStmt::PplanSplit},
-			{EdxlopPhysicalRowTrigger,				&gpopt::CTranslatorDXLToPlStmt::PplanRowTrigger},
-			{EdxlopPhysicalAssert,					&gpopt::CTranslatorDXLToPlStmt::PplanAssert},
-			{EdxlopPhysicalCTEProducer, 			&gpopt::CTranslatorDXLToPlStmt::PshscanFromDXLCTEProducer},
-			{EdxlopPhysicalCTEConsumer, 			&gpopt::CTranslatorDXLToPlStmt::PshscanFromDXLCTEConsumer},
-			{EdxlopPhysicalBitmapTableScan,			&gpopt::CTranslatorDXLToPlStmt::PplanBitmapTableScan},
-			{EdxlopPhysicalDynamicBitmapTableScan,	&gpopt::CTranslatorDXLToPlStmt::PplanBitmapTableScan},
-			{EdxlopPhysicalCTAS, 					&gpopt::CTranslatorDXLToPlStmt::PplanCTAS},
-			{EdxlopPhysicalPartitionSelector,		&gpopt::CTranslatorDXLToPlStmt::PplanPartitionSelector},
-			{EdxlopPhysicalValuesScan,				&gpopt::CTranslatorDXLToPlStmt::PplanValueScan},
+			{EdxlopPhysicalTableScan,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
+			{EdxlopPhysicalExternalScan,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
+			{EdxlopPhysicalIndexScan,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLIndexScan},
+			{EdxlopPhysicalHashJoin, 				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLHashJoin},
+			{EdxlopPhysicalNLJoin, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLNLJoin},
+			{EdxlopPhysicalMergeJoin,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMergeJoin},
+			{EdxlopPhysicalMotionGather,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMotion},
+			{EdxlopPhysicalMotionBroadcast,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMotion},
+			{EdxlopPhysicalMotionRedistribute,		&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion},
+			{EdxlopPhysicalMotionRandom,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion},
+			{EdxlopPhysicalMotionRoutedDistribute,	&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMotion},
+			{EdxlopPhysicalLimit, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLLimit},
+			{EdxlopPhysicalAgg, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLAgg},
+			{EdxlopPhysicalWindow, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLWindow},
+			{EdxlopPhysicalSort,					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLSort},
+			{EdxlopPhysicalSubqueryScan,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLSubQueryScan},
+			{EdxlopPhysicalResult, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLResult},
+			{EdxlopPhysicalAppend, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLAppend},
+			{EdxlopPhysicalMaterialize, 			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMaterialize},
+			{EdxlopPhysicalSequence, 				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLSequence},
+			{EdxlopPhysicalDynamicTableScan,		&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDynTblScan},
+			{EdxlopPhysicalDynamicIndexScan,		&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan},
+			{EdxlopPhysicalTVF,						&gpopt::CTranslatorDXLToPlStmt::TranslateDXLTvf},
+			{EdxlopPhysicalDML,						&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDml},
+			{EdxlopPhysicalSplit,					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLSplit},
+			{EdxlopPhysicalRowTrigger,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLRowTrigger},
+			{EdxlopPhysicalAssert,					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLAssert},
+			{EdxlopPhysicalCTEProducer, 			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan},
+			{EdxlopPhysicalCTEConsumer, 			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan},
+			{EdxlopPhysicalBitmapTableScan,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan},
+			{EdxlopPhysicalDynamicBitmapTableScan,	&gpopt::CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan},
+			{EdxlopPhysicalCTAS, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLCtas},
+			{EdxlopPhysicalPartitionSelector,		&gpopt::CTranslatorDXLToPlStmt::TranslateDXLPartSelector},
+			{EdxlopPhysicalValuesScan,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLValueScan},
 	};
 
-	const ULONG ulTranslators = GPOS_ARRAY_SIZE(rgTranslators);
+	const ULONG num_of_translators = GPOS_ARRAY_SIZE(dxlop_translator_func_mapping_array);
 
-	for (ULONG ul = 0; ul < ulTranslators; ul++)
+	for (ULONG idx = 0; idx < num_of_translators; idx++)
 	{
-		STranslatorMapping elem = rgTranslators[ul];
-		m_rgpfTranslators[elem.edxlopid] = elem.pf;
+		STranslatorMapping elem = dxlop_translator_func_mapping_array[idx];
+		m_dxlop_translator_func_mapping_array[elem.dxl_op_id] = elem.dxlnode_to_logical_funct;
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplstmtFromDXL
+//		CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL
 //
 //	@doc:
 //		Translate DXL node into a PlannedStmt
 //
 //---------------------------------------------------------------------------
 PlannedStmt *
-CTranslatorDXLToPlStmt::PplstmtFromDXL
+CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL
 	(
-	const CDXLNode *pdxln,
-	bool canSetTag
+	const CDXLNode *dxlnode,
+	bool can_set_tag
 	)
 {
-	GPOS_ASSERT(NULL != pdxln);
+	GPOS_ASSERT(NULL != dxlnode);
 
-	CDXLTranslateContext dxltrctx(m_pmp, false);
+	CDXLTranslateContext dxl_translate_ctxt(m_mp, false);
 
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	Plan *pplan = PplFromDXL(pdxln, &dxltrctx, pdrgpdxltrctxPrevSiblings);
-	pdrgpdxltrctxPrevSiblings->Release();
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	Plan *plan = TranslateDXLOperatorToPlan(dxlnode, &dxl_translate_ctxt, ctxt_translation_prev_siblings);
+	ctxt_translation_prev_siblings->Release();
 
-	GPOS_ASSERT(NULL != pplan);
+	GPOS_ASSERT(NULL != plan);
 
 	// collect oids from rtable
-	List *plOids = NIL;
+	List *oids_list = NIL;
 
-	ListCell *plcRTE = NULL;
-	ForEach (plcRTE, m_pctxdxltoplstmt->PlPrte())
+	ListCell *lc_rte = NULL;
+	ForEach (lc_rte, m_dxl_to_plstmt_context->GetRTableEntriesList())
 	{
-		RangeTblEntry *pRTE = (RangeTblEntry *) lfirst(plcRTE);
+		RangeTblEntry *pRTE = (RangeTblEntry *) lfirst(lc_rte);
 
 		if (pRTE->rtekind == RTE_RELATION)
 		{
-			plOids = gpdb::PlAppendOid(plOids, pRTE->relid);
+			oids_list = gpdb::LAppendOid(oids_list, pRTE->relid);
 		}
 	}
 
 	// assemble planned stmt
-	PlannedStmt *pplstmt = MakeNode(PlannedStmt);
-	pplstmt->planGen = PLANGEN_OPTIMIZER;
+	PlannedStmt *planned_stmt = MakeNode(PlannedStmt);
+	planned_stmt->planGen = PLANGEN_OPTIMIZER;
 	
-	pplstmt->rtable = m_pctxdxltoplstmt->PlPrte();
-	pplstmt->subplans = m_pctxdxltoplstmt->PlPplanSubplan();
-	pplstmt->planTree = pplan;
+	planned_stmt->rtable = m_dxl_to_plstmt_context->GetRTableEntriesList();
+	planned_stmt->subplans = m_dxl_to_plstmt_context->GetSubplanEntriesList();
+	planned_stmt->planTree = plan;
 
 	// store partitioned table indexes in planned stmt
-	pplstmt->queryPartOids = m_pctxdxltoplstmt->PlPartitionedTables();
-	pplstmt->canSetTag = canSetTag;
-	pplstmt->relationOids = plOids;
-	pplstmt->numSelectorsPerScanId = m_pctxdxltoplstmt->PlNumPartitionSelectors();
+	planned_stmt->queryPartOids = m_dxl_to_plstmt_context->GetPartitionedTablesList();
+	planned_stmt->canSetTag = can_set_tag;
+	planned_stmt->relationOids = oids_list;
+	planned_stmt->numSelectorsPerScanId = m_dxl_to_plstmt_context->GetNumPartitionSelectorsList();
 
-	pplan->nMotionNodes  = m_pctxdxltoplstmt->UlCurrentMotionId()-1;
-	pplstmt->nMotionNodes =  m_pctxdxltoplstmt->UlCurrentMotionId()-1;
+	plan->nMotionNodes  = m_dxl_to_plstmt_context->GetCurrentMotionId()-1;
+	planned_stmt->nMotionNodes =  m_dxl_to_plstmt_context->GetCurrentMotionId()-1;
 
-	pplstmt->commandType = m_cmdtype;
+	planned_stmt->commandType = m_cmd_type;
 	
-	GPOS_ASSERT(pplan->nMotionNodes >= 0);
-	if (0 == pplan->nMotionNodes && !m_fTargetTableDistributed)
+	GPOS_ASSERT(plan->nMotionNodes >= 0);
+	if (0 == plan->nMotionNodes && !m_is_tgt_tbl_distributed)
 	{
 		// no motion nodes and not a DML on a distributed table
-		pplan->dispatch = DISPATCH_SEQUENTIAL;
+		plan->dispatch = DISPATCH_SEQUENTIAL;
 	}
 	else
 	{
-		pplan->dispatch = DISPATCH_PARALLEL;
+		plan->dispatch = DISPATCH_PARALLEL;
 	}
 	
-	pplstmt->resultRelations = m_plResultRelations;
+	planned_stmt->resultRelations = m_result_rel_list;
 	// GPDB_92_MERGE_FIXME: we really *should* be handling intoClause
 	// but currently planner cheats (c.f. createas.c)
 	// shift the intoClause handling into planner and re-enable this
 //	pplstmt->intoClause = m_pctxdxltoplstmt->Pintocl();
-	pplstmt->intoPolicy = m_pctxdxltoplstmt->Pdistrpolicy();
+	planned_stmt->intoPolicy = m_dxl_to_plstmt_context->GetDistributionPolicy();
 	
-	SetInitPlanVariables(pplstmt);
+	SetInitPlanVariables(planned_stmt);
 	
-	if (CMD_SELECT == m_cmdtype && NULL != pdxln->Pdxlddinfo())
+	if (CMD_SELECT == m_cmd_type && NULL != dxlnode->GetDXLDirectDispatchInfo())
 	{
-		List *plDirectDispatchSegIds = PlDirectDispatchSegIds(pdxln->Pdxlddinfo());
-		pplan->directDispatch.contentIds = plDirectDispatchSegIds;
-		pplan->directDispatch.isDirectDispatch = (NIL != plDirectDispatchSegIds);
+		List *direct_dispatch_segids = TranslateDXLDirectDispatchInfo(dxlnode->GetDXLDirectDispatchInfo());
+		plan->directDispatch.contentIds = direct_dispatch_segids;
+		plan->directDispatch.isDirectDispatch = (NIL != direct_dispatch_segids);
 		
-		if (pplan->directDispatch.isDirectDispatch)
+		if (plan->directDispatch.isDirectDispatch)
 		{
-			List *plMotions = gpdb::PlExtractNodesPlan(pplstmt->planTree, T_Motion, true /*descendIntoSubqueries*/);
-			ListCell *plc = NULL;
-			ForEach(plc, plMotions)
+			List *motion_node_list = gpdb::ExtractNodesPlan(planned_stmt->planTree, T_Motion, true /*descendIntoSubqueries*/);
+			ListCell *lc = NULL;
+			ForEach(lc, motion_node_list)
 			{
-				Motion *pmotion = (Motion *) lfirst(plc);
-				GPOS_ASSERT(IsA(pmotion, Motion));
-				GPOS_ASSERT(gpdb::FMotionGather(pmotion));
+				Motion *motion = (Motion *) lfirst(lc);
+				GPOS_ASSERT(IsA(motion, Motion));
+				GPOS_ASSERT(gpdb::IsMotionGather(motion));
 				
-				pmotion->plan.directDispatch.isDirectDispatch = true;
-				pmotion->plan.directDispatch.contentIds = pplan->directDispatch.contentIds;
+				motion->plan.directDispatch.isDirectDispatch = true;
+				motion->plan.directDispatch.contentIds = plan->directDispatch.contentIds;
 			}
 		}
 	}
 	
-	return pplstmt;
+	return planned_stmt;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplFromDXL
+//		CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan
 //
 //	@doc:
 //		Translates a DXL tree into a Plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplFromDXL
+CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan
 	(
-	const CDXLNode *pdxln,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	GPOS_ASSERT(NULL != pdxln);
-	GPOS_ASSERT(NULL != pdrgpdxltrctxPrevSiblings);
+	GPOS_ASSERT(NULL != dxlnode);
+	GPOS_ASSERT(NULL != ctxt_translation_prev_siblings);
 
-	CDXLOperator *pdxlop = pdxln->Pdxlop();
-	ULONG ulOpId =  (ULONG) pdxlop->Edxlop();
+	CDXLOperator *dxlop = dxlnode->GetOperator();
+	ULONG ulOpId =  (ULONG) dxlop->GetDXLOperator();
 
-	PfPplan pf = m_rgpfTranslators[ulOpId];
+	PfPplan dxlnode_to_logical_funct = m_dxlop_translator_func_mapping_array[ulOpId];
 
-	if (NULL == pf)
+	if (NULL == dxlnode_to_logical_funct)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, pdxln->Pdxlop()->PstrOpName()->Wsz());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, dxlnode->GetOperator()->GetOpNameStr()->GetBuffer());
 	}
 
-	return (this->* pf)(pdxln, pdxltrctxOut, pdrgpdxltrctxPrevSiblings);
+	return (this->* dxlnode_to_logical_funct)(dxlnode, output_context, ctxt_translation_prev_siblings);
 }
 
 //---------------------------------------------------------------------------
@@ -310,46 +310,46 @@ CTranslatorDXLToPlStmt::PplFromDXL
 //		as well as its subplans. Set the number of parameters used in the plan.
 //---------------------------------------------------------------------------
 void
-CTranslatorDXLToPlStmt::SetInitPlanVariables(PlannedStmt* pplstmt)
+CTranslatorDXLToPlStmt::SetInitPlanVariables(PlannedStmt* planned_stmt)
 {
-	if(1 != m_pctxdxltoplstmt->UlCurrentMotionId()) // For Distributed Tables m_ulMotionId > 1
+	if(1 != m_dxl_to_plstmt_context->GetCurrentMotionId()) // For Distributed Tables m_ulMotionId > 1
 	{
-		pplstmt->nInitPlans = m_pctxdxltoplstmt->UlCurrentParamId();
-		pplstmt->planTree->nInitPlans = m_pctxdxltoplstmt->UlCurrentParamId();
+		planned_stmt->nInitPlans = m_dxl_to_plstmt_context->GetCurrentParamId();
+		planned_stmt->planTree->nInitPlans = m_dxl_to_plstmt_context->GetCurrentParamId();
 	}
 
-	pplstmt->nParamExec = m_pctxdxltoplstmt->UlCurrentParamId();
+	planned_stmt->nParamExec = m_dxl_to_plstmt_context->GetCurrentParamId();
 
 	// Extract all subplans defined in the planTree
-	List *plSubPlans = gpdb::PlExtractNodesPlan(pplstmt->planTree, T_SubPlan, true);
+	List *subplan_list = gpdb::ExtractNodesPlan(planned_stmt->planTree, T_SubPlan, true);
 
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 
-	ForEach (plc, plSubPlans)
+	ForEach (lc, subplan_list)
 	{
-		SubPlan *psubplan = (SubPlan*) lfirst(plc);
-		if (psubplan->is_initplan)
+		SubPlan *subplan = (SubPlan*) lfirst(lc);
+		if (subplan->is_initplan)
 		{
-			SetInitPlanSliceInformation(psubplan);
+			SetInitPlanSliceInformation(subplan);
 		}
 	}
 
 	// InitPlans can also be defined in subplans. We therefore have to iterate
 	// over all the subplans referred to in the planned statement.
 
-	List *plInitPlans = pplstmt->subplans;
+	List *initplan_list = planned_stmt->subplans;
 
-	ForEach (plc,plInitPlans)
+	ForEach (lc,initplan_list)
 	{
-		plSubPlans = gpdb::PlExtractNodesPlan((Plan*) lfirst(plc), T_SubPlan, true);
-		ListCell *plc2;
+		subplan_list = gpdb::ExtractNodesPlan((Plan*) lfirst(lc), T_SubPlan, true);
+		ListCell *lc2;
 
-		ForEach (plc2, plSubPlans)
+		ForEach (lc2, subplan_list)
 		{
-			SubPlan *psubplan = (SubPlan*) lfirst(plc2);
-			if (psubplan->is_initplan)
+			SubPlan *subplan = (SubPlan*) lfirst(lc2);
+			if (subplan->is_initplan)
 			{
-				SetInitPlanSliceInformation(psubplan);
+				SetInitPlanSliceInformation(subplan);
 			}
 		}
 	}
@@ -368,21 +368,21 @@ CTranslatorDXLToPlStmt::SetInitPlanVariables(PlannedStmt* pplstmt)
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorDXLToPlStmt::SetInitPlanSliceInformation(SubPlan * psubplan)
+CTranslatorDXLToPlStmt::SetInitPlanSliceInformation(SubPlan * subplan)
 {
-	GPOS_ASSERT(psubplan->is_initplan && "This is processed for initplans only");
+	GPOS_ASSERT(subplan->is_initplan && "This is processed for initplans only");
 
-	if (psubplan->is_initplan)
+	if (subplan->is_initplan)
 	{
-		GPOS_ASSERT(0 < m_pctxdxltoplstmt->UlCurrentMotionId());
+		GPOS_ASSERT(0 < m_dxl_to_plstmt_context->GetCurrentMotionId());
 
-		if(1 < m_pctxdxltoplstmt->UlCurrentMotionId())
+		if(1 < m_dxl_to_plstmt_context->GetCurrentMotionId())
 		{
-			psubplan->qDispSliceId =  m_pctxdxltoplstmt->UlCurrentMotionId() + psubplan->plan_id-1;
+			subplan->qDispSliceId =  m_dxl_to_plstmt_context->GetCurrentMotionId() + subplan->plan_id-1;
 		}
 		else
 		{
-			psubplan->qDispSliceId = 0;
+			subplan->qDispSliceId = 0;
 		}
 	}
 }
@@ -396,133 +396,133 @@ CTranslatorDXLToPlStmt::SetInitPlanSliceInformation(SubPlan * psubplan)
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorDXLToPlStmt::SetParamIds(Plan* pplan)
+CTranslatorDXLToPlStmt::SetParamIds(Plan* plan)
 {
-	List *plParams = gpdb::PlExtractNodesPlan(pplan, T_Param, true);
+	List *params_node_list = gpdb::ExtractNodesPlan(plan, T_Param, true);
 
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 
-	Bitmapset  *pbitmapset = NULL;
+	Bitmapset  *bitmapset = NULL;
 
-	ForEach (plc, plParams)
+	ForEach (lc, params_node_list)
 	{
-		Param *pparam = (Param*) lfirst(plc);
-		pbitmapset = gpdb::PbmsAddMember(pbitmapset, pparam->paramid);
+		Param *param = (Param*) lfirst(lc);
+		bitmapset = gpdb::BmsAddMember(bitmapset, param->paramid);
 	}
 
-	pplan->extParam = pbitmapset;
-	pplan->allParam = pbitmapset;
+	plan->extParam = bitmapset;
+	plan->allParam = bitmapset;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PtsFromDXLTblScan
+//		CTranslatorDXLToPlStmt::TranslateDXLTblScan
 //
 //	@doc:
 //		Translates a DXL table scan node into a TableScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PtsFromDXLTblScan
+CTranslatorDXLToPlStmt::TranslateDXLTblScan
 	(
-	const CDXLNode *pdxlnTblScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *tbl_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translate table descriptor into a range table entry
-	CDXLPhysicalTableScan *pdxlopTS = CDXLPhysicalTableScan::PdxlopConvert(pdxlnTblScan->Pdxlop());
+	CDXLPhysicalTableScan *phy_tbl_scan_dxlop = CDXLPhysicalTableScan::Cast(tbl_scan_dxlnode->GetOperator());
 
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// we will add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	const CDXLTableDescr *pdxltabdesc = pdxlopTS->Pdxltabdesc();
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
-	m_pctxdxltoplstmt->AddRTE(prte);
+	const CDXLTableDescr *dxl_table_descr = phy_tbl_scan_dxlop->GetDXLTableDescr();
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(dxl_table_descr->MDId());
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dxl_table_descr, NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	Plan *pplan = NULL;
-	Plan *pplanReturn = NULL;
-	if (IMDRelation::ErelstorageExternal == pmdrel->Erelstorage())
+	Plan *plan = NULL;
+	Plan *plan_return = NULL;
+	if (IMDRelation::ErelstorageExternal == md_rel->RetrieveRelStorageType())
 	{
-		const IMDRelationExternal *pmdrelext = dynamic_cast<const IMDRelationExternal*>(pmdrel);
-		OID oidRel = CMDIdGPDB::PmdidConvert(pmdrel->Pmdid())->OidObjectId();
-		ExtTableEntry *pextentry = gpdb::Pexttable(oidRel);
+		const IMDRelationExternal *md_rel_ext = dynamic_cast<const IMDRelationExternal*>(md_rel);
+		OID oidRel = CMDIdGPDB::CastMdid(md_rel->MDId())->Oid();
+		ExtTableEntry *ext_table_entry = gpdb::GetExternalTableEntry(oidRel);
 		bool isMasterOnly;
 		
 		// create external scan node
-		ExternalScan *pes = MakeNode(ExternalScan);
-		pes->scan.scanrelid = iRel;
-		pes->uriList = gpdb::PlExternalScanUriList(pextentry, &isMasterOnly);
-		pes->fmtOptString = pextentry->fmtopts;
-		pes->fmtType = pextentry->fmtcode;
-		pes->isMasterOnly = isMasterOnly;
-		GPOS_ASSERT((IMDRelation::EreldistrMasterOnly == pmdrelext->Ereldistribution()) == isMasterOnly);
-		pes->logErrors = pextentry->logerrors;
-		pes->rejLimit = pmdrelext->IRejectLimit();
-		pes->rejLimitInRows = pmdrelext->FRejLimitInRows();
+		ExternalScan *ext_scan = MakeNode(ExternalScan);
+		ext_scan->scan.scanrelid = index;
+		ext_scan->uriList = gpdb::GetExternalScanUriList(ext_table_entry, &isMasterOnly);
+		ext_scan->fmtOptString = ext_table_entry->fmtopts;
+		ext_scan->fmtType = ext_table_entry->fmtcode;
+		ext_scan->isMasterOnly = isMasterOnly;
+		GPOS_ASSERT((IMDRelation::EreldistrMasterOnly == md_rel_ext->GetRelDistribution()) == isMasterOnly);
+		ext_scan->logErrors = ext_table_entry->logerrors;
+		ext_scan->rejLimit = md_rel_ext->RejectLimit();
+		ext_scan->rejLimitInRows = md_rel_ext->IsRejectLimitInRows();
 
-		pes->encoding = pextentry->encoding;
-		pes->scancounter = m_ulExternalScanCounter++;
+		ext_scan->encoding = ext_table_entry->encoding;
+		ext_scan->scancounter = m_external_scan_counter++;
 
-		pplan = &(pes->scan.plan);
-		pplanReturn = (Plan *) pes;
+		plan = &(ext_scan->scan.plan);
+		plan_return = (Plan *) ext_scan;
 	}
 	else
 	{
 		// create table scan node
-		TableScan *pts = MakeNode(TableScan);
-		pts->scanrelid = iRel;
-		pplan = &(pts->plan);
-		pplanReturn = (Plan *) pts;
+		TableScan *table_scan = MakeNode(TableScan);
+		table_scan->scanrelid = index;
+		plan = &(table_scan->plan);
+		plan_return = (Plan *) table_scan;
 	}
 
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnTblScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(tbl_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// a table scan node must have 2 children: projection list and filter
-	GPOS_ASSERT(2 == pdxlnTblScan->UlArity());
+	GPOS_ASSERT(2 == tbl_scan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnTblScan)[EdxltsIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnTblScan)[EdxltsIndexFilter];
+	CDXLNode *project_list_dxlnode = (*tbl_scan_dxlnode)[EdxltsIndexProjList];
+	CDXLNode *filter_dxlnode = (*tbl_scan_dxlnode)[EdxltsIndexFilter];
 
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
-		&dxltrctxbt,	// translate context for the base table
-		NULL,			// pdxltrctxLeft and pdxltrctxRight,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		project_list_dxlnode,
+		filter_dxlnode,
+		&base_table_context,	// translate context for the base table
+		NULL,			// translate_ctxt_left and pdxltrctxRight,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return pplanReturn;
+	return plan_return;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::FSetIndexVarAttno
+//		CTranslatorDXLToPlStmt::SetIndexVarAttnoWalker
 //
 //	@doc:
 //		Walker to set index var attno's,
@@ -531,189 +531,189 @@ CTranslatorDXLToPlStmt::PtsFromDXLTblScan
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorDXLToPlStmt::FSetIndexVarAttno
+CTranslatorDXLToPlStmt::SetIndexVarAttnoWalker
 	(
-	Node *pnode,
-	SContextIndexVarAttno *pctxtidxvarattno
+	Node *node,
+	SContextIndexVarAttno *ctxt_index_var_attno_walker
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return false;
 	}
 
-	if (IsA(pnode, Var) && ((Var *)pnode)->varno != OUTER_VAR)
+	if (IsA(node, Var) && ((Var *)node)->varno != OUTER_VAR)
 	{
-		INT iAttno = ((Var *)pnode)->varattno;
-		const IMDRelation *pmdrel = pctxtidxvarattno->m_pmdrel;
-		const IMDIndex *pmdindex = pctxtidxvarattno->m_pmdindex;
+		INT attno = ((Var *)node)->varattno;
+		const IMDRelation *md_rel = ctxt_index_var_attno_walker->m_md_rel;
+		const IMDIndex *index = ctxt_index_var_attno_walker->m_md_index;
 
-		ULONG ulIndexColPos = gpos::ulong_max;
-		const ULONG ulArity = pmdrel->UlColumns();
-		for (ULONG ulColPos = 0; ulColPos < ulArity; ulColPos++)
+		ULONG index_col_pos_idx_max = gpos::ulong_max;
+		const ULONG arity = md_rel->ColumnCount();
+		for (ULONG col_pos_idx = 0; col_pos_idx < arity; col_pos_idx++)
 		{
-			const IMDColumn *pmdcol = pmdrel->Pmdcol(ulColPos);
-			if (iAttno == pmdcol->IAttno())
+			const IMDColumn *md_col = md_rel->GetMdCol(col_pos_idx);
+			if (attno == md_col->AttrNum())
 			{
-				ulIndexColPos = ulColPos;
+				index_col_pos_idx_max = col_pos_idx;
 				break;
 			}
 		}
 
-		if (gpos::ulong_max > ulIndexColPos)
+		if (gpos::ulong_max > index_col_pos_idx_max)
 		{
-			((Var *)pnode)->varattno =  1 + pmdindex->UlPosInKey(ulIndexColPos);
+			((Var *)node)->varattno =  1 + index->GetKeyPos(index_col_pos_idx_max);
 		}
 
 		return false;
 	}
 
-	return gpdb::FWalkExpressionTree
+	return gpdb::WalkExpressionTree
 			(
-			pnode,
-			(BOOL (*)()) CTranslatorDXLToPlStmt::FSetIndexVarAttno,
-			pctxtidxvarattno
+			node,
+			(BOOL (*)()) CTranslatorDXLToPlStmt::SetIndexVarAttnoWalker,
+			ctxt_index_var_attno_walker
 			);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PisFromDXLIndexScan
+//		CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 //
 //	@doc:
 //		Translates a DXL index scan node into a IndexScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PisFromDXLIndexScan
+CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 	(
-	const CDXLNode *pdxlnIndexScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *index_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translate table descriptor into a range table entry
-	CDXLPhysicalIndexScan *pdxlopIndexScan = CDXLPhysicalIndexScan::PdxlopConvert(pdxlnIndexScan->Pdxlop());
+	CDXLPhysicalIndexScan *physical_idx_scan_dxlop = CDXLPhysicalIndexScan::Cast(index_scan_dxlnode->GetOperator());
 
-	return PisFromDXLIndexScan(pdxlnIndexScan, pdxlopIndexScan, pdxltrctxOut, false /*fIndexOnlyScan*/, pdrgpdxltrctxPrevSiblings);
+	return TranslateDXLIndexScan(index_scan_dxlnode, physical_idx_scan_dxlop, output_context, false /*is_index_only_scan*/, ctxt_translation_prev_siblings);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PisFromDXLIndexScan
+//		CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 //
 //	@doc:
 //		Translates a DXL index scan node into a IndexScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PisFromDXLIndexScan
+CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 	(
-	const CDXLNode *pdxlnIndexScan,
-	CDXLPhysicalIndexScan *pdxlopIndexScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	BOOL fIndexOnlyScan,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *index_scan_dxlnode,
+	CDXLPhysicalIndexScan *physical_idx_scan_dxlop,
+	CDXLTranslateContext *output_context,
+	BOOL is_index_only_scan,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	const CDXLIndexDescr *pdxlid = NULL;
-	if (fIndexOnlyScan)
+	const CDXLIndexDescr *index_descr_dxl = NULL;
+	if (is_index_only_scan)
 	{
-		pdxlid = pdxlopIndexScan->Pdxlid();
+		index_descr_dxl = physical_idx_scan_dxlop->GetDXLIndexDescr();
 	}
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlopIndexScan->Pdxltabdesc()->Pmdid());
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(physical_idx_scan_dxlop->GetDXLTableDescr()->MDId());
 
-	RangeTblEntry *prte = PrteFromTblDescr(pdxlopIndexScan->Pdxltabdesc(), pdxlid, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
-	m_pctxdxltoplstmt->AddRTE(prte);
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(physical_idx_scan_dxlop->GetDXLTableDescr(), index_descr_dxl, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	IndexScan *pis = NULL;
-	GPOS_ASSERT(!fIndexOnlyScan);
-	pis = MakeNode(IndexScan);
-	pis->scan.scanrelid = iRel;
+	IndexScan *index_scan = NULL;
+	GPOS_ASSERT(!is_index_only_scan);
+	index_scan = MakeNode(IndexScan);
+	index_scan->scan.scanrelid = index;
 
-	CMDIdGPDB *pmdidIndex = CMDIdGPDB::PmdidConvert(pdxlopIndexScan->Pdxlid()->Pmdid());
-	const IMDIndex *pmdindex = m_pmda->Pmdindex(pmdidIndex);
-	Oid oidIndex = pmdidIndex->OidObjectId();
+	CMDIdGPDB *mdid_index = CMDIdGPDB::CastMdid(physical_idx_scan_dxlop->GetDXLIndexDescr()->MDId());
+	const IMDIndex *md_index = m_md_accessor->RetrieveIndex(mdid_index);
+	Oid index_oid = mdid_index->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidIndex);
-	pis->indexid = oidIndex;
+	GPOS_ASSERT(InvalidOid != index_oid);
+	index_scan->indexid = index_oid;
 
-	Plan *pplan = &(pis->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	Plan *plan = &(index_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnIndexScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(index_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// an index scan node must have 3 children: projection list, filter and index condition list
-	GPOS_ASSERT(3 == pdxlnIndexScan->UlArity());
+	GPOS_ASSERT(3 == index_scan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnIndexScan)[EdxlisIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnIndexScan)[EdxlisIndexFilter];
-	CDXLNode *pdxlnIndexCondList = (*pdxlnIndexScan)[EdxlisIndexCondition];
+	CDXLNode *project_list_dxlnode = (*index_scan_dxlnode)[EdxlisIndexProjList];
+	CDXLNode *filter_dxlnode = (*index_scan_dxlnode)[EdxlisIndexFilter];
+	CDXLNode *index_cond_list_dxlnode = (*index_scan_dxlnode)[EdxlisIndexCondition];
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList(pdxlnPrL, &dxltrctxbt, NULL /*pdrgpdxltrctx*/, pdxltrctxOut);
+	plan->targetlist = TranslateDXLProjList(project_list_dxlnode, &base_table_context, NULL /*child_contexts*/, output_context);
 
 	// translate index filter
-	pplan->qual = PlTranslateIndexFilter
+	plan->qual = TranslateDXLIndexFilter
 					(
-					pdxlnFilter,
-					pdxltrctxOut,
-					&dxltrctxbt,
-					pdrgpdxltrctxPrevSiblings
+					filter_dxlnode,
+					output_context,
+					&base_table_context,
+					ctxt_translation_prev_siblings
 					);
 
-	pis->indexorderdir = CTranslatorUtils::Scandirection(pdxlopIndexScan->EdxlScanDirection());
+	index_scan->indexorderdir = CTranslatorUtils::GetScanDirection(physical_idx_scan_dxlop->GetIndexScanDir());
 
 	// translate index condition list
-	List *plIndexConditions = NIL;
-	List *plIndexOrigConditions = NIL;
-	List *plIndexStratgey = NIL;
-	List *plIndexSubtype = NIL;
+	List *index_cond = NIL;
+	List *index_orig_cond = NIL;
+	List *index_strategy_list = NIL;
+	List *index_subtype_list = NIL;
 
 	TranslateIndexConditions
 		(
-		pdxlnIndexCondList, 
-		pdxlopIndexScan->Pdxltabdesc(), 
-		fIndexOnlyScan, 
-		pmdindex, 
-		pmdrel,
-		pdxltrctxOut,
-		&dxltrctxbt, 
-		pdrgpdxltrctxPrevSiblings,
-		&plIndexConditions, 
-		&plIndexOrigConditions, 
-		&plIndexStratgey, 
-		&plIndexSubtype
+		index_cond_list_dxlnode,
+		physical_idx_scan_dxlop->GetDXLTableDescr(),
+		is_index_only_scan,
+		md_index,
+		md_rel,
+		output_context,
+		&base_table_context,
+		ctxt_translation_prev_siblings,
+		&index_cond,
+		&index_orig_cond,
+		&index_strategy_list,
+		&index_subtype_list
 		);
 
-	pis->indexqual = plIndexConditions;
-	pis->indexqualorig = plIndexOrigConditions;
+	index_scan->indexqual = index_cond;
+	index_scan->indexqualorig = index_orig_cond;
 	/*
 	 * As of 8.4, the indexstrategy and indexsubtype fields are no longer
 	 * available or needed in IndexScan. Ignore them.
 	 */
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pis;
+	return (Plan *) index_scan;
 }
 
 //---------------------------------------------------------------------------
@@ -725,28 +725,28 @@ CTranslatorDXLToPlStmt::PisFromDXLIndexScan
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTranslateIndexFilter
+CTranslatorDXLToPlStmt::TranslateDXLIndexFilter
 	(
-	CDXLNode *pdxlnFilter,
-	CDXLTranslateContext *pdxltrctxOut,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	CDXLNode *filter_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	List *plQuals = NIL;
+	List *quals_list = NIL;
 
 	// build colid->var mapping
-	CMappingColIdVarPlStmt mapcidvarplstmt(m_pmp, pdxltrctxbt, pdrgpdxltrctxPrevSiblings, pdxltrctxOut, m_pctxdxltoplstmt);
+	CMappingColIdVarPlStmt colid_var_mapping(m_mp, base_table_context, ctxt_translation_prev_siblings, output_context, m_dxl_to_plstmt_context);
 
-	const ULONG ulArity = pdxlnFilter->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = filter_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnIndexFilter = (*pdxlnFilter)[ul];
-		Expr *pexprIndexFilter = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnIndexFilter, &mapcidvarplstmt);
-		plQuals = gpdb::PlAppendElement(plQuals, pexprIndexFilter);
+		CDXLNode *index_filter_dxlnode = (*filter_dxlnode)[ul];
+		Expr *index_filter_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(index_filter_dxlnode, &colid_var_mapping);
+		quals_list = gpdb::LAppend(quals_list, index_filter_expr);
 	}
 
-	return plQuals;
+	return quals_list;
 }
 
 
@@ -761,1249 +761,1245 @@ CTranslatorDXLToPlStmt::PlTranslateIndexFilter
 void 
 CTranslatorDXLToPlStmt::TranslateIndexConditions
 	(
-	CDXLNode *pdxlnIndexCondList,
-	const CDXLTableDescr *pdxltd,
-	BOOL fIndexOnlyScan,
-	const IMDIndex *pmdindex,
-	const IMDRelation *pmdrel,
-	CDXLTranslateContext *pdxltrctxOut,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-	List **pplIndexConditions,
-	List **pplIndexOrigConditions,
-	List **pplIndexStratgey,
-	List **pplIndexSubtype
+	CDXLNode *index_cond_list_dxlnode,
+	const CDXLTableDescr *dxl_tbl_descr,
+	BOOL is_index_only_scan,
+	const IMDIndex *index,
+	const IMDRelation *md_rel,
+	CDXLTranslateContext *output_context,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+	List **index_cond,
+	List **index_orig_cond,
+	List **index_strategy_list,
+	List **index_subtype_list
 	)
 {
 	// array of index qual info
-	DrgPindexqualinfo *pdrgpindexqualinfo = GPOS_NEW(m_pmp) DrgPindexqualinfo(m_pmp);
+	CIndexQualInfoArray *index_qual_info_array = GPOS_NEW(m_mp) CIndexQualInfoArray(m_mp);
 
 	// build colid->var mapping
-	CMappingColIdVarPlStmt mapcidvarplstmt(m_pmp, pdxltrctxbt, pdrgpdxltrctxPrevSiblings, pdxltrctxOut, m_pctxdxltoplstmt);
+	CMappingColIdVarPlStmt colid_var_mapping(m_mp, base_table_context, ctxt_translation_prev_siblings, output_context, m_dxl_to_plstmt_context);
 
-	const ULONG ulArity = pdxlnIndexCondList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = index_cond_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnIndexCond = (*pdxlnIndexCondList)[ul];
+		CDXLNode *index_cond_dxlnode = (*index_cond_list_dxlnode)[ul];
 
-		Expr *pexprOrigIndexCond = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnIndexCond, &mapcidvarplstmt);
-		Expr *pexprIndexCond = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnIndexCond, &mapcidvarplstmt);
-		GPOS_ASSERT((IsA(pexprIndexCond, OpExpr) || IsA(pexprIndexCond, ScalarArrayOpExpr))
+		Expr *original_index_cond_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(index_cond_dxlnode, &colid_var_mapping);
+		Expr *index_cond_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(index_cond_dxlnode, &colid_var_mapping);
+		GPOS_ASSERT((IsA(index_cond_expr, OpExpr) || IsA(index_cond_expr, ScalarArrayOpExpr))
 				&& "expected OpExpr or ScalarArrayOpExpr in index qual");
 
-		if (IsA(pexprIndexCond, ScalarArrayOpExpr) && IMDIndex::EmdindBitmap != pmdindex->Emdindt())
+		if (IsA(index_cond_expr, ScalarArrayOpExpr) && IMDIndex::EmdindBitmap != index->IndexType())
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, GPOS_WSZ_LIT("ScalarArrayOpExpr condition on index scan"));
 		}
 
 		// for indexonlyscan, we already have the attno referring to the index
-		if (!fIndexOnlyScan)
+		if (!is_index_only_scan)
 		{
 			// Otherwise, we need to perform mapping of Varattnos relative to column positions in index keys
-			SContextIndexVarAttno ctxtidxvarattno(pmdrel, pmdindex);
-			FSetIndexVarAttno((Node *) pexprIndexCond, &ctxtidxvarattno);
+			SContextIndexVarAttno index_varattno_ctxt(md_rel, index);
+			SetIndexVarAttnoWalker((Node *) index_cond_expr, &index_varattno_ctxt);
 		}
 		
 		// find index key's attno
-		List *plistArgs = NULL;
-		if (IsA(pexprIndexCond, OpExpr))
+		List *args_list = NULL;
+		if (IsA(index_cond_expr, OpExpr))
 		{
-			plistArgs = ((OpExpr *) pexprIndexCond)->args;
+			args_list = ((OpExpr *) index_cond_expr)->args;
 		}
 		else
 		{
-			plistArgs = ((ScalarArrayOpExpr *) pexprIndexCond)->args;
+			args_list = ((ScalarArrayOpExpr *) index_cond_expr)->args;
 		}
 
-		Node *pnodeFst = (Node *) lfirst(gpdb::PlcListHead(plistArgs));
-		Node *pnodeSnd = (Node *) lfirst(gpdb::PlcListTail(plistArgs));
+		Node *left_arg = (Node *) lfirst(gpdb::ListHead(args_list));
+		Node *right_arg = (Node *) lfirst(gpdb::ListTail(args_list));
 				
-		BOOL fRelabel = false;
-		if (IsA(pnodeFst, RelabelType) && IsA(((RelabelType *) pnodeFst)->arg, Var))
+		BOOL is_relabel_type = false;
+		if (IsA(left_arg, RelabelType) && IsA(((RelabelType *) left_arg)->arg, Var))
 		{
-			pnodeFst = (Node *) ((RelabelType *) pnodeFst)->arg;
-			fRelabel = true;
+			left_arg = (Node *) ((RelabelType *) left_arg)->arg;
+			is_relabel_type = true;
 		}
-		else if (IsA(pnodeSnd, RelabelType) && IsA(((RelabelType *) pnodeSnd)->arg, Var))
+		else if (IsA(right_arg, RelabelType) && IsA(((RelabelType *) right_arg)->arg, Var))
 		{
-			pnodeSnd = (Node *) ((RelabelType *) pnodeSnd)->arg;
-			fRelabel = true;
+			right_arg = (Node *) ((RelabelType *) right_arg)->arg;
+			is_relabel_type = true;
 		}
 		
-		if (fRelabel)
+		if (is_relabel_type)
 		{
-			List *plNewArgs = ListMake2(pnodeFst, pnodeSnd);
-			gpdb::GPDBFree(plistArgs);
-			if (IsA(pexprIndexCond, OpExpr))
+			List *new_args_list = ListMake2(left_arg, right_arg);
+			gpdb::GPDBFree(args_list);
+			if (IsA(index_cond_expr, OpExpr))
 			{
-				((OpExpr *) pexprIndexCond)->args = plNewArgs;
+				((OpExpr *) index_cond_expr)->args = new_args_list;
 			}
 			else
 			{
-				((ScalarArrayOpExpr *) pexprIndexCond)->args = plNewArgs;
+				((ScalarArrayOpExpr *) index_cond_expr)->args = new_args_list;
 			}
 		}
 		
-		GPOS_ASSERT((IsA(pnodeFst, Var) || IsA(pnodeSnd, Var)) && "expected index key in index qual");
+		GPOS_ASSERT((IsA(left_arg, Var) || IsA(right_arg, Var)) && "expected index key in index qual");
 
-		INT iAttno = 0;
-		// GPDB_92_MERGE_FIXME: I don't believe we can have index key on the
-		// RHS of OpExpr for indexqual, so why do we have this conditional here
-		// at all?
-		if (IsA(pnodeFst, Var) && ((Var *) pnodeFst)->varno != OUTER_VAR)
+		INT attno = 0;
+		if (IsA(left_arg, Var) && ((Var *) left_arg)->varno != OUTER_VAR)
 		{
 			// index key is on the left side
-			iAttno =  ((Var *) pnodeFst)->varattno;
-
+			attno =  ((Var *) left_arg)->varattno;
 			// GPDB_92_MERGE_FIXME: helluva hack
 			// Upstream commit a0185461 cleaned up how the varno of indices
 			// We are patching up varno here, but it seems this really should
 			// happen in CTranslatorDXLToScalar::PexprFromDXLNodeScalar .
 			// Furthermore, should we guard against nonsensical varno?
-			((Var *) pnodeFst)->varno = INDEX_VAR;
+			((Var *) left_arg)->varno = INDEX_VAR;
 		}
 		else
 		{
 			// index key is on the right side
-			GPOS_ASSERT(((Var *) pnodeSnd)->varno != OUTER_VAR && "unexpected outer reference in index qual");
-			iAttno = ((Var *) pnodeSnd)->varattno;
+			GPOS_ASSERT(((Var *) right_arg)->varno != OUTER_VAR && "unexpected outer reference in index qual");
+			attno = ((Var *) right_arg)->varattno;
 		}
 		
 		// retrieve index strategy and subtype
-		INT iSN = 0;
-		OID oidIndexSubtype = InvalidOid;
+		INT strategy_num = 0;
+		OID index_subtype_oid = InvalidOid;
 		
-		OID oidCmpOperator = CTranslatorUtils::OidCmpOperator(pexprIndexCond);
-		GPOS_ASSERT(InvalidOid != oidCmpOperator);
-		OID oidOpFamily = CTranslatorUtils::OidIndexQualOpFamily(iAttno, CMDIdGPDB::PmdidConvert(pmdindex->Pmdid())->OidObjectId());
-		GPOS_ASSERT(InvalidOid != oidOpFamily);
-		gpdb::IndexOpProperties(oidCmpOperator, oidOpFamily, &iSN, &oidIndexSubtype);
+		OID cmp_operator_oid = CTranslatorUtils::OidCmpOperator(index_cond_expr);
+		GPOS_ASSERT(InvalidOid != cmp_operator_oid);
+		OID op_family_oid = CTranslatorUtils::GetOpFamilyForIndexQual(attno, CMDIdGPDB::CastMdid(index->MDId())->Oid());
+		GPOS_ASSERT(InvalidOid != op_family_oid);
+		gpdb::IndexOpProperties(cmp_operator_oid, op_family_oid, &strategy_num, &index_subtype_oid);
 		
 		// create index qual
-		pdrgpindexqualinfo->Append(GPOS_NEW(m_pmp) CIndexQualInfo(iAttno, pexprIndexCond, pexprOrigIndexCond, (StrategyNumber) iSN, oidIndexSubtype));
+		index_qual_info_array->Append(GPOS_NEW(m_mp) CIndexQualInfo(attno, index_cond_expr, original_index_cond_expr, (StrategyNumber) strategy_num, index_subtype_oid));
 	}
 
 	// the index quals much be ordered by attribute number
-	pdrgpindexqualinfo->Sort(CIndexQualInfo::IIndexQualInfoCmp);
+	index_qual_info_array->Sort(CIndexQualInfo::IndexQualInfoCmp);
 
-	ULONG ulLen = pdrgpindexqualinfo->UlLength();
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	ULONG length = index_qual_info_array->Size();
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		CIndexQualInfo *pindexqualinfo = (*pdrgpindexqualinfo)[ul];
-		*pplIndexConditions = gpdb::PlAppendElement(*pplIndexConditions, pindexqualinfo->m_pexpr);
-		*pplIndexOrigConditions = gpdb::PlAppendElement(*pplIndexOrigConditions, pindexqualinfo->m_pexprOriginal);
-		*pplIndexStratgey = gpdb::PlAppendInt(*pplIndexStratgey, pindexqualinfo->m_sn);
-		*pplIndexSubtype = gpdb::PlAppendOid(*pplIndexSubtype, pindexqualinfo->m_oidIndexSubtype);
+		CIndexQualInfo *index_qual_info = (*index_qual_info_array)[ul];
+		*index_cond = gpdb::LAppend(*index_cond, index_qual_info->m_expr);
+		*index_orig_cond = gpdb::LAppend(*index_orig_cond, index_qual_info->m_original_expr);
+		*index_strategy_list = gpdb::LAppendInt(*index_strategy_list, index_qual_info->m_index_subtype_oid);
+		*index_subtype_list = gpdb::LAppendOid(*index_subtype_list, index_qual_info->m_index_subtype_oid);
 	}
 
 	// clean up
-	pdrgpindexqualinfo->Release();
+	index_qual_info_array->Release();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlTranslateAssertConstraints
+//		CTranslatorDXLToPlStmt::TranslateDXLAssertConstraints
 //
 //	@doc:
 //		Translate the constraints from an Assert node into a list of quals
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTranslateAssertConstraints
+CTranslatorDXLToPlStmt::TranslateDXLAssertConstraints
 	(
-	CDXLNode *pdxlnAssertConstraintList,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctx
+	CDXLNode *assert_contraint_list_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *child_contexts
 	)
 {
-	List *plQuals = NIL;
+	List *quals_list = NIL;
 
 	// build colid->var mapping
-	CMappingColIdVarPlStmt mapcidvarplstmt(m_pmp, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
+	CMappingColIdVarPlStmt colid_var_mapping(m_mp, NULL /*base_table_context*/, child_contexts, output_context, m_dxl_to_plstmt_context);
 
-	const ULONG ulArity = pdxlnAssertConstraintList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = assert_contraint_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnpdxlnAssertConstraint = (*pdxlnAssertConstraintList)[ul];
-		Expr *pexprAssertConstraint = m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnpdxlnAssertConstraint)[0], &mapcidvarplstmt);
-		plQuals = gpdb::PlAppendElement(plQuals, pexprAssertConstraint);
+		CDXLNode *assert_contraint_dxlnode = (*assert_contraint_list_dxlnode)[ul];
+		Expr *assert_contraint_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar((*assert_contraint_dxlnode)[0], &colid_var_mapping);
+		quals_list = gpdb::LAppend(quals_list, assert_contraint_expr);
 	}
 
-	return plQuals;
+	return quals_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlimitFromDXLLimit
+//		CTranslatorDXLToPlStmt::TranslateDXLLimit
 //
 //	@doc:
 //		Translates a DXL Limit node into a Limit node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PlimitFromDXLLimit
+CTranslatorDXLToPlStmt::TranslateDXLLimit
 	(
-	const CDXLNode *pdxlnLimit,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *limit_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create limit node
-	Limit *plimit = MakeNode(Limit);
+	Limit *limit = MakeNode(Limit);
 
-	Plan *pplan = &(plimit->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(limit->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnLimit->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(limit_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	GPOS_ASSERT(4 == pdxlnLimit->UlArity());
+	GPOS_ASSERT(4 == limit_dxlnode->Arity());
 
-	CDXLTranslateContext dxltrctxLeft(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext left_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
 	// translate proj list
-	CDXLNode *pdxlnPrL = (*pdxlnLimit)[EdxllimitIndexProjList];
-	CDXLNode *pdxlnChildPlan = (*pdxlnLimit)[EdxllimitIndexChildPlan];
-	CDXLNode *pdxlnLimitCount = (*pdxlnLimit)[EdxllimitIndexLimitCount];
-	CDXLNode *pdxlnLimitOffset = (*pdxlnLimit)[EdxllimitIndexLimitOffset];
+	CDXLNode *project_list_dxlnode = (*limit_dxlnode)[EdxllimitIndexProjList];
+	CDXLNode *child_plan_dxlnode = (*limit_dxlnode)[EdxllimitIndexChildPlan];
+	CDXLNode *limit_count_dxlnode = (*limit_dxlnode)[EdxllimitIndexLimitCount];
+	CDXLNode *limit_offset_dxlnode = (*limit_dxlnode)[EdxllimitIndexLimitOffset];
 
 	// NOTE: Limit node has only the left plan while the right plan is left empty
-	Plan *pplanLeft = PplFromDXL(pdxlnChildPlan, &dxltrctxLeft, pdrgpdxltrctxPrevSiblings);
+	Plan *left_plan = TranslateDXLOperatorToPlan(child_plan_dxlnode, &left_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxLeft);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&left_dxl_translate_ctxt);
 
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 								(
-								pdxlnPrL,
+								project_list_dxlnode,
 								NULL,		// base table translation context
-								pdrgpdxltrctx,
-								pdxltrctxOut
+								child_contexts,
+								output_context
 								);
 
-	pplan->lefttree = pplanLeft;
+	plan->lefttree = left_plan;
 
-	if(NULL != pdxlnLimitCount && pdxlnLimitCount->UlArity() >0)
+	if(NULL != limit_count_dxlnode && limit_count_dxlnode->Arity() >0)
 	{
-		CMappingColIdVarPlStmt mapcidvarplstmt(m_pmp, NULL, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
-		Node *pnodeLimitCount = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnLimitCount)[0], &mapcidvarplstmt);
-		plimit->limitCount = pnodeLimitCount;
+		CMappingColIdVarPlStmt colid_var_mapping(m_mp, NULL, child_contexts, output_context, m_dxl_to_plstmt_context);
+		Node *limit_count = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar((*limit_count_dxlnode)[0], &colid_var_mapping);
+		limit->limitCount = limit_count;
 	}
 
-	if(NULL != pdxlnLimitOffset && pdxlnLimitOffset->UlArity() >0)
+	if(NULL != limit_offset_dxlnode && limit_offset_dxlnode->Arity() >0)
 	{
-		CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt(m_pmp, NULL, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
-		Node *pexprLimitOffset = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnLimitOffset)[0], &mapcidvarplstmt);
-		plimit->limitOffset = pexprLimitOffset;
+		CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt(m_mp, NULL, child_contexts, output_context, m_dxl_to_plstmt_context);
+		Node *limit_offset = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar((*limit_offset_dxlnode)[0], &colid_var_mapping);
+		limit->limitOffset = limit_offset;
 	}
 
-	pplan->nMotionNodes = pplanLeft->nMotionNodes;
-	SetParamIds(pplan);
+	plan->nMotionNodes = left_plan->nMotionNodes;
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return  (Plan *) plimit;
+	return  (Plan *) limit;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PhjFromDXLHJ
+//		CTranslatorDXLToPlStmt::TranslateDXLHashJoin
 //
 //	@doc:
 //		Translates a DXL hash join node into a HashJoin node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PhjFromDXLHJ
+CTranslatorDXLToPlStmt::TranslateDXLHashJoin
 	(
-	const CDXLNode *pdxlnHJ,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *hj_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	GPOS_ASSERT(pdxlnHJ->Pdxlop()->Edxlop() == EdxlopPhysicalHashJoin);
-	GPOS_ASSERT(pdxlnHJ->UlArity() == EdxlhjIndexSentinel);
+	GPOS_ASSERT(hj_dxlnode->GetOperator()->GetDXLOperator() == EdxlopPhysicalHashJoin);
+	GPOS_ASSERT(hj_dxlnode->Arity() == EdxlhjIndexSentinel);
 
 	// create hash join node
-	HashJoin *phj = MakeNode(HashJoin);
+	HashJoin *hashjoin = MakeNode(HashJoin);
 
-	Join *pj = &(phj->join);
-	Plan *pplan = &(pj->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Join *join = &(hashjoin->join);
+	Plan *plan = &(join->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalHashJoin *pdxlopHashJoin = CDXLPhysicalHashJoin::PdxlopConvert(pdxlnHJ->Pdxlop());
+	CDXLPhysicalHashJoin *hashjoin_dxlop = CDXLPhysicalHashJoin::Cast(hj_dxlnode->GetOperator());
 
 	// set join type
-	pj->jointype = JtFromEdxljt(pdxlopHashJoin->Edxltype());
-	pj->prefetch_inner = true;
+	join->jointype = GetGPDBJoinTypeFromDXLJoinType(hashjoin_dxlop->GetJoinType());
+	join->prefetch_inner = true;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnHJ->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(hj_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate join children
-	CDXLNode *pdxlnLeft = (*pdxlnHJ)[EdxlhjIndexHashLeft];
-	CDXLNode *pdxlnRight = (*pdxlnHJ)[EdxlhjIndexHashRight];
-	CDXLNode *pdxlnPrL = (*pdxlnHJ)[EdxlhjIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnHJ)[EdxlhjIndexFilter];
-	CDXLNode *pdxlnJoinFilter = (*pdxlnHJ)[EdxlhjIndexJoinFilter];
-	CDXLNode *pdxlnHashCondList = (*pdxlnHJ)[EdxlhjIndexHashCondList];
+	CDXLNode *left_tree_dxlnode = (*hj_dxlnode)[EdxlhjIndexHashLeft];
+	CDXLNode *right_tree_dxlnode = (*hj_dxlnode)[EdxlhjIndexHashRight];
+	CDXLNode *project_list_dxlnode = (*hj_dxlnode)[EdxlhjIndexProjList];
+	CDXLNode *filter_dxlnode = (*hj_dxlnode)[EdxlhjIndexFilter];
+	CDXLNode *join_filter_dxlnode = (*hj_dxlnode)[EdxlhjIndexJoinFilter];
+	CDXLNode *hash_cond_list_dxlnode = (*hj_dxlnode)[EdxlhjIndexHashCondList];
 
-	CDXLTranslateContext dxltrctxLeft(m_pmp, false, pdxltrctxOut->PhmColParam());
-	CDXLTranslateContext dxltrctxRight(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext left_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
+	CDXLTranslateContext right_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanLeft = PplFromDXL(pdxlnLeft, &dxltrctxLeft, pdrgpdxltrctxPrevSiblings);
+	Plan *left_plan = TranslateDXLOperatorToPlan(left_tree_dxlnode, &left_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
 	// the right side of the join is the one where the hash phase is done
-	DrgPdxltrctx *pdrgpdxltrctxWithSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctxWithSiblings->Append(&dxltrctxLeft);
-	pdrgpdxltrctxWithSiblings->AppendArray(pdrgpdxltrctxPrevSiblings);
-	Plan *pplanRight = (Plan*) PhhashFromDXL(pdxlnRight, &dxltrctxRight, pdrgpdxltrctxWithSiblings);
+	CDXLTranslationContextArray *translation_context_arr_with_siblings = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	translation_context_arr_with_siblings->Append(&left_dxl_translate_ctxt);
+	translation_context_arr_with_siblings->AppendArray(ctxt_translation_prev_siblings);
+	Plan *right_plan = (Plan*) TranslateDXLHash(right_tree_dxlnode, &right_dxl_translate_ctxt, translation_context_arr_with_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxLeft));
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxRight));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&left_dxl_translate_ctxt));
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&right_dxl_translate_ctxt));
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate join filter
-	pj->joinqual = PlQualFromFilter
+	join->joinqual = TranslateDXLFilterToQual
 					(
-					pdxlnJoinFilter,
+					join_filter_dxlnode,
 					NULL,			// translate context for the base table
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					child_contexts,
+					output_context
 					);
 
 	// translate hash cond
-	List *plHashConditions = NIL;
+	List *hash_conditions_list = NIL;
 
-	BOOL fHasINDFCond = false;
+	BOOL has_is_not_distinct_from_cond = false;
 
-	const ULONG ulArity = pdxlnHashCondList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = hash_cond_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnHashCond = (*pdxlnHashCondList)[ul];
+		CDXLNode *hash_cond_dxlnode = (*hash_cond_list_dxlnode)[ul];
 
-		List *plHashCond = PlQualFromScalarCondNode
+		List *hash_cond_list = TranslateDXLScCondToQual
 				(
-				pdxlnHashCond,
+				hash_cond_dxlnode,
 				NULL,			// base table translation context
-				pdrgpdxltrctx,
-				pdxltrctxOut
+				child_contexts,
+				output_context
 				);
 
-		GPOS_ASSERT(1 == gpdb::UlListLength(plHashCond));
+		GPOS_ASSERT(1 == gpdb::ListLength(hash_cond_list));
 
-		Expr *pexpr = (Expr *) LInitial(plHashCond);
-		if (IsA(pexpr, BoolExpr) && ((BoolExpr *) pexpr)->boolop == NOT_EXPR)
+		Expr *expr = (Expr *) LInitial(hash_cond_list);
+		if (IsA(expr, BoolExpr) && ((BoolExpr *) expr)->boolop == NOT_EXPR)
 		{
 			// INDF test
-			GPOS_ASSERT(gpdb::UlListLength(((BoolExpr *) pexpr)->args) == 1 &&
-						(IsA((Expr *) LInitial(((BoolExpr *) pexpr)->args), DistinctExpr)));
-			fHasINDFCond = true;
+			GPOS_ASSERT(gpdb::ListLength(((BoolExpr *) expr)->args) == 1 &&
+						(IsA((Expr *) LInitial(((BoolExpr *) expr)->args), DistinctExpr)));
+			has_is_not_distinct_from_cond = true;
 		}
-		plHashConditions = gpdb::PlConcat(plHashConditions, plHashCond);
+		hash_conditions_list = gpdb::ListConcat(hash_conditions_list, hash_cond_list);
 	}
 
-	if (!fHasINDFCond)
+	if (!has_is_not_distinct_from_cond)
 	{
 		// no INDF conditions in the hash condition list
-		phj->hashclauses = plHashConditions;
+		hashjoin->hashclauses = hash_conditions_list;
 	}
 	else
 	{
 		// hash conditions contain INDF clauses -> extract equality conditions to
 		// construct the hash clauses list
-		List *plHashClauses = NIL;
+		List *hash_clauses_list = NIL;
 
-		for (ULONG ul = 0; ul < ulArity; ul++)
+		for (ULONG ul = 0; ul < arity; ul++)
 		{
-			CDXLNode *pdxlnHashCond = (*pdxlnHashCondList)[ul];
+			CDXLNode *hash_cond_dxlnode = (*hash_cond_list_dxlnode)[ul];
 
 			// condition can be either a scalar comparison or a NOT DISTINCT FROM expression
-			GPOS_ASSERT(EdxlopScalarCmp == pdxlnHashCond->Pdxlop()->Edxlop() ||
-						EdxlopScalarBoolExpr == pdxlnHashCond->Pdxlop()->Edxlop());
+			GPOS_ASSERT(EdxlopScalarCmp == hash_cond_dxlnode->GetOperator()->GetDXLOperator() ||
+						EdxlopScalarBoolExpr == hash_cond_dxlnode->GetOperator()->GetDXLOperator());
 
-			if (EdxlopScalarBoolExpr == pdxlnHashCond->Pdxlop()->Edxlop())
+			if (EdxlopScalarBoolExpr == hash_cond_dxlnode->GetOperator()->GetDXLOperator())
 			{
 				// clause is a NOT DISTINCT FROM check -> extract the distinct comparison node
-				GPOS_ASSERT(Edxlnot == CDXLScalarBoolExpr::PdxlopConvert(pdxlnHashCond->Pdxlop())->EdxlBoolType());
-				pdxlnHashCond = (*pdxlnHashCond)[0];
-				GPOS_ASSERT(EdxlopScalarDistinct == pdxlnHashCond->Pdxlop()->Edxlop());
+				GPOS_ASSERT(Edxlnot == CDXLScalarBoolExpr::Cast(hash_cond_dxlnode->GetOperator())->GetDxlBoolTypeStr());
+				hash_cond_dxlnode = (*hash_cond_dxlnode)[0];
+				GPOS_ASSERT(EdxlopScalarDistinct == hash_cond_dxlnode->GetOperator()->GetDXLOperator());
 			}
 
-			CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+			CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 														(
-														m_pmp,
+														m_mp,
 														NULL,
-														pdrgpdxltrctx,
-														pdxltrctxOut,
-														m_pctxdxltoplstmt
+														child_contexts,
+														output_context,
+														m_dxl_to_plstmt_context
 														);
 
 			// translate the DXL scalar or scalar distinct comparison into an equality comparison
 			// to store in the hash clauses
-			Expr *pexpr2 = (Expr *) m_pdxlsctranslator->PopexprFromDXLNodeScCmp
+			Expr *hash_clause_expr = (Expr *) m_translator_dxl_to_scalar->TranslateDXLScalarCmpToScalar
 									(
-									pdxlnHashCond,
-									&mapcidvarplstmt
+									hash_cond_dxlnode,
+									&colid_var_mapping
 									);
 
-			plHashClauses = gpdb::PlAppendElement(plHashClauses, pexpr2);
+			hash_clauses_list = gpdb::LAppend(hash_clauses_list, hash_clause_expr);
 		}
 
-		phj->hashclauses = plHashClauses;
-		phj->hashqualclauses = plHashConditions;
+		hashjoin->hashclauses = hash_clauses_list;
+		hashjoin->hashqualclauses = hash_conditions_list;
 	}
 
-	GPOS_ASSERT(NIL != phj->hashclauses);
+	GPOS_ASSERT(NIL != hashjoin->hashclauses);
 
-	pplan->lefttree = pplanLeft;
-	pplan->righttree = pplanRight;
-	pplan->nMotionNodes = pplanLeft->nMotionNodes + pplanRight->nMotionNodes;
-	SetParamIds(pplan);
+	plan->lefttree = left_plan;
+	plan->righttree = right_plan;
+	plan->nMotionNodes = left_plan->nMotionNodes + right_plan->nMotionNodes;
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctxWithSiblings->Release();
-	pdrgpdxltrctx->Release();
+	translation_context_arr_with_siblings->Release();
+	child_contexts->Release();
 
-	return  (Plan *) phj;
+	return  (Plan *) hashjoin;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanFunctionScanFromDXLTVF
+//		CTranslatorDXLToPlStmt::TranslateDXLTvf
 //
 //	@doc:
 //		Translates a DXL TVF node into a GPDB Function scan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanFunctionScanFromDXLTVF
+CTranslatorDXLToPlStmt::TranslateDXLTvf
 	(
-	const CDXLNode *pdxlnTVF,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *tvf_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translation context for column mappings
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// create function scan node
-	FunctionScan *pfuncscan = MakeNode(FunctionScan);
-	Plan *pplan = &(pfuncscan->scan.plan);
+	FunctionScan *func_scan = MakeNode(FunctionScan);
+	Plan *plan = &(func_scan->scan.plan);
 
-	RangeTblEntry *prte = PrteFromDXLTVF(pdxlnTVF, pdxltrctxOut, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
+	RangeTblEntry *rte = TranslateDXLTvfToRangeTblEntry(tvf_dxlnode, output_context, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
 
-	pfuncscan->funcexpr = prte->funcexpr;
-	pfuncscan->funccolnames = prte->eref->colnames;
+	func_scan->funcexpr = rte->funcexpr;
+	func_scan->funccolnames = rte->eref->colnames;
 
 	// we will add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
-	dxltrctxbt.SetIdx(iRel);
-	pfuncscan->scan.scanrelid = iRel;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
+	base_table_context.SetRelIndex(index);
+	func_scan->scan.scanrelid = index;
 
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnTVF->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(tvf_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// a table scan node must have at least 1 child: projection list
-	GPOS_ASSERT(1 <= pdxlnTVF->UlArity());
+	GPOS_ASSERT(1 <= tvf_dxlnode->Arity());
 
-	CDXLNode *pdxlnPrL = (*pdxlnTVF)[EdxltsIndexProjList];
+	CDXLNode *project_list_dxlnode = (*tvf_dxlnode)[EdxltsIndexProjList];
 
 	// translate proj list
-	List *plTargetList = PlTargetListFromProjList
+	List *target_list = TranslateDXLProjList
 						(
-						pdxlnPrL,
-						&dxltrctxbt,
+						project_list_dxlnode,
+						&base_table_context,
 						NULL,
-						pdxltrctxOut
+						output_context
 						);
 
-	pplan->targetlist = plTargetList;
+	plan->targetlist = target_list;
 
-	ListCell *plcTe = NULL;
+	ListCell *lc_target_entry = NULL;
 
-	ForEach (plcTe, plTargetList)
+	ForEach (lc_target_entry, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTe);
-		OID oidType = gpdb::OidExprType((Node*) pte->expr);
-		GPOS_ASSERT(InvalidOid != oidType);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc_target_entry);
+		OID oid_type = gpdb::ExprType((Node*) target_entry->expr);
+		GPOS_ASSERT(InvalidOid != oid_type);
 
-		INT typMod = gpdb::IExprTypeMod((Node*) pte->expr);
-		Oid typCollation = gpdb::OidTypeCollation(oidType);
+		INT typ_mod = gpdb::ExprTypeMod((Node*) target_entry->expr);
+		Oid collation_type_oid = gpdb::TypeCollation(oid_type);
 
-		pfuncscan->funccoltypes = gpdb::PlAppendOid(pfuncscan->funccoltypes, oidType);
-		pfuncscan->funccoltypmods = gpdb::PlAppendInt(pfuncscan->funccoltypmods, typMod);
-		// GPORCA currently does not support collations, so infer them using type defaults
-		pfuncscan->funccolcollations = gpdb::PlAppendOid(pfuncscan->funccolcollations, typCollation);
+		func_scan->funccoltypes = gpdb::LAppendOid(func_scan->funccoltypes, oid_type);
+		func_scan->funccoltypmods = gpdb::LAppendInt(func_scan->funccoltypmods, typ_mod);
+		// GDPB_91_MERGE_FIXME: collation
+		func_scan->funccolcollations = gpdb::LAppendOid(func_scan->funccolcollations, collation_type_oid);
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pfuncscan;
+	return (Plan *) func_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PrteFromDXLTVF
+//		CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry
 //
 //	@doc:
 //		Create a range table entry from a CDXLPhysicalTVF node
 //
 //---------------------------------------------------------------------------
 RangeTblEntry *
-CTranslatorDXLToPlStmt::PrteFromDXLTVF
+CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry
 	(
-	const CDXLNode *pdxlnTVF,
-	CDXLTranslateContext *pdxltrctxOut,
-	CDXLTranslateContextBaseTable *pdxltrctxbt
+	const CDXLNode *tvf_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslateContextBaseTable *base_table_context
 	)
 {
-	CDXLPhysicalTVF *pdxlop = CDXLPhysicalTVF::PdxlopConvert(pdxlnTVF->Pdxlop());
+	CDXLPhysicalTVF *dxlop = CDXLPhysicalTVF::Cast(tvf_dxlnode->GetOperator());
 
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
-	prte->rtekind = RTE_FUNCTION;
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
+	rte->rtekind = RTE_FUNCTION;
 
-	FuncExpr *pfuncexpr = MakeNode(FuncExpr);
+	FuncExpr *func_expr = MakeNode(FuncExpr);
 
-	pfuncexpr->funcid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidFunc())->OidObjectId();
-	pfuncexpr->funcretset = true;
+	func_expr->funcid = CMDIdGPDB::CastMdid(dxlop->FuncMdId())->Oid();
+	func_expr->funcretset = true;
 	// this is a function call, as opposed to a cast
-	pfuncexpr->funcformat = COERCE_EXPLICIT_CALL;
-	pfuncexpr->funcresulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidRetType())->OidObjectId();
+	func_expr->funcformat = COERCE_EXPLICIT_CALL;
+	func_expr->funcresulttype = CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
 
-	Alias *palias = MakeNode(Alias);
-	palias->colnames = NIL;
+	Alias *alias = MakeNode(Alias);
+	alias->colnames = NIL;
 
 	// get function alias
-	palias->aliasname = CTranslatorUtils::SzFromWsz(pdxlop->Pstr()->Wsz());
+	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxlop->Pstr()->GetBuffer());
 
 	// project list
-	CDXLNode *pdxlnPrL = (*pdxlnTVF)[EdxltsIndexProjList];
+	CDXLNode *project_list_dxlnode = (*tvf_dxlnode)[EdxltsIndexProjList];
 
 	// get column names
-	const ULONG ulCols = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulCols; ul++)
+	const ULONG num_of_cols = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < num_of_cols; ul++)
 	{
-		CDXLNode *pdxlnPrElem = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrEl = CDXLScalarProjElem::PdxlopConvert(pdxlnPrElem->Pdxlop());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		CDXLScalarProjElem *dxl_proj_elem = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
 
-		CHAR *szColName = CTranslatorUtils::SzFromWsz(pdxlopPrEl->PmdnameAlias()->Pstr()->Wsz());
+		CHAR *col_name_char_array = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxl_proj_elem->GetMdNameAlias()->GetMDName()->GetBuffer());
 
-		Value *pvalColName = gpdb::PvalMakeString(szColName);
-		palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalColName);
+		Value *val_colname = gpdb::MakeStringValue(col_name_char_array);
+		alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
 
 		// save mapping col id -> index in translate context
-		(void) pdxltrctxbt->FInsertMapping(pdxlopPrEl->UlId(), ul+1 /*iAttno*/);
+		(void) base_table_context->InsertMapping(dxl_proj_elem->Id(), ul+1 /*attno*/);
 	}
 
 	// function arguments
-	const ULONG ulChildren = pdxlnTVF->UlArity();
-	for (ULONG ul = 1; ul < ulChildren; ++ul)
+	const ULONG num_of_child = tvf_dxlnode->Arity();
+	for (ULONG ul = 1; ul < num_of_child; ++ul)
 	{
-		CDXLNode *pdxlnFuncArg = (*pdxlnTVF)[ul];
+		CDXLNode *func_arg_dxlnode = (*tvf_dxlnode)[ul];
 
-		CMappingColIdVarPlStmt mapcidvarplstmt
+		CMappingColIdVarPlStmt colid_var_mapping
 									(
-									m_pmp,
-									pdxltrctxbt,
+									m_mp,
+									base_table_context,
 									NULL,
-									pdxltrctxOut,
-									m_pctxdxltoplstmt
+									output_context,
+									m_dxl_to_plstmt_context
 									);
 
-		Expr *pexprFuncArg = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnFuncArg, &mapcidvarplstmt);
-		pfuncexpr->args = gpdb::PlAppendElement(pfuncexpr->args, pexprFuncArg);
+		Expr *pexprFuncArg = m_translator_dxl_to_scalar->TranslateDXLToScalar(func_arg_dxlnode, &colid_var_mapping);
+		func_expr->args = gpdb::LAppend(func_expr->args, pexprFuncArg);
 	}
 
 	// GDPB_91_MERGE_FIXME: collation
-	pfuncexpr->inputcollid = gpdb::OidExprCollation((Node *) pfuncexpr->args);
-	pfuncexpr->funccollid = gpdb::OidTypeCollation(pfuncexpr->funcresulttype);
+	func_expr->inputcollid = gpdb::ExprCollation((Node *) func_expr->args);
+	func_expr->funccollid = gpdb::TypeCollation(func_expr->funcresulttype);
 
-	prte->funcexpr = (Node *)pfuncexpr;
-	prte->inFromCl = true;
-	prte->eref = palias;
+	rte->funcexpr = (Node *)func_expr;
+	rte->inFromCl = true;
+	rte->eref = alias;
 	// GDPB_91_MERGE_FIXME: collation
-	// set prte->funccoltypemods & prte->funccolcollations?
+	// set rte->funccoltypemods & rte->funccolcollations?
 
-	return prte;
+	return rte;
 }
 
 
 // create a range table entry from a CDXLPhysicalValuesScan node
 RangeTblEntry *
-CTranslatorDXLToPlStmt::PrteFromDXLValueScan
+CTranslatorDXLToPlStmt::TranslateDXLValueScanToRangeTblEntry
 	(
-	const CDXLNode *pdxlnValueScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	CDXLTranslateContextBaseTable *pdxltrctxbt
+	const CDXLNode *value_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslateContextBaseTable *base_table_context
 	)
 {
-	CDXLPhysicalValuesScan *pdxlop = CDXLPhysicalValuesScan::PdxlopConvert(pdxlnValueScan->Pdxlop());
+	CDXLPhysicalValuesScan *phy_values_scan_dxlop = CDXLPhysicalValuesScan::Cast(value_scan_dxlnode->GetOperator());
 
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
 
-	prte->relid = InvalidOid;
-	prte->subquery = NULL;
-	prte->rtekind = RTE_VALUES;
-	prte->inh = false;			/* never true for values RTEs */
-	prte->inFromCl = true;
-	prte->requiredPerms = 0;
-	prte->checkAsUser = InvalidOid;
+	rte->relid = InvalidOid;
+	rte->subquery = NULL;
+	rte->rtekind = RTE_VALUES;
+	rte->inh = false;			/* never true for values RTEs */
+	rte->inFromCl = true;
+	rte->requiredPerms = 0;
+	rte->checkAsUser = InvalidOid;
 
-	Alias *palias = MakeNode(Alias);
-	palias->colnames = NIL;
+	Alias *alias = MakeNode(Alias);
+	alias->colnames = NIL;
 
 	// get value alias
-	palias->aliasname = CTranslatorUtils::SzFromWsz(pdxlop->PstrOpName()->Wsz());
+	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(phy_values_scan_dxlop->GetOpNameStr()->GetBuffer());
 
 	// project list
-	CDXLNode *pdxlnPrL = (*pdxlnValueScan)[EdxltsIndexProjList];
+	CDXLNode *project_list_dxlnode = (*value_scan_dxlnode)[EdxltsIndexProjList];
 
 	// get column names
-	const ULONG ulCols = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulCols; ul++)
+	const ULONG num_of_cols = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < num_of_cols; ul++)
 	{
-		CDXLNode *pdxlnPrElem = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrEl = CDXLScalarProjElem::PdxlopConvert(pdxlnPrElem->Pdxlop());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		CDXLScalarProjElem *dxl_proj_elem = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
 
-		CHAR *szColName = CTranslatorUtils::SzFromWsz(pdxlopPrEl->PmdnameAlias()->Pstr()->Wsz());
+		CHAR *col_name_char_array = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxl_proj_elem->GetMdNameAlias()->GetMDName()->GetBuffer());
 
-		Value *pvalColName = gpdb::PvalMakeString(szColName);
-		palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalColName);
+		Value *val_colname = gpdb::MakeStringValue(col_name_char_array);
+		alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
 
 		// save mapping col id -> index in translate context
-		(void) pdxltrctxbt->FInsertMapping(pdxlopPrEl->UlId(), ul+1 /*iAttno*/);
+		(void) base_table_context->InsertMapping(dxl_proj_elem->Id(), ul+1 /*attno*/);
 	}
 
-	CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt(m_pmp, pdxltrctxbt, NULL, pdxltrctxOut, m_pctxdxltoplstmt);
-	const ULONG ulChildren = pdxlnValueScan->UlArity();
+	CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt(m_mp, base_table_context, NULL, output_context, m_dxl_to_plstmt_context);
+	const ULONG num_of_child = value_scan_dxlnode->Arity();
 	List *values_lists = NIL;
 	List *values_collations = NIL;
 
-	for (ULONG ulValue = EdxlValIndexConstStart; ulValue < ulChildren; ulValue++)
+	for (ULONG ulValue = EdxlValIndexConstStart; ulValue < num_of_child; ulValue++)
 	{
-		CDXLNode *pdxlnValueList = (*pdxlnValueScan)[ulValue];
-		const ULONG ulCols = pdxlnValueList->UlArity();
+		CDXLNode *value_list_dxlnode = (*value_scan_dxlnode)[ulValue];
+		const ULONG num_of_cols = value_list_dxlnode->Arity();
 		List *value = NIL;
-		for (ULONG ulCol = 0; ulCol < ulCols ; ulCol++)
+		for (ULONG ulCol = 0; ulCol < num_of_cols ; ulCol++)
 		{
-			Expr *pconst = m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnValueList)[ulCol], &mapcidvarplstmt);
-			value = gpdb::PlAppendElement(value, pconst);
+			Expr *const_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar((*value_list_dxlnode)[ulCol], &colid_var_mapping);
+			value = gpdb::LAppend(value, const_expr);
 
 		}
-		values_lists = gpdb::PlAppendElement(values_lists, value);
+		values_lists = gpdb::LAppend(values_lists, value);
 
 		// GPDB_91_MERGE_FIXME: collation
 		if (NIL == values_collations)
 		{
 			// Set collation based on the first list of values
-			for (ULONG ulCol = 0; ulCol < ulCols ; ulCol++)
+			for (ULONG ulCol = 0; ulCol < num_of_cols ; ulCol++)
 			{
-				values_collations = gpdb::PlAppendOid(values_collations, gpdb::OidExprCollation((Node *) value));
+				values_collations = gpdb::LAppendOid(values_collations, gpdb::ExprCollation((Node *) value));
 			}
 		}
 	}
 
-	prte->values_lists = values_lists;
-	prte->values_collations = values_collations;
-	prte->eref = palias;
+	rte->values_lists = values_lists;
+	rte->values_collations = values_collations;
+	rte->eref = alias;
 
-	return prte;
+	return rte;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PnljFromDXLNLJ
+//		CTranslatorDXLToPlStmt::TranslateDXLNLJoin
 //
 //	@doc:
 //		Translates a DXL nested loop join node into a NestLoop plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PnljFromDXLNLJ
+CTranslatorDXLToPlStmt::TranslateDXLNLJoin
 	(
-	const CDXLNode *pdxlnNLJ,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *nl_join_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	GPOS_ASSERT(pdxlnNLJ->Pdxlop()->Edxlop() == EdxlopPhysicalNLJoin);
-	GPOS_ASSERT(pdxlnNLJ->UlArity() == EdxlnljIndexSentinel);
+	GPOS_ASSERT(nl_join_dxlnode->GetOperator()->GetDXLOperator() == EdxlopPhysicalNLJoin);
+	GPOS_ASSERT(nl_join_dxlnode->Arity() == EdxlnljIndexSentinel);
 
 	// create hash join node
-	NestLoop *pnlj = MakeNode(NestLoop);
+	NestLoop *nested_loop = MakeNode(NestLoop);
 
-	Join *pj = &(pnlj->join);
-	Plan *pplan = &(pj->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Join *join = &(nested_loop->join);
+	Plan *plan = &(join->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalNLJoin *pdxlnlj = CDXLPhysicalNLJoin::PdxlConvert(pdxlnNLJ->Pdxlop());
+	CDXLPhysicalNLJoin *dxl_nlj = CDXLPhysicalNLJoin::PdxlConvert(nl_join_dxlnode->GetOperator());
 
 	// set join type
-	pj->jointype = JtFromEdxljt(pdxlnlj->Edxltype());
+	join->jointype = GetGPDBJoinTypeFromDXLJoinType(dxl_nlj->GetJoinType());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnNLJ->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(nl_join_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate join children
-	CDXLNode *pdxlnLeft = (*pdxlnNLJ)[EdxlnljIndexLeftChild];
-	CDXLNode *pdxlnRight = (*pdxlnNLJ)[EdxlnljIndexRightChild];
+	CDXLNode *left_tree_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexLeftChild];
+	CDXLNode *right_tree_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexRightChild];
 
-	CDXLNode *pdxlnPrL = (*pdxlnNLJ)[EdxlnljIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnNLJ)[EdxlnljIndexFilter];
-	CDXLNode *pdxlnJoinFilter = (*pdxlnNLJ)[EdxlnljIndexJoinFilter];
+	CDXLNode *project_list_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexProjList];
+	CDXLNode *filter_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexFilter];
+	CDXLNode *join_filter_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexJoinFilter];
 
-	CDXLTranslateContext dxltrctxLeft(m_pmp, false, pdxltrctxOut->PhmColParam());
-	CDXLTranslateContext dxltrctxRight(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext left_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
+	CDXLTranslateContext right_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
 	// setting of prefetch_inner to true except for the case of index NLJ where we cannot prefetch inner
 	// because inner child depends on variables coming from outer child
-	pj->prefetch_inner = !pdxlnlj->FIndexNLJ();
+	join->prefetch_inner = !dxl_nlj->IsIndexNLJ();
 
-	DrgPdxltrctx *pdrgpdxltrctxWithSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	Plan *pplanLeft = NULL;
-	Plan *pplanRight = NULL;
-	if (pdxlnlj->FIndexNLJ())
+	CDXLTranslationContextArray *translation_context_arr_with_siblings = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	Plan *left_plan = NULL;
+	Plan *right_plan = NULL;
+	if (dxl_nlj->IsIndexNLJ())
 	{
-		const DrgPdxlcr *pdrgdxlcrOuterRefs = pdxlnlj->GetNestLoopParamsColRefs();
-		const ULONG ulLen = pdrgdxlcrOuterRefs->UlLength();
+		const CDXLColRefArray *pdrgdxlcrOuterRefs = dxl_nlj->GetNestLoopParamsColRefs();
+		const ULONG ulLen = pdrgdxlcrOuterRefs->Size();
 		for (ULONG ul = 0; ul < ulLen; ul++)
 		{
 			CDXLColRef *pdxlcr = (*pdrgdxlcrOuterRefs)[ul];
-			IMDId *pmdid = pdxlcr->PmdidType();
-			ULONG ulColid = pdxlcr->UlID();
-			INT iTypeModifier = pdxlcr->ITypeModifier();
+			IMDId *pmdid = pdxlcr->MdidType();
+			ULONG ulColid = pdxlcr->Id();
+			INT iTypeModifier = pdxlcr->TypeModifier();
 
-			if (NULL == dxltrctxRight.Pmecolidparamid(ulColid))
+			if (NULL == right_dxl_translate_ctxt.GetParamIdMappingElement(ulColid))
 			{
-				CMappingElementColIdParamId *pmecolidparamid = GPOS_NEW(m_pmp) CMappingElementColIdParamId(ulColid, m_pctxdxltoplstmt->UlNextParamId(), pmdid, iTypeModifier);
+				CMappingElementColIdParamId *pmecolidparamid = GPOS_NEW(m_mp) CMappingElementColIdParamId(ulColid, m_dxl_to_plstmt_context->GetNextParamId(), pmdid, iTypeModifier);
 #ifdef GPOS_DEBUG
 					BOOL fInserted =
 #endif
-						dxltrctxRight.FInsertParamMapping(ulColid, pmecolidparamid);
+						right_dxl_translate_ctxt.FInsertParamMapping(ulColid, pmecolidparamid);
 					GPOS_ASSERT(fInserted);
 			}
 		}
 		// right child (the index scan side) has references to left child's columns,
 		// we need to translate left child first to load its columns into translation context
-		pplanLeft = PplFromDXL(pdxlnLeft, &dxltrctxLeft, pdrgpdxltrctxPrevSiblings);
+		left_plan = TranslateDXLOperatorToPlan(left_tree_dxlnode, &left_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-		pdrgpdxltrctxWithSiblings->Append(&dxltrctxLeft);
-		 pdrgpdxltrctxWithSiblings->AppendArray(pdrgpdxltrctxPrevSiblings);
+		translation_context_arr_with_siblings->Append(&left_dxl_translate_ctxt);
+		 translation_context_arr_with_siblings->AppendArray(ctxt_translation_prev_siblings);
 
 		 // translate right child after left child translation is complete
-		pplanRight = PplFromDXL(pdxlnRight, &dxltrctxRight, pdrgpdxltrctxWithSiblings);
+		right_plan = TranslateDXLOperatorToPlan(right_tree_dxlnode, &right_dxl_translate_ctxt, translation_context_arr_with_siblings);
 	}
 	else
 	{
 		// left child may include a PartitionSelector with references to right child's columns,
 		// we need to translate right child first to load its columns into translation context
-		pplanRight = PplFromDXL(pdxlnRight, &dxltrctxRight, pdrgpdxltrctxPrevSiblings);
+		right_plan = TranslateDXLOperatorToPlan(right_tree_dxlnode, &right_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-		pdrgpdxltrctxWithSiblings->Append(&dxltrctxRight);
-		pdrgpdxltrctxWithSiblings->AppendArray(pdrgpdxltrctxPrevSiblings);
+		translation_context_arr_with_siblings->Append(&right_dxl_translate_ctxt);
+		translation_context_arr_with_siblings->AppendArray(ctxt_translation_prev_siblings);
 
 		// translate left child after right child translation is complete
-		pplanLeft = PplFromDXL(pdxlnLeft, &dxltrctxLeft, pdrgpdxltrctxWithSiblings);
+		left_plan = TranslateDXLOperatorToPlan(left_tree_dxlnode, &left_dxl_translate_ctxt, translation_context_arr_with_siblings);
 	}
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxLeft);
-	pdrgpdxltrctx->Append(&dxltrctxRight);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&left_dxl_translate_ctxt);
+	child_contexts->Append(&right_dxl_translate_ctxt);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate join condition
-	pj->joinqual = PlQualFromFilter
+	join->joinqual = TranslateDXLFilterToQual
 					(
-					pdxlnJoinFilter,
+					join_filter_dxlnode,
 					NULL,			// translate context for the base table
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					child_contexts,
+					output_context
 					);
 
 	// create nest loop params for index nested loop joins
-	if (pdxlnlj->FIndexNLJ())
+	if (dxl_nlj->IsIndexNLJ())
 	{
-		((NestLoop *)pplan)->nestParams = TranslateNestLoopParamList(pdxlnlj->GetNestLoopParamsColRefs(), &dxltrctxLeft, &dxltrctxRight);
+		((NestLoop *)plan)->nestParams = TranslateNestLoopParamList(dxl_nlj->GetNestLoopParamsColRefs(), &left_dxl_translate_ctxt, &right_dxl_translate_ctxt);
 	}
-	pplan->lefttree = pplanLeft;
-	pplan->righttree = pplanRight;
-	pplan->nMotionNodes = pplanLeft->nMotionNodes + pplanRight->nMotionNodes;
-	SetParamIds(pplan);
+	plan->lefttree = left_plan;
+	plan->righttree = right_plan;
+	plan->nMotionNodes = left_plan->nMotionNodes + right_plan->nMotionNodes;
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctxWithSiblings->Release();
-	pdrgpdxltrctx->Release();
+	translation_context_arr_with_siblings->Release();
+	child_contexts->Release();
 
-	return  (Plan *) pnlj;
+	return  (Plan *) nested_loop;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PmjFromDXLMJ
+//		CTranslatorDXLToPlStmt::TranslateDXLMergeJoin
 //
 //	@doc:
 //		Translates a DXL merge join node into a MergeJoin node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PmjFromDXLMJ
+CTranslatorDXLToPlStmt::TranslateDXLMergeJoin
 	(
-	const CDXLNode *pdxlnMJ,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *merge_join_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	GPOS_ASSERT(pdxlnMJ->Pdxlop()->Edxlop() == EdxlopPhysicalMergeJoin);
-	GPOS_ASSERT(pdxlnMJ->UlArity() == EdxlmjIndexSentinel);
+	GPOS_ASSERT(merge_join_dxlnode->GetOperator()->GetDXLOperator() == EdxlopPhysicalMergeJoin);
+	GPOS_ASSERT(merge_join_dxlnode->Arity() == EdxlmjIndexSentinel);
 
 	// create merge join node
-	MergeJoin *pmj = MakeNode(MergeJoin);
+	MergeJoin *merge_join = MakeNode(MergeJoin);
 
-	Join *pj = &(pmj->join);
-	Plan *pplan = &(pj->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Join *join = &(merge_join->join);
+	Plan *plan = &(join->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalMergeJoin *pdxlopMergeJoin = CDXLPhysicalMergeJoin::PdxlopConvert(pdxlnMJ->Pdxlop());
+	CDXLPhysicalMergeJoin *merge_join_dxlop = CDXLPhysicalMergeJoin::Cast(merge_join_dxlnode->GetOperator());
 
 	// set join type
-	pj->jointype = JtFromEdxljt(pdxlopMergeJoin->Edxltype());
+	join->jointype = GetGPDBJoinTypeFromDXLJoinType(merge_join_dxlop->GetJoinType());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnMJ->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(merge_join_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate join children
-	CDXLNode *pdxlnLeft = (*pdxlnMJ)[EdxlmjIndexLeftChild];
-	CDXLNode *pdxlnRight = (*pdxlnMJ)[EdxlmjIndexRightChild];
+	CDXLNode *left_tree_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexLeftChild];
+	CDXLNode *right_tree_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexRightChild];
 
-	CDXLNode *pdxlnPrL = (*pdxlnMJ)[EdxlmjIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnMJ)[EdxlmjIndexFilter];
-	CDXLNode *pdxlnJoinFilter = (*pdxlnMJ)[EdxlmjIndexJoinFilter];
-	CDXLNode *pdxlnMergeCondList = (*pdxlnMJ)[EdxlmjIndexMergeCondList];
+	CDXLNode *project_list_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexProjList];
+	CDXLNode *filter_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexFilter];
+	CDXLNode *join_filter_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexJoinFilter];
+	CDXLNode *merge_cond_list_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexMergeCondList];
 
-	CDXLTranslateContext dxltrctxLeft(m_pmp, false, pdxltrctxOut->PhmColParam());
-	CDXLTranslateContext dxltrctxRight(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext left_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
+	CDXLTranslateContext right_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanLeft = PplFromDXL(pdxlnLeft, &dxltrctxLeft, pdrgpdxltrctxPrevSiblings);
+	Plan *left_plan = TranslateDXLOperatorToPlan(left_tree_dxlnode, &left_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctxWithSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctxWithSiblings->Append(&dxltrctxLeft);
-	pdrgpdxltrctxWithSiblings->AppendArray(pdrgpdxltrctxPrevSiblings);
+	CDXLTranslationContextArray *translation_context_arr_with_siblings = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	translation_context_arr_with_siblings->Append(&left_dxl_translate_ctxt);
+	translation_context_arr_with_siblings->AppendArray(ctxt_translation_prev_siblings);
 
-	Plan *pplanRight = PplFromDXL(pdxlnRight, &dxltrctxRight, pdrgpdxltrctxWithSiblings);
+	Plan *right_plan = TranslateDXLOperatorToPlan(right_tree_dxlnode, &right_dxl_translate_ctxt, translation_context_arr_with_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxLeft));
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxRight));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&left_dxl_translate_ctxt));
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&right_dxl_translate_ctxt));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate join filter
-	pj->joinqual = PlQualFromFilter
+	join->joinqual = TranslateDXLFilterToQual
 					(
-					pdxlnJoinFilter,
+					join_filter_dxlnode,
 					NULL,			// translate context for the base table
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					child_contexts,
+					output_context
 					);
 
 	// translate merge cond
-	List *plMergeConditions = NIL;
+	List *merge_conditions_list = NIL;
 
-	const ULONG ulArity = pdxlnMergeCondList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = merge_cond_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnMergeCond = (*pdxlnMergeCondList)[ul];
-		List *plMergeCond = PlQualFromScalarCondNode
+		CDXLNode *merge_condition_dxlnode = (*merge_cond_list_dxlnode)[ul];
+		List *merge_condition_list = TranslateDXLScCondToQual
 				(
-				pdxlnMergeCond,
+				merge_condition_dxlnode,
 				NULL,			// base table translation context
-				pdrgpdxltrctx,
-				pdxltrctxOut
+				child_contexts,
+				output_context
 				);
 
-		GPOS_ASSERT(1 == gpdb::UlListLength(plMergeCond));
-		plMergeConditions = gpdb::PlConcat(plMergeConditions, plMergeCond);
+		GPOS_ASSERT(1 == gpdb::ListLength(merge_condition_list));
+		merge_conditions_list = gpdb::ListConcat(merge_conditions_list, merge_condition_list);
 	}
 
-	GPOS_ASSERT(NIL != plMergeConditions);
+	GPOS_ASSERT(NIL != merge_conditions_list);
 
-	pmj->mergeclauses = plMergeConditions;
+	merge_join->mergeclauses = merge_conditions_list;
 
-	pplan->lefttree = pplanLeft;
-	pplan->righttree = pplanRight;
-	pplan->nMotionNodes = pplanLeft->nMotionNodes + pplanRight->nMotionNodes;
-	SetParamIds(pplan);
+	plan->lefttree = left_plan;
+	plan->righttree = right_plan;
+	plan->nMotionNodes = left_plan->nMotionNodes + right_plan->nMotionNodes;
+	SetParamIds(plan);
 
 	// GDPB_91_MERGE_FIXME: collation
-	// Need to set pmj->mergeCollations, but ORCA does not produce plans with
+	// Need to set merge_join->mergeCollations, but ORCA does not produce plans with
 	// Merge Joins.
 
 	// cleanup
-	pdrgpdxltrctxWithSiblings->Release();
-	pdrgpdxltrctx->Release();
+	translation_context_arr_with_siblings->Release();
+	child_contexts->Release();
 
-	return  (Plan *) pmj;
+	return  (Plan *) merge_join;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PhhashFromDXL
+//		CTranslatorDXLToPlStmt::TranslateDXLHash
 //
 //	@doc:
 //		Translates a DXL physical operator node into a Hash node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PhhashFromDXL
+CTranslatorDXLToPlStmt::TranslateDXLHash
 	(
-	const CDXLNode *pdxln,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	Hash *ph = MakeNode(Hash);
+	Hash *hash = MakeNode(Hash);
 
-	Plan *pplan = &(ph->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(hash->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate dxl node
-	CDXLTranslateContext dxltrctx(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanLeft = PplFromDXL(pdxln, &dxltrctx, pdrgpdxltrctxPrevSiblings);
+	Plan *left_plan = TranslateDXLOperatorToPlan(dxlnode, &dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-	GPOS_ASSERT(0 < pdxln->UlArity());
+	GPOS_ASSERT(0 < dxlnode->Arity());
 
 	// create a reference to each entry in the child project list to create the target list of
 	// the hash node
-	CDXLNode *pdxlnPrL = (*pdxln)[0];
-	List *plTargetList = PlTargetListForHashNode(pdxlnPrL, &dxltrctx, pdxltrctxOut);
+	CDXLNode *project_list_dxlnode = (*dxlnode)[0];
+	List *target_list = TranslateDXLProjectListToHashTargetList(project_list_dxlnode, &dxl_translate_ctxt, output_context);
 
 	// copy costs from child node; the startup cost for the hash node is the total cost
 	// of the child plan, see make_hash in createplan.c
-	pplan->startup_cost = pplanLeft->total_cost;
-	pplan->total_cost = pplanLeft->total_cost;
-	pplan->plan_rows = pplanLeft->plan_rows;
-	pplan->plan_width = pplanLeft->plan_width;
+	plan->startup_cost = left_plan->total_cost;
+	plan->total_cost = left_plan->total_cost;
+	plan->plan_rows = left_plan->plan_rows;
+	plan->plan_width = left_plan->plan_width;
 
-	pplan->targetlist = plTargetList;
-	pplan->lefttree = pplanLeft;
-	pplan->righttree = NULL;
-	pplan->nMotionNodes = pplanLeft->nMotionNodes;
-	pplan->qual = NIL;
-	ph->rescannable = false;
+	plan->targetlist = target_list;
+	plan->lefttree = left_plan;
+	plan->righttree = NULL;
+	plan->nMotionNodes = left_plan->nMotionNodes;
+	plan->qual = NIL;
+	hash->rescannable = false;
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) ph;
+	return (Plan *) hash;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanTranslateDXLMotion
+//		CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion
 //
 //	@doc:
 //		Translate DXL motion node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanTranslateDXLMotion
+CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion
 	(
-	const CDXLNode *pdxlnMotion,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *motion_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalMotion *pdxlopMotion = CDXLPhysicalMotion::PdxlopConvert(pdxlnMotion->Pdxlop());
-	if (CTranslatorUtils::FDuplicateSensitiveMotion(pdxlopMotion))
+	CDXLPhysicalMotion *motion_dxlop = CDXLPhysicalMotion::Cast(motion_dxlnode->GetOperator());
+	if (CTranslatorUtils::IsDuplicateSensitiveMotion(motion_dxlop))
 	{
-		return PplanResultHashFilters(pdxlnMotion, pdxltrctxOut, pdrgpdxltrctxPrevSiblings);
+		return TranslateDXLRedistributeMotionToResultHashFilters(motion_dxlnode, output_context, ctxt_translation_prev_siblings);
 	}
 	
-	return PplanMotionFromDXLMotion(pdxlnMotion, pdxltrctxOut, pdrgpdxltrctxPrevSiblings);
+	return TranslateDXLMotion(motion_dxlnode, output_context, ctxt_translation_prev_siblings);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion
+//		CTranslatorDXLToPlStmt::TranslateDXLMotion
 //
 //	@doc:
 //		Translate DXL motion node into GPDB Motion plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion
+CTranslatorDXLToPlStmt::TranslateDXLMotion
 	(
-	const CDXLNode *pdxlnMotion,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *motion_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalMotion *pdxlopMotion = CDXLPhysicalMotion::PdxlopConvert(pdxlnMotion->Pdxlop());
+	CDXLPhysicalMotion *motion_dxlop = CDXLPhysicalMotion::Cast(motion_dxlnode->GetOperator());
 
 	// create motion node
-	Motion *pmotion = MakeNode(Motion);
+	Motion *motion = MakeNode(Motion);
 
-	Plan *pplan = &(pmotion->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(motion->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnMotion->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(motion_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	CDXLNode *pdxlnPrL = (*pdxlnMotion)[EdxlgmIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnMotion)[EdxlgmIndexFilter];
-	CDXLNode *pdxlnSortColList = (*pdxlnMotion)[EdxlgmIndexSortColList];
+	CDXLNode *project_list_dxlnode = (*motion_dxlnode)[EdxlgmIndexProjList];
+	CDXLNode *filter_dxlnode = (*motion_dxlnode)[EdxlgmIndexFilter];
+	CDXLNode *sort_col_list_dxl = (*motion_dxlnode)[EdxlgmIndexSortColList];
 
 	// translate motion child
 	// child node is in the same position in broadcast and gather motion nodes
 	// but different in redistribute motion nodes
 
-	ULONG ulChildIndex = pdxlopMotion->UlChildIndex();
+	ULONG child_index = motion_dxlop->GetRelationChildIdx();
 
-	CDXLNode *pdxlnChild = (*pdxlnMotion)[ulChildIndex];
+	CDXLNode *child_dxlnode = (*motion_dxlnode)[child_index];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate sorting info
-	ULONG ulNumSortCols = pdxlnSortColList->UlArity();
-	if (0 < ulNumSortCols)
+	ULONG num_sort_cols = sort_col_list_dxl->Arity();
+	if (0 < num_sort_cols)
 	{
-		pmotion->sendSorted = true;
-		pmotion->numSortCols = ulNumSortCols;
-		pmotion->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(ulNumSortCols * sizeof(AttrNumber));
-		pmotion->sortOperators = (Oid *) gpdb::GPDBAlloc(ulNumSortCols * sizeof(Oid));
-		pmotion->collations = (Oid *) gpdb::GPDBAlloc(ulNumSortCols * sizeof(Oid));
-		pmotion->nullsFirst = (bool *) gpdb::GPDBAlloc(ulNumSortCols * sizeof(bool));
+		motion->sendSorted = true;
+		motion->numSortCols = num_sort_cols;
+		motion->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(num_sort_cols * sizeof(AttrNumber));
+		motion->sortOperators = (Oid *) gpdb::GPDBAlloc(num_sort_cols * sizeof(Oid));
+		motion->collations = (Oid *) gpdb::GPDBAlloc(num_sort_cols * sizeof(Oid));
+		motion->nullsFirst = (bool *) gpdb::GPDBAlloc(num_sort_cols * sizeof(bool));
 
-		TranslateSortCols(pdxlnSortColList, pdxltrctxOut, pmotion->sortColIdx, pmotion->sortOperators, pmotion->collations, pmotion->nullsFirst);
+		TranslateSortCols(sort_col_list_dxl, output_context, motion->sortColIdx, motion->sortOperators, motion->collations, motion->nullsFirst);
 	}
 	else
 	{
 		// not a sorting motion
-		pmotion->sendSorted = false;
-		pmotion->numSortCols = 0;
-		pmotion->sortColIdx = NULL;
-		pmotion->sortOperators = NULL;
-		pmotion->nullsFirst = NULL;
+		motion->sendSorted = false;
+		motion->numSortCols = 0;
+		motion->sortColIdx = NULL;
+		motion->sortOperators = NULL;
+		motion->nullsFirst = NULL;
 	}
 
-	if (pdxlopMotion->Edxlop() == EdxlopPhysicalMotionRedistribute ||
-		pdxlopMotion->Edxlop() == EdxlopPhysicalMotionRoutedDistribute ||
-		pdxlopMotion->Edxlop() == EdxlopPhysicalMotionRandom)
+	if (motion_dxlop->GetDXLOperator() == EdxlopPhysicalMotionRedistribute ||
+		motion_dxlop->GetDXLOperator() == EdxlopPhysicalMotionRoutedDistribute ||
+		motion_dxlop->GetDXLOperator() == EdxlopPhysicalMotionRandom)
 	{
 		// translate hash expr list
-		List *plHashExpr = NIL;
-		List *plHashExprTypes = NIL;
+		List *hash_expr_list = NIL;
+		List *hash_expr_types_list = NIL;
 
-		if (EdxlopPhysicalMotionRedistribute == pdxlopMotion->Edxlop())
+		if (EdxlopPhysicalMotionRedistribute == motion_dxlop->GetDXLOperator())
 		{
-			CDXLNode *pdxlnHashExprList = (*pdxlnMotion)[EdxlrmIndexHashExprList];
+			CDXLNode *hash_expr_list_dxlnode = (*motion_dxlnode)[EdxlrmIndexHashExprList];
 
 			TranslateHashExprList
 				(
-				pdxlnHashExprList,
-				&dxltrctxChild,
-				&plHashExpr,
-				&plHashExprTypes,
-				pdxltrctxOut
+				hash_expr_list_dxlnode,
+				&child_context,
+				&hash_expr_list,
+				&hash_expr_types_list,
+				output_context
 				);
 		}
-		GPOS_ASSERT(gpdb::UlListLength(plHashExpr) == gpdb::UlListLength(plHashExprTypes));
+		GPOS_ASSERT(gpdb::ListLength(hash_expr_list) == gpdb::ListLength(hash_expr_types_list));
 
-		pmotion->hashExpr = plHashExpr;
-		pmotion->hashDataTypes = plHashExprTypes;
+		motion->hashExpr = hash_expr_list;
+		motion->hashDataTypes = hash_expr_types_list;
 	}
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 	// create flow for child node to distinguish between singleton flows and all-segment flows
-	Flow *pflow = MakeNode(Flow);
+	Flow *flow = MakeNode(Flow);
 
-	const DrgPi *pdrgpiInputSegmentIds = pdxlopMotion->PdrgpiInputSegIds();
+	const IntPtrArray *input_segids_array = motion_dxlop->GetInputSegIdsArray();
 
 
 	// only one sender
-	if (1 == pdrgpiInputSegmentIds->UlLength())
+	if (1 == input_segids_array->Size())
 	{
-		pflow->segindex = *((*pdrgpiInputSegmentIds)[0]);
+		flow->segindex = *((*input_segids_array)[0]);
 
 		// only one segment in total
-		if (1 == gpdb::UlSegmentCountGP())
+		if (1 == gpdb::GetGPSegmentCount())
 		{
-			if (pflow->segindex == MASTER_CONTENT_ID)
+			if (flow->segindex == MASTER_CONTENT_ID)
 				// sender is on master, must be singleton flow
-				pflow->flotype = FLOW_SINGLETON;
+				flow->flotype = FLOW_SINGLETON;
 			else
 				// sender is on segment, can not tell it's singleton or
 				// all-segment flow, just treat it as all-segment flow so
 				// it can be promoted to writer gang later if needed.
-				pflow->flotype = FLOW_UNDEFINED;
+				flow->flotype = FLOW_UNDEFINED;
 		}
 		else
 		{
 			// multiple segments, must be singleton flow
-			pflow->flotype = FLOW_SINGLETON;
+			flow->flotype = FLOW_SINGLETON;
 		}
 	}
 	else
 	{
-		pflow->flotype = FLOW_UNDEFINED;
+		flow->flotype = FLOW_UNDEFINED;
 	}
 
-	pplanChild->flow = pflow;
+	child_plan->flow = flow;
 
-	pmotion->motionID = m_pctxdxltoplstmt->UlNextMotionId();
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes + 1;
+	motion->motionID = m_dxl_to_plstmt_context->GetNextMotionId();
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes + 1;
 
 	// translate properties of the specific type of motion operator
 
-	switch (pdxlopMotion->Edxlop())
+	switch (motion_dxlop->GetDXLOperator())
 	{
 		case EdxlopPhysicalMotionGather:
 		{
-			pmotion->motionType = MOTIONTYPE_FIXED;
+			motion->motionType = MOTIONTYPE_FIXED;
 			// get segment id
-			INT iSegId = CDXLPhysicalGatherMotion::PdxlopConvert(pdxlopMotion)->IOutputSegIdx();
-			pmotion->numOutputSegs = 1;
-			pmotion->outputSegIdx = (INT *) gpdb::GPDBAlloc(sizeof(INT));
-			*(pmotion->outputSegIdx) = iSegId;
+			INT segid = CDXLPhysicalGatherMotion::Cast(motion_dxlop)->IOutputSegIdx();
+			motion->numOutputSegs = 1;
+			motion->outputSegIdx = (INT *) gpdb::GPDBAlloc(sizeof(INT));
+			*(motion->outputSegIdx) = segid;
 			break;
 		}
 		case EdxlopPhysicalMotionRedistribute:
 		case EdxlopPhysicalMotionRandom:
 		{
-			pmotion->motionType = MOTIONTYPE_HASH;
+			motion->motionType = MOTIONTYPE_HASH;
 			// translate output segment ids
-			const DrgPi *pdrgpiSegIds = CDXLPhysicalMotion::PdxlopConvert(pdxlopMotion)->PdrgpiOutputSegIds();
+			const IntPtrArray *output_segids_array = CDXLPhysicalMotion::Cast(motion_dxlop)->GetOutputSegIdsArray();
 
-			GPOS_ASSERT(NULL != pdrgpiSegIds && 0 < pdrgpiSegIds->UlLength());
-			ULONG ulSegIdCount = pdrgpiSegIds->UlLength();
-			pmotion->outputSegIdx = (INT *) gpdb::GPDBAlloc (ulSegIdCount * sizeof(INT));
-			pmotion->numOutputSegs = ulSegIdCount;
+			GPOS_ASSERT(NULL != output_segids_array && 0 < output_segids_array->Size());
+			ULONG segid_count = output_segids_array->Size();
+			motion->outputSegIdx = (INT *) gpdb::GPDBAlloc (segid_count * sizeof(INT));
+			motion->numOutputSegs = segid_count;
 
-			for(ULONG ul = 0; ul < ulSegIdCount; ul++)
+			for(ULONG ul = 0; ul < segid_count; ul++)
 			{
-				INT iSegId = *((*pdrgpiSegIds)[ul]);
-				pmotion->outputSegIdx[ul] = iSegId;
+				INT segid = *((*output_segids_array)[ul]);
+				motion->outputSegIdx[ul] = segid;
 			}
 
 			break;
 		}
 		case EdxlopPhysicalMotionBroadcast:
 		{
-			pmotion->motionType = MOTIONTYPE_FIXED;
-			pmotion->numOutputSegs = 0;
-			pmotion->outputSegIdx = NULL;
+			motion->motionType = MOTIONTYPE_FIXED;
+			motion->numOutputSegs = 0;
+			motion->outputSegIdx = NULL;
 			break;
 		}
 		case EdxlopPhysicalMotionRoutedDistribute:
 		{
-			pmotion->motionType = MOTIONTYPE_EXPLICIT;
-			pmotion->numOutputSegs = 0;
-			pmotion->outputSegIdx = NULL;
-			ULONG ulSegIdCol = CDXLPhysicalRoutedDistributeMotion::PdxlopConvert(pdxlopMotion)->UlSegmentIdCol();
-			const TargetEntry *pteSortCol = dxltrctxChild.Pte(ulSegIdCol);
-			pmotion->segidColIdx = pteSortCol->resno;
+			motion->motionType = MOTIONTYPE_EXPLICIT;
+			motion->numOutputSegs = 0;
+			motion->outputSegIdx = NULL;
+			ULONG segid_col = CDXLPhysicalRoutedDistributeMotion::Cast(motion_dxlop)->SegmentIdCol();
+			const TargetEntry *te_sort_col = child_context.GetTargetEntry(segid_col);
+			motion->segidColIdx = te_sort_col->resno;
 
 			break;
 			
@@ -2013,14 +2009,14 @@ CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion
 			return NULL;
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pmotion;
+	return (Plan *) motion;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanResultHashFilters
+//		CTranslatorDXLToPlStmt::TranslateDXLRedistributeMotionToResultHashFilters
 //
 //	@doc:
 //		Translate DXL duplicate sensitive redistribute motion node into 
@@ -2028,73 +2024,73 @@ CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanResultHashFilters
+CTranslatorDXLToPlStmt::TranslateDXLRedistributeMotionToResultHashFilters
 	(
-	const CDXLNode *pdxlnMotion,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *motion_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create motion node
-	Result *presult = MakeNode(Result);
+	Result *result = MakeNode(Result);
 
-	Plan *pplan = &(presult->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(result->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalMotion *pdxlopMotion = CDXLPhysicalMotion::PdxlopConvert(pdxlnMotion->Pdxlop());
+	CDXLPhysicalMotion *motion_dxlop = CDXLPhysicalMotion::Cast(motion_dxlnode->GetOperator());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnMotion->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(motion_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	CDXLNode *pdxlnPrL = (*pdxlnMotion)[EdxlrmIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnMotion)[EdxlrmIndexFilter];
-	CDXLNode *pdxlnChild = (*pdxlnMotion)[pdxlopMotion->UlChildIndex()];
+	CDXLNode *project_list_dxlnode = (*motion_dxlnode)[EdxlrmIndexProjList];
+	CDXLNode *filter_dxlnode = (*motion_dxlnode)[EdxlrmIndexFilter];
+	CDXLNode *child_dxlnode = (*motion_dxlnode)[motion_dxlop->GetRelationChildIdx()];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate hash expr list
-	presult->hashFilter = true;
+	result->hashFilter = true;
 
-	if (EdxlopPhysicalMotionRedistribute == pdxlopMotion->Edxlop())
+	if (EdxlopPhysicalMotionRedistribute == motion_dxlop->GetDXLOperator())
 	{
-		CDXLNode *pdxlnHashExprList = (*pdxlnMotion)[EdxlrmIndexHashExprList];
-		const ULONG ulLength = pdxlnHashExprList->UlArity();
-		GPOS_ASSERT(0 < ulLength);
+		CDXLNode *hash_expr_list_dxlnode = (*motion_dxlnode)[EdxlrmIndexHashExprList];
+		const ULONG length = hash_expr_list_dxlnode->Arity();
+		GPOS_ASSERT(0 < length);
 		
-		for (ULONG ul = 0; ul < ulLength; ul++)
+		for (ULONG ul = 0; ul < length; ul++)
 		{
-			CDXLNode *pdxlnHashExpr = (*pdxlnHashExprList)[ul];
-			CDXLNode *pdxlnExpr = (*pdxlnHashExpr)[0];
+			CDXLNode *hash_expr_dxlnode = (*hash_expr_list_dxlnode)[ul];
+			CDXLNode *expr_dxlnode = (*hash_expr_dxlnode)[0];
 			
-			INT iResno = gpos::int_max;
-			if (EdxlopScalarIdent == pdxlnExpr->Pdxlop()->Edxlop())
+			INT resno = gpos::int_max;
+			if (EdxlopScalarIdent == expr_dxlnode->GetOperator()->GetDXLOperator())
 			{
-				ULONG ulColId = CDXLScalarIdent::PdxlopConvert(pdxlnExpr->Pdxlop())->Pdxlcr()->UlID();
-				iResno = pdxltrctxOut->Pte(ulColId)->resno;
+				ULONG colid = CDXLScalarIdent::Cast(expr_dxlnode->GetOperator())->GetDXLColRef()->Id();
+				resno = output_context->GetTargetEntry(colid)->resno;
 			}
 			else
 			{
@@ -2102,345 +2098,345 @@ CTranslatorDXLToPlStmt::PplanResultHashFilters
 				// Rather, it is an expresssion that is evaluated by the hash filter such as CAST(a) or a+b.
 				// We therefore, create a corresponding GPDB scalar expression and add it to the project list
 				// of the hash filter
-				CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+				CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 															(
-															m_pmp,
+															m_mp,
 															NULL, // translate context for the base table
-															pdrgpdxltrctx,
-															pdxltrctxOut,
-															m_pctxdxltoplstmt
+															child_contexts,
+															output_context,
+															m_dxl_to_plstmt_context
 															);
 				
-				Expr *pexpr = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnExpr, &mapcidvarplstmt);
-				GPOS_ASSERT(NULL != pexpr);
+				Expr *expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(expr_dxlnode, &colid_var_mapping);
+				GPOS_ASSERT(NULL != expr);
 
 				// create a target entry for the hash filter
-				CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
-				TargetEntry *pte = gpdb::PteMakeTargetEntry
+				CWStringConst str_unnamed_col(GPOS_WSZ_LIT("?column?"));
+				TargetEntry *target_entry = gpdb::MakeTargetEntry
 											(
-											pexpr, 
-											gpdb::UlListLength(pplan->targetlist) + 1, 
-											CTranslatorUtils::SzFromWsz(strUnnamedCol.Wsz()), 
+											expr,
+											gpdb::ListLength(plan->targetlist) + 1,
+											CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_unnamed_col.GetBuffer()),
 											false /* resjunk */
 											);
-				pplan->targetlist = gpdb::PlAppendElement(pplan->targetlist, pte);
+				plan->targetlist = gpdb::LAppend(plan->targetlist, target_entry);
 
-				iResno = pte->resno;
+				resno = target_entry->resno;
 			}
-			GPOS_ASSERT(gpos::int_max != iResno);
+			GPOS_ASSERT(gpos::int_max != resno);
 			
-			presult->hashList = gpdb::PlAppendInt(presult->hashList, iResno);
+			result->hashList = gpdb::LAppendInt(result->hashList, resno);
 		}
 	}
 	
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) presult;
+	return (Plan *) result;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PaggFromDXLAgg
+//		CTranslatorDXLToPlStmt::TranslateDXLAgg
 //
 //	@doc:
 //		Translate DXL aggregate node into GPDB Agg plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PaggFromDXLAgg
+CTranslatorDXLToPlStmt::TranslateDXLAgg
 	(
-	const CDXLNode *pdxlnAgg,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *agg_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create aggregate plan node
-	Agg *pagg = MakeNode(Agg);
+	Agg *agg = MakeNode(Agg);
 
-	Plan *pplan = &(pagg->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(agg->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalAgg *pdxlopAgg = CDXLPhysicalAgg::PdxlopConvert(pdxlnAgg->Pdxlop());
+	CDXLPhysicalAgg *dxl_phy_agg_dxlop = CDXLPhysicalAgg::Cast(agg_dxlnode->GetOperator());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnAgg->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(agg_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate agg child
-	CDXLNode *pdxlnChild = (*pdxlnAgg)[EdxlaggIndexChild];
+	CDXLNode *child_dxlnode = (*agg_dxlnode)[EdxlaggIndexChild];
 
-	CDXLNode *pdxlnPrL = (*pdxlnAgg)[EdxlaggIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnAgg)[EdxlaggIndexFilter];
+	CDXLNode *project_list_dxlnode = (*agg_dxlnode)[EdxlaggIndexProjList];
+	CDXLNode *filter_dxlnode = (*agg_dxlnode)[EdxlaggIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, true, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, true, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,			// pdxltrctxRight,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,			// pdxltrctxRight,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
 	// translate aggregation strategy
-	switch (pdxlopAgg->Edxlaggstr())
+	switch (dxl_phy_agg_dxlop->GetAggStrategy())
 	{
 		case EdxlaggstrategyPlain:
-			pagg->aggstrategy = AGG_PLAIN;
+			agg->aggstrategy = AGG_PLAIN;
 			break;
 		case EdxlaggstrategySorted:
-			pagg->aggstrategy = AGG_SORTED;
+			agg->aggstrategy = AGG_SORTED;
 			break;
 		case EdxlaggstrategyHashed:
-			pagg->aggstrategy = AGG_HASHED;
+			agg->aggstrategy = AGG_HASHED;
 			break;
 		default:
 			GPOS_ASSERT(!"Invalid aggregation strategy");
 	}
 
-	pagg->streaming = pdxlopAgg->FStreamSafe();
+	agg->streaming = dxl_phy_agg_dxlop->IsStreamSafe();
 
 	// translate grouping cols
-	const DrgPul *pdrpulGroupingCols = pdxlopAgg->PdrgpulGroupingCols();
-	pagg->numCols = pdrpulGroupingCols->UlLength();
-	if (pagg->numCols > 0)
+	const ULongPtrArray *grouping_colid_array = dxl_phy_agg_dxlop->GetGroupingColidArray();
+	agg->numCols = grouping_colid_array->Size();
+	if (agg->numCols > 0)
 	{
-		pagg->grpColIdx = (AttrNumber *) gpdb::GPDBAlloc(pagg->numCols * sizeof(AttrNumber));
-		pagg->grpOperators = (Oid *) gpdb::GPDBAlloc(pagg->numCols * sizeof(Oid));
+		agg->grpColIdx = (AttrNumber *) gpdb::GPDBAlloc(agg->numCols * sizeof(AttrNumber));
+		agg->grpOperators = (Oid *) gpdb::GPDBAlloc(agg->numCols * sizeof(Oid));
 	}
 	else
 	{
-		pagg->grpColIdx = NULL;
-		pagg->grpOperators = NULL;
+		agg->grpColIdx = NULL;
+		agg->grpOperators = NULL;
 	}
 
-	const ULONG ulLen = pdrpulGroupingCols->UlLength();
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	const ULONG length = grouping_colid_array->Size();
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		ULONG ulGroupingColId = *((*pdrpulGroupingCols)[ul]);
-		const TargetEntry *pteGroupingCol = dxltrctxChild.Pte(ulGroupingColId);
-		if (NULL  == pteGroupingCol)
+		ULONG grouping_colid = *((*grouping_colid_array)[ul]);
+		const TargetEntry *target_entry_grouping_col = child_context.GetTargetEntry(grouping_colid);
+		if (NULL  == target_entry_grouping_col)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, ulGroupingColId);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, grouping_colid);
 		}
-		pagg->grpColIdx[ul] = pteGroupingCol->resno;
+		agg->grpColIdx[ul] = target_entry_grouping_col->resno;
 
 		// Also find the equality operators to use for each grouping col.
-		Oid typeId = gpdb::OidExprType((Node *) pteGroupingCol->expr);
-		pagg->grpOperators[ul] = gpdb::OidEqualityOp(typeId);
-		Assert(pagg->grpOperators[ul] != 0);
+		Oid typeId = gpdb::ExprType((Node *) target_entry_grouping_col->expr);
+		agg->grpOperators[ul] = gpdb::GetEqualityOp(typeId);
+		Assert(agg->grpOperators[ul] != 0);
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pagg;
+	return (Plan *) agg;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PwindowFromDXLWindow
+//		CTranslatorDXLToPlStmt::TranslateDXLWindow
 //
 //	@doc:
 //		Translate DXL window node into GPDB window plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PwindowFromDXLWindow
+CTranslatorDXLToPlStmt::TranslateDXLWindow
 	(
-	const CDXLNode *pdxlnWindow,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *window_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create a WindowAgg plan node
-	WindowAgg *pwindow = MakeNode(WindowAgg);
+	WindowAgg *window = MakeNode(WindowAgg);
 
-	Plan *pplan = &(pwindow->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(window->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalWindow *pdxlopWindow = CDXLPhysicalWindow::PdxlopConvert(pdxlnWindow->Pdxlop());
+	CDXLPhysicalWindow *window_dxlop = CDXLPhysicalWindow::Cast(window_dxlnode->GetOperator());
 
 	// translate the operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnWindow->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(window_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate children
-	CDXLNode *pdxlnChild = (*pdxlnWindow)[EdxlwindowIndexChild];
-	CDXLNode *pdxlnPrL = (*pdxlnWindow)[EdxlwindowIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnWindow)[EdxlwindowIndexFilter];
+	CDXLNode *child_dxlnode = (*window_dxlnode)[EdxlwindowIndexChild];
+	CDXLNode *project_list_dxlnode = (*window_dxlnode)[EdxlwindowIndexProjList];
+	CDXLNode *filter_dxlnode = (*window_dxlnode)[EdxlwindowIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, true, pdxltrctxOut->PhmColParam());
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	CDXLTranslateContext child_context(m_mp, true, output_context->GetColIdToParamIdMap());
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,			// pdxltrctxRight,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,			// pdxltrctxRight,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	ListCell *plc;
+	ListCell *lc;
 
-	foreach (plc, pplan->targetlist)
+	foreach (lc, plan->targetlist)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plc);
-		if (IsA(pte->expr, WindowFunc))
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		if (IsA(target_entry->expr, WindowFunc))
 		{
-			WindowFunc *pwinfunc = (WindowFunc *) pte->expr;
-			pwindow->winref = pwinfunc->winref;
+			WindowFunc *window_func = (WindowFunc *) target_entry->expr;
+			window->winref = window_func->winref;
 			break;
 		}
 	}
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
 	// translate partition columns
-	const DrgPul *pdrpulPartCols = pdxlopWindow->PrgpulPartCols();
-	pwindow->partNumCols = pdrpulPartCols->UlLength();
-	pwindow->partColIdx = NULL;
-	pwindow->partOperators = NULL;
+	const ULongPtrArray *part_by_cols_array = window_dxlop->GetPartByColsArray();
+	window->partNumCols = part_by_cols_array->Size();
+	window->partColIdx = NULL;
+	window->partOperators = NULL;
 
-	if (pwindow->partNumCols > 0)
+	if (window->partNumCols > 0)
 	{
-		pwindow->partColIdx = (AttrNumber *) gpdb::GPDBAlloc(pwindow->partNumCols * sizeof(AttrNumber));
-		pwindow->partOperators = (Oid *) gpdb::GPDBAlloc(pwindow->partNumCols * sizeof(Oid));
+		window->partColIdx = (AttrNumber *) gpdb::GPDBAlloc(window->partNumCols * sizeof(AttrNumber));
+		window->partOperators = (Oid *) gpdb::GPDBAlloc(window->partNumCols * sizeof(Oid));
 	}
 
-	const ULONG ulPartCols = pdrpulPartCols->UlLength();
-	for (ULONG ul = 0; ul < ulPartCols; ul++)
+	const ULONG num_of_part_cols = part_by_cols_array->Size();
+	for (ULONG ul = 0; ul < num_of_part_cols; ul++)
 	{
-		ULONG ulPartColId = *((*pdrpulPartCols)[ul]);
-		const TargetEntry *ptePartCol = dxltrctxChild.Pte(ulPartColId);
-		if (NULL  == ptePartCol)
+		ULONG part_colid = *((*part_by_cols_array)[ul]);
+		const TargetEntry *te_part_colid = child_context.GetTargetEntry(part_colid);
+		if (NULL  == te_part_colid)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, ulPartColId);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, part_colid);
 		}
-		pwindow->partColIdx[ul] = ptePartCol->resno;
+		window->partColIdx[ul] = te_part_colid->resno;
 
 		// Also find the equality operators to use for each partitioning key col.
-		Oid typeId = gpdb::OidExprType((Node *) ptePartCol->expr);
-		pwindow->partOperators[ul] = gpdb::OidEqualityOp(typeId);
-		Assert(pwindow->partOperators[ul] != 0);
+		Oid type_id = gpdb::ExprType((Node *) te_part_colid->expr);
+		window->partOperators[ul] = gpdb::GetEqualityOp(type_id);
+		Assert(window->partOperators[ul] != 0);
 	}
 
 	// translate window keys
-	const ULONG ulSize = pdxlopWindow->UlWindowKeys();
-	if (ulSize > 1)
+	const ULONG size = window_dxlop->WindowKeysCount();
+	if (size > 1)
 	  {
 	    GpdbEreport(ERRCODE_INTERNAL_ERROR,
 			ERROR,
 			"ORCA produced a plan with more than one window key",
 			NULL);
 	  }
-	GPOS_ASSERT(ulSize <= 1 && "cannot have more than one window key");
+	GPOS_ASSERT(size <= 1 && "cannot have more than one window key");
 
-	if (ulSize == 1)
+	if (size == 1)
 	{
 		// translate the sorting columns used in the window key
-		const CDXLWindowKey *pdxlwindowkey = pdxlopWindow->PdxlWindowKey(0);
-		const CDXLWindowFrame *pdxlwf = pdxlwindowkey->Pdxlwf();
-		const CDXLNode *pdxlnSortColList = pdxlwindowkey->PdxlnSortColList();
+		const CDXLWindowKey *window_key = window_dxlop->GetDXLWindowKeyAt(0);
+		const CDXLWindowFrame *window_frame = window_key->GetWindowFrame();
+		const CDXLNode *sort_col_list_dxlnode = window_key->GetSortColListDXL();
 
-		const ULONG ulNumCols = pdxlnSortColList->UlArity();
+		const ULONG num_of_cols = sort_col_list_dxlnode->Arity();
 
-		pwindow->ordNumCols = ulNumCols;
-		pwindow->ordColIdx = (AttrNumber *) gpdb::GPDBAlloc(ulNumCols * sizeof(AttrNumber));
-		pwindow->ordOperators = (Oid *) gpdb::GPDBAlloc(ulNumCols * sizeof(Oid));
-		bool *pNullsFirst = (bool *) gpdb::GPDBAlloc(ulNumCols * sizeof(bool));
-		TranslateSortCols(pdxlnSortColList, &dxltrctxChild, pwindow->ordColIdx, pwindow->ordOperators, NULL, pNullsFirst);
+		window->ordNumCols = num_of_cols;
+		window->ordColIdx = (AttrNumber *) gpdb::GPDBAlloc(num_of_cols * sizeof(AttrNumber));
+		window->ordOperators = (Oid *) gpdb::GPDBAlloc(num_of_cols * sizeof(Oid));
+		bool *is_nulls_first = (bool *) gpdb::GPDBAlloc(num_of_cols * sizeof(bool));
+		TranslateSortCols(sort_col_list_dxlnode, &child_context, window->ordColIdx, window->ordOperators, NULL, is_nulls_first);
 
 		// The firstOrder* fields are separate from just picking the first of ordCol*,
 		// because the Postgres planner might omit columns that are redundant with the
 		// PARTITION BY from ordCol*. But ORCA doesn't do that, so we can just copy
 		// the first entry of ordColIdx/ordOperators into firstOrder* fields.
-		if (ulNumCols > 0)
+		if (num_of_cols > 0)
 		{
-			pwindow->firstOrderCol = pwindow->ordColIdx[0];
-			pwindow->firstOrderCmpOperator = pwindow->ordOperators[0];
-			pwindow->firstOrderNullsFirst = pNullsFirst[0];
+			window->firstOrderCol = window->ordColIdx[0];
+			window->firstOrderCmpOperator = window->ordOperators[0];
+			window->firstOrderNullsFirst = is_nulls_first[0];
 		}
-		gpdb::GPDBFree(pNullsFirst);
+		gpdb::GPDBFree(is_nulls_first);
 
 		// The ordOperators array is actually supposed to contain equality operators,
 		// not ordering operators (< or >). So look up the corresponding equality
 		// operator for each ordering operator.
-		for (ULONG i = 0; i < ulNumCols; i++)
+		for (ULONG i = 0; i < num_of_cols; i++)
 		{
-			pwindow->ordOperators[i] = gpdb::OidEqualityOpForOrderingOp(pwindow->ordOperators[i], NULL);
+			window->ordOperators[i] = gpdb::GetEqualityOpForOrderingOp(window->ordOperators[i], NULL);
 		}
 
 		// translate the window frame specified in the window key
-		if (NULL != pdxlwindowkey->Pdxlwf())
+		if (NULL != window_key->GetWindowFrame())
 		{
-			pwindow->frameOptions = FRAMEOPTION_NONDEFAULT;
-			if (EdxlfsRow == pdxlwf->Edxlfs())
+			window->frameOptions = FRAMEOPTION_NONDEFAULT;
+			if (EdxlfsRow == window_frame->ParseDXLFrameSpec())
 			{
-				pwindow->frameOptions |= FRAMEOPTION_ROWS;
+				window->frameOptions |= FRAMEOPTION_ROWS;
 			}
 			else
 			{
-				pwindow->frameOptions |= FRAMEOPTION_RANGE;
+				window->frameOptions |= FRAMEOPTION_RANGE;
 			}
 
-			if (pdxlwf->Edxlfes() != EdxlfesNulls)
+			if (window_frame->ParseFrameExclusionStrategy() != EdxlfesNulls)
 			{
 				GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 					   GPOS_WSZ_LIT("EXCLUDE clause in window frame"));
 			}
 
 			// translate the CDXLNodes representing the leading and trailing edge
-			DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-			pdrgpdxltrctx->Append(&dxltrctxChild);
+			CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+			child_contexts->Append(&child_context);
 
-			CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+			CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 			(
-			 m_pmp,
+			 m_mp,
 			 NULL,
-			 pdrgpdxltrctx,
-			 pdxltrctxOut,
-			 m_pctxdxltoplstmt
+			 child_contexts,
+			 output_context,
+			 m_dxl_to_plstmt_context
 			);
 
 			// Translate lead boundary
@@ -2449,816 +2445,816 @@ CTranslatorDXLToPlStmt::PwindowFromDXLWindow
 			// versions beoynd this point. Executor will make that decision
 			// without our help.
 			//
-			CDXLNode *pdxlnLead = pdxlwf->PdxlnLeading();
-			EdxlFrameBoundary leadBoundary = CDXLScalarWindowFrameEdge::PdxlopConvert(pdxlnLead->Pdxlop())->Edxlfb();
-			if (leadBoundary == EdxlfbUnboundedPreceding)
-				pwindow->frameOptions |= FRAMEOPTION_END_UNBOUNDED_PRECEDING;
-			if (leadBoundary == EdxlfbBoundedPreceding)
-				pwindow->frameOptions |= FRAMEOPTION_END_VALUE_PRECEDING;
-			if (leadBoundary == EdxlfbCurrentRow)
-				pwindow->frameOptions |= FRAMEOPTION_END_CURRENT_ROW;
-			if (leadBoundary == EdxlfbBoundedFollowing)
-				pwindow->frameOptions |= FRAMEOPTION_END_VALUE_FOLLOWING;
-			if (leadBoundary == EdxlfbUnboundedFollowing)
-				pwindow->frameOptions |= FRAMEOPTION_END_UNBOUNDED_FOLLOWING;
-			if (leadBoundary == EdxlfbDelayedBoundedPreceding)
-				pwindow->frameOptions |= FRAMEOPTION_END_VALUE_PRECEDING;
-			if (leadBoundary == EdxlfbDelayedBoundedFollowing)
-				pwindow->frameOptions |= FRAMEOPTION_END_VALUE_FOLLOWING;
-			if (0 != pdxlnLead->UlArity())
+			CDXLNode *win_frame_leading_dxlnode = window_frame->PdxlnLeading();
+			EdxlFrameBoundary lead_boundary_type = CDXLScalarWindowFrameEdge::Cast(win_frame_leading_dxlnode->GetOperator())->ParseDXLFrameBoundary();
+			if (lead_boundary_type == EdxlfbUnboundedPreceding)
+				window->frameOptions |= FRAMEOPTION_END_UNBOUNDED_PRECEDING;
+			if (lead_boundary_type == EdxlfbBoundedPreceding)
+				window->frameOptions |= FRAMEOPTION_END_VALUE_PRECEDING;
+			if (lead_boundary_type == EdxlfbCurrentRow)
+				window->frameOptions |= FRAMEOPTION_END_CURRENT_ROW;
+			if (lead_boundary_type == EdxlfbBoundedFollowing)
+				window->frameOptions |= FRAMEOPTION_END_VALUE_FOLLOWING;
+			if (lead_boundary_type == EdxlfbUnboundedFollowing)
+				window->frameOptions |= FRAMEOPTION_END_UNBOUNDED_FOLLOWING;
+			if (lead_boundary_type == EdxlfbDelayedBoundedPreceding)
+				window->frameOptions |= FRAMEOPTION_END_VALUE_PRECEDING;
+			if (lead_boundary_type == EdxlfbDelayedBoundedFollowing)
+				window->frameOptions |= FRAMEOPTION_END_VALUE_FOLLOWING;
+			if (0 != win_frame_leading_dxlnode->Arity())
 			{
-				pwindow->endOffset = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnLead)[0], &mapcidvarplstmt);
+				window->endOffset = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar((*win_frame_leading_dxlnode)[0], &colid_var_mapping);
 			}
 
 			// And the same for the trail boundary
-			CDXLNode *pdxlnTrail = pdxlwf->PdxlnTrailing();
-			EdxlFrameBoundary trailBoundary = CDXLScalarWindowFrameEdge::PdxlopConvert(pdxlnTrail->Pdxlop())->Edxlfb();
-			if (trailBoundary == EdxlfbUnboundedPreceding)
-				pwindow->frameOptions |= FRAMEOPTION_START_UNBOUNDED_PRECEDING;
-			if (trailBoundary == EdxlfbBoundedPreceding)
-				pwindow->frameOptions |= FRAMEOPTION_START_VALUE_PRECEDING;
-			if (trailBoundary == EdxlfbCurrentRow)
-				pwindow->frameOptions |= FRAMEOPTION_START_CURRENT_ROW;
-			if (trailBoundary == EdxlfbBoundedFollowing)
-				pwindow->frameOptions |= FRAMEOPTION_START_VALUE_FOLLOWING;
-			if (trailBoundary == EdxlfbUnboundedFollowing)
-				pwindow->frameOptions |= FRAMEOPTION_START_UNBOUNDED_FOLLOWING;
-			if (trailBoundary == EdxlfbDelayedBoundedPreceding)
-				pwindow->frameOptions |= FRAMEOPTION_START_VALUE_PRECEDING;
-			if (trailBoundary == EdxlfbDelayedBoundedFollowing)
-				pwindow->frameOptions |= FRAMEOPTION_START_VALUE_FOLLOWING;
-			if (0 != pdxlnTrail->UlArity())
+			CDXLNode *win_frame_trailing_dxlnode = window_frame->PdxlnTrailing();
+			EdxlFrameBoundary trail_boundary_type = CDXLScalarWindowFrameEdge::Cast(win_frame_trailing_dxlnode->GetOperator())->ParseDXLFrameBoundary();
+			if (trail_boundary_type == EdxlfbUnboundedPreceding)
+				window->frameOptions |= FRAMEOPTION_START_UNBOUNDED_PRECEDING;
+			if (trail_boundary_type == EdxlfbBoundedPreceding)
+				window->frameOptions |= FRAMEOPTION_START_VALUE_PRECEDING;
+			if (trail_boundary_type == EdxlfbCurrentRow)
+				window->frameOptions |= FRAMEOPTION_START_CURRENT_ROW;
+			if (trail_boundary_type == EdxlfbBoundedFollowing)
+				window->frameOptions |= FRAMEOPTION_START_VALUE_FOLLOWING;
+			if (trail_boundary_type == EdxlfbUnboundedFollowing)
+				window->frameOptions |= FRAMEOPTION_START_UNBOUNDED_FOLLOWING;
+			if (trail_boundary_type == EdxlfbDelayedBoundedPreceding)
+				window->frameOptions |= FRAMEOPTION_START_VALUE_PRECEDING;
+			if (trail_boundary_type == EdxlfbDelayedBoundedFollowing)
+				window->frameOptions |= FRAMEOPTION_START_VALUE_FOLLOWING;
+			if (0 != win_frame_trailing_dxlnode->Arity())
 			{
-				pwindow->startOffset = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnTrail)[0], &mapcidvarplstmt);
+				window->startOffset = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar((*win_frame_trailing_dxlnode)[0], &colid_var_mapping);
 			}
 
 			// cleanup
-			pdrgpdxltrctx->Release();
+			child_contexts->Release();
 		}
 		else
-			pwindow->frameOptions = FRAMEOPTION_DEFAULTS;
+			window->frameOptions = FRAMEOPTION_DEFAULTS;
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pwindow;
+	return (Plan *) window;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PsortFromDXLSort
+//		CTranslatorDXLToPlStmt::TranslateDXLSort
 //
 //	@doc:
 //		Translate DXL sort node into GPDB Sort plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PsortFromDXLSort
+CTranslatorDXLToPlStmt::TranslateDXLSort
 	(
-	const CDXLNode *pdxlnSort,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *sort_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create sort plan node
-	Sort *psort = MakeNode(Sort);
+	Sort *sort = MakeNode(Sort);
 
-	Plan *pplan = &(psort->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(sort->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalSort *pdxlopSort = CDXLPhysicalSort::PdxlopConvert(pdxlnSort->Pdxlop());
+	CDXLPhysicalSort *sort_dxlop = CDXLPhysicalSort::Cast(sort_dxlnode->GetOperator());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnSort->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(sort_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate sort child
-	CDXLNode *pdxlnChild = (*pdxlnSort)[EdxlsortIndexChild];
-	CDXLNode *pdxlnPrL = (*pdxlnSort)[EdxlsortIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnSort)[EdxlsortIndexFilter];
+	CDXLNode *child_dxlnode = (*sort_dxlnode)[EdxlsortIndexChild];
+	CDXLNode *project_list_dxlnode = (*sort_dxlnode)[EdxlsortIndexProjList];
+	CDXLNode *filter_dxlnode = (*sort_dxlnode)[EdxlsortIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
 	// set sorting info
-	psort->noduplicates = pdxlopSort->FDiscardDuplicates();
+	sort->noduplicates = sort_dxlop->FDiscardDuplicates();
 
 	// translate sorting columns
 
-	const CDXLNode *pdxlnSortColList = (*pdxlnSort)[EdxlsortIndexSortColList];
+	const CDXLNode *sort_col_list_dxl = (*sort_dxlnode)[EdxlsortIndexSortColList];
 
-	const ULONG ulNumCols = pdxlnSortColList->UlArity();
-	psort->numCols = ulNumCols;
-	psort->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(ulNumCols * sizeof(AttrNumber));
-	psort->sortOperators = (Oid *) gpdb::GPDBAlloc(ulNumCols * sizeof(Oid));
-	psort->collations = (Oid *) gpdb::GPDBAlloc(ulNumCols * sizeof(Oid));
-	psort->nullsFirst = (bool *) gpdb::GPDBAlloc(ulNumCols * sizeof(bool));
+	const ULONG num_of_cols = sort_col_list_dxl->Arity();
+	sort->numCols = num_of_cols;
+	sort->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(num_of_cols * sizeof(AttrNumber));
+	sort->sortOperators = (Oid *) gpdb::GPDBAlloc(num_of_cols * sizeof(Oid));
+	sort->collations = (Oid *) gpdb::GPDBAlloc(num_of_cols * sizeof(Oid));
+	sort->nullsFirst = (bool *) gpdb::GPDBAlloc(num_of_cols * sizeof(bool));
 
-	TranslateSortCols(pdxlnSortColList, &dxltrctxChild, psort->sortColIdx, psort->sortOperators, psort->collations, psort->nullsFirst);
+	TranslateSortCols(sort_col_list_dxl, &child_context, sort->sortColIdx, sort->sortOperators, sort->collations, sort->nullsFirst);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) psort;
+	return (Plan *) sort;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PsubqscanFromDXLSubqScan
+//		CTranslatorDXLToPlStmt::TranslateDXLSubQueryScan
 //
 //	@doc:
 //		Translate DXL subquery scan node into GPDB SubqueryScan plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PsubqscanFromDXLSubqScan
+CTranslatorDXLToPlStmt::TranslateDXLSubQueryScan
 	(
-	const CDXLNode *pdxlnSubqScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *subquery_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create sort plan node
-	SubqueryScan *psubqscan = MakeNode(SubqueryScan);
+	SubqueryScan *subquery_scan = MakeNode(SubqueryScan);
 
-	Plan *pplan = &(psubqscan->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(subquery_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalSubqueryScan *pdxlopSubqscan = CDXLPhysicalSubqueryScan::PdxlopConvert(pdxlnSubqScan->Pdxlop());
+	CDXLPhysicalSubqueryScan *subquery_scan_dxlop = CDXLPhysicalSubqueryScan::Cast(subquery_scan_dxlnode->GetOperator());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnSubqScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(subquery_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate subplan
-	CDXLNode *pdxlnChild = (*pdxlnSubqScan)[EdxlsubqscanIndexChild];
-	CDXLNode *pdxlnPrL = (*pdxlnSubqScan)[EdxlsubqscanIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnSubqScan)[EdxlsubqscanIndexFilter];
+	CDXLNode *child_dxlnode = (*subquery_scan_dxlnode)[EdxlsubqscanIndexChild];
+	CDXLNode *project_list_dxlnode = (*subquery_scan_dxlnode)[EdxlsubqscanIndexProjList];
+	CDXLNode *filter_dxlnode = (*subquery_scan_dxlnode)[EdxlsubqscanIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
 	// create an rtable entry for the subquery scan
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
-	prte->rtekind = RTE_SUBQUERY;
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
+	rte->rtekind = RTE_SUBQUERY;
 
-	Alias *palias = MakeNode(Alias);
-	palias->colnames = NIL;
+	Alias *alias = MakeNode(Alias);
+	alias->colnames = NIL;
 
 	// get table alias
-	palias->aliasname = CTranslatorUtils::SzFromWsz(pdxlopSubqscan->Pmdname()->Pstr()->Wsz());
+	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(subquery_scan_dxlop->MdName()->GetMDName()->GetBuffer());
 
 	// get column names from child project list
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
-	(psubqscan->scan).scanrelid = iRel;
-	dxltrctxbt.SetIdx(iRel);
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
+	(subquery_scan->scan).scanrelid = index;
+	base_table_context.SetRelIndex(index);
 
-	ListCell *plcTE = NULL;
+	ListCell *lc_tgtentry = NULL;
 
-	CDXLNode *pdxlnChildProjList = (*pdxlnChild)[0];
+	CDXLNode *child_proj_list_dxlnode = (*child_dxlnode)[0];
 
 	ULONG ul = 0;
 
-	ForEach (plcTE, pplanChild->targetlist)
+	ForEach (lc_tgtentry, child_plan->targetlist)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc_tgtentry);
 
 		// non-system attribute
-		CHAR *szColName = PStrDup(pte->resname);
-		Value *pvalColName = gpdb::PvalMakeString(szColName);
-		palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalColName);
+		CHAR *col_name_char_array = PStrDup(target_entry->resname);
+		Value *val_colname = gpdb::MakeStringValue(col_name_char_array);
+		alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
 
 		// get corresponding child project element
-		CDXLScalarProjElem *pdxlopPrel = CDXLScalarProjElem::PdxlopConvert((*pdxlnChildProjList)[ul]->Pdxlop());
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast((*child_proj_list_dxlnode)[ul]->GetOperator());
 
 		// save mapping col id -> index in translate context
-		(void) dxltrctxbt.FInsertMapping(pdxlopPrel->UlId(), pte->resno);
+		(void) base_table_context.InsertMapping(sc_proj_elem_dxlop->Id(), target_entry->resno);
 		ul++;
 	}
 
-	prte->eref = palias;
+	rte->eref = alias;
 
 	// add range table entry for the subquery to the list
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
-		&dxltrctxbt,		// translate context for the base table
+		project_list_dxlnode,
+		filter_dxlnode,
+		&base_table_context,		// translate context for the base table
 		NULL,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	psubqscan->subplan = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	subquery_scan->subplan = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
-	SetParamIds(pplan);
-	return (Plan *) psubqscan;
+	SetParamIds(plan);
+	return (Plan *) subquery_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PresultFromDXLResult
+//		CTranslatorDXLToPlStmt::TranslateDXLResult
 //
 //	@doc:
 //		Translate DXL result node into GPDB result plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PresultFromDXLResult
+CTranslatorDXLToPlStmt::TranslateDXLResult
 	(
-	const CDXLNode *pdxlnResult,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *result_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create result plan node
-	Result *presult = MakeNode(Result);
+	Result *result = MakeNode(Result);
 
-	Plan *pplan = &(presult->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(result->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnResult->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(result_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	pplan->nMotionNodes = 0;
+	plan->nMotionNodes = 0;
 
-	CDXLNode *pdxlnChild = NULL;
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLNode *child_dxlnode = NULL;
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	if (pdxlnResult->UlArity() - 1 == EdxlresultIndexChild)
+	if (result_dxlnode->Arity() - 1 == EdxlresultIndexChild)
 	{
 		// translate child plan
-		pdxlnChild = (*pdxlnResult)[EdxlresultIndexChild];
+		child_dxlnode = (*result_dxlnode)[EdxlresultIndexChild];
 
-		Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+		Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-		GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+		GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-		presult->plan.lefttree = pplanChild;
+		result->plan.lefttree = child_plan;
 
-		pplan->nMotionNodes = pplanChild->nMotionNodes;
+		plan->nMotionNodes = child_plan->nMotionNodes;
 	}
 
-	CDXLNode *pdxlnPrL = (*pdxlnResult)[EdxlresultIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnResult)[EdxlresultIndexFilter];
-	CDXLNode *pdxlnOneTimeFilter = (*pdxlnResult)[EdxlresultIndexOneTimeFilter];
+	CDXLNode *project_list_dxlnode = (*result_dxlnode)[EdxlresultIndexProjList];
+	CDXLNode *filter_dxlnode = (*result_dxlnode)[EdxlresultIndexFilter];
+	CDXLNode *one_time_filter_dxlnode = (*result_dxlnode)[EdxlresultIndexOneTimeFilter];
 
-	List *plQuals = NULL;
+	List *quals_list = NULL;
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,		// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&plQuals,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&quals_list,
+		output_context
 		);
 
 	// translate one time filter
-	List *plOneTimeQuals = PlQualFromFilter
+	List *one_time_quals_list = TranslateDXLFilterToQual
 							(
-							pdxlnOneTimeFilter,
+							one_time_filter_dxlnode,
 							NULL,			// base table translation context
-							pdrgpdxltrctx,
-							pdxltrctxOut
+							child_contexts,
+							output_context
 							);
 
-	pplan->qual = plQuals;
+	plan->qual = quals_list;
 
-	presult->resconstantqual = (Node *) plOneTimeQuals;
+	result->resconstantqual = (Node *) one_time_quals_list;
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) presult;
+	return (Plan *) result;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanPartitionSelector
+//		CTranslatorDXLToPlStmt::TranslateDXLPartSelector
 //
 //	@doc:
 //		Translate DXL PartitionSelector into a GPDB PartitionSelector node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanPartitionSelector
+CTranslatorDXLToPlStmt::TranslateDXLPartSelector
 	(
-	const CDXLNode *pdxlnPartitionSelector,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *partition_selector_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	PartitionSelector *ppartsel = MakeNode(PartitionSelector);
+	PartitionSelector *partition_selector = MakeNode(PartitionSelector);
 
-	Plan *pplan = &(ppartsel->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(partition_selector->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalPartitionSelector *pdxlopPartSel = CDXLPhysicalPartitionSelector::PdxlopConvert(pdxlnPartitionSelector->Pdxlop());
-	const ULONG ulLevels = pdxlopPartSel->UlLevels();
-	ppartsel->nLevels = ulLevels;
-	ppartsel->scanId = pdxlopPartSel->UlScanId();
-	ppartsel->relid = CMDIdGPDB::PmdidConvert(pdxlopPartSel->PmdidRel())->OidObjectId();
-	ppartsel->selectorId = m_ulPartitionSelectorCounter++;
+	CDXLPhysicalPartitionSelector *partition_selector_dxlop = CDXLPhysicalPartitionSelector::Cast(partition_selector_dxlnode->GetOperator());
+	const ULONG num_of_levels = partition_selector_dxlop->GetPartitioningLevel();
+	partition_selector->nLevels = num_of_levels;
+	partition_selector->scanId = partition_selector_dxlop->ScanId();
+	partition_selector->relid = CMDIdGPDB::CastMdid(partition_selector_dxlop->GetRelMdId())->Oid();
+	partition_selector->selectorId = m_partition_selector_counter++;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnPartitionSelector->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(partition_selector_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	pplan->nMotionNodes = 0;
+	plan->nMotionNodes = 0;
 
-	CDXLNode *pdxlnChild = NULL;
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
+	CDXLNode *child_dxlnode = NULL;
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	BOOL fHasChild = (EdxlpsIndexChild == pdxlnPartitionSelector->UlArity() - 1);
-	if (fHasChild)
+	BOOL has_childs = (EdxlpsIndexChild == partition_selector_dxlnode->Arity() - 1);
+	if (has_childs)
 	{
 		// translate child plan
-		pdxlnChild = (*pdxlnPartitionSelector)[EdxlpsIndexChild];
+		child_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexChild];
 
-		Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
-		GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+		Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
+		GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-		ppartsel->plan.lefttree = pplanChild;
-		pplan->nMotionNodes = pplanChild->nMotionNodes;
+		partition_selector->plan.lefttree = child_plan;
+		plan->nMotionNodes = child_plan->nMotionNodes;
 	}
 
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	child_contexts->Append(&child_context);
 
-	CDXLNode *pdxlnPrL = (*pdxlnPartitionSelector)[EdxlpsIndexProjList];
-	CDXLNode *pdxlnEqFilters = (*pdxlnPartitionSelector)[EdxlpsIndexEqFilters];
-	CDXLNode *pdxlnFilters = (*pdxlnPartitionSelector)[EdxlpsIndexFilters];
-	CDXLNode *pdxlnResidualFilter = (*pdxlnPartitionSelector)[EdxlpsIndexResidualFilter];
-	CDXLNode *pdxlnPropExpr = (*pdxlnPartitionSelector)[EdxlpsIndexPropExpr];
+	CDXLNode *project_list_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexProjList];
+	CDXLNode *eq_filters_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexEqFilters];
+	CDXLNode *filters_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexFilters];
+	CDXLNode *residual_filter_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexResidualFilter];
+	CDXLNode *proj_expr_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexPropExpr];
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList(pdxlnPrL, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut);
+	plan->targetlist = TranslateDXLProjList(project_list_dxlnode, NULL /*base_table_context*/, child_contexts, output_context);
 
 	// translate filter lists
-	GPOS_ASSERT(pdxlnEqFilters->UlArity() == ulLevels);
-	ppartsel->levelEqExpressions = PlFilterList(pdxlnEqFilters, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut);
+	GPOS_ASSERT(eq_filters_dxlnode->Arity() == num_of_levels);
+	partition_selector->levelEqExpressions = TranslateDXLFilterList(eq_filters_dxlnode, NULL /*base_table_context*/, child_contexts, output_context);
 
-	GPOS_ASSERT(pdxlnFilters->UlArity() == ulLevels);
-	ppartsel->levelExpressions = PlFilterList(pdxlnFilters, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut);
+	GPOS_ASSERT(filters_dxlnode->Arity() == num_of_levels);
+	partition_selector->levelExpressions = TranslateDXLFilterList(filters_dxlnode, NULL /*base_table_context*/, child_contexts, output_context);
 
 	//translate residual filter
-	CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt(m_pmp, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
-	if (!m_pdxlsctranslator->FConstTrue(pdxlnResidualFilter, m_pmda))
+	CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt(m_mp, NULL /*base_table_context*/, child_contexts, output_context, m_dxl_to_plstmt_context);
+	if (!m_translator_dxl_to_scalar->HasConstTrue(residual_filter_dxlnode, m_md_accessor))
 	{
-		ppartsel->residualPredicate = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnResidualFilter, &mapcidvarplstmt);
+		partition_selector->residualPredicate = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar(residual_filter_dxlnode, &colid_var_mapping);
 	}
 
 	//translate propagation expression
-	if (!m_pdxlsctranslator->FConstNull(pdxlnPropExpr))
+	if (!m_translator_dxl_to_scalar->HasConstNull(proj_expr_dxlnode))
 	{
-		ppartsel->propagationExpression = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnPropExpr, &mapcidvarplstmt);
+		partition_selector->propagationExpression = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar(proj_expr_dxlnode, &colid_var_mapping);
 	}
 
 	// no need to translate printable filter - since it is not needed by the executor
 
-	ppartsel->staticPartOids = NIL;
-	ppartsel->staticScanIds = NIL;
-	ppartsel->staticSelection = !fHasChild;
+	partition_selector->staticPartOids = NIL;
+	partition_selector->staticScanIds = NIL;
+	partition_selector->staticSelection = !has_childs;
 
-	if (ppartsel->staticSelection)
+	if (partition_selector->staticSelection)
 	{
-		SelectedParts *sp = gpdb::SpStaticPartitionSelection(ppartsel);
-		ppartsel->staticPartOids = sp->partOids;
-		ppartsel->staticScanIds = sp->scanIds;
+		SelectedParts *sp = gpdb::RunStaticPartitionSelection(partition_selector);
+		partition_selector->staticPartOids = sp->partOids;
+		partition_selector->staticScanIds = sp->scanIds;
 		gpdb::GPDBFree(sp);
 	}
 	else
 	{
 		// if we cannot do static elimination then add this partitioned table oid
 		// to the planned stmt so we can ship the constraints with the plan
-		m_pctxdxltoplstmt->AddPartitionedTable(ppartsel->relid);
+		m_dxl_to_plstmt_context->AddPartitionedTable(partition_selector->relid);
 	}
 
 	// increment the number of partition selectors for the given scan id
-	m_pctxdxltoplstmt->IncrementPartitionSelectors(ppartsel->scanId);
+	m_dxl_to_plstmt_context->IncrementPartitionSelectors(partition_selector->scanId);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) ppartsel;
+	return (Plan *) partition_selector;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlFilterList
+//		CTranslatorDXLToPlStmt::TranslateDXLFilterList
 //
 //	@doc:
 //		Translate DXL filter list into GPDB filter list
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlFilterList
+CTranslatorDXLToPlStmt::TranslateDXLFilterList
 	(
-	const CDXLNode *pdxlnFilterList,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *filter_list_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	CDXLTranslateContext *output_context
 	)
 {
-	GPOS_ASSERT(EdxlopScalarOpList == pdxlnFilterList->Pdxlop()->Edxlop());
+	GPOS_ASSERT(EdxlopScalarOpList == filter_list_dxlnode->GetOperator()->GetDXLOperator());
 
-	List *plFilters = NIL;
+	List *filters_list = NIL;
 
-	CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt(m_pmp, pdxltrctxbt, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
-	const ULONG ulArity = pdxlnFilterList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt(m_mp, base_table_context, child_contexts, output_context, m_dxl_to_plstmt_context);
+	const ULONG arity = filter_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnChildFilter = (*pdxlnFilterList)[ul];
+		CDXLNode *child_filter_dxlnode = (*filter_list_dxlnode)[ul];
 
-		if (m_pdxlsctranslator->FConstTrue(pdxlnChildFilter, m_pmda))
+		if (m_translator_dxl_to_scalar->HasConstTrue(child_filter_dxlnode, m_md_accessor))
 		{
-			plFilters = gpdb::PlAppendElement(plFilters, NULL /*datum*/);
+			filters_list = gpdb::LAppend(filters_list, NULL /*datum*/);
 			continue;
 		}
 
-		Expr *pexprFilter = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnChildFilter, &mapcidvarplstmt);
-		plFilters = gpdb::PlAppendElement(plFilters, pexprFilter);
+		Expr *filter_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(child_filter_dxlnode, &colid_var_mapping);
+		filters_list = gpdb::LAppend(filters_list, filter_expr);
 	}
 
-	return plFilters;
+	return filters_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PappendFromDXLAppend
+//		CTranslatorDXLToPlStmt::TranslateDXLAppend
 //
 //	@doc:
 //		Translate DXL append node into GPDB Append plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PappendFromDXLAppend
+CTranslatorDXLToPlStmt::TranslateDXLAppend
 	(
-	const CDXLNode *pdxlnAppend,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *append_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create append plan node
-	Append *pappend = MakeNode(Append);
+	Append *append = MakeNode(Append);
 
-	Plan *pplan = &(pappend->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(append->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnAppend->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(append_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	const ULONG ulArity = pdxlnAppend->UlArity();
-	GPOS_ASSERT(EdxlappendIndexFirstChild < ulArity);
-	pplan->nMotionNodes = 0;
-	pappend->appendplans = NIL;
+	const ULONG arity = append_dxlnode->Arity();
+	GPOS_ASSERT(EdxlappendIndexFirstChild < arity);
+	plan->nMotionNodes = 0;
+	append->appendplans = NIL;
 	
 	// translate children
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
-	for (ULONG ul = EdxlappendIndexFirstChild; ul < ulArity; ul++)
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
+	for (ULONG ul = EdxlappendIndexFirstChild; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnChild = (*pdxlnAppend)[ul];
+		CDXLNode *child_dxlnode = (*append_dxlnode)[ul];
 
-		Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+		Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-		GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+		GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-		pappend->appendplans = gpdb::PlAppendElement(pappend->appendplans, pplanChild);
-		pplan->nMotionNodes += pplanChild->nMotionNodes;
+		append->appendplans = gpdb::LAppend(append->appendplans, child_plan);
+		plan->nMotionNodes += child_plan->nMotionNodes;
 	}
 
-	CDXLNode *pdxlnPrL = (*pdxlnAppend)[EdxlappendIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnAppend)[EdxlappendIndexFilter];
+	CDXLNode *project_list_dxlnode = (*append_dxlnode)[EdxlappendIndexProjList];
+	CDXLNode *filter_dxlnode = (*append_dxlnode)[EdxlappendIndexFilter];
 
-	pplan->targetlist = NIL;
-	const ULONG ulLen = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulLen; ++ul)
+	plan->targetlist = NIL;
+	const ULONG length = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < length; ++ul)
 	{
-		CDXLNode *pdxlnPrEl = (*pdxlnPrL)[ul];
-		GPOS_ASSERT(EdxlopScalarProjectElem == pdxlnPrEl->Pdxlop()->Edxlop());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		GPOS_ASSERT(EdxlopScalarProjectElem == proj_elem_dxlnode->GetOperator()->GetDXLOperator());
 
-		CDXLScalarProjElem *pdxlopPrel = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop());
-		GPOS_ASSERT(1 == pdxlnPrEl->UlArity());
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
+		GPOS_ASSERT(1 == proj_elem_dxlnode->Arity());
 
 		// translate proj element expression
-		CDXLNode *pdxlnExpr = (*pdxlnPrEl)[0];
-		CDXLScalarIdent *pdxlopScIdent = CDXLScalarIdent::PdxlopConvert(pdxlnExpr->Pdxlop());
+		CDXLNode *expr_dxlnode = (*proj_elem_dxlnode)[0];
+		CDXLScalarIdent *sc_ident_dxlop = CDXLScalarIdent::Cast(expr_dxlnode->GetOperator());
 
 		Index idxVarno = OUTER_VAR;
 		AttrNumber attno = (AttrNumber) (ul + 1);
 
-		Var *pvar = gpdb::PvarMakeVar
+		Var *var = gpdb::MakeVar
 							(
 							idxVarno,
 							attno,
-							CMDIdGPDB::PmdidConvert(pdxlopScIdent->PmdidType())->OidObjectId(),
-							pdxlopScIdent->ITypeModifier(),
+							CMDIdGPDB::CastMdid(sc_ident_dxlop->MdidType())->Oid(),
+							sc_ident_dxlop->TypeModifier(),
 							0	// varlevelsup
 							);
 
-		TargetEntry *pte = MakeNode(TargetEntry);
-		pte->expr = (Expr *) pvar;
-		pte->resname = CTranslatorUtils::SzFromWsz(pdxlopPrel->PmdnameAlias()->Pstr()->Wsz());
-		pte->resno = attno;
+		TargetEntry *target_entry = MakeNode(TargetEntry);
+		target_entry->expr = (Expr *) var;
+		target_entry->resname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
+		target_entry->resno = attno;
 
 		// add column mapping to output translation context
-		pdxltrctxOut->InsertMapping(pdxlopPrel->UlId(), pte);
+		output_context->InsertMapping(sc_proj_elem_dxlop->Id(), target_entry);
 
-		pplan->targetlist = gpdb::PlAppendElement(pplan->targetlist, pte);
+		plan->targetlist = gpdb::LAppend(plan->targetlist, target_entry);
 	}
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(pdxltrctxOut));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(output_context));
 
 	// translate filter
-	pplan->qual = PlQualFromFilter
+	plan->qual = TranslateDXLFilterToQual
 					(
-					pdxlnFilter,
+					filter_dxlnode,
 					NULL, // translate context for the base table
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					child_contexts,
+					output_context
 					);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pappend;
+	return (Plan *) append;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PmatFromDXLMaterialize
+//		CTranslatorDXLToPlStmt::TranslateDXLMaterialize
 //
 //	@doc:
 //		Translate DXL materialize node into GPDB Material plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PmatFromDXLMaterialize
+CTranslatorDXLToPlStmt::TranslateDXLMaterialize
 	(
-	const CDXLNode *pdxlnMaterialize,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *materialize_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create materialize plan node
-	Material *pmat = MakeNode(Material);
+	Material *materialize = MakeNode(Material);
 
-	Plan *pplan = &(pmat->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(materialize->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalMaterialize *pdxlopMat = CDXLPhysicalMaterialize::PdxlopConvert(pdxlnMaterialize->Pdxlop());
+	CDXLPhysicalMaterialize *materialize_dxlop = CDXLPhysicalMaterialize::Cast(materialize_dxlnode->GetOperator());
 
-	pmat->cdb_strict = pdxlopMat->FEager();
+	materialize->cdb_strict = materialize_dxlop->IsEager();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnMaterialize->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(materialize_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate materialize child
-	CDXLNode *pdxlnChild = (*pdxlnMaterialize)[EdxlmatIndexChild];
+	CDXLNode *child_dxlnode = (*materialize_dxlnode)[EdxlmatIndexChild];
 
-	CDXLNode *pdxlnPrL = (*pdxlnMaterialize)[EdxlmatIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnMaterialize)[EdxlmatIndexFilter];
+	CDXLNode *project_list_dxlnode = (*materialize_dxlnode)[EdxlmatIndexProjList];
+	CDXLNode *filter_dxlnode = (*materialize_dxlnode)[EdxlmatIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
 	// set spooling info
-	if (pdxlopMat->FSpooling())
+	if (materialize_dxlop->IsSpooling())
 	{
-		pmat->share_id = pdxlopMat->UlSpoolId();
-		pmat->driver_slice = pdxlopMat->IExecutorSlice();
-		pmat->nsharer_xslice = pdxlopMat->UlConsumerSlices();
-		pmat->share_type = (0 < pdxlopMat->UlConsumerSlices()) ?
+		materialize->share_id = materialize_dxlop->GetSpoolingOpId();
+		materialize->driver_slice = materialize_dxlop->GetExecutorSlice();
+		materialize->nsharer_xslice = materialize_dxlop->GetNumConsumerSlices();
+		materialize->share_type = (0 < materialize_dxlop->GetNumConsumerSlices()) ?
 							SHARE_MATERIAL_XSLICE : SHARE_MATERIAL;
 	}
 	else
 	{
-		pmat->share_type = SHARE_NOTSHARED;
+		materialize->share_type = SHARE_NOTSHARED;
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pmat;
+	return (Plan *) materialize;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PshscanFromDXLCTEProducer
+//		CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan
 //
 //	@doc:
 //		Translate DXL CTE Producer node into GPDB share input scan plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PshscanFromDXLCTEProducer
+CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan
 	(
-	const CDXLNode *pdxlnCTEProducer,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *cte_producer_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalCTEProducer *pdxlopCTEProducer = CDXLPhysicalCTEProducer::PdxlopConvert(pdxlnCTEProducer->Pdxlop());
-	ULONG ulCTEId = pdxlopCTEProducer->UlId();
+	CDXLPhysicalCTEProducer *cte_prod_dxlop = CDXLPhysicalCTEProducer::Cast(cte_producer_dxlnode->GetOperator());
+	ULONG cte_id = cte_prod_dxlop->Id();
 
 	// create the shared input scan representing the CTE Producer
-	ShareInputScan *pshscanCTEProducer = MakeNode(ShareInputScan);
-	pshscanCTEProducer->share_id = ulCTEId;
-	Plan *pplan = &(pshscanCTEProducer->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	ShareInputScan *shared_input_scan = MakeNode(ShareInputScan);
+	shared_input_scan->share_id = cte_id;
+	Plan *plan = &(shared_input_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// store share scan node for the translation of CTE Consumers
-	m_pctxdxltoplstmt->AddCTEConsumerInfo(ulCTEId, pshscanCTEProducer);
+	m_dxl_to_plstmt_context->AddCTEConsumerInfo(cte_id, shared_input_scan);
 
 	// translate cost of the producer
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnCTEProducer->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(cte_producer_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate child plan
-	CDXLNode *pdxlnPrL = (*pdxlnCTEProducer)[0];
-	CDXLNode *pdxlnChild = (*pdxlnCTEProducer)[1];
+	CDXLNode *project_list_dxlnode = (*cte_producer_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*cte_producer_dxlnode)[1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
-	GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
+	GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 							(
-							pdxlnPrL,
+							project_list_dxlnode,
 							NULL,		// base table translation context
-							pdrgpdxltrctx,
-							pdxltrctxOut
+							child_contexts,
+							output_context
 							);
 
 	// if the child node is neither a sort or materialize node then add a materialize node
-	if (!IsA(pplanChild, Material) && !IsA(pplanChild, Sort))
+	if (!IsA(child_plan, Material) && !IsA(child_plan, Sort))
 	{
-		Material *pmat = MakeNode(Material);
-		pmat->cdb_strict = false; // eager-free
+		Material *materialize = MakeNode(Material);
+		materialize->cdb_strict = false; // eager-free
 
-		Plan *pplanMat = &(pmat->plan);
-		pplanMat->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+		Plan *materialize_plan = &(materialize->plan);
+		materialize_plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 		TranslatePlanCosts
 			(
-			CDXLPhysicalProperties::PdxlpropConvert(pdxlnCTEProducer->Pdxlprop())->Pdxlopcost(),
-			&(pplanMat->startup_cost),
-			&(pplanMat->total_cost),
-			&(pplanMat->plan_rows),
-			&(pplanMat->plan_width)
+			CDXLPhysicalProperties::PdxlpropConvert(cte_producer_dxlnode->GetProperties())->GetDXLOperatorCost(),
+			&(materialize_plan->startup_cost),
+			&(materialize_plan->total_cost),
+			&(materialize_plan->plan_rows),
+			&(materialize_plan->plan_width)
 			);
 
 		// create a target list for the newly added materialize
-		ListCell *plcTe = NULL;
-		pplanMat->targetlist = NIL;
-		ForEach (plcTe, pplan->targetlist)
+		ListCell *lc_target_entry = NULL;
+		materialize_plan->targetlist = NIL;
+		ForEach (lc_target_entry, plan->targetlist)
 		{
-			TargetEntry *pte = (TargetEntry *) lfirst(plcTe);
-			Expr *pexpr = pte->expr;
-			GPOS_ASSERT(IsA(pexpr, Var));
+			TargetEntry *target_entry = (TargetEntry *) lfirst(lc_target_entry);
+			Expr *expr = target_entry->expr;
+			GPOS_ASSERT(IsA(expr, Var));
 
-			Var *pvar = (Var *) pexpr;
-			Var *pvarNew = gpdb::PvarMakeVar(OUTER_VAR, pvar->varattno, pvar->vartype, pvar->vartypmod, 0 /* varlevelsup */);
-			pvarNew->varnoold = pvar->varnoold;
-			pvarNew->varoattno = pvar->varoattno;
+			Var *var = (Var *) expr;
+			Var *var_new = gpdb::MakeVar(OUTER_VAR, var->varattno, var->vartype, var->vartypmod,	0 /* varlevelsup */);
+			var_new->varnoold = var->varnoold;
+			var_new->varoattno = var->varoattno;
 
-			TargetEntry *pteNew = gpdb::PteMakeTargetEntry((Expr *) pvarNew, pvar->varattno, PStrDup(pte->resname), pte->resjunk);
-			pplanMat->targetlist = gpdb::PlAppendElement(pplanMat->targetlist, pteNew);
+			TargetEntry *te_new = gpdb::MakeTargetEntry((Expr *) var_new, var->varattno, PStrDup(target_entry->resname), target_entry->resjunk);
+			materialize_plan->targetlist = gpdb::LAppend(materialize_plan->targetlist, te_new);
 		}
 
-		pplanMat->lefttree = pplanChild;
-		pplanMat->nMotionNodes = pplanChild->nMotionNodes;
+		materialize_plan->lefttree = child_plan;
+		materialize_plan->nMotionNodes = child_plan->nMotionNodes;
 
-		pplanChild = pplanMat;
+		child_plan = materialize_plan;
 	}
 
-	InitializeSpoolingInfo(pplanChild, ulCTEId);
+	InitializeSpoolingInfo(child_plan, cte_id);
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
-	pplan->qual = NIL;
-	SetParamIds(pplan);
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
+	plan->qual = NIL;
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pshscanCTEProducer;
+	return (Plan *) shared_input_scan;
 }
 
 //---------------------------------------------------------------------------
@@ -3273,62 +3269,62 @@ CTranslatorDXLToPlStmt::PshscanFromDXLCTEProducer
 void
 CTranslatorDXLToPlStmt::InitializeSpoolingInfo
 	(
-	Plan *pplan,
-	ULONG ulShareId
+	Plan *plan,
+	ULONG share_id
 	)
 {
-	List *plshscanCTEConsumer = m_pctxdxltoplstmt->PshscanCTEConsumer(ulShareId);
-	GPOS_ASSERT(NULL != plshscanCTEConsumer);
+	List *shared_scan_cte_consumer_list = m_dxl_to_plstmt_context->GetCTEConsumerList(share_id);
+	GPOS_ASSERT(NULL != shared_scan_cte_consumer_list);
 
-	Flow *pflow = PflowCTEConsumer(plshscanCTEConsumer);
+	Flow *flow = GetFlowCTEConsumer(shared_scan_cte_consumer_list);
 
-	const ULONG ulLenSis = gpdb::UlListLength(plshscanCTEConsumer);
+	const ULONG num_of_shared_scan = gpdb::ListLength(shared_scan_cte_consumer_list);
 
 	ShareType share_type = SHARE_NOTSHARED;
 
-	if (IsA(pplan, Material))
+	if (IsA(plan, Material))
 	{
-		Material *pmat = (Material *) pplan;
-		pmat->share_id = ulShareId;
-		pmat->nsharer = ulLenSis;
+		Material *materialize = (Material *) plan;
+		materialize->share_id = share_id;
+		materialize->nsharer = num_of_shared_scan;
 		share_type = SHARE_MATERIAL;
 		// the share_type is later reset to SHARE_MATERIAL_XSLICE (if needed) by the apply_shareinput_xslice
-		pmat->share_type = share_type;
-		GPOS_ASSERT(NULL == (pmat->plan).flow);
-		(pmat->plan).flow = pflow;
+		materialize->share_type = share_type;
+		GPOS_ASSERT(NULL == (materialize->plan).flow);
+		(materialize->plan).flow = flow;
 	}
 	else
 	{
-		GPOS_ASSERT(IsA(pplan, Sort));
-		Sort *psort = (Sort *) pplan;
-		psort->share_id = ulShareId;
-		psort->nsharer = ulLenSis;
+		GPOS_ASSERT(IsA(plan, Sort));
+		Sort *sort = (Sort *) plan;
+		sort->share_id = share_id;
+		sort->nsharer = num_of_shared_scan;
 		share_type = SHARE_SORT;
 		// the share_type is later reset to SHARE_SORT_XSLICE (if needed) the apply_shareinput_xslice
-		psort->share_type = share_type;
-		GPOS_ASSERT(NULL == (psort->plan).flow);
-		(psort->plan).flow = pflow;
+		sort->share_type = share_type;
+		GPOS_ASSERT(NULL == (sort->plan).flow);
+		(sort->plan).flow = flow;
 	}
 
 	GPOS_ASSERT(SHARE_NOTSHARED != share_type);
 
 	// set the share type of the consumer nodes based on the producer
-	ListCell *plcShscanCTEConsumer = NULL;
-	ForEach (plcShscanCTEConsumer, plshscanCTEConsumer)
+	ListCell *lc_sh_scan_cte_consumer = NULL;
+	ForEach (lc_sh_scan_cte_consumer, shared_scan_cte_consumer_list)
 	{
-		ShareInputScan *pshscanConsumer = (ShareInputScan *) lfirst(plcShscanCTEConsumer);
-		pshscanConsumer->share_type = share_type;
-		pshscanConsumer->driver_slice = -1; // default
-		if (NULL == (pshscanConsumer->scan.plan).flow)
+		ShareInputScan *share_input_scan_consumer = (ShareInputScan *) lfirst(lc_sh_scan_cte_consumer);
+		share_input_scan_consumer->share_type = share_type;
+		share_input_scan_consumer->driver_slice = -1; // default
+		if (NULL == (share_input_scan_consumer->scan.plan).flow)
 		{
-			(pshscanConsumer->scan.plan).flow = (Flow *) gpdb::PvCopyObject(pflow);
+			(share_input_scan_consumer->scan.plan).flow = (Flow *) gpdb::CopyObject(flow);
 		}
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PflowCTEConsumer
+//		CTranslatorDXLToPlStmt::GetFlowCTEConsumer
 //
 //	@doc:
 //		Retrieve the flow of the shared input scan of the cte consumers. If
@@ -3336,423 +3332,423 @@ CTranslatorDXLToPlStmt::InitializeSpoolingInfo
 //		same type
 //---------------------------------------------------------------------------
 Flow *
-CTranslatorDXLToPlStmt::PflowCTEConsumer
+CTranslatorDXLToPlStmt::GetFlowCTEConsumer
 	(
-	List *plshscanCTEConsumer
+	List *shared_scan_cte_consumer_list
 	)
 {
-	Flow *pflow = NULL;
+	Flow *flow = NULL;
 
-	ListCell *plcShscanCTEConsumer = NULL;
-	ForEach (plcShscanCTEConsumer, plshscanCTEConsumer)
+	ListCell *lc_sh_scan_cte_consumer = NULL;
+	ForEach (lc_sh_scan_cte_consumer, shared_scan_cte_consumer_list)
 	{
-		ShareInputScan *pshscanConsumer = (ShareInputScan *) lfirst(plcShscanCTEConsumer);
-		Flow *pflowCte = (pshscanConsumer->scan.plan).flow;
-		if (NULL != pflowCte)
+		ShareInputScan *share_input_scan_consumer = (ShareInputScan *) lfirst(lc_sh_scan_cte_consumer);
+		Flow *flow_cte = (share_input_scan_consumer->scan.plan).flow;
+		if (NULL != flow_cte)
 		{
-			if (NULL == pflow)
+			if (NULL == flow)
 			{
-				pflow = (Flow *) gpdb::PvCopyObject(pflowCte);
+				flow = (Flow *) gpdb::CopyObject(flow_cte);
 			}
 			else
 			{
-				GPOS_ASSERT(pflow->flotype == pflowCte->flotype);
+				GPOS_ASSERT(flow->flotype == flow_cte->flotype);
 			}
 		}
 	}
 
-	if (NULL == pflow)
+	if (NULL == flow)
 	{
-		pflow = MakeNode(Flow);
-		pflow->flotype = FLOW_UNDEFINED; // default flow
+		flow = MakeNode(Flow);
+		flow->flotype = FLOW_UNDEFINED; // default flow
 	}
 
-	return pflow;
+	return flow;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PshscanFromDXLCTEConsumer
+//		CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan
 //
 //	@doc:
 //		Translate DXL CTE Consumer node into GPDB share input scan plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PshscanFromDXLCTEConsumer
+CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan
 	(
-	const CDXLNode *pdxlnCTEConsumer,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *cte_consumer_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalCTEConsumer *pdxlopCTEConsumer = CDXLPhysicalCTEConsumer::PdxlopConvert(pdxlnCTEConsumer->Pdxlop());
-	ULONG ulCTEId = pdxlopCTEConsumer->UlId();
+	CDXLPhysicalCTEConsumer *cte_consumer_dxlop = CDXLPhysicalCTEConsumer::Cast(cte_consumer_dxlnode->GetOperator());
+	ULONG cte_id = cte_consumer_dxlop->Id();
 
-	ShareInputScan *pshscanCTEConsumer = MakeNode(ShareInputScan);
-	pshscanCTEConsumer->share_id = ulCTEId;
+	ShareInputScan *share_input_scan_cte_consumer = MakeNode(ShareInputScan);
+	share_input_scan_cte_consumer->share_id = cte_id;
 
-	Plan *pplan = &(pshscanCTEConsumer->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(share_input_scan_cte_consumer->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnCTEConsumer->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(cte_consumer_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 #ifdef GPOS_DEBUG
-	DrgPul *pdrgpulCTEColId = pdxlopCTEConsumer->PdrgpulColIds();
+	ULongPtrArray *output_colids_array = cte_consumer_dxlop->GetOutputColIdsArray();
 #endif
 
 	// generate the target list of the CTE Consumer
-	pplan->targetlist = NIL;
-	CDXLNode *pdxlnPrL = (*pdxlnCTEConsumer)[0];
-	const ULONG ulLenPrL = pdxlnPrL->UlArity();
-	GPOS_ASSERT(ulLenPrL == pdrgpulCTEColId->UlLength());
-	for (ULONG ul = 0; ul < ulLenPrL; ul++)
+	plan->targetlist = NIL;
+	CDXLNode *project_list_dxlnode = (*cte_consumer_dxlnode)[0];
+	const ULONG num_of_proj_list_elem = project_list_dxlnode->Arity();
+	GPOS_ASSERT(num_of_proj_list_elem == output_colids_array->Size());
+	for (ULONG ul = 0; ul < num_of_proj_list_elem; ul++)
 	{
-		CDXLNode *pdxlnPrE = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrE = CDXLScalarProjElem::PdxlopConvert(pdxlnPrE->Pdxlop());
-		ULONG ulColId = pdxlopPrE->UlId();
-		GPOS_ASSERT(ulColId == *(*pdrgpulCTEColId)[ul]);
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
+		ULONG colid = sc_proj_elem_dxlop->Id();
+		GPOS_ASSERT(colid == *(*output_colids_array)[ul]);
 
-		CDXLNode *pdxlnScIdent = (*pdxlnPrE)[0];
-		CDXLScalarIdent *pdxlopScIdent = CDXLScalarIdent::PdxlopConvert(pdxlnScIdent->Pdxlop());
-		OID oidType = CMDIdGPDB::PmdidConvert(pdxlopScIdent->PmdidType())->OidObjectId();
+		CDXLNode *sc_ident_dxlnode = (*proj_elem_dxlnode)[0];
+		CDXLScalarIdent *sc_ident_dxlop = CDXLScalarIdent::Cast(sc_ident_dxlnode->GetOperator());
+		OID oid_type = CMDIdGPDB::CastMdid(sc_ident_dxlop->MdidType())->Oid();
 
-		Var *pvar = gpdb::PvarMakeVar(OUTER_VAR, (AttrNumber) (ul + 1), oidType, pdxlopScIdent->ITypeModifier(),  0	/* varlevelsup */);
+		Var *var = gpdb::MakeVar(OUTER_VAR, (AttrNumber) (ul + 1), oid_type, sc_ident_dxlop->TypeModifier(),  0	/* varlevelsup */);
 
-		CHAR *szResname = CTranslatorUtils::SzFromWsz(pdxlopPrE->PmdnameAlias()->Pstr()->Wsz());
-		TargetEntry *pte = gpdb::PteMakeTargetEntry((Expr *) pvar, (AttrNumber) (ul + 1), szResname, false /* resjunk */);
-		pplan->targetlist = gpdb::PlAppendElement(pplan->targetlist, pte);
+		CHAR *resname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
+		TargetEntry *target_entry = gpdb::MakeTargetEntry((Expr *) var, (AttrNumber) (ul + 1), resname, false /* resjunk */);
+		plan->targetlist = gpdb::LAppend(plan->targetlist, target_entry);
 
-		pdxltrctxOut->InsertMapping(ulColId, pte);
+		output_context->InsertMapping(colid, target_entry);
 	}
 
-	pplan->qual = NULL;
+	plan->qual = NULL;
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// store share scan node for the translation of CTE Consumers
-	m_pctxdxltoplstmt->AddCTEConsumerInfo(ulCTEId, pshscanCTEConsumer);
+	m_dxl_to_plstmt_context->AddCTEConsumerInfo(cte_id, share_input_scan_cte_consumer);
 
-	return (Plan *) pshscanCTEConsumer;
+	return (Plan *) share_input_scan_cte_consumer;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanSequence
+//		CTranslatorDXLToPlStmt::TranslateDXLSequence
 //
 //	@doc:
 //		Translate DXL sequence node into GPDB Sequence plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanSequence
+CTranslatorDXLToPlStmt::TranslateDXLSequence
 	(
-	const CDXLNode *pdxlnSequence,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *sequence_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create append plan node
 	Sequence *psequence = MakeNode(Sequence);
 
-	Plan *pplan = &(psequence->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(psequence->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnSequence->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(sequence_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	ULONG ulArity = pdxlnSequence->UlArity();
+	ULONG arity = sequence_dxlnode->Arity();
 	
 	// translate last child
 	// since last child may be a DynamicIndexScan with outer references,
 	// we pass the context received from parent to translate outer refs here
 
-	CDXLNode *pdxlnLastChild = (*pdxlnSequence)[ulArity - 1];
+	CDXLNode *last_child_dxlnode = (*sequence_dxlnode)[arity - 1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanLastChild = PplFromDXL(pdxlnLastChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
-	pplan->nMotionNodes = pplanLastChild->nMotionNodes;
+	Plan *last_child_plan = TranslateDXLOperatorToPlan(last_child_dxlnode, &child_context, ctxt_translation_prev_siblings);
+	plan->nMotionNodes = last_child_plan->nMotionNodes;
 
-	CDXLNode *pdxlnPrL = (*pdxlnSequence)[0];
+	CDXLNode *project_list_dxlnode = (*sequence_dxlnode)[0];
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 						(
-						pdxlnPrL,
+						project_list_dxlnode,
 						NULL,		// base table translation context
-						pdrgpdxltrctx,
-						pdxltrctxOut
+						child_contexts,
+						output_context
 						);
 
 	// translate the rest of the children
-	for (ULONG ul = 1; ul < ulArity - 1; ul++)
+	for (ULONG ul = 1; ul < arity - 1; ul++)
 	{
-		CDXLNode *pdxlnChild = (*pdxlnSequence)[ul];
+		CDXLNode *child_dxlnode = (*sequence_dxlnode)[ul];
 
-		Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+		Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-		psequence->subplans = gpdb::PlAppendElement(psequence->subplans, pplanChild);
-		pplan->nMotionNodes += pplanChild->nMotionNodes;
+		psequence->subplans = gpdb::LAppend(psequence->subplans, child_plan);
+		plan->nMotionNodes += child_plan->nMotionNodes;
 	}
 
-	psequence->subplans = gpdb::PlAppendElement(psequence->subplans, pplanLastChild);
+	psequence->subplans = gpdb::LAppend(psequence->subplans, last_child_plan);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 	return (Plan *) psequence;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanDTS
+//		CTranslatorDXLToPlStmt::TranslateDXLDynTblScan
 //
 //	@doc:
 //		Translates a DXL dynamic table scan node into a DynamicTableScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanDTS
+CTranslatorDXLToPlStmt::TranslateDXLDynTblScan
 	(
-	const CDXLNode *pdxlnDTS,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dyn_tbl_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translate table descriptor into a range table entry
-	CDXLPhysicalDynamicTableScan *pdxlop = CDXLPhysicalDynamicTableScan::PdxlopConvert(pdxlnDTS->Pdxlop());
+	CDXLPhysicalDynamicTableScan *dyn_tbl_scan_dxlop = CDXLPhysicalDynamicTableScan::Cast(dyn_tbl_scan_dxlnode->GetOperator());
 
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dyn_tbl_scan_dxlop->GetDXLTableDescr(), NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
 
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
 	// create dynamic scan node
-	DynamicTableScan *pdts = MakeNode(DynamicTableScan);
+	DynamicTableScan *dyn_tbl_scan = MakeNode(DynamicTableScan);
 
-	pdts->scanrelid = iRel;
-	pdts->partIndex = pdxlop->UlPartIndexId();
-	pdts->partIndexPrintable = pdxlop->UlPartIndexIdPrintable();
+	dyn_tbl_scan->scanrelid = index;
+	dyn_tbl_scan->partIndex = dyn_tbl_scan_dxlop->GetPartIndexId();
+	dyn_tbl_scan->partIndexPrintable = dyn_tbl_scan_dxlop->GetPartIndexIdPrintable();
 
-	Plan *pplan = &(pdts->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	Plan *plan = &(dyn_tbl_scan->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnDTS->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(dyn_tbl_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	GPOS_ASSERT(2 == pdxlnDTS->UlArity());
+	GPOS_ASSERT(2 == dyn_tbl_scan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnDTS)[EdxltsIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnDTS)[EdxltsIndexFilter];
+	CDXLNode *project_list_dxlnode = (*dyn_tbl_scan_dxlnode)[EdxltsIndexProjList];
+	CDXLNode *filter_dxlnode = (*dyn_tbl_scan_dxlnode)[EdxltsIndexFilter];
 
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
-		&dxltrctxbt,	// translate context for the base table
-		NULL,			// pdxltrctxLeft and pdxltrctxRight,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		project_list_dxlnode,
+		filter_dxlnode,
+		&base_table_context,	// translate context for the base table
+		NULL,			// translate_ctxt_left and pdxltrctxRight,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pdts;
+	return (Plan *) dyn_tbl_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanDIS
+//		CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan
 //
 //	@doc:
 //		Translates a DXL dynamic index scan node into a DynamicIndexScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanDIS
+CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan
 	(
-	const CDXLNode *pdxlnDIS,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dyn_idx_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalDynamicIndexScan *pdxlop = CDXLPhysicalDynamicIndexScan::PdxlopConvert(pdxlnDIS->Pdxlop());
+	CDXLPhysicalDynamicIndexScan *dyn_index_scan_dxlop = CDXLPhysicalDynamicIndexScan::Cast(dyn_idx_scan_dxlnode->GetOperator());
 	
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
-	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
-	m_pctxdxltoplstmt->AddRTE(prte);
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(dyn_index_scan_dxlop->GetDXLTableDescr()->MDId());
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dyn_index_scan_dxlop->GetDXLTableDescr(), NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	DynamicIndexScan *pdis = MakeNode(DynamicIndexScan);
+	DynamicIndexScan *dyn_idx_scan = MakeNode(DynamicIndexScan);
 
-	pdis->indexscan.scan.scanrelid = iRel;
-	pdis->indexscan.scan.partIndex = pdxlop->UlPartIndexId();
-	pdis->indexscan.scan.partIndexPrintable = pdxlop->UlPartIndexIdPrintable();
+	dyn_idx_scan->indexscan.scan.scanrelid = index;
+	dyn_idx_scan->indexscan.scan.partIndex = dyn_index_scan_dxlop->GetPartIndexId();
+	dyn_idx_scan->indexscan.scan.partIndexPrintable = dyn_index_scan_dxlop->GetPartIndexIdPrintable();
 
-	CMDIdGPDB *pmdidIndex = CMDIdGPDB::PmdidConvert(pdxlop->Pdxlid()->Pmdid());
-	const IMDIndex *pmdindex = m_pmda->Pmdindex(pmdidIndex);
-	Oid oidIndex = pmdidIndex->OidObjectId();
+	CMDIdGPDB *mdid_index = CMDIdGPDB::CastMdid(dyn_index_scan_dxlop->GetDXLIndexDescr()->MDId());
+	const IMDIndex *md_index = m_md_accessor->RetrieveIndex(mdid_index);
+	Oid index_oid = mdid_index->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidIndex);
-	pdis->indexscan.indexid = oidIndex;
-	pdis->logicalIndexInfo = gpdb::Plgidxinfo(prte->relid, oidIndex);
+	GPOS_ASSERT(InvalidOid != index_oid);
+	dyn_idx_scan->indexscan.indexid = index_oid;
+	dyn_idx_scan->logicalIndexInfo = gpdb::GetLogicalIndexInfo(rte->relid, index_oid);
 
-	Plan *pplan = &(pdis->indexscan.scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	Plan *plan = &(dyn_idx_scan->indexscan.scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnDIS->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(dyn_idx_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// an index scan node must have 3 children: projection list, filter and index condition list
-	GPOS_ASSERT(3 == pdxlnDIS->UlArity());
+	GPOS_ASSERT(3 == dyn_idx_scan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnDIS)[CDXLPhysicalDynamicIndexScan::EdxldisIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnDIS)[CDXLPhysicalDynamicIndexScan::EdxldisIndexFilter];
-	CDXLNode *pdxlnIndexCondList = (*pdxlnDIS)[CDXLPhysicalDynamicIndexScan::EdxldisIndexCondition];
+	CDXLNode *project_list_dxlnode = (*dyn_idx_scan_dxlnode)[CDXLPhysicalDynamicIndexScan::EdxldisIndexProjList];
+	CDXLNode *filter_dxlnode = (*dyn_idx_scan_dxlnode)[CDXLPhysicalDynamicIndexScan::EdxldisIndexFilter];
+	CDXLNode *index_cond_list_dxlnode = (*dyn_idx_scan_dxlnode)[CDXLPhysicalDynamicIndexScan::EdxldisIndexCondition];
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList(pdxlnPrL, &dxltrctxbt, NULL /*pdrgpdxltrctx*/, pdxltrctxOut);
+	plan->targetlist = TranslateDXLProjList(project_list_dxlnode, &base_table_context, NULL /*child_contexts*/, output_context);
 
 	// translate index filter
-	pplan->qual = PlTranslateIndexFilter
+	plan->qual = TranslateDXLIndexFilter
 					(
-					pdxlnFilter,
-					pdxltrctxOut,
-					&dxltrctxbt,
-					pdrgpdxltrctxPrevSiblings
+					filter_dxlnode,
+					output_context,
+					&base_table_context,
+					ctxt_translation_prev_siblings
 					);
 
-	pdis->indexscan.indexorderdir = CTranslatorUtils::Scandirection(pdxlop->EdxlScanDirection());
+	dyn_idx_scan->indexscan.indexorderdir = CTranslatorUtils::GetScanDirection(dyn_index_scan_dxlop->GetIndexScanDir());
 
 	// translate index condition list
-	List *plIndexConditions = NIL;
-	List *plIndexOrigConditions = NIL;
-	List *plIndexStratgey = NIL;
-	List *plIndexSubtype = NIL;
+	List *index_cond = NIL;
+	List *index_orig_cond = NIL;
+	List *index_strategy_list = NIL;
+	List *index_subtype_list = NIL;
 
 	TranslateIndexConditions
 		(
-		pdxlnIndexCondList, 
-		pdxlop->Pdxltabdesc(), 
-		false, // fIndexOnlyScan 
-		pmdindex, 
-		pmdrel,
-		pdxltrctxOut,
-		&dxltrctxbt,
-		pdrgpdxltrctxPrevSiblings,
-		&plIndexConditions, 
-		&plIndexOrigConditions, 
-		&plIndexStratgey, 
-		&plIndexSubtype
+		index_cond_list_dxlnode,
+		dyn_index_scan_dxlop->GetDXLTableDescr(),
+		false, // is_index_only_scan
+		md_index,
+		md_rel,
+		output_context,
+		&base_table_context,
+		ctxt_translation_prev_siblings,
+		&index_cond,
+		&index_orig_cond,
+		&index_strategy_list,
+		&index_subtype_list
 		);
 
 
-	pdis->indexscan.indexqual = plIndexConditions;
-	pdis->indexscan.indexqualorig = plIndexOrigConditions;
+	dyn_idx_scan->indexscan.indexqual = index_cond;
+	dyn_idx_scan->indexscan.indexqualorig = index_orig_cond;
 	/*
 	 * As of 8.4, the indexstrategy and indexsubtype fields are no longer
 	 * available or needed in IndexScan. Ignore them.
 	 */
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pdis;
+	return (Plan *) dyn_idx_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanDML
+//		CTranslatorDXLToPlStmt::TranslateDXLDml
 //
 //	@doc:
 //		Translates a DXL DML node 
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanDML
+CTranslatorDXLToPlStmt::TranslateDXLDml
 	(
-	const CDXLNode *pdxlnDML,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dml_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translate table descriptor into a range table entry
-	CDXLPhysicalDML *pdxlop = CDXLPhysicalDML::PdxlopConvert(pdxlnDML->Pdxlop());
+	CDXLPhysicalDML *phy_dml_dxlop = CDXLPhysicalDML::Cast(dml_dxlnode->GetOperator());
 
 	// create DML node
-	DML *pdml = MakeNode(DML);
-	Plan *pplan = &(pdml->plan);
-	AclMode aclmode = ACL_NO_RIGHTS;
+	DML *dml = MakeNode(DML);
+	Plan *plan = &(dml->plan);
+	AclMode acl_mode = ACL_NO_RIGHTS;
 	
-	switch (pdxlop->EdxlDmlOpType())
+	switch (phy_dml_dxlop->GetDmlOpType())
 	{
 		case gpdxl::Edxldmldelete:
 		{
-			m_cmdtype = CMD_DELETE;
-			aclmode = ACL_DELETE;
+			m_cmd_type = CMD_DELETE;
+			acl_mode = ACL_DELETE;
 			break;
 		}
 		case gpdxl::Edxldmlupdate:
 		{
-			m_cmdtype = CMD_UPDATE;
-			aclmode = ACL_UPDATE;
+			m_cmd_type = CMD_UPDATE;
+			acl_mode = ACL_UPDATE;
 			break;
 		}
 		case gpdxl::Edxldmlinsert:
 		{
-			m_cmdtype = CMD_INSERT;
-			aclmode = ACL_INSERT;
+			m_cmd_type = CMD_INSERT;
+			acl_mode = ACL_INSERT;
 			break;
 		}
 		case gpdxl::EdxldmlSentinel:
@@ -3764,461 +3760,461 @@ CTranslatorDXLToPlStmt::PplanDML
 		}
 	}
 	
-	IMDId *pmdidTargetTable = pdxlop->Pdxltabdesc()->Pmdid();
-	if (IMDRelation::EreldistrMasterOnly != m_pmda->Pmdrel(pmdidTargetTable)->Ereldistribution())
+	IMDId *mdid_target_table = phy_dml_dxlop->GetDXLTableDescr()->MDId();
+	if (IMDRelation::EreldistrMasterOnly != m_md_accessor->RetrieveRel(mdid_target_table)->GetRelDistribution())
 	{
-		m_fTargetTableDistributed = true;
+		m_is_tgt_tbl_distributed = true;
 	}
 	
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
-	pdml->scanrelid = iRel;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
+	dml->scanrelid = index;
 	
-	m_plResultRelations = gpdb::PlAppendInt(m_plResultRelations, iRel);
+	m_result_rel_list = gpdb::LAppendInt(m_result_rel_list, index);
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(phy_dml_dxlop->GetDXLTableDescr()->MDId());
 
-	CDXLTableDescr *pdxltabdesc = pdxlop->Pdxltabdesc();
-	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= aclmode;
-	m_pctxdxltoplstmt->AddRTE(prte);
+	CDXLTableDescr *table_descr = phy_dml_dxlop->GetDXLTableDescr();
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(table_descr, NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= acl_mode;
+	m_dxl_to_plstmt_context->AddRTE(rte);
 	
-	CDXLNode *pdxlnPrL = (*pdxlnDML)[0];
-	CDXLNode *pdxlnChild = (*pdxlnDML)[1];
+	CDXLNode *project_list_dxlnode = (*dml_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*dml_dxlnode)[1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 
 	// translate proj list
-	List *plTargetListDML = PlTargetListFromProjList
+	List *dml_target_list = TranslateDXLProjList
 		(
-		pdxlnPrL,
+		project_list_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		pdxltrctxOut
+		child_contexts,
+		output_context
 		);
 	
-	if (pmdrel->FHasDroppedColumns())
+	if (md_rel->HasDroppedColumns())
 	{
 		// pad DML target list with NULLs for dropped columns for all DML operator types
-		List *plTargetListWithDroppedCols = PlTargetListWithDroppedCols(plTargetListDML, pmdrel);
-		gpdb::GPDBFree(plTargetListDML);
-		plTargetListDML = plTargetListWithDroppedCols;
+		List *target_list_with_dropped_cols = CreateTargetListWithNullsForDroppedCols(dml_target_list, md_rel);
+		gpdb::GPDBFree(dml_target_list);
+		dml_target_list = target_list_with_dropped_cols;
 	}
 
 	// Extract column numbers of the action and ctid columns from the
 	// target list. ORCA also includes a third similar column for
 	// partition Oid to the target list, but we don't use it for anything
 	// in GPDB.
-	pdml->actionColIdx = UlAddTargetEntryForColId(&plTargetListDML, &dxltrctxChild, pdxlop->UlAction(), true /*fResjunk*/);
-	pdml->ctidColIdx = UlAddTargetEntryForColId(&plTargetListDML, &dxltrctxChild, pdxlop->UlCtid(), true /*fResjunk*/);
-	if (pdxlop->FPreserveOids())
+	dml->actionColIdx = AddTargetEntryForColId(&dml_target_list, &child_context, phy_dml_dxlop->ActionColId(), true /*is_resjunk*/);
+	dml->ctidColIdx = AddTargetEntryForColId(&dml_target_list, &child_context, phy_dml_dxlop->GetCtIdColId(), true /*is_resjunk*/);
+	if (phy_dml_dxlop->IsOidsPreserved())
 	{
-		pdml->tupleoidColIdx = UlAddTargetEntryForColId(&plTargetListDML, &dxltrctxChild, pdxlop->UlTupleOid(), true /*fResjunk*/);
+		dml->tupleoidColIdx = AddTargetEntryForColId(&dml_target_list, &child_context, phy_dml_dxlop->GetTupleOid(), true /*is_resjunk*/);
 	}
 	else
 	{
-		pdml->tupleoidColIdx = 0;
+		dml->tupleoidColIdx = 0;
 	}
 
-	GPOS_ASSERT(0 != pdml->actionColIdx);
+	GPOS_ASSERT(0 != dml->actionColIdx);
 
-	pplan->targetlist = plTargetListDML;
+	plan->targetlist = dml_target_list;
 	
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	if (CMD_INSERT == m_cmdtype && 0 == pplan->nMotionNodes)
+	if (CMD_INSERT == m_cmd_type && 0 == plan->nMotionNodes)
 	{
-		List *plDirectDispatchSegIds = PlDirectDispatchSegIds(pdxlop->Pdxlddinfo());
-		pplan->directDispatch.contentIds = plDirectDispatchSegIds;
-		pplan->directDispatch.isDirectDispatch = (NIL != plDirectDispatchSegIds);
+		List *direct_dispatch_segids = TranslateDXLDirectDispatchInfo(phy_dml_dxlop->GetDXLDirectDispatchInfo());
+		plan->directDispatch.contentIds = direct_dispatch_segids;
+		plan->directDispatch.isDirectDispatch = (NIL != direct_dispatch_segids);
 	}
 	
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnDML->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(dml_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	return (Plan *) pdml;
+	return (Plan *) dml;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlDirectDispatchSegIds
+//		CTranslatorDXLToPlStmt::TranslateDXLDirectDispatchInfo
 //
 //	@doc:
 //		Translate the direct dispatch info
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlDirectDispatchSegIds
+CTranslatorDXLToPlStmt::TranslateDXLDirectDispatchInfo
 	(
-	CDXLDirectDispatchInfo *pdxlddinfo
+	CDXLDirectDispatchInfo *dxl_direct_dispatch_info
 	)
 {
-	if (!optimizer_enable_direct_dispatch || NULL == pdxlddinfo)
+	if (!optimizer_enable_direct_dispatch || NULL == dxl_direct_dispatch_info)
 	{
 		return NIL;
 	}
 	
-	DrgPdrgPdxldatum *pdrgpdrgpdxldatum = pdxlddinfo->Pdrgpdrgpdxldatum();
+	CDXLDatum2dArray *dispatch_identifier_datum_arrays = dxl_direct_dispatch_info->GetDispatchIdentifierDatumArray();
 	
-	if (pdrgpdrgpdxldatum == NULL || 0 == pdrgpdrgpdxldatum->UlLength())
+	if (dispatch_identifier_datum_arrays == NULL || 0 == dispatch_identifier_datum_arrays->Size())
 	{
 		return NIL;
 	}
 	
-	DrgPdxldatum *pdrgpdxldatum = (*pdrgpdrgpdxldatum)[0];
-	GPOS_ASSERT(0 < pdrgpdxldatum->UlLength());
+	CDXLDatumArray *dxl_datum_array = (*dispatch_identifier_datum_arrays)[0];
+	GPOS_ASSERT(0 < dxl_datum_array->Size());
 		
-	ULONG ulHashCode = UlCdbHash(pdrgpdxldatum);
-	const ULONG ulLength = pdrgpdrgpdxldatum->UlLength();
-	for (ULONG ul = 0; ul < ulLength; ul++)
+	ULONG hash_code = GetDXLDatumGPDBHash(dxl_datum_array);
+	const ULONG length = dispatch_identifier_datum_arrays->Size();
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		DrgPdxldatum *pdrgpdxldatumDisj = (*pdrgpdrgpdxldatum)[ul];
-		GPOS_ASSERT(0 < pdrgpdxldatumDisj->UlLength());
-		ULONG ulHashCodeNew = UlCdbHash(pdrgpdxldatumDisj);
+		CDXLDatumArray *dispatch_identifier_datum_array = (*dispatch_identifier_datum_arrays)[ul];
+		GPOS_ASSERT(0 < dispatch_identifier_datum_array->Size());
+		ULONG hash_code_new = GetDXLDatumGPDBHash(dispatch_identifier_datum_array);
 		
-		if (ulHashCode != ulHashCodeNew)
+		if (hash_code != hash_code_new)
 		{
 			// values don't hash to the same segment
 			return NIL;
 		}
 	}
 	
-	List *plSegIds = gpdb::PlAppendInt(NIL, ulHashCode);
-	return plSegIds;
+	List *segids_list = gpdb::LAppendInt(NIL, hash_code);
+	return segids_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::UlCdbHash
+//		CTranslatorDXLToPlStmt::GetDXLDatumGPDBHash
 //
 //	@doc:
 //		Hash a DXL datum
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorDXLToPlStmt::UlCdbHash
+CTranslatorDXLToPlStmt::GetDXLDatumGPDBHash
 	(
-	DrgPdxldatum *pdrgpdxldatum
+	CDXLDatumArray *dxl_datum_array
 	)
 {
-	List *plConsts = NIL;
+	List *consts_list = NIL;
 	
-	const ULONG ulLength = pdrgpdxldatum->UlLength();
+	const ULONG length = dxl_datum_array->Size();
 	
-	for (ULONG ul = 0; ul < ulLength; ul++)
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		CDXLDatum *pdxldatum = (*pdrgpdxldatum)[ul];
+		CDXLDatum *datum_dxl = (*dxl_datum_array)[ul];
 		
-		Const *pconst = (Const *) m_pdxlsctranslator->PconstFromDXLDatum(pdxldatum);
-		plConsts = gpdb::PlAppendElement(plConsts, pconst);
+		Const *const_expr = (Const *) m_translator_dxl_to_scalar->TranslateDXLDatumToScalar(datum_dxl);
+		consts_list = gpdb::LAppend(consts_list, const_expr);
 	}
 
-	ULONG ulHash = gpdb::ICdbHashList(plConsts, m_ulSegments);
+	ULONG hash = gpdb::CdbHashConstList(consts_list, m_num_of_segments);
 
-	gpdb::FreeListDeep(plConsts);
+	gpdb::ListFreeDeep(consts_list);
 	
-	return ulHash;
+	return hash;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanSplit
+//		CTranslatorDXLToPlStmt::TranslateDXLSplit
 //
 //	@doc:
 //		Translates a DXL Split node 
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanSplit
+CTranslatorDXLToPlStmt::TranslateDXLSplit
 	(
-	const CDXLNode *pdxlnSplit,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *split_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalSplit *pdxlop = CDXLPhysicalSplit::PdxlopConvert(pdxlnSplit->Pdxlop());
+	CDXLPhysicalSplit *phy_split_dxlop = CDXLPhysicalSplit::Cast(split_dxlnode->GetOperator());
 
 	// create SplitUpdate node
-	SplitUpdate *psplit = MakeNode(SplitUpdate);
-	Plan *pplan = &(psplit->plan);
+	SplitUpdate *split = MakeNode(SplitUpdate);
+	Plan *plan = &(split->plan);
 	
-	CDXLNode *pdxlnPrL = (*pdxlnSplit)[0];
-	CDXLNode *pdxlnChild = (*pdxlnSplit)[1];
+	CDXLNode *project_list_dxlnode = (*split_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*split_dxlnode)[1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 		(
-		pdxlnPrL,
+		project_list_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		pdxltrctxOut
+		child_contexts,
+		output_context
 		);
 
 	// translate delete and insert columns
-	DrgPul *pdrgpulDeleteCols = pdxlop->PdrgpulDelete();
-	DrgPul *pdrgpulInsertCols = pdxlop->PdrgpulInsert();
+	ULongPtrArray *deletion_colid_array = phy_split_dxlop->GetDeletionColIdArray();
+	ULongPtrArray *insertion_colid_array = phy_split_dxlop->GetInsertionColIdArray();
 		
-	GPOS_ASSERT(pdrgpulInsertCols->UlLength() == pdrgpulDeleteCols->UlLength());
+	GPOS_ASSERT(insertion_colid_array->Size() == deletion_colid_array->Size());
 	
-	psplit->deleteColIdx = CTranslatorUtils::PlAttnosFromColids(pdrgpulDeleteCols, &dxltrctxChild);
-	psplit->insertColIdx = CTranslatorUtils::PlAttnosFromColids(pdrgpulInsertCols, &dxltrctxChild);
+	split->deleteColIdx = CTranslatorUtils::ConvertColidToAttnos(deletion_colid_array, &child_context);
+	split->insertColIdx = CTranslatorUtils::ConvertColidToAttnos(insertion_colid_array, &child_context);
 	
-	const TargetEntry *pteActionCol = pdxltrctxOut->Pte(pdxlop->UlAction());
-	const TargetEntry *pteCtidCol = pdxltrctxOut->Pte(pdxlop->UlCtid());
-	const TargetEntry *pteTupleOidCol = pdxltrctxOut->Pte(pdxlop->UlTupleOid());
+	const TargetEntry *te_action_col = output_context->GetTargetEntry(phy_split_dxlop->ActionColId());
+	const TargetEntry *te_ctid_col = output_context->GetTargetEntry(phy_split_dxlop->GetCtIdColId());
+	const TargetEntry *te_tuple_oid_col = output_context->GetTargetEntry(phy_split_dxlop->GetTupleOid());
 
-	if (NULL  == pteActionCol)
+	if (NULL  == te_action_col)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, pdxlop->UlAction());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, phy_split_dxlop->ActionColId());
 	}
-	if (NULL  == pteCtidCol)
+	if (NULL  == te_ctid_col)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, pdxlop->UlCtid());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, phy_split_dxlop->GetCtIdColId());
 	}	 
 	
-	psplit->actionColIdx = pteActionCol->resno;
-	psplit->ctidColIdx = pteCtidCol->resno;
+	split->actionColIdx = te_action_col->resno;
+	split->ctidColIdx = te_ctid_col->resno;
 	
-	psplit->tupleoidColIdx = FirstLowInvalidHeapAttributeNumber;
-	if (NULL != pteTupleOidCol)
+	split->tupleoidColIdx = FirstLowInvalidHeapAttributeNumber;
+	if (NULL != te_tuple_oid_col)
 	{
-		psplit->tupleoidColIdx = pteTupleOidCol->resno;
+		split->tupleoidColIdx = te_tuple_oid_col->resno;
 	}
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnSplit->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(split_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	return (Plan *) psplit;
+	return (Plan *) split;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanAssert
+//		CTranslatorDXLToPlStmt::TranslateDXLAssert
 //
 //	@doc:
 //		Translate DXL assert node into GPDB assert plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanAssert
+CTranslatorDXLToPlStmt::TranslateDXLAssert
 	(
-	const CDXLNode *pdxlnAssert,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *assert_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create assert plan node
-	AssertOp *passert = MakeNode(AssertOp);
+	AssertOp *assert_node = MakeNode(AssertOp);
 
-	Plan *pplan = &(passert->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(assert_node->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalAssert *pdxlopAssert = CDXLPhysicalAssert::PdxlopConvert(pdxlnAssert->Pdxlop());
+	CDXLPhysicalAssert *assert_dxlop = CDXLPhysicalAssert::Cast(assert_dxlnode->GetOperator());
 
 	// translate error code into the its internal GPDB representation
-	const CHAR *szErrorCode = pdxlopAssert->SzSQLState();
-	GPOS_ASSERT(GPOS_SQLSTATE_LENGTH == clib::UlStrLen(szErrorCode));
+	const CHAR *error_code = assert_dxlop->GetSQLState();
+	GPOS_ASSERT(GPOS_SQLSTATE_LENGTH == clib::Strlen(error_code));
 	
-	passert->errcode = MAKE_SQLSTATE(szErrorCode[0], szErrorCode[1], szErrorCode[2], szErrorCode[3], szErrorCode[4]);
-	CDXLNode *pdxlnFilter = (*pdxlnAssert)[CDXLPhysicalAssert::EdxlassertIndexFilter];
+	assert_node->errcode = MAKE_SQLSTATE(error_code[0], error_code[1], error_code[2], error_code[3], error_code[4]);
+	CDXLNode *filter_dxlnode = (*assert_dxlnode)[CDXLPhysicalAssert::EdxlassertIndexFilter];
 
-	passert->errmessage = CTranslatorUtils::PlAssertErrorMsgs(pdxlnFilter);
+	assert_node->errmessage = CTranslatorUtils::GetAssertErrorMsgs(filter_dxlnode);
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnAssert->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(assert_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
 	// translate child plan
-	CDXLNode *pdxlnChild = (*pdxlnAssert)[CDXLPhysicalAssert::EdxlassertIndexChild];
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	CDXLNode *child_dxlnode = (*assert_dxlnode)[CDXLPhysicalAssert::EdxlassertIndexChild];
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+	GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-	passert->plan.lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	assert_node->plan.lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
-	CDXLNode *pdxlnPrL = (*pdxlnAssert)[CDXLPhysicalAssert::EdxlassertIndexProjList];
+	CDXLNode *project_list_dxlnode = (*assert_dxlnode)[CDXLPhysicalAssert::EdxlassertIndexProjList];
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 				(
-				pdxlnPrL,
+				project_list_dxlnode,
 				NULL,			// translate context for the base table
-				pdrgpdxltrctx,
-				pdxltrctxOut
+				child_contexts,
+				output_context
 				);
 
 	// translate assert constraints
-	pplan->qual = PlTranslateAssertConstraints
+	plan->qual = TranslateDXLAssertConstraints
 					(
-					pdxlnFilter,
-					pdxltrctxOut,
-					pdrgpdxltrctx
+					filter_dxlnode,
+					output_context,
+					child_contexts
 					);
 	
-	GPOS_ASSERT(gpdb::UlListLength(pplan->qual) == gpdb::UlListLength(passert->errmessage));
-	SetParamIds(pplan);
+	GPOS_ASSERT(gpdb::ListLength(plan->qual) == gpdb::ListLength(assert_node->errmessage));
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) passert;
+	return (Plan *) assert_node;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanRowTrigger
+//		CTranslatorDXLToPlStmt::TranslateDXLRowTrigger
 //
 //	@doc:
 //		Translates a DXL Row Trigger node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanRowTrigger
+CTranslatorDXLToPlStmt::TranslateDXLRowTrigger
 	(
-	const CDXLNode *pdxlnRowTrigger,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *row_trigger_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalRowTrigger *pdxlop = CDXLPhysicalRowTrigger::PdxlopConvert(pdxlnRowTrigger->Pdxlop());
+	CDXLPhysicalRowTrigger *phy_row_trigger_dxlop = CDXLPhysicalRowTrigger::Cast(row_trigger_dxlnode->GetOperator());
 
 	// create RowTrigger node
-	RowTrigger *prowtrigger = MakeNode(RowTrigger);
-	Plan *pplan = &(prowtrigger->plan);
+	RowTrigger *row_trigger = MakeNode(RowTrigger);
+	Plan *plan = &(row_trigger->plan);
 
-	CDXLNode *pdxlnPrL = (*pdxlnRowTrigger)[0];
-	CDXLNode *pdxlnChild = (*pdxlnRowTrigger)[1];
+	CDXLNode *project_list_dxlnode = (*row_trigger_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*row_trigger_dxlnode)[1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 		(
-		pdxlnPrL,
+		project_list_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		pdxltrctxOut
+		child_contexts,
+		output_context
 		);
 
-	Oid oidRelid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidRel())->OidObjectId();
-	GPOS_ASSERT(InvalidOid != oidRelid);
-	prowtrigger->relid = oidRelid;
-	prowtrigger->eventFlags = pdxlop->IType();
+	Oid relid_oid = CMDIdGPDB::CastMdid(phy_row_trigger_dxlop->GetRelMdId())->Oid();
+	GPOS_ASSERT(InvalidOid != relid_oid);
+	row_trigger->relid = relid_oid;
+	row_trigger->eventFlags = phy_row_trigger_dxlop->GetType();
 
 	// translate old and new columns
-	DrgPul *pdrgpulOldCols = pdxlop->PdrgpulOld();
-	DrgPul *pdrgpulNewCols = pdxlop->PdrgpulNew();
+	ULongPtrArray *colids_old_array = phy_row_trigger_dxlop->GetColIdsOld();
+	ULongPtrArray *colids_new_array = phy_row_trigger_dxlop->GetColIdsNew();
 
-	GPOS_ASSERT_IMP(NULL != pdrgpulOldCols && NULL != pdrgpulNewCols,
-					pdrgpulNewCols->UlLength() == pdrgpulOldCols->UlLength());
+	GPOS_ASSERT_IMP(NULL != colids_old_array && NULL != colids_new_array,
+					colids_new_array->Size() == colids_old_array->Size());
 
-	if (NULL == pdrgpulOldCols)
+	if (NULL == colids_old_array)
 	{
-		prowtrigger->oldValuesColIdx = NIL;
+		row_trigger->oldValuesColIdx = NIL;
 	}
 	else
 	{
-		prowtrigger->oldValuesColIdx = CTranslatorUtils::PlAttnosFromColids(pdrgpulOldCols, &dxltrctxChild);
+		row_trigger->oldValuesColIdx = CTranslatorUtils::ConvertColidToAttnos(colids_old_array, &child_context);
 	}
 
-	if (NULL == pdrgpulNewCols)
+	if (NULL == colids_new_array)
 	{
-		prowtrigger->newValuesColIdx = NIL;
+		row_trigger->newValuesColIdx = NIL;
 	}
 	else
 	{
-		prowtrigger->newValuesColIdx = CTranslatorUtils::PlAttnosFromColids(pdrgpulNewCols, &dxltrctxChild);
+		row_trigger->newValuesColIdx = CTranslatorUtils::ConvertColidToAttnos(colids_new_array, &child_context);
 	}
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnRowTrigger->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(row_trigger_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	return (Plan *) prowtrigger;
+	return (Plan *) row_trigger;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PrteFromTblDescr
+//		CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry
 //
 //	@doc:
 //		Translates a DXL table descriptor into a range table entry. If an index
@@ -4227,216 +4223,216 @@ CTranslatorDXLToPlStmt::PplanRowTrigger
 //
 //---------------------------------------------------------------------------
 RangeTblEntry *
-CTranslatorDXLToPlStmt::PrteFromTblDescr
+CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry
 	(
-	const CDXLTableDescr *pdxltabdesc,
-	const CDXLIndexDescr *pdxlid, // should be NULL unless we have an index-only scan
-	Index iRel,
-	CDXLTranslateContextBaseTable *pdxltrctxbtOut
+	const CDXLTableDescr *table_descr,
+	const CDXLIndexDescr *index_descr_dxl, // should be NULL unless we have an index-only scan
+	Index index,
+	CDXLTranslateContextBaseTable *base_table_context
 	)
 {
-	GPOS_ASSERT(NULL != pdxltabdesc);
+	GPOS_ASSERT(NULL != table_descr);
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	const ULONG ulRelColumns = CTranslatorUtils::UlNonSystemColumns(pmdrel);
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
+	const ULONG num_of_non_sys_cols = CTranslatorUtils::GetNumNonSystemColumns(md_rel);
 
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
-	prte->rtekind = RTE_RELATION;
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
+	rte->rtekind = RTE_RELATION;
 
 	// get the index if given
-	const IMDIndex *pmdindex = NULL;
-	if (NULL != pdxlid)
+	const IMDIndex *md_index = NULL;
+	if (NULL != index_descr_dxl)
 	{
-		pmdindex = m_pmda->Pmdindex(pdxlid->Pmdid());
+		md_index = m_md_accessor->RetrieveIndex(index_descr_dxl->MDId());
 	}
 
 	// get oid for table
-	Oid oid = CMDIdGPDB::PmdidConvert(pdxltabdesc->Pmdid())->OidObjectId();
+	Oid oid = CMDIdGPDB::CastMdid(table_descr->MDId())->Oid();
 	GPOS_ASSERT(InvalidOid != oid);
 
-	prte->relid = oid;
-	prte->checkAsUser = pdxltabdesc->UlExecuteAsUser();
-	prte->requiredPerms |= ACL_NO_RIGHTS;
+	rte->relid = oid;
+	rte->checkAsUser = table_descr->GetExecuteAsUserId();
+	rte->requiredPerms |= ACL_NO_RIGHTS;
 
 	// save oid and range index in translation context
-	pdxltrctxbtOut->SetOID(oid);
-	pdxltrctxbtOut->SetIdx(iRel);
+	base_table_context->SetOID(oid);
+	base_table_context->SetRelIndex(index);
 
-	Alias *palias = MakeNode(Alias);
-	palias->colnames = NIL;
+	Alias *alias = MakeNode(Alias);
+	alias->colnames = NIL;
 
 	// get table alias
-	palias->aliasname = CTranslatorUtils::SzFromWsz(pdxltabdesc->Pmdname()->Pstr()->Wsz());
+	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(table_descr->MdName()->GetMDName()->GetBuffer());
 
 	// get column names
-	const ULONG ulArity = pdxltabdesc->UlArity();
+	const ULONG arity = table_descr->Arity();
 	
-	INT iLastAttno = 0;
+	INT last_attno = 0;
 	
-	for (ULONG ul = 0; ul < ulArity; ++ul)
+	for (ULONG ul = 0; ul < arity; ++ul)
 	{
-		const CDXLColDescr *pdxlcd = pdxltabdesc->Pdxlcd(ul);
-		GPOS_ASSERT(NULL != pdxlcd);
+		const CDXLColDescr *dxl_col_descr = table_descr->GetColumnDescrAt(ul);
+		GPOS_ASSERT(NULL != dxl_col_descr);
 
-		INT iAttno = pdxlcd->IAttno();
+		INT attno = dxl_col_descr->AttrNum();
 
-		GPOS_ASSERT(0 != iAttno);
+		GPOS_ASSERT(0 != attno);
 
-		if (0 < iAttno)
+		if (0 < attno)
 		{
-			// if iAttno > iLastAttno + 1, there were dropped attributes
+			// if attno > last_attno + 1, there were dropped attributes
 			// add those to the RTE as they are required by GPDB
-			for (INT iDroppedColAttno = iLastAttno + 1; iDroppedColAttno < iAttno; iDroppedColAttno++)
+			for (INT dropped_col_attno = last_attno + 1; dropped_col_attno < attno; dropped_col_attno++)
 			{
-				Value *pvalDroppedColName = gpdb::PvalMakeString(PStrDup(""));
-				palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalDroppedColName);
+				Value *val_dropped_colname = gpdb::MakeStringValue(PStrDup(""));
+				alias->colnames = gpdb::LAppend(alias->colnames, val_dropped_colname);
 			}
 			
 			// non-system attribute
-			CHAR *szColName = CTranslatorUtils::SzFromWsz(pdxlcd->Pmdname()->Pstr()->Wsz());
-			Value *pvalColName = gpdb::PvalMakeString(szColName);
+			CHAR *col_name_char_array = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxl_col_descr->MdName()->GetMDName()->GetBuffer());
+			Value *val_colname = gpdb::MakeStringValue(col_name_char_array);
 
-			palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalColName);
-			iLastAttno = iAttno;
+			alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
+			last_attno = attno;
 		}
 
 		// get the attno from the index, in case of indexonlyscan
-		if (NULL != pmdindex)
+		if (NULL != md_index)
 		{
-			iAttno = 1 + pmdindex->UlPosInKey((ULONG) iAttno - 1);
+			attno = 1 + md_index->GetKeyPos((ULONG) attno - 1);
 		}
 
 		// save mapping col id -> index in translate context
-		(void) pdxltrctxbtOut->FInsertMapping(pdxlcd->UlID(), iAttno);
+		(void) base_table_context->InsertMapping(dxl_col_descr->Id(), attno);
 	}
 
 	// if there are any dropped columns at the end, add those too to the RangeTblEntry
-	for (ULONG ul = iLastAttno + 1; ul <= ulRelColumns; ul++)
+	for (ULONG ul = last_attno + 1; ul <= num_of_non_sys_cols; ul++)
 	{
-		Value *pvalDroppedColName = gpdb::PvalMakeString(PStrDup(""));
-		palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalDroppedColName);
+		Value *val_dropped_colname = gpdb::MakeStringValue(PStrDup(""));
+		alias->colnames = gpdb::LAppend(alias->colnames, val_dropped_colname);
 	}
 	
-	prte->eref = palias;
+	rte->eref = alias;
 
-	return prte;
+	return rte;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlTargetListFromProjList
+//		CTranslatorDXLToPlStmt::TranslateDXLProjList
 //
 //	@doc:
 //		Translates a DXL projection list node into a target list.
 //		For base table projection lists, the caller should provide a base table
 //		translation context with table oid, rtable index and mappings for the columns.
-//		For other nodes pdxltrctxLeft and pdxltrctxRight give
+//		For other nodes translate_ctxt_left and pdxltrctxRight give
 //		the mappings of column ids to target entries in the corresponding child nodes
 //		for resolving the origin of the target entries
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTargetListFromProjList
+CTranslatorDXLToPlStmt::TranslateDXLProjList
 	(
-	const CDXLNode *pdxlnPrL,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *project_list_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	CDXLTranslateContext *output_context
 	)
 {
-	if (NULL == pdxlnPrL)
+	if (NULL == project_list_dxlnode)
 	{
 		return NULL;
 	}
 
-	List *plTargetList = NIL;
+	List *target_list = NIL;
 
 	// translate each DXL project element into a target entry
-	const ULONG ulArity = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ++ul)
+	const ULONG arity = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ++ul)
 	{
-		CDXLNode *pdxlnPrEl = (*pdxlnPrL)[ul];
-		GPOS_ASSERT(EdxlopScalarProjectElem == pdxlnPrEl->Pdxlop()->Edxlop());
-		CDXLScalarProjElem *pdxlopPrel = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop());
-		GPOS_ASSERT(1 == pdxlnPrEl->UlArity());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		GPOS_ASSERT(EdxlopScalarProjectElem == proj_elem_dxlnode->GetOperator()->GetDXLOperator());
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
+		GPOS_ASSERT(1 == proj_elem_dxlnode->Arity());
 
 		// translate proj element expression
-		CDXLNode *pdxlnExpr = (*pdxlnPrEl)[0];
+		CDXLNode *expr_dxlnode = (*proj_elem_dxlnode)[0];
 
-		CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+		CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 																(
-																m_pmp,
-																pdxltrctxbt,
-																pdrgpdxltrctx,
-																pdxltrctxOut,
-																m_pctxdxltoplstmt
+																m_mp,
+																base_table_context,
+																child_contexts,
+																output_context,
+																m_dxl_to_plstmt_context
 																);
 
-		Expr *pexpr = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnExpr, &mapcidvarplstmt);
+		Expr *expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(expr_dxlnode, &colid_var_mapping);
 
-		GPOS_ASSERT(NULL != pexpr);
+		GPOS_ASSERT(NULL != expr);
 
-		TargetEntry *pte = MakeNode(TargetEntry);
-		pte->expr = pexpr;
-		pte->resname = CTranslatorUtils::SzFromWsz(pdxlopPrel->PmdnameAlias()->Pstr()->Wsz());
-		pte->resno = (AttrNumber) (ul + 1);
+		TargetEntry *target_entry = MakeNode(TargetEntry);
+		target_entry->expr = expr;
+		target_entry->resname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
+		target_entry->resno = (AttrNumber) (ul + 1);
 
-		if (IsA(pexpr, Var))
+		if (IsA(expr, Var))
 		{
 			// check the origin of the left or the right side
 			// of the current operator and if it is derived from a base relation,
 			// set resorigtbl and resorigcol appropriately
 
-			if (NULL != pdxltrctxbt)
+			if (NULL != base_table_context)
 			{
 				// translating project list of a base table
-				pte->resorigtbl = pdxltrctxbt->OidRel();
-				pte->resorigcol = ((Var *) pexpr)->varattno;
+				target_entry->resorigtbl = base_table_context->GetOid();
+				target_entry->resorigcol = ((Var *) expr)->varattno;
 			}
 			else
 			{
 				// not translating a base table proj list: variable must come from
 				// the left or right child of the operator
 
-				GPOS_ASSERT(NULL != pdrgpdxltrctx);
-				GPOS_ASSERT(0 != pdrgpdxltrctx->UlLength());
-				ULONG ulColId = CDXLScalarIdent::PdxlopConvert(pdxlnExpr->Pdxlop())->Pdxlcr()->UlID();
+				GPOS_ASSERT(NULL != child_contexts);
+				GPOS_ASSERT(0 != child_contexts->Size());
+				ULONG colid = CDXLScalarIdent::Cast(expr_dxlnode->GetOperator())->GetDXLColRef()->Id();
 
-				const CDXLTranslateContext *pdxltrctxLeft = (*pdrgpdxltrctx)[0];
-				GPOS_ASSERT(NULL != pdxltrctxLeft);
-				const TargetEntry *pteOriginal = pdxltrctxLeft->Pte(ulColId);
+				const CDXLTranslateContext *translate_ctxt_left = (*child_contexts)[0];
+				GPOS_ASSERT(NULL != translate_ctxt_left);
+				const TargetEntry *pteOriginal = translate_ctxt_left->GetTargetEntry(colid);
 
 				if (NULL == pteOriginal)
 				{
 					// variable not found on the left side
-					GPOS_ASSERT(2 == pdrgpdxltrctx->UlLength());
-					const CDXLTranslateContext *pdxltrctxRight = (*pdrgpdxltrctx)[1];
+					GPOS_ASSERT(2 == child_contexts->Size());
+					const CDXLTranslateContext *pdxltrctxRight = (*child_contexts)[1];
 
 					GPOS_ASSERT(NULL != pdxltrctxRight);
-					pteOriginal = pdxltrctxRight->Pte(ulColId);
+					pteOriginal = pdxltrctxRight->GetTargetEntry(colid);
 				}
 
 				if (NULL  == pteOriginal)
 				{
-					GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, ulColId);
+					GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, colid);
 				}	
-				pte->resorigtbl = pteOriginal->resorigtbl;
-				pte->resorigcol = pteOriginal->resorigcol;
+				target_entry->resorigtbl = pteOriginal->resorigtbl;
+				target_entry->resorigcol = pteOriginal->resorigcol;
 			}
 		}
 
 		// add column mapping to output translation context
-		pdxltrctxOut->InsertMapping(pdxlopPrel->UlId(), pte);
+		output_context->InsertMapping(sc_proj_elem_dxlop->Id(), target_entry);
 
-		plTargetList = gpdb::PlAppendElement(plTargetList, pte);
+		target_list = gpdb::LAppend(target_list, target_entry);
 	}
 
-	return plTargetList;
+	return target_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlTargetListWithDroppedCols
+//		CTranslatorDXLToPlStmt::CreateTargetListWithNullsForDroppedCols
 //
 //	@doc:
 //		Construct the target list for a DML statement by adding NULL elements
@@ -4444,57 +4440,57 @@ CTranslatorDXLToPlStmt::PlTargetListFromProjList
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTargetListWithDroppedCols
+CTranslatorDXLToPlStmt::CreateTargetListWithNullsForDroppedCols
 	(
-	List *plTargetList,
-	const IMDRelation *pmdrel
+	List *target_list,
+	const IMDRelation *md_rel
 	)
 {
-	GPOS_ASSERT(NULL != plTargetList);
-	GPOS_ASSERT(gpdb::UlListLength(plTargetList) <= pmdrel->UlColumns());
+	GPOS_ASSERT(NULL != target_list);
+	GPOS_ASSERT(gpdb::ListLength(target_list) <= md_rel->ColumnCount());
 
-	List *plResult = NIL;
-	ULONG ulLastTLElem = 0;
-	ULONG ulResno = 1;
+	List *result_list = NIL;
+	ULONG last_tgt_elem = 0;
+	ULONG resno = 1;
 	
-	const ULONG ulRelCols = pmdrel->UlColumns();
+	const ULONG num_of_rel_cols = md_rel->ColumnCount();
 	
-	for (ULONG ul = 0; ul < ulRelCols; ul++)
+	for (ULONG ul = 0; ul < num_of_rel_cols; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
+		const IMDColumn *md_col = md_rel->GetMdCol(ul);
 		
-		if (pmdcol->FSystemColumn())
+		if (md_col->IsSystemColumn())
 		{
 			continue;
 		}
 		
-		Expr *pexpr = NULL;	
-		if (pmdcol->FDropped())
+		Expr *expr = NULL;
+		if (md_col->IsDropped())
 		{
 			// add a NULL element
-			OID oidType = CMDIdGPDB::PmdidConvert(m_pmda->PtMDType<IMDTypeInt4>()->Pmdid())->OidObjectId();
+			OID oid_type = CMDIdGPDB::CastMdid(m_md_accessor->PtMDType<IMDTypeInt4>()->MDId())->Oid();
 
-			pexpr = (Expr *) gpdb::PnodeMakeNULLConst(oidType);
+			expr = (Expr *) gpdb::MakeNULLConst(oid_type);
 		}
 		else
 		{
-			TargetEntry *pte = (TargetEntry *) gpdb::PvListNth(plTargetList, ulLastTLElem);
-			pexpr = (Expr *) gpdb::PvCopyObject(pte->expr);
-			ulLastTLElem++;
+			TargetEntry *target_entry = (TargetEntry *) gpdb::ListNth(target_list, last_tgt_elem);
+			expr = (Expr *) gpdb::CopyObject(target_entry->expr);
+			last_tgt_elem++;
 		}
 		
-		CHAR *szName = CTranslatorUtils::SzFromWsz(pmdcol->Mdname().Pstr()->Wsz());
-		TargetEntry *pteNew = gpdb::PteMakeTargetEntry(pexpr, ulResno, szName, false /*resjunk*/);
-		plResult = gpdb::PlAppendElement(plResult, pteNew);
-		ulResno++;
+		CHAR *name_str = CTranslatorUtils::CreateMultiByteCharStringFromWCString(md_col->Mdname().GetMDName()->GetBuffer());
+		TargetEntry *te_new = gpdb::MakeTargetEntry(expr, resno, name_str, false /*resjunk*/);
+		result_list = gpdb::LAppend(result_list, te_new);
+		resno++;
 	}
 	
-	return plResult;
+	return result_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlTargetListForHashNode
+//		CTranslatorDXLToPlStmt::TranslateDXLProjectListToHashTargetList
 //
 //	@doc:
 //		Create a target list for the hash node of a hash join plan node by creating a list
@@ -4502,150 +4498,150 @@ CTranslatorDXLToPlStmt::PlTargetListWithDroppedCols
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTargetListForHashNode
+CTranslatorDXLToPlStmt::TranslateDXLProjectListToHashTargetList
 	(
-	const CDXLNode *pdxlnPrL,
-	CDXLTranslateContext *pdxltrctxChild,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *project_list_dxlnode,
+	CDXLTranslateContext *child_context,
+	CDXLTranslateContext *output_context
 	)
 {
-	List *plTargetList = NIL;
-	const ULONG ulArity = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	List *target_list = NIL;
+	const ULONG arity = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnPrEl = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrel = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
 
-		const TargetEntry *pteChild = pdxltrctxChild->Pte(pdxlopPrel->UlId());
-		if (NULL  == pteChild)
+		const TargetEntry *te_child = child_context->GetTargetEntry(sc_proj_elem_dxlop->Id());
+		if (NULL  == te_child)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, pdxlopPrel->UlId());
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, sc_proj_elem_dxlop->Id());
 		}	
 
 		// get type oid for project element's expression
-		GPOS_ASSERT(1 == pdxlnPrEl->UlArity());
+		GPOS_ASSERT(1 == proj_elem_dxlnode->Arity());
 
 		// find column type
-		OID oidType = gpdb::OidExprType((Node*) pteChild->expr);
-		INT iTypeModifier = gpdb::IExprTypeMod((Node *) pteChild->expr);
+		OID oid_type = gpdb::ExprType((Node*) te_child->expr);
+		INT type_modifier = gpdb::ExprTypeMod((Node *) te_child->expr);
 
 		// find the original varno and attno for this column
-		Index idxVarnoold = 0;
-		AttrNumber attnoOld = 0;
+		Index idx_varnoold = 0;
+		AttrNumber attno_old = 0;
 
-		if (IsA(pteChild->expr, Var))
+		if (IsA(te_child->expr, Var))
 		{
-			Var *pv = (Var*) pteChild->expr;
-			idxVarnoold = pv->varnoold;
-			attnoOld = pv->varoattno;
+			Var *pv = (Var*) te_child->expr;
+			idx_varnoold = pv->varnoold;
+			attno_old = pv->varoattno;
 		}
 		else
 		{
-			idxVarnoold = OUTER_VAR;
-			attnoOld = pteChild->resno;
+			idx_varnoold = OUTER_VAR;
+			attno_old = te_child->resno;
 		}
 
 		// create a Var expression for this target list entry expression
-		Var *pvar = gpdb::PvarMakeVar
+		Var *var = gpdb::MakeVar
 					(
 					OUTER_VAR,
-					pteChild->resno,
-					oidType,
-					iTypeModifier,
+					te_child->resno,
+					oid_type,
+					type_modifier,
 					0	// varlevelsup
 					);
 
 		// set old varno and varattno since makeVar does not set them
-		pvar->varnoold = idxVarnoold;
-		pvar->varoattno = attnoOld;
+		var->varnoold = idx_varnoold;
+		var->varoattno = attno_old;
 
-		CHAR *szResname = CTranslatorUtils::SzFromWsz(pdxlopPrel->PmdnameAlias()->Pstr()->Wsz());
+		CHAR *resname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
 
-		TargetEntry *pte = gpdb::PteMakeTargetEntry
+		TargetEntry *target_entry = gpdb::MakeTargetEntry
 							(
-							(Expr *) pvar,
+							(Expr *) var,
 							(AttrNumber) (ul + 1),
-							szResname,
+							resname,
 							false		// resjunk
 							);
 
-		plTargetList = gpdb::PlAppendElement(plTargetList, pte);
-		pdxltrctxOut->InsertMapping(pdxlopPrel->UlId(), pte);
+		target_list = gpdb::LAppend(target_list, target_entry);
+		output_context->InsertMapping(sc_proj_elem_dxlop->Id(), target_entry);
 	}
 
-	return plTargetList;
+	return target_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlQualFromFilter
+//		CTranslatorDXLToPlStmt::TranslateDXLFilterToQual
 //
 //	@doc:
 //		Translates a DXL filter node into a Qual list.
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlQualFromFilter
+CTranslatorDXLToPlStmt::TranslateDXLFilterToQual
 	(
-	const CDXLNode * pdxlnFilter,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode * filter_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	CDXLTranslateContext *output_context
 	)
 {
-	const ULONG ulArity = pdxlnFilter->UlArity();
-	if (0 == ulArity)
+	const ULONG arity = filter_dxlnode->Arity();
+	if (0 == arity)
 	{
 		return NIL;
 	}
 
-	GPOS_ASSERT(1 == ulArity);
+	GPOS_ASSERT(1 == arity);
 
-	CDXLNode *pdxlnFilterCond = (*pdxlnFilter)[0];
-	GPOS_ASSERT(CTranslatorDXLToScalar::FBoolean(pdxlnFilterCond, m_pmda));
+	CDXLNode *filter_cond_dxlnode = (*filter_dxlnode)[0];
+	GPOS_ASSERT(CTranslatorDXLToScalar::HasBoolResult(filter_cond_dxlnode, m_md_accessor));
 
-	return PlQualFromScalarCondNode(pdxlnFilterCond, pdxltrctxbt, pdrgpdxltrctx, pdxltrctxOut);
+	return TranslateDXLScCondToQual(filter_cond_dxlnode, base_table_context, child_contexts, output_context);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlQualFromScalarCondNode
+//		CTranslatorDXLToPlStmt::TranslateDXLScCondToQual
 //
 //	@doc:
 //		Translates a DXL scalar condition node node into a Qual list.
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlQualFromScalarCondNode
+CTranslatorDXLToPlStmt::TranslateDXLScCondToQual
 	(
-	const CDXLNode *pdxlnCond,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *condition_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	CDXLTranslateContext *output_context
 	)
 {
-	List *plQuals = NIL;
+	List *quals_list = NIL;
 
-	GPOS_ASSERT(CTranslatorDXLToScalar::FBoolean(const_cast<CDXLNode*>(pdxlnCond), m_pmda));
+	GPOS_ASSERT(CTranslatorDXLToScalar::HasBoolResult(const_cast<CDXLNode*>(condition_dxlnode), m_md_accessor));
 
-	CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+	CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 															(
-															m_pmp,
-															pdxltrctxbt,
-															pdrgpdxltrctx,
-															pdxltrctxOut,
-															m_pctxdxltoplstmt
+															m_mp,
+															base_table_context,
+															child_contexts,
+															output_context,
+															m_dxl_to_plstmt_context
 															);
 
-	Expr *pexpr = m_pdxlsctranslator->PexprFromDXLNodeScalar
+	Expr *expr = m_translator_dxl_to_scalar->TranslateDXLToScalar
 					(
-					pdxlnCond,
-					&mapcidvarplstmt
+					condition_dxlnode,
+					&colid_var_mapping
 					);
 
-	plQuals = gpdb::PlAppendElement(plQuals, pexpr);
+	quals_list = gpdb::LAppend(quals_list, expr);
 
-	return plQuals;
+	return quals_list;
 }
 
 //---------------------------------------------------------------------------
@@ -4659,17 +4655,17 @@ CTranslatorDXLToPlStmt::PlQualFromScalarCondNode
 void
 CTranslatorDXLToPlStmt::TranslatePlanCosts
 	(
-	const CDXLOperatorCost *pdxlopcost,
-	Cost *pcostStartupOut,
-	Cost *pcostTotalOut,
-	Cost *pcostRowsOut,
-	INT * piWidthOut
+	const CDXLOperatorCost *dxl_operator_cost,
+	Cost *startup_cost_out,
+	Cost *total_cost_out,
+	Cost *cost_rows_out,
+	INT * width_out
 	)
 {
-	*pcostStartupOut = CostFromStr(pdxlopcost->PstrStartupCost());
-	*pcostTotalOut = CostFromStr(pdxlopcost->PstrTotalCost());
-	*pcostRowsOut = CostFromStr(pdxlopcost->PstrRows());
-	*piWidthOut = CTranslatorUtils::IFromStr(pdxlopcost->PstrWidth());
+	*startup_cost_out = CostFromStr(dxl_operator_cost->GetStartUpCostStr());
+	*total_cost_out = CostFromStr(dxl_operator_cost->GetTotalCostStr());
+	*cost_rows_out = CostFromStr(dxl_operator_cost->GetRowsOutStr());
+	*width_out = CTranslatorUtils::GetIntFromStr(dxl_operator_cost->GetWidthStr());
 }
 
 //---------------------------------------------------------------------------
@@ -4684,31 +4680,31 @@ CTranslatorDXLToPlStmt::TranslatePlanCosts
 void
 CTranslatorDXLToPlStmt::TranslateProjListAndFilter
 	(
-	const CDXLNode *pdxlnPrL,
-	const CDXLNode *pdxlnFilter,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	List **pplTargetListOut,
-	List **pplQualOut,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *project_list_dxlnode,
+	const CDXLNode *filter_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	List **targetlist_out,
+	List **qual_out,
+	CDXLTranslateContext *output_context
 	)
 {
 	// translate proj list
-	*pplTargetListOut = PlTargetListFromProjList
+	*targetlist_out = TranslateDXLProjList
 						(
-						pdxlnPrL,
-						pdxltrctxbt,		// base table translation context
-						pdrgpdxltrctx,
-						pdxltrctxOut
+						project_list_dxlnode,
+						base_table_context,		// base table translation context
+						child_contexts,
+						output_context
 						);
 
 	// translate filter
-	*pplQualOut = PlQualFromFilter
+	*qual_out = TranslateDXLFilterToQual
 					(
-					pdxlnFilter,
-					pdxltrctxbt,			// base table translation context
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					filter_dxlnode,
+					base_table_context,			// base table translation context
+					child_contexts,
+					output_context
 					);
 }
 
@@ -4725,62 +4721,62 @@ CTranslatorDXLToPlStmt::TranslateProjListAndFilter
 void
 CTranslatorDXLToPlStmt::TranslateHashExprList
 	(
-	const CDXLNode *pdxlnHashExprList,
-	const CDXLTranslateContext *pdxltrctxChild,
-	List **pplHashExprOut,
-	List **pplHashExprTypesOut,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *hash_expr_list_dxlnode,
+	const CDXLTranslateContext *child_context,
+	List **hash_expr_out_list,
+	List **hash_expr_types_out_list,
+	CDXLTranslateContext *output_context
 	)
 {
-	GPOS_ASSERT(NIL == *pplHashExprOut);
-	GPOS_ASSERT(NIL == *pplHashExprTypesOut);
+	GPOS_ASSERT(NIL == *hash_expr_out_list);
+	GPOS_ASSERT(NIL == *hash_expr_types_out_list);
 
-	List *plHashExpr = NIL;
-	List *plHashExprTypes = NIL;
+	List *hash_expr_list = NIL;
+	List *hash_expr_types_list = NIL;
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(pdxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(child_context);
 
-	const ULONG ulArity = pdxlnHashExprList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = hash_expr_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnHashExpr = (*pdxlnHashExprList)[ul];
-		CDXLScalarHashExpr *pdxlopHashExpr = CDXLScalarHashExpr::PdxlopConvert(pdxlnHashExpr->Pdxlop());
+		CDXLNode *hash_expr_dxlnode = (*hash_expr_list_dxlnode)[ul];
+		CDXLScalarHashExpr *hash_expr_dxlop = CDXLScalarHashExpr::Cast(hash_expr_dxlnode->GetOperator());
 
 		// the type of the hash expression in GPDB is computed as the left operand 
 		// of the equality operator of the actual hash expression type
-		const IMDType *pmdtype = m_pmda->Pmdtype(pdxlopHashExpr->PmdidType());
-		const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pmdtype->PmdidCmp(IMDType::EcmptEq));
+		const IMDType *md_type = m_md_accessor->RetrieveType(hash_expr_dxlop->MdidType());
+		const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(md_type->GetMdidForCmpType(IMDType::EcmptEq));
 		
-		const IMDId *pmdidHashType = pmdscop->PmdidTypeLeft();
+		const IMDId *mdid_hash_type = md_scalar_op->GetLeftMdid();
 		
-		plHashExprTypes = gpdb::PlAppendOid(plHashExprTypes, CMDIdGPDB::PmdidConvert(pmdidHashType)->OidObjectId());
+		hash_expr_types_list = gpdb::LAppendOid(hash_expr_types_list, CMDIdGPDB::CastMdid(mdid_hash_type)->Oid());
 
-		GPOS_ASSERT(1 == pdxlnHashExpr->UlArity());
-		CDXLNode *pdxlnExpr = (*pdxlnHashExpr)[0];
+		GPOS_ASSERT(1 == hash_expr_dxlnode->Arity());
+		CDXLNode *expr_dxlnode = (*hash_expr_dxlnode)[0];
 
-		CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+		CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 																(
-																m_pmp,
+																m_mp,
 																NULL,
-																pdrgpdxltrctx,
-																pdxltrctxOut,
-																m_pctxdxltoplstmt
+																child_contexts,
+																output_context,
+																m_dxl_to_plstmt_context
 																);
 
-		Expr *pexpr = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnExpr, &mapcidvarplstmt);
+		Expr *expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(expr_dxlnode, &colid_var_mapping);
 
-		plHashExpr = gpdb::PlAppendElement(plHashExpr, pexpr);
+		hash_expr_list = gpdb::LAppend(hash_expr_list, expr);
 
-		GPOS_ASSERT((ULONG) gpdb::UlListLength(plHashExpr) == ul + 1);
+		GPOS_ASSERT((ULONG) gpdb::ListLength(hash_expr_list) == ul + 1);
 	}
 
 
-	*pplHashExprOut = plHashExpr;
-	*pplHashExprTypesOut = plHashExprTypes;
+	*hash_expr_out_list = hash_expr_list;
+	*hash_expr_types_out_list = hash_expr_types_list;
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 }
 
 //---------------------------------------------------------------------------
@@ -4796,34 +4792,34 @@ CTranslatorDXLToPlStmt::TranslateHashExprList
 void
 CTranslatorDXLToPlStmt::TranslateSortCols
 	(
-	const CDXLNode *pdxlnSortColList,
-	const CDXLTranslateContext *pdxltrctxChild,
-	AttrNumber *pattnoSortColIds,
-	Oid *poidSortOpIds,
-	Oid *poidSortCollations,
-	bool *pboolNullsFirst
+	const CDXLNode *sort_col_list_dxl,
+	const CDXLTranslateContext *child_context,
+	AttrNumber *att_no_sort_colids,
+	Oid *sort_op_oids,
+	Oid *sort_collations_oids,
+	bool *is_nulls_first
 	)
 {
-	const ULONG ulArity = pdxlnSortColList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = sort_col_list_dxl->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnSortCol = (*pdxlnSortColList)[ul];
-		CDXLScalarSortCol *pdxlopSortCol = CDXLScalarSortCol::PdxlopConvert(pdxlnSortCol->Pdxlop());
+		CDXLNode *sort_col_dxlnode = (*sort_col_list_dxl)[ul];
+		CDXLScalarSortCol *sc_sort_col_dxlop = CDXLScalarSortCol::Cast(sort_col_dxlnode->GetOperator());
 
-		ULONG ulSortColId = pdxlopSortCol->UlColId();
-		const TargetEntry *pteSortCol = pdxltrctxChild->Pte(ulSortColId);
-		if (NULL  == pteSortCol)
+		ULONG sort_colid = sc_sort_col_dxlop->GetColId();
+		const TargetEntry *te_sort_col = child_context->GetTargetEntry(sort_colid);
+		if (NULL  == te_sort_col)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, ulSortColId);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, sort_colid);
 		}	
 
-		pattnoSortColIds[ul] = pteSortCol->resno;
-		poidSortOpIds[ul] = CMDIdGPDB::PmdidConvert(pdxlopSortCol->PmdidSortOp())->OidObjectId();
-		if (poidSortCollations)
+		att_no_sort_colids[ul] = te_sort_col->resno;
+		sort_op_oids[ul] = CMDIdGPDB::CastMdid(sc_sort_col_dxlop->GetMdIdSortOp())->Oid();
+		if (sort_collations_oids)
 		{
-			poidSortCollations[ul] = gpdb::OidExprCollation((Node *) pteSortCol->expr);
+			sort_collations_oids[ul] = gpdb::ExprCollation((Node *) te_sort_col->expr);
 		}
-		pboolNullsFirst[ul] = pdxlopSortCol->FSortNullsFirst();
+		is_nulls_first[ul] = sc_sort_col_dxlop->IsSortedNullsFirst();
 	}
 }
 
@@ -4838,37 +4834,37 @@ CTranslatorDXLToPlStmt::TranslateSortCols
 Cost
 CTranslatorDXLToPlStmt::CostFromStr
 	(
-	const CWStringBase *pstr
+	const CWStringBase *str
 	)
 {
-	CHAR *sz = CTranslatorUtils::SzFromWsz(pstr->Wsz());
-	return gpos::clib::DStrToD(sz);
+	CHAR *sz = CTranslatorUtils::CreateMultiByteCharStringFromWCString(str->GetBuffer());
+	return gpos::clib::Strtod(sz);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::FTargetTableDistributed
+//		CTranslatorDXLToPlStmt::IsTgtTblDistributed
 //
 //	@doc:
 //		Check if given operator is a DML on a distributed table
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorDXLToPlStmt::FTargetTableDistributed
+CTranslatorDXLToPlStmt::IsTgtTblDistributed
 	(
-	CDXLOperator *pdxlop
+	CDXLOperator *dxlop
 	)
 {
-	if (EdxlopPhysicalDML != pdxlop->Edxlop())
+	if (EdxlopPhysicalDML != dxlop->GetDXLOperator())
 	{
 		return false;
 	}
 
-	CDXLPhysicalDML *pdxlopDML = CDXLPhysicalDML::PdxlopConvert(pdxlop);
-	IMDId *pmdid = pdxlopDML->Pdxltabdesc()->Pmdid();
+	CDXLPhysicalDML *phy_dml_dxlop = CDXLPhysicalDML::Cast(dxlop);
+	IMDId *mdid = phy_dml_dxlop->GetDXLTableDescr()->MDId();
 
-	return IMDRelation::EreldistrMasterOnly != m_pmda->Pmdrel(pmdid)->Ereldistribution();
+	return IMDRelation::EreldistrMasterOnly != m_md_accessor->RetrieveRel(mdid)->GetRelDistribution();
 }
 
 //---------------------------------------------------------------------------
@@ -4881,19 +4877,19 @@ CTranslatorDXLToPlStmt::FTargetTableDistributed
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorDXLToPlStmt::UlAddTargetEntryForColId
+CTranslatorDXLToPlStmt::AddTargetEntryForColId
 	(
-	List **pplTargetList,
-	CDXLTranslateContext *pdxltrctx,
-	ULONG ulColId,
-	BOOL fResjunk
+	List **target_list,
+	CDXLTranslateContext *dxl_translate_ctxt,
+	ULONG colid,
+	BOOL is_resjunk
 	)
 {
-	GPOS_ASSERT(NULL != pplTargetList);
+	GPOS_ASSERT(NULL != target_list);
 	
-	const TargetEntry *pte = pdxltrctx->Pte(ulColId);
+	const TargetEntry *target_entry = dxl_translate_ctxt->GetTargetEntry(colid);
 	
-	if (NULL == pte)
+	if (NULL == target_entry)
 	{
 		// colid not found in translate context
 		return 0;
@@ -4901,43 +4897,43 @@ CTranslatorDXLToPlStmt::UlAddTargetEntryForColId
 	
 	// TODO: Oct 29, 2012; see if entry already exists in the target list
 	
-	OID oidExpr = gpdb::OidExprType((Node*) pte->expr);
-	INT iTypeModifier = gpdb::IExprTypeMod((Node *) pte->expr);
-	Var *pvar = gpdb::PvarMakeVar
+	OID expr_oid = gpdb::ExprType((Node*) target_entry->expr);
+	INT type_modifier = gpdb::ExprTypeMod((Node *) target_entry->expr);
+	Var *var = gpdb::MakeVar
 						(
 						OUTER_VAR,
-						pte->resno,
-						oidExpr,
-						iTypeModifier,
+						target_entry->resno,
+						expr_oid,
+						type_modifier,
 						0	// varlevelsup
 						);
-	ULONG ulResNo = gpdb::UlListLength(*pplTargetList) + 1;
-	CHAR *szResName = PStrDup(pte->resname);
-	TargetEntry *pteNew = gpdb::PteMakeTargetEntry((Expr*) pvar, ulResNo, szResName, fResjunk);
-	*pplTargetList = gpdb::PlAppendElement(*pplTargetList, pteNew);
+	ULONG resno = gpdb::ListLength(*target_list) + 1;
+	CHAR *resname_str = PStrDup(target_entry->resname);
+	TargetEntry *te_new = gpdb::MakeTargetEntry((Expr*) var, resno, resname_str, is_resjunk);
+	*target_list = gpdb::LAppend(*target_list, te_new);
 	
-	return pte->resno;
+	return target_entry->resno;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::JtFromEdxljt
+//		CTranslatorDXLToPlStmt::GetGPDBJoinTypeFromDXLJoinType
 //
 //	@doc:
 //		Translates the join type from its DXL representation into the GPDB one
 //
 //---------------------------------------------------------------------------
 JoinType
-CTranslatorDXLToPlStmt::JtFromEdxljt
+CTranslatorDXLToPlStmt::GetGPDBJoinTypeFromDXLJoinType
 	(
-	EdxlJoinType edxljt
+	EdxlJoinType join_type
 	)
 {
-	GPOS_ASSERT(EdxljtSentinel > edxljt);
+	GPOS_ASSERT(EdxljtSentinel > join_type);
 
 	JoinType jt = JOIN_INNER;
 
-	switch (edxljt)
+	switch (join_type)
 	{
 		case EdxljtInner:
 			jt = JOIN_INNER;
@@ -4969,7 +4965,7 @@ CTranslatorDXLToPlStmt::JtFromEdxljt
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanCTAS
+//		CTranslatorDXLToPlStmt::TranslateDXLCtas
 //
 //	@doc:
 //		Sets the vartypmod fields in the target entries of the given target list
@@ -4978,26 +4974,26 @@ CTranslatorDXLToPlStmt::JtFromEdxljt
 void
 CTranslatorDXLToPlStmt::SetVarTypMod
 	(
-	const CDXLPhysicalCTAS *pdxlop,
-	List *plTargetList
+	const CDXLPhysicalCTAS *phy_ctas_dxlop,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != plTargetList);
+	GPOS_ASSERT(NULL != target_list);
 
-	DrgPi *pdrgpi = pdxlop->PdrgpiVarTypeMod();
-	GPOS_ASSERT(pdrgpi->UlLength() == gpdb::UlListLength(plTargetList));
+	IntPtrArray *var_type_mod_array = phy_ctas_dxlop->GetVarTypeModArray();
+	GPOS_ASSERT(var_type_mod_array->Size() == gpdb::ListLength(target_list));
 
 	ULONG ul = 0;
-	ListCell *plc = NULL;
-	ForEach (plc, plTargetList)
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plc);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
 
-		if (IsA(pte->expr, Var))
+		if (IsA(target_entry->expr, Var))
 		{
-			Var *var = (Var*) pte->expr;
-			var->vartypmod = *(*pdrgpi)[ul];
+			Var *var = (Var*) target_entry->expr;
+			var->vartypmod = *(*var_type_mod_array)[ul];
 		}
 		++ul;
 	}
@@ -5005,356 +5001,356 @@ CTranslatorDXLToPlStmt::SetVarTypMod
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanCTAS
+//		CTranslatorDXLToPlStmt::TranslateDXLCtas
 //
 //	@doc:
 //		Translates a DXL CTAS node 
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanCTAS
+CTranslatorDXLToPlStmt::TranslateDXLCtas
 	(
-	const CDXLNode *pdxlnCTAS,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *ctas_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalCTAS *pdxlop = CDXLPhysicalCTAS::PdxlopConvert(pdxlnCTAS->Pdxlop());
-	CDXLNode *pdxlnPrL = (*pdxlnCTAS)[0];
-	CDXLNode *pdxlnChild = (*pdxlnCTAS)[1];
+	CDXLPhysicalCTAS *phy_ctas_dxlop = CDXLPhysicalCTAS::Cast(ctas_dxlnode->GetOperator());
+	CDXLNode *project_list_dxlnode = (*ctas_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*ctas_dxlnode)[1];
 
-	GPOS_ASSERT(NULL == pdxlop->Pdxlctasopt()->Pdrgpctasopt());
+	GPOS_ASSERT(NULL == phy_ctas_dxlop->GetDxlCtasStorageOption()->GetDXLCtasOptionArray());
 	
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplan = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 	
 	// fix target list to match the required column names
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 	
-	List *plTargetList = PlTargetListFromProjList
+	List *target_list = TranslateDXLProjList
 						(
-						pdxlnPrL,
-						NULL,		// pdxltrctxbt
-						pdrgpdxltrctx,
-						pdxltrctxOut
+						project_list_dxlnode,
+						NULL,		// base_table_context
+						child_contexts,
+						output_context
 						);
-	SetVarTypMod(pdxlop, plTargetList);
+	SetVarTypMod(phy_ctas_dxlop, target_list);
 	
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnCTAS->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(ctas_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-//	IntoClause *pintocl = PintoclFromCtas(pdxlop);
-	IntoClause *pintocl = NULL;
-	GpPolicy *pdistrpolicy = PdistrpolicyFromCtas(pdxlop);
-	m_pctxdxltoplstmt->AddCtasInfo(pintocl, pdistrpolicy);
+	//IntoClause *into_clause = TranslateDXLPhyCtasToIntoClause(phy_ctas_dxlop);
+	IntoClause *into_clause = NULL;
+	GpPolicy *distr_policy = TranslateDXLPhyCtasToDistrPolicy(phy_ctas_dxlop);
+	m_dxl_to_plstmt_context->AddCtasInfo(into_clause, distr_policy);
 	
-	GPOS_ASSERT(IMDRelation::EreldistrMasterOnly != pdxlop->Ereldistrpolicy());
+	GPOS_ASSERT(IMDRelation::EreldistrMasterOnly != phy_ctas_dxlop->Ereldistrpolicy());
 	
-	m_fTargetTableDistributed = true;
+	m_is_tgt_tbl_distributed = true;
 	
 	// Add a result node on top with the correct projection list
-	Result *presult = MakeNode(Result);
-	Plan *pplanResult = &(presult->plan);
-	pplanResult->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplanResult->nMotionNodes = pplan->nMotionNodes;
-	pplanResult->lefttree = pplan;
+	Result *result = MakeNode(Result);
+	Plan *result_plan = &(result->plan);
+	result_plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	result_plan->nMotionNodes = plan->nMotionNodes;
+	result_plan->lefttree = plan;
 
-	pplanResult->targetlist = plTargetList;
-	SetParamIds(pplanResult);
+	result_plan->targetlist = target_list;
+	SetParamIds(result_plan);
 
-	pplan = (Plan *) presult;
+	plan = (Plan *) result;
 
-	return (Plan *) pplan;
+	return (Plan *) plan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PintoclFromCtas
+//		CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToIntoClause
 //
 //	@doc:
 //		Translates a DXL CTAS into clause 
 //
 //---------------------------------------------------------------------------
 IntoClause *
-CTranslatorDXLToPlStmt::PintoclFromCtas
+CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToIntoClause
 	(
-	const CDXLPhysicalCTAS *pdxlop
+	const CDXLPhysicalCTAS *phy_ctas_dxlop
 	)
 {
-	IntoClause *pintocl = MakeNode(IntoClause);
-	pintocl->rel = MakeNode(RangeVar);
+	IntoClause *into_clause = MakeNode(IntoClause);
+	into_clause->rel = MakeNode(RangeVar);
 	/* GPDB_91_MERGE_FIXME: what about unlogged? */
-	pintocl->rel->relpersistence = pdxlop->FTemporary() ? RELPERSISTENCE_TEMP : RELPERSISTENCE_PERMANENT;
-	pintocl->rel->relname = CTranslatorUtils::SzFromWsz(pdxlop->Pmdname()->Pstr()->Wsz());
-	pintocl->rel->schemaname = NULL;
-	if (NULL != pdxlop->PmdnameSchema())
+	into_clause->rel->relpersistence = phy_ctas_dxlop->IsTemporary() ? RELPERSISTENCE_TEMP : RELPERSISTENCE_PERMANENT;
+	into_clause->rel->relname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(phy_ctas_dxlop->MdName()->GetMDName()->GetBuffer());
+	into_clause->rel->schemaname = NULL;
+	if (NULL != phy_ctas_dxlop->GetMdNameSchema())
 	{
-		pintocl->rel->schemaname = CTranslatorUtils::SzFromWsz(pdxlop->PmdnameSchema()->Pstr()->Wsz());
+		into_clause->rel->schemaname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(phy_ctas_dxlop->GetMdNameSchema()->GetMDName()->GetBuffer());
 	}
 	
-	CDXLCtasStorageOptions *pdxlctasopt = pdxlop->Pdxlctasopt();
-	if (NULL != pdxlctasopt->PmdnameTablespace())
+	CDXLCtasStorageOptions *dxl_ctas_storage_option = phy_ctas_dxlop->GetDxlCtasStorageOption();
+	if (NULL != dxl_ctas_storage_option->GetMdNameTableSpace())
 	{
-		pintocl->tableSpaceName = CTranslatorUtils::SzFromWsz(pdxlop->Pdxlctasopt()->PmdnameTablespace()->Pstr()->Wsz());
+		into_clause->tableSpaceName = CTranslatorUtils::CreateMultiByteCharStringFromWCString(phy_ctas_dxlop->GetDxlCtasStorageOption()->GetMdNameTableSpace()->GetMDName()->GetBuffer());
 	}
 	
-	pintocl->onCommit = (OnCommitAction) pdxlctasopt->Ectascommit(); 
-	pintocl->options = PlCtasOptions(pdxlctasopt->Pdrgpctasopt());
+	into_clause->onCommit = (OnCommitAction) dxl_ctas_storage_option->GetOnCommitAction();
+	into_clause->options = TranslateDXLCtasStorageOptions(dxl_ctas_storage_option->GetDXLCtasOptionArray());
 	
 	// get column names
-	DrgPdxlcd *pdrgpdxlcd = pdxlop->Pdrgpdxlcd();
-	const ULONG ulCols = pdrgpdxlcd->UlLength();
-	pintocl->colNames = NIL;
-	for (ULONG ul = 0; ul < ulCols; ++ul)
+	CDXLColDescrArray *dxl_col_descr_array = phy_ctas_dxlop->GetDXLColumnDescrArray();
+	const ULONG num_of_cols = dxl_col_descr_array->Size();
+	into_clause->colNames = NIL;
+	for (ULONG ul = 0; ul < num_of_cols; ++ul)
 	{
-		const CDXLColDescr *pdxlcd = (*pdrgpdxlcd)[ul];
+		const CDXLColDescr *dxl_col_descr = (*dxl_col_descr_array)[ul];
 
-		CHAR *szColName = CTranslatorUtils::SzFromWsz(pdxlcd->Pmdname()->Pstr()->Wsz());
+		CHAR *col_name_char_array = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxl_col_descr->MdName()->GetMDName()->GetBuffer());
 		
-		ColumnDef *pcoldef = MakeNode(ColumnDef);
-		pcoldef->colname = szColName;
-		pcoldef->is_local = true;
+		ColumnDef *col_def = MakeNode(ColumnDef);
+		col_def->colname = col_name_char_array;
+		col_def->is_local = true;
 
 		// GDPB_91_MERGE_FIXME: collation
-		pcoldef->collClause = NULL;
-		pcoldef->collOid = gpdb::OidTypeCollation(CMDIdGPDB::PmdidConvert(pdxlcd->PmdidType())->OidObjectId());
-		pintocl->colNames = gpdb::PlAppendElement(pintocl->colNames, pcoldef);
+		col_def->collClause = NULL;
+		col_def->collOid = gpdb::TypeCollation(CMDIdGPDB::CastMdid(dxl_col_descr->MdidType())->Oid());
+		into_clause->colNames = gpdb::LAppend(into_clause->colNames, col_def);
 
 	}
 
-	return pintocl;
+	return into_clause;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PdistrpolicyFromCtas
+//		CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy
 //
 //	@doc:
 //		Translates distribution policy given by a physical CTAS operator 
 //
 //---------------------------------------------------------------------------
 GpPolicy *
-CTranslatorDXLToPlStmt::PdistrpolicyFromCtas
+CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy
 	(
-	const CDXLPhysicalCTAS *pdxlop
+	const CDXLPhysicalCTAS *dxlop
 	)
 {
-	DrgPul *pdrgpulDistrCols = pdxlop->PdrgpulDistr();
+	ULongPtrArray *distr_col_pos_array = dxlop->GetDistrColPosArray();
 
-	const ULONG ulDistrCols = (pdrgpulDistrCols == NULL) ? 0 : pdrgpulDistrCols->UlLength();
+	const ULONG num_of_distr_cols = (distr_col_pos_array == NULL) ? 0 : distr_col_pos_array->Size();
 
-	ULONG ulDistrColsAlloc = 1;
-	if (0 < ulDistrCols)
+	ULONG num_of_distr_cols_alloc = 1;
+	if (0 < num_of_distr_cols)
 	{
-		ulDistrColsAlloc = ulDistrCols;
+		num_of_distr_cols_alloc = num_of_distr_cols;
 	}
 	
-	GpPolicy *pdistrpolicy = gpdb::PMakeGpPolicy(NULL, POLICYTYPE_PARTITIONED, ulDistrColsAlloc);
+	GpPolicy *distr_policy = gpdb::MakeGpPolicy(NULL, POLICYTYPE_PARTITIONED, num_of_distr_cols_alloc);
 
-	GPOS_ASSERT(IMDRelation::EreldistrHash == pdxlop->Ereldistrpolicy() ||
-				IMDRelation::EreldistrRandom == pdxlop->Ereldistrpolicy());
+	GPOS_ASSERT(IMDRelation::EreldistrHash == dxlop->Ereldistrpolicy() ||
+				IMDRelation::EreldistrRandom == dxlop->Ereldistrpolicy());
 	
-	pdistrpolicy->ptype = POLICYTYPE_PARTITIONED;
-	pdistrpolicy->nattrs = 0;
-	if (IMDRelation::EreldistrHash == pdxlop->Ereldistrpolicy())
+	distr_policy->ptype = POLICYTYPE_PARTITIONED;
+	distr_policy->nattrs = 0;
+	if (IMDRelation::EreldistrHash == dxlop->Ereldistrpolicy())
 	{
 		
-		GPOS_ASSERT(0 < ulDistrCols);
-		pdistrpolicy->nattrs = ulDistrCols;
+		GPOS_ASSERT(0 < num_of_distr_cols);
+		distr_policy->nattrs = num_of_distr_cols;
 		
-		for (ULONG ul = 0; ul < ulDistrCols; ul++)
+		for (ULONG ul = 0; ul < num_of_distr_cols; ul++)
 		{
-			ULONG ulColPos = *((*pdrgpulDistrCols)[ul]);
-			pdistrpolicy->attrs[ul] = ulColPos + 1;
+			ULONG col_pos_idx = *((*distr_col_pos_array)[ul]);
+			distr_policy->attrs[ul] = col_pos_idx + 1;
 		}
 	}
-	return pdistrpolicy;
+	return distr_policy;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlCtasOptions
+//		CTranslatorDXLToPlStmt::TranslateDXLCtasStorageOptions
 //
 //	@doc:
 //		Translates CTAS options
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlCtasOptions
+CTranslatorDXLToPlStmt::TranslateDXLCtasStorageOptions
 	(
-	CDXLCtasStorageOptions::DrgPctasOpt *pdrgpctasopt
+	CDXLCtasStorageOptions::CDXLCtasOptionArray *ctas_storage_options
 	)
 {
-	if (NULL == pdrgpctasopt)
+	if (NULL == ctas_storage_options)
 	{
 		return NIL;
 	}
 	
-	const ULONG ulOptions = pdrgpctasopt->UlLength();
-	List *plOptions = NIL;
-	for (ULONG ul = 0; ul < ulOptions; ul++)
+	const ULONG num_of_options = ctas_storage_options->Size();
+	List *options = NIL;
+	for (ULONG ul = 0; ul < num_of_options; ul++)
 	{
-		CDXLCtasStorageOptions::CDXLCtasOption *pdxlopt = (*pdrgpctasopt)[ul];
-		CWStringBase *pstrName = pdxlopt->m_pstrName;
-		CWStringBase *pstrValue = pdxlopt->m_pstrValue;
-		DefElem *pdefelem = MakeNode(DefElem);
-		pdefelem->defname = CTranslatorUtils::SzFromWsz(pstrName->Wsz());
+		CDXLCtasStorageOptions::CDXLCtasOption *pdxlopt = (*ctas_storage_options)[ul];
+		CWStringBase *str_name = pdxlopt->m_str_name;
+		CWStringBase *str_value = pdxlopt->m_str_value;
+		DefElem *def_elem = MakeNode(DefElem);
+		def_elem->defname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_name->GetBuffer());
 
-		if (!pdxlopt->m_fNull)
+		if (!pdxlopt->m_is_null)
 		{
-			NodeTag argType = (NodeTag) pdxlopt->m_ulType;
+			NodeTag arg_type = (NodeTag) pdxlopt->m_type;
 
-			GPOS_ASSERT(T_Integer == argType || T_String == argType);
-			if (T_Integer == argType)
+			GPOS_ASSERT(T_Integer == arg_type || T_String == arg_type);
+			if (T_Integer == arg_type)
 			{
-				pdefelem->arg = (Node *) gpdb::PvalMakeInteger(CTranslatorUtils::LFromStr(pstrValue));
+				def_elem->arg = (Node *) gpdb::MakeIntegerValue(CTranslatorUtils::GetLongFromStr(str_value));
 			}
 			else
 			{
-				pdefelem->arg = (Node *) gpdb::PvalMakeString(CTranslatorUtils::SzFromWsz(pstrValue->Wsz()));
+				def_elem->arg = (Node *) gpdb::MakeStringValue(CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_value->GetBuffer()));
 			}
 		}
 
-		plOptions = gpdb::PlAppendElement(plOptions, pdefelem);
+		options = gpdb::LAppend(options, def_elem);
 	}
 	
-	return plOptions;
+	return options;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanBitmapTableScan
+//		CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan
 //
 //	@doc:
 //		Translates a DXL bitmap table scan node into a BitmapTableScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanBitmapTableScan
+CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan
 	(
-	const CDXLNode *pdxlnBitmapScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *bitmapscan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	ULONG ulPartIndex = INVALID_PART_INDEX;
-	ULONG ulPartIndexPrintable = INVALID_PART_INDEX;
-	const CDXLTableDescr *pdxltabdesc = NULL;
-	BOOL fDynamic = false;
+	ULONG part_index_id = INVALID_PART_INDEX;
+	ULONG part_idx_printable_id = INVALID_PART_INDEX;
+	const CDXLTableDescr *table_descr = NULL;
+	BOOL is_dynamic = false;
 
-	CDXLOperator *pdxlop = pdxlnBitmapScan->Pdxlop();
-	if (EdxlopPhysicalBitmapTableScan == pdxlop->Edxlop())
+	CDXLOperator *dxl_operator = bitmapscan_dxlnode->GetOperator();
+	if (EdxlopPhysicalBitmapTableScan == dxl_operator->GetDXLOperator())
 	{
-		pdxltabdesc = CDXLPhysicalBitmapTableScan::PdxlopConvert(pdxlop)->Pdxltabdesc();
+		table_descr = CDXLPhysicalBitmapTableScan::Cast(dxl_operator)->GetDXLTableDescr();
 	}
 	else
 	{
-		GPOS_ASSERT(EdxlopPhysicalDynamicBitmapTableScan == pdxlop->Edxlop());
-		CDXLPhysicalDynamicBitmapTableScan *pdxlopDynamic =
-				CDXLPhysicalDynamicBitmapTableScan::PdxlopConvert(pdxlop);
-		pdxltabdesc = pdxlopDynamic->Pdxltabdesc();
+		GPOS_ASSERT(EdxlopPhysicalDynamicBitmapTableScan == dxl_operator->GetDXLOperator());
+		CDXLPhysicalDynamicBitmapTableScan *phy_dyn_bitmap_tblscan_dxlop =
+				CDXLPhysicalDynamicBitmapTableScan::Cast(dxl_operator);
+		table_descr = phy_dyn_bitmap_tblscan_dxlop->GetDXLTableDescr();
 
-		ulPartIndex = pdxlopDynamic->UlPartIndexId();
-		ulPartIndexPrintable = pdxlopDynamic->UlPartIndexIdPrintable();
-		fDynamic = true;
+		part_index_id = phy_dyn_bitmap_tblscan_dxlop->GetPartIndexId();
+		part_idx_printable_id = phy_dyn_bitmap_tblscan_dxlop->GetPartIndexIdPrintable();
+		is_dynamic = true;
 	}
 
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 
-	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(table_descr, NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
 
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	BitmapTableScan *pdbts = MakeNode(BitmapTableScan);
-	pdbts->scan.scanrelid = iRel;
-	pdbts->scan.partIndex = ulPartIndex;
-	pdbts->scan.partIndexPrintable = ulPartIndexPrintable;
+	BitmapTableScan *bitmap_tbl_scan = MakeNode(BitmapTableScan);
+	bitmap_tbl_scan->scan.scanrelid = index;
+	bitmap_tbl_scan->scan.partIndex = part_index_id;
+	bitmap_tbl_scan->scan.partIndexPrintable = part_idx_printable_id;
 
-	Plan *pplan = &(pdbts->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	Plan *plan = &(bitmap_tbl_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnBitmapScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(bitmapscan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	GPOS_ASSERT(4 == pdxlnBitmapScan->UlArity());
+	GPOS_ASSERT(4 == bitmapscan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnBitmapScan)[0];
-	CDXLNode *pdxlnFilter = (*pdxlnBitmapScan)[1];
-	CDXLNode *pdxlnRecheckCond = (*pdxlnBitmapScan)[2];
-	CDXLNode *pdxlnBitmapAccessPath = (*pdxlnBitmapScan)[3];
+	CDXLNode *project_list_dxlnode = (*bitmapscan_dxlnode)[0];
+	CDXLNode *filter_dxlnode = (*bitmapscan_dxlnode)[1];
+	CDXLNode *recheck_cond_dxlnode = (*bitmapscan_dxlnode)[2];
+	CDXLNode *bitmap_access_path_dxlnode = (*bitmapscan_dxlnode)[3];
 
-	List *plQuals = NULL;
+	List *quals_list = NULL;
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
-		&dxltrctxbt,	// translate context for the base table
-		pdrgpdxltrctxPrevSiblings,
-		&pplan->targetlist,
-		&plQuals,
-		pdxltrctxOut
+		project_list_dxlnode,
+		filter_dxlnode,
+		&base_table_context,	// translate context for the base table
+		ctxt_translation_prev_siblings,
+		&plan->targetlist,
+		&quals_list,
+		output_context
 		);
-	pplan->qual = plQuals;
+	plan->qual = quals_list;
 
-	pdbts->bitmapqualorig = PlQualFromFilter
+	bitmap_tbl_scan->bitmapqualorig = TranslateDXLFilterToQual
 							(
-							pdxlnRecheckCond,
-							&dxltrctxbt,
-							pdrgpdxltrctxPrevSiblings,
-							pdxltrctxOut
+							recheck_cond_dxlnode,
+							&base_table_context,
+							ctxt_translation_prev_siblings,
+							output_context
 							);
 
-	pdbts->scan.plan.lefttree = PplanBitmapAccessPath
+	bitmap_tbl_scan->scan.plan.lefttree = TranslateDXLBitmapAccessPath
 								(
-								pdxlnBitmapAccessPath,
-								pdxltrctxOut,
-								pmdrel,
-								pdxltabdesc,
-								&dxltrctxbt,
-								pdrgpdxltrctxPrevSiblings,
-								pdbts
+								bitmap_access_path_dxlnode,
+								output_context,
+								md_rel,
+								table_descr,
+								&base_table_context,
+								ctxt_translation_prev_siblings,
+								bitmap_tbl_scan
 								);
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pdbts;
+	return (Plan *) bitmap_tbl_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanBitmapAccessPath
+//		CTranslatorDXLToPlStmt::TranslateDXLBitmapAccessPath
 //
 //	@doc:
 //		Translate the tree of bitmap index operators that are under the given
@@ -5362,121 +5358,121 @@ CTranslatorDXLToPlStmt::PplanBitmapTableScan
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanBitmapAccessPath
+CTranslatorDXLToPlStmt::TranslateDXLBitmapAccessPath
 	(
-	const CDXLNode *pdxlnBitmapAccessPath,
-	CDXLTranslateContext *pdxltrctxOut,
-	const IMDRelation *pmdrel,
-	const CDXLTableDescr *pdxltabdesc,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-	BitmapTableScan *pdbts
+	const CDXLNode *bitmap_access_path_dxlnode,
+	CDXLTranslateContext *output_context,
+	const IMDRelation *md_rel,
+	const CDXLTableDescr *table_descr,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+	BitmapTableScan *bitmap_tbl_scan
 	)
 {
-	Edxlopid edxlopid = pdxlnBitmapAccessPath->Pdxlop()->Edxlop();
-	if (EdxlopScalarBitmapIndexProbe == edxlopid)
+	Edxlopid dxl_op_id = bitmap_access_path_dxlnode->GetOperator()->GetDXLOperator();
+	if (EdxlopScalarBitmapIndexProbe == dxl_op_id)
 	{
-		return PplanBitmapIndexProbe
+		return TranslateDXLBitmapIndexProbe
 				(
-				pdxlnBitmapAccessPath,
-				pdxltrctxOut,
-				pmdrel,
-				pdxltabdesc,
-				pdxltrctxbt,
-				pdrgpdxltrctxPrevSiblings,
-				pdbts
+				bitmap_access_path_dxlnode,
+				output_context,
+				md_rel,
+				table_descr,
+				base_table_context,
+				ctxt_translation_prev_siblings,
+				bitmap_tbl_scan
 				);
 	}
-	GPOS_ASSERT(EdxlopScalarBitmapBoolOp == edxlopid);
+	GPOS_ASSERT(EdxlopScalarBitmapBoolOp == dxl_op_id);
 
-	return PplanBitmapBoolOp
+	return TranslateDXLBitmapBoolOp
 			(
-			pdxlnBitmapAccessPath, 
-			pdxltrctxOut, 
-			pmdrel, 
-			pdxltabdesc, 
-			pdxltrctxbt,
-			pdrgpdxltrctxPrevSiblings,
-			pdbts
+			bitmap_access_path_dxlnode,
+			output_context,
+			md_rel,
+			table_descr,
+			base_table_context,
+			ctxt_translation_prev_siblings,
+			bitmap_tbl_scan
 			);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PplanBitmapBoolOp
+//		CTranslatorDXLToScalar::TranslateDXLBitmapBoolOp
 //
 //	@doc:
 //		Translates a DML bitmap bool op expression 
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanBitmapBoolOp
+CTranslatorDXLToPlStmt::TranslateDXLBitmapBoolOp
 	(
-	const CDXLNode *pdxlnBitmapBoolOp,
-	CDXLTranslateContext *pdxltrctxOut,
-	const IMDRelation *pmdrel,
-	const CDXLTableDescr *pdxltabdesc,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-	BitmapTableScan *pdbts
+	const CDXLNode *bitmap_boolop_dxlnode,
+	CDXLTranslateContext *output_context,
+	const IMDRelation *md_rel,
+	const CDXLTableDescr *table_descr,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+	BitmapTableScan *bitmap_tbl_scan
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnBitmapBoolOp);
-	GPOS_ASSERT(EdxlopScalarBitmapBoolOp == pdxlnBitmapBoolOp->Pdxlop()->Edxlop());
+	GPOS_ASSERT(NULL != bitmap_boolop_dxlnode);
+	GPOS_ASSERT(EdxlopScalarBitmapBoolOp == bitmap_boolop_dxlnode->GetOperator()->GetDXLOperator());
 
-	CDXLScalarBitmapBoolOp *pdxlop = CDXLScalarBitmapBoolOp::PdxlopConvert(pdxlnBitmapBoolOp->Pdxlop());
+	CDXLScalarBitmapBoolOp *sc_bitmap_boolop_dxlop = CDXLScalarBitmapBoolOp::Cast(bitmap_boolop_dxlnode->GetOperator());
 	
-	CDXLNode *pdxlnLeft = (*pdxlnBitmapBoolOp)[0];
-	CDXLNode *pdxlnRight = (*pdxlnBitmapBoolOp)[1];
+	CDXLNode *left_tree_dxlnode = (*bitmap_boolop_dxlnode)[0];
+	CDXLNode *right_tree_dxlnode = (*bitmap_boolop_dxlnode)[1];
 	
-	Plan *pplanLeft = PplanBitmapAccessPath
+	Plan *left_plan = TranslateDXLBitmapAccessPath
 						(
-						pdxlnLeft,
-						pdxltrctxOut,
-						pmdrel,
-						pdxltabdesc,
-						pdxltrctxbt,
-						pdrgpdxltrctxPrevSiblings,
-						pdbts
+						left_tree_dxlnode,
+						output_context,
+						md_rel,
+						table_descr,
+						base_table_context,
+						ctxt_translation_prev_siblings,
+						bitmap_tbl_scan
 						);
-	Plan *pplanRight = PplanBitmapAccessPath
+	Plan *right_plan = TranslateDXLBitmapAccessPath
 						(
-						pdxlnRight,
-						pdxltrctxOut,
-						pmdrel,
-						pdxltabdesc,
-						pdxltrctxbt,
-						pdrgpdxltrctxPrevSiblings,
-						pdbts
+						right_tree_dxlnode,
+						output_context,
+						md_rel,
+						table_descr,
+						base_table_context,
+						ctxt_translation_prev_siblings,
+						bitmap_tbl_scan
 						);
-	List *plChildPlans = ListMake2(pplanLeft, pplanRight);
+	List *child_plan_list = ListMake2(left_plan, right_plan);
 
-	Plan *pplan = NULL;
+	Plan *plan = NULL;
 	
-	if (CDXLScalarBitmapBoolOp::EdxlbitmapAnd == pdxlop->Edxlbitmapboolop())
+	if (CDXLScalarBitmapBoolOp::EdxlbitmapAnd == sc_bitmap_boolop_dxlop->GetDXLBitmapOpType())
 	{
 		BitmapAnd *bitmapand = MakeNode(BitmapAnd);
-		bitmapand->bitmapplans = plChildPlans;
+		bitmapand->bitmapplans = child_plan_list;
 		bitmapand->plan.targetlist = NULL;
 		bitmapand->plan.qual = NULL;
-		pplan = (Plan *) bitmapand;
+		plan = (Plan *) bitmapand;
 	}
 	else
 	{
 		BitmapOr *bitmapor = MakeNode(BitmapOr);
-		bitmapor->bitmapplans = plChildPlans;
+		bitmapor->bitmapplans = child_plan_list;
 		bitmapor->plan.targetlist = NULL;
 		bitmapor->plan.qual = NULL;
-		pplan = (Plan *) bitmapor;
+		plan = (Plan *) bitmapor;
 	}
 	
 	
-	return pplan;
+	return plan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanBitmapIndexProbe
+//		CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe
 //
 //	@doc:
 //		Translate CDXLScalarBitmapIndexProbe into a BitmapIndexScan
@@ -5484,181 +5480,181 @@ CTranslatorDXLToPlStmt::PplanBitmapBoolOp
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanBitmapIndexProbe
+CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe
 	(
-	const CDXLNode *pdxlnBitmapIndexProbe,
-	CDXLTranslateContext *pdxltrctxOut,
-	const IMDRelation *pmdrel,
-	const CDXLTableDescr *pdxltabdesc,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-	BitmapTableScan *pdbts
+	const CDXLNode *bitmap_index_probe_dxlnode,
+	CDXLTranslateContext *output_context,
+	const IMDRelation *md_rel,
+	const CDXLTableDescr *table_descr,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+	BitmapTableScan *bitmap_tbl_scan
 	)
 {
-	CDXLScalarBitmapIndexProbe *pdxlopScalar =
-			CDXLScalarBitmapIndexProbe::PdxlopConvert(pdxlnBitmapIndexProbe->Pdxlop());
+	CDXLScalarBitmapIndexProbe *sc_bitmap_idx_probe_dxlop =
+			CDXLScalarBitmapIndexProbe::Cast(bitmap_index_probe_dxlnode->GetOperator());
 
-	BitmapIndexScan *pbis;
-	DynamicBitmapIndexScan *pdbis;
+	BitmapIndexScan *bitmap_idx_scan;
+	DynamicBitmapIndexScan *dyn_bitmap_idx_scan;
 
-	if (pdbts->scan.partIndex)
+	if (bitmap_tbl_scan->scan.partIndex)
 	{
 		/* It's a Dynamic Bitmap Index Scan */
-		pdbis = MakeNode(DynamicBitmapIndexScan);
-		pbis = &(pdbis->biscan);
+		dyn_bitmap_idx_scan = MakeNode(DynamicBitmapIndexScan);
+		bitmap_idx_scan = &(dyn_bitmap_idx_scan->biscan);
 	}
 	else
 	{
-		pdbis = NULL;
-		pbis = MakeNode(BitmapIndexScan);
+		dyn_bitmap_idx_scan = NULL;
+		bitmap_idx_scan = MakeNode(BitmapIndexScan);
 	}
-	pbis->scan.scanrelid = pdbts->scan.scanrelid;
-	pbis->scan.partIndex = pdbts->scan.partIndex;
+	bitmap_idx_scan->scan.scanrelid = bitmap_tbl_scan->scan.scanrelid;
+	bitmap_idx_scan->scan.partIndex = bitmap_tbl_scan->scan.partIndex;
 
-	CMDIdGPDB *pmdidIndex = CMDIdGPDB::PmdidConvert(pdxlopScalar->Pdxlid()->Pmdid());
-	const IMDIndex *pmdindex = m_pmda->Pmdindex(pmdidIndex);
-	Oid oidIndex = pmdidIndex->OidObjectId();
+	CMDIdGPDB *mdid_index = CMDIdGPDB::CastMdid(sc_bitmap_idx_probe_dxlop->GetDXLIndexDescr()->MDId());
+	const IMDIndex *index = m_md_accessor->RetrieveIndex(mdid_index);
+	Oid index_oid = mdid_index->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidIndex);
-	pbis->indexid = oidIndex;
-	OID oidRel = CMDIdGPDB::PmdidConvert(pdxltabdesc->Pmdid())->OidObjectId();
-	Plan *pplan = &(pbis->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	GPOS_ASSERT(InvalidOid != index_oid);
+	bitmap_idx_scan->indexid = index_oid;
+	OID oidRel = CMDIdGPDB::CastMdid(table_descr->MDId())->Oid();
+	Plan *plan = &(bitmap_idx_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
-	GPOS_ASSERT(1 == pdxlnBitmapIndexProbe->UlArity());
-	CDXLNode *pdxlnIndexCondList = (*pdxlnBitmapIndexProbe)[0];
-	List *plIndexConditions = NIL;
-	List *plIndexOrigConditions = NIL;
-	List *plIndexStratgey = NIL;
-	List *plIndexSubtype = NIL;
+	GPOS_ASSERT(1 == bitmap_index_probe_dxlnode->Arity());
+	CDXLNode *index_cond_list_dxlnode = (*bitmap_index_probe_dxlnode)[0];
+	List *index_cond = NIL;
+	List *index_orig_cond = NIL;
+	List *index_strategy_list = NIL;
+	List *index_subtype_list = NIL;
 
 	TranslateIndexConditions
 		(
-		pdxlnIndexCondList,
-		pdxltabdesc,
-		false /*fIndexOnlyScan*/,
-		pmdindex,
-		pmdrel,
-		pdxltrctxOut,
-		pdxltrctxbt,
-		pdrgpdxltrctxPrevSiblings,
-		&plIndexConditions,
-		&plIndexOrigConditions,
-		&plIndexStratgey,
-		&plIndexSubtype
+		index_cond_list_dxlnode,
+		table_descr,
+		false /*is_index_only_scan*/,
+		index,
+		md_rel,
+		output_context,
+		base_table_context,
+		ctxt_translation_prev_siblings,
+		&index_cond,
+		&index_orig_cond,
+		&index_strategy_list,
+		&index_subtype_list
 		);
 
-	pbis->indexqual = plIndexConditions;
-	pbis->indexqualorig = plIndexOrigConditions;
+	bitmap_idx_scan->indexqual = index_cond;
+	bitmap_idx_scan->indexqualorig = index_orig_cond;
 	/*
 	 * As of 8.4, the indexstrategy and indexsubtype fields are no longer
 	 * available or needed in IndexScan. Ignore them.
 	 */
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	/*
 	 * If it's a Dynamic Bitmap Index Scan, also fill in the information
 	 * about the indexes on the partitions.
 	 */
-	if (pdbis)
+	if (dyn_bitmap_idx_scan)
 	{
-		pdbis->logicalIndexInfo = gpdb::Plgidxinfo(oidRel, oidIndex);
+		dyn_bitmap_idx_scan->logicalIndexInfo = gpdb::GetLogicalIndexInfo(oidRel, index_oid);
 	}
 
-	return pplan;
+	return plan;
 }
 
 // translates a DXL Value Scan node into a GPDB Value scan node
 Plan *
-CTranslatorDXLToPlStmt::PplanValueScan
+CTranslatorDXLToPlStmt::TranslateDXLValueScan
 	(
-	const CDXLNode *pdxlnValueScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *value_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translation context for column mappings
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// we will add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	dxltrctxbt.SetIdx(iRel);
+	base_table_context.SetRelIndex(index);
 
 	// create value scan node
-	ValuesScan *pvaluescan = MakeNode(ValuesScan);
-	pvaluescan->scan.scanrelid = iRel;
-	Plan *pplan = &(pvaluescan->scan.plan);
+	ValuesScan *value_scan = MakeNode(ValuesScan);
+	value_scan->scan.scanrelid = index;
+	Plan *plan = &(value_scan->scan.plan);
 
-	RangeTblEntry *prte = PrteFromDXLValueScan(pdxlnValueScan, pdxltrctxOut, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
+	RangeTblEntry *rte = TranslateDXLValueScanToRangeTblEntry(value_scan_dxlnode, output_context, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
 
-	pvaluescan->values_lists = (List *)gpdb::PvCopyObject(prte->values_lists);
+	value_scan->values_lists = (List *)gpdb::CopyObject(rte->values_lists);
 
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 	(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnValueScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(value_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 	);
 
 	// a table scan node must have at least 2 children: projection list and at least 1 value list
-	GPOS_ASSERT(2 <= pdxlnValueScan->UlArity());
+	GPOS_ASSERT(2 <= value_scan_dxlnode->Arity());
 
-	CDXLNode *pdxlnPrL = (*pdxlnValueScan)[EdxltsIndexProjList];
+	CDXLNode *project_list_dxlnode = (*value_scan_dxlnode)[EdxltsIndexProjList];
 
 	// translate proj list
-	List *plTargetList = PlTargetListFromProjList
+	List *target_list = TranslateDXLProjList
 							(
-							pdxlnPrL,
-							&dxltrctxbt,
+							project_list_dxlnode,
+							&base_table_context,
 							NULL,
-							pdxltrctxOut
+							output_context
 							);
 
-	pplan->targetlist = plTargetList;
+	plan->targetlist = target_list;
 
-	return (Plan *) pvaluescan;
+	return (Plan *) value_scan;
 }
 
 List *
 CTranslatorDXLToPlStmt::TranslateNestLoopParamList
 	(
-	DrgPdxlcr *pdrgdxlcrOuterRefs,
+	CDXLColRefArray *pdrgdxlcrOuterRefs,
 	CDXLTranslateContext *dxltrctxLeft,
 	CDXLTranslateContext *dxltrctxRight
 	)
 {
 	List *nest_params_list = NIL;
-	for (ULONG ul = 0; ul < pdrgdxlcrOuterRefs->UlLength(); ul++)
+	for (ULONG ul = 0; ul < pdrgdxlcrOuterRefs->Size(); ul++)
 	{
 		CDXLColRef *pdxlcr = (*pdrgdxlcrOuterRefs)[ul];
-		ULONG ulColid = pdxlcr->UlID();
+		ULONG ulColid = pdxlcr->Id();
 		// left child context contains the target entry for the nest params col refs
-		const TargetEntry *target_entry = dxltrctxLeft->Pte(ulColid);
+		const TargetEntry *target_entry = dxltrctxLeft->GetTargetEntry(ulColid);
 		GPOS_ASSERT(NULL != target_entry);
 		Var *old_var = (Var *) target_entry->expr;
 
-		Var *new_var = gpdb::PvarMakeVar(OUTER_VAR, target_entry->resno, old_var->vartype, old_var->vartypmod, 0/*varlevelsup*/);
+		Var *new_var = gpdb::MakeVar(OUTER_VAR, target_entry->resno, old_var->vartype, old_var->vartypmod, 0/*varlevelsup*/);
 		new_var->varnoold = old_var->varnoold;
 		new_var->varoattno = old_var->varoattno;
 
 		NestLoopParam *nest_params = MakeNode(NestLoopParam);
 		// right child context contains the param entry for the nest params col refs
-		const CMappingElementColIdParamId *colid_param_mapping = dxltrctxRight->Pmecolidparamid(ulColid);
+		const CMappingElementColIdParamId *colid_param_mapping = dxltrctxRight->GetParamIdMappingElement(ulColid);
 		GPOS_ASSERT(NULL != colid_param_mapping);
-		nest_params->paramno = colid_param_mapping->UlParamId();
+		nest_params->paramno = colid_param_mapping->ParamId();
 		nest_params->paramval = new_var;
-		nest_params_list = gpdb::PlAppendElement(nest_params_list, (void *) nest_params);
+		nest_params_list = gpdb::LAppend(nest_params_list, (void *) nest_params);
 	}
 	return nest_params_list;
 }

--- a/src/backend/gpopt/utils/CCatalogUtils.cpp
+++ b/src/backend/gpopt/utils/CCatalogUtils.cpp
@@ -17,57 +17,57 @@
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CCatalogUtils::PlRelationOids
+//		CCatalogUtils::GetRelationOids
 //
 //	@doc:
 //		Return list of relation oids from the catalog
 //
 //---------------------------------------------------------------------------
 List *
-CCatalogUtils::PlRelationOids()
+CCatalogUtils::GetRelationOids()
 {
 	return relation_oids();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CCatalogUtils::PlOperatorOids
+//		CCatalogUtils::GetOperatorOids
 //
 //	@doc:
 //		Return list of operator oids from the catalog
 //
 //---------------------------------------------------------------------------
 List *
-CCatalogUtils::PlOperatorOids()
+CCatalogUtils::GetOperatorOids()
 {
 	return operator_oids();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CCatalogUtils::PlFunctionOids
+//		CCatalogUtils::GetFunctionOids
 //
 //	@doc:
-//		Return list of function plOids from the catalog
+//		Return list of function oids_list from the catalog
 //
 //---------------------------------------------------------------------------
 List *
-CCatalogUtils::PlFunctionOids()
+CCatalogUtils::GetFunctionOids()
 {
 	return function_oids();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CCatalogUtils::PlAllOids
+//		CCatalogUtils::GetAllOids
 //
 //	@doc:
-//		Return list of all plOids from the catalog
+//		Return list of all oids_list from the catalog
 //
 //---------------------------------------------------------------------------
-List *CCatalogUtils::PlAllOids()
+List *CCatalogUtils::GetAllOids()
 {
-	return list_concat(list_concat(PlRelationOids(), PlOperatorOids()), PlFunctionOids());
+	return list_concat(list_concat(GetRelationOids(), GetOperatorOids()), GetFunctionOids());
 }
 
 // EOF

--- a/src/backend/gpopt/utils/funcs.cpp
+++ b/src/backend/gpopt/utils/funcs.cpp
@@ -43,12 +43,12 @@ Datum
 DisableXform(PG_FUNCTION_ARGS)
 {
 	char *szXform = text_to_cstring(PG_GETARG_TEXT_P(0));
-	bool fResult = COptTasks::FSetXform(szXform, true /*fDisable*/);
+	bool is_result = COptTasks::SetXform(szXform, true /*fDisable*/);
 
 	StringInfoData str;
 	initStringInfo(&str);
 
-	if (fResult)
+	if (is_result)
 	{
 		appendStringInfo(&str, "%s is disabled", szXform);
 	}
@@ -76,12 +76,12 @@ Datum
 EnableXform(PG_FUNCTION_ARGS)
 {
 	char *szXform = text_to_cstring(PG_GETARG_TEXT_P(0));
-	bool fResult = COptTasks::FSetXform(szXform, false /*fDisable*/);
+	bool is_result = COptTasks::SetXform(szXform, false /*fDisable*/);
 
 	StringInfoData str;
 	initStringInfo(&str);
 
-	if (fResult)
+	if (is_result)
 	{
 		appendStringInfo(&str, "%s is enabled", szXform);
 	}

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -34,7 +34,7 @@
 #include "utils/lsyscache.h"
 
 /* GPORCA entry point */
-extern PlannedStmt * PplstmtOptimize(Query *parse, bool *pfUnexpectedFailure);
+extern PlannedStmt * GPOPTOptimizedPlan(Query *parse, bool *had_unexpected_failure);
 
 /*
  * Logging of optimization outcome
@@ -141,7 +141,7 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 	pqueryCopy = preprocess_query_optimizer(root, pqueryCopy, boundParams);
 
 	/* Ok, invoke ORCA. */
-	result = PplstmtOptimize(pqueryCopy, &fUnexpectedFailure);
+	result = GPOPTOptimizedPlan(pqueryCopy, &fUnexpectedFailure);
 
 	log_optimizer(result, fUnexpectedFailure);
 

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -26,15 +26,15 @@ class CGPOptimizer
 
 		// optimize given query using GP optimizer
 		static
-		PlannedStmt *PplstmtOptimize
+		PlannedStmt *GPOPTOptimizedPlan
 			(
-			Query *pquery,
-			bool *pfUnexpectedFailure // output : set to true if optimizer unexpectedly failed to produce plan
+			Query *query,
+			bool *had_unexpected_failure // output : set to true if optimizer unexpectedly failed to produce plan
 			);
 
 		// serialize planned statement into DXL
 		static
-		char *SzDXLPlan(Query *pquery);
+		char *SerializeDXLPlan(Query *query);
 
     // gpopt initialize and terminate
     static

--- a/src/include/gpopt/config/CConfigParamMapping.h
+++ b/src/include/gpopt/config/CConfigParamMapping.h
@@ -48,20 +48,20 @@ namespace gpdxl
 			struct SConfigMappingElem
 			{
 				// trace flag
-				EOptTraceFlag m_etf;
+				EOptTraceFlag m_trace_flag;
 
 				// config param address
-				BOOL *m_pfParam;
+				BOOL *m_is_param;
 
 				// if true, we negate the config param value before setting traceflag value
-				BOOL m_fNegate;
+				BOOL m_negate_param;
 
 				// description
-				const WCHAR *wszDescription;
+				const WCHAR *description_str;
 			};
 
 			// array of mapping elements
-			static SConfigMappingElem m_elem[];
+			static SConfigMappingElem m_elements[];
 
 			// private ctor
 			CConfigParamMapping(const CConfigParamMapping &);
@@ -69,7 +69,7 @@ namespace gpdxl
 		public:
 			// pack enabled optimizer config params in a traceflag bitset
 			static
-			CBitSet *PbsPack(IMemoryPool *pmp, ULONG ulXforms);
+			CBitSet *PackConfigParamInBitset(IMemoryPool *mp, ULONG xform_id);
 	};
 }
 

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -58,382 +58,378 @@ struct ArrayExpr;
 namespace gpdb {
 
 	// convert datum to bool
-	bool FBoolFromDatum(Datum d);
+	bool BoolFromDatum(Datum d);
 
 	// convert bool to datum
-	Datum DDatumFromBool(bool b);
+	Datum DatumFromBool(bool b);
 
 	// convert datum to char
-	char CCharFromDatum(Datum d);
+	char CharFromDatum(Datum d);
 
 	// convert char to datum
-	Datum DDatumFromChar(char c);
+	Datum DatumFromChar(char c);
 
 	// convert datum to int8
-	int8 CInt8FromDatum(Datum d);
+	int8 Int8FromDatum(Datum d);
 
 	// convert int8 to datum
-	Datum DDatumFromInt8(int8 i8);
+	Datum DatumFromInt8(int8 i8);
 
 	// convert datum to uint8
-	uint8 UcUint8FromDatum(Datum d);
+	uint8 Uint8FromDatum(Datum d);
 
 	// convert uint8 to datum
-	Datum DDatumFromUint8(uint8 ui8);
+	Datum DatumFromUint8(uint8 ui8);
 
 	// convert datum to int16
-	int16 SInt16FromDatum(Datum d);
+	int16 Int16FromDatum(Datum d);
 
 	// convert int16 to datum
-	Datum DDatumFromInt16(int16 i16);
+	Datum DatumFromInt16(int16 i16);
 
 	// convert datum to uint16
-	uint16 UsUint16FromDatum(Datum d);
+	uint16 Uint16FromDatum(Datum d);
 
 	// convert uint16 to datum
-	Datum DDatumFromUint16(uint16 ui16);
+	Datum DatumFromUint16(uint16 ui16);
 
 	// convert datum to int32
-	int32 IInt32FromDatum(Datum d);
+	int32 Int32FromDatum(Datum d);
 
 	// convert int32 to datum
-	Datum DDatumFromInt32(int32 i32);
+	Datum DatumFromInt32(int32 i32);
 
 	// convert datum to uint32
-	uint32 UlUint32FromDatum(Datum d);
+	uint32 lUint32FromDatum(Datum d);
 
 	// convert uint32 to datum
-	Datum DDatumFromUint32(uint32 ui32);
+	Datum DatumFromUint32(uint32 ui32);
 
 	// convert datum to int64
-	int64 LlInt64FromDatum(Datum d);
+	int64 Int64FromDatum(Datum d);
 
 	// convert int64 to datum
-	Datum DDatumFromInt64(int64 i64);
+	Datum DatumFromInt64(int64 i64);
 
 	// convert datum to uint64
-	uint64 UllUint64FromDatum(Datum d);
+	uint64 Uint64FromDatum(Datum d);
 
 	// convert uint64 to datum
-	Datum DDatumFromUint64(uint64 ui64);
+	Datum DatumFromUint64(uint64 ui64);
 
 	// convert datum to oid
 	Oid OidFromDatum(Datum d);
 
 	// convert datum to generic object with pointer handle
-	void *PvPointerFromDatum(Datum d);
+	void *PointerFromDatum(Datum d);
 
 	// convert datum to float4
-	float4 FpFloat4FromDatum(Datum d);
+	float4 Float4FromDatum(Datum d);
 
 	// convert datum to float8
-	float8 DFloat8FromDatum(Datum d);
+	float8 Float8FromDatum(Datum d);
 
 	// convert pointer to datum
-	Datum DDatumFromPointer(const void *p);
+	Datum DatumFromPointer(const void *p);
 
 	// does an aggregate exist with the given oid
-	bool FAggregateExists(Oid oid);
+	bool AggregateExists(Oid oid);
 
 	// add member to Bitmapset
-	Bitmapset *PbmsAddMember(Bitmapset *a, int x);
+	Bitmapset *BmsAddMember(Bitmapset *a, int x);
 
 	// create a copy of an object
-	void *PvCopyObject(void *from);
+	void *CopyObject(void *from);
 
 	// datum size
-	Size SDatumSize(Datum value, bool typByVal, int typLen);
+	Size DatumSize(Datum value, bool type_by_val, int type_len);
 
 	// expression type
-	Oid OidExprType(Node *expr);
+	Oid ExprType(Node *expr);
 
 	// expression type modifier
-	int32 IExprTypeMod(Node *expr);
+	int32 ExprTypeMod(Node *expr);
 
 	// expression collation
-	Oid	OidExprCollation(Node *expr);
+	Oid	ExprCollation(Node *expr);
 
 	// expression collation - GDPB_91_MERGE_FIXME
-	Oid	OidTypeCollation(Oid type);
+	Oid	TypeCollation(Oid type);
 
 	// extract nodes with specific tag from a plan tree
-	List *PlExtractNodesPlan(Plan *pl, int nodeTag, bool descendIntoSubqueries);
+	List *ExtractNodesPlan(Plan *pl, int node_tag, bool descend_into_subqueries);
 
 	// extract nodes with specific tag from an expression tree
-	List *PlExtractNodesExpression(Node *node, int nodeTag, bool descendIntoSubqueries);
+	List *ExtractNodesExpression(Node *node, int node_tag, bool descend_into_subqueries);
 	
 	// intermediate result type of given aggregate
-	Oid OidAggIntermediateResultType(Oid aggid);
+	Oid GetAggIntermediateResultType(Oid aggid);
 
 	// replace Vars that reference JOIN outputs with references to the original
 	// relation variables instead
-	Query *PqueryFlattenJoinAliasVar(Query *pquery, gpos::ULONG ulQueryLevel);
+	Query *FlattenJoinAliasVar(Query *query, gpos::ULONG query_level);
 
 	// is aggregate ordered
-	bool FOrderedAgg(Oid aggid);
+	bool IsOrderedAgg(Oid aggid);
 	
 	// does aggregate have a preliminary function
-	bool FAggHasPrelimFunc(Oid aggid);
+	bool AggHasPrelimFunc(Oid aggid);
 
 	// does aggregate have a prelim or inverse prelim function
-	bool FAggHasPrelimOrInvPrelimFunc(Oid aggid);
+	bool AggHasPrelimOrInvPrelimFunc(Oid aggid);
 
 	// intermediate result type of given aggregate
-	Oid OidAggregate(const char*szArg, Oid oidType);
+	Oid GetAggregate(const char* agg, Oid type_oid);
 
 	// array type oid
-	Oid OidArrayType(Oid typid);
+	Oid GetArrayType(Oid typid);
 
 	// deconstruct array
 	void DeconstructArray(struct ArrayType *array, Oid elmtype, int elmlen, bool elmbyval,
 			char elmalign, Datum **elemsp, bool **nullsp, int *nelemsp);
 
 	// attribute stats slot
-	bool FGetAttrStatsSlot(AttStatsSlot *sslot, HeapTuple statstuple, int reqkind,
+	bool GetAttrStatsSlot(AttStatsSlot *sslot, HeapTuple statstuple, int reqkind,
 			Oid reqop, int flags);
 
 	// free attribute stats slot
 	void FreeAttrStatsSlot(AttStatsSlot *sslot);
 
 	// attribute statistics
-	HeapTuple HtAttrStats(Oid relid, AttrNumber attnum);
+	HeapTuple GetAttStats(Oid relid, AttrNumber attnum);
 
 	// function oids
-	List *PlFunctionOids(void);
+	List *FunctionOids(void);
 
 	// does a function exist with the given oid
-	bool FFunctionExists(Oid oid);
+	bool FunctionExists(Oid oid);
 
 	// is the given function strict
-	bool FFuncStrict(Oid funcid);
+	bool FuncStrict(Oid funcid);
 
 	// stability property of given function
-	char CFuncStability(Oid funcid);
+	char FuncStability(Oid funcid);
 
 	// data access property of given function
-	char CFuncDataAccess(Oid funcid);
+	char FuncDataAccess(Oid funcid);
 
 	// exec location property of given function
-	char CFuncExecLocation(Oid funcid);
+	char FuncExecLocation(Oid funcid);
 
 	// trigger name
-	char *SzTriggerName(Oid triggerid);
+	char *GetTriggerName(Oid triggerid);
 
 	// trigger relid
-	Oid OidTriggerRelid(Oid triggerid);
+	Oid GetTriggerRelid(Oid triggerid);
 
 	// trigger funcid
-	Oid OidTriggerFuncid(Oid triggerid);
+	Oid GetTriggerFuncid(Oid triggerid);
 
 	// trigger type
-	int32 ITriggerType(Oid triggerid);
+	int32 GetTriggerType(Oid triggerid);
 
 	// is trigger enabled
-	bool FTriggerEnabled(Oid triggerid);
+	bool IsTriggerEnabled(Oid triggerid);
 
 	// does trigger exist
-	bool FTriggerExists(Oid oid);
+	bool TriggerExists(Oid oid);
 
 	// does check constraint exist
-	bool FCheckConstraintExists(Oid oidCheckConstraint);
+	bool CheckConstraintExists(Oid check_constraint_oid);
 
 	// check constraint name
-	char *SzCheckConstraintName(Oid oidCheckConstraint);
+	char *GetCheckConstraintName(Oid check_constraint_oid);
 
 	// check constraint relid
-	Oid OidCheckConstraintRelid(Oid oidCheckConstraint);
+	Oid GetCheckConstraintRelid(Oid check_constraint_oid);
 
 	// check constraint expression tree
-	Node *PnodeCheckConstraint(Oid oidCheckConstraint);
+	Node *PnodeCheckConstraint(Oid check_constraint_oid);
 
 	// get the list of check constraints for a given relation
-	List *PlCheckConstraint(Oid oidRel);
+	List *GetCheckConstraintOids(Oid rel_oid);
 
 	// part constraint expression tree
-	Node *PnodePartConstraintRel(Oid oidRel, List **pplDefaultLevels);
+	Node *GetRelationPartContraints(Oid rel_oid, List **default_levels);
 
 	// get the cast function for the specified source and destination types
-	bool FCastFunc(Oid oidSrc, Oid oidDest, bool *is_binary_coercible, Oid *oidCastFunc, CoercionPathType *pathtype);
+	bool GetCastFunc(Oid src_oid, Oid dest_oid, bool *is_binary_coercible, Oid *cast_fn_oid, CoercionPathType *pathtype);
 	
 	// get type of operator
-	unsigned int UlCmpt(Oid oidOp, Oid oidLeft, Oid oidRight);
+	unsigned int GetComparisonType(Oid op_oid, Oid left_oid, Oid right_oid);
 	
 	// get scalar comparison between given types
-	Oid OidScCmp(Oid oidLeft, Oid oidRight, unsigned int ulCmpt);
+	Oid GetComparisonOperator(Oid left_oid, Oid right_oid, unsigned int cmpt);
 
 	// get equality operator for given type
-	Oid OidEqualityOp(Oid oidType);
+	Oid GetEqualityOp(Oid type_oid);
 
 	// get equality operator for given ordering op (i.e. < or >)
-	Oid OidEqualityOpForOrderingOp(Oid opno, bool *reverse);
+	Oid GetEqualityOpForOrderingOp(Oid opno, bool *reverse);
 	
 	// get ordering operator for given equality op (i.e. =)
-	Oid OidOrderingOpForEqualityOp(Oid opno, bool *reverse);
+	Oid GetOrderingOpForEqualityOp(Oid opno, bool *reverse);
 
 	// function name
-	char *SzFuncName(Oid funcid);
+	char *GetFuncName(Oid funcid);
 
 	// output argument types of the given function
-	List *PlFuncOutputArgTypes(Oid funcid);
+	List *GetFuncOutputArgTypes(Oid funcid);
 
 	// argument types of the given function
-	List *PlFuncArgTypes(Oid funcid);
+	List *GetFuncArgTypes(Oid funcid);
 
 	// does a function return a set of rows
-	bool FFuncRetset(Oid funcid);
+	bool GetFuncRetset(Oid funcid);
 
 	// return type of the given function
-	Oid OidFuncRetType(Oid funcid);
+	Oid GetFuncRetType(Oid funcid);
 
 	// commutator operator of the given operator
-	Oid OidCommutatorOp(Oid opno);
+	Oid GetCommutatorOp(Oid opno);
 
 	// inverse operator of the given operator
-	Oid OidInverseOp(Oid opno);
+	Oid GetInverseOp(Oid opno);
 
 	// function oid corresponding to the given operator oid
-	RegProcedure OidOpFunc(Oid opno);
+	RegProcedure GetOpFunc(Oid opno);
 
 	// operator name
-	char *SzOpName(Oid opno);
+	char *GetOpName(Oid opno);
 
 	// parts of a partitioned table
-	bool FLeafPartition(Oid oid);
+	bool IsLeafPartition(Oid oid);
 
 	// partition table has an external partition
-	bool FHasExternalPartition(Oid oid);
+	bool HasExternalPartition(Oid oid);
 
 	// find the oid of the root partition given partition oid belongs to
-	Oid OidRootPartition(Oid oid);
+	Oid GetRootPartition(Oid oid);
 	
 	// partition attributes
-	List *PlPartitionAttrs(Oid oid);
+	List *GetPartitionAttrs(Oid oid);
 
 	// get partition keys and kinds ordered by partition level
 	void GetOrderedPartKeysAndKinds(Oid oid, List **pkeys, List **pkinds);
 
 	// parts of a partitioned table
-	PartitionNode *PpnParts(Oid relid, int2 level, Oid parent, bool inctemplate, bool includesubparts);
+	PartitionNode *GetParts(Oid relid, int2 level, Oid parent, bool inctemplate, bool includesubparts);
 
 	// keys of the relation with the given oid
-	List *PlRelationKeys(Oid relid);
+	List *GetRelationKeys(Oid relid);
 
 	// relid of a composite type
-	Oid OidTypeRelid(Oid typid);
+	Oid GetTypeRelid(Oid typid);
 
 	// name of the type with the given oid
-	char *SzTypeName(Oid typid);
+	char *GetTypeName(Oid typid);
 
 	// number of GP segments
-	int UlSegmentCountGP(void);
+	int GetGPSegmentCount(void);
 
 	// heap attribute is null
-	bool FHeapAttIsNull(HeapTuple tup, int attnum);
+	bool HeapAttIsNull(HeapTuple tup, int attnum);
 
 	// free heap tuple
 	void FreeHeapTuple(HeapTuple htup);
 
 	// does an index exist with the given oid
-	bool FIndexExists(Oid oid);
+	bool IndexExists(Oid oid);
 
 	// check if given oid is hashable internally in Greenplum Database
-	bool FGreenplumDbHashable(Oid typid);
+	bool IsGreenplumDbHashable(Oid typid);
 
 	// append an element to a list
-	List *PlAppendElement(List *list, void *datum);
+	List *LAppend(List *list, void *datum);
 
 	// append an integer to a list
-	List *PlAppendInt(List *list, int datum);
+	List *LAppendInt(List *list, int datum);
 
 	// append an oid to a list
-	List *PlAppendOid(List *list, Oid datum);
+	List *LAppendOid(List *list, Oid datum);
 
 	// prepend a new element to the list
-	List *PlPrependElement(void *datum, List *list);
+	List *LPrepend(void *datum, List *list);
 
 	// prepend an integer to the list
-	List *PlPrependInt(int datum, List *list);
+	List *LPrependInt(int datum, List *list);
 
 	// prepend an oid to a list
-	List *PlPrependOid(Oid datum, List *list);
+	List *LPrependOid(Oid datum, List *list);
 
 	// concatenate lists
-	List *PlConcat(List *list1, List *list2);
+	List *ListConcat(List *list1, List *list2);
 
 	// copy list
-	List *PlCopy(List *list);
+	List *ListCopy(List *list);
 
 	// first cell in a list
-	ListCell *PlcListHead(List *l);
+	ListCell *ListHead(List *l);
 
 	// last cell in a list
-	ListCell *PlcListTail(List *l);
+	ListCell *ListTail(List *l);
 
 	// number of items in a list
-	uint32 UlListLength(List *l);
+	uint32 ListLength(List *l);
 
 	// return the nth element in a list of pointers
-	void *PvListNth(List *list, int n);
+	void *ListNth(List *list, int n);
 
 	// return the nth element in a list of ints
-	int IListNth(List *list, int n);
+	int ListNthInt(List *list, int n);
 
 	// return the nth element in a list of oids
-	Oid OidListNth(List *list, int n);
+	Oid ListNthOid(List *list, int n);
 
 	// check whether the given oid is a member of the given list
-	bool FMemberOid(List *list, Oid oid);
+	bool ListMemberOid(List *list, Oid oid);
 
 	// free list
-	void FreeList(List *plist);
+	void ListFree(List *list);
 	
 	// deep free of a list
-	void FreeListDeep(List *plist);
-
-	// if pplist is non-NULL, and *pplist is non-NULL then free the list and set
-	// *pplist to NULL
-	void FreeListAndNull(List **pplist);
+	void ListFreeDeep(List *list);
 
 	// is this a Gather motion
-	bool FMotionGather(const Motion *pmotion);
+	bool IsMotionGather(const Motion *motion);
 
 	// does a partition table have an appendonly child
-	bool FAppendOnlyPartitionTable(Oid rootOid);
+	bool IsAppendOnlyPartitionTable(Oid root_oid);
 
 	// does a multi-level partitioned table have uniform partitioning hierarchy
-	bool FMultilevelPartitionUniform(Oid rootOid);
+	bool IsMultilevelPartitionUniform(Oid root_oid);
 
 	// lookup type cache
-	TypeCacheEntry *PtceLookup(Oid type_id, int flags);
+	TypeCacheEntry *LookupTypeCache(Oid type_id, int flags);
 
 	// create a value node for a string
-	Value *PvalMakeString(char *str);
+	Value *MakeStringValue(char *str);
 
 	// create a value node for an integer
-	Value *PvalMakeInteger(long i);
+	Value *MakeIntegerValue(long i);
 
 	// create a bool constant
-	Node *PnodeMakeBoolConst(bool value, bool isnull);
+	Node *MakeBoolConst(bool value, bool isnull);
 
 	// make a NULL constant of the given type
-	Node *PnodeMakeNULLConst(Oid oidType);
+	Node *MakeNULLConst(Oid type_oid);
 	
 	// create a new target entry
-	TargetEntry *PteMakeTargetEntry(Expr *expr, AttrNumber resno, char *resname, bool resjunk);
+	TargetEntry *MakeTargetEntry(Expr *expr, AttrNumber resno, char *resname, bool resjunk);
 
 	// create a new var node
-	Var *PvarMakeVar(Index varno, AttrNumber varattno, Oid vartype, int32 vartypmod, Index varlevelsup);
+	Var *MakeVar(Index varno, AttrNumber varattno, Oid vartype, int32 vartypmod, Index varlevelsup);
 
 	// memory allocation functions
-	void *PvMemoryContextAllocImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
-	void *PvMemoryContextAllocZeroAlignedImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
-	void *PvMemoryContextAllocZeroImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
-	void *PvMemoryContextReallocImpl(void *pointer, Size size, const char* file, const char * func, int line);
+	void *MemCtxtAllocImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
+	void *MemCtxtAllocZeroAlignedImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
+	void *MemCtxtAllocZeroImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
+	void *MemCtxtReallocImpl(void *pointer, Size size, const char* file, const char * func, int line);
 	void *GPDBAlloc(Size size);
 	void GPDBFree(void *ptr);
 
 	// create a duplicate of the given string in the given memory context
-	char *SzMemoryContextStrdup(MemoryContext context, const char *string);
+	char *MemCtxtStrdup(MemoryContext context, const char *string);
 
 	// similar to ereport for logging messages
 	void GpdbEreportImpl(int xerrcode, int severitylevel, const char *xerrmsg, const char *xerrhint, const char *filename, int lineno, const char *funcname);
@@ -441,88 +437,88 @@ namespace gpdb {
 	gpdb::GpdbEreportImpl(xerrcode, severitylevel, xerrmsg, xerrhint , __FILE__, __LINE__, PG_FUNCNAME_MACRO)
 
 	// string representation of a node
-	char *SzNodeToString(void *obj);
+	char *NodeToString(void *obj);
 
 	// node representation from a string
-	Node *Pnode(char *string);
+	Node *StringToNode(char *string);
 
 	// return the default value of the type
-	Node *PnodeTypeDefault(Oid typid);
+	Node *GetTypeDefault(Oid typid);
 
 	// convert numeric to double; if out of range, return +/- HUGE_VAL
-	double DNumericToDoubleNoOverflow(Numeric num);
+	double NumericToDoubleNoOverflow(Numeric num);
 
 	// convert time-related datums to double for stats purpose
-	double DConvertTimeValueToScalar(Datum datum, Oid typid);
+	double ConvertTimeValueToScalar(Datum datum, Oid typid);
 
 	// convert network-related datums to double for stats purpose
-	double DConvertNetworkToScalar(Datum datum, Oid typid);
+	double ConvertNetworkToScalar(Datum datum, Oid typid);
 
 	// is the given operator hash-joinable
-	bool FOpHashJoinable(Oid opno, Oid inputtype);
+	bool IsOpHashJoinable(Oid opno, Oid inputtype);
 
 	// is the given operator strict
-	bool FOpStrict(Oid opno);
+	bool IsOpStrict(Oid opno);
 
 	// get input types for a given operator
 	void GetOpInputTypes(Oid opno, Oid *lefttype, Oid *righttype);
 
 	// does an operator exist with the given oid
-	bool FOperatorExists(Oid oid);
+	bool OperatorExists(Oid oid);
 
 	// fetch detoasted copies of toastable datatypes
-	struct varlena *PvlenDetoastDatum(struct varlena * datum);
+	struct varlena *DetoastDatum(struct varlena * datum);
 
 	// expression tree walker
-	bool FWalkExpressionTree(Node *node, bool(*walker)(), void *context);
+	bool WalkExpressionTree(Node *node, bool(*walker)(), void *context);
 
 	// query or expression tree walker
-	bool FWalkQueryOrExpressionTree(Node *node, bool(*walker)(), void *context, int flags);
+	bool WalkQueryOrExpressionTree(Node *node, bool(*walker)(), void *context, int flags);
 
 	// modify a query tree
-	Query *PqueryMutateQueryTree(Query *query, Node *(*mutator)(), void *context, int flags);
+	Query *MutateQueryTree(Query *query, Node *(*mutator)(), void *context, int flags);
 
 	// modify an expression tree
-	Node *PnodeMutateExpressionTree(Node *node, Node *(*mutator)(), void *context);
+	Node *MutateExpressionTree(Node *node, Node *(*mutator)(), void *context);
 
 	// modify a query or an expression tree
-	Node *PnodeMutateQueryOrExpressionTree(Node *node, Node *(*mutator)(), void *context, int flags);
+	Node *MutateQueryOrExpressionTree(Node *node, Node *(*mutator)(), void *context, int flags);
 
-	// the part of PqueryMutateQueryTree that processes a query's rangetable
-	List *PlMutateRangeTable(List *rtable, Node *(*mutator)(), void *context, int flags);
+	// the part of MutateQueryTree that processes a query's rangetable
+	List *MutateRangeTable(List *rtable, Node *(*mutator)(), void *context, int flags);
 
 	// check whether the part with the given oid is the root of a partition table
-	bool FRelPartIsRoot(Oid relid);
+	bool RelPartIsRoot(Oid relid);
 	
 	// check whether the part with the given oid is an interior subpartition
-	bool FRelPartIsInterior(Oid relid);
+	bool RelPartIsInterior(Oid relid);
 	
 	// check whether table with the given oid is a regular table and not part of a partitioned table
-	bool FRelPartIsNone(Oid relid);
+	bool RelPartIsNone(Oid relid);
 
 	// check whether a relation is inherited
-	bool FHasSubclassSlow(Oid oidRel);
+	bool HasSubclassSlow(Oid rel_oid);
 
     // check whether a relation has parquet children
-    bool FHasParquetChildren(Oid oidRel);
+    bool HasParquetChildren(Oid rel_oid);
     
     // return the distribution policy of a relation; if the table is partitioned
     // and the parts are distributed differently, return Random distribution
-    GpPolicy *Pdistrpolicy(Relation rel);
+    GpPolicy *GetDistributionPolicy(Relation rel);
     
     // return true if the table is partitioned and hash-distributed, and one of  
     // the child partitions is randomly distributed
-    gpos::BOOL FChildPartDistributionMismatch(Relation rel);
+    gpos::BOOL IsChildPartDistributionMismatched(Relation rel);
 
     // return true if the table is partitioned and any of the child partitions
     // have a trigger of the given type
-    gpos::BOOL FChildTriggers(Oid oid, int triggerType);
+    gpos::BOOL ChildPartHasTriggers(Oid oid, int trigger_type);
 
 	// does a relation exist with the given oid
-	bool FRelationExists(Oid oid);
+	bool RelationExists(Oid oid);
 
 	// extract all relation oids from the catalog
-	List *PlRelationOids(void);
+	List *GetAllRelationOids(void);
 
 	// estimate the relation size using the real number of blocks and tuple density
 	void EstimateRelationSize(Relation rel,	int32 *attr_widths,	BlockNumber *pages,	double *tuples, double *allvisfrac);
@@ -532,123 +528,123 @@ namespace gpdb {
 	void CloseRelation(Relation rel);
 
 	// return the logical indexes for a partitioned table
-	LogicalIndexes *Plgidx(Oid oid);
+	LogicalIndexes *GetLogicalPartIndexes(Oid oid);
 	
 	// return the logical info structure for a given logical index oid
-	LogicalIndexInfo *Plgidxinfo(Oid rootOid, Oid indexOid);
+	LogicalIndexInfo *GetLogicalIndexInfo(Oid root_oid, Oid index_oid);
 	
 	// return a list of index oids for a given relation
-	List *PlRelationIndexes(Relation relation);
+	List *GetRelationIndexes(Relation relation);
 
 	// build an array of triggers for this relation
 	void BuildRelationTriggers(Relation rel);
 
 	// get relation with given oid
-	Relation RelGetRelation(Oid relationId);
+	Relation GetRelation(Oid rel_oid);
 
 	// get external table entry with given oid
-	ExtTableEntry *Pexttable(Oid relationId);
+	ExtTableEntry *GetExternalTableEntry(Oid rel_oid);
 
 	// get external table entry with given oid
-	List *PlExternalScanUriList(ExtTableEntry *ext, bool *isMasterOnlyP);
+	List *GetExternalScanUriList(ExtTableEntry *ext, bool *ismasteronlyp);
 
 	// return the first member of the given targetlist whose expression is
 	// equal to the given expression, or NULL if no such member exists
-	TargetEntry *PteMember(Node *node, List *targetlist);
+	TargetEntry *FindFirstMatchingMemberInTargetList(Node *node, List *targetlist);
 
 	// return a list of members of the given targetlist whose expression is
 	// equal to the given expression, or NULL if no such member exists
-	List *PteMembers(Node *node, List *targetlist);
+	List *FindMatchingMembersInTargetList(Node *node, List *targetlist);
 
 	// check if two gpdb objects are equal
-	bool FEqual(void *p1, void *p2);
+	bool Equals(void *p1, void *p2);
 
 	// does a type exist with the given oid
-	bool FTypeExists(Oid oid);
+	bool TypeExists(Oid oid);
 
 	// check whether a type is composite
-	bool FCompositeType(Oid typid);
+	bool IsCompositeType(Oid typid);
 
 	// get integer value from an Integer value node
-	int IValue(Node *node);
+	int GetIntFromValue(Node *node);
 
 	// parse external table URI
-	Uri *PuriParseExternalTable(const char *szUri);
+	Uri *ParseExternalTableUri(const char *uri);
 	
 	// returns ComponentDatabases
-	CdbComponentDatabases *PcdbComponentDatabases(void);
+	CdbComponentDatabases *GetComponentDatabases(void);
 
 	// compare two strings ignoring case
-	int IStrCmpIgnoreCase(const char *sz1, const char *sz2);
+	int StrCmpIgnoreCase(const char *s1, const char *s2);
 
 	// construct random segment map
-	bool *RgfRandomSegMap(int total_primaries, int total_to_skip);
+	bool *ConstructRandomSegMap(int total_primaries, int total_to_skip);
 
 	// create an empty 'StringInfoData' & return a pointer to it
-	StringInfo SiMakeStringInfo(void);
+	StringInfo MakeStringInfo(void);
 
 	// append the two given strings to the StringInfo object
 	void AppendStringInfo(StringInfo str, const char *str1, const char *str2);
 
 	// look for the given node tags in the given tree and return the index of
 	// the first one found, or -1 if there are none
-	int IFindNodes(Node *node, List *nodeTags);
+	int FindNodes(Node *node, List *nodeTags);
 
 	// GDPB_91_MERGE_FIXME: collation
 	// look for nodes with non-default collation; returns 1 if any exist, -1 otherwise
-	int ICheckCollation(Node *node);
+	int CheckCollation(Node *node);
 
-	Node *PnodeCoerceToCommonType(ParseState *pstate, Node *pnode, Oid oidTargetType, const char *context);
+	Node *CoerceToCommonType(ParseState *pstate, Node *node, Oid target_type, const char *context);
 
 	// replace any polymorphic type with correct data type deduced from input arguments
-	bool FResolvePolymorphicType(int numargs, Oid *argtypes, char *argmodes, FuncExpr *call_expr);
+	bool ResolvePolymorphicArgType(int numargs, Oid *argtypes, char *argmodes, FuncExpr *call_expr);
 	
 	// hash a const value with GPDB's hash function
-	int32 ICdbHash(Const *pconst, int iSegments);
+	int32 CdbHashConst(Const *constant, int num_segments);
 	
 	// hash a list of const values with GPDB's hash function
-	int32 ICdbHashList(List *plConsts, int iSegments);
+	int32 CdbHashConstList(List *constants, int num_segments);
 	
 	// check permissions on range table 
-	void CheckRTPermissions(List *plRangeTable);
+	void CheckRTPermissions(List *rtable);
 	
 	// get index operator family properties
 	void IndexOpProperties(Oid opno, Oid opfamily, int *strategy, Oid *subtype);
 	
 	// get oids of families this operator belongs to
-	List *PlScOpOpFamilies(Oid opno);
+	List *GetOpFamiliesForScOp(Oid opno);
 	
 	// get oids of op classes for the index keys
-	List *PlIndexOpFamilies(Oid oidIndex);
+	List *GetIndexOpFamilies(Oid index_oid);
 
-	// returns the result of evaluating 'pexpr' as an Expr. Caller keeps ownership of 'pexpr'
+	// returns the result of evaluating 'expr' as an Expr. Caller keeps ownership of 'expr'
 	// and takes ownership of the result 
-	Expr *PexprEvaluate(Expr *pexpr, Oid oidResultType, int32 iTypeMod);
+	Expr *EvaluateExpr(Expr *expr, Oid result_type, int32 typmod);
 	
 	// interpret the value of "With oids" option from a list of defelems
-	bool FInterpretOidsOption(List *plOptions);
+	bool InterpretOidsOption(List *options);
 	
 	// extract string value from defelem's value
-	char *SzDefGetString(DefElem *pdefelem);
+	char *DefGetString(DefElem *defelem);
 
 	// transform array Const to an ArrayExpr
-	Expr *PexprTransformArrayConstToArrayExpr(Const *pConst);
+	Expr *TransformArrayConstToArrayExpr(Const *constant);
 
 	// transform array Const to an ArrayExpr
-	Node *PnodeEvalConstExpressions(Node *node);
+	Node *EvalConstExpressions(Node *node);
 
 	// static partition selection given a PartitionSelector node
-	SelectedParts *SpStaticPartitionSelection(PartitionSelector *ps);
+	SelectedParts *RunStaticPartitionSelection(PartitionSelector *ps);
 
 	// simple fault injector used by COptTasks.cpp to inject GPDB fault
-	FaultInjectorType_e OptTasksFaultInjector(FaultInjectorIdentifier_e identifier);
+	FaultInjectorType_e InjectFaultInOptTasks(FaultInjectorIdentifier_e identifier);
 
 	// return the number of leaf partition for a given table oid
-	gpos::ULONG UlLeafPartitions(Oid oidRelation);
+	gpos::ULONG CountLeafPartTables(Oid oidRelation);
 
 	// Does the metadata cache need to be reset (because of a catalog
 	// table has been changed?)
-	bool FMDCacheNeedsReset(void);
+	bool MDCacheNeedsReset(void);
 
 	// functions for tracking ORCA memory consumption
 	void *OptimizerAlloc(size_t size);
@@ -656,47 +652,47 @@ namespace gpdb {
 	void OptimizerFree(void *ptr);
 
 	// returns true if a query cancel is requested in GPDB
-	bool FAbortRequested(void);
+	bool IsAbortRequested(void);
 
-	GpPolicy *PMakeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs);
+	GpPolicy *MakeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs);
 
 } //namespace gpdb
 
 #define ForEach(cell, l)	\
-	for ((cell) = gpdb::PlcListHead(l); (cell) != NULL; (cell) = lnext(cell))
+	for ((cell) = gpdb::ListHead(l); (cell) != NULL; (cell) = lnext(cell))
 
 #define ForBoth(cell1, list1, cell2, list2)							\
-	for ((cell1) = gpdb::PlcListHead(list1), (cell2) = gpdb::PlcListHead(list2);	\
+	for ((cell1) = gpdb::ListHead(list1), (cell2) = gpdb::ListHead(list2);	\
 		 (cell1) != NULL && (cell2) != NULL;						\
 		 (cell1) = lnext(cell1), (cell2) = lnext(cell2))
 
 #define ForThree(cell1, list1, cell2, list2, cell3, list3)							\
-	for ((cell1) = gpdb::PlcListHead(list1), (cell2) = gpdb::PlcListHead(list2), (cell3) = gpdb::PlcListHead(list3);	\
+	for ((cell1) = gpdb::ListHead(list1), (cell2) = gpdb::ListHead(list2), (cell3) = gpdb::ListHead(list3);	\
 		 (cell1) != NULL && (cell2) != NULL && (cell3) != NULL;						\
 		 (cell1) = lnext(cell1), (cell2) = lnext(cell2), (cell3) = lnext(cell3))
 
 #define ForEachWithCount(cell, list, counter) \
-	for ((cell) = gpdb::PlcListHead(list), (counter)=0; \
+	for ((cell) = gpdb::ListHead(list), (counter)=0; \
 	     (cell) != NULL; \
 	     (cell) = lnext(cell), ++(counter))
 
-#define ListMake1(x1) gpdb::PlPrependElement(x1, NIL)
+#define ListMake1(x1) gpdb::LPrepend(x1, NIL)
 
-#define ListMake2(x1,x2) gpdb::PlPrependElement(x1, ListMake1(x2))
+#define ListMake2(x1,x2) gpdb::LPrepend(x1, ListMake1(x2))
 
-#define ListMake1Int(x1) gpdb::PlPrependInt(x1, NIL)
+#define ListMake1Int(x1) gpdb::LPrependInt(x1, NIL)
 
-#define ListMake1Oid(x1) gpdb::PlPrependOid(x1, NIL)
-#define ListMake2Oid(x1,x2) gpdb::PlPrependOid(x1, ListMake1Oid(x2))
+#define ListMake1Oid(x1) gpdb::LPrependOid(x1, NIL)
+#define ListMake2Oid(x1,x2) gpdb::LPrependOid(x1, ListMake1Oid(x2))
 
-#define LInitial(l) lfirst(gpdb::PlcListHead(l))
+#define LInitial(l) lfirst(gpdb::ListHead(l))
 
-#define LInitialOID(l) lfirst_oid(gpdb::PlcListHead(l))
+#define LInitialOID(l) lfirst_oid(gpdb::ListHead(l))
 
 #define Palloc0Fast(sz) \
 	( MemSetTest(0, (sz)) ? \
-		gpdb::PvMemoryContextAllocZeroAlignedImpl(CurrentMemoryContext, (sz), __FILE__, PG_FUNCNAME_MACRO, __LINE__) : \
-		gpdb::PvMemoryContextAllocZeroImpl(CurrentMemoryContext, (sz), __FILE__, PG_FUNCNAME_MACRO, __LINE__))
+		gpdb::MemCtxtAllocZeroAlignedImpl(CurrentMemoryContext, (sz), __FILE__, PG_FUNCNAME_MACRO, __LINE__) : \
+		gpdb::MemCtxtAllocZeroImpl(CurrentMemoryContext, (sz), __FILE__, PG_FUNCNAME_MACRO, __LINE__))
 
 #ifdef __GNUC__
 
@@ -729,7 +725,7 @@ extern PGDLLIMPORT Node *newNodeMacroHolder;
 
 #define MakeNode(_type_) 		((_type_ *) NewNode(sizeof(_type_),T_##_type_))
 
-#define PStrDup(str) gpdb::SzMemoryContextStrdup(CurrentMemoryContext, (str))
+#define PStrDup(str) gpdb::MemCtxtStrdup(CurrentMemoryContext, (str))
 
 #endif // !GPDB_gpdbwrappers_H
 

--- a/src/include/gpopt/relcache/CMDProviderRelcache.h
+++ b/src/include/gpopt/relcache/CMDProviderRelcache.h
@@ -47,7 +47,7 @@ namespace gpmd
 	{
 		private:
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// private copy ctor
 			CMDProviderRelcache(const CMDProviderRelcache&);
@@ -55,7 +55,7 @@ namespace gpmd
 		public:
 			// ctor/dtor
 			explicit
-			CMDProviderRelcache(IMemoryPool *pmp);
+			CMDProviderRelcache(IMemoryPool *mp);
 
 			~CMDProviderRelcache()
 			{
@@ -63,19 +63,19 @@ namespace gpmd
 
 			// returns the DXL string of the requested metadata object
 			virtual
-			CWStringBase *PstrObject(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid) const;
+			CWStringBase *GetMDObjDXLStr(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *md_id) const;
 
 			// return the mdid for the requested type
 			virtual
-			IMDId *Pmdid
+			IMDId *MDId
 				(
-				IMemoryPool *pmp,
+				IMemoryPool *mp,
 				CSystemId sysid,
-				IMDType::ETypeInfo eti
+				IMDType::ETypeInfo type_info
 				)
 				const
 			{
-				return PmdidTypeGPDB(pmp, sysid, eti);
+				return GetGPDBTypeMdid(mp, sysid, type_info);
 			}
 
 	};

--- a/src/include/gpopt/translate/CCTEListEntry.h
+++ b/src/include/gpopt/translate/CCTEListEntry.h
@@ -35,19 +35,19 @@ namespace gpdxl
 	
 	// hash on character arrays
 	inline
-	ULONG UlHashSz
+	ULONG HashStr
 		(
-		const CHAR *sz
+		const CHAR *str
 		)
 	{
-		return gpos::UlHashByteArray((BYTE *) sz, clib::UlStrLen(sz));
+		return gpos::HashByteArray((BYTE *) str, clib::Strlen(str));
 	}
 	
 	// equality on character arrays
 	inline
-	BOOL FEqualSz(const CHAR *szA, const CHAR *szB)
+	BOOL StrEqual(const CHAR *str_a, const CHAR *str_b)
 	{
-		return (0 == clib::IStrCmp(szA, szB));
+		return (0 == clib::Strcmp(str_a, str_b));
 	}
 	
 
@@ -67,66 +67,66 @@ namespace gpdxl
 			// pair of DXL CTE producer and target list of the original CTE query
 			struct SCTEProducerInfo
 			{
-				const CDXLNode *m_pdxlnCTEProducer;
-				List *m_plTargetList;
+				const CDXLNode *m_cte_producer;
+				List *m_target_list;
 				
 				// ctor
 				SCTEProducerInfo
 					(
-					const CDXLNode *pdxlnCTEProducer,
-					List *plTargetList
+					const CDXLNode *cte_producer,
+					List *target_list
 					)
 					:
-					m_pdxlnCTEProducer(pdxlnCTEProducer),
-					m_plTargetList(plTargetList)
+					m_cte_producer(cte_producer),
+					m_target_list(target_list)
 				{}
 			};
 			
 			// hash maps mapping CHAR *->SCTEProducerInfo
-			typedef CHashMap<CHAR, SCTEProducerInfo, UlHashSz, FEqualSz, CleanupNULL, CleanupDelete > HMSzCTEInfo;
+			typedef CHashMap<CHAR, SCTEProducerInfo, HashStr, StrEqual, CleanupNULL, CleanupDelete > HMSzCTEInfo;
 
 			// query level where the CTEs are defined
-			ULONG m_ulQueryLevel;
+			ULONG m_query_level;
 
 			// CTE producers at that level indexed by their name
-			HMSzCTEInfo *m_phmszcteinfo; 
+			HMSzCTEInfo *m_cte_info; 
 
 		public:
 			// ctor: single CTE 
-			CCTEListEntry(IMemoryPool *pmp, ULONG ulQueryLevel, CommonTableExpr *pcte, CDXLNode *pdxlnCTEProducer);
+			CCTEListEntry(IMemoryPool *mp, ULONG query_level, CommonTableExpr *cte, CDXLNode *cte_producer);
 			
 			// ctor: multiple CTEs
-			CCTEListEntry(IMemoryPool *pmp, ULONG ulQueryLevel, List *plCTE, DrgPdxln *pdrgpdxln);
+			CCTEListEntry(IMemoryPool *mp, ULONG query_level, List *cte_list, CDXLNodeArray *dxlnodes);
 
 			// dtor
 			virtual
 			~CCTEListEntry()
 			{
-				m_phmszcteinfo->Release();
+				m_cte_info->Release();
 			};
 
 			// the query level
-			ULONG UlQueryLevel() const
+			ULONG GetQueryLevel() const
 			{
-				return m_ulQueryLevel;
+				return m_query_level;
 			}
 
 			// lookup CTE producer by its name
-			const CDXLNode *PdxlnCTEProducer(const CHAR *szCTE) const;
+			const CDXLNode *GetCTEProducer(const CHAR *cte_str) const;
 
 			// lookup CTE producer target list by its name
-			List *PlCTEProducerTL(const CHAR *szCTE) const;
+			List *GetCTEProducerTargetList(const CHAR *cte_str) const;
 
 			// add a new CTE producer for this level
-			void AddCTEProducer(IMemoryPool *pmp, CommonTableExpr *pcte, const CDXLNode *pdxlnCTEProducer);
+			void AddCTEProducer(IMemoryPool *mp, CommonTableExpr *cte, const CDXLNode *cte_producer);
 	};
 
 	// hash maps mapping ULONG -> CCTEListEntry
-	typedef CHashMap<ULONG, CCTEListEntry, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>,
+	typedef CHashMap<ULONG, CCTEListEntry, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
 	CleanupDelete<ULONG>, CleanupRelease > HMUlCTEListEntry;
 
 	// iterator
-	typedef CHashMapIter<ULONG, CCTEListEntry, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>,
+	typedef CHashMapIter<ULONG, CCTEListEntry, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
 	CleanupDelete<ULONG>, CleanupRelease > HMIterUlCTEListEntry;
 
 	}

--- a/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
+++ b/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
@@ -44,47 +44,47 @@ namespace gpdxl
 	class CDXLTranslateContextBaseTable
 	{
 		// hash maps mapping ULONG -> INT
-		typedef CHashMap<ULONG, INT, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>,
-			CleanupDelete<ULONG>, CleanupDelete<INT> > HMUlI;
+		typedef CHashMap<ULONG, INT, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			CleanupDelete<ULONG>, CleanupDelete<INT> > UlongToIntMap;
 
 
 		private:
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// oid of the base table
 			OID m_oid;
 
 			// index of the relation in the rtable
-			Index m_iRel;
+			Index m_rel_index;
 
 			// maps a colid of a column to the attribute number of that column in the schema of the underlying relation
-			HMUlI *m_phmuli;
+			UlongToIntMap *m_colid_to_attno_map;
 
 			// private copy ctor
 			CDXLTranslateContextBaseTable(const CDXLTranslateContextBaseTable&);
 
 		public:
 			// ctor/dtor
-			explicit CDXLTranslateContextBaseTable(IMemoryPool *pmp);
+			explicit CDXLTranslateContextBaseTable(IMemoryPool *mp);
 
 
 			~CDXLTranslateContextBaseTable();
 
 			// accessors
-			OID OidRel() const;
+			OID GetOid() const;
 
-			Index IRel() const;
+			Index GetRelIndex() const;
 
 			// return the index of the column in the base relation for the given DXL ColId
-			INT IAttnoForColId(ULONG ulDXLColId) const;
+			INT GetAttnoForColId(ULONG dxl_colid) const;
 
 			// setters
 			void SetOID(OID oid);
 
-			void SetIdx(Index iRel);
+			void SetRelIndex(Index rel_index);
 
 			// store the mapping of the given DXL column id and index in the base relation schema
-			BOOL FInsertMapping(ULONG ulDXLColId, INT iAttno);
+			BOOL InsertMapping(ULONG dxl_colid, INT att_no);
 
 	};
 }

--- a/src/include/gpopt/translate/CGPDBAttInfo.h
+++ b/src/include/gpopt/translate/CGPDBAttInfo.h
@@ -38,21 +38,21 @@ namespace gpdxl
 		private:
 
 			// query level number
-			ULONG m_ulQueryLevel;
+			ULONG m_query_level;
 
 			// varno in the rtable
-			ULONG m_ulVarNo;
+			ULONG m_varno;
 
 			// attno
-			INT	m_iAttNo;
+			INT	m_attno;
 
 			// copy c'tor
 			CGPDBAttInfo(const CGPDBAttInfo&);
 
 		public:
 			// ctor
-			CGPDBAttInfo(ULONG ulQueryLevel, ULONG ulVarNo, INT iAttNo)
-				: m_ulQueryLevel(ulQueryLevel), m_ulVarNo(ulVarNo), m_iAttNo(iAttNo)
+			CGPDBAttInfo(ULONG query_level, ULONG var_no, INT attrnum)
+				: m_query_level(query_level), m_varno(var_no), m_attno(attrnum)
 			{}
 
 			// d'tor
@@ -60,60 +60,60 @@ namespace gpdxl
 			~CGPDBAttInfo() {}
 
 			// accessor
-			ULONG UlQueryLevel() const
+			ULONG GetQueryLevel() const
 			{
-				return m_ulQueryLevel;
+				return m_query_level;
 			}
 
 			// accessor
-			ULONG UlVarNo() const
+			ULONG GetVarNo() const
 			{
-				return m_ulVarNo;
+				return m_varno;
 			}
 
 			// accessor
-			INT IAttNo() const
+			INT GetAttNo() const
 			{
-				return m_iAttNo;
+				return m_attno;
 			}
 
 			// equality check
-			BOOL FEquals(const CGPDBAttInfo& gpdbattinfo) const
+			BOOL Equals(const CGPDBAttInfo& gpdb_att_info) const
 			{
-				return m_ulQueryLevel == gpdbattinfo.m_ulQueryLevel
-						&& m_ulVarNo == gpdbattinfo.m_ulVarNo
-						&& m_iAttNo == gpdbattinfo.m_iAttNo;
+				return m_query_level == gpdb_att_info.m_query_level
+						&& m_varno == gpdb_att_info.m_varno
+						&& m_attno == gpdb_att_info.m_attno;
 			}
 
 			// hash value
-			ULONG UlHash() const
+			ULONG HashValue() const
 			{
-				return gpos::UlCombineHashes(
-						gpos::UlHash(&m_ulQueryLevel),
-						gpos::UlCombineHashes(gpos::UlHash(&m_ulVarNo),
-								gpos::UlHash(&m_iAttNo)));
+				return gpos::CombineHashes(
+						gpos::HashValue(&m_query_level),
+						gpos::CombineHashes(gpos::HashValue(&m_varno),
+								gpos::HashValue(&m_attno)));
 			}
 	};
 
 	// hash function
-	inline ULONG UlHashGPDBAttInfo
+	inline ULONG HashGPDBAttInfo
 		(
-		const CGPDBAttInfo *pgpdbattinfo
+		const CGPDBAttInfo *gpdb_att_info
 		)
 	{
-		GPOS_ASSERT(NULL != pgpdbattinfo);
-		return pgpdbattinfo->UlHash();
+		GPOS_ASSERT(NULL != gpdb_att_info);
+		return gpdb_att_info->HashValue();
 	}
 
 	// equality function
-	inline BOOL FEqualGPDBAttInfo
+	inline BOOL EqualGPDBAttInfo
 		(
-		const CGPDBAttInfo *pgpdbattinfoA,
-		const CGPDBAttInfo *pgpdbattinfoB
+		const CGPDBAttInfo *gpdb_att_info_a,
+		const CGPDBAttInfo *gpdb_att_info_b
 		)
 	{
-		GPOS_ASSERT(NULL != pgpdbattinfoA && NULL != pgpdbattinfoB);
-		return pgpdbattinfoA->FEquals(*pgpdbattinfoB);
+		GPOS_ASSERT(NULL != gpdb_att_info_a && NULL != gpdb_att_info_b);
+		return gpdb_att_info_a->Equals(*gpdb_att_info_b);
 	}
 
 }

--- a/src/include/gpopt/translate/CGPDBAttOptCol.h
+++ b/src/include/gpopt/translate/CGPDBAttOptCol.h
@@ -37,41 +37,41 @@ namespace gpdxl
 		private:
 
 			// gpdb att info
-			CGPDBAttInfo *m_pgpdbattinfo;
+			CGPDBAttInfo *m_gpdb_att_info;
 
 			// optimizer col info
-			COptColInfo *m_poptcolinfo;
+			COptColInfo *m_opt_col_info;
 
 			// copy c'tor
 			CGPDBAttOptCol(const CGPDBAttOptCol&);
 
 		public:
 			// ctor
-			CGPDBAttOptCol(CGPDBAttInfo *pgpdbattinfo, COptColInfo *poptcolinfo)
-				: m_pgpdbattinfo(pgpdbattinfo), m_poptcolinfo(poptcolinfo)
+			CGPDBAttOptCol(CGPDBAttInfo *gpdb_att_info, COptColInfo *opt_col_info)
+				: m_gpdb_att_info(gpdb_att_info), m_opt_col_info(opt_col_info)
 			{
-				GPOS_ASSERT(NULL != m_pgpdbattinfo);
-				GPOS_ASSERT(NULL != m_poptcolinfo);
+				GPOS_ASSERT(NULL != m_gpdb_att_info);
+				GPOS_ASSERT(NULL != m_opt_col_info);
 			}
 
 			// d'tor
 			virtual
 			~CGPDBAttOptCol()
 			{
-				m_pgpdbattinfo->Release();
-				m_poptcolinfo->Release();
+				m_gpdb_att_info->Release();
+				m_opt_col_info->Release();
 			}
 
 			// accessor
-			const CGPDBAttInfo *Pgpdbattinfo() const
+			const CGPDBAttInfo *GetGPDBAttInfo() const
 			{
-				return m_pgpdbattinfo;
+				return m_gpdb_att_info;
 			}
 
 			// accessor
-			const COptColInfo *Poptcolinfo() const
+			const COptColInfo *GetOptColInfo() const
 			{
-				return m_poptcolinfo;
+				return m_opt_col_info;
 			}
 
 	};

--- a/src/include/gpopt/translate/CIndexQualInfo.h
+++ b/src/include/gpopt/translate/CIndexQualInfo.h
@@ -43,35 +43,35 @@ namespace gpdxl
 			AttrNumber m_attno;
 
 			// index qual expression tailored for GPDB
-			Expr *m_pexpr;
+			Expr *m_expr;
 
 			// original index qual expression
-			Expr *m_pexprOriginal;
+			Expr *m_original_expr;
 
 			// index strategy information
-			StrategyNumber m_sn;
+			StrategyNumber m_strategy_num;
 
 			// index subtype
-			OID m_oidIndexSubtype;
+			OID m_index_subtype_oid;
 			
 			// ctor
 			CIndexQualInfo
 				(
 				AttrNumber attno,
-				Expr *pexpr,
-				Expr *pexprOriginal,
-				StrategyNumber sn,
-				OID oidIndexSubtype
+				Expr *expr,
+				Expr *original_expr,
+				StrategyNumber strategy_number,
+				OID index_subtype_oid
 				)
 				:
 				m_attno(attno),
-				m_pexpr(pexpr),
-				m_pexprOriginal(pexprOriginal),
-				m_sn(sn),
-				m_oidIndexSubtype(oidIndexSubtype)
+				m_expr(expr),
+				m_original_expr(original_expr),
+				m_strategy_num(strategy_number),
+				m_index_subtype_oid(index_subtype_oid)
 				{
-					GPOS_ASSERT((IsA(m_pexpr, OpExpr) && IsA(m_pexprOriginal, OpExpr)) ||
-						(IsA(m_pexpr, ScalarArrayOpExpr) && IsA(m_pexprOriginal, ScalarArrayOpExpr)));
+					GPOS_ASSERT((IsA(m_expr, OpExpr) && IsA(m_original_expr, OpExpr)) ||
+						(IsA(m_expr, ScalarArrayOpExpr) && IsA(original_expr, ScalarArrayOpExpr)));
 				}
 
 				// dtor
@@ -80,20 +80,20 @@ namespace gpdxl
 
 				// comparison function for sorting index qualifiers
 				static
-				INT IIndexQualInfoCmp
+				INT IndexQualInfoCmp
 					(
-					const void *pv1,
-					const void *pv2
+					const void *p1,
+					const void *p2
 					)
 				{
-					const CIndexQualInfo *pidxqualinfo1 = *(const CIndexQualInfo **) pv1;
-					const CIndexQualInfo *pidxqualinfo2 = *(const CIndexQualInfo **) pv2;
+					const CIndexQualInfo *qual_info1 = *(const CIndexQualInfo **) p1;
+					const CIndexQualInfo *qual_info2 = *(const CIndexQualInfo **) p2;
 
-					return (INT) pidxqualinfo1->m_attno - (INT) pidxqualinfo2->m_attno;
+					return (INT) qual_info1->m_attno - (INT) qual_info2->m_attno;
 				}
 	};
 	// array of index qual info
-	typedef CDynamicPtrArray<CIndexQualInfo, CleanupDelete> DrgPindexqualinfo;
+	typedef CDynamicPtrArray<CIndexQualInfo, CleanupDelete> CIndexQualInfoArray;
 }
 
 #endif // !GPDXL_CIndexQualInfo_H

--- a/src/include/gpopt/translate/CMappingColIdVar.h
+++ b/src/include/gpopt/translate/CMappingColIdVar.h
@@ -47,7 +47,7 @@ namespace gpdxl
 	{
 		protected:
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 		public:
 
@@ -60,7 +60,7 @@ namespace gpdxl
 
 			// translate DXL ScalarIdent node into GPDB Var node
 			virtual
-			Var *PvarFromDXLNodeScId(const CDXLScalarIdent *) = 0;
+			Var *VarFromDXLNodeScId(const CDXLScalarIdent *) = 0;
 	};
 }
 

--- a/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
+++ b/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
@@ -48,40 +48,40 @@ namespace gpdxl
 	{
 		private:
 
-			const CDXLTranslateContextBaseTable *m_pdxltrctxbt;
+			const CDXLTranslateContextBaseTable *m_base_table_context;
 
 			// the array of translator context (one for each child of the DXL operator)
-			DrgPdxltrctx *m_pdrgpdxltrctx;
+			CDXLTranslationContextArray *m_child_contexts;
 
-			CDXLTranslateContext *m_pdxltrctxOut;
+			CDXLTranslateContext *m_output_context;
 
 			// translator context used to translate initplan and subplans associated
 			// with a param node
-			CContextDXLToPlStmt *m_pctxdxltoplstmt;
+			CContextDXLToPlStmt *m_dxl_to_plstmt_context;
 
 		public:
 
 			CMappingColIdVarPlStmt
 				(
-				IMemoryPool *pmp,
-				const CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut,
-				CContextDXLToPlStmt *pctxdxltoplstmt
+				IMemoryPool *mp,
+				const CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *child_contexts,
+				CDXLTranslateContext *output_context,
+				CContextDXLToPlStmt *dxl_to_plstmt_context
 				);
 
 			// translate DXL ScalarIdent node into GPDB Var node
 			virtual
-			Var *PvarFromDXLNodeScId(const CDXLScalarIdent *pdxlop);
+			Var *VarFromDXLNodeScId(const CDXLScalarIdent *dxlop);
 
 			// translate DXL ScalarIdent node into GPDB Param node
-			Param *PparamFromDXLNodeScId(const CDXLScalarIdent *pdxlop);
+			Param *ParamFromDXLNodeScId(const CDXLScalarIdent *dxlop);
 
 			// get the output translator context
-			CDXLTranslateContext *PpdxltrctxOut();
+			CDXLTranslateContext *GetOutputContext();
 
 			// return the context of the DXL->PlStmt translation
-			CContextDXLToPlStmt *Pctxdxltoplstmt();
+			CContextDXLToPlStmt *GetDXLToPlStmtContext();
 	};
 }
 

--- a/src/include/gpopt/translate/CMappingElementColIdParamId.h
+++ b/src/include/gpopt/translate/CMappingElementColIdParamId.h
@@ -38,46 +38,46 @@ namespace gpdxl
 		private:
 
 			// column identifier that is used as the key
-			ULONG m_ulColId;
+			ULONG m_colid;
 
 			// param identifier
-			ULONG m_ulParamId;
+			ULONG m_paramid;
 
 			// param type
-			IMDId *m_pmdid;
+			IMDId *m_mdid;
 
-			INT m_iTypeModifier;
+			INT m_type_modifier;
 
 		public:
 
 			// ctors and dtor
-			CMappingElementColIdParamId(ULONG ulColId, ULONG ulParamId, IMDId *pmdid, INT iTypeModifier);
+			CMappingElementColIdParamId(ULONG colid, ULONG paramid, IMDId *mdid, INT type_modifier);
 
 			virtual
 			~CMappingElementColIdParamId()
 			{}
 
 			// return the ColId
-			ULONG UlColId() const
+			ULONG GetColId() const
 			{
-				return m_ulColId;
+				return m_colid;
 			}
 
 			// return the ParamId
-			ULONG UlParamId() const
+			ULONG ParamId() const
 			{
-				return m_ulParamId;
+				return m_paramid;
 			}
 
 			// return the type
-			IMDId *PmdidType() const
+			IMDId *MdidType() const
 			{
-				return m_pmdid;
+				return m_mdid;
 			}
 
-			INT ITypeModifier() const
+			INT TypeModifier() const
 			{
-				return m_iTypeModifier;
+				return m_type_modifier;
 			}
 	};
 }

--- a/src/include/gpopt/translate/CMappingElementColIdTE.h
+++ b/src/include/gpopt/translate/CMappingElementColIdTE.h
@@ -44,13 +44,13 @@ namespace gpdxl
 		private:
 
 			// the column identifier that is used as the key
-			ULONG m_ulColId;
+			ULONG m_colid;
 
 			// the query level
-			ULONG m_ulQueryLevel;
+			ULONG m_query_level;
 
 			// the target entry
-			TargetEntry *m_pte;
+			TargetEntry *m_target_entry;
 
 		public:
 
@@ -58,21 +58,21 @@ namespace gpdxl
 			CMappingElementColIdTE(ULONG, ULONG, TargetEntry *);
 
 			// return the ColId
-			ULONG UlColId() const
+			ULONG GetColId() const
 			{
-				return m_ulColId;
+				return m_colid;
 			}
 
 			// return the query level
-			ULONG UlQueryLevel() const
+			ULONG GetQueryLevel() const
 			{
-				return m_ulQueryLevel;
+				return m_query_level;
 			}
 
 			// return the column name for the given attribute no
-			const TargetEntry *Pte() const
+			const TargetEntry *GetTargetEntry() const
 			{
-				return m_pte;
+				return m_target_entry;
 			}
 	};
 }

--- a/src/include/gpopt/translate/CMappingVarColId.h
+++ b/src/include/gpopt/translate/CMappingVarColId.h
@@ -76,31 +76,31 @@ namespace gpdxl
 	{
 		private:
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// hash map structure to store gpdb att -> opt col information
-			typedef CHashMap<CGPDBAttInfo, CGPDBAttOptCol, UlHashGPDBAttInfo, FEqualGPDBAttInfo,
-							CleanupRelease, CleanupRelease > CMVCMap;
+			typedef CHashMap<CGPDBAttInfo, CGPDBAttOptCol, HashGPDBAttInfo, EqualGPDBAttInfo,
+							CleanupRelease, CleanupRelease > GPDBAttOptColHashMap;
 
 			// iterator
-			typedef CHashMapIter<CGPDBAttInfo, CGPDBAttOptCol, UlHashGPDBAttInfo, FEqualGPDBAttInfo,
-							CleanupRelease, CleanupRelease > CMVCMapIter;
+			typedef CHashMapIter<CGPDBAttInfo, CGPDBAttOptCol, HashGPDBAttInfo, EqualGPDBAttInfo,
+							CleanupRelease, CleanupRelease > GPDBAttOptColHashMapIter;
 
 			// map from gpdb att to optimizer col
-			CMVCMap	*m_pmvcmap;
+			GPDBAttOptColHashMap	*m_gpdb_att_opt_col_mapping;
 
 			// insert mapping entry
-			void Insert(ULONG, ULONG, INT, ULONG, CWStringBase *pstr);
+			void Insert(ULONG, ULONG, INT, ULONG, CWStringBase *str);
 
 			// no copy constructor
 			CMappingVarColId(const CMappingVarColId &);
 
 			// helper function to access mapping
-			const CGPDBAttOptCol *Pgpdbattoptcol
+			const CGPDBAttOptCol *GetGPDBAttOptColMapping
 								(
-								ULONG ulCurrentQueryLevel,
-								const Var *pvar,
-								EPlStmtPhysicalOpType eplsphoptype
+								ULONG current_query_level,
+								const Var *var,
+								EPlStmtPhysicalOpType plstmt_physical_op_type
 								)
 								const;
 
@@ -114,62 +114,62 @@ namespace gpdxl
 			virtual
 			~CMappingVarColId()
 			{
-				m_pmvcmap->Release();
+				m_gpdb_att_opt_col_mapping->Release();
 			}
 
 			// given a gpdb attribute, return a column name in optimizer world
 			virtual
-			const CWStringBase *PstrColName
+			const CWStringBase *GetOptColName
 											(
-											ULONG ulCurrentQueryLevel,
-											const Var *pvar,
-											EPlStmtPhysicalOpType eplsphoptype
+											ULONG current_query_level,
+											const Var *var,
+											EPlStmtPhysicalOpType plstmt_physical_op_type
 											)
 											const;
 
 			// given a gpdb attribute, return column id
 			virtual
-			ULONG UlColId
+			ULONG GetColId
 							(
-							ULONG ulCurrentQueryLevel,
-							const Var *pvar,
-							EPlStmtPhysicalOpType eplsphoptype
+							ULONG current_query_level,
+							const Var *var,
+							EPlStmtPhysicalOpType plstmt_physical_op_type
 							)
 							const;
 
 			// load up mapping information from an index
-			void LoadIndexColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const IMDIndex *pmdindex, const CDXLTableDescr *pdxltabdesc);
+			void LoadIndexColumns(ULONG query_level, ULONG RTE_index, const IMDIndex *index, const CDXLTableDescr *table_descr);
 
 			// load up mapping information from table descriptor
-			void LoadTblColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const CDXLTableDescr *pdxltabdesc);
+			void LoadTblColumns(ULONG query_level, ULONG RTE_index, const CDXLTableDescr *table_descr);
 
 			// load up column id mapping information from the array of column descriptors
-			void LoadColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const DrgPdxlcd *pdrgdxlcd);
+			void LoadColumns(ULONG query_level, ULONG RTE_index, const CDXLColDescrArray *column_descrs);
 
 			// load up mapping information from derived table columns
-			void LoadDerivedTblColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const DrgPdxln *pdrgpdxlnDerivedColumns, List *plTargetList);
+			void LoadDerivedTblColumns(ULONG query_level, ULONG RTE_index, const CDXLNodeArray *derived_columns_dxl, List *target_list);
 
 			// load information from CTE columns
-			void LoadCTEColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const DrgPul *pdrgpulCTE, List *plTargetList);
+			void LoadCTEColumns(ULONG query_level, ULONG RTE_index, const ULongPtrArray *pdrgpulCTE, List *target_list);
 
 			// load up mapping information from scalar projection list
-			void LoadProjectElements(ULONG ulQueryLevel, ULONG ulRTEIndex, const CDXLNode *pdxlnPrL);
+			void LoadProjectElements(ULONG query_level, ULONG RTE_index, const CDXLNode *project_list_dxlnode);
 
 			// load up mapping information from list of column names
-			void Load(ULONG ulQueryLevel, ULONG ulRTEIndex,	CIdGenerator *pidgtor, List *plColNames);
+			void Load(ULONG query_level, ULONG RTE_index,	CIdGenerator *id_generator, List *col_names);
 
 			// create a deep copy
-			CMappingVarColId *PmapvarcolidCopy(IMemoryPool *pmp) const;
+			CMappingVarColId *CopyMapColId(IMemoryPool *mp) const;
 
 			// create a deep copy
-			CMappingVarColId *PmapvarcolidCopy(ULONG ulQueryLevel) const;
+			CMappingVarColId *CopyMapColId(ULONG query_level) const;
 			
 			// create a copy of the mapping replacing old col ids with new ones
-			CMappingVarColId *PmapvarcolidRemap
+			CMappingVarColId *CopyRemapColId
 				(
-				IMemoryPool *pmp,
-				DrgPul *pdrgpulOld,
-				DrgPul *pdrgpulNew
+				IMemoryPool *mp,
+				ULongPtrArray *old_colids,
+				ULongPtrArray *new_colids
 				)
 				const;
 	};

--- a/src/include/gpopt/translate/COptColInfo.h
+++ b/src/include/gpopt/translate/COptColInfo.h
@@ -37,51 +37,51 @@ namespace gpdxl
 		private:
 
 			// column id
-			ULONG m_ulColId;
+			ULONG m_colid;
 
 			// column name
-			CWStringBase *m_pstr;
+			CWStringBase *m_str;
 
 			// private copy c'tor
 			COptColInfo(const COptColInfo&);
 
 		public:
 			// ctor
-			COptColInfo(ULONG ulColId, CWStringBase *pstr)
-				: m_ulColId(ulColId), m_pstr(pstr)
+			COptColInfo(ULONG colid, CWStringBase *str)
+				: m_colid(colid), m_str(str)
 			{
-				GPOS_ASSERT(m_pstr);
+				GPOS_ASSERT(m_str);
 			}
 
 			// dtor
 			virtual
 			~COptColInfo()
 			{
-				GPOS_DELETE(m_pstr);
+				GPOS_DELETE(m_str);
 			}
 
 			// accessors
-			ULONG UlColId() const
+			ULONG GetColId() const
 			{
-				return m_ulColId;
+				return m_colid;
 			}
 
-			CWStringBase* PstrColName() const
+			CWStringBase* GetOptColName() const
 			{
-				return m_pstr;
+				return m_str;
 			}
 
 			// equality check
-			BOOL FEquals(const COptColInfo& optcolinfo) const
+			BOOL Equals(const COptColInfo& optcolinfo) const
 			{
 				// don't need to check name as column id is unique
-				return m_ulColId == optcolinfo.m_ulColId;
+				return m_colid == optcolinfo.m_colid;
 			}
 
 			// hash value
-			ULONG UlHash() const
+			ULONG HashValue() const
 			{
-				return gpos::UlHash(&m_ulColId);
+				return gpos::HashValue(&m_colid);
 			}
 
 	};
@@ -90,23 +90,23 @@ namespace gpdxl
 	inline
 	ULONG UlHashOptColInfo
 		(
-		const COptColInfo *poptcolinfo
+		const COptColInfo *opt_col_info
 		)
 	{
-		GPOS_ASSERT(NULL != poptcolinfo);
-		return poptcolinfo->UlHash();
+		GPOS_ASSERT(NULL != opt_col_info);
+		return opt_col_info->HashValue();
 	}
 
 	// equality function
 	inline
 	BOOL FEqualOptColInfo
 		(
-		const COptColInfo *poptcolinfoA,
-		const COptColInfo *poptcolinfoB
+		const COptColInfo *opt_col_infoA,
+		const COptColInfo *opt_col_infoB
 		)
 	{
-		GPOS_ASSERT(NULL != poptcolinfoA && NULL != poptcolinfoB);
-		return poptcolinfoA->FEquals(*poptcolinfoB);
+		GPOS_ASSERT(NULL != opt_col_infoA && NULL != opt_col_infoB);
+		return opt_col_infoA->Equals(*opt_col_infoB);
 	}
 
 }

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -52,52 +52,56 @@ namespace gpdxl
 	//---------------------------------------------------------------------------
 	class CQueryMutators
 	{
-		typedef Node *(*Pfnode) ();
-		typedef BOOL (*PfFallback) ();
+		typedef Node *(*MutatorWalkerFn) ();
+		typedef BOOL (*FallbackWalkerFn) ();
 
 		typedef struct SContextHavingQualMutator
 		{
 			public:
 				// memory pool
-				IMemoryPool *m_pmp;
+				IMemoryPool *m_mp;
 
 				// MD accessor for function names
-				CMDAccessor *m_pmda;
+				CMDAccessor *m_md_accessor;
 
 				// the counter for Query's total number of target entries
-				ULONG m_ulTECount;
+				ULONG m_num_target_entries;
 
 				// the target list of the new group by query
-				List *m_plTENewGroupByQuery;
+				List *m_groupby_target_list;
 
 				// the current query level
-				ULONG m_ulCurrLevelsUp;
+				ULONG m_current_query_level;
 
 		 	 	// indicate whether we are mutating the argument of an aggregate
-				BOOL m_fAggregateArg;
+				BOOL m_is_mutating_agg_arg;
 
 				// indicate the levels up of the aggregate we are mutating
-				ULONG m_ulAggregateLevelUp;
+				ULONG m_agg_levels_up;
 				
 				// fall back to the planner by raising an expression since we encountered an
 				// expression / attribute that we could not resolve
-				BOOL m_fFallbackToPlanner;
+				BOOL m_should_fallback;
 
 				// ctor
-				SContextHavingQualMutator(IMemoryPool *pmp,
-										  CMDAccessor *pmda,
-										  ULONG ulTECount,
-										  List *plTENewGroupByQuery)
-					: m_pmp(pmp),
-					  m_pmda(pmda),
-					  m_ulTECount(ulTECount),
-					  m_plTENewGroupByQuery(plTENewGroupByQuery),
-					  m_ulCurrLevelsUp(0),
-					  m_fAggregateArg(false),
-					  m_ulAggregateLevelUp(gpos::ulong_max),
-					  m_fFallbackToPlanner(false)
+				SContextHavingQualMutator
+					(
+					IMemoryPool *mp,
+					CMDAccessor *md_accessor,
+					ULONG num_target_entries,
+					List *groupby_target_list
+					)
+					:
+					m_mp(mp),
+					m_md_accessor(md_accessor),
+					m_num_target_entries(num_target_entries),
+					m_groupby_target_list(groupby_target_list),
+					m_current_query_level(0),
+					m_is_mutating_agg_arg(false),
+					m_agg_levels_up(gpos::ulong_max),
+					m_should_fallback(false)
 				{
-					GPOS_ASSERT(NULL != plTENewGroupByQuery);
+					GPOS_ASSERT(NULL != groupby_target_list);
 				}
 
 				// dtor
@@ -111,42 +115,42 @@ namespace gpdxl
 			public:
 
 				// memory pool
-				IMemoryPool *m_pmp;
+				IMemoryPool *m_mp;
 
 				// MD accessor to get the function name
-				CMDAccessor *m_pmda;
+				CMDAccessor *m_md_accessor;
 
 				// original query
-				Query *m_pquery;
+				Query *m_query;
 
 				// the new target list of the group by query
-				List *m_plTENewGroupByQuery;
+				List *m_groupby_target_list;
 
 				// the current query level
-				ULONG m_ulCurrLevelsUp;
+				ULONG m_current_query_level;
 
 				// the sorting / grouping reference of the original target list entry
-				ULONG m_ulRessortgroupref;
+				ULONG m_sort_group_ref;
 
 				// indicate whether we are mutating the argument of an aggregate
-				BOOL m_fAggregateArg;
+				BOOL m_is_mutating_agg_arg;
 
 				// ctor
 				SContextGrpbyPlMutator
 					(
-					IMemoryPool *pmp,
-					CMDAccessor *pmda,
-					Query *pquery,
-					List *plTENewGroupByQuery
+					IMemoryPool *mp,
+					CMDAccessor *md_accessor,
+					Query *query,
+					List *groupby_target_list
 					)
 					:
-					m_pmp(pmp),
-					m_pmda(pmda),
-					m_pquery(pquery),
-					m_plTENewGroupByQuery(plTENewGroupByQuery),
-					m_ulCurrLevelsUp(0),
-					m_ulRessortgroupref(0),
-					m_fAggregateArg(false)
+					m_mp(mp),
+					m_md_accessor(md_accessor),
+					m_query(query),
+					m_groupby_target_list(groupby_target_list),
+					m_current_query_level(0),
+					m_sort_group_ref(0),
+					m_is_mutating_agg_arg(false)
 				{
 				}
 
@@ -161,20 +165,20 @@ namespace gpdxl
 			public:
 
 				// the current query level
-				ULONG m_ulCurrLevelsUp;
+				ULONG m_current_query_level;
 				
 				// fix target list entry of the top level
-				BOOL m_fFixTargetListTopLevel;
+				BOOL m_should_fix_top_level_target_list;
 
 				// ctor
 				SContextIncLevelsupMutator
 					(
-					ULONG ulCurrLevelsUp,
-					BOOL fFixTargetListTopLevel
+					ULONG current_query_level,
+					BOOL should_fix_top_level_target_list
 					)
 					:
-					m_ulCurrLevelsUp(ulCurrLevelsUp),
-					m_fFixTargetListTopLevel(fFixTargetListTopLevel)
+					m_current_query_level(current_query_level),
+					m_should_fix_top_level_target_list(should_fix_top_level_target_list)
 				{
 				}
 
@@ -190,20 +194,20 @@ namespace gpdxl
 					public:
 
 						// list of target list entries in the query
-						List *m_plTE;
+						List *m_target_entries;
 
 						// list of grouping clauses
-						List *m_groupClause;
+						List *m_group_clause;
 
 						// ctor
 						SContextTLWalker
 							(
-							List *plTE,
-							List *groupClause
+							List *target_entries,
+							List *group_clause
 							)
 							:
-							m_plTE(plTE),
-							m_groupClause(groupClause)
+							m_target_entries(target_entries),
+							m_group_clause(group_clause)
 						{
 						}
 
@@ -217,107 +221,107 @@ namespace gpdxl
 
 			// check if the cte levels up needs to be corrected
 			static
-			BOOL FNeedsLevelsUpCorrection(SContextIncLevelsupMutator *pctxinclvlmutator, Index idxCtelevelsup);
+			BOOL NeedsLevelsUpCorrection(SContextIncLevelsupMutator *context, Index cte_levels_up);
 
 		public:
 
 			// fall back during since the target list refers to a attribute which algebrizer at this point cannot resolve
 			static
-			BOOL FNeedsToFallback(Node *pnode, void *pctx);
+			BOOL ShouldFallback(Node *node, SContextTLWalker *context);
 
 			// check if the project list contains expressions on aggregates thereby needing normalization
 			static
-			BOOL FNeedsPrLNormalization(const Query *pquery);
+			BOOL NeedsProjListNormalization(const Query *query);
 
 			// normalize query
 			static
-			Query *PqueryNormalize(IMemoryPool *pmp, CMDAccessor *pmda, const Query *pquery, ULONG ulQueryLevel);
+			Query *NormalizeQuery(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query, ULONG query_level);
 
 			// check if the project list contains expressions on window operators thereby needing normalization
 			static
-			BOOL FNeedsWindowPrLNormalization(const Query *pquery);
+			BOOL NeedsProjListWindowNormalization(const Query *query);
 
 			// flatten expressions in window operation project list
 			static
-			Query *PqueryNormalizeWindowPrL(IMemoryPool *pmp, CMDAccessor *pmda, const Query *pquery);
+			Query *NormalizeWindowProjList(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
 
 			// traverse the project list to extract all window functions in an arbitrarily complex project element
 			static
-			Node *PnodeWindowPrLMutator(Node *pnode, void *ctx);
+			Node *RunWindowProjListMutator(Node *node, SContextGrpbyPlMutator *context);
 
 			// flatten expressions in project list
 			static
-			Query *PqueryNormalizeGrpByPrL(IMemoryPool *pmp, CMDAccessor *pmda, const Query *pquery);
+			Query *NormalizeGroupByProjList(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
 
 			// make a copy of the aggref (minus the arguments)
 			static
-			Aggref *PaggrefFlatCopy(Aggref *paggrefOld);
+			Aggref *FlatCopyAggref(Aggref *aggref);
 
 			// create a new entry in the derived table and return its corresponding var
 			static
-			Var *PvarInsertIntoDerivedTable(Node *pnode, SContextHavingQualMutator *context);
+			Var *MakeVarInDerivedTable(Node *node, SContextHavingQualMutator *context);
 
 			// check if a matching node exists in the list of target entries
 			static
-			Node *PnodeFind(Node *pnode, SContextHavingQualMutator *pctx);
+			Node *FindNodeInTargetEntries(Node *node, SContextHavingQualMutator *context);
 
 			// increment the levels up of outer references
 			static
-			Var *PvarOuterReferenceIncrLevelsUp(Var *pvar);
+			Var *IncrLevelsUpInVar(Var *var);
 
 			// pull up having clause into a select
 			static
-			Query *PqueryNormalizeHaving(IMemoryPool *pmp, CMDAccessor *pmda, const Query *pquery);
+			Query *NormalizeHaving(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
 
 			// traverse the expression and fix the levels up of any outer reference
 			static
-			Node *PnodeIncrementLevelsupMutator(Node *pnode, void *ctx);
+			Node *RunIncrLevelsUpMutator(Node *node, SContextIncLevelsupMutator *context);
 
 			// traverse the expression and fix the levels up of any CTE
 			static
-			Node *PnodeFixCTELevelsupMutator(Node *pnode, void *ctx);
+			Node *RunFixCTELevelsUpMutator(Node *node, SContextIncLevelsupMutator *context);
 
 			// traverse the project list of a groupby operator, to
 			// extract all aggregate functions in an arbitrarily complex project element,
 			static
-			Node *PnodeGrpbyPrLMutator(Node *pnode, void *ctx);
+			Node *RunGroupByProjListMutator(Node *node, SContextGrpbyPlMutator *context);
 
 			// mutate the grouping columns, fix levels up when necessary
 			static
-			Node *PnodeGrpColMutator(Node *pnode, void *pctx);
+			Node *RunGroupingColMutator(Node *node, SContextGrpbyPlMutator *context);
 
 			// fix the level up of grouping columns when necessary
 			static
-			Node *PnodeFixGrpCol(Node *pnode, TargetEntry *pteOriginal, SContextGrpbyPlMutator *pctxGrpByMutator);
+			Node *FixGroupingCols(Node *node, TargetEntry *original, SContextGrpbyPlMutator *context);
 
 			// return a target entry for the aggregate expression
 			static
-			TargetEntry *PteAggregateExpr(IMemoryPool *pmp, CMDAccessor *pmda, Node *pnode, ULONG ulAttno);
+			TargetEntry *GetTargetEntryForAggExpr(IMemoryPool *mp, CMDAccessor *md_accessor, Node *node, ULONG attno);
 
 			// traverse the having qual to extract all aggregate functions,
 			// fix correlated vars and return the modified having qual
 			static
-			Node *PnodeHavingQualMutator(Node *pnode, void *ctx);
+			Node *RunHavingQualMutator(Node *node, SContextHavingQualMutator *context);
 
 			// for a given an TE in the derived table, create a new TE to be added to the top level query
 			static
-			TargetEntry *Pte(TargetEntry *pte, ULONG ulVarAttno);
+			TargetEntry *MakeTopLevelTargetEntry(TargetEntry *target_entry, ULONG attno);
 
 			// return the column name of the target entry
 			static
-			CHAR* SzTEName(TargetEntry *pte, Query *pquery);
+			CHAR* GetTargetEntryColName(TargetEntry *target_entry, Query *query);
 
 			// make the input query into a derived table and return a new root query
 			static
-			Query *PqueryConvertToDerivedTable(const Query *pquery, BOOL fFixTargetList, BOOL fFixHavingQual);
+			Query *ConvertToDerivedTable(const Query *query, BOOL should_fix_target_list, BOOL should_fix_having_qual);
 
 			// eliminate distinct clause
 			static
-			Query *PqueryEliminateDistinctClause(const Query *pquery);
+			Query *EliminateDistinctClause(const Query *query);
 
 			// reassign the sorting clause from the derived table to the new top-level query
 			static
-			void ReassignSortClause(Query *pqueryNew, Query *pqueryDrdTbl);
+			void ReassignSortClause(Query *top_level_query, Query *derive_table_query);
 	};
 }
 #endif // GPDXL_CWalkerUtils_H

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -74,7 +74,7 @@ namespace gpdxl
 	class CTranslatorDXLToScalar
 	{
 		// shorthand for functions for translating DXL nodes to GPDB expressions
-		typedef Expr * (CTranslatorDXLToScalar::*PfPexpr)(const CDXLNode *pdxln, CMappingColIdVar *pmapcidvar);
+		typedef Expr * (CTranslatorDXLToScalar::*expr_func_ptr)(const CDXLNode *dxlnode, CMappingColIdVar *colid_var);
 
 		private:
 
@@ -82,248 +82,248 @@ namespace gpdxl
 			struct STranslatorElem
 			{
 				Edxlopid eopid;
-				PfPexpr pf;
+				expr_func_ptr translate_func;
 			};
 
 			// shorthand for functions for translating DXL nodes to GPDB expressions
-			typedef Const * (CTranslatorDXLToScalar::*PfPconst)(CDXLDatum *);
+			typedef Const * (CTranslatorDXLToScalar::*const_func_ptr)(CDXLDatum *);
 
 			// pair of DXL datum type and translator function
 			struct SDatumTranslatorElem
 			{
 				CDXLDatum::EdxldatumType edxldt;
-				PfPconst pf;
+				const_func_ptr translate_func;
 			};
 
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// meta data accessor
-			CMDAccessor *m_pmda;
+			CMDAccessor *m_md_accessor;
 
 			// The parent plan needed when translating an initplan
-			Plan *m_pplan;
+			Plan *m_plan;
 
 			// indicates whether a sublink was encountered during translation of the scalar subtree
-			BOOL m_fHasSubqueries;
+			BOOL m_has_subqueries;
 			
 			// number of segments
-			ULONG m_ulSegments; 
+			ULONG m_num_of_segments; 
 
 			// translate a CDXLScalarArrayComp into a GPDB ScalarArrayOpExpr
-			Expr *PstrarrayopexprFromDXLNodeScArrayComp
+			Expr *TranslateDXLScalarArrayCompToScalar
 				(
-				const CDXLNode *pdxlnScArrayComp,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_array_cmp_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PopexprFromDXLNodeScOpExpr
+			Expr *TranslateDXLScalarOpExprToScalar
 				(
-				const CDXLNode *pdxlnScOpExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_op_expr_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PdistexprFromDXLNodeScDistinctComp
+			Expr *TranslateDXLScalarDistinctToScalar
 				(
-				const CDXLNode *pdxlnScDistComp,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_distinct_cmp_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PboolexprFromDXLNodeScBoolExpr
+			Expr *TranslateDXLScalarBoolExprToScalar
 				(
-				const CDXLNode *pdxlnScBoolExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_bool_expr_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PbooleantestFromDXLNodeScBooleanTest
+			Expr *TranslateDXLScalarBooleanTestToScalar
 				(
-				const CDXLNode *pdxlnScBooleanTest,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_boolean_test_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PrelabeltypeFromDXLNodeScCast
+			Expr *TranslateDXLScalarCastToScalar
 				(
-				const CDXLNode *pdxlnScRelabelType,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_relabel_type_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcoerceFromDXLNodeScCoerceToDomain
+			Expr *TranslateDXLScalarCoerceToDomainToScalar
 				(
-				const CDXLNode *pdxlnScCoerceToDomain,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *coerce_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcoerceFromDXLNodeScCoerceViaIO
+			Expr *TranslateDXLScalarCoerceViaIOToScalar
 				(
-				const CDXLNode *pdxlnScCoerceViaIO,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *coerce_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcoerceFromDXLNodeScArrayCoerceExpr
+			Expr *TranslateDXLScalarArrayCoerceExprToScalar
 				(
-				const CDXLNode *pdxlnScArrayCoerceExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *coerce_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PnulltestFromDXLNodeScNullTest
+			Expr *TranslateDXLScalarNullTestToScalar
 				(
-				const CDXLNode *pdxlnScNullTest,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_null_test_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PnullifFromDXLNodeScNullIf
+			Expr *TranslateDXLScalarNullIfToScalar
 				(
-				const CDXLNode *pdxlnScNullIf,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_null_if_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcaseexprFromDXLNodeScIfStmt
+			Expr *TranslateDXLScalarIfStmtToScalar
 				(
-				const CDXLNode *pdxlnScCaseExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_if_stmt_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcaseexprFromDXLNodeScSwitch
+			Expr *TranslateDXLScalarSwitchToScalar
 				(
-				const CDXLNode *pdxlnScSwitch,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_switch_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcasetestexprFromDXLNodeScCaseTest
+			Expr *TranslateDXLScalarCaseTestToScalar
 				(
-				const CDXLNode *pdxlnScSwitch,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_case_test_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PaggrefFromDXLNodeScAggref
+			Expr *TranslateDXLScalarAggrefToScalar
 				(
-				const CDXLNode *pdxlnAggref,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *aggref_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PwindowrefFromDXLNodeScWindowRef
+			Expr *TranslateDXLScalarWindowRefToScalar
 				(
-				const CDXLNode *pdxlnAggref,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_winref_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PfuncexprFromDXLNodeScFuncExpr
+			Expr *TranslateDXLScalarFuncExprToScalar
 				(
-				const CDXLNode *pdxlnFuncExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_func_expr_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// return a GPDB subplan from a DXL subplan
-			Expr *PsubplanFromDXLNodeScSubPlan
+			Expr *TranslateDXLScalarSubplanToScalar
 				(
-				const CDXLNode *pdxlnSubPlan,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_sub_plan_node,
+				CMappingColIdVar *colid_var
 				);
 			
 			// build subplan node
-			SubPlan *PsubplanFromChildPlan
+			SubPlan *TranslateSubplanFromChildPlan
 				(
-				Plan *pplanChild,
+				Plan *plan_child,
 				SubLinkType slink,
-				CContextDXLToPlStmt *pctxdxltoplstmt
+				CContextDXLToPlStmt *dxl_to_plstmt_ctxt
 				);
 
 			// translate subplan test expression
-			Expr *PexprSubplanTestExpr
+			Expr *TranslateDXLSubplanTestExprToScalar
 				(
-				CDXLNode *pdxlnTestExpr,
+				CDXLNode *test_expr_node,
 				SubLinkType slink,
-				CMappingColIdVar *pmapcidvar,
-				List **plparamIds
+				CMappingColIdVar *colid_var,
+				List **param_ids_list
 				);
 			
 			// translate subplan parameters
 			void TranslateSubplanParams
         			(
-        			SubPlan *psubplan,
-        			CDXLTranslateContext *pdxltrctx,
-        			const DrgPdxlcr *pdrgdxlcrOuterRefs,
-				CMappingColIdVar *pmapcidvar
+        			SubPlan *sub_plan,
+        			CDXLTranslateContext *dxl_translator_ctxt,
+        			const CDXLColRefArray *outer_refs,
+				CMappingColIdVar *colid_var
        	 			);
 
-			CHAR *SzSubplanAlias(ULONG ulPlanId);
+			CHAR *GetSubplanAlias(ULONG plan_id);
 
-			Param *PparamFromMapping
+			Param *TranslateParamFromMapping
 				(
-				const CMappingElementColIdParamId *pmecolidparamid
+				const CMappingElementColIdParamId *colid_to_param_id_map
 				);
 
 			// translate a scalar coalesce
-			Expr *PcoalesceFromDXLNodeScCoalesce
+			Expr *TranslateDXLScalarCoalesceToScalar
 				(
-				const CDXLNode *pdxlnScCoalesce,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_coalesce_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar minmax
-			Expr *PminmaxFromDXLNodeScMinMax
+			Expr *TranslateDXLScalarMinMaxToScalar
 				(
-				const CDXLNode *pdxlnScMinMax,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_min_max_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scconstval
-			Expr *PconstFromDXLNodeScConst
+			Expr *TranslateDXLScalarConstToScalar
 				(
-				const CDXLNode *pdxlnScConst,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_const_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate an array expression
-			Expr *PexprArray
+			Expr *TranslateDXLScalarArrayToScalar
 				(
-				const CDXLNode *pdxlnArray,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_array_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate an arrayref expression
-			Expr *PexprArrayRef
+			Expr *TranslateDXLScalarArrayRefToScalar
 				(
-				const CDXLNode *pdxlnArrayref,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_array_ref_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate an arrayref index list
-			List *PlTranslateArrayRefIndexList
+			List *TranslateDXLArrayRefIndexListToScalar
 				(
-				const CDXLNode *pdxlnIndexlist,
-				CDXLScalarArrayRefIndexList::EIndexListBound eilb,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *index_list_node,
+				CDXLScalarArrayRefIndexList::EIndexListBound index_list_bound,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a DML action expression
-			Expr *PexprDMLAction
+			Expr *TranslateDXLScalarDMLActionToScalar
 				(
-				const CDXLNode *pdxlnDMLAction,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *dml_action_node,
+				CMappingColIdVar *colid_var
 				);
 			
 			
 			// translate children of DXL node, and add them to list
-			List *PlistTranslateScalarChildren
+			List *TranslateScalarChildren
 				(
-				List *plist,
-				const CDXLNode *pdxln,
-				CMappingColIdVar *pmapcidvar
+				List *list,
+				const CDXLNode *dxlnode,
+				CMappingColIdVar *colid_var
 				);
 
 			// return the operator return type oid for the given func id.
-			OID OidFunctionReturnType(IMDId *pmdid) const;
+			OID GetFunctionReturnTypeOid(IMDId *mdid) const;
 
 			// translate dxldatum to GPDB Const
-			Const *PconstOid(CDXLDatum *pdxldatum);
-			Const *PconstInt2(CDXLDatum *pdxldatum);
-			Const *PconstInt4(CDXLDatum *pdxldatum);
-			Const *PconstInt8(CDXLDatum *pdxldatum);
-			Const *PconstBool(CDXLDatum *pdxldatum);
-			Const *PconstGeneric(CDXLDatum *pdxldatum);
-			Expr *PrelabeltypeOrFuncexprFromDXLNodeScalarCast
+			Const *ConvertDXLDatumToConstOid(CDXLDatum *datum_dxl);
+			Const *ConvertDXLDatumToConstInt2(CDXLDatum *datum_dxl);
+			Const *ConvertDXLDatumToConstInt4(CDXLDatum *datum_dxl);
+			Const *ConvertDXLDatumToConstInt8(CDXLDatum *datum_dxl);
+			Const *ConvertDXLDatumToConstBool(CDXLDatum *datum_dxl);
+			Const *TranslateDXLDatumGenericToScalar(CDXLDatum *datum_dxl);
+			Expr *TranslateRelabelTypeOrFuncExprFromDXL
 				(
-				const CDXLScalarCast *pdxlscalarcast,
+				const CDXLScalarCast *scalar_cast,
 				Expr *pexprChild
 				);
 
@@ -333,98 +333,98 @@ namespace gpdxl
 		public:
 			struct STypeOidAndTypeModifier
 			{
-				OID OidType;
-				INT ITypeModifier;
+				OID oid_type;
+				INT type_modifier;
 			};
 
 			// ctor
-			CTranslatorDXLToScalar(IMemoryPool *pmp, CMDAccessor *pmda, ULONG ulSegments);
+			CTranslatorDXLToScalar(IMemoryPool *mp, CMDAccessor *md_accessor, ULONG num_segments);
 
 			// translate DXL scalar operator node into an Expr expression
 			// This function is called during the translation of DXL->Query or DXL->Query
-			Expr *PexprFromDXLNodeScalar
+			Expr *TranslateDXLToScalar
 				(
-				const CDXLNode *pdxlnScOp,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_op_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part default into an Expr
-			Expr *PexprPartDefault
+			Expr *TranslateDXLScalarPartDefaultToScalar
 				(
-				const CDXLNode *pdxlnPartDefault,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_default_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part bound into an Expr
-			Expr *PexprPartBound
+			Expr *TranslateDXLScalarPartBoundToScalar
 				(
-				const CDXLNode *pdxlnPartBound,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_bound_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part bound inclusion into an Expr
-			Expr *PexprPartBoundInclusion
+			Expr *TranslateDXLScalarPartBoundInclusionToScalar
 				(
-				const CDXLNode *pdxlnPartBoundIncl,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_bound_incl_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part bound openness into an Expr
-			Expr *PexprPartBoundOpen
+			Expr *TranslateDXLScalarPartBoundOpenToScalar
 				(
-				const CDXLNode *pdxlnPartBoundOpen,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_bound_open_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part list values into an Expr
-			Expr *PexprPartListValues
+			Expr *TranslateDXLScalarPartListValuesToScalar
 				(
-				const CDXLNode *pdxlnPartListValues,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_list_values_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part list null test into an Expr
-			Expr *PexprPartListNullTest
+			Expr *TranslateDXLScalarPartListNullTestToScalar
 				(
-				const CDXLNode *pdxlnPartListNullTest,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_list_null_test_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar ident into an Expr
-			Expr *PexprFromDXLNodeScId
+			Expr *TranslateDXLScalarIdentToScalar
 				(
-				const CDXLNode *pdxlnScId,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_id_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar comparison into an Expr
-			Expr *PopexprFromDXLNodeScCmp
+			Expr *TranslateDXLScalarCmpToScalar
 				(
-				const CDXLNode *pdxlnScCmp,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_cmp_node,
+				CMappingColIdVar *colid_var
 				);
 
 
 			// checks if the operator return a boolean result
 			static
-			BOOL FBoolean(CDXLNode *pdxln, CMDAccessor *pmda);
+			BOOL HasBoolResult(CDXLNode *dxlnode, CMDAccessor *md_accessor);
 
 			// check if the operator is a "true" bool constant
 			static
-			BOOL FConstTrue(CDXLNode *pdxln, CMDAccessor *pmda);
+			BOOL HasConstTrue(CDXLNode *dxlnode, CMDAccessor *md_accessor);
 
 			// check if the operator is a NULL constant
 			static
-			BOOL FConstNull(CDXLNode *pdxln);
+			BOOL HasConstNull(CDXLNode *dxlnode);
 
 			// are there subqueries in the tree
-			BOOL FHasSubqueries() const
+			BOOL HasSubqueries() const
 			{
-				return m_fHasSubqueries;
+				return m_has_subqueries;
 			}
 			
 			// translate a DXL datum into GPDB const expression
-			Expr *PconstFromDXLDatum(CDXLDatum *pdxldatum);
+			Expr *TranslateDXLDatumToScalar(CDXLDatum *datum_dxl);
 	};
 }
 #endif // !GPDXL_CTranslatorDXLToScalar_H

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -87,16 +87,16 @@ namespace gpdxl
 				OID m_oid;
 
 				// function stability
-				IMDFunction::EFuncStbl m_efs;
+				IMDFunction::EFuncStbl m_stability;
 
 				// function data access
-				IMDFunction::EFuncDataAcc m_efda;
+				IMDFunction::EFuncDataAcc m_access;
 
 				// is function strict?
-				BOOL m_fStrict;
+				BOOL m_is_strict;
 
 				// can the function return multiple rows?
-				BOOL m_fReturnsSet;
+				BOOL m_returns_set;
 
 			public:
 
@@ -104,17 +104,17 @@ namespace gpdxl
 				SFuncProps
 					(
 					OID oid,
-					IMDFunction::EFuncStbl efs,
-					IMDFunction::EFuncDataAcc efda,
-					BOOL fStrict,
-					BOOL fReturnsSet
+					IMDFunction::EFuncStbl stability,
+					IMDFunction::EFuncDataAcc access,
+					BOOL is_strict,
+					BOOL ReturnsSet
 					)
 					:
 					m_oid(oid),
-					m_efs(efs),
-					m_efda(efda),
-					m_fStrict(fStrict),
-					m_fReturnsSet(fReturnsSet)
+					m_stability(stability),
+					m_access(access),
+					m_is_strict(is_strict),
+					m_returns_set(ReturnsSet)
 				{}
 
 				// dtor
@@ -129,340 +129,340 @@ namespace gpdxl
 				}
 
 				// return function stability
-				IMDFunction::EFuncStbl Efs() const
+				IMDFunction::EFuncStbl GetStability() const
 				{
-					return m_efs;
+					return m_stability;
 				}
 
 				// return data access property
-				IMDFunction::EFuncDataAcc Efda() const
+				IMDFunction::EFuncDataAcc GetDataAccess() const
 				{
-					return m_efda;
+					return m_access;
 				}
 
 				// is function strict?
-				BOOL FStrict() const
+				BOOL IsStrict() const
 				{
-					return m_fStrict;
+					return m_is_strict;
 				}
 
 				// does function return set?
-				BOOL FReturnsSet() const
+				BOOL ReturnsSet() const
 				{
-					return m_fReturnsSet;
+					return m_returns_set;
 				}
 
 			}; // struct SFuncProps
 
 			// array of function properties map
 			static
-			const SFuncProps m_rgfp[];
+			const SFuncProps m_func_props[];
 
 			// lookup function properties
 			static
 			void LookupFuncProps
 				(
-				OID oidFunc,
-				IMDFunction::EFuncStbl *pefs, // output: function stability
-				IMDFunction::EFuncDataAcc *pefda, // output: function data access
-				BOOL *fStrict, // output: is function strict?
-				BOOL *fReturnsSet // output: does function return set?
+				OID func_oid,
+				IMDFunction::EFuncStbl *stability, // output: function stability
+				IMDFunction::EFuncDataAcc *access, // output: function data access
+				BOOL *is_strict, // output: is function strict?
+				BOOL *ReturnsSet // output: does function return set?
 				);
 
 			// check and fall back for unsupported relations
 			static
-			void CheckUnsupportedRelation(OID oidRel);
+			void CheckUnsupportedRelation(OID rel_oid);
 
 			// get type name from the relcache
 			static
-			CMDName *PmdnameType(IMemoryPool *pmp, IMDId *pmdid);
+			CMDName *GetTypeName(IMemoryPool *mp, IMDId *mdid);
 
 			// get function stability property from the GPDB character representation
 			static
-			CMDFunctionGPDB::EFuncStbl EFuncStability(CHAR c);
+			CMDFunctionGPDB::EFuncStbl GetFuncStability(CHAR c);
 
 			// get function data access property from the GPDB character representation
 			static
-			CMDFunctionGPDB::EFuncDataAcc EFuncDataAccess(CHAR c);
+			CMDFunctionGPDB::EFuncDataAcc GetEFuncDataAccess(CHAR c);
 
 			// get type of aggregate's intermediate result from the relcache
 			static
-			IMDId *PmdidAggIntermediateResultType(IMemoryPool *pmp, IMDId *pmdid);
+			IMDId *RetrieveAggIntermediateResultType(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a GPDB metadata object from the relcache
 			static
-			IMDCacheObject *PimdobjGPDB(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			IMDCacheObject *RetrieveObjectGPDB(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// retrieve relstats object from the relcache
 			static
-			IMDCacheObject *PimdobjRelStats(IMemoryPool *pmp, IMDId *pmdid);
+			IMDCacheObject *RetrieveRelStats(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve column stats object from the relcache
 			static
-			IMDCacheObject *PimdobjColStats(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			IMDCacheObject *RetrieveColStats(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// retrieve cast object from the relcache
 			static
-			IMDCacheObject *PimdobjCast(IMemoryPool *pmp, IMDId *pmdid);
+			IMDCacheObject *RetrieveCast(IMemoryPool *mp, IMDId *mdid);
 			
 			// retrieve scalar comparison object from the relcache
 			static
-			IMDCacheObject *PmdobjScCmp(IMemoryPool *pmp, IMDId *pmdid);
+			IMDCacheObject *RetrieveScCmp(IMemoryPool *mp, IMDId *mdid);
 
 			// transform GPDB's MCV information to optimizer's histogram structure
 			static
-			CHistogram *PhistTransformGPDBMCV
+			CHistogram *TransformMcvToOrcaHistogram
 								(
-								IMemoryPool *pmp,
-								const IMDType *pmdtype,
-								const Datum *pdrgdatumMCVValues,
-								const float4 *pdrgfMCVFrequencies,
-								ULONG ulNumMCVValues
+								IMemoryPool *mp,
+								const IMDType *md_type,
+								const Datum *mcv_values,
+								const float4 *mcv_frequencies,
+								ULONG num_mcv_values
 								);
 
 			// transform GPDB's hist information to optimizer's histogram structure
 			static
-			CHistogram *PhistTransformGPDBHist
+			CHistogram *TransformHistToOrcaHistogram
 								(
-								IMemoryPool *pmp,
-								const IMDType *pmdtype,
-								const Datum *pdrgdatumHistValues,
-								ULONG ulNumHistValues,
-								CDouble dDistinctHist,
-								CDouble dFreqHist
+								IMemoryPool *mp,
+								const IMDType *md_type,
+								const Datum *hist_values,
+								ULONG num_hist_values,
+								CDouble num_distinct,
+								CDouble hist_freq
 								);
 
 			// histogram to array of dxl buckets
 			static
-			DrgPdxlbucket *Pdrgpdxlbucket
+			CDXLBucketArray *TransformHistogramToDXLBucketArray
 								(
-								IMemoryPool *pmp,
-								const IMDType *pmdtype,
-								const CHistogram *phist
+								IMemoryPool *mp,
+								const IMDType *md_type,
+								const CHistogram *hist
 								);
 
 			// transform stats from pg_stats form to optimizer's preferred form
 			static
-			DrgPdxlbucket *PdrgpdxlbucketTransformStats
+			CDXLBucketArray *TransformStatsToDXLBucketArray
 								(
-								IMemoryPool *pmp,
-								OID oidAttType,
-								CDouble dDistinct,
-								CDouble dNullFreq,
-								const Datum *pdrgdatumMCVValues,
-								const float4 *pdrgfMCVFrequencies,
-								ULONG ulNumMCVValues,
-								const Datum *pdrgdatumHistValues,
-								ULONG ulNumHistValues
+								IMemoryPool *mp,
+								OID att_type,
+								CDouble num_distinct,
+								CDouble null_freq,
+								const Datum *mcv_values,
+								const float4 *mcv_frequencies,
+								ULONG num_mcv_values,
+								const Datum *hist_values,
+								ULONG num_hist_values
 								);
 
 			// get partition keys and types for a relation
 			static
-			void GetPartKeysAndTypes(IMemoryPool *pmp, Relation rel, OID oid, DrgPul **pdrgpulPartKeys, DrgPsz **pdrgpszPartTypes);
+			void RetrievePartKeysAndTypes(IMemoryPool *mp, Relation rel, OID oid, ULongPtrArray **part_keys, CharPtrArray **part_types);
 
 			// get keysets for relation
 			static
-			DrgPdrgPul *PdrgpdrgpulKeys(IMemoryPool *pmp, OID oid, BOOL fAddDefaultKeys, BOOL fPartitioned, ULONG *pulMapping);
+			ULongPtr2dArray *RetrieveRelKeysets(IMemoryPool *mp, OID oid, BOOL should_add_default_keys, BOOL is_partitioned, ULONG *attno_mapping);
 
 			// storage type for a relation
 			static
-			IMDRelation::Erelstoragetype Erelstorage(CHAR cStorageType);
+			IMDRelation::Erelstoragetype RetrieveRelStorageType(CHAR storage_type);
 
 			// fix frequencies if they add up to more than 1.0
 			static
-			void NormalizeFrequencies(float4 *pdrgf, ULONG ulLength, CDouble *pdNullFrequency);
+			void NormalizeFrequencies(float4 *pdrgf, ULONG length, CDouble *null_freq);
 
 			// get the relation columns
 			static
-			DrgPmdcol *Pdrgpmdcol(IMemoryPool *pmp, CMDAccessor *pmda, Relation rel, IMDRelation::Erelstoragetype erelstorage);
+			CMDColumnArray *RetrieveRelColumns(IMemoryPool *mp, CMDAccessor *md_accessor, Relation rel, IMDRelation::Erelstoragetype rel_storage_type);
 
 			// return the dxl representation of the column's default value
 			static
-			CDXLNode *PdxlnDefaultColumnValue(IMemoryPool *pmp, CMDAccessor *pmda, TupleDesc rd_att, AttrNumber attrno);
+			CDXLNode *GetDefaultColumnValue(IMemoryPool *mp, CMDAccessor *md_accessor, TupleDesc rd_att, AttrNumber attrno);
 
 
 			// get the distribution columns
 			static
-			DrgPul *PdrpulDistrCols(IMemoryPool *pmp, GpPolicy *pgppolicy, DrgPmdcol *pdrgpmdcol, ULONG ulSize);
+			ULongPtrArray *RetrieveRelDistrbutionCols(IMemoryPool *mp, GpPolicy *gp_policy, CMDColumnArray *mdcol_array, ULONG size);
 
 			// construct a mapping GPDB attnos -> position in the column array
 			static
-			ULONG *PulAttnoMapping(IMemoryPool *pmp, DrgPmdcol *pdrgpmdcol, ULONG ulMaxCols);
+			ULONG *ConstructAttnoMapping(IMemoryPool *mp, CMDColumnArray *mdcol_array, ULONG max_cols);
 
 			// check if index is supported
 			static
-			BOOL FIndexSupported(Relation relIndex);
+			BOOL IsIndexSupported(Relation index_rel);
 			
 			// retrieve index info list of partitioned table
 			static
-			List *PlIndexInfoPartTable(Relation rel);
+			List *RetrievePartTableIndexInfo(Relation rel);
 			 
 			// compute the array of included columns
 			static
-			DrgPul *PdrgpulIndexIncludedColumns(IMemoryPool *pmp, const IMDRelation *pmdrel);
+			ULongPtrArray *ComputeIncludedCols(IMemoryPool *mp, const IMDRelation *md_rel);
 			
 			// is given level included in the default partitions
 			static 
-			BOOL FDefaultPartition(List *plDefaultLevels, ULONG ulLevel);
+			BOOL LevelHasDefaultPartition(List *default_levels, ULONG level);
 			
 			// retrieve part constraint for index
 			static
-			CMDPartConstraintGPDB *PmdpartcnstrIndex
+			CMDPartConstraintGPDB *RetrievePartConstraintForIndex
 				(
-				IMemoryPool *pmp, 
-				CMDAccessor *pmda, 
-				const IMDRelation *pmdrel, 
-				Node *pnodePartCnstr,
-				DrgPul *pdrgpulDefaultParts,
-				BOOL fUnbounded
+				IMemoryPool *mp, 
+				CMDAccessor *md_accessor, 
+				const IMDRelation *md_rel, 
+				Node *part_constraint,
+				ULongPtrArray *level_with_default_part_array,
+				BOOL is_unbounded
 				);
 
 			// retrieve part constraint for relation
 			static
-			CMDPartConstraintGPDB *PmdpartcnstrRelation(IMemoryPool *pmp, CMDAccessor *pmda, OID oidRel, DrgPmdcol *pdrgpmdcol, BOOL fhasIndex);
+			CMDPartConstraintGPDB *RetrievePartConstraintForRel(IMemoryPool *mp, CMDAccessor *md_accessor, OID rel_oid, CMDColumnArray *mdcol_array, BOOL has_index);
 
 			// retrieve part constraint from a GPDB node
 			static
-			CMDPartConstraintGPDB *PmdpartcnstrFromNode
+			CMDPartConstraintGPDB *RetrievePartConstraintFromNode
 				(
-				IMemoryPool *pmp, 
-				CMDAccessor *pmda, 
-				DrgPdxlcd *pdrgpdxlcd, 
-				Node *pnodePartCnstr, 
-				DrgPul *pdrgpulDefaultParts,
-				BOOL fUnbounded
+				IMemoryPool *mp, 
+				CMDAccessor *md_accessor,
+				CDXLColDescrArray *dxl_col_descr_array, 
+				Node *part_constraint,
+				ULongPtrArray *level_with_default_part_array,
+				BOOL is_unbounded
 				);
 	
 			// return relation name
 			static
-			CMDName *PmdnameRel(IMemoryPool *pmp, Relation rel);
+			CMDName *GetRelName(IMemoryPool *mp, Relation rel);
 
 			// return the index info list defined on the given relation
 			static
-			DrgPmdIndexInfo *PdrgpmdRelIndexInfo(IMemoryPool *pmp, Relation rel);
+			CMDIndexInfoArray *RetrieveRelIndexInfo(IMemoryPool *mp, Relation rel);
 
 			// return index info list of indexes defined on a partitoned table
 			static
-			DrgPmdIndexInfo *PdrgpmdRelIndexInfoPartTable(IMemoryPool *pmp, Relation relRoot);
+			CMDIndexInfoArray *RetrieveRelIndexInfoForPartTable(IMemoryPool *mp, Relation root_rel);
 
 			// return index info list of indexes defined on regular, external tables or leaf partitions
 			static
-			DrgPmdIndexInfo *PdrgpmdRelIndexInfoNonPartTable(IMemoryPool *pmp, Relation rel);
+			CMDIndexInfoArray *RetrieveRelIndexInfoForNonPartTable(IMemoryPool *mp, Relation rel);
 
 			// retrieve an index over a partitioned table from the relcache
 			static
-			IMDIndex *PmdindexPartTable(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdidIndex, const IMDRelation *pmdrel, LogicalIndexes *plind);
+			IMDIndex *RetrievePartTableIndex(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid_index, const IMDRelation *md_rel, LogicalIndexes *logical_indexes);
 			
 			// lookup an index given its id from the logical indexes structure
 			static
-			LogicalIndexInfo *PidxinfoLookup(LogicalIndexes *plind, OID oid);
+			LogicalIndexInfo *LookupLogicalIndexById(LogicalIndexes *logical_indexes, OID oid);
 			
 			// construct an MD cache index object given its logical index representation
 			static
-			IMDIndex *PmdindexPartTable(IMemoryPool *pmp, CMDAccessor *pmda, LogicalIndexInfo *pidxinfo, IMDId *pmdidIndex, const IMDRelation *pmdrel);
+			IMDIndex *RetrievePartTableIndex(IMemoryPool *mp, CMDAccessor *md_accessor, LogicalIndexInfo *index_info, IMDId *mdid_index, const IMDRelation *md_rel);
 
 			// return the triggers defined on the given relation
 			static
-			DrgPmdid *PdrgpmdidTriggers(IMemoryPool *pmp, Relation rel);
+			IMdIdArray *RetrieveRelTriggers(IMemoryPool *mp, Relation rel);
 
 			// return the check constraints defined on the relation with the given oid
 			static
-			DrgPmdid *PdrgpmdidCheckConstraints(IMemoryPool *pmp, OID oid);
+			IMdIdArray *RetrieveRelCheckConstraints(IMemoryPool *mp, OID oid);
 
 			// does attribute number correspond to a transaction visibility attribute
 			static 
-			BOOL FTransactionVisibilityAttribute(INT iAttNo);
+			BOOL IsTransactionVisibilityAttribute(INT attrnum);
 			
 			// does relation type have system columns
 			static
-			BOOL FHasSystemColumns(char	cRelKind);
+			BOOL RelHasSystemColumns(char	rel_kind);
 			
 			// translate Optimizer comparison types to GPDB
 			static
-			ULONG UlCmpt(IMDType::ECmpType ecmpt);
+			ULONG GetComparisonType(IMDType::ECmpType cmp_type);
 			
 			// retrieve the opfamilies mdids for the given scalar op
 			static
-			DrgPmdid *PdrgpmdidScOpOpFamilies(IMemoryPool *pmp, IMDId *pmdidScOp);
+			IMdIdArray *RetrieveScOpOpFamilies(IMemoryPool *mp, IMDId *mdid_scalar_op);
 			
 			// retrieve the opfamilies mdids for the given index
 			static
-			DrgPmdid *PdrgpmdidIndexOpFamilies(IMemoryPool *pmp, IMDId *pmdidIndex);
+			IMdIdArray *RetrieveIndexOpFamilies(IMemoryPool *mp, IMDId *mdid_index);
 
             // for non-leaf partition tables return the number of child partitions
             // else return 1
             static
-            ULONG UlTableCount(OID oidRelation);
+            ULONG RetrieveNumChildPartitions(OID rel_oid);
 
             // generate statistics for the system level columns
             static
-            CDXLColStats *PdxlcolstatsSystemColumn
+            CDXLColStats *GenerateStatsForSystemCols
                               (
-                              IMemoryPool *pmp,
-                              OID oidRelation,
-                              CMDIdColStats *pmdidColStats,
-                              CMDName *pmdnameCol,
-                              OID oidAttType,
+                              IMemoryPool *mp,
+                              OID rel_oid,
+                              CMDIdColStats *mdid_col_stats,
+                              CMDName *md_colname,
+                              OID att_type,
                               AttrNumber attrnum,
-                              DrgPdxlbucket *pdrgpdxlbucket,
-                              CDouble dRows
+                              CDXLBucketArray *dxl_stats_bucket_array,
+                              CDouble rows
                               );
 		public:
 			// retrieve a metadata object from the relcache
 			static
-			IMDCacheObject *Pimdobj(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			IMDCacheObject *RetrieveObject(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// retrieve a relation from the relcache
 			static
-			IMDRelation *Pmdrel(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			IMDRelation *RetrieveRel(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// add system columns (oid, tid, xmin, etc) in table descriptors
 			static
-			void AddSystemColumns(IMemoryPool *pmp, DrgPmdcol *pdrgpmdcol, Relation rel, BOOL fAOTable);
+			void AddSystemColumns(IMemoryPool *mp, CMDColumnArray *mdcol_array, Relation rel, BOOL is_ao_table);
 
 			// retrieve an index from the relcache
 			static
-			IMDIndex *Pmdindex(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdidIndex);
+			IMDIndex *RetrieveIndex(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid_index);
 
 			// retrieve a check constraint from the relcache
 			static
-			CMDCheckConstraintGPDB *Pmdcheckconstraint(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			CMDCheckConstraintGPDB *RetrieveCheckConstraints(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// populate the attribute number to position mapping
 			static
-			ULONG *PulAttnoPositionMap(IMemoryPool *pmp, const IMDRelation *pmdrel, ULONG ulRgSize);
+			ULONG *PopulateAttnoPositionMap(IMemoryPool *mp, const IMDRelation *md_rel, ULONG size);
 
 			// return the position of a given attribute number
 			static
-			ULONG UlPosition(INT iAttno, ULONG *pul);
+			ULONG GetAttributePosition(INT attno, ULONG *attno_mapping);
 
 			// retrieve a type from the relcache
 			static
-			IMDType *Pmdtype(IMemoryPool *pmp, IMDId *pmdid);
+			IMDType *RetrieveType(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a scalar operator from the relcache
 			static
-			CMDScalarOpGPDB *Pmdscop(IMemoryPool *pmp, IMDId *pmdid);
+			CMDScalarOpGPDB *RetrieveScOp(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a function from the relcache
 			static
-			CMDFunctionGPDB *Pmdfunc(IMemoryPool *pmp, IMDId *pmdid);
+			CMDFunctionGPDB *RetrieveFunc(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve an aggregate from the relcache
 			static
-			CMDAggregateGPDB *Pmdagg(IMemoryPool *pmp, IMDId *pmdid);
+			CMDAggregateGPDB *RetrieveAgg(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a trigger from the relcache
 			static
-			CMDTriggerGPDB *Pmdtrigger(IMemoryPool *pmp, IMDId *pmdid);
+			CMDTriggerGPDB *RetrieveTrigger(IMemoryPool *mp, IMDId *mdid);
 			
 			// translate GPDB comparison type
 			static
-			IMDType::ECmpType Ecmpt(ULONG ulCmpt);
+			IMDType::ECmpType ParseCmpType(ULONG cmpt);
 			
 			// get the distribution policy of the relation
 			static
-			IMDRelation::Ereldistrpolicy Ereldistribution(GpPolicy *pgppolicy);
+			IMDRelation::Ereldistrpolicy GetRelDistribution(GpPolicy *gp_policy);
 	};
 }
 

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -40,7 +40,7 @@ namespace gpopt
 	class CMDAccessor;
 
 	// dynamic array of bitsets
-	typedef CDynamicPtrArray<CBitSet, CleanupRelease> DrgPbs;
+	typedef CDynamicPtrArray<CBitSet, CleanupRelease> CBitSetArray;
 }
 
 namespace gpdxl
@@ -67,351 +67,350 @@ namespace gpdxl
 
 			// construct a set of column attnos corresponding to a single grouping set
 			static
-			CBitSet *PbsGroupingSet(IMemoryPool *pmp, List *plGroupElems, ULONG ulCols, HMUlUl *phmululGrpColPos, CBitSet *pbsGrpCols);
+			CBitSet *CreateAttnoSetForGroupingSet(IMemoryPool *mp, List *group_elems, ULONG num_cols, UlongToUlongMap *group_col_pos, CBitSet *group_cols);
 
 			// create a set of grouping sets for a rollup
 			static
-			DrgPbs *PdrgpbsRollup(IMemoryPool *pmp, GroupingClause *pgrcl, ULONG ulCols, HMUlUl *phmululGrpColPos, CBitSet *pbsGrpCols);
+			CBitSetArray *CreateGroupingSetsForRollup(IMemoryPool *mp, GroupingClause *grouping_clause, ULONG num_cols, UlongToUlongMap *grouping_col_to_pos_map, CBitSet *group_cols);
 
 			// check if the given mdid array contains any of the polymorphic
 			// types (ANYELEMENT, ANYARRAY)
 			static
-			BOOL FContainsPolymorphicTypes(DrgPmdid *pdrgpmdidTypes);
+			BOOL ContainsPolymorphicTypes(IMdIdArray *mdid_array);
 
 			// resolve polymorphic types in the given array of type ids, replacing
 			// them with the actual types obtained from the query
 			static
-			DrgPmdid *PdrgpmdidResolvePolymorphicTypes
+			IMdIdArray *ResolvePolymorphicTypes
 						(
-						IMemoryPool *pmp,
-						DrgPmdid *pdrgpmdidTypes,
-						List *plArgTypes,
-						FuncExpr *pfuncexpr
+						IMemoryPool *mp,
+						IMdIdArray *mdid_array,
+						List *arg_types,
+						FuncExpr *func_expr
 						);
 			
 			// update grouping col position mappings
 			static
-			void UpdateGrpColMapping(IMemoryPool *pmp, HMUlUl *phmululGrpColPos, CBitSet *pbsGrpCols, ULONG ulSortGrpRef);
+			void UpdateGrpColMapping(IMemoryPool *mp, UlongToUlongMap *grouping_col_to_pos_map, CBitSet *group_cols, ULONG sort_group_ref);
 
 		public:
 
 			struct SCmptypeStrategy
 			{
-				IMDType::ECmpType ecomptype;
-				StrategyNumber sn;
+				IMDType::ECmpType comptype;
+				StrategyNumber strategy_no;
 
 			};
 
 			// get the GPDB scan direction from its corresponding DXL representation
 			static
-			ScanDirection Scandirection(EdxlIndexScanDirection edxlisd);
+			ScanDirection GetScanDirection(EdxlIndexScanDirection idx_scan_direction);
 
 			// get the oid of comparison operator
 			static
-			OID OidCmpOperator(Expr* pexpr);
+			OID OidCmpOperator(Expr* expr);
 
 			// get the opfamily for index key
 			static
-			OID OidIndexQualOpFamily(INT iAttno, OID oidIndex);
+			OID GetOpFamilyForIndexQual(INT attno, OID oid_index);
 			
 			// return the type for the system column with the given number
 			static
-			CMDIdGPDB *PmdidSystemColType(IMemoryPool *pmp, AttrNumber attno);
+			CMDIdGPDB *GetSystemColType(IMemoryPool *mp, AttrNumber attno);
 
 			// find the n-th column descriptor in the table descriptor
 			static
-			const CDXLColDescr *Pdxlcd(const CDXLTableDescr *pdxltabdesc, ULONG ulPos);
+			const CDXLColDescr *GetColumnDescrAt(const CDXLTableDescr *table_descr, ULONG pos);
 
 			// return the name for the system column with given number
 			static
-			const CWStringConst *PstrSystemColName(AttrNumber attno);
+			const CWStringConst *GetSystemColName(AttrNumber attno);
 
 			// returns the length for the system column with given attno number
 			static
-			const ULONG UlSystemColLength(AttrNumber attno);
+			const ULONG GetSystemColLength(AttrNumber attno);
 
 			// translate the join type from its GPDB representation into the DXL one
 			static
-			EdxlJoinType EdxljtFromJoinType(JoinType jt);
+			EdxlJoinType ConvertToDXLJoinType(JoinType jt);
 
 			// translate the index scan direction from its GPDB representation into the DXL one
 			static
-			EdxlIndexScanDirection EdxlIndexDirection(ScanDirection sd);
+			EdxlIndexScanDirection ConvertToDXLIndexScanDirection(ScanDirection sd);
 
 			// create a DXL index descriptor from an index MD id
 			static
-			CDXLIndexDescr *Pdxlid(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			CDXLIndexDescr *GetIndexDescr(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// translate a RangeTableEntry into a CDXLTableDescr
 			static
-			CDXLTableDescr *Pdxltabdesc
+			CDXLTableDescr *GetTableDescr
 								(
-								IMemoryPool *pmp,
-								CMDAccessor *pmda,
-								CIdGenerator *pidgtor,
-								const RangeTblEntry *prte,
-								BOOL *pfDistributedTable = NULL
+								IMemoryPool *mp,
+								CMDAccessor *md_accessor,
+								CIdGenerator *id_generator,
+								const RangeTblEntry *rte,
+								BOOL *is_distributed_table = NULL
 								);
 
 			// translate a RangeTableEntry into a CDXLLogicalTVF
 			static
-			CDXLLogicalTVF *Pdxltvf
+			CDXLLogicalTVF *ConvertToCDXLLogicalTVF
 								(
-								IMemoryPool *pmp,
-								CMDAccessor *pmda,
-								CIdGenerator *pidgtor,
-								const RangeTblEntry *prte
+								IMemoryPool *mp,
+								CMDAccessor *md_accessor,
+								CIdGenerator *id_generator,
+								const RangeTblEntry *rte
 								);
 
 			// get column descriptors from a record type
 			static
-			DrgPdxlcd *PdrgdxlcdRecord
+			CDXLColDescrArray *GetColumnDescriptorsFromRecord
 						(
-						IMemoryPool *pmp,
-						CIdGenerator *pidgtor,
-						List *plColNames,
-						List *plColTypes,
-						List *plColTypeModifiers
+						IMemoryPool *mp,
+						CIdGenerator *id_generator,
+						List *col_names,
+						List *col_types,
+						List *col_type_modifiers
 						);
 
 			// get column descriptors from a record type
 			static
-			DrgPdxlcd *PdrgdxlcdRecord
+			CDXLColDescrArray *GetColumnDescriptorsFromRecord
 						(
-						IMemoryPool *pmp,
-						CIdGenerator *pidgtor,
-						List *plColNames,
-						DrgPmdid *pdrgpmdidOutArgTypes
+						IMemoryPool *mp,
+						CIdGenerator *id_generator,
+						List *col_names,
+						IMdIdArray *out_arg_types
 						);
 
 			// get column descriptor from a base type
 			static
-			DrgPdxlcd *PdrgdxlcdBase
+			CDXLColDescrArray *GetColumnDescriptorsFromBase
 						(
-						IMemoryPool *pmp,
-						CIdGenerator *pidgtor,
-						IMDId *pmdidRetType,
-						INT iTypeModifier,
-						CMDName *pmdName
+						IMemoryPool *mp,
+						CIdGenerator *id_generator,
+						IMDId *mdid_return_type,
+						INT type_modifier,
+						CMDName *md_name
 						);
 
 			// get column descriptors from a composite type
 			static
-			DrgPdxlcd *PdrgdxlcdComposite
+			CDXLColDescrArray *GetColumnDescriptorsFromComposite
 						(
-						IMemoryPool *pmp,
-						CMDAccessor *pmda,
-						CIdGenerator *pidgtor,
-						const IMDType *pmdType
+						IMemoryPool *mp,
+						CMDAccessor *md_accessor,
+						CIdGenerator *id_generator,
+						const IMDType *md_type
 						);
 
 			// expand a composite type into an array of IMDColumns
 			static
-			DrgPmdcol *ExpandCompositeType
+			CMDColumnArray *ExpandCompositeType
 						(
-						IMemoryPool *pmp,
-						CMDAccessor *pmda,
-						const IMDType *pmdType
+						IMemoryPool *mp,
+						CMDAccessor *md_accessor,
+						const IMDType *md_type
 						);
 
 			// return the dxl representation of the set operation
 			static
-			EdxlSetOpType Edxlsetop(SetOperation setop, BOOL fAll);
+			EdxlSetOpType GetSetOpType(SetOperation setop, BOOL is_all);
 
 			// construct a dynamic array of sets of column attnos corresponding
 			// to the group by clause
 			static
-			DrgPbs *PdrgpbsGroupBy(IMemoryPool *pmp, List *plGroupClause, ULONG ulCols, HMUlUl *phmululGrpColPos, CBitSet *pbsGrpCols);
+			CBitSetArray *GetColumnAttnosForGroupBy(IMemoryPool *mp, List *group_clause, ULONG num_cols, UlongToUlongMap *group_col_pos, CBitSet *group_cold);
 
 			// return a copy of the query with constant of unknown type being coerced
 			// to the common data type of the output target list
 			static
-			Query *PqueryFixUnknownTypeConstant(Query *pquery, List *plTargetList);
+			Query *FixUnknownTypeConstant(Query *query, List *target_list);
 
 			// return the type of the nth non-resjunked target list entry
-			static OID OidTargetListReturnType(List *plTargetList, ULONG ulColPos);
+			static OID GetTargetListReturnTypeOid(List *target_list, ULONG col_pos);
 
 			// construct an array of DXL column identifiers for a target list
 			static
-			DrgPul *PdrgpulGenerateColIds
+			ULongPtrArray *GenerateColIds
 					(
-					IMemoryPool *pmp,
-					List *plTargetList,
-					DrgPmdid *pdrgpmdidInput,
-					DrgPul *pdrgpulInput,
-					BOOL *pfOuterRef,
-					CIdGenerator *pidgtorColId
+					IMemoryPool *mp,
+					List *target_list,
+					IMdIdArray *input_mdids,
+					ULongPtrArray *input_nums,
+					BOOL *is_outer_ref,
+					CIdGenerator *colid_generator
 					);
 
 			// construct an array of DXL column descriptors for a target list
 			// using the column ids in the given array
 			static
-			DrgPdxlcd *Pdrgpdxlcd(IMemoryPool *pmp, List *plTargetList, DrgPul *pdrgpulColIds, BOOL fKeepResjunked);
+			CDXLColDescrArray *GetDXLColumnDescrArray(IMemoryPool *mp, List *target_list, ULongPtrArray *colids, BOOL keep_res_junked);
 
 			// return the positions of the target list entries included in the output
 			static
-			DrgPul *PdrgpulPosInTargetList(IMemoryPool *pmp, List *plTargetList, BOOL fKeepResjunked);
+			ULongPtrArray *GetPosInTargetList(IMemoryPool *mp, List *target_list, BOOL keep_res_junked);
 
 			// construct a column descriptor from the given target entry, column identifier and position in the output
 			static
-			CDXLColDescr *Pdxlcd(IMemoryPool *pmp, TargetEntry *pte, ULONG ulColId, ULONG ulPos);
+			CDXLColDescr *GetColumnDescrAt(IMemoryPool *mp, TargetEntry *target_entry, ULONG colid, ULONG pos);
 
 			// create a dummy project element to rename the input column identifier
 			static
-			CDXLNode *PdxlnDummyPrElem(IMemoryPool *pmp, ULONG ulColIdInput, ULONG ulColIdOutput, CDXLColDescr *pdxlcd);
+			CDXLNode *CreateDummyProjectElem(IMemoryPool *mp, ULONG colid_input, ULONG colid_output, CDXLColDescr *dxl_col_descr);
 
 			// construct a list of colids corresponding to the given target list
 			// using the given attno->colid map
 			static
-			DrgPul *PdrgpulColIds(IMemoryPool *pmp, List *plTargetList, HMIUl *phmiulAttnoColId);
+			ULongPtrArray *GetOutputColIdsArray(IMemoryPool *mp, List *target_list, IntToUlongMap *attno_to_colid_map);
 
 			// construct an array of column ids for the given group by set
 			static
-			DrgPul *PdrgpulGroupingCols(IMemoryPool *pmp, CBitSet *pbsGroupByCols, HMIUl *phmiulSortGrpColsColId);
+			ULongPtrArray *GetGroupingColidArray(IMemoryPool *mp, CBitSet *group_by_cols, IntToUlongMap *sort_group_cols_to_colid_map);
 
 			// return the Colid of column with given index
 			static
-			ULONG UlColId(INT iIndex, HMIUl *phmiul);
+			ULONG GetColId(INT index, IntToUlongMap *index_to_colid_map);
 
 			// return the corresponding ColId for the given varno, varattno and querylevel
 			static
-			ULONG UlColId(ULONG ulQueryLevel, INT iVarno, INT iVarAttno, IMDId *pmdid, CMappingVarColId *pmapvarcolid);
+			ULONG GetColId(ULONG query_level, INT varno, INT var_attno, IMDId *mdid, CMappingVarColId *var_colid_mapping);
 
 			// check to see if the target list entry is a sorting column
 			static
-			BOOL FSortingColumn(const TargetEntry *pte, List *plSortCl);
-
+			BOOL IsSortingColumn(const TargetEntry *target_entry, List *sort_clause_list); 
 			// check to see if the target list entry is used in the window reference
 			static
-			BOOL FWindowSpec(const TargetEntry *pte, List *plWindowClause);
+			BOOL IsWindowSpec(const TargetEntry *target_entry, List *window_clause_list);
 
 			// extract a matching target entry that is a window spec
 			static
-			TargetEntry *PteWindowSpec(Node *pnode, List *plWindowClause, List *plTargetList);
+			TargetEntry *GetWindowSpecTargetEntry(Node *node, List *window_clause_list, List *target_list);
 
 			// check if the expression has a matching target entry that is a window spec
 			static
-			BOOL FWindowSpec(Node *pnode, List *plWindowClause, List *plTargetList);
+			BOOL IsWindowSpec(Node *node, List *window_clause_list, List *target_list);
 
 			// create a scalar const value expression for the given int8 value
 			static
-			CDXLNode *PdxlnInt8Const(IMemoryPool *pmp, CMDAccessor *pmda, INT iVal);
+			CDXLNode *CreateDXLProjElemFromInt8Const(IMemoryPool *mp, CMDAccessor *md_accessor, INT val);
 
 			// check to see if the target list entry is a grouping column
 			static
-			BOOL FGroupingColumn(const TargetEntry *pte, List *plGrpCl);
+			BOOL IsGroupingColumn(const TargetEntry *target_entry, List *group_clause_list);
 
 			// check to see if the target list entry is a grouping column
 			static
-			BOOL FGroupingColumn(const TargetEntry *pte, const SortGroupClause *pgrcl);
+			BOOL IsGroupingColumn(const TargetEntry *target_entry, const SortGroupClause *sort_group_clause);
 
 			// check to see if the sorting column entry is a grouping column
 			static
-			BOOL FGroupingColumn(const SortGroupClause *psortcl, List *plGrpCl);
+			BOOL IsGroupingColumn(const SortGroupClause *sort_group_clause, List *group_clause_list);
 
 			// check if the expression has a matching target entry that is a grouping column
 			static
-			BOOL FGroupingColumn(Node *pnode, List *plGrpCl, List *plTargetList);
+			BOOL IsGroupingColumn(Node *node, List *group_clause_list, List *target_list);
 
 			// extract a matching target entry that is a grouping column
 			static
-			TargetEntry *PteGroupingColumn(Node *pnode, List *plGrpCl, List *plTargetList);
+			TargetEntry *GetGroupingColumnTargetEntry(Node *node, List *group_clause_list, List *target_list);
 
 			// convert a list of column ids to a list of attribute numbers using
 			// the provided context with mappings
 			static
-			List *PlAttnosFromColids(DrgPul *pdrgpul, CDXLTranslateContext *pdxltrctx);
+			List *ConvertColidToAttnos(ULongPtrArray *pdrgpul, CDXLTranslateContext *dxl_translate_ctxt);
 			
 			// parse string value into a Long Integer
 			static
-			LINT LFromStr(const CWStringBase *pstr);
+			LINT GetLongFromStr(const CWStringBase *wcstr);
 
 			// parse string value into an Integer
 			static
-			INT IFromStr(const CWStringBase *pstr);
+			INT GetIntFromStr(const CWStringBase *wcstr);
 
 			// check whether the given project list has a project element of the given
 			// operator type
 			static
-			BOOL FHasProjElem(CDXLNode *pdxlnPrL, Edxlopid edxlopid);
+			BOOL HasProjElem(CDXLNode *project_list_dxlnode, Edxlopid dxl_op_id);
 
 			// create a multi-byte character string from a wide character string
 			static
-			CHAR *SzFromWsz(const WCHAR *wsz);
+			CHAR *CreateMultiByteCharStringFromWCString(const WCHAR *wcstr);
 			
 			static 
-			HMUlUl *PhmululMap(IMemoryPool *pmp, DrgPul *pdrgpulOld, DrgPul *pdrgpulNew);
+			UlongToUlongMap *MakeNewToOldColMapping(IMemoryPool *mp, ULongPtrArray *old_colids, ULongPtrArray *new_colids);
 
 			// check if the given tree contains a subquery
 			static
-			BOOL FHasSubquery(Node *pnode);
+			BOOL HasSubquery(Node *node);
 
 			// check if the given function is a SIRV (single row volatile) that reads
 			// or modifies SQL data
 			static
-			BOOL FSirvFunc(IMemoryPool *pmp, CMDAccessor *pmda, OID oidFunc);
+			BOOL IsSirvFunc(IMemoryPool *mp, CMDAccessor *md_accessor, OID func_oid);
 			
 			// is this a motion sensitive to duplicates
 			static
-			BOOL FDuplicateSensitiveMotion(CDXLPhysicalMotion *pdxlopMotion);
+			BOOL IsDuplicateSensitiveMotion(CDXLPhysicalMotion *dxl_motion);
 
 			// construct a project element with a const NULL expression
 			static
-			CDXLNode *PdxlnPrElNull(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid, ULONG ulColId, const WCHAR *wszColName);
+			CDXLNode *CreateDXLProjElemConstNULL(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid, ULONG colid, const WCHAR *col_name);
 
 			// construct a project element with a const NULL expression
 			static
-			CDXLNode *PdxlnPrElNull(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid, ULONG ulColId, CHAR *szAliasName);
+			CDXLNode *CreateDXLProjElemConstNULL(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid, ULONG colid, CHAR *alias_name);
 
 			// create a DXL project element node with a Const NULL of type provided
 			// by the column descriptor
 			static
-			CDXLNode *PdxlnPrElNull(IMemoryPool *pmp, CMDAccessor *pmda, CIdGenerator *pidgtorCol, const IMDColumn *pmdcol);
+			CDXLNode *CreateDXLProjElemConstNULL(IMemoryPool *mp, CMDAccessor *md_accessor, CIdGenerator *colid_generator, const IMDColumn *col);
 
 			// check required permissions for the range table
 			static 
-			void CheckRTEPermissions(List *plRangeTable);
+			void CheckRTEPermissions(List *range_table_list);
 
 			// check if an aggregate window function has either prelim or inverse prelim func
 			static
-			void CheckAggregateWindowFn(Node *pnode);
+			void CheckAggregateWindowFn(Node *node);
 
 			// check if given column ids are outer references in the tree rooted by given node
                         static
-			void MarkOuterRefs(ULONG *pulColId, BOOL *pfOuterRef, ULONG ulColumns, CDXLNode *pdxlnode);
+			void MarkOuterRefs(ULONG *colid, BOOL *is_outer_ref, ULONG num_columns, CDXLNode *node);
 
 			// map DXL Subplan type to GPDB SubLinkType
 			static
-			SubLinkType Slink(EdxlSubPlanType edxlsubplantype);
+			SubLinkType MapDXLSubplanToSublinkType(EdxlSubPlanType dxl_subplan_type);
 
 			// map GPDB SubLinkType to DXL Subplan type
 			static
-			EdxlSubPlanType Edxlsubplantype(SubLinkType slink);
+			EdxlSubPlanType MapSublinkTypeToDXLSubplan(SubLinkType slink);
 
 			// check whether there are triggers for the given operation on
 			// the given relation
 			static
-			BOOL FRelHasTriggers(IMemoryPool *pmp, CMDAccessor *pmda, const IMDRelation *pmdrel, const EdxlDmlType edxldmltype);
+			BOOL RelHasTriggers(IMemoryPool *mp, CMDAccessor *md_accessor, const IMDRelation *mdrel, const EdxlDmlType dml_type_dxl);
 
 			// check whether the given trigger is applicable to the given DML operation
 			static
-			BOOL FApplicableTrigger(CMDAccessor *pmda, IMDId *pmdidTrigger, const EdxlDmlType edxldmltype);
+			BOOL IsApplicableTrigger(CMDAccessor *md_accessor, IMDId *trigger_mdid, const EdxlDmlType dml_type_dxl);
 						
 			// check whether there are NOT NULL or CHECK constraints for the given relation
 			static
-			BOOL FRelHasConstraints(const IMDRelation *pmdrel);
+			BOOL RelHasConstraints(const IMDRelation *rel);
 
 			// translate the list of error messages from an assert constraint list
 			static 
-			List *PlAssertErrorMsgs(CDXLNode *pdxlnAssertConstraintList);
+			List *GetAssertErrorMsgs(CDXLNode *assert_constraint_list);
 
 			// return the count of non-system columns in the relation
 			static
-			ULONG UlNonSystemColumns(const IMDRelation *pmdrel);
+			ULONG GetNumNonSystemColumns(const IMDRelation *mdrel);
 
 			// check if we need to create stats buckets in DXL for the column attribute
 			static
-			BOOL FCreateStatsBucket(OID oidAttType);
+			BOOL ShouldCreateStatsBucket(OID att_type_oid);
 	};
 }
 

--- a/src/include/gpopt/utils/CCatalogUtils.h
+++ b/src/include/gpopt/utils/CCatalogUtils.h
@@ -22,23 +22,23 @@
 class CCatalogUtils {
 
 	private:
-		// return list of relation plOids in catalog
+		// return list of relation oids_list in catalog
 		static
-		List *PlRelationOids();
+		List *GetRelationOids();
 
-		// return list of operator plOids in catalog
+		// return list of operator oids_list in catalog
 		static
-		List *PlOperatorOids();
+		List *GetOperatorOids();
 
-		// return list of function plOids in catalog
+		// return list of function oids_list in catalog
 		static
-		List *PlFunctionOids();
+		List *GetFunctionOids();
 
 	public:
 
-		// return list of all object plOids in catalog
+		// return list of all object oids_list in catalog
 		static
-		List *PlAllOids();
+		List *GetAllOids();
 };
 
 #endif // CCatalogUtils_H

--- a/src/include/gpopt/utils/CConstExprEvaluatorProxy.h
+++ b/src/include/gpopt/utils/CConstExprEvaluatorProxy.h
@@ -57,10 +57,10 @@ namespace gpdxl
 					explicit
 					CEmptyMappingColIdVar
 						(
-						IMemoryPool *pmp
+						IMemoryPool *mp
 						)
 						:
-						CMappingColIdVar(pmp)
+						CMappingColIdVar(mp)
 					{
 					}
 
@@ -70,34 +70,34 @@ namespace gpdxl
 					}
 
 					virtual
-					Var *PvarFromDXLNodeScId(const CDXLScalarIdent *pdxlop);
+					Var *VarFromDXLNodeScId(const CDXLScalarIdent *scalar_ident);
 
 			};
 
 			// memory pool, not owned
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// empty mapping needed for the translator
 			CEmptyMappingColIdVar m_emptymapcidvar;
 
 			// pointer to metadata cache accessor
-			CMDAccessor *m_pmda;
+			CMDAccessor *m_md_accessor;
 
 			// translator for the DXL input -> GPDB Expr
-			CTranslatorDXLToScalar m_trdxl2scalar;
+			CTranslatorDXLToScalar m_dxl2scalar_translator;
 
 		public:
 			// ctor
 			CConstExprEvaluatorProxy
 				(
-				IMemoryPool *pmp,
-				CMDAccessor *pmda
+				IMemoryPool *mp,
+				CMDAccessor *md_accessor
 				)
 				:
-				m_pmp(pmp),
-				m_emptymapcidvar(m_pmp),
-				m_pmda(pmda),
-				m_trdxl2scalar(m_pmp, m_pmda, 0)
+				m_mp(mp),
+				m_emptymapcidvar(m_mp),
+				m_md_accessor(md_accessor),
+				m_dxl2scalar_translator(m_mp, m_md_accessor, 0)
 			{
 			}
 
@@ -109,9 +109,9 @@ namespace gpdxl
 
 			// evaluate given constant expressionand return the DXL representation of the result.
 			// if the expression has variables, an error is thrown.
-			// caller keeps ownership of 'pdxlnExpr' and takes ownership of the returned pointer
+			// caller keeps ownership of 'expr_dxlnode' and takes ownership of the returned pointer
 			virtual
-			CDXLNode *PdxlnEvaluateExpr(const CDXLNode *pdxlnExpr);
+			CDXLNode *EvaluateExpr(const CDXLNode *expr);
 
 			// returns true iff the evaluator can evaluate constant expressions without subqueries
 			virtual

--- a/src/include/gpopt/utils/COptClient.h
+++ b/src/include/gpopt/utils/COptClient.h
@@ -63,47 +63,47 @@ namespace gpoptudfs
 			struct SOptParams
 			{
 				// path where socket is initialized
-				const char *m_szPath;
+				const char *m_path;
 
 				// input query
-				Query *m_pquery;
+				Query *m_query;
 			};
 
 			// input query
-			Query *m_pquery;
+			Query *m_query;
 
 			// path where socket is initialized
-			const char *m_szPath;
+			const char *m_path;
 
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// communicator
-			CCommunicator *m_pcomm;
+			CCommunicator *m_communicator;
 
 			// default id for the source system
 			static
-			const CSystemId m_sysidDefault;
+			const CSystemId m_default_sysid;
 
 			// error severity levels
 
 			// array mapping GPOS to elog() error severity
 			static
-			ULONG m_rgrgulSev[CException::ExsevSentinel][2];
+			ULONG elog_to_severity_map[CException::ExsevSentinel][2];
 
 			// ctor
 			COptClient
 				(
-				SOptParams *pop
+				SOptParams *op
 				)
 				:
-				m_pquery(pop->m_pquery),
-				m_szPath(pop->m_szPath),
-				m_pmp(NULL),
-				m_pcomm(NULL)
+				m_query(op->m_query),
+				m_path(op->m_path),
+				m_mp(NULL),
+				m_communicator(NULL)
 			{
-				GPOS_ASSERT(NULL != m_pquery);
-				GPOS_ASSERT(NULL != m_szPath);
+				GPOS_ASSERT(NULL != m_query);
+				GPOS_ASSERT(NULL != m_path);
 			}
 
 			// dtor
@@ -111,31 +111,31 @@ namespace gpoptudfs
 			{}
 
 			// request optimization from server
-			PlannedStmt *PplstmtOptimize();
+			PlannedStmt *GPOPTOptimizedPlan();
 
 			// set traceflags
 			void SetTraceflags();
 
 			// send query optimization request to server
-			void SendRequest(CMDAccessor *pmda);
+			void SendRequest(CMDAccessor *md_accessor);
 
 			// retrieve DXL plan
-			const CHAR *SzPlanDXL(IMDProvider *pmdp);
+			const CHAR *SzPlanDXL(IMDProvider *md_provider);
 
 			// send MD response
-			void SendMDResponse(CMDProviderCommProxy *pmdpcp, const WCHAR *wszReq);
+			void SendMDResponse(CMDProviderCommProxy *md_provider_proxy, const WCHAR *req);
 
 			// build planned statement from serialized plan
-			PlannedStmt *PplstmtConstruct(CMDAccessor *pmda, const CHAR *szPlan);
+			PlannedStmt *ConstructPlanStmt(CMDAccessor *md_accessor, const CHAR *serialized_plan);
 
 			// elog wrapper
-			void Elog(ULONG ulSev, const WCHAR *wszMsg);
+			void Elog(ULONG severity, const WCHAR *msg);
 
 		public:
 
 			// invoke optimizer instance
 			static
-			void *PvRun(void *pv);
+			void *Run(void *pv);
 
 	}; // class COptClient
 }

--- a/src/include/gpopt/utils/COptServer.h
+++ b/src/include/gpopt/utils/COptServer.h
@@ -63,31 +63,31 @@ namespace gpoptudfs
 			struct SConnectionDescriptor
 			{
 				// ID
-				ULONG_PTR m_ulpId;
+				ULONG_PTR m_id;
 
 				// task
-				CTask *m_ptsk;
+				CTask *m_task;
 
 				// socket
-				CSocket *m_psocket;
+				CSocket *m_socket;
 
 				// link for hashtable
 				SLink m_link;
 
 				// invalid connection id
 				static
-				ULONG_PTR m_ulpInvalid;
+				ULONG_PTR m_invalid_id;
 
 				// ctor
 				SConnectionDescriptor
 					(
-					CTask *ptsk,
-					CSocket *psocket
+					CTask *task,
+					CSocket *socket
 					)
 					:
-					m_ulpId((ULONG_PTR) ptsk),
-					m_ptsk(ptsk),
-					m_psocket(psocket)
+					m_id((ULONG_PTR) task),
+					m_task(task),
+					m_socket(socket)
 				{}
 
 			};
@@ -105,21 +105,21 @@ namespace gpoptudfs
 				ConnectionIterAccessor;
 
 			// path where socket is initialized
-			const CHAR *m_szSocketPath;
+			const CHAR *m_socket_path;
 
 			// memory pool for connections
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// hashtable of connections
-			ConnectionHT *m_pshtConnections;
+			ConnectionHT *m_connections_ht;
 
 			// default id for the source system
 			static
-			const CSystemId m_sysidDefault;
+			const CSystemId m_default_id;
 
 			// ctor
 			explicit
-			COptServer(const CHAR *szPath);
+			COptServer(const CHAR *path);
 
 			// dtor
 			~COptServer();
@@ -131,43 +131,43 @@ namespace gpoptudfs
 			void InitHT();
 
 			// register connection for status checking
-			void TrackConnection(CTask *ptsk, CSocket *psocket);
+			void TrackConnection(CTask *task, CSocket *socket);
 
 			// release connection
-			void ReleaseConnection(CTask *ptsk);
+			void ReleaseConnection(CTask *task);
 
 			// connection check task
 			static
-			void * PvCheckConnections(void *pv);
+			void * CheckConnections(void *ptr);
 
 			// optimization task
 			static
-			void *PvOptimize(void *pv);
+			void *Optimize(void *ptr);
 
 			// receive optimization request and construct query context for it
 			static
-			CQueryContext *PqcRecvQuery(IMemoryPool *pmp, CCommunicator *pcomm, CMDAccessor *pmda);
+			CQueryContext *RecvQuery(IMemoryPool *mp, CCommunicator *communicator, CMDAccessor *md_accessor);
 
 			// extract query plan, serialize it and send it to client
 			static
 			void SendPlan
 				(
-				IMemoryPool *pmp,
-				CCommunicator *pcomm,
-				CMDAccessor *pmda,
-				CQueryContext *pqc,
-				CExpression *pexprPlan
+				IMemoryPool *mp,
+				CCommunicator *communicator,
+				CMDAccessor *md_accessor,
+				CQueryContext *query_ctxt,
+				CExpression *plan_expr
 				);
 
 			// dump collected artifacts to file
 			static
-			void FinalizeMinidump(CMiniDumperDXL *pmdmp);
+			void FinalizeMinidump(CMiniDumperDXL *dump);
 
 		public:
 
 			// invoke optimizer instance
 			static
-			void *PvRun(void *pv);
+			void *Run(void *ptr);
 
 	}; // class COptServer
 }

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -60,53 +60,53 @@ struct SOptContext
 	// when calling Free() function
 	enum EPin
 	{
-		epinQueryDXL, // keep m_szQueryDXL
-		epinQuery, 	 // keep m_pquery
-		epinPlanDXL, // keep m_szPlanDXL
-		epinPlStmt, // keep m_pplstmt
-		epinErrorMsg // keep m_szErrorMsg
+		epinQueryDXL, // keep m_query_dxl
+		epinQuery, 	 // keep m_query
+		epinPlanDXL, // keep m_plan_dxl
+		epinPlStmt, // keep m_plan_stmt
+		epinErrorMsg // keep m_error_msg
 	};
 
 	// query object serialized to DXL
-	CHAR *m_szQueryDXL;
+	CHAR *m_query_dxl;
 
 	// query object
-	Query *m_pquery;
+	Query *m_query;
 
 	// plan object serialized to DXL
-	CHAR *m_szPlanDXL;
+	CHAR *m_plan_dxl;
 
 	// plan object
-	PlannedStmt *m_pplstmt;
+	PlannedStmt *m_plan_stmt;
 
 	// is generating a plan object required ?
-	BOOL m_fGeneratePlStmt;
+	BOOL m_should_generate_plan_stmt;
 
 	// is serializing a plan to DXL required ?
-	BOOL m_fSerializePlanDXL;
+	BOOL m_should_serialize_plan_dxl;
 
 	// did the optimizer fail unexpectedly?
-	BOOL m_fUnexpectedFailure;
+	BOOL m_is_unexpected_failure;
 
 	// buffer for optimizer error messages
-	CHAR *m_szErrorMsg;
+	CHAR *m_error_msg;
 
 	// ctor
 	SOptContext();
 
 	// If there is an error print as warning and throw exception to abort
 	// plan generation
-	void HandleError(BOOL *pfUnexpectedFailure);
+	void HandleError(BOOL *had_unexpected_failure);
 
 	// free all members except input and output pointers
-	void Free(EPin epinInput, EPin epinOutput);
+	void Free(EPin input, EPin epinOutput);
 
 	// Clone the error message in given context.
 	CHAR* CloneErrorMsg(struct MemoryContextData *context);
 
 	// casting function
 	static
-	SOptContext *PoptctxtConvert(void *pv);
+	SOptContext *Cast(void *ptr);
 
 }; // struct SOptContext
 
@@ -118,37 +118,37 @@ class COptTasks
 		struct SContextRelcacheToDXL
 		{
 			// list of object oids to lookup
-			List *m_plistOids;
+			List *m_oid_list;
 
 			// comparison type for tasks retrieving scalar comparisons
-			ULONG m_ulCmpt;
+			ULONG m_cmp_type;
 
 			// if filename is not null, then output will be written to file
-			const char *m_szFilename;
+			const char *m_filename;
 
 			// if filename is null, then output will be stored here
-			char *m_szDXL;
+			char *m_dxl;
 
 			// ctor
-			SContextRelcacheToDXL(List *plistOids, ULONG ulCmpt, const char *szFilename);
+			SContextRelcacheToDXL(List *oid_list, ULONG cmp_type, const char *filename);
 
 			// casting function
 			static
-			SContextRelcacheToDXL *PctxrelcacheConvert(void *pv);
+			SContextRelcacheToDXL *RelcacheConvert(void *ptr);
 		};
 
 		// Structure containing the input and output string for a task that evaluates expressions.
 		struct SEvalExprContext
 		{
 			// Serialized DXL of the expression to be evaluated
-			char *m_szDXL;
+			char *m_dxl;
 
 			// The result of evaluating the expression
-			char *m_szDXLResult;
+			char *m_dxl_result;
 
 			// casting function
 			static
-			SEvalExprContext *PevalctxtConvert(void *pv);
+			SEvalExprContext *PevalctxtConvert(void *ptr);
 		};
 
 		// context of minidump load and execution
@@ -158,123 +158,123 @@ class COptTasks
 			char *m_szFileName;
 
 			// the result of optimizing the minidump
-			char *m_szDXLResult;
+			char *m_dxl_result;
 
 			// casting function
 			static
-			SOptimizeMinidumpContext *PoptmdpConvert(void *pv);
+			SOptimizeMinidumpContext *Cast(void *ptr);
 		};
 
 		// execute a task given the argument
 		static
-		void Execute ( void *(*pfunc) (void *), void *pfuncArg);
+		void Execute ( void *(*func) (void *), void *func_arg);
 
 		// map GPOS log severity level to GPDB, print error and delete the given error buffer
 		static
-		void LogExceptionMessageAndDelete(CHAR* err_buf, ULONG ulSeverityLevel=CException::ExsevInvalid);
+		void LogExceptionMessageAndDelete(CHAR* err_buf, ULONG severity_level=CException::ExsevInvalid);
 
-		// task that does the translation from xml to dxl to pplstmt
+		// task that does the translation from xml to dxl to planned_stmt
 		static
-		void* PvPlstmtFromDXLTask(void *pv);
+		void* ConvertToPlanStmtFromDXLTask(void *ptr);
 
 		// task that does the translation from query to XML
 		static
-		void* PvDXLFromQueryTask(void *pv);
+		void* ConvertToDXLFromQueryTask(void *ptr);
 
 		// dump relcache info for an object into DXL
 		static
-		void* PvDXLFromMDObjsTask(void *pv);
+		void* ConvertToDXLFromMDObjsTask(void *ptr);
 
 		// dump metadata about cast objects from relcache to a string in DXL format
 		static
-		void *PvMDCast(void *pv);
+		void *ConvertToDXLFromMDCast(void *ptr);
 		
 		// dump metadata about scalar comparison objects from relcache to a string in DXL format
 		static
-		void *PvMDScCmp(void *pv);
+		void *ConvertToDXLFromMDScalarCmp(void *ptr);
 		
 		// dump relstats info for an object into DXL
 		static
-		void* PvDXLFromRelStatsTask(void *pv);
+		void* ConvertToDXLFromRelStatsTask(void *ptr);
 
 		// evaluates an expression given as a serialized DXL string and returns the serialized DXL result
 		static
-		void* PvEvalExprFromDXLTask(void *pv);
+		void* EvalExprFromDXLTask(void *ptr);
 
 		// create optimizer configuration object
 		static
-		COptimizerConfig *PoconfCreate(IMemoryPool *pmp, ICostModel *pcm);
+		COptimizerConfig *CreateOptimizerConfig(IMemoryPool *mp, ICostModel *cost_model);
 
 		// optimize a query to a physical DXL
 		static
-		void* PvOptimizeTask(void *pv);
+		void* OptimizeTask(void *ptr);
 
 		// optimize the query in a minidump and return resulting plan in DXL format
 		static
-		void* PvOptimizeMinidumpTask(void *pv);
+		void* OptimizeMinidumpTask(void *ptr);
 
 		// translate a DXL tree into a planned statement
 		static
-		PlannedStmt *Pplstmt(IMemoryPool *pmp, CMDAccessor *pmda, const CDXLNode *pdxln, bool canSetTag);
+		PlannedStmt *ConvertToPlanStmtFromDXL(IMemoryPool *mp, CMDAccessor *md_accessor, const CDXLNode *dxlnode, bool can_set_tag);
 
 		// load search strategy from given path
 		static
-		DrgPss *PdrgPssLoad(IMemoryPool *pmp, char *szPath);
+		CSearchStageArray *LoadSearchStrategy(IMemoryPool *mp, char *path);
 
 		// helper for converting wide character string to regular string
 		static
-		CHAR *SzFromWsz(const WCHAR *wsz);
+		CHAR *CreateMultiByteCharStringFromWCString(const WCHAR *wcstr);
 
 		// lookup given exception type in the given array
 		static
-		BOOL FExceptionFound(gpos::CException &exc, const ULONG *pulExceptions, ULONG ulSize);
+		BOOL FoundException(gpos::CException &exc, const ULONG *exceptions, ULONG size);
 
 		// check if given exception is an unexpected reason for failing to produce a plan
 		static
-		BOOL FUnexpectedFailure(gpos::CException &exc);
+		BOOL IsUnexpectedFailure(gpos::CException &exc);
 
 		// check if given exception should error out
 		static
-		BOOL FErrorOut(gpos::CException &exc);
+		BOOL ShouldErrorOut(gpos::CException &exc);
 
 		// set cost model parameters
 		static
-		void SetCostModelParams(ICostModel *pcm);
+		void SetCostModelParams(ICostModel *cost_model);
 
 		// generate an instance of optimizer cost model
 		static
-		ICostModel *Pcm(IMemoryPool *pmp, ULONG ulSegments);
+		ICostModel *GetCostModel(IMemoryPool *mp, ULONG num_segments);
 
 		// print warning messages for columns with missing statistics
 		static
-		void PrintMissingStatsWarning(IMemoryPool *pmp, CMDAccessor *pmda, DrgPmdid *pdrgmdidCol, HSMDId *phsmdidRel);
+		void PrintMissingStatsWarning(IMemoryPool *mp, CMDAccessor *md_accessor, IMdIdArray *col_stats, MdidHashSet *phsmdidRel);
 
 	public:
 
 		// convert Query->DXL->LExpr->Optimize->PExpr->DXL
 		static
-		char *SzOptimize(Query *pquery);
+		char *Optimize(Query *query);
 
 		// optimize Query->DXL->LExpr->Optimize->PExpr->DXL->PlannedStmt
 		static
-		PlannedStmt *PplstmtOptimize
+		PlannedStmt *GPOPTOptimizedPlan
 			(
-			Query *pquery,
-			SOptContext* octx,
-			BOOL *pfUnexpectedFailure // output : set to true if optimizer unexpectedly failed to produce plan
+			Query *query,
+			SOptContext* gpopt_context,
+			BOOL *had_unexpected_failure // output : set to true if optimizer unexpectedly failed to produce plan
 			);
 
 		// convert query to DXL to xml string.
 		static
-		char *SzDXL(Query *pquery);
+		char *ConvertQueryToDXL(Query *query);
 
 		// convert xml string to DXL and to PS
 		static
-		PlannedStmt *PplstmtFromXML(char *szXmlString);
+		PlannedStmt *ConvertToiPlanStmtFromXML(char *xml_string);
 
 		// dump metadata objects from relcache to file in DXL format
 		static
-		void DumpMDObjs(List *oids, const char *szFilename);
+		void DumpMDObjs(List *oids, const char *filename);
 
 		// dump metadata objects from relcache to a string in DXL format
 		static
@@ -282,32 +282,32 @@ class COptTasks
 		
 		// dump cast function from relcache to a string in DXL format
 		static
-		char *SzMDCast(List *oids);
+		char *DumpMDCast(List *oids);
 		
 		// dump scalar comparison from relcache to a string in DXL format
 		static
-		char *SzMDScCmp(List *oids, char *szCmpType);
+		char *DumpMDScalarCmp(List *oids, char *cmp_type);
 
 		// dump statistics from relcache to a string in DXL format
 		static
-		char *SzRelStats(List *oids);
+		char *DumpRelStats(List *oids);
 
 		// enable/disable a given xforms
 		static
-		bool FSetXform(char *szXform, bool fDisable);
+		bool SetXform(char *xform_str, bool should_disable);
 		
 		// return comparison type code
 		static
-		ULONG UlCmpt(char *szCmpType);
+		ULONG GetComparisonType(char *cmp_type);
 
 		// converts XML string to DXL and evaluates the expression
 		static
-		char *SzEvalExprFromXML(char *szXmlString);
+		char *EvalExprFromXML(char *xml_string);
 
 		// loads a minidump from the given file path, executes it and returns
 		// the serialized representation of the result as DXL
 		static
-		char *SzOptimizeMinidumpFromFile(char *szFileName);
+		char *OptimizeMinidumpFromFile(char *file_name);
 };
 
 #endif // COptTasks_H

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -69,7 +69,7 @@ extern "C" {
 #include "funcapi.h"
 
 extern
-Query *preprocess_query_optimizer(Query *pquery, ParamListInfo boundParams);
+Query *preprocess_query_optimizer(Query *query, ParamListInfo boundParams);
 
 extern
 List *pg_parse_and_rewrite(const char *query_string, Oid *paramTypes, int iNumParams);

--- a/src/test/tinc/tincrepo/mpp/models/test/sql_related/optimizer/function_owners2.csv
+++ b/src/test/tinc/tincrepo/mpp/models/test/sql_related/optimizer/function_owners2.csv
@@ -3725,7 +3725,7 @@ libgpoptudf/src/CCatalogUtils.cpp,libgpoptudf/src/CCatalogUtils.cpp,CCatalogUtil
 libgpoptudf/src/CCatalogUtils.cpp,libgpoptudf/src/CCatalogUtils.cpp,CCatalogUtils::PlFunctionOids,raghav
 libgpoptudf/src/CCatalogUtils.cpp,libgpoptudf/src/CCatalogUtils.cpp,CCatalogUtils::PlAllOids,raghav
 libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::PvRun,solimm1
-libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::PplstmtOptimize,solimm1
+libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::GPOPTOptimizedPlan,solimm1
 libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::SetTraceflags,solimm1
 libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::SendRequest,solimm1
 libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::SzPlanDXL,solimm1
@@ -3755,7 +3755,7 @@ libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PvQueryFr
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PvDXLFromMDObjsTask,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PvDXLFromRelStatsTask,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::SzOptimize,raghav
-libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PplstmtOptimize,raghav
+libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::GPOPTOptimizedPlan,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::SzDXL,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::SzDXL,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PqueryFromXML,raghav

--- a/src/test/unit/mock/gpopt_mock.c
+++ b/src/test/unit/mock/gpopt_mock.c
@@ -5,16 +5,16 @@
 #include "nodes/plannodes.h"
 
 char *
-SzDXLPlan(Query *pquery)
+SerializeDXLPlan(Query *pquery)
 {
-	elog(ERROR, "mock implementation of SzDXLPlan called");
+	elog(ERROR, "mock implementation of SerializeDXLPlan called");
 	return NULL;
 }
 
 PlannedStmt *
-PplstmtOptimize(Query *pquery, bool pfUnexpectedFailure)
+GPOPTOptimizedPlan(Query *pquery, bool pfUnexpectedFailure)
 {
-	elog(ERROR, "mock implementation of PplStmtOptimize called");
+	elog(ERROR, "mock implementation of GPOPTOptimizedPlan called");
 	return NULL;
 }
 


### PR DESCRIPTION
As part of moving away from Hungarian notation in the GPORCA codebase,
the integration points between GPORCA and GPDB in the translator have
been renamed to the new convention used in GPORCA. The libraries
currently updated to the new notation in GPORCA are Naucrates and GPOS.
The new naming convention is a custom version of common C++ naming
conventions. The style guide for this convention is forthcoming. Look
for an updated README to this effect in GPORCA in future commits.

Co-authored-by: Shreedhar Hardikar <shardikar@pivotal.io>
Co-authored-by: Melanie Plageman <mplageman@pivotal.io>
Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>
Co-authored-by: Abhijit Subramanya <asubramanya@pivotal.io>
Co-authored-by: Sambitesh Dash <sdash@pivotal.io><Paste>