### PR TITLE
Remove unused statistics warning and rel duplication from join ordering codepath

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -672,7 +672,6 @@ _outIndexOptInfo(StringInfo str, IndexOptInfo *node)
 	WRITE_BOOL_FIELD(hypothetical);
 
 	WRITE_BOOL_FIELD(amoptionalkey);
-	WRITE_BOOL_FIELD(cdb_default_stats_used);
 }
 
 /*****************************************************************************

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2338,7 +2338,6 @@ _outIndexOptInfo(StringInfo str, IndexOptInfo *node)
 	WRITE_BOOL_FIELD(hypothetical);
 
 	WRITE_BOOL_FIELD(amoptionalkey);
-	WRITE_BOOL_FIELD(cdb_default_stats_used);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1444,7 +1444,6 @@ standard_join_search(PlannerInfo *root, int levels_needed, List *initial_rels, b
 		ListCell   *lc;
 		ListCell   *prev;
 		ListCell   *next;
-		List	   *backup;
 
 		/*
 		 * Determine all possible pairs of relations to be joined at this
@@ -1456,7 +1455,6 @@ standard_join_search(PlannerInfo *root, int levels_needed, List *initial_rels, b
 		/*
 		 * Do cleanup work on each just-processed rel.
 		 */
-		backup = list_copy(root->join_rel_level[lev]);
 		prev = NULL;
 		for (lc = list_head(root->join_rel_level[lev]);
 			 lc != NULL;

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -113,27 +113,6 @@ make_one_rel(PlannerInfo *root, List *joinlist)
 	set_base_rel_pathlists(root);
 
 	/*
-	 * CDB: If join, warn of any tables that need ANALYZE.
-	 */
-	if (has_multiple_baserels(root))
-	{
-		Index		rti;
-		RelOptInfo *brel;
-		RangeTblEntry *brte;
-
-		for (rti = 1; rti < root->simple_rel_array_size; rti++)
-		{
-			brel = root->simple_rel_array[rti];
-			if (brel &&
-				brel->cdb_default_stats_used)
-			{
-				brte = rt_fetch(rti, root->parse->rtable);
-				cdb_default_stats_warning_for_table(brte->relid);
-			}
-		}
-	}
-
-	/*
 	 * Generate access paths for the entire join tree.
 	 */
 	rel = make_rel_from_joinlist(root, joinlist);

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -118,8 +118,7 @@ make_one_rel(PlannerInfo *root, List *joinlist)
 	rel = make_rel_from_joinlist(root, joinlist);
 
 	/* CDB: No path might be found if user set enable_xxx = off */
-	if (!rel ||
-		!rel->cheapest_total_path)
+	if (!rel || !rel->cheapest_total_path)
 		cdb_no_path_for_query();	/* raise error - no return */
 
 	/*
@@ -1335,8 +1334,7 @@ make_rel_from_joinlist(PlannerInfo *root, List *joinlist)
 		}
 
 		/* CDB: Fail if no path could be built due to set enable_xxx = off. */
-		if (!thisrel ||
-			!thisrel->cheapest_total_path)
+		if (!thisrel || !thisrel->cheapest_total_path)
 			return NULL;
 
 		initial_rels = lappend(initial_rels, thisrel);
@@ -1456,9 +1454,7 @@ standard_join_search(PlannerInfo *root, int levels_needed, List *initial_rels, b
 		 * Do cleanup work on each just-processed rel.
 		 */
 		prev = NULL;
-		for (lc = list_head(root->join_rel_level[lev]);
-			 lc != NULL;
-			 lc = next)
+		for (lc = list_head(root->join_rel_level[lev]); lc != NULL; lc = next)
 		{
 			next = lnext(lc);
 			rel = (RelOptInfo *) lfirst(lc);

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -550,7 +550,6 @@ typedef struct RelOptInfo
 	double		tuples;
     struct GpPolicy   *cdbpolicy;      /* distribution of stored tuples */
 	char		relstorage;		/* from pg_class.relstorage */
-    bool        cdb_default_stats_used; /* true if ANALYZE needed */
 	struct Plan *subplan;		/* if subquery */
 	List	   *subrtable;		/* if subquery */
 	List	   *subrowmark;		/* if subquery */
@@ -637,7 +636,6 @@ typedef struct IndexOptInfo
 	bool		amsearchnulls;	/* can AM search for NULL/NOT NULL entries? */
 	bool		amhasgettuple;	/* does AM have amgettuple interface? */
 	bool		amhasgetbitmap; /* does AM have amgetbitmap interface? */
-    bool        cdb_default_stats_used; /* true if ANALYZE needed */
     int         num_leading_eq; /* CDB: always 0, except amcostestimate proc may
                                  * set it briefly; it is transferred forthwith
                                  * to the IndexPath (q.v.), then reset. Kludge.


### PR DESCRIPTION
Commit e040935 moved to using default estimates rather than interrogating the QEs for relations which lack statistics. As an effect of this, the cdb_default_stats_used member was hardcoded to false and the warnings for missing statistics did never fire.

Rather than resurrecting the warnings (they have been turned off for years by now anyways), this removes the code that attempts to figure out if the warnings at all apply since it seems quite expensive to run that in the hot path of every join query being planned.

Also remove a superfluous copy of the rel list and perform some cosmetic cleanup of the code while in there. It's recommended to review this on a per-commit basis.