### PR TITLE
docs - remove max_fsm_* refs, update free space map content

### DIFF
--- a/gpdb-doc/dita/admin_guide/dml.xml
+++ b/gpdb-doc/dita/admin_guide/dml.xml
@@ -340,23 +340,5 @@
         database data. See the <codeph>VACUUM</codeph> command in the <cite>Greenplum Database
           Reference Guide</cite> for information about using the command.</note>
     </body>
-    <topic id="topic10" xml:lang="en">
-      <title>Configuring the Free Space Map</title>
-      <body>
-        <p>Expired rows are held in the <i>free space map</i>. The free space map must be sized
-          large enough to hold all expired rows in your database. If not, a regular
-            <codeph>VACUUM</codeph> command cannot reclaim space occupied by expired rows that
-          overflow the free space map.</p>
-        <p><codeph>VACUUM FULL</codeph> reclaims all expired row space, but it is an expensive
-          operation and can take an unacceptably long time to finish on large, distributed Greenplum
-          Database tables. If the free space map overflows, you can recreate the table with a
-            <codeph>CREATE TABLE AS </codeph>statement and drop the old table. Using <codeph>VACUUM FULL</codeph> is discouraged.</p>
-        <p>Size the free space map with the following server configuration parameters:<ul
-            id="ul_cj2_xc5_h4">
-            <li><codeph>max_fsm_pages</codeph></li>
-            <li><codeph>max_fsm_relations</codeph></li>
-          </ul></p>
-      </body>
-    </topic>
   </topic>
 </topic>

--- a/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
@@ -217,9 +217,9 @@ COMMIT;
         rows. Performance suffers due to the increased disk I/O required to execute queries. This
         condition is called <i>bloat</i> and it should be managed by regularly vacuuming tables. </p>
       <p>The <codeph>VACUUM</codeph> command (without <codeph>FULL</codeph>) can run concurrently
-        with other queries. It marks the space previously used by the expired rows as free. If the
-        amount of remaining free space is significant, it adds the page to the table's free space
-        map. When Greenplum Database later needs space for new rows, it first consults the table's
+        with other queries. It marks the space previously used by the expired rows as free,
+        and updates the free space map. 
+        When Greenplum Database later needs space for new rows, it first consults the table's
         free space map to find pages with available space. If none are found, new pages will be
         appended to the file. </p>
       <p><codeph>VACUUM</codeph> (without <codeph>FULL</codeph>) does not consolidate pages or
@@ -239,35 +239,6 @@ COMMIT;
         vacuuming regularly. It is best to run <codeph>VACUUM FULL</codeph> during a maintenance
         period. An alternative to <codeph>VACUUM FULL</codeph> is to recreate the table with a
           <codeph>CREATE TABLE AS</codeph> statement and then drop the old table. </p>
-      <p>The free space map resides in shared memory and keeps track of free space for all tables
-        and indexes. Each table or index uses about 60 bytes of memory and each page with free space
-        consumes six bytes. Two system configuration parameters configure the size of the free space
-        map:</p>
-      <parml>
-        <plentry>
-          <pt>
-            <b>max_fsm_pages</b>
-          </pt>
-          <pd>Sets the maximum number of disk pages that can be added to the shared free space map.
-            Six bytes of shared memory are consumed for each page slot. The default is 200000. This
-            parameter must be set to at least 16 times the value of <i>max_fsm_relations</i>.</pd>
-        </plentry>
-        <plentry>
-          <pt>
-            <b>max_fsm_relations</b>
-          </pt>
-          <pd>
-            <p>Sets the maximum number of relations that will be tracked in the shared memory free
-              space map. This parameter should be set to a value larger than the total number of
-                <i>tables + indexes + system tables</i>. The default is 1000. About 60 bytes of
-              memory are consumed for each relation per segment instance. It is better to set the
-              parameter too high than too low.</p>
-          </pd>
-        </plentry>
-      </parml>
-      <p>If the free space map is undersized, some disk pages with available space will not be added
-        to the map, and that space cannot be reused until at least the next <codeph>VACUUM</codeph>
-        command runs. This causes files to grow. </p>
       <p>You can run <codeph>VACUUM VERBOSE <varname>tablename</varname></codeph> to get a report,
         by segment, of the number of dead rows removed, the number of pages affected, and the number
         of pages with usable free space. </p>

