### PR TITLE
Implement resource group bypass mode

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -89,6 +89,7 @@ static void assign_gp_default_storage_options(const char *newval, void *extra);
 
 static bool check_pljava_classpath_insecure(bool *newval, void **extra, GucSource source);
 static void assign_pljava_classpath_insecure(bool newval, void *extra);
+static bool check_gp_resource_group_bypass(bool *newval, void **extra, GucSource source);
 
 extern struct config_generic *find_option(const char *name, bool create_placeholders, int elevel);
 
@@ -263,6 +264,7 @@ bool		gp_debug_resqueue_priority = false;
 int			gp_resource_group_cpu_priority;
 double		gp_resource_group_cpu_limit;
 double		gp_resource_group_memory_limit;
+bool		gp_resource_group_bypass;
 
 /* Perfmon segment GUCs */
 int			gp_perfmon_segment_interval;
@@ -3117,6 +3119,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false, NULL, NULL
 	},
 
+	{
+		{"gp_resource_group_bypass", PGC_USERSET, RESOURCES,
+			gettext_noop("If the value is true, the query in this session will not be limited by resource group."),
+			NULL
+		},
+		&gp_resource_group_bypass,
+		false,
+		check_gp_resource_group_bypass, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL
@@ -5253,6 +5265,16 @@ assign_pljava_classpath_insecure(bool newval, void *extra)
 			pljava_cp->context = PGC_USERSET;
 		}
 	}
+}
+
+static bool
+check_gp_resource_group_bypass(bool *newval, void **extra, GucSource source)
+{
+	if (!ResGroupIsAssigned())
+		return true;
+
+	GUC_check_errmsg("SET gp_resource_group_bypass cannot run inside a transaction block");
+	return false;
 }
 
 static bool

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -79,6 +79,7 @@ extern int						memory_spill_ratio;
 extern int gp_resource_group_cpu_priority;
 extern double gp_resource_group_cpu_limit;
 extern double gp_resource_group_memory_limit;
+extern bool gp_resource_group_bypass;
 
 /*
  * Non-GUC global variables.
@@ -143,6 +144,8 @@ extern bool ShouldUnassignResGroup(void);
 extern void AssignResGroupOnMaster(void);
 extern void UnassignResGroup(void);
 extern void SwitchResGroupOnSegment(const char *buf, int len);
+
+extern bool ResGroupIsAssigned(void);
 
 /* Retrieve statistic information of type from resource group */
 extern Datum ResGroupGetStat(Oid groupId, ResGroupStatType type);

--- a/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
@@ -433,6 +433,69 @@ DROP
 DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
+-- test10: gp_resource_group_bypass
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=0, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+61: SET ROLE role_concurrency_test;
+SET
+61: SET gp_resource_group_bypass to on;
+SET
+61: SHOW gp_resource_group_bypass;
+gp_resource_group_bypass
+------------------------
+on                      
+(1 row)
+61: CREATE TABLE table_concurrency_test (c1 int);
+CREATE
+61: INSERT INTO  table_concurrency_test SELECT generate_series(1,100);
+INSERT 100
+61: SELECT count(*) FROM table_concurrency_test;
+count
+-----
+100  
+(1 row)
+61: DROP TABLE table_concurrency_test;
+DROP
+61: SET gp_resource_group_bypass to off;
+SET
+61: SHOW gp_resource_group_bypass;
+gp_resource_group_bypass
+------------------------
+off                     
+(1 row)
+61q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- test11: gp_resource_group_bypass is not allowed inside a transaction block
+DROP FUNCTION IF EXISTS func_resgroup_bypass_test(int);
+DROP
+
+CREATE FUNCTION func_resgroup_bypass_test(c1 int) RETURNS INT AS $$ SET gp_resource_group_bypass TO ON; -- inside a function SELECT 1 $$ LANGUAGE SQL;
+CREATE
+BEGIN;
+BEGIN
+SET gp_resource_group_bypass to on;
+ERROR:  SET gp_resource_group_bypass cannot run inside a transaction block
+ABORT;
+ABORT
+SELECT func_resgroup_bypass_test(1);
+ERROR:  SET gp_resource_group_bypass cannot run inside a transaction block
+CONTEXT:  SQL function "func_resgroup_bypass_test" statement 1
+DROP FUNCTION func_resgroup_bypass_test(int);
+DROP
+
 --
 -- Test cursors, pl/* functions only take one slot.
 --

--- a/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
@@ -223,6 +223,40 @@ ALTER RESOURCE GROUP rg_concurrency_test set concurrency 0;
 DROP ROLE role_concurrency_test;
 DROP RESOURCE GROUP rg_concurrency_test;
 
+-- test10: gp_resource_group_bypass
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=0, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+61: SET ROLE role_concurrency_test;
+61: SET gp_resource_group_bypass to on;
+61: SHOW gp_resource_group_bypass;
+61: CREATE TABLE table_concurrency_test (c1 int);
+61: INSERT INTO  table_concurrency_test SELECT generate_series(1,100);
+61: SELECT count(*) FROM table_concurrency_test;
+61: DROP TABLE table_concurrency_test;
+61: SET gp_resource_group_bypass to off;
+61: SHOW gp_resource_group_bypass;
+61q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test11: gp_resource_group_bypass is not allowed inside a transaction block
+DROP FUNCTION IF EXISTS func_resgroup_bypass_test(int);
+
+CREATE FUNCTION func_resgroup_bypass_test(c1 int) RETURNS INT AS $$
+	SET gp_resource_group_bypass TO ON; -- inside a function
+	SELECT 1
+$$ LANGUAGE SQL;
+BEGIN;
+SET gp_resource_group_bypass to on;
+ABORT;
+SELECT func_resgroup_bypass_test(1);
+DROP FUNCTION func_resgroup_bypass_test(int);
+
 --
 -- Test cursors, pl/* functions only take one slot.
 --


### PR DESCRIPTION
- Introduce a new GUC gp_resource_group_bypass, when it is on,
  the query in this session will not be limited by resource group