### PR TITLE
Remove creating pg_xlog/archive_status directory in utilities.

### DIFF
--- a/gpAux/gpdemo/gpsegwalrep.py
+++ b/gpAux/gpdemo/gpsegwalrep.py
@@ -99,7 +99,7 @@ class InitMirrors():
         # 1. create base backup
         commands.append("rm -rf %s" % mirror_dir);
         commands.append("pg_basebackup -x -R -c fast -E ./pg_log -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D %s -h %s -p %d" % (mirror_dir, self.hostname, primary_port))
-        commands.append("mkdir %s/pg_log; mkdir %s/pg_xlog/archive_status" % (mirror_dir, mirror_dir))
+        commands.append("mkdir %s/pg_log;" % (mirror_dir))
 
         if self.init:
             # 2. update catalog

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -22,7 +22,7 @@ from gppylib.commands.unix import check_pid_on_remotehost, Scp
 logger = gplog.get_default_logger()
 
 gDatabaseDirectories = [
-    # this list and the gDatabaseSubDirectories occur combined inside initdb.c
+    # this list occur inside initdb.c
     "global",
     "pg_log",
     "pg_xlog",
@@ -37,12 +37,6 @@ gDatabaseDirectories = [
     "base",
     "pg_tblspc",
     "pg_stat_tmp"
-]
-gDatabaseSubDirectories = [
-    "pg_xlog/archive_status",
-    "pg_multixact/members",
-    "pg_multixact/offsets",
-    "base/1"
 ]
 
 #

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -162,13 +162,6 @@ class ConfExpSegCmd(Command):
                     logger.info("create gp_dbid file for segment")
                     writeGpDbidFile(self.datadir, self.dbid, logger=gplog.get_logger_if_verbose())
 
-                    # Create pg_xlog/archive_status for new segment in case it dosen't exist.
-                    try:
-                        self.makeOrUpdatePathAsNeeded(os.path.join(self.datadir, "pg_xlog/archive_status"))
-                    except Exception, e:
-                        self.set_results(CommandResult(1,'',e,True,False))
-                        raise
-
                     logger.info("Updating %s/postgresql.conf" % self.datadir)
                     modifyPostgresqlConfCmd = ModifyPostgresqlConfSetting('Updating %s/postgresql.conf' % self.datadir,
                                                                           self.datadir + '/postgresql.conf',

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -139,7 +139,7 @@ PROCESS_QE () {
     if [ x"" != x"$COPY_FROM_PRIMARY_HOSTADDRESS" ]; then
         LOG_MSG "[INFO]:-Running pg_basebackup to init mirror on ${GP_HOSTADDRESS} using primary on ${COPY_FROM_PRIMARY_HOSTADDRESS} ..." 1
         RUN_COMMAND_REMOTE ${COPY_FROM_PRIMARY_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; echo 'host  replication ${GP_USER} samenet trust' >> ${COPY_FROM_PRIMARY_DIR}/pg_hba.conf; pg_ctl -D ${COPY_FROM_PRIMARY_DIR} reload"
-        RUN_COMMAND_REMOTE ${GP_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; rm -rf ${GP_DIR}; ${GPHOME}/bin/pg_basebackup -x -R -c fast -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D ${GP_DIR} -h ${COPY_FROM_PRIMARY_HOSTADDRESS} -p ${COPY_FROM_PRIMARY_PORT}; mkdir ${GP_DIR}/pg_xlog/archive_status"
+        RUN_COMMAND_REMOTE ${GP_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; rm -rf ${GP_DIR}; ${GPHOME}/bin/pg_basebackup -x -R -c fast -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D ${GP_DIR} -h ${COPY_FROM_PRIMARY_HOSTADDRESS} -p ${COPY_FROM_PRIMARY_PORT};"
         REGISTER_MIRROR
         START_QE "-w"
         RETVAL=$?


### PR DESCRIPTION
Starting with this 8.4 commit 1d577f5e49400465bd8cc3f91b67d03a551528c3, backend
checks for the existence of the directory and if not present creates the
same. So, we can avoid creating the same in utilities.