--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -346,23 +346,6 @@
           </simpletable>
         </body>
       </topic>
-      <topic id="topic17" xml:lang="en">
-        <title>Free Space Map Parameters</title>
-        <body>
-          <p>These parameters control the sizing of the free space map, which contains expired rows.
-            Use <codeph>VACUUM</codeph> to reclaim the free space map disk space. See <xref
-              href="maintain.xml#topic1" type="topic" format="dita"/> for information about
-            vacuuming a database.</p>
-          <ul>
-            <li id="kh183337">
-              <codeph>max_fsm_pages</codeph>
-            </li>
-            <li id="kh161010">
-              <codeph>max_fsm_relations</codeph>
-            </li>
-          </ul>
-        </body>
-      </topic>
       <topic id="topic18" xml:lang="en">
         <title>OS Resource Parameters</title>
         <body>

--- a/gpdb-doc/dita/best_practices/bloat.xml
+++ b/gpdb-doc/dita/best_practices/bloat.xml
@@ -39,32 +39,6 @@
     <note type="caution"><b>Never</b> run <codeph>VACUUM FULL &lt;database_name></codeph> and do not
       run <codeph>VACUUM FULL</codeph> on large tables in a Greenplum Database.</note>
     <section>
-      <title>Sizing the Free Space Map</title>
-
-      <p>Expired rows in heap tables are added to a shared free space map when you run
-          <codeph>VACUUM</codeph>. The free space map must be adequately sized to accommodate these
-        rows. If the free space map is not large enough, any space occupied by rows that overflow
-        the free space map cannot be reclaimed by a regular <codeph>VACUUM</codeph> statement. You
-        will have to use <codeph>VACUUM FULL</codeph> or an alternative method to recover the
-        space.</p>
-      <p>You can avoid overflowing the free space map by running the <codeph>VACUUM</codeph>
-        statement regularly. The more bloated a table becomes, the more rows that must be tracked in
-        the free space map. For very large databases with many objects, you may need to increase the
-        size of the free space map to prevent overflow. </p>
-
-      <p>The <codeph>max_fsm_pages</codeph> configuration parameter sets the maximum number of disk
-        pages for which free space will be tracked in the shared free-space map. Each page slot
-        consumes six bytes of shared memory. The default value for <codeph>max_fsm_pages</codeph> is
-        200,000.</p>
-      <p>The <codeph>max_fsm_relations</codeph> configuration parameter sets the maximum number of
-        relations for which free space will be tracked in the shared memory free-space map. It
-        should be set to a value larger than the total number of tables, indexes, and system tables
-        in the database. It costs about 60 bytes of memory for each relation per segment instance.
-        The default value is 1000.</p>
-      <p>See the <i>Greenplum Database Reference Guide</i> for detailed information about these
-        configuration parameters.</p>
-    </section>
-    <section>
       <title>Detecting Bloat</title>
       <p>The statistics collected by the <codeph>ANALYZE</codeph> statement can be used to calculate
         the expected number of disk pages required to store a table. The difference between the
@@ -99,7 +73,7 @@
     </section>
     <section id="remove_bloat">
       <title>Removing Bloat from Database Tables</title>
-      <p>The <codeph>VACUUM</codeph> command adds expired rows to the shared free space map so that
+      <p>The <codeph>VACUUM</codeph> command adds expired rows to the free space map so that
         the space can be reused. When <codeph>VACUUM</codeph> is run regularly on a table that is
         frequently updated, the space occupied by the expired rows can be promptly reused,
         preventing the table file from growing larger. It is also important to run

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -595,12 +595,6 @@
               <xref href="#max_files_per_process"/>
             </li>
             <li>
-              <xref href="#max_fsm_pages"/>
-            </li>
-            <li>
-              <xref href="#max_fsm_relations"/>
-            </li>
-            <li>
               <xref href="#max_function_args"/>
             </li>
             <li>
@@ -6970,65 +6964,6 @@
         setting. Some platforms such as BSD, the kernel will allow individual processes to open many
         more files than the system can really support.</p>
       <table id="max_files_per_process_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">integer</entry>
