### PR TITLE
Do not automatically create an array type for child partitions

### DIFF
--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -179,7 +179,8 @@ _bitmap_create_lov_heapandindex(Relation rel,
 								 false, 0,
 								 ONCOMMIT_NOOP, NULL /* GP Policy */,
 								 (Datum)0, false, true,
-								 /* valid_opts */ true);
+								 /* valid_opts */ true,
+								 /* is_part_child */ false);
 	*lovHeapOid = heapid;
 
 	/*

--- a/src/backend/bootstrap/bootparse.y
+++ b/src/backend/bootstrap/bootparse.y
@@ -267,7 +267,8 @@ Boot_CreateStmt:
 													  (Datum) 0,
 													  false,
 													  true,
-													  /* valid_opts */ false);
+													  /* valid_opts */ false,
+													  /* is_part_child */ false);
 						elog(DEBUG4, "relation created with oid %u", id);
 					}
 					do_end();

--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -148,7 +148,8 @@ CreateAOAuxiliaryTable(
 											     (Datum) 0,
 												 /* use_user_acl */ false,
 											     true,
-												 /* valid_opts */ false);
+												 /* valid_opts */ false,
+												 /* is_part_child */ false);
 
 	/* Make this table visible, else index creation will fail */
 	CommandCounterIncrement();

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -261,7 +261,8 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid, Datum reloptio
 										   reloptions,
 										   false,
 										   true,
-										   /* valid_opts */ false);
+										   /* valid_opts */ false,
+										   /* is_part_child */ false);
 	Assert(toast_relid != InvalidOid);
 
 	/* make the toast relation visible, else heap_open will fail */

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -733,7 +733,8 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace,
 										  reloptions,
 										  false,
 										  /* allowSystemTableModsDDL */ true,
-										  /* valid_opts */ true);
+										  /* valid_opts */ true,
+										  /* is_part_child */ false);
 	Assert(OIDNewHeap != InvalidOid);
 
 	ReleaseSysCache(tuple);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -812,7 +812,8 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId, char relstorage, boo
                                           reloptions,
 										  true,
 										  allowSystemTableModsDDL,
-										  valid_opts);
+										  valid_opts,
+										  stmt->is_part_child);
 
 	/*
 	 * Give a warning if you use OIDS=TRUE on user tables. We do this after calling

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4046,7 +4046,8 @@ OpenIntoRel(QueryDesc *queryDesc)
 											  reloptions,
 											  true,
 											  allowSystemTableModsDDL,
-											  /* valid_opts */ !validate_reloptions);
+											  /* valid_opts */ !validate_reloptions,
+											  /* is_part_child */ false);
 	Assert(intoRelationId != InvalidOid);
 
 	FreeTupleDesc(tupdesc);

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -83,7 +83,8 @@ extern Oid heap_create_with_catalog(const char *relname,
 						 Datum reloptions,
 						 bool use_user_acl,
 						 bool allow_system_table_mods,
-						 bool valid_opts);
+						 bool valid_opts,
+						 bool is_part_child);
 
 extern void heap_drop_with_catalog(Oid relid);
 

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -7715,6 +7715,21 @@ NOTICE:  exchanged partition "other_log_ids" of relation "test_split_part" with 
 NOTICE:  dropped partition "other_log_ids" for relation "test_split_part"
 NOTICE:  CREATE TABLE will create partition "test_split_part_1_prt_New" for table "test_split_part"
 NOTICE:  CREATE TABLE will create partition "test_split_part_1_prt_other_log_ids" for table "test_split_part"
