### PR TITLE
Fix a couple issues related to AppendOnlyHash and AOSEG_STATE_AWAITING_DROP state

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -880,25 +880,21 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 
 			if (!onerel)
 			{
-				/*
-				 * Couldn't get AccessExclusiveLock.
-				 *
-				 * Since the drop phase needs to be skipped, we need to
-				 * deregister the segnos which were marked for drop in the
-				 * compaction phase
-				 */
-				DeregisterSegnoForCompactionDrop(relid, compactNowList);
-
+				/* Couldn't get AccessExclusiveLock. */
 				PopActiveSnapshot();
 				CommitTransactionCommand();
 
 				/*
-				 * To ensure that vacuum decreases the age for appendonly
-				 * tables even if drop phase is getting skipped, perform
-				 * cleanup phase so that the relfrozenxid value is updated
-				 * correctly in pg_class.
+				 * Skip the performing DROP and continue with other segfiles
+				 * in case they have crossed threshold and need to be
+				 * compacted or marked as AOSEG_STATE_AWAITING_DROP (depending
+				 * if above try_relation_open succeeds or not). To ensure that
+				 * vacuum decreases the age for appendonly tables even if drop
+				 * phase is getting skipped, perform cleanup phase when done
+				 * iterating through all segfiles so that the relfrozenxid
+				 * value is updated correctly in pg_class.
 				 */
-				break;
+				continue;
 			}
 
 			if (HasSerializableBackends(false))

--- a/src/test/isolation2/expected/mark_all_aoseg_await_drop.out
+++ b/src/test/isolation2/expected/mark_all_aoseg_await_drop.out
@@ -1,0 +1,68 @@
+-- Ensure all segfiles crossing vacuum threshold but cannot compact
+-- due to concurrent transaction should be marked in state
+-- AOSEG_STATE_AWAITING_DROP.
+
+CREATE TABLE mark_all_aoseg_await_drop (a int) WITH (appendonly=true);
+CREATE
+
+-- Create 3 aoseg entries
+0: BEGIN;
+BEGIN
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+0: INSERT INTO mark_all_aoseg_await_drop SELECT i FROM generate_series(1, 10)i;
+INSERT 10
+1: INSERT INTO mark_all_aoseg_await_drop SELECT i FROM generate_series(1, 10)i;
+INSERT 10
+2: INSERT INTO mark_all_aoseg_await_drop SELECT i FROM generate_series(1, 10)i;
+INSERT 10
+0: COMMIT;
+COMMIT
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+
+DELETE FROM mark_all_aoseg_await_drop;
+DELETE 30
+
+-- We should see all 3 aosegs in state 1
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('mark_all_aoseg_await_drop');
+segno|state
+-----+-----
+1    |1    
+2    |1    
+3    |1    
+(3 rows)
+
+-- VACUUM while another session holds lock
+1: BEGIN;
+BEGIN
+1: SELECT COUNT(*) FROM mark_all_aoseg_await_drop;
+count
+-----
+0    
+(1 row)
+1: INSERT INTO mark_all_aoseg_await_drop SELECT i FROM generate_series(1, 10)i;
+INSERT 10
+2: VACUUM mark_all_aoseg_await_drop;
+VACUUM
+1: END;
+END
+
+-- We should see segno 2 and 3 in state 2 (AOSEG_STATE_AWAITING_DROP)
+-- and segno 1 and 4 in state 1 (AOSEG_STATE_DEFAULT). Segno 1 is not
+-- marked as state 2 because a concurrent transaction has written to
+-- it and did not commit before the vacuum got to it. The vacuum
+-- correctly skipped segno 1 and continued to cycle through the aoseg
+-- entries.
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('mark_all_aoseg_await_drop');
+segno|state
+-----+-----
+1    |1    
+2    |2    
+3    |2    
+4    |1    
+(4 rows)

