### PR TITLE
Implement resource group bypass mode (5X)

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -249,6 +249,9 @@ static ResGroupProcData *self = &__self;
 /* If we are waiting on a group, this points to the associated group */
 static ResGroupData *groupAwaited = NULL;
 
+/* Is the transaction in bypass mode? */
+static bool bypassed = false;
+
 /* static functions */
 
 static bool groupApplyMemCaps(ResGroupData *group);
@@ -910,6 +913,12 @@ ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx)
 	LWLockRelease(ResGroupLock);
 }
 
+bool
+ResGroupIsAssigned(void)
+{
+	return selfIsAssigned();
+}
+
 int32
 ResGroupGetVmemLimitChunks(void)
 {
@@ -1087,7 +1096,13 @@ ResGroupReserveMemory(int32 memoryChunks, int32 overuseChunks, bool *waiverUsed)
 	 */
 	self->memUsage += memoryChunks;
 	if (!selfIsAssigned())
+	{
+		if (bypassed && self->memUsage > 10)
+			LOG_RESGROUP_DEBUG(LOG,
+							   "too many memory allocated in resource group bypass mode: %d",
+							   self->memUsage);
 		return true;
+	}
 
 	Assert(slotIsInUse(slot));
 	Assert(group->memUsage >= 0);
@@ -1152,6 +1167,10 @@ ResourceGroupGetQueryMemoryLimit(void)
 {
 	ResGroupSlotData	*slot = self->slot;
 	int64				memSpill;
+
+	/* In bypass mode we assume memory usage should be low */
+	if (bypassed)
+		return 0;
 
 	Assert(selfIsAssigned());
 
@@ -2346,7 +2365,8 @@ AssignResGroupOnMaster(void)
 	 * if query should be bypassed, do not assign a
 	 * resource group, leave self unassigned
 	 */
-	if (shouldBypassQuery(debug_query_string))
+	bypassed = shouldBypassQuery(debug_query_string);
+	if (bypassed)
 	{
 		ResGroupCaps	caps;
 
@@ -2482,6 +2502,12 @@ SwitchResGroupOnSegment(const char *buf, int len)
 
 	if (newGroupId == InvalidOid)
 	{
+		/*
+		 * if query should be bypassed, do not assign a
+		 * resource group, leave self unassigned
+		 */
+		bypassed = gp_resource_group_bypass;
+
 		UnassignResGroup();
 		return;
 	}
@@ -3253,6 +3279,9 @@ shouldBypassQuery(const char *query_string)
 	List *parsetree_list; 
 	ListCell *parsetree_item;
 	Node *parsetree;
+
+	if (gp_resource_group_bypass)
+		return true;
 
 	if (!query_string)
 		return false;

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -80,6 +80,7 @@ extern int						memory_spill_ratio;
 extern int gp_resource_group_cpu_priority;
 extern double gp_resource_group_cpu_limit;
 extern double gp_resource_group_memory_limit;
+extern bool gp_resource_group_bypass;
 
 /*
  * Non-GUC global variables.
@@ -144,6 +145,8 @@ extern bool ShouldUnassignResGroup(void);
 extern void AssignResGroupOnMaster(void);
 extern void UnassignResGroup(void);
 extern void SwitchResGroupOnSegment(const char *buf, int len);
+
+extern bool ResGroupIsAssigned(void);
 
 /* Retrieve statistic information of type from resource group */
 extern Datum ResGroupGetStat(Oid groupId, ResGroupStatType type);

--- a/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
@@ -433,6 +433,69 @@ DROP
 DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
+-- test10: gp_resource_group_bypass
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=0, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+61: SET ROLE role_concurrency_test;
+SET
+61: SET gp_resource_group_bypass to on;
+SET
+61: SHOW gp_resource_group_bypass;
+gp_resource_group_bypass
+------------------------
+on                      
+(1 row)
+61: CREATE TABLE table_concurrency_test (c1 int);
+CREATE
+61: INSERT INTO  table_concurrency_test SELECT generate_series(1,100);
+INSERT 100
+61: SELECT count(*) FROM table_concurrency_test;
+count
+-----
+100  
+(1 row)
+61: DROP TABLE table_concurrency_test;
+DROP
+61: SET gp_resource_group_bypass to off;
+SET
+61: SHOW gp_resource_group_bypass;
+gp_resource_group_bypass
+------------------------
+off                     
+(1 row)
+61q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- test11: gp_resource_group_bypass is not allowed inside a transaction block
+DROP FUNCTION IF EXISTS func_resgroup_bypass_test(int);
+DROP
+
+CREATE FUNCTION func_resgroup_bypass_test(c1 int) RETURNS INT AS $$ SET gp_resource_group_bypass TO ON; -- inside a function SELECT 1 $$ LANGUAGE SQL;
+CREATE
+BEGIN;
+BEGIN
+SET gp_resource_group_bypass to on;
+ERROR:  SET gp_resource_group_bypass cannot run inside a transaction block (guc_gp.c:5891)
+ABORT;
+ABORT
+SELECT func_resgroup_bypass_test(1);
+ERROR:  SET gp_resource_group_bypass cannot run inside a transaction block (guc_gp.c:5891)
+CONTEXT:  SQL function "func_resgroup_bypass_test" statement 1
+DROP FUNCTION func_resgroup_bypass_test(int);
+DROP
+
 --
 -- Test cursors, pl/* functions only take one slot.
 --

--- a/src/test/isolation2/init_file_resgroup
+++ b/src/test/isolation2/init_file_resgroup
@@ -17,4 +17,7 @@ s/(seg\d+ slice\d+ \d+.\d+.\d+.\d+:\d+ pid=\d+)/(SEG SLICE ADDR:PORT pid=PID)/
 
 m/^ERROR:  Role with Oid \d+ was dropped$/
 s/Oid \d+ was/Oid OID was/
+
+m/^ERROR:  SET gp_resource_group_bypass cannot run inside a transaction block.*$/
+s/(?<=guc_gp\.c:)\d+/0/
 -- end_matchsubs

--- a/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
@@ -223,6 +223,40 @@ ALTER RESOURCE GROUP rg_concurrency_test set concurrency 0;
 DROP ROLE role_concurrency_test;
 DROP RESOURCE GROUP rg_concurrency_test;
 
+-- test10: gp_resource_group_bypass
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=0, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+61: SET ROLE role_concurrency_test;
+61: SET gp_resource_group_bypass to on;
+61: SHOW gp_resource_group_bypass;
+61: CREATE TABLE table_concurrency_test (c1 int);
+61: INSERT INTO  table_concurrency_test SELECT generate_series(1,100);
+61: SELECT count(*) FROM table_concurrency_test;
+61: DROP TABLE table_concurrency_test;
+61: SET gp_resource_group_bypass to off;
+61: SHOW gp_resource_group_bypass;
+61q:
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
+-- test11: gp_resource_group_bypass is not allowed inside a transaction block
+DROP FUNCTION IF EXISTS func_resgroup_bypass_test(int);
+
+CREATE FUNCTION func_resgroup_bypass_test(c1 int) RETURNS INT AS $$
+	SET gp_resource_group_bypass TO ON; -- inside a function
+	SELECT 1
+$$ LANGUAGE SQL;
+BEGIN;
+SET gp_resource_group_bypass to on;
+ABORT;
+SELECT func_resgroup_bypass_test(1);
+DROP FUNCTION func_resgroup_bypass_test(int);
+
 --
 -- Test cursors, pl/* functions only take one slot.
 --


### PR DESCRIPTION
- Introduce a new GUC gp_resource_group_bypass, when it is on,
  the query in this session will not be limited by resource group