### PR TITLE
Why set gp_vmem_protect_limit differently for darwin ?

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1192,11 +1192,6 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 		hints.ai_family = AF_INET;
 #endif
 
-#ifdef __darwin__
-	hints.ai_family = AF_INET;	/* Due to a bug in OSX Leopard, disable IPv6
-								 * for UDP interconnect on all OSX platforms */
-#endif
-
 	fun = "getaddrinfo";
 	s = getaddrinfo(BackendListenAddress, service, &hints, &addrs);
 	if (s != 0)

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -150,11 +150,7 @@ bool	pljava_classpath_insecure = false;
 
 
 /* Memory protection GUCs*/
-#ifdef __darwin__
-int gp_vmem_protect_limit = 0; 
-#else
 int gp_vmem_protect_limit = 8192;
-#endif
 int gp_vmem_protect_gang_cache_limit = 500;
 
 /*

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4002,12 +4002,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			NULL,
 		},
 		&gp_vmem_protect_limit,
-#ifdef __darwin__
-		0,
-#else
-		8192,
-#endif
-		0, INT_MAX / 2,
+		8192, 0, INT_MAX / 2,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
Not sure why setting of guc gp_vmem_protect_limit has specific value for darwin. This causes segment to not come-up at all if postgresql.conf file is empty only on mac but on ubuntu its fine.