### PR TITLE
Fix alter table CLI help documentation

### DIFF
--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -28,9 +28,9 @@ ALTER TABLE name RENAME TO new_name
 ALTER TABLE name SET SCHEMA new_schema
 
 ALTER TABLE [ONLY] name SET 
-     DISTRIBUTED BY (column, [ ... ] ) 
+     WITH (REORGANIZE=true|false) 
+   | DISTRIBUTED BY (column, [ ... ] ) 
    | DISTRIBUTED RANDOMLY 
-   | WITH (REORGANIZE=true|false) 
 
 ALTER TABLE [ONLY] name action [, ... ]
 

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -14,9 +14,9 @@ ALTER TABLE <varname>name</varname> RENAME TO <varname>new_name</varname>
 ALTER TABLE <varname>name</varname> SET SCHEMA <varname>new_schema</varname>
 
 ALTER TABLE [ONLY] <varname>name</varname> SET 
-     DISTRIBUTED BY (<varname>column</varname>, [ ... ] ) 
+     WITH (REORGANIZE=true|false)
+   | DISTRIBUTED BY (<varname>column</varname>, [ ... ] ) 
    | DISTRIBUTED RANDOMLY 
-   | WITH (REORGANIZE=true|false)
  
 ALTER TABLE [ONLY] <varname>name</varname> <varname>action</varname> [, ... ]
 


### PR DESCRIPTION
In ALTER TABLE SET DISTRIBUTED BY, the "WITH(reorganize=...)" option must be specified before the "DISTRIBUTED ..." clause.