### PR TITLE
COPY: don't dispatch AO segno map for unloading

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1932,7 +1932,7 @@ CopyDispatchOnSegment(CopyState cstate, const CopyStmt *stmt)
 	all_relids = list_make1_oid(RelationGetRelid(cstate->rel));
 
 	/* add in AO segno map for dispatch */
-	if (rel_is_partitioned(RelationGetRelid(cstate->rel)))
+	if (dispatchStmt->is_from && rel_is_partitioned(RelationGetRelid(cstate->rel)))
 	{
 		if (gp_enable_segment_copy_checking &&
 			!partition_policies_equal(cstate->rel->rd_cdbpolicy, RelationBuildPartitionDesc(cstate->rel, false)))
@@ -1945,8 +1945,10 @@ CopyDispatchOnSegment(CopyState cstate, const CopyStmt *stmt)
 		PartitionNode *pn = RelationBuildPartitionDesc(cstate->rel, false);
 
 		all_relids = list_concat(all_relids, all_partition_relids(pn));
+
+		dispatchStmt->ao_segnos = assignPerRelSegno(all_relids);
 	}
-	dispatchStmt->ao_segnos = assignPerRelSegno(all_relids);
+
 	dispatchStmt->skip_ext_partition = cstate->skip_ext_partition;
 
 	if (policy)

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1166,7 +1166,5 @@ CREATE EXTERNAL WEB TABLE ext_dec17(LIKE sales_1_prt_dec17) EXECUTE 'printf "12\
 ALTER TABLE sales ALTER PARTITION dec17 EXCHANGE PARTITION dec17 WITH TABLE ext_dec17 WITHOUT VALIDATION;
 DROP TABLE ext_dec17;
 COPY sales TO PROGRAM 'cat > /dev/null' IGNORE EXTERNAL PARTITIONS;
-SET gp_enable_segment_copy_checking=off;
 COPY sales TO PROGRAM 'printf <SEGID> && cat > /dev/null' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
-SET gp_enable_segment_copy_checking=on;
 DROP TABLE sales;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1349,8 +1349,6 @@ NOTICE:  exchanged partition "dec17" of partition "dec17" of relation "sales" wi
 DROP TABLE ext_dec17;
 COPY sales TO PROGRAM 'cat > /dev/null' IGNORE EXTERNAL PARTITIONS;
 NOTICE:  COPY ignores external partition(s)
-SET gp_enable_segment_copy_checking=off;
 COPY sales TO PROGRAM 'printf <SEGID> && cat > /dev/null' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 NOTICE:  COPY ignores external partition(s)
-SET gp_enable_segment_copy_checking=on;
 DROP TABLE sales;


### PR DESCRIPTION
Unloading doesn't need it, checking the distribution policy neither.