--- a/src/test/isolation2/expected/reorganize_after_ao_vacuum_skip_drop.out
+++ b/src/test/isolation2/expected/reorganize_after_ao_vacuum_skip_drop.out
@@ -1,0 +1,57 @@
+-- Ensure segfiles in AOSEG_STATE_AWAITING_DROP are not leaked in
+-- AppendOnlyHash after doing an AT_SetDistributedBy operation which
+-- rewrites the relation differently than other ALTER operations.
+
+CREATE TABLE reorganize_after_ao_vacuum_skip_drop (a INT, b INT) WITH (appendonly=true);
+CREATE
+INSERT INTO reorganize_after_ao_vacuum_skip_drop SELECT i as a, i as b FROM generate_series(1, 10) AS i;
+INSERT 10
+
+DELETE FROM reorganize_after_ao_vacuum_skip_drop;
+DELETE 10
+
+-- We should see all aosegs in state 1
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('reorganize_after_ao_vacuum_skip_drop');
+segno|state
+-----+-----
+1    |1    
+(1 row)
+
+-- VACUUM while another session holds lock
+1: BEGIN;
+BEGIN
+1: SELECT COUNT(*) FROM reorganize_after_ao_vacuum_skip_drop;
+count
+-----
+0    
+(1 row)
+2: VACUUM reorganize_after_ao_vacuum_skip_drop;
+VACUUM
+1: END;
+END
+
+-- We should see an aoseg in state 2 (AOSEG_STATE_AWAITING_DROP)
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('reorganize_after_ao_vacuum_skip_drop');
+segno|state
+-----+-----
+1    |2    
+2    |1    
+(2 rows)
+
+-- The AO relation should be rewritten and AppendOnlyHash entry invalidated
+1: ALTER TABLE reorganize_after_ao_vacuum_skip_drop SET WITH (reorganize=true);
+ALTER
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('reorganize_after_ao_vacuum_skip_drop');
+segno|state
+-----+-----
+(0 rows)
+
+-- Check if insert goes into segno 1 instead of segno 2. If it did not
+-- go into segno 1, there was a leak in the AppendOnlyHash entry.
+1: INSERT INTO reorganize_after_ao_vacuum_skip_drop SELECT i as a, i as b FROM generate_series(1, 100) AS i;
+INSERT 100
+0U: SELECT segno, tupcount > 0, state FROM gp_toolkit.__gp_aoseg_name('reorganize_after_ao_vacuum_skip_drop');
+segno|?column?|state
+-----+--------+-----
+1    |t       |1    
+(1 row)

--- a/src/test/isolation2/expected/truncate_after_ao_vacuum_skip_drop.out
+++ b/src/test/isolation2/expected/truncate_after_ao_vacuum_skip_drop.out
@@ -1,0 +1,56 @@
+-- Ensure segfiles in AOSEG_STATE_AWAITING_DROP are not leaked in
+-- AppendOnlyHash after doing a TRUNCATE.
+
+CREATE TABLE truncate_after_ao_vacuum_skip_drop (a INT, b INT) WITH (appendonly=true);
+CREATE
+INSERT INTO truncate_after_ao_vacuum_skip_drop SELECT i as a, i as b FROM generate_series(1, 10) AS i;
+INSERT 10
+
+DELETE FROM truncate_after_ao_vacuum_skip_drop;
+DELETE 10
+
+-- We should see all aosegs in state 1
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('truncate_after_ao_vacuum_skip_drop');
+segno|state
+-----+-----
+1    |1    
+(1 row)
+
+-- VACUUM while another session holds lock
+1: BEGIN;
+BEGIN
+1: SELECT COUNT(*) FROM truncate_after_ao_vacuum_skip_drop;
+count
+-----
+0    
+(1 row)
+2: VACUUM truncate_after_ao_vacuum_skip_drop;
+VACUUM
+1: END;
+END
+
+-- We should see an aoseg in state 2 (AOSEG_STATE_AWAITING_DROP)
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('truncate_after_ao_vacuum_skip_drop');
+segno|state
+-----+-----
+1    |2    
+2    |1    
+(2 rows)
+
+-- The AO relation should be rewritten and AppendOnlyHash entry invalidated
+1: TRUNCATE truncate_after_ao_vacuum_skip_drop;
+TRUNCATE
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('truncate_after_ao_vacuum_skip_drop');
+segno|state
+-----+-----
+(0 rows)
+
+-- Check if insert goes into segno 1 instead of segno 2. If it did not
+-- go into segno 1, there was a leak in the AppendOnlyHash entry.
+1: INSERT INTO truncate_after_ao_vacuum_skip_drop SELECT i as a, i as b FROM generate_series(1, 100) AS i;
+INSERT 100
+0U: SELECT segno, tupcount > 0, state FROM gp_toolkit.__gp_aoseg_name('truncate_after_ao_vacuum_skip_drop');
+segno|?column?|state
+-----+--------+-----
+1    |t       |1    
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -61,6 +61,7 @@ test: uao/vacuum_self_serializable3_row
 test: uao/vacuum_while_insert_row
 test: uao/vacuum_while_vacuum_row
 test: uao/vacuum_cleanup_row
