### PR TITLE
Release access share lock in pg_get_partition_def functions

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -8754,7 +8754,7 @@ pg_get_partition_template_def_worker(Oid relid, int prettyFlags,
 		templatelevel++;
 	} /* end while pn */
 
-	heap_close(rel, NoLock);
+	heap_close(rel, AccessShareLock);
 
 	return sid1.data;
 } /* end pg_get_partition_template_def_worker */
@@ -8787,7 +8787,7 @@ pg_get_partition_def_worker(Oid relid, int prettyFlags, int bLeafTablename)
 
 	get_partition_recursive(pn, &headc, &bodyc, &leveldone, bLeafTablename);
 
-	heap_close(rel, NoLock);
+	heap_close(rel, AccessShareLock);
 
 	if (strlen(body.data))
 		appendStringInfo(&head, " %s", body.data);


### PR DESCRIPTION
The pg_get_partition_template_def and pg_get_partition_def functions
take accesss share locks, but do not release them until the end of the
transaction. If a transaction is long-running, this can conflict with
other user operations. Is it not necessary to hold the lock indefinitely
as the lock is only needed for the duration of the function call.

This will be backported to gpdb5.

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>