### PR TITLE
Error out when an N-way join cannot be found

### DIFF
--- a/src/backend/optimizer/path/joinrels.c
+++ b/src/backend/optimizer/path/joinrels.c
@@ -234,7 +234,7 @@ join_search_one_level(PlannerInfo *root, int level)
 		 *----------
 		 */
 		if (joinrels[level] == NIL && root->join_info_list == NIL)
-			elog(DEBUG1, "failed to build any %d-way joins", level);
+			elog(ERROR, "failed to build any %d-way joins", level);
 	}
 }
 


### PR DESCRIPTION
Following the change in 8fcd3fddd6337f8150981ed0518c28259cf6d219 to cost-based enable GUCs, failing to find a way to construct an N-way join should be an error rather than debug (as in upstream).

Reported-by: Heikki Linnakangas <hlinnakangas@pivotal.io>