+test: reorganize_after_ao_vacuum_skip_drop
 
 # Tests on Append-Optimized tables (column-oriented).
 test: uao/alter_while_vacuum_column uao/alter_while_vacuum2_column

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -61,7 +61,7 @@ test: uao/vacuum_self_serializable3_row
 test: uao/vacuum_while_insert_row
 test: uao/vacuum_while_vacuum_row
 test: uao/vacuum_cleanup_row
-test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop
+test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
 
 # Tests on Append-Optimized tables (column-oriented).
 test: uao/alter_while_vacuum_column uao/alter_while_vacuum2_column

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -61,7 +61,7 @@ test: uao/vacuum_self_serializable3_row
 test: uao/vacuum_while_insert_row
 test: uao/vacuum_while_vacuum_row
 test: uao/vacuum_cleanup_row
-test: reorganize_after_ao_vacuum_skip_drop
+test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop
 
 # Tests on Append-Optimized tables (column-oriented).
 test: uao/alter_while_vacuum_column uao/alter_while_vacuum2_column

--- a/src/test/isolation2/sql/mark_all_aoseg_await_drop.sql
+++ b/src/test/isolation2/sql/mark_all_aoseg_await_drop.sql
@@ -1,0 +1,36 @@
+-- Ensure all segfiles crossing vacuum threshold but cannot compact
+-- due to concurrent transaction should be marked in state
+-- AOSEG_STATE_AWAITING_DROP.
+
+CREATE TABLE mark_all_aoseg_await_drop (a int) WITH (appendonly=true);
+
+-- Create 3 aoseg entries
+0: BEGIN;
+1: BEGIN;
+2: BEGIN;
+0: INSERT INTO mark_all_aoseg_await_drop SELECT i FROM generate_series(1, 10)i;
+1: INSERT INTO mark_all_aoseg_await_drop SELECT i FROM generate_series(1, 10)i;
+2: INSERT INTO mark_all_aoseg_await_drop SELECT i FROM generate_series(1, 10)i;
+0: COMMIT;
+1: COMMIT;
+2: COMMIT;
+
+DELETE FROM mark_all_aoseg_await_drop;
+
+-- We should see all 3 aosegs in state 1
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('mark_all_aoseg_await_drop');
+
+-- VACUUM while another session holds lock
+1: BEGIN;
+1: SELECT COUNT(*) FROM mark_all_aoseg_await_drop;
+1: INSERT INTO mark_all_aoseg_await_drop SELECT i FROM generate_series(1, 10)i;
+2: VACUUM mark_all_aoseg_await_drop;
+1: END;
+
+-- We should see segno 2 and 3 in state 2 (AOSEG_STATE_AWAITING_DROP)
+-- and segno 1 and 4 in state 1 (AOSEG_STATE_DEFAULT). Segno 1 is not
+-- marked as state 2 because a concurrent transaction has written to
+-- it and did not commit before the vacuum got to it. The vacuum
+-- correctly skipped segno 1 and continued to cycle through the aoseg
+-- entries.
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('mark_all_aoseg_await_drop');

--- a/src/test/isolation2/sql/reorganize_after_ao_vacuum_skip_drop.sql
+++ b/src/test/isolation2/sql/reorganize_after_ao_vacuum_skip_drop.sql
@@ -1,0 +1,29 @@
+-- Ensure segfiles in AOSEG_STATE_AWAITING_DROP are not leaked in
+-- AppendOnlyHash after doing an AT_SetDistributedBy operation which
+-- rewrites the relation differently than other ALTER operations.
+
+CREATE TABLE reorganize_after_ao_vacuum_skip_drop (a INT, b INT) WITH (appendonly=true);
+INSERT INTO reorganize_after_ao_vacuum_skip_drop SELECT i as a, i as b FROM generate_series(1, 10) AS i;
+
+DELETE FROM reorganize_after_ao_vacuum_skip_drop;
+
+-- We should see all aosegs in state 1
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('reorganize_after_ao_vacuum_skip_drop');
+
+-- VACUUM while another session holds lock
+1: BEGIN;
+1: SELECT COUNT(*) FROM reorganize_after_ao_vacuum_skip_drop;
+2: VACUUM reorganize_after_ao_vacuum_skip_drop;
+1: END;
+
+-- We should see an aoseg in state 2 (AOSEG_STATE_AWAITING_DROP)
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('reorganize_after_ao_vacuum_skip_drop');
+
+-- The AO relation should be rewritten and AppendOnlyHash entry invalidated
+1: ALTER TABLE reorganize_after_ao_vacuum_skip_drop SET WITH (reorganize=true);
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('reorganize_after_ao_vacuum_skip_drop');
+
+-- Check if insert goes into segno 1 instead of segno 2. If it did not
+-- go into segno 1, there was a leak in the AppendOnlyHash entry.
+1: INSERT INTO reorganize_after_ao_vacuum_skip_drop SELECT i as a, i as b FROM generate_series(1, 100) AS i;
+0U: SELECT segno, tupcount > 0, state FROM gp_toolkit.__gp_aoseg_name('reorganize_after_ao_vacuum_skip_drop');

