### PR TITLE
Don't attempt to truncate external tables in gpdbrestore

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
@@ -635,9 +635,10 @@ Feature: Validate command line arguments
         And the timestamp from gpcrondump is stored
         And all the data from "bkdb39" is saved for verification
 
-    Scenario: 40 Full backup and restore with -T and --truncate with dropped table
+    Scenario: 40 Full backup and restore with -T and --truncate with dropped table and external table
         Given the backup test is initialized with database "bkdb40"
         And there is a "heap" table "public.heap_table" in "bkdb40" with data
+        And there is an external table "ext_tab" in "bkdb40" with data for file "/tmp/ext_tab"
         When the user runs "gpcrondump -a -x bkdb40"
         Then gpcrondump should return a return code of 0
         And the timestamp from gpcrondump is stored
@@ -1877,6 +1878,14 @@ Feature: Validate command line arguments
         And gpcrondump should return a return code of 0
         And the timestamp from gpcrondump is stored
         And all the data from "bkdb138" is saved for verification
+
+    Scenario: 139 Full backup and restore with -S and --truncate
+        Given the backup test is initialized with database "bkdb139"
+        And there is a "heap" table "public.heap_table" in "bkdb139" with data
+        And there is an external table "ext_tab" in "bkdb139" with data for file "/tmp/ext_tab"
+        When the user runs "gpcrondump -a -x bkdb139"
+        Then gpcrondump should return a return code of 0
+        And the timestamp from gpcrondump is stored
 
     Scenario: 141 Backup with all GUC (system settings) set to defaults will succeed
         Given the backup test is initialized with database "bkdb141"

--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
@@ -371,12 +371,13 @@ Feature: Validate command line arguments
         Then gpdbrestore should return a return code of 0
         And verify that there is a "ao" table "public.ao_part_table" in "bkdb39" with data
 
-    Scenario: 40 Full backup and restore with -T and --truncate with dropped table
+    Scenario: 40 Full backup and restore with -T and --truncate with dropped table and external table
         Given the old timestamps are read from json
         And the backup test is initialized with database "bkdb40"
-        When the user runs gpdbrestore without -e with the stored timestamp and options "-T public.heap_table --truncate"
+        When the user runs gpdbrestore without -e with the stored timestamp and options "-T public.heap_table -T public.ext_tab --truncate"
         Then gpdbrestore should return a return code of 0
-        And gpdbrestore should print "Skipping truncate of bkdb40.public.heap_table because the relation does not exist" to stdout
+        And gpdbrestore should print "Skipping truncate of bkdb40.public.heap_table because the relation does not exist or is an external table." to stdout
+        And gpdbrestore should print "Skipping truncate of bkdb40.public.ext_tab because the relation does not exist or is an external table." to stdout
         And verify that there is a "heap" table "public.heap_table" in "bkdb40" with data
 
     @nbupartII
@@ -1376,6 +1377,15 @@ Feature: Validate command line arguments
         And the segments are synchronized
         When the user runs "gprecoverseg -ra"
         Then gprecoverseg should return a return code of 0
+
+    Scenario: 139 Full backup and restore with -S and --truncate
+        Given the old timestamps are read from json
+        And the backup test is initialized with database "bkdb139"
+        And there is a "heap" table "public.heap_table" in "bkdb139" with data
+        And there is an external table "ext_tab" in "bkdb139" with data for file "/tmp/ext_tab"
+        When the user runs gpdbrestore without -e with the stored timestamp and options "-S public --truncate"
+        Then gpdbrestore should return a return code of 0
+        And verify that there is a "heap" table "public.heap_table" in "bkdb40" with data
 
     Scenario: 141 Backup with all GUC (system settings) set to defaults will succeed
         Given the old timestamps are read from json


### PR DESCRIPTION
Previously, gpdbrestore attempted to truncate tables in the restore set
when --truncate was passed. However, if one of these tables was an
external table, the restore would return an error as external tables
cannot be truncated. We no longer attempt to truncate external tables at
the beginning of the restore.

The `get_full_tables_in_schema` function call is also used to determine which tables to analyze. However, external tables also cannot be analyzed (they won't error out, just generate a warning). Therefore, excluding external tables from the return set of this function is safe.

Authored-by: Chris Hajas <chajas@pivotal.io>

This is only relevant to 5X_STABLE since gpdbrestore does not exist in the master branch.