### PR TITLE
Fix psql \db command for Greenplum 6 servers

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -267,7 +267,7 @@ describeTablespaces(const char *pattern, bool verbose)
 
 	initPQExpBuffer(&buf);
 
-	if (pset.sversion >= 90200)
+	if (pset.sversion >= 90200 || isGPDB6000OrLater())
 		printfPQExpBuffer(&buf,
 						  "SELECT spcname AS \"%s\",\n"
 						  "  pg_catalog.pg_get_userbyid(spcowner) AS \"%s\",\n"


### PR DESCRIPTION
Commit 4483b7d3bc16fd8b78076543f1ae696d267944b7 remove `spclocation` from the tablespace catalog, but the `\db` command in psql wasn't updated to match the corresponding Greenplum version as it was backported prior to when it was introduced in upstream. This will eventually go away as we merge with PostgreSQL, but that's not an excuse for not fixing what is broken.