### PR TITLE
Improve handling of rd_cdbpolicy.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1917,7 +1917,6 @@ BeginCopy(bool is_from,
 static uint64
 CopyDispatchOnSegment(CopyState cstate, const CopyStmt *stmt)
 {
-	GpPolicy *policy = cstate->rel->rd_cdbpolicy;
 	CopyStmt   *dispatchStmt;
 	List	   *all_relids;
 	CdbPgResults pgresults = {0};
@@ -1955,9 +1954,10 @@ CopyDispatchOnSegment(CopyState cstate, const CopyStmt *stmt)
 
 	dispatchStmt->skip_ext_partition = cstate->skip_ext_partition;
 
-	if (policy)
+	if (cstate->rel->rd_cdbpolicy)
 	{
-		dispatchStmt->policy = GpPolicyCopy(CurrentMemoryContext, policy);
+		dispatchStmt->policy = GpPolicyCopy(CurrentMemoryContext,
+											cstate->rel->rd_cdbpolicy);
 	}
 	else
 	{

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -5088,14 +5088,12 @@ AdjustReplicatedTableCounts(EState *estate)
 	/* check if result_relations contain replicated table*/
 	for (i = 0; i < estate->es_num_result_relations; i++)
 	{
-		GpPolicy *policy = NULL;
 		resultRelInfo = estate->es_result_relations + i;
 
-		policy = resultRelInfo->ri_RelationDesc->rd_cdbpolicy;
-		if (!policy)
+		if (!resultRelInfo->ri_RelationDesc->rd_cdbpolicy)
 			continue;
 
-		if (GpPolicyIsReplicated(policy))
+		if (GpPolicyIsReplicated(resultRelInfo->ri_RelationDesc->rd_cdbpolicy))
 			containReplicatedTable = true;
 		else if (containReplicatedTable)
 		{


### PR DESCRIPTION
Pointers from Relation object needs to be handled with special care. As having
refcount on the object doesn't mean the object is not modified. Incase of cache
invalidation message handling Relation object gets *rebuild*. As part of rebuild
only guarantee maintained is that Relation object address will not change. But
the memory addresses inside the Relation object gets freed and freshly allocated
and populated with latest data from catalog.

For example below code sequence is dangerous

            rel->rd_cdbpolicy = original_policy;
            GpPolicyReplace(RelationGetRelid(rel), original_policy);

If relcache invalidation message is served after assigning value to
rd_cdbpolicy, the rebuild will free the memory for rd_cdbpolicy (which means
original_policy) and replaced with current contents of
gp_distribution_policy. So, when GpPolicyReplace() called with original_policy
is going to access freed memory. Plus, rd_cdbpolicy will have stale value in
cache and not intended refreshed value. This issue was hit in CI few times and
reproduces with higher frequency with `-DRELCACHE_FORCE_RELEASE`.

Hence this patch fixes all uses to rd_cdbpolicy to make use of rd_cdbpolicy
pointer directly from Relation object and also to update the catalog first
before assigning the value to rd_cdbpolicy.