### PR TITLE
copy.c: dispatch missing AO segno map for not-partitioned tables

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1932,19 +1932,22 @@ CopyDispatchOnSegment(CopyState cstate, const CopyStmt *stmt)
 	all_relids = list_make1_oid(RelationGetRelid(cstate->rel));
 
 	/* add in AO segno map for dispatch */
-	if (dispatchStmt->is_from && rel_is_partitioned(RelationGetRelid(cstate->rel)))
+	if (dispatchStmt->is_from)
 	{
-		if (gp_enable_segment_copy_checking &&
-			!partition_policies_equal(cstate->rel->rd_cdbpolicy, RelationBuildPartitionDesc(cstate->rel, false)))
+		if (rel_is_partitioned(RelationGetRelid(cstate->rel)))
 		{
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table"),
-					 errhint("\"SET gp_enable_segment_copy_checking=off\" can be used to disable distribution key checking.")));
-		}
-		PartitionNode *pn = RelationBuildPartitionDesc(cstate->rel, false);
+			if (gp_enable_segment_copy_checking &&
+				!partition_policies_equal(cstate->rel->rd_cdbpolicy, RelationBuildPartitionDesc(cstate->rel, false)))
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("COPY FROM ON SEGMENT doesn't support checking distribution key restriction when the distribution policy of the partition table is different from the main table"),
+						 errhint("\"SET gp_enable_segment_copy_checking=off\" can be used to disable distribution key checking.")));
+			}
+			PartitionNode *pn = RelationBuildPartitionDesc(cstate->rel, false);
 
-		all_relids = list_concat(all_relids, all_partition_relids(pn));
+			all_relids = list_concat(all_relids, all_partition_relids(pn));
+		}
 
 		dispatchStmt->ao_segnos = assignPerRelSegno(all_relids);
 	}

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -293,7 +293,7 @@ COPY copy_regression_text3 from stdin with delimiter '|';
 an embedded linefeed sequence\nin column a|7|c text data|d text data|e text data
 \.
 
-SELECT * FROM copy_regression_text3 ORDER BY b;
+SELECT * FROM copy_regression_text3 ORDER BY b,a;
 
 DROP TABLE copy_regression_text1;
 DROP TABLE copy_regression_text2;
@@ -1168,3 +1168,7 @@ DROP TABLE ext_dec17;
 COPY sales TO PROGRAM 'cat > /dev/null' IGNORE EXTERNAL PARTITIONS;
 COPY sales TO PROGRAM 'printf <SEGID> && cat > /dev/null' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 DROP TABLE sales;
+CREATE TABLE ao_copy(c int) WITH (appendonly=true);
+COPY ao_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+COPY ao_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+DROP TABLE ao_copy;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -253,7 +253,7 @@ COPY copy_regression_text3 from stdin with delimiter '|';
 -- this, but let's test it.)
 COPY copy_regression_text3 from stdin with delimiter '|';
 COPY copy_regression_text3 from stdin with delimiter '|';
-SELECT * FROM copy_regression_text3 ORDER BY b;
+SELECT * FROM copy_regression_text3 ORDER BY b,a;
                  a                  | b |      c      |      d      |      e       
 ------------------------------------+---+-------------+-------------+--------------
  the at sign: @                     | 1 | c text data | d text data | e text data 
@@ -262,11 +262,11 @@ SELECT * FROM copy_regression_text3 ORDER BY b;
  a single backslash \ in col a      | 4 | c text data | d text data | e text data
  c:\\file\data\neew\path            | 5 | c text data | d text data | e text data
  the at sign: @                     | 6 | c text data | d text data | e text data
- an embedded linefeed sequence     +| 7 | c text data | d text data | e text data
- in column a                        |   |             |             | 
  an embedded linefeed              +| 7 | c text data | d text data | e text data
  and another one                   +|   |             |             | 
   in column a                       |   |             |             | 
+ an embedded linefeed sequence     +| 7 | c text data | d text data | e text data
+ in column a                        |   |             |             | 
  a single backslash \ in col a      | 8 | c text data | d text data | e text data
 (9 rows)
 
@@ -1352,3 +1352,7 @@ NOTICE:  COPY ignores external partition(s)
 COPY sales TO PROGRAM 'printf <SEGID> && cat > /dev/null' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 NOTICE:  COPY ignores external partition(s)
 DROP TABLE sales;
+CREATE TABLE ao_copy(c int) WITH (appendonly=true);
+COPY ao_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+COPY ao_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+DROP TABLE ao_copy;


### PR DESCRIPTION
The map was missed by mistake, all AO loading actions need it.