### PR TITLE
Restrict max_wal_senders guc to 1 in GPDB.

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -967,12 +967,6 @@ PostmasterMain(int argc, char *argv[])
              )));
 	}
 
-	/*
-	 * This value of max_wal_senders will be inherited by all the child processes
-	 * through fork(). This value is used by XLogIsNeeded().
-	 */
-	max_wal_senders = 1;
-
 	if ( GpIdentity.numsegments < 0 )
 	{
 	    ereport(FATAL,

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2078,7 +2078,7 @@ static struct config_int ConfigureNamesInt[] =
 			NULL
 		},
 		&max_wal_senders,
-		0, 0, MAX_BACKENDS,
+		1, 0, 1, /* GPDB doesn't support 1:n replication yet */
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
GPDB only supports 1 replica currently. Need to adopt in FTS and all to support
1:n till then restrict max_wal_senders GUC to 1. Later when code can handle the
same the max value of guc can be changed.

Also, remove the setting of max_wal_senders in postmaster which was added
earlier for dealing with filerep/walrep co-existence.