### PR TITLE
docs - foreign data wrapper catalog and view ref pages

### DIFF
--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -138,6 +138,12 @@
 			<topicref href="system_catalogs/catalog_ref-tables.xml#topic1"/>
 			<topicref href="system_catalogs/catalog_ref-views.xml#topic1"/>
 			<topicref href="system_catalogs/catalog_ref-html.xml#topic1">
+				<topicref href="system_catalogs/foreign_data_wrapper_options.xml"/>
+				<topicref href="system_catalogs/foreign_data_wrappers.xml"/>
+				<topicref href="system_catalogs/foreign_server_options.xml"/>
+				<topicref href="system_catalogs/foreign_servers.xml"/>
+				<topicref href="system_catalogs/foreign_table_options.xml"/>
+				<topicref href="system_catalogs/foreign_tables.xml"/>
 				<topicref href="system_catalogs/gp_configuration_history.xml"/>
 				<topicref href="system_catalogs/gp_distributed_log.xml"/>
 				<topicref href="system_catalogs/gp_distributed_xacts.xml"/>
@@ -177,6 +183,9 @@
 				<topicref href="system_catalogs/pg_enum.xml"/>
 				<topicref href="system_catalogs/pg_extension.xml"/>
 				<topicref href="system_catalogs/pg_exttable.xml"/>
+				<topicref href="system_catalogs/pg_foreign_data_wrapper.xml"/>
+				<topicref href="system_catalogs/pg_foreign_server.xml"/>
+				<topicref href="system_catalogs/pg_foreign_table.xml"/>
 				<topicref href="system_catalogs/pg_index.xml"/>
 				<topicref href="system_catalogs/pg_inherits.xml"/>
 				<topicref href="system_catalogs/pg_language.xml"/>
@@ -218,6 +227,9 @@
 				<topicref href="system_catalogs/pg_type.xml"/>
 				<topicref href="system_catalogs/pg_type_encoding.xml"/>
 				<topicref href="system_catalogs/pg_user_mapping.xml"/>
+				<topicref href="system_catalogs/pg_user_mappings.xml"/>
+				<topicref href="system_catalogs/user_mapping_options.xml"/>
+				<topicref href="system_catalogs/user_mappings.xml"/>
 			</topicref>
 		</topicref>
 		<topicref href="gp_toolkit.ditamap" format="ditamap"/>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-tables.xml
@@ -90,9 +90,15 @@
       <li id="eu150510">
         <xref href="./pg_exttable.xml#topic1" type="topic" format="dita"/>
       </li>
-      <li id="eu150585">pg_foreign_data_wrapper (not supported)</li>
-      <li id="eu150589">pg_foreign_server (not supported)</li>
-      <li id="eu150593">pg_foreign_table (not supported)</li>
+      <li id="eu150585">
+        <xref href="./pg_foreign_data_wrapper.xml#topic1" type="topic" format="dita"/>
+      </li>
+      <li id="eu150589">
+        <xref href="./pg_foreign_server.xml#topic1" type="topic" format="dita"/>
+      </li>
+      <li id="eu150593">
+        <xref href="./pg_foreign_table.xml#topic1" type="topic" format="dita"/>
+      </li>
       <li id="eu149914">
         <xref href="./pg_index.xml#topic1" type="topic" format="dita"/>
       </li>
@@ -171,7 +177,9 @@
       <li id="eu151117">
         <xref href="./pg_type.xml#topic1" type="topic" format="dita"/>
       </li>
-      <li id="eu151122">pg_user_mapping (not supported)</li>
+      <li id="eu151122">
+        <xref href="./pg_user_mapping.xml#topic1" type="topic" format="dita"/>
+      </li>
     </ul>
   </body>
 </topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_data_wrapper_options.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_data_wrapper_options.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fs142834">foreign_data_wrapper_options</title>