-              <entry colname="col2">1000</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="max_fsm_pages">
-    <title>max_fsm_pages</title>
-    <body>
-      <p>Sets the maximum number of disk pages for which free space will be tracked in the shared
-        free-space map. Six bytes of shared memory are consumed for each page slot. </p>
-      <table id="max_fsm_pages_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">integer &gt; 16 * <i>max_fsm_relations</i></entry>
-              <entry colname="col2">200000</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="max_fsm_relations">
-    <title>max_fsm_relations</title>
-    <body>
-      <p>Sets the maximum number of relations for which free space will be tracked in the shared
-        memory free-space map. Should be set to a value larger than the total number of:</p>
-      <p>tables + indexes + system tables.</p>
-      <p>It costs about 60 bytes of memory for each relation per segment instance. It is better to
-        allow some room for overhead and set too high rather than too low.</p>
-      <table id="max_fsm_relations_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
           <colspec colnum="2" colname="col2" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -226,25 +226,6 @@
         </simpletable>
       </body>
     </topic>
-    <topic id="topic17" xml:lang="en">
-      <title>Free Space Map Parameters</title>
-      <body>
-        <p>These parameters control the sizing of the <i>free space map, which contains </i>expired
-          rows. Use <codeph>VACUUM</codeph> to reclaim the free space map disk space.</p>
-        <simpletable id="d1e409" frame="none">
-          <strow>
-            <stentry>
-              <p>
-                <xref href="guc-list.xml#max_fsm_pages" type="section">max_fsm_pages</xref>
-              </p>
-              <p>
-                <xref href="guc-list.xml#max_fsm_relations" type="section">max_fsm_relations</xref>
-              </p>
-            </stentry>
-          </strow>
-        </simpletable>
-      </body>
-    </topic>
     <topic id="topic18" xml:lang="en">
       <title>OS Resource Parameters</title>
       <body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -217,8 +217,6 @@
             <topicref href="guc-list.xml#max_appendonly_tables"/>
             <topicref href="guc-list.xml#max_connections"/>
             <topicref href="guc-list.xml#max_files_per_process"/>
-            <topicref href="guc-list.xml#max_fsm_pages"/>
-            <topicref href="guc-list.xml#max_fsm_relations"/>
             <topicref href="guc-list.xml#max_function_args"/>
             <topicref href="guc-list.xml#max_identifier_length"/>
             <topicref href="guc-list.xml#max_index_keys"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/VACUUM.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/VACUUM.xml
@@ -116,10 +116,6 @@ VACUUM [FULL] [FREEZE] [VERBOSE] ANALYZE
       <p><codeph>VACUUM</codeph> causes a substantial increase in I/O traffic, which can cause poor
         performance for other active sessions. Therefore, it is advisable to vacuum the database at
         low usage times.</p>
-      <p>For heap tables, expired rows are held in what is called the <i>free space map</i>. The
-        free space map must be sized large enough to cover the dead rows of all heap tables in your
-        database. If not sized large enough, space occupied by dead rows that overflow the free
-        space map cannot be reclaimed by a regular <codeph>VACUUM</codeph> command.</p>
       <p><codeph>VACUUM</codeph> commands skip external tables.</p>
       <p><codeph>VACUUM FULL</codeph> reclaims all expired row space, however it requires an
         exclusive lock on each table being processed, is a very expensive operation, and might take
@@ -127,11 +123,6 @@ VACUUM [FULL] [FREEZE] [VERBOSE] ANALYZE
           <codeph>VACUUM FULL</codeph> operations during database maintenance periods. </p>
       <p>As an alternative to <codeph>VACUUM FULL</codeph>, you can re-create the table with a
           <codeph>CREATE TABLE AS</codeph> statement and drop the old table. </p>
-      <p>Size the free space map appropriately. You configure the free space map using the following
-        server configuration parameters:<ul id="ul_tyn_t3k_dp">
-          <li><codeph>max_fsm_pages</codeph></li>
-          <li><codeph>max_fsm_relations</codeph></li>
-        </ul></p>
       <p>For append-optimized tables, <codeph>VACUUM</codeph> requires enough available disk space
         to accommodate the new segment file during the <codeph>VACUUM</codeph> process. If the ratio
         of hidden rows to total rows in a segment file is less than a threshold value (10, by


### PR DESCRIPTION
updates include:
- removed references to free space map GUCs max_fsm_pages and max_fsm_relations
- the old free space map scheme used shared memory.  removed references to sizing the map.
- revised some free space map discussions to better reflect the new scheme.