### PR TITLE
Fix invalid reference to relcache entries.

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -1704,7 +1704,6 @@ aocol_compression_ratio_internal(Relation parentrel)
 	StringInfoData sqlstmt;
 	Relation	aosegrel;
 	bool		connected = false;
-	char		aocsseg_relname[NAMEDATALEN];
 	int			proc;	/* 32 bit, only holds number of segments */
 	int			ret;
 	int64		eof = 0;
@@ -1719,11 +1718,9 @@ aocol_compression_ratio_internal(Relation parentrel)
 	Assert(OidIsValid(segrelid));
 
 	/*
-	 * get the name of the aoseg relation
+	 * open the aoseg relation
 	 */
 	aosegrel = heap_open(segrelid, AccessShareLock);
-	snprintf(aocsseg_relname, NAMEDATALEN, "%s", RelationGetRelationName(aosegrel));
-	heap_close(aosegrel, AccessShareLock);
 
 	/*
 	 * assemble our query string.
@@ -1742,6 +1739,8 @@ aocol_compression_ratio_internal(Relation parentrel)
 						 "from %s.%s",
 						 get_namespace_name(RelationGetNamespace(aosegrel)),
 						 RelationGetRelationName(aosegrel));
+
+	heap_close(aosegrel, AccessShareLock);
 
 	PG_TRY();
 	{

--- a/src/backend/cdb/cdbpartindex.c
+++ b/src/backend/cdb/cdbpartindex.c
@@ -424,7 +424,6 @@ getPartitionIndexNode(Oid rootOid,
 static char *
 constructIndexHashKey(Oid partOid,
 					  Oid rootOid,
-					  HeapTuple tup,
 					  AttrNumber *attMap,
 					  IndexInfo *ii,
 					  LogicalIndexType indType)
@@ -569,8 +568,6 @@ recordIndexesOnLeafPart(PartitionIndexNode **pNodePtr,
 
 	char		relstorage = partRel->rd_rel->relstorage;
 
-	heap_close(partRel, AccessShareLock);
-
 	/* fetch each index on part */
 	indexoidlist = RelationGetIndexList(partRel);
 	foreach(lc, indexoidlist)
@@ -603,7 +600,6 @@ recordIndexesOnLeafPart(PartitionIndexNode **pNodePtr,
 		 */
 		if (!attmap)
 		{
-			Relation	partRel = heap_open(partOid, AccessShareLock);
 			Relation	rootRel = heap_open(rootOid, AccessShareLock);
 
 			TupleDesc	rootTupDesc = rootRel->rd_att;
@@ -612,7 +608,6 @@ recordIndexesOnLeafPart(PartitionIndexNode **pNodePtr,
 			attmap = varattnos_map(partTupDesc, rootTupDesc);
 
 			/* can we close here ? */
-			heap_close(partRel, AccessShareLock);
 			heap_close(rootRel, AccessShareLock);
 		}
 
@@ -622,7 +617,7 @@ recordIndexesOnLeafPart(PartitionIndexNode **pNodePtr,
 		index_close(indRel, NoLock);
 
 		/* construct hash key for the index */
-		partIndexHashKey = constructIndexHashKey(partOid, rootOid, indRel->rd_indextuple, attmap, ii, indType);
+		partIndexHashKey = constructIndexHashKey(partOid, rootOid, attmap, ii, indType);
 
 		/* lookup PartitionIndexHash table */
 		partIndexHashEntry = (PartitionIndexHashEntry *) hash_search(PartitionIndexHash,
@@ -685,6 +680,8 @@ recordIndexesOnLeafPart(PartitionIndexNode **pNodePtr,
 		/* update the PartitionIndexNode -> index bitmap */
 		pNode->index = bms_add_member(pNode->index, partIndexHashEntry->logicalIndexId);
 	}
+
+	heap_close(partRel, AccessShareLock);
 }
 
 /*

--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -192,7 +192,7 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 	{
 		/* Get a copy of the rel's GpPolicy from the relcache. */
 		relation = relation_open(rte->relid, NoLock);
-		policy = RelationGetPartitioningKey(relation);
+		policy = relation->rd_cdbpolicy;
 
 		if (policy != NULL)
 		{

--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -162,6 +162,7 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 
 	DirectDispatchCalculationInfo result;
 	RangeTblEntry *rte;
+	Relation	relation;
 
 	InitDirectDispatchCalculationInfo(&result);
 
@@ -186,33 +187,28 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 	Assert(plan->righttree == NULL);
 
 	/* open and get relation info */
+	rte = rt_fetch(rangeTableIndex, rtable);
+	if (rte->rtekind == RTE_RELATION)
 	{
-		Relation	relation;
+		/* Get a copy of the rel's GpPolicy from the relcache. */
+		relation = relation_open(rte->relid, NoLock);
+		policy = RelationGetPartitioningKey(relation);
 
-		rte = rt_fetch(rangeTableIndex, rtable);
-		if (rte->rtekind == RTE_RELATION)
+		if (policy != NULL)
 		{
-			/* Get a copy of the rel's GpPolicy from the relcache. */
-			relation = relation_open(rte->relid, NoLock);
-			policy = RelationGetPartitioningKey(relation);
-
-			if (policy != NULL)
+			parts = (PartitionKeyInfo *) palloc(policy->nattrs * sizeof(PartitionKeyInfo));
+			for (i = 0; i < policy->nattrs; i++)
 			{
-				parts = (PartitionKeyInfo *) palloc(policy->nattrs * sizeof(PartitionKeyInfo));
-				for (i = 0; i < policy->nattrs; i++)
-				{
-					parts[i].attr = relation->rd_att->attrs[policy->attrs[i] - 1];
-					parts[i].values = NULL;
-					parts[i].numValues = 0;
-					parts[i].counter = 0;
-				}
+				parts[i].attr = relation->rd_att->attrs[policy->attrs[i] - 1];
+				parts[i].values = NULL;
+				parts[i].numValues = 0;
+				parts[i].counter = 0;
 			}
-			relation_close(relation, NoLock);
 		}
-		else
-		{
-			/* fall through, policy will be NULL so we won't direct dispatch */
-		}
+	}
+	else
+	{
+		/* fall through, policy will be NULL so we won't direct dispatch */
 	}
 
 	if (rte->forceDistRandom ||
@@ -338,6 +334,9 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 			result.dd.isDirectDispatch = false;
 		}
 	}
+
+	if (rte->rtekind == RTE_RELATION)
+		relation_close(relation, NoLock);
 
 	result.haveProcessedAnyCalculations = true;
 	return result;


### PR DESCRIPTION
After a relation is closed, the relcache entry
might be freed if its refcount goes to zero and we
should avoid further reference to it.

This is a fix to already existing bug and current
tests can cover the code changes here. So there is
no need to add new test case.