### PR TITLE
ci: gen pipeline will try and guess git details

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -47,14 +47,43 @@ TEMPLATE_ENVIRONMENT = Environment(
 
 # Variables that govern pipeline validation
 RELEASE_VALIDATOR_JOB = ['Release_Candidate']
-JOBS_THAT_ARE_GATES = ['gate_compile_start', 'gate_compile_end', 'gate_icw_start',
-                    'gate_icw_end', 'gate_cs_start', 'gate_cs_end', 'gate_mpp_start',
-                    'gate_mpp_end', 'gate_mm_start', 'gate_mm_end', 'gate_dpm_start',
-                    'gate_dpm_end', 'gate_ud_start', 'gate_ud_end', 'gate_advanced_analytics_start',
-                    'gate_advanced_analytics_end', 'gate_filerep_start', 'gate_filerep_end', 
-                    'gate_release_candidate_start']
+JOBS_THAT_ARE_GATES = ['gate_compile_start', 'gate_compile_end',
+                       'gate_icw_start', 'gate_icw_end',
+                       'gate_cs_start', 'gate_cs_end',
+                       'gate_mpp_start', 'gate_mpp_end',
+                       'gate_mm_start', 'gate_mm_end',
+                       'gate_dpm_start', 'gate_dpm_end',
+                       'gate_ud_start', 'gate_ud_end',
+                       'gate_advanced_analytics_start', 'gate_advanced_analytics_end',
+                       'gate_filerep_start', 'gate_filerep_end',
+                       'gate_release_candidate_start']
 JOBS_THAT_ARE_PAUSED = ['DPM_backup-restore_netbackup_part1', 'DPM_backup-restore_netbackup_part2', 'DPM_backup-restore_netbackup_part3']
 JOBS_THAT_SHOULD_NOT_BLOCK_RELEASE = ['compile_gpdb_binary_swap_centos6'] + RELEASE_VALIDATOR_JOB + JOBS_THAT_ARE_GATES + JOBS_THAT_ARE_PAUSED
+
+def suggested_git_remote():
+    default_remote = "<https://github.com/<github-user>/gpdb>"
+
+    remote = subprocess.check_output("git ls-remote --get-url", shell=True).rstrip()
+
+    if "greenplum-db/gpdb"  in remote:
+        return default_remote
+
+    if "git@" in remote:
+        git_uri = remote.split('@')[1]
+        hostname, path = git_uri.split(':')
+        return 'https://%s/%s' % (hostname, path)
+
+    return remote
+
+def suggested_git_branch():
+    default_branch = "<branch-name>"
+
+    branch = subprocess.check_output("git rev-parse --abbrev-ref HEAD", shell=True).rstrip()
+
+    if branch == "master" or branch == "5X_STABLE":
+        return default_branch
+    else:
+        return branch
 
 
 def render_template(template_filename, context):
@@ -153,8 +182,8 @@ def how_to_use_generated_pipeline_message():
         msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_5X_STABLE-ci-secrets.yml \\\n'
         msg += '    -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \\\n'
         msg += '    -v bucket-name=gpdb5-concourse-builds-dev \\\n'
-        msg += '    -v gpdb-git-remote=<https://github.com/<github-user>/gpdb> \\\n'
-        msg += '    -v gpdb-git-branch=<branch-name>\n'
+        msg += '    -v gpdb-git-remote=%s \\\n' % suggested_git_remote()
+        msg += '    -v gpdb-git-branch=%s \n' % suggested_git_branch()
 
     return msg
 


### PR DESCRIPTION
The gen pipeline script outputs a suggested command when setting a dev
pipeline.  Currently the git remote and git branch have to be edited
before executing the command.  Since often times the branch has been
created and is tracing remote, it is possible to guess those details.
The case statements attempt to prevent suggesting using the production
branches, and fall back to the same string as before.

Authored-by: Jim Doty <jdoty@pivotal.io>
(cherry picked from commit ea12d3a1863108e63249b23a1126ba58714e129f)