### PR TITLE
Perform analyze on specific table in spilltodisk test.

### DIFF
--- a/src/test/regress/expected/workfile/spilltodisk.out
+++ b/src/test/regress/expected/workfile/spilltodisk.out
@@ -31,8 +31,7 @@ create table spilltest (a integer, b integer);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into spilltest select a, a%25 from generate_series(1,8000) a;
-analyze;
-NOTICE:  ANALYZE detected all empty sample pages for table pg_auth_members, please run VACUUM FULL for accurate estimation.
+analyze spilltest;
 set enable_hashagg=on;
 set enable_groupagg=off;
 set statement_mem=10000;
@@ -102,8 +101,7 @@ create table spilltest (a integer, b integer);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into spilltest select a, a%25 from generate_series(1,800000) a;
-analyze; -- We have to do an analyze to force a hash join
-NOTICE:  ANALYZE detected all empty sample pages for table pg_auth_members, please run VACUUM FULL for accurate estimation.
+analyze spilltest; -- We have to do an analyze to force a hash join
 set enable_mergejoin=off;
 set enable_nestloop=off;
 set enable_hashjoin=on;

--- a/src/test/regress/sql/workfile/spilltodisk.sql
+++ b/src/test/regress/sql/workfile/spilltodisk.sql
@@ -22,7 +22,7 @@ select count(*), sum(t1a), sum(t2a), sum(t1a - t2a) from spilltestresult1;
 -- Test Hash Aggregation when the work mem is too small for the hash table
 create table spilltest (a integer, b integer);
 insert into spilltest select a, a%25 from generate_series(1,8000) a;
-analyze;
+analyze spilltest;
 set enable_hashagg=on;
 set enable_groupagg=off;
 set statement_mem=10000;
@@ -34,7 +34,7 @@ select b,count(*) from spilltest group by b;
 drop table if exists spilltest;
 create table spilltest (a integer, b integer);
 insert into spilltest select a, a%25 from generate_series(1,800000) a;
-analyze; -- We have to do an analyze to force a hash join
+analyze spilltest; -- We have to do an analyze to force a hash join
 set enable_mergejoin=off;
 set enable_nestloop=off;
 set enable_hashjoin=on;


### PR DESCRIPTION
No need to have database scope analyze, only specific table needs to be
analyzed for the test.