--- a/src/test/isolation2/sql/truncate_after_ao_vacuum_skip_drop.sql
+++ b/src/test/isolation2/sql/truncate_after_ao_vacuum_skip_drop.sql
@@ -1,0 +1,28 @@
+-- Ensure segfiles in AOSEG_STATE_AWAITING_DROP are not leaked in
+-- AppendOnlyHash after doing a TRUNCATE.
+
+CREATE TABLE truncate_after_ao_vacuum_skip_drop (a INT, b INT) WITH (appendonly=true);
+INSERT INTO truncate_after_ao_vacuum_skip_drop SELECT i as a, i as b FROM generate_series(1, 10) AS i;
+
+DELETE FROM truncate_after_ao_vacuum_skip_drop;
+
+-- We should see all aosegs in state 1
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('truncate_after_ao_vacuum_skip_drop');
+
+-- VACUUM while another session holds lock
+1: BEGIN;
+1: SELECT COUNT(*) FROM truncate_after_ao_vacuum_skip_drop;
+2: VACUUM truncate_after_ao_vacuum_skip_drop;
+1: END;
+
+-- We should see an aoseg in state 2 (AOSEG_STATE_AWAITING_DROP)
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('truncate_after_ao_vacuum_skip_drop');
+
+-- The AO relation should be rewritten and AppendOnlyHash entry invalidated
+1: TRUNCATE truncate_after_ao_vacuum_skip_drop;
+0U: SELECT segno, state FROM gp_toolkit.__gp_aoseg_name('truncate_after_ao_vacuum_skip_drop');
+
+-- Check if insert goes into segno 1 instead of segno 2. If it did not
+-- go into segno 1, there was a leak in the AppendOnlyHash entry.
+1: INSERT INTO truncate_after_ao_vacuum_skip_drop SELECT i as a, i as b FROM generate_series(1, 100) AS i;
+0U: SELECT segno, tupcount > 0, state FROM gp_toolkit.__gp_aoseg_name('truncate_after_ao_vacuum_skip_drop');


### PR DESCRIPTION
There were a couple issues related to the AppendOnlyHash cache and its representation in pg_aoseg auxiliary tables.  All are related to AOSEG_STATE_AWAITING_DROP state.
```
Invalidate AppendOnlyHash cache entry for AT_SetDistributedBy cases

ALTER TABLE commands that are tagged as AT_SetDistributedBy require a
gather motion and does its own variation of creating a temporary table
for CTAS (basically bypassing the usual ATRewriteTable which actually
does do AppendOnlyHash cache entry invalidation). Without the
AppendOnlyHash cache entry invalidation, the entry could have
invisible leaks in its AOSegfileStatus array that will be stuck in
state AOSEG_STATE_AWAITING_DROP. These leaks will persist until the
user evicts the cache entry by not using the table to allow another AO
table to cache itself in that slot or by restarting the database. We
fix this issue by invalidating the cache entry at the end of
AT_SetDistributedBy ALTER TABLE cases.
```

```
Invalidate AppendOnlyHash cache entry at end of TRUNCATE

TRUNCATE will rewrite the relation by creating a temporary table and
swapping it with the real relation. For AO, this includes the
auxiliary tables which is concerning for the AO relation's pg_aoseg
table which holds information that a AO segment file is available for
write or waiting to be compacted/dropped. Since we do not currently
invalidate the AppendOnlyHash cache entry, the entry could have
invisible leaks in its AOSegfileStatus array that will be stuck in
state AOSEG_STATE_AWAITING_DROP. These leaks will persist until the
user evicts the cache entry by not using the table to allow another AO
table to cache itself in that slot or by restarting the database. We
fix this issue by invalidating the cache entry at the end of TRUNCATE
on AO relations.
```

```
Check all AO segment files during concurrent AO VACUUM

We currently exit VACUUM early when there is a concurrent operation on
an AO relation. Instead of exiting early, go through the rest of the
AO segment files to see if they have crossed threshold for compaction.
```