+-- Only the root partition should have automatically created an array type
+select typname, typtype, typcategory from pg_type where typname like '%test_split_part%' and typcategory = 'A';
+     typname      | typtype | typcategory 
+------------------+---------+-------------
+ _test_split_part | b       | A
+(1 row)
+
+select array_agg(test_split_part) from test_split_part where log_id = 500;
+   array_agg    
+----------------
+ {"(500,{10})"}
+(1 row)
+
+select array_agg(test_split_part_1_prt_other_log_ids) from test_split_part_1_prt_other_log_ids where log_id = 500;
+ERROR:  could not find array type for data type test_split_part_1_prt_other_log_ids
 -- Test that pg_get_partition_def() correctly dumps the renamed names for
 -- partitions. Originally reported in MPP-7232
 create table mpp7232a (a int, b int) distributed by (a) partition by range (b) (start (1) end (3) every (1));

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -7709,6 +7709,21 @@ NOTICE:  exchanged partition "other_log_ids" of relation "test_split_part" with 
 NOTICE:  dropped partition "other_log_ids" for relation "test_split_part"
 NOTICE:  CREATE TABLE will create partition "test_split_part_1_prt_New" for table "test_split_part"
 NOTICE:  CREATE TABLE will create partition "test_split_part_1_prt_other_log_ids" for table "test_split_part"
+-- Only the root partition should have automatically created an array type
+select typname, typtype, typcategory from pg_type where typname like '%test_split_part%' and typcategory = 'A';
+     typname      | typtype | typcategory 
+------------------+---------+-------------
+ _test_split_part | b       | A
+(1 row)
+
+select array_agg(test_split_part) from test_split_part where log_id = 500;
+   array_agg    
+----------------
+ {"(500,{10})"}
+(1 row)
+
+select array_agg(test_split_part_1_prt_other_log_ids) from test_split_part_1_prt_other_log_ids where log_id = 500;
+ERROR:  could not find array type for data type test_split_part_1_prt_other_log_ids
 -- Test that pg_get_partition_def() correctly dumps the renamed names for
 -- partitions. Originally reported in MPP-7232
 create table mpp7232a (a int, b int) distributed by (a) partition by range (b) (start (1) end (3) every (1));

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3713,6 +3713,11 @@ insert into test_split_part (log_id , f_array) select id, '{10}' from generate_s
 
 ALTER TABLE test_split_part SPLIT DEFAULT PARTITION START (201) INCLUSIVE END (301) EXCLUSIVE INTO (PARTITION "New", DEFAULT PARTITION);
 
+-- Only the root partition should have automatically created an array type
+select typname, typtype, typcategory from pg_type where typname like '%test_split_part%' and typcategory = 'A';
+select array_agg(test_split_part) from test_split_part where log_id = 500;
+select array_agg(test_split_part_1_prt_other_log_ids) from test_split_part_1_prt_other_log_ids where log_id = 500;
+
 -- Test that pg_get_partition_def() correctly dumps the renamed names for
 -- partitions. Originally reported in MPP-7232
 create table mpp7232a (a int, b int) distributed by (a) partition by range (b) (start (1) end (3) every (1));


### PR DESCRIPTION
As part of the Postgres 8.3 merge, all heap tables now automatically
create an array type. The array type will usually be created with
typname '\_<heap_name>' since the automatically created composite type
already takes the typname '<heap_name>' first. If typname
'\_<heap_name>' is taken, the logic will continue to prepend
underscores until no collision (truncating the end if typname gets
past NAMEDATALEN of 64). This might be an oversight in upstream
Postgres since certain scenarios involving creating a large number of
heap tables with similar names could result in a lot of typname
collisions until no heap tables with similar names can be
created. This is very noticable in Greenplum heap partition tables
because Greenplum has logic to automatically name child partitions
with similar names instead of having the user name each child
partition.

To prevent typname collision failures when creating a heap partition
table with a large number of child partitions, we will now stop
automatically creating the array type for child partitions.

References:
https://www.postgresql.org/message-id/flat/20070302234016.GF3665%40fetter.org
https://github.com/postgres/postgres/commit/bc8036fc666a8f846b1d4b2f935af7edd90eb5aa

This will also be backported to 5X_STABLE.