+  <body>
+    <p>The <codeph>foreign_data_wrapper_options</codeph> view contains all of the otpions defined for
+      foreign-data wrappers in the current database. Greenplum Database displays only those foreign-data
+       wrappers to which the current user has access (by way of being the owner or having some privilege).</p>
+    <table id="fs142842">
+      <title>foreign_data_wrapper_options</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="73pt"/>
+        <colspec colnum="3" colname="col3" colwidth="101pt"/>
+        <colspec colnum="4" colname="col4" colwidth="145pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_data_wrapper_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign-data wrapper
+              (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_data_wrapper_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign-data wrapper.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>option_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of an option.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>option_value</codeph>
+            </entry>
+            <entry colname="col2">character_data</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Value of the option.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_data_wrappers.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_data_wrappers.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fs142834">foreign_data_wrappers</title>
+  <body>
+    <p>The <codeph>foreign_data_wrappers</codeph> view contains all foreign-data wrappers defined
+      in the current database. Greenplum Database displays only those foreign-data wrappers to
+       which the current user has access (by way of being the owner or having some privilege).</p>
+    <table id="fs142842">
+      <title>foreign_data_wrappers</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="73pt"/>
+        <colspec colnum="3" colname="col3" colwidth="101pt"/>
+        <colspec colnum="4" colname="col4" colwidth="145pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_data_wrapper_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign-data wrapper
+              (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_data_wrapper_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign-data wrapper.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>authorization_identifier</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of the owner of the foreign server.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>library_name</codeph>
+            </entry>
+            <entry colname="col2">character_data</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">File name of the library that implements this foreign-data wrapper.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_data_wrapper_language</codeph>
+            </entry>
+            <entry colname="col2">character_data</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Language used to implement the foreign-data wrapper.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_server_options.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_server_options.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fs142834">foreign_server_options</title>
+  <body>
+    <p>The <codeph>foreign_server_options</codeph> view contains all of the options defined for
+      foreign servers in the current database. Greenplum Database displays only those foreign
+       servers to which the current user has access (by way of being the owner or having some privilege).</p>
+    <table id="fs142842">
+      <title>foreign_server_options</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="73pt"/>
+        <colspec colnum="3" colname="col3" colwidth="101pt"/>
+        <colspec colnum="4" colname="col4" colwidth="145pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign server
+              (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign server.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>option_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of an option.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>option_value</codeph>
+            </entry>
+            <entry colname="col2">character_data</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Value of the option.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_servers.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_servers.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fs142834">foreign_servers</title>
+  <body>
+    <p>The <codeph>foreign_servers</codeph> view contains all foreign servers  defined
+      in the current database. Greenplum Database displays only those foreign servers to
+       which the current user has access (by way of being the owner or having some privilege).</p>
+    <table id="fs142842">
+      <title>foreign_servers</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="73pt"/>
+        <colspec colnum="3" colname="col3" colwidth="101pt"/>
+        <colspec colnum="4" colname="col4" colwidth="145pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign server
+              (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign server.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_data_wrapper_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign-data wrapper
+              used by the foreign server (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_data_wrapper_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign-data wrapper used by the foreign server.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_type</codeph>
+            </entry>
+            <entry colname="col2">character_data</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Foreign server type information, if specified upon creation.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_version</codeph>
+            </entry>
+            <entry colname="col2">character_data</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Foreign server version information, if specified upon creation.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>authorization_identifier</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of the owner of the foreign server.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_table_options.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_table_options.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fs142834">foreign_table_options</title>
+  <body>
+    <p>The <codeph>foreign_table_options</codeph> view contains all of the options defined for
+      foreign tables in the current database. Greenplum Database displays only those foreign
+       tables to which the current user has access (by way of being the owner or having some privilege).</p>
+    <table id="fs142842">
+      <title>foreign_table_options</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="73pt"/>
+        <colspec colnum="3" colname="col3" colwidth="101pt"/>
+        <colspec colnum="4" colname="col4" colwidth="145pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_table_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign table
+              (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_table_schema</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the schema that contains the foreign table.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_table_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign table.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>option_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of an option.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>option_value</codeph>
+            </entry>
+            <entry colname="col2">character_data</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Value of the option.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_tables.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fs142834">foreign_tables</title>
+  <body>
+    <p>The <codeph>foreign_tables</codeph> view contains all foreign tables defined
+      in the current database. Greenplum Database displays only those foreign tables to
+       which the current user has access (by way of being the owner or having some privilege).</p>
+    <table id="fs142842">
+      <title>foreign_tables</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="73pt"/>
+        <colspec colnum="3" colname="col3" colwidth="101pt"/>
+        <colspec colnum="4" colname="col4" colwidth="145pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_table_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign table
+              (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_table_schema</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the schema that contains the foreign table.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_table_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign table.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign server
+              (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign server.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_foreign_data_wrapper.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_foreign_data_wrapper.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic xml:lang="en" id="topic1">
+  <title>pg_foreign_data_wrapper</title>
+  <body>
+    <p>The system catalog table <codeph>pg_foreign_data_wrapper</codeph> stores foreign-data wrapper definitions. A foreign-data wrapper is a mechanism by which you access external data residing on foreign servers.</p>
+    <table id="table_zgy_xfx_tz">
+      <title>pg_catalog.pg_foreign_data_wrapper</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>fdwname</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of the foreign-data wrapper.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>fdwowner</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_authid.oid</entry>
+            <entry colname="col4">Owner of the foreign-data wrapper.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>fdwhandler</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">A reference to a handler function that is responsible for supplying execution routines for the foreign-data wrapper. Zero if no handler is provided.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>fdwvalidator</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">A reference to a validator function that is responsible for checking the validity of the options provided to the foreign-data wrapper. This function also checks the options for foreign servers and user mappings using the foreign-data wrapper. Zero if no validator is provided.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>fdwacl</codeph></entry>
+            <entry colname="col2">aclitem[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Access privileges; see <codeph><xref href="../sql_commands/GRANT.xml#topic1" type="topic" format="dita"/></codeph> and <codeph><xref href="../sql_commands/REVOKE.xml#topic1" type="topic" format="dita"/></codeph> for details.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>fdwoptions</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Foreign-data wrapper-specific options, as "keyword=value" strings.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_foreign_server.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_foreign_server.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic xml:lang="en" id="topic1">
+  <title>pg_foreign_server</title>
+  <body>
+    <p>The system catalog table <codeph>pg_foreign_server</codeph> stores foreign server definitions. A foreign server describes a source of external data, such as a remote server. You access a foreign server via a foreign-data wrapper.</p>
+    <table id="table_zgy_xfx_tz">
+      <title>pg_catalog.pg_foreign_server</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>srvname</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of the foreign server.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>srvowner</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_authid.oid</entry>
+            <entry colname="col4">Owner of the foreign server.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>srvfdw</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_foreign_data_wrapper.oid</entry>
+            <entry colname="col4">OID of the foreign-data wrapper of this foreign server.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>srvtype</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Type of server (optional).</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>srvversion</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Version of the server (optional).</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>srvacl</codeph></entry>
+            <entry colname="col2">aclitem[]</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Access privileges; see <codeph><xref href="../sql_commands/GRANT.xml#topic1" type="topic" format="dita"/></codeph> and <codeph><xref href="../sql_commands/REVOKE.xml#topic1" type="topic" format="dita"/></codeph> for details.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>srvoptions</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Foreign server-specific options, as "keyword=value" strings.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_foreign_table.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_foreign_table.xml
@@ -2,11 +2,11 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic xml:lang="en" id="topic1">
-  <title>pg_user_mapping</title>
+  <title>pg_foreign_table</title>
   <body>
-    <p>The system catalog table <codeph>pg_user_mapping</codeph> stores the mappings from local user to remote user. You must have administrator privileges to view this catalog. Access to this catalog is restricted from normal users, use the <codeph>pg_user_mappings</codeph> view instead.</p>
+    <p>The system catalog table <codeph>pg_foreign_table</codeph> contains auxiliary information about foreign tables. A foreign table is primarily represented by a <codeph>pg_class</codeph> entry, just like a regular table. Its <codeph>pg_foreign_table</codeph> entry contains the information that is pertinent only to foreign tables and not any other kind of relation.</p>
     <table id="table_zgy_xfx_tz">
-      <title>pg_catalog.pg_user_mapping</title>
+      <title>pg_catalog.pg_foreign_table</title>
       <tgroup cols="4">
         <colspec colnum="1" colname="col1" colwidth="131pt"/>
         <colspec colnum="2" colname="col2" colwidth="86pt"/>
@@ -22,22 +22,22 @@
         </thead>
         <tbody>
           <row>
-            <entry colname="col1"><codeph>umuser</codeph></entry>
+            <entry colname="col1"><codeph>ftrelid</codeph></entry>
             <entry colname="col2">oid</entry>
-            <entry colname="col3">pg_authid.oid</entry>
-            <entry colname="col4">OID of the local role being mapped, 0 if the user mapping is public.</entry>
+            <entry colname="col3">pg_class.oid</entry>
+            <entry colname="col4">OID of the <codeph>pg_class</codeph> entry for this foreign table.</entry>
           </row>
           <row>
-            <entry colname="col1"><codeph>umserver</codeph></entry>
+            <entry colname="col1"><codeph>ftserver</codeph></entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_foreign_server.oid</entry>
-            <entry colname="col4">OID of the foreign server that contains this mapping.</entry>
+            <entry colname="col4">OID of the foreign server for this foreign table.</entry>
           </row>
           <row>
-            <entry colname="col1"><codeph>umoptions</codeph></entry>
+            <entry colname="col1"><codeph>ftoptions</codeph></entry>
             <entry colname="col2">text[]</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">User mapping-specific options, as "keyword=value" strings.</entry>
+            <entry colname="col4">Foreign table options, as "keyword=value" strings.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_user_mappings.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_user_mappings.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic xml:lang="en" id="topic1">
+  <title>pg_user_mappings</title>
+  <body>
+    <p>The <codeph>pg_user_mappings</codeph> view provides access to information about user
+       mappings. This view is essentially a public-readble view of the <codeph>pg_user_mapping</codeph>
+       system catalog table that omits the options field if the user does not have access rights
+        to view it.</p>
+    <table id="table_zgy_xfx_tz">
+      <title>pg_user_mappings</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>umid</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_user_mapping.oid</entry>
+            <entry colname="col4">OID of the user mapping.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>srvid</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_foreign_server.oid</entry>
+            <entry colname="col4">OID of the foreign server that contains this mapping.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>srvname</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign server.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>umuser</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_authid.oid</entry>
+            <entry colname="col4">OID of the local role being mapped, 0 if the user mapping is public.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>usename</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the local user to be mapped.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>umoptions</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">User mapping-specific options, as "keyword=value" strings;
+               viewable only if the current user is the owner of the foreign server, else
+                null.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/user_mapping_options.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/user_mapping_options.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fs142834">user_mapping_options</title>
+  <body>
+    <p>The <codeph>user_mapping_options</codeph> view contains all of the options defined for
+      user mappings in the current database. Greenplum Database displays only those user
+       mappings to which the current user has access (by way of being the owner or having some privilege).</p>
+    <table id="fs142842">
+      <title>user_mapping_options</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="73pt"/>
+        <colspec colnum="3" colname="col3" colwidth="101pt"/>
+        <colspec colnum="4" colname="col4" colwidth="145pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>authorization_identifier</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the user being mapped, or <codeph>PUBLIC</codeph> if
+             the mapping is public.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign server used by
+              this mapping (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign server used by this mapping.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>option_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of an option.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>option_value</codeph>
+            </entry>
+            <entry colname="col2">character_data</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Value of the option. This column will display null unless:<ul>
+              <li>The current user is the user being mapped.</li>
+              <li>The mapping is for <codeph>PUBLIC</codeph> and the current user is the foreign server owner.</li>
+              <li>The current user is a superuser.</li></ul>
+              <p>The intent is to protect password information stored as a user mapping option.</p></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/user_mappings.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/user_mappings.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fs142834">user_mappings</title>
+  <body>
+    <p>The <codeph>user_mappings</codeph> view contains all of the user mappgins defined 
+      in the current database. Greenplum Database displays only those user
+       mappings to which the current user has access (by way of being the owner or having some privilege).</p>
+    <table id="fs142842">
+      <title>user_mappings</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="73pt"/>
+        <colspec colnum="3" colname="col3" colwidth="101pt"/>
+        <colspec colnum="4" colname="col4" colwidth="145pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>authorization_identifier</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the user being mapped, or <codeph>PUBLIC</codeph> if
+             the mapping is public.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_catalog</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the database that contains the foreign server used by
+              this mapping (always the current database).</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>foreign_server_name</codeph>
+            </entry>
+            <entry colname="col2">sql_identifier</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Name of the foreign server used by this mapping.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>


### PR DESCRIPTION
add foreign-data wrapper-specific system catalog tables and views (based on postgresql 9.1).

doc review site links (catalog tables):
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/pg_foreign_data_wrapper.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/pg_foreign_server.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/pg_foreign_table.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/pg_user_mapping.html

doc review site links (system views):
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/foreign_data_wrapper_options.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/foreign_data_wrappers.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/foreign_server_options.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/foreign_servers.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/foreign_table_options.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/foreign_tables.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/pg_user_mappings.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/user_mapping_options.html
- http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/system_catalogs/user_mappings.html
