### PR TITLE
Fix schema in rangefuncs_cdb ICG test

### DIFF
--- a/src/test/regress/sql/rangefuncs_cdb.sql
+++ b/src/test/regress/sql/rangefuncs_cdb.sql
@@ -1,6 +1,6 @@
 SELECT name, setting FROM pg_settings WHERE name LIKE 'enable%';
 -- start_ignore
-create schema rangefuns_cdb;
+create schema rangefuncs_cdb;
 set search_path to rangefuncs_cdb, public;
 -- end_ignore
 


### PR DESCRIPTION
The schema is named differently from the one being used in the
search_path so all the tables, views, functions, and etc. were
incorrectly being created in the public schema.