### PR TITLE
Enable update on distribution column in legacy planner.

### DIFF
--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -872,6 +872,18 @@ plan_tree_mutator(Node *node,
 			}
 			break;
 
+		case T_SplitUpdate:
+			{
+				SplitUpdate	*splitUpdate = (SplitUpdate *) node;
+				SplitUpdate	*newSplitUpdate;
+
+				FLATCOPY(newSplitUpdate, splitUpdate, SplitUpdate);
+				PLANMUTATE(newSplitUpdate, splitUpdate);
+				return (Node *) newSplitUpdate;
+			}
+			break;
+
+
 			/*
 			 * The following cases are handled by expression_tree_mutator.	In
 			 * addition, we let expression_tree_mutator handle unrecognized

--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -630,6 +630,8 @@ AssignContentIdsToPlanData_Walker(Node *node, void *context)
 					pushNewDirectDispatchInfo = true;
 					break;
 				}
+			case T_SplitUpdate:
+				break;
 			default:
 				elog(ERROR, "Invalid plan node %d", nodeTag(node));
 				break;

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -121,7 +121,8 @@ ExecDML(DMLState *node)
 				   node->ps.state,
 				   true, /* GPDB_91_MERGE_FIXME: canSetTag, where to get this? */
 				   PLANGEN_OPTIMIZER /* Plan origin */,
-				   isUpdate);
+				   isUpdate,
+				   InvalidOid);
 	}
 	else /* DML_DELETE */
 	{
@@ -153,10 +154,9 @@ ExecDML(DMLState *node)
 DMLState*
 ExecInitDML(DML *node, EState *estate, int eflags)
 {
-	
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK | EXEC_FLAG_REWIND)));
-	
+
 	DMLState *dmlstate = makeNode(DMLState);
 	dmlstate->ps.plan = (Plan *)node;
 	dmlstate->ps.state = estate;
@@ -190,7 +190,7 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 	 */
 	TupleTableSlot *childResultSlot = outerPlanState(dmlstate)->ps_ResultTupleSlot;
 	ExecAssignProjectionInfo(&dmlstate->ps, childResultSlot->tts_tupleDescriptor);
-	
+
 	/*
 	 * Initialize slot to insert/delete using output relation descriptor.
 	 */

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -310,6 +310,9 @@ _copyModifyTable(ModifyTable *from)
 	COPY_NODE_FIELD(returningLists);
 	COPY_NODE_FIELD(rowMarks);
 	COPY_SCALAR_FIELD(epqParam);
+	COPY_NODE_FIELD(action_col_idxes);
+	COPY_NODE_FIELD(ctid_col_idxes);
+	COPY_NODE_FIELD(oid_col_idxes);
 
 	return newnode;
 }

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -2812,7 +2812,14 @@ expression_tree_mutator(Node *node,
 				MUTATE(newnode->groupsets, grpingcl->groupsets, List *);
 				return (Node *)newnode;
 			}
+		case T_DMLActionExpr:
+			{
+				DMLActionExpr *action_expr = (DMLActionExpr *) node;
+				DMLActionExpr *new_action_expr;
 
+				FLATCOPY(new_action_expr, action_expr, DMLActionExpr);
+				return (Node *)new_action_expr;
+			}
 		default:
 			elog(ERROR, "unrecognized node type: %d",
 				 (int) nodeTag(node));

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -459,6 +459,9 @@ _outModifyTable(StringInfo str, ModifyTable *node)
 	WRITE_NODE_FIELD(returningLists);
 	WRITE_NODE_FIELD(rowMarks);
 	WRITE_INT_FIELD(epqParam);
+	WRITE_NODE_FIELD(action_col_idxes);
+	WRITE_NODE_FIELD(ctid_col_idxes);
+	WRITE_NODE_FIELD(oid_col_idxes);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -954,9 +954,9 @@ static AlternativeSubPlan *
 _readAlternativeSubPlan(void)
 {
 	READ_LOCALS(AlternativeSubPlan);
-	
+
 	READ_NODE_FIELD(subplans);
-	
+
 	READ_DONE();
 }
 
@@ -2762,27 +2762,27 @@ static PlaceHolderVar *
 _readPlaceHolderVar(void)
 {
 	READ_LOCALS(PlaceHolderVar);
-	
+
 	READ_NODE_FIELD(phexpr);
 	READ_BITMAPSET_FIELD(phrels);
 	READ_INT_FIELD(phid);
 	READ_INT_FIELD(phlevelsup);
-	
+
 	READ_DONE();
 }
-	
+
 static PlaceHolderInfo *
 _readPlaceHolderInfo(void)
 {
 	READ_LOCALS(PlaceHolderInfo);
-	
+
 	READ_INT_FIELD(phid);
 	READ_NODE_FIELD(ph_var);
 	READ_BITMAPSET_FIELD(ph_eval_at);
 	READ_BITMAPSET_FIELD(ph_needed);
 	READ_BITMAPSET_FIELD(ph_may_need);
 	READ_INT_FIELD(ph_width);
-	
+
 	READ_DONE();
 }
 
@@ -2961,6 +2961,9 @@ _readModifyTable(void)
 	READ_NODE_FIELD(returningLists);
 	READ_NODE_FIELD(rowMarks);
 	READ_INT_FIELD(epqParam);
+	READ_NODE_FIELD(action_col_idxes);
+	READ_NODE_FIELD(ctid_col_idxes);
+	READ_NODE_FIELD(oid_col_idxes);
 
 	READ_DONE();
 }

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1088,6 +1088,12 @@ set_plan_refs(PlannerGlobal *glob, Plan *plan, int rtoffset)
 				pfree(childplan_itlist);
 			}
 			break;
+		case T_SplitUpdate:
+			/*
+			 * when we make the target list for SplitUpdate node, we
+			 * have used the OUTER as the varno, so we can skip to fix the varno.
+			 */
+			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d",
 				 (int) nodeTag(plan));

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -2740,6 +2740,7 @@ finalize_plan(PlannerInfo *root, Plan *plan, Bitmapset *valid_params,
 		case T_Unique:
 		case T_SetOp:
 		case T_Repeat:
+		case T_SplitUpdate:
 			break;
 
 		default:

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -65,6 +65,8 @@ extern void fixup_subplans(Plan *plan, PlannerInfo *root, SubPlanWalkerContext *
 extern void request_explicit_motion(Plan *plan, Index resultRelationIdx, List *rtable);
 extern void sri_optimize_for_result(PlannerInfo *root, Plan *plan, RangeTblEntry *rte,
 									GpPolicy **targetPolicy, List **hashExpr);
+extern SplitUpdate *make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan,
+									 RangeTblEntry *rte, Index resultRelationsIdx);
 
 
 #endif   /* CDBMUTATE_H */

--- a/src/include/executor/execDML.h
+++ b/src/include/executor/execDML.h
@@ -34,7 +34,8 @@ ExecInsert(TupleTableSlot *slot,
 		   EState *estate,
 		   bool canSetTag,
 		   PlanGenerator planGen,
-		   bool isUpdate);
+		   bool isUpdate,
+		   Oid	tupleOid);
 
 extern TupleTableSlot *
 ExecDelete(ItemPointer tupleid,

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1529,6 +1529,9 @@ typedef struct ModifyTableState
 	List	  **mt_arowmarks;	/* per-subplan ExecAuxRowMark lists */
 	EPQState	mt_epqstate;	/* for evaluating EvalPlanQual rechecks */
 	bool		fireBSTriggers; /* do we need to fire stmt triggers? */
+	AttrNumber		*mt_action_col_idxes;
+	AttrNumber		*mt_ctid_col_idxes;
+	AttrNumber		*mt_oid_col_idxes;
 } ModifyTableState;
 
 /* ----------------

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -358,6 +358,9 @@ typedef struct ModifyTable
 	List	   *returningLists; /* per-target-table RETURNING tlists */
 	List	   *rowMarks;		/* PlanRowMarks (non-locking only) */
 	int			epqParam;		/* ID of Param for EvalPlanQual re-eval */
+	List	   *action_col_idxes;
+	List	   *ctid_col_idxes;
+	List	   *oid_col_idxes;
 } ModifyTable;
 
 /* ----------------

--- a/src/pl/plperl/expected/plperl_trigger.out
+++ b/src/pl/plperl/expected/plperl_trigger.out
@@ -248,9 +248,9 @@ SELECT * FROM trigger_test;
 (4 rows)
 
 UPDATE trigger_test SET i = 5 where i=3;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 UPDATE trigger_test SET i = 100 where i=1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 SELECT * FROM trigger_test;
  i |                v                 |   foo   
 ---+----------------------------------+---------

--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -419,7 +419,6 @@ NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
 NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
 insert into p select generate_series(1,10000), generate_series(1,10000)*3, generate_series(1,10000)%6;
 update s set a = r.a from r where r.b = s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- start_ignore
 ------------------------------------------------------------
 --	Statement contains correlated subquery
@@ -465,7 +464,6 @@ NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
 NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
 insert into p select generate_series(1,10000), generate_series(1,10000)*3, generate_series(1,10000)%6;
 update s set a = r.a from r where r.b = s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- start_ignore
 ------------------------------------------------------------
 --	Statement contains correlated subquery
@@ -511,7 +509,6 @@ NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
 NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
 insert into p select generate_series(1,10000), generate_series(1,10000)*3, generate_series(1,10000)%6;
 update s set a = r.a from r where r.b = s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- start_ignore
 ------------------------------------------------------------
 --	Statement contains correlated subquery
@@ -557,7 +554,6 @@ NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
 NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
 insert into p select generate_series(1,10000), generate_series(1,10000)*3, generate_series(1,10000)%6;
 update s set a = r.a from r where r.b = s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- start_ignore
 ------------------------------------------------------------
 --	Statement contains correlated subquery
@@ -603,7 +599,6 @@ NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
 NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
 insert into p select generate_series(1,10000), generate_series(1,10000)*3, generate_series(1,10000)%6;
 update s set a = r.a from r where r.b = s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- start_ignore
 ------------------------------------------------------------
 --	Statement contains correlated subquery
@@ -649,7 +644,6 @@ NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
 NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
 insert into p select generate_series(1,10000), generate_series(1,10000)*3, generate_series(1,10000)%6;
 update s set a = r.a from r where r.b = s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- start_ignore
 ------------------------------------------------------------
 --	Statement contains correlated subquery

--- a/src/test/regress/expected/ao_create_alter_valid_table.out
+++ b/src/test/regress/expected/ao_create_alter_valid_table.out
@@ -73,8 +73,6 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 --invalid operations
 -- start_ignore
-update foo_ao set a=5;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 delete from foo_ao;
 -- end_ignore
 -- try and trick by setting rules

--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -140,7 +140,7 @@ insert into zzz select a,b from m;
 -- that difference in the error DETAIL line
 \set VERBOSITY terse
 update zzz set a=m.b from m where m.a=zzz.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  duplicate key value violates unique constraint "zzz_pkey"  (seg1 10.152.10.32:25433 pid=2877)
 select * from zzz order by 1, 2;
  a  | b 
 ----+---
@@ -202,13 +202,21 @@ select * from update_pk_test order by 1,2;
 (1 row)
 
 explain update update_pk_test set a = 5;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Update on update_pk_test  (cost=0.00..1.01 rows=1 width=14)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=14)
+         Hash Key: a
+         ->  Split  (cost=0.00..1.01 rows=1 width=14)
+               ->  Seq Scan on update_pk_test  (cost=0.00..1.01 rows=1 width=14)
+ Optimizer: legacy query optimizer
+(6 rows)
+
 update update_pk_test set a = 5;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select * from update_pk_test order by 1,2;
  a | b 
 ---+---
- 1 | 5
+ 5 | 5
 (1 row)
 
 -- MPP-22599 DML queries that fallback to planner don't check for updates on
@@ -224,7 +232,12 @@ set optimizer_trace_fallback = on;
 -- Subquery that returns a row rather than a single scalar isn't supported
 -- in ORCA currently, so we can use that to trigger fallback.
 update update_pk_test set a=1 where row(1,2) = (SELECT 1, 2);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+select * from update_pk_test order by 1,2;
+ a | b 
+---+---
+ 1 | 5
+(1 row)
+
 reset optimizer_trace_fallback;
 --
 -- Check that INSERT and DELETE triggers don't fire on UPDATE.
@@ -249,7 +262,6 @@ FOR EACH ROW
 EXECUTE PROCEDURE bfv_dml_error_func();
 UPDATE bfv_dml_trigger_test SET t = 'bar';
 UPDATE bfv_dml_trigger_test SET id = id + 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 --
 -- Verify that ExecInsert doesn't scribble on the old tuple, when the new
 -- tuple comes directly from the old table.

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -242,7 +242,12 @@ set optimizer_trace_fallback = on;
 -- in ORCA currently, so we can use that to trigger fallback.
 update update_pk_test set a=1 where row(1,2) = (SELECT 1, 2);
 INFO:  GPORCA failed to produce a plan, falling back to planner
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+select * from update_pk_test order by 1,2;
+ a | b 
+---+---
+ 1 | 5
+(1 row)
+
 reset optimizer_trace_fallback;
 --
 -- Check that INSERT and DELETE triggers don't fire on UPDATE.

--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -43,7 +43,7 @@ NOTICE:  CREATE TABLE will create partition "mpp3061_1_prt_3" for table "mpp3061
 NOTICE:  CREATE TABLE will create partition "mpp3061_1_prt_4" for table "mpp3061"
 insert into mpp3061 values(1);
 update mpp3061 set i = 2 where i = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  moving tuple from partition "mpp3061_1_prt_1" to partition "mpp3061_1_prt_2" not supported
 drop table mpp3061;
 --
 -- Tests if it produces SIGSEGV from "select from partition_table group by rollup or cube function"

--- a/src/test/regress/expected/gp_types.out
+++ b/src/test/regress/expected/gp_types.out
@@ -18,11 +18,10 @@ SELECT * FROM dml_bitvarying ORDER BY 1;
 (1 row)
 
 UPDATE dml_bitvarying SET a = '00';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM dml_bitvarying ORDER BY 1;
  a  
 ----
- 11
+ 00
 (1 row)
 
 -- out of range values
@@ -31,7 +30,7 @@ ERROR:  bit string too long for type bit varying(2)
 SELECT * FROM dml_bitvarying ORDER BY 1;
  a  
 ----
- 11
+ 00
 (1 row)
 
 UPDATE dml_bitvarying SET a = '000';
@@ -39,7 +38,7 @@ ERROR:  bit string too long for type bit varying(2)
 SELECT * FROM dml_bitvarying ORDER BY 1;
  a  
 ----
- 11
+ 00
 (1 row)
 
 --
@@ -65,12 +64,11 @@ SELECT * FROM dml_interval ORDER BY 1;
 (2 rows)
 
 UPDATE dml_interval SET a = '-178000000 years';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM dml_interval ORDER BY 1;
         a         
 ------------------
  -178000000 years
- 178000000 years
+ -178000000 years
 (2 rows)
 
 -- out of range values
@@ -79,7 +77,7 @@ SELECT * FROM dml_interval ORDER BY 1;
            a           
 -----------------------
  -178000000 years
- 178000000 years
+ -178000000 years
  178000000 years 1 mon
 (3 rows)
 
@@ -88,20 +86,19 @@ SELECT * FROM dml_interval ORDER BY 1;
              a             
 ---------------------------
  -178000000 years
+ -178000000 years
  -177999999 years -11 mons
- 178000000 years
  178000000 years 1 mon
 (4 rows)
 
 UPDATE dml_interval SET a = '-178000000 years 1 month';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM dml_interval ORDER BY 1;
              a             
 ---------------------------
- -178000000 years
  -177999999 years -11 mons
- 178000000 years
- 178000000 years 1 mon
+ -177999999 years -11 mons
+ -177999999 years -11 mons
+ -177999999 years -11 mons
 (4 rows)
 
 --
@@ -164,11 +161,10 @@ SELECT * FROM dml_numeric2 ORDER BY 1;
 (1 row)
 
 UPDATE dml_numeric2 SET a = 1.00e+1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM dml_numeric2 ORDER BY 1;
-   a    
---------
- 100.00
+   a   
+-------
+ 10.00
 (1 row)
 
 -- out of range values
@@ -176,18 +172,18 @@ INSERT  INTO  dml_numeric2 VALUES (1.00e+3);
 ERROR:  numeric field overflow
 DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3. Rounded overflowing value: 1000.00
 SELECT * FROM dml_numeric2 ORDER BY 1;
-   a    
---------
- 100.00
+   a   
+-------
+ 10.00
 (1 row)
 
 UPDATE dml_numeric2 SET a = 1.00e+3;
 ERROR:  numeric field overflow
 DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3. Rounded overflowing value: 1000.00
 SELECT * FROM dml_numeric2 ORDER BY 1;
-   a    
---------
- 100.00
+   a   
+-------
+ 10.00
 (1 row)
 
 --
@@ -213,12 +209,11 @@ SELECT * FROM dml_timestamp ORDER BY 1;
 (2 rows)
 
 UPDATE dml_timestamp SET a = to_date('2012-02-31', 'YYYY-MM-DD BC');
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
  2012-03-02 00:00:00
- 4714-01-27 00:00:00
+ 2012-03-02 00:00:00
 (2 rows)
 
 -- out of range values
@@ -230,7 +225,7 @@ SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
  2012-03-02 00:00:00
- 4714-01-27 00:00:00
+ 2012-03-02 00:00:00
 (2 rows)
 
 UPDATE dml_timestamp SET a = '294277-01-27 AD'::timestamp;
@@ -241,7 +236,7 @@ SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
  2012-03-02 00:00:00
- 4714-01-27 00:00:00
+ 2012-03-02 00:00:00
 (2 rows)
 
 --
@@ -259,7 +254,6 @@ SELECT * FROM dml_timestamptz ORDER BY 1;
 (1 row)
 
 UPDATE dml_timestamptz SET a = to_date('4714-01-27 AD', 'YYYY-MM-DD BC');
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM dml_timestamptz ORDER BY 1;
            a            
 ------------------------

--- a/src/test/regress/expected/hash_index.out
+++ b/src/test/regress/expected/hash_index.out
@@ -111,13 +111,12 @@ SELECT h.seqno AS i1492, h.random AS i1
 UPDATE hash_i4_heap
    SET seqno = 20000
    WHERE hash_i4_heap.random = 1492795354;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT h.seqno AS i20000
    FROM hash_i4_heap h
    WHERE h.random = 1492795354;
  i20000 
 --------
-   6866
+  20000
 (1 row)
 
 UPDATE hash_name_heap
@@ -134,7 +133,6 @@ SELECT h.seqno AS i6543, h.random AS c0_to_f
 UPDATE hash_name_heap
    SET seqno = 20000
    WHERE hash_name_heap.random = '76652222'::name;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 --
 -- this is the row we just replaced; index scan should return zero rows
 --
@@ -159,13 +157,12 @@ SELECT h.seqno AS i4002, h.random AS c0_to_p
 UPDATE hash_txt_heap
    SET seqno = 20000
    WHERE hash_txt_heap.random = '959363399'::text;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT h.seqno AS t20000
    FROM hash_txt_heap h
    WHERE h.random = '959363399'::text;
  t20000 
 --------
-   5489
+  20000
 (1 row)
 
 UPDATE hash_f8_heap
@@ -182,13 +179,12 @@ SELECT h.seqno AS i8096, h.random AS f1234_1234
 UPDATE hash_f8_heap
    SET seqno = 20000
    WHERE hash_f8_heap.random = '488912369'::float8;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT h.seqno AS f20000
    FROM hash_f8_heap h
    WHERE h.random = '488912369'::float8;
  f20000 
 --------
-   8932
+  20000
 (1 row)
 
 -- UPDATE hash_ovfl_heap

--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -1555,7 +1555,7 @@ PL/pgSQL function "tg_pslot_biu" line 6 at SQL statement
 -- Fix the wrong name for patchfield PF0_2
 --
 update PField set name = 'PF0_2' where name = 'PF0_X';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 select * from PSlot order by slotname;
  slotname | pfname | slotlink | backlink 
 ----------+--------+----------+----------
@@ -1844,13 +1844,21 @@ create function test_found()
   return true;
   end;' language plpgsql;
 select test_found();
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
-CONTEXT:  SQL statement "update found_test_tbl set a = 100 where a = 1"
-PL/pgSQL function "test_found" line 9 at SQL statement
+ test_found 
+------------
+ t
+(1 row)
+
 select * from found_test_tbl;
- a 
----
-(0 rows)
+  a  
+-----
+   3
+   4
+   5
+   6
+   2
+ 100
+(6 rows)
 
 --
 -- Test set-returning functions for PL/pgSQL
@@ -1865,9 +1873,15 @@ BEGIN
 	RETURN;
 END;' language plpgsql;
 select * from test_table_func_rec();
- a 
----
-(0 rows)
+  a  
+-----
+   2
+   3
+   4
+   5
+   6
+ 100
+(6 rows)
 
 create function test_table_func_row() returns setof found_test_tbl as '
 DECLARE
@@ -1879,9 +1893,15 @@ BEGIN
 	RETURN;
 END;' language plpgsql;
 select * from test_table_func_row();
- a 
----
-(0 rows)
+  a  
+-----
+   3
+   4
+   5
+   6
+ 100
+   2
+(6 rows)
 
 create function test_ret_set_scalar(int,int) returns setof int as '
 DECLARE

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -1555,7 +1555,7 @@ PL/pgSQL function "tg_pslot_biu" line 6 at SQL statement
 -- Fix the wrong name for patchfield PF0_2
 --
 update PField set name = 'PF0_2' where name = 'PF0_X';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 select * from PSlot order by slotname;
  slotname | pfname | slotlink | backlink 
 ----------+--------+----------+----------

--- a/src/test/regress/expected/portals_updatable.out
+++ b/src/test/regress/expected/portals_updatable.out
@@ -388,9 +388,6 @@ DECLARE c CURSOR FOR SELECT * FROM portals_updatable_rank_1_prt_extra WHERE rank
 DELETE FROM portals_updatable_rank WHERE CURRENT OF c;	-- error out on wrong table
 ERROR:  cursor "c" is not a simply updatable scan of table "portals_updatable_rank"
 ROLLBACK;
--- Partitioning, negative, cursor-agnostic: cannot update distribution key
-UPDATE portals_updatable_rank SET id = id + 1 WHERE CURRENT OF c;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- Partitioning, negative, cursor-agnostic: cannot move tuple across partitions
 BEGIN;
 DECLARE c CURSOR FOR SELECT * FROM portals_updatable_rank WHERE rank = 1;
@@ -570,6 +567,33 @@ SELECT * FROM bar ORDER BY 1, 2, 3, 4;
  10 | 4 | 4 |    10
  11 | 5 | 5 |    11
 (12 rows)
+
+-- Partitioning, update distribution key
+BEGIN;
+DECLARE c CURSOR FOR SELECT * FROM portals_updatable_rank  WHERE rank = 10;
+FETCH 1 FROM c;
+ id | rank | f  
+----+------+----
+ 10 |   10 | 10
+(1 row)
+
+UPDATE portals_updatable_rank SET id = id + 1 WHERE CURRENT OF c;
+COMMIT;
+SELECT * FROM portals_updatable_rank  ORDER BY 1, 2, 3;
+ id | rank | f  
+----+------+----
+  0 |    0 |  0
+  1 |    1 | -1
+  2 |    2 |  2
+  3 |    3 |  3
+  4 |    4 |  4
+  5 |    5 |  5
+  6 |    6 |  6
+  7 |    7 |  7
+  8 |    8 |  8
+  9 |    9 |  9
+ 11 |   10 | 10
+(11 rows)
 
 -- 
 -- Expected Failure
@@ -771,9 +795,6 @@ FETCH 1 FROM c1;
 DELETE FROM ucview WHERE CURRENT OF c1;
 ERROR:  WHERE CURRENT OF on a view is not implemented
 ROLLBACK;
--- Negative, cursor-agnostic: cannot update distribution key
-UPDATE uctest SET f1 = f1 + 10 WHERE CURRENT OF a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- Negative, cursor-agnostic: cannot update external tables
 CREATE EXTERNAL WEB TABLE ucexttest (x text) EXECUTE 'echo "foo";' FORMAT 'TEXT';
 BEGIN;

--- a/src/test/regress/expected/portals_updatable_optimizer.out
+++ b/src/test/regress/expected/portals_updatable_optimizer.out
@@ -388,9 +388,6 @@ DECLARE c CURSOR FOR SELECT * FROM portals_updatable_rank_1_prt_extra WHERE rank
 DELETE FROM portals_updatable_rank WHERE CURRENT OF c;	-- error out on wrong table
 ERROR:  cursor "c" is not a simply updatable scan of table "portals_updatable_rank"
 ROLLBACK;
--- Partitioning, negative, cursor-agnostic: cannot update distribution key
-UPDATE portals_updatable_rank SET id = id + 1 WHERE CURRENT OF c;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- Partitioning, negative, cursor-agnostic: cannot move tuple across partitions
 BEGIN;
 DECLARE c CURSOR FOR SELECT * FROM portals_updatable_rank WHERE rank = 1;
@@ -570,6 +567,33 @@ SELECT * FROM bar ORDER BY 1, 2, 3, 4;
  10 | 4 | 4 |    10
  11 | 5 | 5 |    11
 (12 rows)
+
+-- Partitioning, update distribution key
+BEGIN;
+DECLARE c CURSOR FOR SELECT * FROM portals_updatable_rank  WHERE rank = 10;
+FETCH 1 FROM c;
+ id | rank | f  
+----+------+----
+ 10 |   10 | 10
+(1 row)
+
+UPDATE portals_updatable_rank SET id = id + 1 WHERE CURRENT OF c;
+COMMIT;
+SELECT * FROM portals_updatable_rank  ORDER BY 1, 2, 3;
+ id | rank | f  
+----+------+----
+  0 |    0 |  0
+  1 |    1 | -1
+  2 |    2 |  2
+  3 |    3 |  3
+  4 |    4 |  4
+  5 |    5 |  5
+  6 |    6 |  6
+  7 |    7 |  7
+  8 |    8 |  8
+  9 |    9 |  9
+ 11 |   10 | 10
+(11 rows)
 
 -- 
 -- Expected Failure
@@ -771,9 +795,6 @@ FETCH 1 FROM c1;
 DELETE FROM ucview WHERE CURRENT OF c1;
 ERROR:  WHERE CURRENT OF on a view is not implemented
 ROLLBACK;
--- Negative, cursor-agnostic: cannot update distribution key
-UPDATE uctest SET f1 = f1 + 10 WHERE CURRENT OF a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- Negative, cursor-agnostic: cannot update external tables
 CREATE EXTERNAL WEB TABLE ucexttest (x text) EXECUTE 'echo "foo";' FORMAT 'TEXT';
 BEGIN;

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+-- m/ERROR:  moving tuple from partition .* to partition .* not supported/
+-- s/ERROR:  moving tuple from partition .* to partition .* not supported/ERROR:  cross-partition or multi-update to a row/
+-- m/ERROR:  multiple updates to a row by the same query is not allowed/
+-- s/ERROR:  multiple updates to a row by the same query is not allowed/ERROR:  cross-partition or multi-update to a row/
+-- end_matchsubs
 -- First create a bunch of test tables
 SET statement_mem='250 MB';
 CREATE TABLE dml_ao_check_r (
@@ -2078,13 +2084,13 @@ SELECT SUM(d) FROM dml_heap_check_s;
 rollback;
 --Negative test: Update data that does not satisfy the check constraints
 UPDATE dml_heap_check_s SET a = 100 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a AND dml_heap_check_s.a = 99;
-ERROR:  moving tuple from partition "dml_heap_check_s_1_prt_11" to partition "dml_heap_check_s_1_prt_def" not supported  (seg0 127.0.0.1:40000 pid=18972)
+ERROR:  cross-partition or multi-update to a row  (seg0 127.0.0.1:40000 pid=18972)
 --Negative test - Update violates check constraint(not NULL constraint)
 UPDATE dml_heap_check_s SET b = NULL FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.b and dml_heap_check_s.b = 99;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  new row for relation "dml_heap_check_s_1_prt_5" violates check constraint "scheck_b"  (seg1 10.152.10.75:25433 pid=28939)
 --Negative test - Update moving tuple across partition .also violates the check constraint
 UPDATE dml_heap_check_s SET a = 110 + dml_heap_check_s.a FROM dml_heap_check_r WHERE dml_heap_check_r.a = dml_heap_check_s.a;
-ERROR:  moving tuple from partition "dml_heap_check_s_1_prt_2" to partition "dml_heap_check_s_1_prt_def" not supported  (seg0 127.0.0.1:40000 pid=18972)
+ERROR:  cross-partition or multi-update to a row  (seg0 127.0.0.1:40000 pid=18972)
 --Delete with generate_series
 begin;
 SELECT COUNT(*) FROM dml_heap_s;
@@ -3065,9 +3071,12 @@ SELECT COUNT(*) FROM (SELECT DISTINCT(b) FROM dml_heap_pt_s)foo;
 (1 row)
 
 UPDATE dml_heap_pt_s SET b = 10;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM (SELECT DISTINCT(b) FROM dml_heap_pt_s)foo;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+     1
+(1 row)
+
 rollback;
 --Update to default value
 begin;
@@ -3078,9 +3087,12 @@ SELECT SUM(a) FROM dml_heap_pt_r;
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = DEFAULT;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT SUM(a) FROM dml_heap_pt_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ sum 
+-----
+    
+(1 row)
+
 rollback;
 --Update to default value
 begin;
@@ -3098,7 +3110,7 @@ SELECT SUM(b) FROM dml_heap_pt_r;
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  cross-partition or multi-update to a row  (seg1 10.152.10.75:25433 pid=28939)
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT SUM(b) FROM dml_heap_pt_r;
@@ -3135,7 +3147,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = generate_series(1,10), c ='n';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg0 10.152.10.75:25432 pid=28938)
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
@@ -3150,7 +3162,7 @@ SELECT SUM(a) FROM dml_heap_pt_r;
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.a + 1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg0 10.152.10.75:25432 pid=28938)
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
@@ -3162,9 +3174,11 @@ SELECT * FROM dml_heap_pt_r WHERE b = 20 ORDER BY 1;
 (0 rows)
 
 UPDATE dml_heap_pt_r SET a = v.i + 1 FROM (VALUES(100, 20)) as v(i, j) WHERE dml_heap_pt_r.b = v.j;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM dml_heap_pt_r WHERE b = 20 ORDER BY 1;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ a | b | c | d 
+---+---+---+---
+(0 rows)
+
 rollback;
 --Update with Joins and set to constant value
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = 10;
@@ -3174,17 +3188,15 @@ SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = 10;
 (1 row)
 
 UPDATE dml_heap_pt_s SET b = 10 FROM dml_heap_pt_r WHERE dml_heap_pt_r.b = dml_heap_pt_s.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = 10;
  count 
 -------
-     0
+    36
 (1 row)
 
 --Update distcol with predicate in subquery
 begin;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.a + 1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a and dml_heap_pt_s.b in (SELECT dml_heap_pt_s.b + dml_heap_pt_r.a FROM dml_heap_pt_s,dml_heap_pt_r WHERE dml_heap_pt_r.a > 10);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 rollback;
 --Update with aggregate in subquery
 begin;
@@ -3201,9 +3213,12 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 UPDATE dml_heap_pt_s SET b = (SELECT COUNT(*) FROM dml_heap_pt_s) FROM dml_heap_pt_r WHERE dml_heap_pt_r.a = dml_heap_pt_s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM dml_heap_pt_s WHERE b = (SELECT COUNT(*) FROM dml_heap_pt_s);
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+    60
+(1 row)
+
 rollback;
 --Update and limit in subquery
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
@@ -3219,7 +3234,7 @@ SELECT DISTINCT(b) FROM dml_heap_pt_s ORDER BY 1 LIMIT 1;
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = (SELECT DISTINCT(b) FROM dml_heap_pt_s ORDER BY 1 LIMIT 1) FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg1 slice1 10.152.10.75:25433 pid=28939)
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
  count 
 -------
@@ -3248,7 +3263,7 @@ SELECT * FROM dml_heap_pt_r WHERE a = 1;
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  cross-partition or multi-update to a row  (seg2 10.152.10.75:25434 pid=14697)
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;
@@ -3271,7 +3286,7 @@ SELECT dml_heap_pt_s.a ,dml_heap_pt_s.b,'z' FROM dml_heap_pt_r,dml_heap_pt_s WHE
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
 UPDATE dml_heap_pt_r SET (a,b,c) = (dml_heap_pt_s.a ,dml_heap_pt_s.b,'z') FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 1= dml_heap_pt_s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  cross-partition or multi-update to a row  (seg2 10.152.10.75:25434 pid=14697)
 SELECT * FROM dml_heap_pt_r WHERE c='z' ORDER BY 1 LIMIT 1;
  a | b | c | d 
 ---+---+---+---
@@ -3288,9 +3303,8 @@ NOTICE:  dropped partition "def" for relation "dml_heap_pt_r"
 --Update with prepare plans
 begin;
 PREPARE plan_upd as UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a +1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.b ;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 EXECUTE plan_upd;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ERROR:  multiple updates to a row by the same query is not allowed  (seg0 10.152.10.75:25432 pid=2898)
 rollback;
 --Update and case
 begin;
@@ -3301,9 +3315,12 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 20 ;
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = (SELECT case when c = 'r' then MAX(b) else 100 end FROM dml_heap_pt_r GROUP BY c) ;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 20 ;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+     0
+(1 row)
+
 rollback;
 --Negative test - Update with sub-query returning more than one row
 SELECT SUM(a) FROM dml_heap_pt_r;
@@ -3313,7 +3330,7 @@ SELECT SUM(a) FROM dml_heap_pt_r;
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = ( SELECT DISTINCT(b) FROM dml_heap_pt_s ) FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  more than one row returned by a subquery used as an expression
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum  
 ------
@@ -3345,7 +3362,6 @@ SELECT SUM(a) FROM dml_heap_pt_v;
 (1 row)
 
 UPDATE dml_heap_pt_v SET a = dml_heap_pt_u.a FROM dml_heap_pt_u WHERE dml_heap_pt_u.b = dml_heap_pt_v.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT SUM(a) FROM dml_heap_pt_v;
  sum 
 -----
@@ -3361,27 +3377,17 @@ SELECT SUM(a) FROM dml_heap_pt_r;
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.b+1 FROM dml_heap_pt_p,dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b and dml_heap_pt_r.a = dml_heap_pt_p.b+1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg0 10.152.10.75:25432 pid=2898)
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
 --Update on table with composite distribution key
 -- This currently falls back to planner, even if ORCA is enabled. And planner can't
 -- produce plans that update distribution key columns.
-SELECT SUM(a) FROM dml_heap_pt_r;
- sum  
-------
- 5050
-(1 row)
-
-UPDATE dml_heap_pt_p SET a = dml_heap_pt_p.b % 2 FROM dml_heap_pt_r WHERE dml_heap_pt_p.b::int = dml_heap_pt_r.b::int and dml_heap_pt_p.a = dml_heap_pt_r.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
-SELECT SUM(a) FROM dml_heap_pt_r;
- sum  
-------
- 5050
-(1 row)
-
+begin;
+UPDATE dml_heap_pt_p SET a = dml_heap_pt_p.b % 2 FROM dml_heap_pt_r WHERE dml_heap_pt_p.b::int = dml_heap_pt_r.b::int and dml_heap_pt_p.a = dml_heap_pt_r.a and dml_heap_pt_p.b = 63;
+ERROR:  cross-partition or multi-update to a row  (seg0 10.152.10.75:25432 pid=9661)
+rollback;
 --Update on table with composite distribution key
 begin;
 SELECT SUM(b) FROM dml_heap_pt_p;
@@ -3391,9 +3397,12 @@ SELECT SUM(b) FROM dml_heap_pt_p;
 (1 row)
 
 UPDATE dml_heap_pt_p SET b = (dml_heap_pt_p.b * 1.1)::int FROM dml_heap_pt_r WHERE dml_heap_pt_p.b = dml_heap_pt_r.a and dml_heap_pt_p.b = dml_heap_pt_r.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT SUM(b) FROM dml_heap_pt_p;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+  sum  
+-------
+ 15152
+(1 row)
+
 rollback;
 --Update the partition key and move tuples across partitions( moving tuple to default partition)
 begin;
@@ -3404,7 +3413,7 @@ SELECT SUM(a) FROM dml_heap_pt_s;
 (1 row)
 
 UPDATE dml_heap_pt_s SET a = dml_heap_pt_r.a + 30000 FROM dml_heap_pt_r WHERE dml_heap_pt_r.b = dml_heap_pt_s.b;
-ERROR:  moving tuple from partition "dml_heap_pt_s_1_prt_2" to partition "dml_heap_pt_s_1_prt_def" not supported  (seg0 127.0.0.1:40000 pid=18972)
+ERROR:  cross-partition or multi-update to a row  (seg0 127.0.0.1:40000 pid=18972)
 SELECT SUM(a) FROM dml_heap_pt_s;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
@@ -3793,7 +3802,7 @@ SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
 (1 row)
 
 UPDATE dml_heap_r SET a = generate_series(1,10), c ='n';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg1 10.152.10.75:25433 pid=4138)
 SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
@@ -3808,9 +3817,12 @@ SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 (1 row)
 
 UPDATE dml_heap_r SET a = dml_heap_r.a + 1 FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ sum 
+-----
+    
+(1 row)
+
 rollback;
 --Update and from values
 begin;
@@ -3821,9 +3833,12 @@ SELECT SUM(b) FROM dml_heap_r WHERE b = 20;
 (1 row)
 
 UPDATE dml_heap_r SET a = v.i + 1 FROM (VALUES(100, 20)) as v(i, j) WHERE dml_heap_r.b = v.j;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT SUM(b) FROM dml_heap_r WHERE b = 20;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ sum 
+-----
+  20
+(1 row)
+
 rollback;
 --Update with Joins and set to constant value
 begin;
@@ -3834,14 +3849,16 @@ SELECT COUNT(*) FROM dml_heap_s WHERE b = 10;
 (1 row)
 
 UPDATE dml_heap_s SET b = 10 FROM dml_heap_r WHERE dml_heap_r.b = dml_heap_s.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM dml_heap_s WHERE b = 10;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+   102
+(1 row)
+
 rollback;
 --Update distcol with predicate in subquery
 begin;
 UPDATE dml_heap_r SET a = dml_heap_r.a + 1 FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a and dml_heap_s.b in (SELECT dml_heap_s.b + dml_heap_r.a FROM dml_heap_s,dml_heap_r WHERE dml_heap_r.a > 10);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 rollback;
 --Update with aggregate in subquery
 begin;
@@ -3852,7 +3869,7 @@ SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
 (1 row)
 
 UPDATE dml_heap_s SET b = (SELECT COUNT(*) FROM dml_heap_s) FROM dml_heap_r WHERE dml_heap_r.a = dml_heap_s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg0 slice1 10.152.10.75:25432 pid=4139)
 SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
@@ -3865,9 +3882,12 @@ SELECT COUNT(*) FROM dml_heap_r WHERE a = 1;
 (1 row)
 
 UPDATE dml_heap_r SET a = (SELECT DISTINCT(b) FROM dml_heap_s ORDER BY 1 LIMIT 1) FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 1;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+   103
+(1 row)
+
 rollback;
 --Update multiple columns
 begin;
@@ -3890,11 +3910,18 @@ SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
 (1 row)
 
 UPDATE dml_heap_r SET a = dml_heap_s.a + 10 ,b = NULL FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ sum 
+-----
+    
+(1 row)
+
 SELECT COUNT(*) FROM dml_heap_r WHERE b is NULL;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+   112
+(1 row)
+
 rollback;
 --Update multiple columns
 begin;
@@ -3911,7 +3938,7 @@ SELECT dml_heap_s.a ,dml_heap_s.b,'z' FROM dml_heap_r,dml_heap_s WHERE dml_heap_
 (1 row)
 
 UPDATE dml_heap_r SET (a,b,c) = (dml_heap_s.a ,dml_heap_s.b,'z') FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg1 10.152.10.75:25433 pid=4138)
 SELECT * FROM dml_heap_r WHERE c='z' ORDER BY 1 LIMIT 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT COUNT(*) FROM dml_heap_r WHERE c='z';
@@ -3920,9 +3947,8 @@ rollback;
 --Update with prepare plans
 begin;
 PREPARE plan_upd_2 as UPDATE dml_heap_r SET a = dml_heap_s.a +1 FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.b ;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 EXECUTE plan_upd_2;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ERROR:  multiple updates to a row by the same query is not allowed  (seg0 10.152.10.75:25432 pid=4139)
 rollback;
 --Update and case
 begin;
@@ -3933,9 +3959,12 @@ SELECT COUNT(*) FROM dml_heap_r WHERE a = 100 ;
 (1 row)
 
 UPDATE dml_heap_r SET a = (SELECT case when c = 'r' then MAX(b) else 100 end FROM dml_heap_r GROUP BY c ORDER BY 1 LIMIT 1) ;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM dml_heap_r WHERE a = 100 ;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+   113
+(1 row)
+
 rollback;
 --Negative test - Update with sub-query returning more than one row
 SELECT SUM(a) FROM dml_heap_r;
@@ -3945,7 +3974,7 @@ SELECT SUM(a) FROM dml_heap_r;
 (1 row)
 
 UPDATE dml_heap_r SET a = ( SELECT DISTINCT(b) FROM dml_heap_s ) FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  more than one row returned by a subquery used as an expression
 SELECT SUM(a) FROM dml_heap_r;
  sum  
 ------
@@ -3994,7 +4023,7 @@ SELECT SUM(a) FROM dml_heap_v;
 (1 row)
 
 UPDATE dml_heap_v SET a = dml_heap_u.a FROM dml_heap_u WHERE dml_heap_u.b = dml_heap_v.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg0 10.152.10.75:25432 pid=4139)
 SELECT SUM(a) FROM dml_heap_v;
  sum 
 -----
@@ -4003,10 +4032,8 @@ SELECT SUM(a) FROM dml_heap_v;
 
 --Update with joins on multiple table
 UPDATE dml_heap_r SET a = dml_heap_r.b+1 FROM dml_heap_p,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b and dml_heap_r.a = dml_heap_p.b+1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg0 10.152.10.75:25432 pid=4139)
 --Update on table with composite distribution key
 UPDATE dml_heap_p SET a = dml_heap_p.b % 2 FROM dml_heap_r WHERE dml_heap_p.b::int = dml_heap_r.b::int and dml_heap_p.a = dml_heap_r.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 --Update on table with composite distribution key
 UPDATE dml_heap_p SET b = (dml_heap_p.b * 1.1)::int FROM dml_heap_r WHERE dml_heap_p.b = dml_heap_r.a and dml_heap_p.b = dml_heap_r.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+-- m/ERROR:  moving tuple from partition .* to partition .* not supported/
+-- s/ERROR:  moving tuple from partition .* to partition .* not supported/ERROR:  cross-partition or multi-update to a row/
+-- m/ERROR:  multiple updates to a row by the same query is not allowed/
+-- s/ERROR:  multiple updates to a row by the same query is not allowed/ERROR:  cross-partition or multi-update to a row/
+-- end_matchsubs
 -- First create a bunch of test tables
 SET statement_mem='250 MB';
 CREATE TABLE dml_ao_check_r (
@@ -3150,7 +3156,7 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = generate_series(1,10), c ='n';
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
@@ -3165,7 +3171,7 @@ SELECT SUM(a) FROM dml_heap_pt_r;
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.a + 1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
@@ -3237,7 +3243,7 @@ SELECT DISTINCT(b) FROM dml_heap_pt_s ORDER BY 1 LIMIT 1;
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = (SELECT DISTINCT(b) FROM dml_heap_pt_s ORDER BY 1 LIMIT 1) FROM dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.a;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
  count 
 -------
@@ -3266,7 +3272,7 @@ SELECT * FROM dml_heap_pt_r WHERE a = 1;
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;
@@ -3289,7 +3295,7 @@ SELECT dml_heap_pt_s.a ,dml_heap_pt_s.b,'z' FROM dml_heap_pt_r,dml_heap_pt_s WHE
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
 UPDATE dml_heap_pt_r SET (a,b,c) = (dml_heap_pt_s.a ,dml_heap_pt_s.b,'z') FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 1= dml_heap_pt_s.b;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 SELECT * FROM dml_heap_pt_r WHERE c='z' ORDER BY 1 LIMIT 1;
  a | b | c | d 
 ---+---+---+---
@@ -3307,7 +3313,7 @@ NOTICE:  dropped partition "def" for relation "dml_heap_pt_r"
 begin;
 PREPARE plan_upd as UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a +1 FROM dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.b ;
 EXECUTE plan_upd;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 rollback;
 --Update and case
 begin;
@@ -3382,27 +3388,17 @@ SELECT SUM(a) FROM dml_heap_pt_r;
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_r.b+1 FROM dml_heap_pt_p,dml_heap_pt_s WHERE dml_heap_pt_r.b = dml_heap_pt_s.b and dml_heap_pt_r.a = dml_heap_pt_p.b+1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  cross-partition or multi-update to a row  (seg0 10.34.53.37:25432 pid=9227)
 SELECT SUM(a) FROM dml_heap_pt_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
 --Update on table with composite distribution key
 -- This currently falls back to planner, even if ORCA is enabled. And planner can't
 -- produce plans that update distribution key columns.
-SELECT SUM(a) FROM dml_heap_pt_r;
- sum  
-------
- 5050
-(1 row)
-
-UPDATE dml_heap_pt_p SET a = dml_heap_pt_p.b % 2 FROM dml_heap_pt_r WHERE dml_heap_pt_p.b::int = dml_heap_pt_r.b::int and dml_heap_pt_p.a = dml_heap_pt_r.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
-SELECT SUM(a) FROM dml_heap_pt_r;
- sum  
-------
- 5050
-(1 row)
-
+begin;
+UPDATE dml_heap_pt_p SET a = dml_heap_pt_p.b % 2 FROM dml_heap_pt_r WHERE dml_heap_pt_p.b::int = dml_heap_pt_r.b::int and dml_heap_pt_p.a = dml_heap_pt_r.a and dml_heap_pt_p.b = 63;
+ERROR:  moving tuple from partition "dml_heap_pt_p_1_prt_def" to partition "dml_heap_pt_p_1_prt_one" not supported  (seg0 10.152.10.75:25432 pid=19629)
+rollback;
 --Update on table with composite distribution key
 begin;
 SELECT SUM(b) FROM dml_heap_pt_p;
@@ -3412,9 +3408,12 @@ SELECT SUM(b) FROM dml_heap_pt_p;
 (1 row)
 
 UPDATE dml_heap_pt_p SET b = (dml_heap_pt_p.b * 1.1)::int FROM dml_heap_pt_r WHERE dml_heap_pt_p.b = dml_heap_pt_r.a and dml_heap_pt_p.b = dml_heap_pt_r.b;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT SUM(b) FROM dml_heap_pt_p;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+  sum  
+-------
+ 15152
+(1 row)
+
 rollback;
 --Update the partition key and move tuples across partitions( moving tuple to default partition)
 begin;
@@ -3817,7 +3816,7 @@ SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
 (1 row)
 
 UPDATE dml_heap_r SET a = generate_series(1,10), c ='n';
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;
@@ -3884,7 +3883,7 @@ SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
 (1 row)
 
 UPDATE dml_heap_s SET b = (SELECT COUNT(*) FROM dml_heap_s) FROM dml_heap_r WHERE dml_heap_r.a = dml_heap_s.b;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 SELECT COUNT(*) FROM dml_heap_s WHERE b = (SELECT COUNT(*) FROM dml_heap_s);
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
@@ -3953,7 +3952,7 @@ SELECT dml_heap_s.a ,dml_heap_s.b,'z' FROM dml_heap_r,dml_heap_s WHERE dml_heap_
 (1 row)
 
 UPDATE dml_heap_r SET (a,b,c) = (dml_heap_s.a ,dml_heap_s.b,'z') FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.b;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 SELECT * FROM dml_heap_r WHERE c='z' ORDER BY 1 LIMIT 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT COUNT(*) FROM dml_heap_r WHERE c='z';
@@ -3963,7 +3962,7 @@ rollback;
 begin;
 PREPARE plan_upd_2 as UPDATE dml_heap_r SET a = dml_heap_s.a +1 FROM dml_heap_s WHERE dml_heap_r.a = dml_heap_s.b ;
 EXECUTE plan_upd_2;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 rollback;
 --Update and case
 begin;
@@ -4040,7 +4039,7 @@ SELECT SUM(a) FROM dml_heap_v;
 (1 row)
 
 UPDATE dml_heap_v SET a = dml_heap_u.a FROM dml_heap_u WHERE dml_heap_u.b = dml_heap_v.b;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 SELECT SUM(a) FROM dml_heap_v;
  sum 
 -----
@@ -4049,7 +4048,7 @@ SELECT SUM(a) FROM dml_heap_v;
 
 --Update with joins on multiple table
 UPDATE dml_heap_r SET a = dml_heap_r.b+1 FROM dml_heap_p,dml_heap_s WHERE dml_heap_r.b = dml_heap_s.b and dml_heap_r.a = dml_heap_p.b+1;
-ERROR:  multiple updates to a row by the same query is not allowed
+ERROR:  cross-partition or multi-update to a row
 --Update on table with composite distribution key
 UPDATE dml_heap_p SET a = dml_heap_p.b % 2 FROM dml_heap_r WHERE dml_heap_p.b::int = dml_heap_r.b::int and dml_heap_p.a = dml_heap_r.a;
 --Update on table with composite distribution key

--- a/src/test/regress/expected/qp_dml_oids.out
+++ b/src/test/regress/expected/qp_dml_oids.out
@@ -21,7 +21,6 @@ CREATE TABLE tempoid as SELECT oid,a FROM dml_ao ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE dml_ao SET a = 100;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select count(distinct oid) from (select oid from tempoid UNION ALL select oid from dml_ao) as x;
  count 
 -------
@@ -32,7 +31,6 @@ select count(distinct oid) from (select oid from tempoid UNION ALL select oid fr
 -- UPDATEs moved the tuples across segments. To make sure that that doesn't
 -- change the OIDs either.
 UPDATE dml_ao SET a = 101;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select count(distinct oid) from (select oid from tempoid UNION ALL select oid from dml_ao) as x;
  count 
 -------
@@ -40,7 +38,6 @@ select count(distinct oid) from (select oid from tempoid UNION ALL select oid fr
 (1 row)
 
 UPDATE dml_ao SET a = 102;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select count(distinct oid) from (select oid from tempoid UNION ALL select oid from dml_ao) as x;
  count 
 -------
@@ -109,7 +106,7 @@ SELECT SUM(a) FROM dml_heap_check_r;
 DROP TABLE IF EXISTS tempoid;
 CREATE TABLE tempoid as SELECT oid,a FROM dml_heap_check_r DISTRIBUTED BY (a);
 UPDATE dml_heap_check_r set a = 110;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  new row for relation "dml_heap_check_r" violates check constraint "dml_heap_check_r_a_check"  (seg1 10.152.10.75:25433 pid=5919)
 SELECT SUM(a) FROM dml_heap_check_r;
  sum 
 -----
@@ -185,7 +182,6 @@ CREATE TABLE tempoid as SELECT oid,col1,a FROM dml_heap_r ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE dml_heap_r SET a = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT SUM(a) FROM dml_heap_r;
  sum 
 -----
@@ -238,7 +234,6 @@ CREATE TABLE tempoid as SELECT oid,col1,a,b FROM dml_heap_p ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a, b' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE dml_heap_p SET a = (SELECT a FROM dml_heap_r ORDER BY 1 LIMIT 1), b = ((SELECT b FROM dml_heap_r ORDER BY 1 LIMIT 1));
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- The query checks that the tuple oids remain the remain pre and post update .
 -- SELECT COUNT(*) FROM tempoid, dml_heap_r WHERE tempoid.oid = dml_heap_r.oid AND tempoid.col1 = dml_heap_r.col1 is a join on the tuple oids before update and after update. If the oids remain the same the below query should return 1 row which is equivalent to the number of rows in the table
 SELECT * FROM ( (SELECT COUNT(*) FROM dml_heap_p) UNION (SELECT COUNT(*) FROM tempoid, dml_heap_p WHERE tempoid.oid = dml_heap_p.oid AND tempoid.col1 = dml_heap_p.col1))foo;

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -42,13 +42,12 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_char ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_changedistpolicy_dml_pttab_char SET col3 ='c' WHERE col3 ='b';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_changedistpolicy_dml_pttab_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
  a    | a    | c    |    2
  g    | g    | a    |    0
- g    | g    | b    |    1
+ g    | g    | c    |    1
 (3 rows)
 
 DELETE FROM mpp21090_changedistpolicy_dml_pttab_char WHERE col3 ='c';
@@ -56,8 +55,7 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
  g    | g    | a    |    0
- g    | g    | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_changedistpolicy_dml_pttab_decimal;
@@ -100,13 +98,12 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_decimal ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_changedistpolicy_dml_pttab_decimal SET col3 ='c' WHERE col3 ='b';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_changedistpolicy_dml_pttab_decimal ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
  1.00 | 1.00 | c    |    2
  2.00 | 2.00 | a    |    0
- 2.00 | 2.00 | b    |    1
+ 2.00 | 2.00 | c    |    1
 (3 rows)
 
 DELETE FROM mpp21090_changedistpolicy_dml_pttab_decimal WHERE col3 ='c';
@@ -114,8 +111,7 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_decimal ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
  2.00 | 2.00 | a    |    0
- 2.00 | 2.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_changedistpolicy_dml_pttab_int4;
@@ -158,13 +154,12 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_int4 ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_changedistpolicy_dml_pttab_int4 SET col3 ='c' WHERE col3 ='b';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_changedistpolicy_dml_pttab_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  10000000 | 10000000 | c    |    2
  20000000 | 20000000 | a    |    0
- 20000000 | 20000000 | b    |    1
+ 20000000 | 20000000 | c    |    1
 (3 rows)
 
 DELETE FROM mpp21090_changedistpolicy_dml_pttab_int4 WHERE col3 ='c';
@@ -172,8 +167,7 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  20000000 | 20000000 | a    |    0
- 20000000 | 20000000 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_changedistpolicy_dml_pttab_int8;
@@ -216,12 +210,11 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_int8 ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_changedistpolicy_dml_pttab_int8 SET col3 ='c' WHERE col3 ='b';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_changedistpolicy_dml_pttab_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
   200000000000000000 |  200000000000000000 | a    |    0
-  200000000000000000 |  200000000000000000 | b    |    1
+  200000000000000000 |  200000000000000000 | c    |    1
  1000000000000000000 | 1000000000000000000 | c    |    2
 (3 rows)
 
@@ -230,8 +223,7 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_int8 ORDER BY 1,2,3;
         col1        |        col2        | col3 | col5 
 --------------------+--------------------+------+------
  200000000000000000 | 200000000000000000 | a    |    0
- 200000000000000000 | 200000000000000000 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_changedistpolicy_dml_pttab_interval;
@@ -274,12 +266,11 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_interval ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_changedistpolicy_dml_pttab_interval SET col3 ='c' WHERE col3 ='b';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_changedistpolicy_dml_pttab_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  00:00:10 | 00:00:10 | a    |    0
- 00:00:10 | 00:00:10 | b    |    1
+ 00:00:10 | 00:00:10 | c    |    1
  11:00:00 | 11:00:00 | c    |    2
 (3 rows)
 
@@ -288,8 +279,7 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  00:00:10 | 00:00:10 | a    |    0
- 00:00:10 | 00:00:10 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_changedistpolicy_dml_pttab_numeric;
@@ -332,13 +322,12 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_numeric ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_changedistpolicy_dml_pttab_numeric SET col3 ='c' WHERE col3 ='b';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_changedistpolicy_dml_pttab_numeric ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  1.000000 | 1.000000 | c    |    2
  2.000000 | 2.000000 | a    |    0
- 2.000000 | 2.000000 | b    |    1
+ 2.000000 | 2.000000 | c    |    1
 (3 rows)
 
 DELETE FROM mpp21090_changedistpolicy_dml_pttab_numeric WHERE col3 ='c';
@@ -346,8 +335,7 @@ SELECT * FROM mpp21090_changedistpolicy_dml_pttab_numeric ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  2.000000 | 2.000000 | a    |    0
- 2.000000 | 2.000000 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_defpt_dropcol_addcol_dml_char;
@@ -386,13 +374,12 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_char ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_defpt_dropcol_addcol_dml_char SET col1 = '-' WHERE col2 = 'z' AND col1 = 'z';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
+ -    | z    | b    | 
  x    | x    | a    | 
  x    | x    | c    | x
- z    | z    | b    | 
 (3 rows)
 
 -- Update partition key
@@ -400,9 +387,9 @@ UPDATE mpp21090_defpt_dropcol_addcol_dml_char SET col2 = '-' WHERE col2 = 'z' AN
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
+ -    | -    | b    | 
  x    | x    | a    | 
  x    | x    | c    | x
- z    | z    | b    | 
 (3 rows)
 
 DELETE FROM mpp21090_defpt_dropcol_addcol_dml_char WHERE col2 = '-';
@@ -411,8 +398,7 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_char ORDER BY 1,2,3;
 ------+------+------+------
  x    | x    | a    | 
  x    | x    | c    | x
- z    | z    | b    | 
-(3 rows)
+(2 rows)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_defpt_dropcol_addcol_dml_decimal;
@@ -451,33 +437,31 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_decimal ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_defpt_dropcol_addcol_dml_decimal SET col1 = 1.00 WHERE col2 = 35.00 AND col1 = 35.00;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_decimal ORDER BY 1,2,3;
- col1  | col2  | col3 | col5 
--------+-------+------+------
-  2.00 |  2.00 | a    |     
-  2.00 |  2.00 | c    | 2.00
- 35.00 | 35.00 | b    |     
+ col1 | col2  | col3 | col5 
+------+-------+------+------
+ 1.00 | 35.00 | b    |     
+ 2.00 |  2.00 | a    |     
+ 2.00 |  2.00 | c    | 2.00
 (3 rows)
 
 -- Update partition key
 UPDATE mpp21090_defpt_dropcol_addcol_dml_decimal SET col2 = 1.00 WHERE col2 = 35.00 AND col1 = 1.00;
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_decimal ORDER BY 1,2,3;
- col1  | col2  | col3 | col5 
--------+-------+------+------
-  2.00 |  2.00 | a    |     
-  2.00 |  2.00 | c    | 2.00
- 35.00 | 35.00 | b    |     
+ col1 | col2 | col3 | col5 
+------+------+------+------
+ 1.00 | 1.00 | b    |     
+ 2.00 | 2.00 | a    |     
+ 2.00 | 2.00 | c    | 2.00
 (3 rows)
 
 DELETE FROM mpp21090_defpt_dropcol_addcol_dml_decimal WHERE col2 = 1.00;
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_decimal ORDER BY 1,2,3;
- col1  | col2  | col3 | col5 
--------+-------+------+------
-  2.00 |  2.00 | a    |     
-  2.00 |  2.00 | c    | 2.00
- 35.00 | 35.00 | b    |     
-(3 rows)
+ col1 | col2 | col3 | col5 
+------+------+------+------
+ 2.00 | 2.00 | a    |     
+ 2.00 | 2.00 | c    | 2.00
+(2 rows)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_defpt_dropcol_addcol_dml_int4;
@@ -516,13 +500,12 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_int4 ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_defpt_dropcol_addcol_dml_int4 SET col1 = 10000000 WHERE col2 = 35000000 AND col1 = 35000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 |   col5   
 ----------+----------+------+----------
+ 10000000 | 35000000 | b    |         
  20000000 | 20000000 | a    |         
  20000000 | 20000000 | c    | 20000000
- 35000000 | 35000000 | b    |         
 (3 rows)
 
 -- Update partition key
@@ -530,9 +513,9 @@ UPDATE mpp21090_defpt_dropcol_addcol_dml_int4 SET col2 = 10000000 WHERE col2 = 3
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 |   col5   
 ----------+----------+------+----------
+ 10000000 | 10000000 | b    |         
  20000000 | 20000000 | a    |         
  20000000 | 20000000 | c    | 20000000
- 35000000 | 35000000 | b    |         
 (3 rows)
 
 DELETE FROM mpp21090_defpt_dropcol_addcol_dml_int4 WHERE col2 = 10000000;
@@ -541,8 +524,7 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_int4 ORDER BY 1,2,3;
 ----------+----------+------+----------
  20000000 | 20000000 | a    |         
  20000000 | 20000000 | c    | 20000000
- 35000000 | 35000000 | b    |         
-(3 rows)
+(2 rows)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_defpt_dropcol_addcol_dml_int8;
@@ -581,13 +563,12 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_int8 ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_defpt_dropcol_addcol_dml_int8 SET col1 = 1000000000000000000 WHERE col2 = 3500000000000000000 AND col1 = 3500000000000000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 |        col5         
 ---------------------+---------------------+------+---------------------
+ 1000000000000000000 | 3500000000000000000 | b    |                    
  2000000000000000000 | 2000000000000000000 | a    |                    
  2000000000000000000 | 2000000000000000000 | c    | 2000000000000000000
- 3500000000000000000 | 3500000000000000000 | b    |                    
 (3 rows)
 
 -- Update partition key
@@ -595,9 +576,9 @@ UPDATE mpp21090_defpt_dropcol_addcol_dml_int8 SET col2 = 1000000000000000000 WHE
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 |        col5         
 ---------------------+---------------------+------+---------------------
+ 1000000000000000000 | 1000000000000000000 | b    |                    
  2000000000000000000 | 2000000000000000000 | a    |                    
  2000000000000000000 | 2000000000000000000 | c    | 2000000000000000000
- 3500000000000000000 | 3500000000000000000 | b    |                    
 (3 rows)
 
 DELETE FROM mpp21090_defpt_dropcol_addcol_dml_int8 WHERE col2 = 1000000000000000000;
@@ -606,8 +587,7 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_int8 ORDER BY 1,2,3;
 ---------------------+---------------------+------+---------------------
  2000000000000000000 | 2000000000000000000 | a    |                    
  2000000000000000000 | 2000000000000000000 | c    | 2000000000000000000
- 3500000000000000000 | 3500000000000000000 | b    |                    
-(3 rows)
+(2 rows)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_defpt_dropcol_addcol_dml_interval;
@@ -646,13 +626,12 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_interval ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_defpt_dropcol_addcol_dml_interval SET col1 = '12 hours' WHERE col2 = '14 hours' AND col1 = '14 hours';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 |   col5   
 ----------+----------+------+----------
  01:00:00 | 01:00:00 | a    | 
  01:00:00 | 01:00:00 | c    | 01:00:00
- 14:00:00 | 14:00:00 | b    | 
+ 12:00:00 | 14:00:00 | b    | 
 (3 rows)
 
 -- Update partition key
@@ -662,7 +641,7 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_interval ORDER BY 1,2,3;
 ----------+----------+------+----------
  01:00:00 | 01:00:00 | a    | 
  01:00:00 | 01:00:00 | c    | 01:00:00
- 14:00:00 | 14:00:00 | b    | 
+ 12:00:00 | 12:00:00 | b    | 
 (3 rows)
 
 DELETE FROM mpp21090_defpt_dropcol_addcol_dml_interval WHERE col2 = '12 hours';
@@ -671,8 +650,7 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_interval ORDER BY 1,2,3;
 ----------+----------+------+----------
  01:00:00 | 01:00:00 | a    | 
  01:00:00 | 01:00:00 | c    | 01:00:00
- 14:00:00 | 14:00:00 | b    | 
-(3 rows)
+(2 rows)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_defpt_dropcol_addcol_dml_numeric;
@@ -711,33 +689,31 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_numeric ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_defpt_dropcol_addcol_dml_numeric SET col1 = 1.000000 WHERE col2 = 35.000000 AND col1 = 35.000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_numeric ORDER BY 1,2,3;
-   col1    |   col2    | col3 |   col5   
------------+-----------+------+----------
-  2.000000 |  2.000000 | a    |         
-  2.000000 |  2.000000 | c    | 2.000000
- 35.000000 | 35.000000 | b    |         
+   col1   |   col2    | col3 |   col5   
+----------+-----------+------+----------
+ 1.000000 | 35.000000 | b    |         
+ 2.000000 |  2.000000 | a    |         
+ 2.000000 |  2.000000 | c    | 2.000000
 (3 rows)
 
 -- Update partition key
 UPDATE mpp21090_defpt_dropcol_addcol_dml_numeric SET col2 = 1.000000 WHERE col2 = 35.000000 AND col1 = 1.000000;
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_numeric ORDER BY 1,2,3;
-   col1    |   col2    | col3 |   col5   
------------+-----------+------+----------
-  2.000000 |  2.000000 | a    |         
-  2.000000 |  2.000000 | c    | 2.000000
- 35.000000 | 35.000000 | b    |         
+   col1   |   col2   | col3 |   col5   
+----------+----------+------+----------
+ 1.000000 | 1.000000 | b    |         
+ 2.000000 | 2.000000 | a    |         
+ 2.000000 | 2.000000 | c    | 2.000000
 (3 rows)
 
 DELETE FROM mpp21090_defpt_dropcol_addcol_dml_numeric WHERE col2 = 1.000000;
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_numeric ORDER BY 1,2,3;
-   col1    |   col2    | col3 |   col5   
------------+-----------+------+----------
-  2.000000 |  2.000000 | a    |         
-  2.000000 |  2.000000 | c    | 2.000000
- 35.000000 | 35.000000 | b    |         
-(3 rows)
+   col1   |   col2   | col3 |   col5   
+----------+----------+------+----------
+ 2.000000 | 2.000000 | a    |         
+ 2.000000 | 2.000000 | c    | 2.000000
+(2 rows)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_defpt_dropcol_addcol_dml_text;
@@ -776,13 +752,12 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_text ORDER BY 1,2,3;
 (3 rows)
 
 UPDATE mpp21090_defpt_dropcol_addcol_dml_text SET col1 = 'qrstuvwxyz' WHERE col2 = 'xyz' AND col1 = 'xyz';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_text ORDER BY 1,2,3;
        col1       |       col2       | col3 |       col5       
 ------------------+------------------+------+------------------
  abcdefghijklmnop | abcdefghijklmnop | a    | 
  abcdefghijklmnop | abcdefghijklmnop | c    | abcdefghijklmnop
- xyz              | xyz              | b    | 
+ qrstuvwxyz       | xyz              | b    | 
 (3 rows)
 
 -- Update partition key
@@ -792,7 +767,7 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_text ORDER BY 1,2,3;
 ------------------+------------------+------+------------------
  abcdefghijklmnop | abcdefghijklmnop | a    | 
  abcdefghijklmnop | abcdefghijklmnop | c    | abcdefghijklmnop
- xyz              | xyz              | b    | 
+ qrstuvwxyz       | qrstuvwxyz       | b    | 
 (3 rows)
 
 DELETE FROM mpp21090_defpt_dropcol_addcol_dml_text WHERE col2 = 'qrstuvwxyz';
@@ -801,8 +776,7 @@ SELECT * FROM mpp21090_defpt_dropcol_addcol_dml_text ORDER BY 1,2,3;
 ------------------+------------------+------+------------------
  abcdefghijklmnop | abcdefghijklmnop | a    | 
  abcdefghijklmnop | abcdefghijklmnop | c    | abcdefghijklmnop
- xyz              | xyz              | b    | 
-(3 rows)
+(2 rows)
 
 -- TEST
 DROP TABLE IF EXISTS dropped_col_tab;
@@ -892,14 +866,13 @@ SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_char ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_char SET col1 = 'z' WHERE col2 = 'a' AND col1 = 'a';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | e    |    1
  x    | x    | a    |   10
  x    | x    | b    |   10
  x    | x    | c    |    1
+ z    | a    | e    |    1
 (4 rows)
 
 -- Update partition key
@@ -907,19 +880,19 @@ UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_char SET col2 = 'z' WHERE col2 = '
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | e    |    1
  x    | x    | a    |   10
  x    | x    | b    |   10
  x    | x    | c    |    1
+ z    | z    | e    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitdefpt_dml_char WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | e    |    1
  x    | x    | a    |   10
  x    | x    | c    |    1
+ z    | z    | e    |    1
 (3 rows)
 
 -- TEST
@@ -981,34 +954,33 @@ SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_decimal ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_decimal SET col1 = 35.00 WHERE col2 = 1.00 AND col1 = 1.00;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | e    |    1
- 2.00 | 2.00 | a    |   10
- 2.00 | 2.00 | b    |   10
- 2.00 | 2.00 | c    |    1
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    |   10
+  2.00 | 2.00 | b    |   10
+  2.00 | 2.00 | c    |    1
+ 35.00 | 1.00 | e    |    1
 (4 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_decimal SET col2 = 35.00 WHERE col2 = 1.00 AND col1 = 35.00;
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | e    |    1
- 2.00 | 2.00 | a    |   10
- 2.00 | 2.00 | b    |   10
- 2.00 | 2.00 | c    |    1
+ col1  | col2  | col3 | col5 
+-------+-------+------+------
+  2.00 |  2.00 | a    |   10
+  2.00 |  2.00 | b    |   10
+  2.00 |  2.00 | c    |    1
+ 35.00 | 35.00 | e    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitdefpt_dml_decimal WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | e    |    1
- 2.00 | 2.00 | a    |   10
- 2.00 | 2.00 | c    |    1
+ col1  | col2  | col3 | col5 
+-------+-------+------+------
+  2.00 |  2.00 | a    |   10
+  2.00 |  2.00 | c    |    1
+ 35.00 | 35.00 | e    |    1
 (3 rows)
 
 -- TEST
@@ -1070,14 +1042,13 @@ SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_int4 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_int4 SET col1 = 35000000 WHERE col2 = 10000000 AND col1 = 10000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | e    |    1
  20000000 | 20000000 | a    |   10
  20000000 | 20000000 | b    |   10
  20000000 | 20000000 | c    |    1
+ 35000000 | 10000000 | e    |    1
 (4 rows)
 
 -- Update partition key
@@ -1085,19 +1056,19 @@ UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_int4 SET col2 = 35000000 WHERE col
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | e    |    1
  20000000 | 20000000 | a    |   10
  20000000 | 20000000 | b    |   10
  20000000 | 20000000 | c    |    1
+ 35000000 | 35000000 | e    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitdefpt_dml_int4 WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | e    |    1
  20000000 | 20000000 | a    |   10
  20000000 | 20000000 | c    |    1
+ 35000000 | 35000000 | e    |    1
 (3 rows)
 
 -- TEST
@@ -1159,14 +1130,13 @@ SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_int8 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_int8 SET col1 = 3500000000000000000 WHERE col2 = 100000000000000000 AND col1 = 100000000000000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | e    |    1
  2000000000000000000 | 2000000000000000000 | a    |   10
  2000000000000000000 | 2000000000000000000 | b    |   10
  2000000000000000000 | 2000000000000000000 | c    |    1
+ 3500000000000000000 |  100000000000000000 | e    |    1
 (4 rows)
 
 -- Update partition key
@@ -1174,19 +1144,19 @@ UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_int8 SET col2 = 350000000000000000
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | e    |    1
  2000000000000000000 | 2000000000000000000 | a    |   10
  2000000000000000000 | 2000000000000000000 | b    |   10
  2000000000000000000 | 2000000000000000000 | c    |    1
+ 3500000000000000000 | 3500000000000000000 | e    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitdefpt_dml_int8 WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | e    |    1
  2000000000000000000 | 2000000000000000000 | a    |   10
  2000000000000000000 | 2000000000000000000 | c    |    1
+ 3500000000000000000 | 3500000000000000000 | e    |    1
 (3 rows)
 
 -- TEST
@@ -1248,14 +1218,13 @@ SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_interval ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_interval SET col1 = '14 hours' WHERE col2 = '1 sec' AND col1 = '1 sec';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | e    |    1
  01:00:00 | 01:00:00 | a    |   10
  01:00:00 | 01:00:00 | b    |   10
  01:00:00 | 01:00:00 | c    |    1
+ 14:00:00 | 00:00:01 | e    |    1
 (4 rows)
 
 -- Update partition key
@@ -1263,19 +1232,19 @@ UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_interval SET col2 = '14 hours' WHE
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | e    |    1
  01:00:00 | 01:00:00 | a    |   10
  01:00:00 | 01:00:00 | b    |   10
  01:00:00 | 01:00:00 | c    |    1
+ 14:00:00 | 14:00:00 | e    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitdefpt_dml_interval WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | e    |    1
  01:00:00 | 01:00:00 | a    |   10
  01:00:00 | 01:00:00 | c    |    1
+ 14:00:00 | 14:00:00 | e    |    1
 (3 rows)
 
 -- TEST
@@ -1337,34 +1306,33 @@ SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_numeric ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_numeric SET col1 = 35.000000 WHERE col2 = 1.000000 AND col1 = 1.000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | e    |    1
- 2.000000 | 2.000000 | a    |   10
- 2.000000 | 2.000000 | b    |   10
- 2.000000 | 2.000000 | c    |    1
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  2.000000 | 2.000000 | a    |   10
+  2.000000 | 2.000000 | b    |   10
+  2.000000 | 2.000000 | c    |    1
+ 35.000000 | 1.000000 | e    |    1
 (4 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_addcol_splitdefpt_dml_numeric SET col2 = 35.000000 WHERE col2 = 1.000000 AND col1 = 35.000000;
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | e    |    1
- 2.000000 | 2.000000 | a    |   10
- 2.000000 | 2.000000 | b    |   10
- 2.000000 | 2.000000 | c    |    1
+   col1    |   col2    | col3 | col5 
+-----------+-----------+------+------
+  2.000000 |  2.000000 | a    |   10
+  2.000000 |  2.000000 | b    |   10
+  2.000000 |  2.000000 | c    |    1
+ 35.000000 | 35.000000 | e    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitdefpt_dml_numeric WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitdefpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | e    |    1
- 2.000000 | 2.000000 | a    |   10
- 2.000000 | 2.000000 | c    |    1
+   col1    |   col2    | col3 | col5 
+-----------+-----------+------+------
+  2.000000 |  2.000000 | a    |   10
+  2.000000 |  2.000000 | c    |    1
+ 35.000000 | 35.000000 | e    |    1
 (3 rows)
 
 -- TEST
@@ -1425,34 +1393,34 @@ SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_char ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_char SET col1 = 'z' WHERE col2 = 'a' AND col1 = 'a';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | d    |    1
  x    | x    | a    |   10
  x    | x    | b    |    0
  x    | x    | c    |    1
+ z    | a    | d    |    1
 (4 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_char SET col2 ='x'  WHERE col2 = 'a' AND col1 = 'z';
+ERROR:  moving tuple from partition "mpp21090_dropcol_addcol_splitpt_dml_char_1_prt_partsplitone" to partition "mpp21090_dropcol_addcol_splitpt_dml_char_1_prt_partthree" not supported  (seg1 10.152.10.75:25433 pid=7636)
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | d    |    1
  x    | x    | a    |   10
  x    | x    | b    |    0
  x    | x    | c    |    1
+ z    | a    | d    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitpt_dml_char WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | d    |    1
  x    | x    | a    |   10
  x    | x    | c    |    1
+ z    | a    | d    |    1
 (3 rows)
 
 -- TEST
@@ -1513,34 +1481,33 @@ SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_decimal ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_decimal SET col1 = 35.00 WHERE col2 = 1.00 AND col1 = 1.00;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | d    |    1
- 2.00 | 2.00 | a    |   10
- 2.00 | 2.00 | b    |    0
- 2.00 | 2.00 | c    |    1
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    |   10
+  2.00 | 2.00 | b    |    0
+  2.00 | 2.00 | c    |    1
+ 35.00 | 1.00 | d    |    1
 (4 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_decimal SET col2 =2.00  WHERE col2 = 1.00 AND col1 = 35.00;
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | d    |    1
- 2.00 | 2.00 | a    |   10
- 2.00 | 2.00 | b    |    0
- 2.00 | 2.00 | c    |    1
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    |   10
+  2.00 | 2.00 | b    |    0
+  2.00 | 2.00 | c    |    1
+ 35.00 | 2.00 | d    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitpt_dml_decimal WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | d    |    1
- 2.00 | 2.00 | a    |   10
- 2.00 | 2.00 | c    |    1
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    |   10
+  2.00 | 2.00 | c    |    1
+ 35.00 | 2.00 | d    |    1
 (3 rows)
 
 -- TEST
@@ -1601,14 +1568,13 @@ SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_int4 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_int4 SET col1 = 35000000 WHERE col2 = 10000000 AND col1 = 10000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | d    |    1
  20000000 | 20000000 | a    |   10
  20000000 | 20000000 | b    |    0
  20000000 | 20000000 | c    |    1
+ 35000000 | 10000000 | d    |    1
 (4 rows)
 
 -- Update partition key
@@ -1616,19 +1582,19 @@ UPDATE mpp21090_dropcol_addcol_splitpt_dml_int4 SET col2 =20000000  WHERE col2 =
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | d    |    1
  20000000 | 20000000 | a    |   10
  20000000 | 20000000 | b    |    0
  20000000 | 20000000 | c    |    1
+ 35000000 | 20000000 | d    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitpt_dml_int4 WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | d    |    1
  20000000 | 20000000 | a    |   10
  20000000 | 20000000 | c    |    1
+ 35000000 | 20000000 | d    |    1
 (3 rows)
 
 -- TEST
@@ -1689,34 +1655,34 @@ SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_int8 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_int8 SET col1 = 3500000000000000000 WHERE col2 = 100000000000000000 AND col1 = 100000000000000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | d    |    1
  2000000000000000000 | 2000000000000000000 | a    |   10
  2000000000000000000 | 2000000000000000000 | b    |    0
  2000000000000000000 | 2000000000000000000 | c    |    1
+ 3500000000000000000 |  100000000000000000 | d    |    1
 (4 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_int8 SET col2 =2000000000000000000  WHERE col2 = 100000000000000000 AND col1 = 3500000000000000000;
+ERROR:  moving tuple from partition "mpp21090_dropcol_addcol_splitpt_dml_int8_1_prt_partsplitone" to partition "mpp21090_dropcol_addcol_splitpt_dml_int8_1_prt_parttwo" not supported  (seg1 10.152.10.75:25433 pid=7636)
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | d    |    1
  2000000000000000000 | 2000000000000000000 | a    |   10
  2000000000000000000 | 2000000000000000000 | b    |    0
  2000000000000000000 | 2000000000000000000 | c    |    1
+ 3500000000000000000 |  100000000000000000 | d    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitpt_dml_int8 WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | d    |    1
  2000000000000000000 | 2000000000000000000 | a    |   10
  2000000000000000000 | 2000000000000000000 | c    |    1
+ 3500000000000000000 |  100000000000000000 | d    |    1
 (3 rows)
 
 -- TEST
@@ -1777,34 +1743,34 @@ SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_interval ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_interval SET col1 = '14 hours' WHERE col2 = '1 sec' AND col1 = '1 sec';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | d    |    1
  01:00:00 | 01:00:00 | a    |   10
  01:00:00 | 01:00:00 | b    |    0
  01:00:00 | 01:00:00 | c    |    1
+ 14:00:00 | 00:00:01 | d    |    1
 (4 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_interval SET col2 ='1 hour'  WHERE col2 = '1 sec' AND col1 = '14 hours';
+ERROR:  moving tuple from partition "mpp21090_dropcol_addcol_splitpt_dml_interval_1_prt_partsplitone" to partition "mpp21090_dropcol_addcol_splitpt_dml_interval_1_prt_partthree" not supported  (seg0 10.152.10.75:25432 pid=7634)
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | d    |    1
  01:00:00 | 01:00:00 | a    |   10
  01:00:00 | 01:00:00 | b    |    0
  01:00:00 | 01:00:00 | c    |    1
+ 14:00:00 | 00:00:01 | d    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitpt_dml_interval WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | d    |    1
  01:00:00 | 01:00:00 | a    |   10
  01:00:00 | 01:00:00 | c    |    1
+ 14:00:00 | 00:00:01 | d    |    1
 (3 rows)
 
 -- TEST
@@ -1865,34 +1831,33 @@ SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_numeric ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_numeric SET col1 = 35.000000 WHERE col2 = 1.000000 AND col1 = 1.000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | d    |    1
- 2.000000 | 2.000000 | a    |   10
- 2.000000 | 2.000000 | b    |    0
- 2.000000 | 2.000000 | c    |    1
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  2.000000 | 2.000000 | a    |   10
+  2.000000 | 2.000000 | b    |    0
+  2.000000 | 2.000000 | c    |    1
+ 35.000000 | 1.000000 | d    |    1
 (4 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_addcol_splitpt_dml_numeric SET col2 =2.000000  WHERE col2 = 1.000000 AND col1 = 35.000000;
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | d    |    1
- 2.000000 | 2.000000 | a    |   10
- 2.000000 | 2.000000 | b    |    0
- 2.000000 | 2.000000 | c    |    1
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  2.000000 | 2.000000 | a    |   10
+  2.000000 | 2.000000 | b    |    0
+  2.000000 | 2.000000 | c    |    1
+ 35.000000 | 2.000000 | d    |    1
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_addcol_splitpt_dml_numeric WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_addcol_splitpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | d    |    1
- 2.000000 | 2.000000 | a    |   10
- 2.000000 | 2.000000 | c    |    1
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  2.000000 | 2.000000 | a    |   10
+  2.000000 | 2.000000 | c    |    1
+ 35.000000 | 2.000000 | d    |    1
 (3 rows)
 
 -- TEST
@@ -1921,11 +1886,10 @@ CREATE TABLE tempoid as SELECT oid,col1,col3,col4,col5 FROM oidtab ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE oidtab SET col4=False WHERE col3 = 'a' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM oidtab ORDER BY 1,2,3,4;
  col1 | col3 | col4 | col5 
 ------+------+------+------
-    1 | a    | t    |    1
+    1 | a    | f    |    1
 (1 row)
 
 SELECT * FROM ((SELECT COUNT(*) FROM oidtab) UNION (SELECT COUNT(*) FROM tempoid, oidtab WHERE tempoid.oid = oidtab.oid AND tempoid.col5 = oidtab.col5))foo;
@@ -1958,11 +1922,10 @@ CREATE TABLE tempoid as SELECT oid,col1,col3,col4,col5 FROM oidtab ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE oidtab SET col4='-' WHERE col3 = 'a' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM oidtab ORDER BY 1,2,3,4;
  col1 | col3 | col4 | col5 
 ------+------+------+------
-    1 | a    | z    |    1
+    1 | a    | -    |    1
 (1 row)
 
 SELECT * FROM ((SELECT COUNT(*) FROM oidtab) UNION (SELECT COUNT(*) FROM tempoid, oidtab WHERE tempoid.oid = oidtab.oid AND tempoid.col5 = oidtab.col5))foo;
@@ -1995,11 +1958,10 @@ CREATE TABLE tempoid as SELECT oid,col1,col3,col4,col5 FROM oidtab ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE oidtab SET col4=1.00 WHERE col3 = 'a' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM oidtab ORDER BY 1,2,3,4;
  col1 | col3 | col4 | col5 
 ------+------+------+------
-    1 | a    | 2.00 |    1
+    1 | a    | 1.00 |    1
 (1 row)
 
 SELECT * FROM ((SELECT COUNT(*) FROM oidtab) UNION (SELECT COUNT(*) FROM tempoid, oidtab WHERE tempoid.oid = oidtab.oid AND tempoid.col5 = oidtab.col5))foo;
@@ -2032,11 +1994,10 @@ CREATE TABLE tempoid as SELECT oid,col1,col3,col4,col5 FROM oidtab ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE oidtab SET col4=1000000000 WHERE col3 = 'a' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM oidtab ORDER BY 1,2,3,4;
  col1 | col3 |    col4    | col5 
 ------+------+------------+------
-    1 | a    | 2000000000 |    1
+    1 | a    | 1000000000 |    1
 (1 row)
 
 SELECT * FROM ((SELECT COUNT(*) FROM oidtab) UNION (SELECT COUNT(*) FROM tempoid, oidtab WHERE tempoid.oid = oidtab.oid AND tempoid.col5 = oidtab.col5))foo;
@@ -2069,11 +2030,10 @@ CREATE TABLE tempoid as SELECT oid,col1,col3,col4,col5 FROM oidtab ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE oidtab SET col4=1000000000000000000 WHERE col3 = 'a' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM oidtab ORDER BY 1,2,3,4;
  col1 | col3 |        col4         | col5 
 ------+------+---------------------+------
-    1 | a    | 2000000000000000000 |    1
+    1 | a    | 1000000000000000000 |    1
 (1 row)
 
 SELECT * FROM ((SELECT COUNT(*) FROM oidtab) UNION (SELECT COUNT(*) FROM tempoid, oidtab WHERE tempoid.oid = oidtab.oid AND tempoid.col5 = oidtab.col5))foo;
@@ -2106,11 +2066,10 @@ CREATE TABLE tempoid as SELECT oid,col1,col3,col4,col5 FROM oidtab ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE oidtab SET col4='1 hour' WHERE col3 = 'a' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM oidtab ORDER BY 1,2,3,4;
- col1 | col3 | col4  | col5 
-------+------+-------+------
-    1 | a    | 1 day |    1
+ col1 | col3 |   col4   | col5 
+------+------+----------+------
+    1 | a    | 01:00:00 |    1
 (1 row)
 
 SELECT * FROM ((SELECT COUNT(*) FROM oidtab) UNION (SELECT COUNT(*) FROM tempoid, oidtab WHERE tempoid.oid = oidtab.oid AND tempoid.col5 = oidtab.col5))foo;
@@ -2143,11 +2102,10 @@ CREATE TABLE tempoid as SELECT oid,col1,col3,col4,col5 FROM oidtab ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE oidtab SET col4=1.000000 WHERE col3 = 'a' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM oidtab ORDER BY 1,2,3,4;
  col1 | col3 |   col4   | col5 
 ------+------+----------+------
-    1 | a    | 2.000000 |    1
+    1 | a    | 1.000000 |    1
 (1 row)
 
 SELECT * FROM ((SELECT COUNT(*) FROM oidtab) UNION (SELECT COUNT(*) FROM tempoid, oidtab WHERE tempoid.oid = oidtab.oid AND tempoid.col5 = oidtab.col5))foo;
@@ -2180,11 +2138,10 @@ CREATE TABLE tempoid as SELECT oid,col1,col3,col4,col5 FROM oidtab ORDER BY 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 UPDATE oidtab SET col4='qrstuvwxyz' WHERE col3 = 'a' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM oidtab ORDER BY 1,2,3,4;
- col1 | col3 |       col4       | col5 
-------+------+------------------+------
-    1 | a    | abcdefghijklmnop |    1
+ col1 | col3 |    col4    | col5 
+------+------+------------+------
+    1 | a    | qrstuvwxyz |    1
 (1 row)
 
 SELECT * FROM ((SELECT COUNT(*) FROM oidtab) UNION (SELECT COUNT(*) FROM tempoid, oidtab WHERE tempoid.oid = oidtab.oid AND tempoid.col5 = oidtab.col5))foo;
@@ -2252,14 +2209,13 @@ SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_char ORDER BY 1,2,3,4;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_char SET col1 = 'z' WHERE col2 = 'a' AND col1 = 'a';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | e    | x
  x    | x    | a    | x
  x    | x    | b    | x
  x    | x    | c    | x
+ z    | a    | e    | x
 (4 rows)
 
 -- Update partition key
@@ -2267,19 +2223,19 @@ UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_char SET col2 = 'z' WHERE col2 = '
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | e    | x
  x    | x    | a    | x
  x    | x    | b    | x
  x    | x    | c    | x
+ z    | z    | e    | x
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_splitdefpt_addcol_dml_char WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | e    | x
  x    | x    | a    | x
  x    | x    | c    | x
+ z    | z    | e    | x
 (3 rows)
 
 -- TEST
@@ -2341,34 +2297,33 @@ SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_decimal ORDER BY 1,2,3,4;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_decimal SET col1 = 35.00 WHERE col2 = 1.00 AND col1 = 1.00;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | e    | 2.00
- 2.00 | 2.00 | a    | 2.00
- 2.00 | 2.00 | b    | 2.00
- 2.00 | 2.00 | c    | 2.00
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    | 2.00
+  2.00 | 2.00 | b    | 2.00
+  2.00 | 2.00 | c    | 2.00
+ 35.00 | 1.00 | e    | 2.00
 (4 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_decimal SET col2 = 35.00 WHERE col2 = 1.00 AND col1 = 35.00;
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | e    | 2.00
- 2.00 | 2.00 | a    | 2.00
- 2.00 | 2.00 | b    | 2.00
- 2.00 | 2.00 | c    | 2.00
+ col1  | col2  | col3 | col5 
+-------+-------+------+------
+  2.00 |  2.00 | a    | 2.00
+  2.00 |  2.00 | b    | 2.00
+  2.00 |  2.00 | c    | 2.00
+ 35.00 | 35.00 | e    | 2.00
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_splitdefpt_addcol_dml_decimal WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | e    | 2.00
- 2.00 | 2.00 | a    | 2.00
- 2.00 | 2.00 | c    | 2.00
+ col1  | col2  | col3 | col5 
+-------+-------+------+------
+  2.00 |  2.00 | a    | 2.00
+  2.00 |  2.00 | c    | 2.00
+ 35.00 | 35.00 | e    | 2.00
 (3 rows)
 
 -- TEST
@@ -2430,14 +2385,13 @@ SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_int4 ORDER BY 1,2,3,4;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_int4 SET col1 = 35000000 WHERE col2 = 10000000 AND col1 = 10000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 |   col5   
 ----------+----------+------+----------
- 10000000 | 10000000 | e    | 20000000
  20000000 | 20000000 | a    | 20000000
  20000000 | 20000000 | b    | 20000000
  20000000 | 20000000 | c    | 20000000
+ 35000000 | 10000000 | e    | 20000000
 (4 rows)
 
 -- Update partition key
@@ -2445,19 +2399,19 @@ UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_int4 SET col2 = 35000000 WHERE col
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 |   col5   
 ----------+----------+------+----------
- 10000000 | 10000000 | e    | 20000000
  20000000 | 20000000 | a    | 20000000
  20000000 | 20000000 | b    | 20000000
  20000000 | 20000000 | c    | 20000000
+ 35000000 | 35000000 | e    | 20000000
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_splitdefpt_addcol_dml_int4 WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 |   col5   
 ----------+----------+------+----------
- 10000000 | 10000000 | e    | 20000000
  20000000 | 20000000 | a    | 20000000
  20000000 | 20000000 | c    | 20000000
+ 35000000 | 35000000 | e    | 20000000
 (3 rows)
 
 -- TEST
@@ -2519,14 +2473,13 @@ SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_int8 ORDER BY 1,2,3,4;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_int8 SET col1 = 3500000000000000000 WHERE col2 = 100000000000000000 AND col1 = 100000000000000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 |        col5         
 ---------------------+---------------------+------+---------------------
-  100000000000000000 |  100000000000000000 | e    | 2000000000000000000
  2000000000000000000 | 2000000000000000000 | a    | 2000000000000000000
  2000000000000000000 | 2000000000000000000 | b    | 2000000000000000000
  2000000000000000000 | 2000000000000000000 | c    | 2000000000000000000
+ 3500000000000000000 |  100000000000000000 | e    | 2000000000000000000
 (4 rows)
 
 -- Update partition key
@@ -2534,19 +2487,19 @@ UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_int8 SET col2 = 350000000000000000
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 |        col5         
 ---------------------+---------------------+------+---------------------
-  100000000000000000 |  100000000000000000 | e    | 2000000000000000000
  2000000000000000000 | 2000000000000000000 | a    | 2000000000000000000
  2000000000000000000 | 2000000000000000000 | b    | 2000000000000000000
  2000000000000000000 | 2000000000000000000 | c    | 2000000000000000000
+ 3500000000000000000 | 3500000000000000000 | e    | 2000000000000000000
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_splitdefpt_addcol_dml_int8 WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 |        col5         
 ---------------------+---------------------+------+---------------------
-  100000000000000000 |  100000000000000000 | e    | 2000000000000000000
  2000000000000000000 | 2000000000000000000 | a    | 2000000000000000000
  2000000000000000000 | 2000000000000000000 | c    | 2000000000000000000
+ 3500000000000000000 | 3500000000000000000 | e    | 2000000000000000000
 (3 rows)
 
 -- TEST
@@ -2608,14 +2561,13 @@ SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_interval ORDER BY 1,2,3,4;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_interval SET col1 = '14 hours' WHERE col2 = '1 sec' AND col1 = '1 sec';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 |   col5   
 ----------+----------+------+----------
- 00:00:01 | 00:00:01 | e    | 01:00:00
  01:00:00 | 01:00:00 | a    | 01:00:00
  01:00:00 | 01:00:00 | b    | 01:00:00
  01:00:00 | 01:00:00 | c    | 01:00:00
+ 14:00:00 | 00:00:01 | e    | 01:00:00
 (4 rows)
 
 -- Update partition key
@@ -2623,19 +2575,19 @@ UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_interval SET col2 = '14 hours' WHE
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 |   col5   
 ----------+----------+------+----------
- 00:00:01 | 00:00:01 | e    | 01:00:00
  01:00:00 | 01:00:00 | a    | 01:00:00
  01:00:00 | 01:00:00 | b    | 01:00:00
  01:00:00 | 01:00:00 | c    | 01:00:00
+ 14:00:00 | 14:00:00 | e    | 01:00:00
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_splitdefpt_addcol_dml_interval WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 |   col5   
 ----------+----------+------+----------
- 00:00:01 | 00:00:01 | e    | 01:00:00
  01:00:00 | 01:00:00 | a    | 01:00:00
  01:00:00 | 01:00:00 | c    | 01:00:00
+ 14:00:00 | 14:00:00 | e    | 01:00:00
 (3 rows)
 
 -- TEST
@@ -2697,34 +2649,33 @@ SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_numeric ORDER BY 1,2,3,4;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_numeric SET col1 = 35.000000 WHERE col2 = 1.000000 AND col1 = 1.000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 |   col5   
-----------+----------+------+----------
- 1.000000 | 1.000000 | e    | 2.000000
- 2.000000 | 2.000000 | a    | 2.000000
- 2.000000 | 2.000000 | b    | 2.000000
- 2.000000 | 2.000000 | c    | 2.000000
+   col1    |   col2   | col3 |   col5   
+-----------+----------+------+----------
+  2.000000 | 2.000000 | a    | 2.000000
+  2.000000 | 2.000000 | b    | 2.000000
+  2.000000 | 2.000000 | c    | 2.000000
+ 35.000000 | 1.000000 | e    | 2.000000
 (4 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitdefpt_addcol_dml_numeric SET col2 = 35.000000 WHERE col2 = 1.000000 AND col1 = 35.000000;
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 |   col5   
-----------+----------+------+----------
- 1.000000 | 1.000000 | e    | 2.000000
- 2.000000 | 2.000000 | a    | 2.000000
- 2.000000 | 2.000000 | b    | 2.000000
- 2.000000 | 2.000000 | c    | 2.000000
+   col1    |   col2    | col3 |   col5   
+-----------+-----------+------+----------
+  2.000000 |  2.000000 | a    | 2.000000
+  2.000000 |  2.000000 | b    | 2.000000
+  2.000000 |  2.000000 | c    | 2.000000
+ 35.000000 | 35.000000 | e    | 2.000000
 (4 rows)
 
 DELETE FROM mpp21090_dropcol_splitdefpt_addcol_dml_numeric WHERE col3='b';
 SELECT * FROM mpp21090_dropcol_splitdefpt_addcol_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 |   col5   
-----------+----------+------+----------
- 1.000000 | 1.000000 | e    | 2.000000
- 2.000000 | 2.000000 | a    | 2.000000
- 2.000000 | 2.000000 | c    | 2.000000
+   col1    |   col2    | col3 |   col5   
+-----------+-----------+------+----------
+  2.000000 |  2.000000 | a    | 2.000000
+  2.000000 |  2.000000 | c    | 2.000000
+ 35.000000 | 35.000000 | e    | 2.000000
 (3 rows)
 
 -- TEST
@@ -2767,12 +2718,11 @@ SELECT * FROM mpp21090_dropcol_splitdfpt_dml_char ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdfpt_dml_char SET col1 = 'z' WHERE col2 = 'a' AND col1 = 'a';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | b    |    1
  x    | x    | a    |    0
+ z    | a    | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -2780,8 +2730,8 @@ UPDATE mpp21090_dropcol_splitdfpt_dml_char SET col2 = 'z' WHERE col2 = 'a' AND c
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | b    |    1
  x    | x    | a    |    0
+ z    | z    | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitdfpt_dml_char WHERE col3='b';
@@ -2831,21 +2781,20 @@ SELECT * FROM mpp21090_dropcol_splitdfpt_dml_decimal ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdfpt_dml_decimal SET col1 = 35.00 WHERE col2 = 1.00 AND col1 = 1.00;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | b    |    1
- 2.00 | 2.00 | a    |    0
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    |    0
+ 35.00 | 1.00 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitdfpt_dml_decimal SET col2 = 35.00 WHERE col2 = 1.00 AND col1 = 35.00;
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | b    |    1
- 2.00 | 2.00 | a    |    0
+ col1  | col2  | col3 | col5 
+-------+-------+------+------
+  2.00 |  2.00 | a    |    0
+ 35.00 | 35.00 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitdfpt_dml_decimal WHERE col3='b';
@@ -2895,12 +2844,11 @@ SELECT * FROM mpp21090_dropcol_splitdfpt_dml_int4 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdfpt_dml_int4 SET col1 = 35000000 WHERE col2 = 10000000 AND col1 = 10000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | b    |    1
  20000000 | 20000000 | a    |    0
+ 35000000 | 10000000 | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -2908,8 +2856,8 @@ UPDATE mpp21090_dropcol_splitdfpt_dml_int4 SET col2 = 35000000 WHERE col2 = 1000
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | b    |    1
  20000000 | 20000000 | a    |    0
+ 35000000 | 35000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitdfpt_dml_int4 WHERE col3='b';
@@ -2959,12 +2907,11 @@ SELECT * FROM mpp21090_dropcol_splitdfpt_dml_int8 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdfpt_dml_int8 SET col1 = 3500000000000000000 WHERE col2 = 100000000000000000 AND col1 = 100000000000000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
+ 3500000000000000000 |  100000000000000000 | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -2972,8 +2919,8 @@ UPDATE mpp21090_dropcol_splitdfpt_dml_int8 SET col2 = 3500000000000000000 WHERE 
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
+ 3500000000000000000 | 3500000000000000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitdfpt_dml_int8 WHERE col3='b';
@@ -3023,12 +2970,11 @@ SELECT * FROM mpp21090_dropcol_splitdfpt_dml_interval ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdfpt_dml_interval SET col1 = '14 hours' WHERE col2 = '1 sec' AND col1 = '1 sec';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | b    |    1
  01:00:00 | 01:00:00 | a    |    0
+ 14:00:00 | 00:00:01 | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -3036,8 +2982,8 @@ UPDATE mpp21090_dropcol_splitdfpt_dml_interval SET col2 = '14 hours' WHERE col2 
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | b    |    1
  01:00:00 | 01:00:00 | a    |    0
+ 14:00:00 | 14:00:00 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitdfpt_dml_interval WHERE col3='b';
@@ -3087,21 +3033,20 @@ SELECT * FROM mpp21090_dropcol_splitdfpt_dml_numeric ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitdfpt_dml_numeric SET col1 = 35.000000 WHERE col2 = 1.000000 AND col1 = 1.000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | b    |    1
- 2.000000 | 2.000000 | a    |    0
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  2.000000 | 2.000000 | a    |    0
+ 35.000000 | 1.000000 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitdfpt_dml_numeric SET col2 = 35.000000 WHERE col2 = 1.000000 AND col1 = 35.000000;
 SELECT * FROM mpp21090_dropcol_splitdfpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | b    |    1
- 2.000000 | 2.000000 | a    |    0
+   col1    |   col2    | col3 | col5 
+-----------+-----------+------+------
+  2.000000 |  2.000000 | a    |    0
+ 35.000000 | 35.000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitdfpt_dml_numeric WHERE col3='b';
@@ -3150,21 +3095,21 @@ SELECT * FROM mpp21090_dropcol_splitpt_dml_char ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_dml_char SET col1 = 'z' WHERE col2 = 'a' AND col1 = 'a';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | b    |    1
  x    | x    | a    |    0
+ z    | a    | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitpt_dml_char SET col2 ='x'  WHERE col2 = 'a' AND col1 = 'z';
+ERROR:  moving tuple from partition "mpp21090_dropcol_splitpt_dml_char_1_prt_partsplitone" to partition "mpp21090_dropcol_splitpt_dml_char_1_prt_partthree" not supported  (seg1 10.152.10.75:25433 pid=7636)
 SELECT * FROM mpp21090_dropcol_splitpt_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | b    |    1
  x    | x    | a    |    0
+ z    | a    | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_dml_char WHERE col3='b';
@@ -3213,21 +3158,20 @@ SELECT * FROM mpp21090_dropcol_splitpt_dml_decimal ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_dml_decimal SET col1 = 35.00 WHERE col2 = 1.00 AND col1 = 1.00;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | b    |    1
- 2.00 | 2.00 | a    |    0
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    |    0
+ 35.00 | 1.00 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitpt_dml_decimal SET col2 =2.00  WHERE col2 = 1.00 AND col1 = 35.00;
 SELECT * FROM mpp21090_dropcol_splitpt_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | b    |    1
- 2.00 | 2.00 | a    |    0
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    |    0
+ 35.00 | 2.00 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_dml_decimal WHERE col3='b';
@@ -3276,12 +3220,11 @@ SELECT * FROM mpp21090_dropcol_splitpt_dml_int4 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_dml_int4 SET col1 = 35000000 WHERE col2 = 10000000 AND col1 = 10000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | b    |    1
  20000000 | 20000000 | a    |    0
+ 35000000 | 10000000 | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -3289,8 +3232,8 @@ UPDATE mpp21090_dropcol_splitpt_dml_int4 SET col2 =20000000  WHERE col2 = 100000
 SELECT * FROM mpp21090_dropcol_splitpt_dml_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 10000000 | 10000000 | b    |    1
  20000000 | 20000000 | a    |    0
+ 35000000 | 20000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_dml_int4 WHERE col3='b';
@@ -3339,21 +3282,21 @@ SELECT * FROM mpp21090_dropcol_splitpt_dml_int8 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_dml_int8 SET col1 = 3500000000000000000 WHERE col2 = 100000000000000000 AND col1 = 100000000000000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
+ 3500000000000000000 |  100000000000000000 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitpt_dml_int8 SET col2 =2000000000000000000  WHERE col2 = 100000000000000000 AND col1 = 3500000000000000000;
+ERROR:  moving tuple from partition "mpp21090_dropcol_splitpt_dml_int8_1_prt_partsplitone" to partition "mpp21090_dropcol_splitpt_dml_int8_1_prt_parttwo" not supported  (seg1 10.152.10.75:25433 pid=7636)
 SELECT * FROM mpp21090_dropcol_splitpt_dml_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
-  100000000000000000 |  100000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
+ 3500000000000000000 |  100000000000000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_dml_int8 WHERE col3='b';
@@ -3402,21 +3345,21 @@ SELECT * FROM mpp21090_dropcol_splitpt_dml_interval ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_dml_interval SET col1 = '14 hours' WHERE col2 = '1 sec' AND col1 = '1 sec';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | b    |    1
  01:00:00 | 01:00:00 | a    |    0
+ 14:00:00 | 00:00:01 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitpt_dml_interval SET col2 ='1 hour'  WHERE col2 = '1 sec' AND col1 = '14 hours';
+ERROR:  moving tuple from partition "mpp21090_dropcol_splitpt_dml_interval_1_prt_partsplitone" to partition "mpp21090_dropcol_splitpt_dml_interval_1_prt_partthree" not supported  (seg0 10.152.10.75:25432 pid=7634)
 SELECT * FROM mpp21090_dropcol_splitpt_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | b    |    1
  01:00:00 | 01:00:00 | a    |    0
+ 14:00:00 | 00:00:01 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_dml_interval WHERE col3='b';
@@ -3465,21 +3408,20 @@ SELECT * FROM mpp21090_dropcol_splitpt_dml_numeric ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_dml_numeric SET col1 = 35.000000 WHERE col2 = 1.000000 AND col1 = 1.000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | b    |    1
- 2.000000 | 2.000000 | a    |    0
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  2.000000 | 2.000000 | a    |    0
+ 35.000000 | 1.000000 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitpt_dml_numeric SET col2 =2.000000  WHERE col2 = 1.000000 AND col1 = 35.000000;
 SELECT * FROM mpp21090_dropcol_splitpt_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | b    |    1
- 2.000000 | 2.000000 | a    |    0
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  2.000000 | 2.000000 | a    |    0
+ 35.000000 | 2.000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_dml_numeric WHERE col3='b';
@@ -3534,12 +3476,11 @@ SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_char ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_char SET col1 = 'z' WHERE col2 = 'a' AND col1 = 'a';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | b    |    1
  g    | g    | a    |    0
+ z    | a    | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -3547,8 +3488,8 @@ UPDATE mpp21090_dropcol_splitpt_idx_dml_char SET col2 ='g'  WHERE col2 = 'a' AND
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
- a    | a    | b    |    1
  g    | g    | a    |    0
+ z    | g    | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_idx_dml_char WHERE col3='b';
@@ -3603,21 +3544,20 @@ SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_decimal ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_decimal SET col1 = 35.00 WHERE col2 = 1.00 AND col1 = 1.00;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | b    |    1
- 2.00 | 2.00 | a    |    0
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    |    0
+ 35.00 | 1.00 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_decimal SET col2 =2.00  WHERE col2 = 1.00 AND col1 = 35.00;
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_decimal ORDER BY 1,2,3;
- col1 | col2 | col3 | col5 
-------+------+------+------
- 1.00 | 1.00 | b    |    1
- 2.00 | 2.00 | a    |    0
+ col1  | col2 | col3 | col5 
+-------+------+------+------
+  2.00 | 2.00 | a    |    0
+ 35.00 | 2.00 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_idx_dml_decimal WHERE col3='b';
@@ -3672,21 +3612,20 @@ SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_int4 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_int4 SET col1 = 350000000 WHERE col2 = 10000000 AND col1 = 10000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_int4 ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 10000000 | 10000000 | b    |    1
- 20000000 | 20000000 | a    |    0
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  20000000 | 20000000 | a    |    0
+ 350000000 | 10000000 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_int4 SET col2 =20000000  WHERE col2 = 10000000 AND col1 = 350000000;
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_int4 ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 10000000 | 10000000 | b    |    1
- 20000000 | 20000000 | a    |    0
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  20000000 | 20000000 | a    |    0
+ 350000000 | 20000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_idx_dml_int4 WHERE col3='b';
@@ -3741,21 +3680,20 @@ SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_int8 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_int8 SET col1 = 3500000000000000000 WHERE col2 = 100000000000000000 AND col1 = 100000000000000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_int8 ORDER BY 1,2,3;
-        col1        |        col2        | col3 | col5 
---------------------+--------------------+------+------
- 100000000000000000 | 100000000000000000 | b    |    1
- 200000000000000000 | 200000000000000000 | a    |    0
+        col1         |        col2        | col3 | col5 
+---------------------+--------------------+------+------
+  200000000000000000 | 200000000000000000 | a    |    0
+ 3500000000000000000 | 100000000000000000 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_int8 SET col2 =200000000000000000  WHERE col2 = 100000000000000000 AND col1 = 3500000000000000000;
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_int8 ORDER BY 1,2,3;
-        col1        |        col2        | col3 | col5 
---------------------+--------------------+------+------
- 100000000000000000 | 100000000000000000 | b    |    1
- 200000000000000000 | 200000000000000000 | a    |    0
+        col1         |        col2        | col3 | col5 
+---------------------+--------------------+------+------
+  200000000000000000 | 200000000000000000 | a    |    0
+ 3500000000000000000 | 200000000000000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_idx_dml_int8 WHERE col3='b';
@@ -3810,12 +3748,11 @@ SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_interval ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_interval SET col1 = '14 hours' WHERE col2 = '1 sec' AND col1 = '1 sec';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | b    |    1
  00:00:10 | 00:00:10 | a    |    0
+ 14:00:00 | 00:00:01 | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -3823,8 +3760,8 @@ UPDATE mpp21090_dropcol_splitpt_idx_dml_interval SET col2 ='10 secs'  WHERE col2
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
- 00:00:01 | 00:00:01 | b    |    1
  00:00:10 | 00:00:10 | a    |    0
+ 14:00:00 | 00:00:10 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_idx_dml_interval WHERE col3='b';
@@ -3879,21 +3816,20 @@ SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_numeric ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_numeric SET col1 = 35.000000 WHERE col2 = 1.000000 AND col1 = 1.000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | b    |    1
- 2.000000 | 2.000000 | a    |    0
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  2.000000 | 2.000000 | a    |    0
+ 35.000000 | 1.000000 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_dropcol_splitpt_idx_dml_numeric SET col2 =2.000000  WHERE col2 = 1.000000 AND col1 = 35.000000;
 SELECT * FROM mpp21090_dropcol_splitpt_idx_dml_numeric ORDER BY 1,2,3;
-   col1   |   col2   | col3 | col5 
-----------+----------+------+------
- 1.000000 | 1.000000 | b    |    1
- 2.000000 | 2.000000 | a    |    0
+   col1    |   col2   | col3 | col5 
+-----------+----------+------+------
+  2.000000 | 2.000000 | a    |    0
+ 35.000000 | 2.000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_dropcol_splitpt_idx_dml_numeric WHERE col3='b';
@@ -4922,12 +4858,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_boolean ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_boolean SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_boolean ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_boolean WHERE col3='c';
@@ -4935,8 +4870,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_boolean ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_boolean;
@@ -4964,12 +4898,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_boolean ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_boolean SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_boolean ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_boolean WHERE col3='c';
@@ -4977,8 +4910,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_boolean ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_boolean;
@@ -5006,12 +4938,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_boolean ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_boolean SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_boolean ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_boolean WHERE col3='c';
@@ -5019,8 +4950,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_boolean ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_char;
@@ -5049,12 +4979,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_char SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_char ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_char WHERE col3='c';
@@ -5062,8 +4991,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_char ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_char;
@@ -5091,12 +5019,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_char SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_char ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_char WHERE col3='c';
@@ -5104,8 +5031,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_char ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_char;
@@ -5133,12 +5059,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_char SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_char ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_char WHERE col3='c';
@@ -5146,8 +5071,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_char ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_decimal;
@@ -5176,12 +5100,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_decimal SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_decimal ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_decimal WHERE col3='c';
@@ -5189,8 +5112,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_decimal ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_decimal;
@@ -5218,12 +5140,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_decimal SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_decimal ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_decimal WHERE col3='c';
@@ -5231,8 +5152,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_decimal ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_decimal;
@@ -5260,12 +5180,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_decimal SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_decimal ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_decimal WHERE col3='c';
@@ -5273,8 +5192,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_decimal ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_int4;
@@ -5303,12 +5221,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_int4 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_int4 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_int4 WHERE col3='c';
@@ -5316,8 +5233,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int4 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_int4;
@@ -5345,12 +5261,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_int4 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_int4 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_int4 WHERE col3='c';
@@ -5358,8 +5273,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int4 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_int4;
@@ -5387,12 +5301,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_int4 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_int4 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_int4 WHERE col3='c';
@@ -5400,8 +5313,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int4 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_int8;
@@ -5430,12 +5342,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_int8 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_int8 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_int8 WHERE col3='c';
@@ -5443,8 +5354,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int8 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_int8;
@@ -5472,12 +5382,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_int8 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_int8 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_int8 WHERE col3='c';
@@ -5485,8 +5394,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int8 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_int8;
@@ -5514,12 +5422,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_int8 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_int8 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_int8 WHERE col3='c';
@@ -5527,8 +5434,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_int8 ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_interval;
@@ -5557,12 +5463,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_interval SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_interval ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_interval WHERE col3='c';
@@ -5570,8 +5475,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_interval ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_interval;
@@ -5599,12 +5503,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_interval SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_interval ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_interval WHERE col3='c';
@@ -5612,8 +5515,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_interval ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_interval;
@@ -5641,12 +5543,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_interval SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_interval ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_interval WHERE col3='c';
@@ -5654,8 +5555,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_interval ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_numeric;
@@ -5684,12 +5584,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_numeric SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_numeric ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_numeric WHERE col3='c';
@@ -5697,8 +5596,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_numeric ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_numeric;
@@ -5726,12 +5624,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_numeric SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_numeric ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_numeric WHERE col3='c';
@@ -5739,8 +5636,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_numeric ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_numeric;
@@ -5768,12 +5664,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_numeric SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_numeric ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_numeric WHERE col3='c';
@@ -5781,8 +5676,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_numeric ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_text;
@@ -5811,12 +5705,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_text ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_text SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_text ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_text WHERE col3='c';
@@ -5824,8 +5717,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_text ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_text;
@@ -5853,12 +5745,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_text ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_text SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_text ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_text WHERE col3='c';
@@ -5866,8 +5757,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_text ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_firstcol_dml_text;
@@ -5895,12 +5785,11 @@ SELECT * FROM mpp21090_drop_firstcol_dml_text ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_firstcol_dml_text SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_firstcol_dml_text ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
+ 1.00 | c    | 2014-01-02 |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_firstcol_dml_text WHERE col3='c';
@@ -5908,8 +5797,7 @@ SELECT * FROM mpp21090_drop_firstcol_dml_text ORDER BY 1,2,3,4;
  col2 | col3 |    col4    | col5 
 ------+------+------------+------
  0.00 | a    | 2014-01-01 |    0
- 1.00 | b    | 2014-01-02 |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_boolean;
@@ -5938,12 +5826,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_boolean ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_boolean SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_boolean ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_boolean WHERE col3='c';
@@ -5951,8 +5838,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_boolean ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_boolean;
@@ -5980,12 +5866,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_boolean ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_boolean SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_boolean ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_boolean WHERE col3='c';
@@ -5993,8 +5878,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_boolean ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_boolean;
@@ -6022,12 +5906,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_boolean ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_boolean SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_boolean ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_boolean WHERE col3='c';
@@ -6035,8 +5918,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_boolean ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_char;
@@ -6065,12 +5947,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_char SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_char WHERE col3='c';
@@ -6078,8 +5959,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_char;
@@ -6107,12 +5987,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_char SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_char WHERE col3='c';
@@ -6120,8 +5999,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_char;
@@ -6149,12 +6027,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_char SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_char WHERE col3='c';
@@ -6162,8 +6039,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_decimal;
@@ -6192,12 +6068,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_decimal SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_decimal WHERE col3='c';
@@ -6205,8 +6080,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_decimal;
@@ -6234,12 +6108,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_decimal SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_decimal WHERE col3='c';
@@ -6247,8 +6120,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_decimal;
@@ -6276,12 +6148,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_decimal SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_decimal WHERE col3='c';
@@ -6289,8 +6160,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_int4;
@@ -6319,12 +6189,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_int4 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_int4 WHERE col3='c';
@@ -6332,8 +6201,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_int4;
@@ -6361,12 +6229,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_int4 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_int4 WHERE col3='c';
@@ -6374,8 +6241,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_int4;
@@ -6403,12 +6269,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_int4 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_int4 WHERE col3='c';
@@ -6416,8 +6281,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_int8;
@@ -6446,12 +6310,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_int8 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_int8 WHERE col3='c';
@@ -6459,8 +6322,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_int8;
@@ -6488,12 +6350,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_int8 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_int8 WHERE col3='c';
@@ -6501,8 +6362,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_int8;
@@ -6530,12 +6390,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_int8 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_int8 WHERE col3='c';
@@ -6543,8 +6402,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_interval;
@@ -6573,12 +6431,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_interval SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_interval WHERE col3='c';
@@ -6586,8 +6443,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_interval;
@@ -6615,12 +6471,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_interval SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_interval WHERE col3='c';
@@ -6628,8 +6483,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_interval;
@@ -6657,12 +6511,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_interval SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_interval WHERE col3='c';
@@ -6670,8 +6523,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_numeric;
@@ -6700,12 +6552,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_numeric SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_numeric WHERE col3='c';
@@ -6713,8 +6564,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_numeric;
@@ -6742,12 +6592,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_numeric SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_numeric WHERE col3='c';
@@ -6755,8 +6604,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_numeric;
@@ -6784,12 +6632,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_numeric SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_numeric WHERE col3='c';
@@ -6797,8 +6644,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_text;
@@ -6827,12 +6673,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_text ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_text SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_text ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_text WHERE col3='c';
@@ -6840,8 +6685,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_text ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_text;
@@ -6869,12 +6713,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_text ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_text SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_text ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_text WHERE col3='c';
@@ -6882,8 +6725,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_text ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_dml_text;
@@ -6911,12 +6753,11 @@ SELECT * FROM mpp21090_drop_lastcol_dml_text ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_dml_text SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_dml_text ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_dml_text WHERE col3='c';
@@ -6924,8 +6765,7 @@ SELECT * FROM mpp21090_drop_lastcol_dml_text ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_char;
@@ -6957,12 +6797,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_char SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_char WHERE col3='c';
@@ -6970,8 +6809,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_char;
@@ -7002,12 +6840,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_char SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_char WHERE col3='c';
@@ -7015,8 +6852,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_char;
@@ -7047,12 +6883,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_char SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_char WHERE col3='c';
@@ -7060,8 +6895,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_decimal;
@@ -7093,12 +6927,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_decimal SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_decimal WHERE col3='c';
@@ -7106,8 +6939,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_decimal;
@@ -7138,12 +6970,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_decimal SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_decimal WHERE col3='c';
@@ -7151,8 +6982,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_decimal;
@@ -7183,12 +7013,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_decimal SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_decimal WHERE col3='c';
@@ -7196,8 +7025,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_int4;
@@ -7229,12 +7057,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_int4 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_int4 WHERE col3='c';
@@ -7242,8 +7069,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_int4;
@@ -7274,12 +7100,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_int4 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_int4 WHERE col3='c';
@@ -7287,8 +7112,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_int4;
@@ -7319,12 +7143,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_int4 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_int4 WHERE col3='c';
@@ -7332,8 +7155,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_int8;
@@ -7365,12 +7187,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_int8 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_int8 WHERE col3='c';
@@ -7378,8 +7199,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_int8;
@@ -7410,12 +7230,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_int8 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_int8 WHERE col3='c';
@@ -7423,8 +7242,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_int8;
@@ -7455,12 +7273,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_int8 SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_int8 WHERE col3='c';
@@ -7468,8 +7285,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_interval;
@@ -7501,12 +7317,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_interval SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_interval WHERE col3='c';
@@ -7514,8 +7329,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_interval;
@@ -7546,12 +7360,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_interval SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_interval WHERE col3='c';
@@ -7559,8 +7372,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_interval;
@@ -7591,12 +7403,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_interval SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_interval WHERE col3='c';
@@ -7604,8 +7415,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_numeric;
@@ -7637,12 +7447,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_numeric SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_numeric WHERE col3='c';
@@ -7650,8 +7459,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_numeric;
@@ -7682,12 +7490,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_numeric SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_numeric WHERE col3='c';
@@ -7695,8 +7502,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_lastcol_index_dml_numeric;
@@ -7727,12 +7533,11 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_lastcol_index_dml_numeric SET col3='c' WHERE col3 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_lastcol_index_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 DELETE FROM mpp21090_drop_lastcol_index_dml_numeric WHERE col3='c';
@@ -7740,8 +7545,7 @@ SELECT * FROM mpp21090_drop_lastcol_index_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col3 |    col4    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_midcol_dml_boolean;
@@ -7771,12 +7575,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_boolean ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_boolean SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_boolean ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -7806,12 +7609,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_boolean ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_boolean SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_boolean ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -7841,12 +7643,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_boolean ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_boolean SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_boolean ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -7877,12 +7678,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_char SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -7912,12 +7712,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_char SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -7947,12 +7746,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_char ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_char SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_char ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -7983,12 +7781,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_decimal SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8018,12 +7815,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_decimal SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8053,12 +7849,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_decimal ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_decimal SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_decimal ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8089,12 +7884,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_int4 SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8124,12 +7918,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_int4 SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8159,12 +7952,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_int4 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_int4 SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_int4 ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8195,12 +7987,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_int8 SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8230,12 +8021,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_int8 SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8265,12 +8055,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_int8 ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_int8 SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_int8 ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8301,12 +8090,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_interval SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8336,12 +8124,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_interval SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8371,12 +8158,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_interval ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_interval SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_interval ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8407,12 +8193,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_numeric SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8442,12 +8227,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_numeric SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8477,12 +8261,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_numeric ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_numeric SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_numeric ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8513,12 +8296,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_text ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_text SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_text ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8548,12 +8330,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_text ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_text SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_text ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8583,12 +8364,11 @@ SELECT * FROM mpp21090_drop_midcol_dml_text ORDER BY 1,2,3,4;
 (2 rows)
 
 UPDATE mpp21090_drop_midcol_dml_text SET col4='c' WHERE col4 = 'b' AND col1 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_midcol_dml_text ORDER BY 1,2,3,4;
  col1 | col2 | col4 |    col5    
 ------+------+------+------------
     0 | 0.00 | a    | 2014-01-01
-    1 | 1.00 | b    | 2014-01-02
+    1 | 1.00 | c    | 2014-01-02
 (2 rows)
 
 -- TEST
@@ -8619,12 +8399,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_boolean ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_boolean SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_boolean ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_boolean WHERE col3='c';
@@ -8632,8 +8411,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_boolean ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_boolean;
@@ -8662,12 +8440,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_boolean ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_boolean SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_boolean ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_boolean WHERE col3='c';
@@ -8675,8 +8452,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_boolean ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_boolean;
@@ -8705,12 +8481,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_boolean ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_boolean SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_boolean ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_boolean WHERE col3='c';
@@ -8718,8 +8493,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_boolean ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_char;
@@ -8749,12 +8523,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_char ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_char SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_char ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_char WHERE col3='c';
@@ -8762,8 +8535,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_char ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_char;
@@ -8792,12 +8564,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_char ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_char SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_char ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_char WHERE col3='c';
@@ -8805,8 +8576,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_char ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_char;
@@ -8835,12 +8605,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_char ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_char SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_char ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_char WHERE col3='c';
@@ -8848,8 +8617,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_char ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_decimal;
@@ -8879,12 +8647,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_decimal ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_decimal SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_decimal ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_decimal WHERE col3='c';
@@ -8892,8 +8659,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_decimal ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_decimal;
@@ -8922,12 +8688,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_decimal ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_decimal SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_decimal ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_decimal WHERE col3='c';
@@ -8935,8 +8700,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_decimal ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_decimal;
@@ -8965,12 +8729,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_decimal ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_decimal SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_decimal ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_decimal WHERE col3='c';
@@ -8978,8 +8741,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_decimal ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_int4;
@@ -9009,12 +8771,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_int4 ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_int4 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_int4 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_int4 WHERE col3='c';
@@ -9022,8 +8783,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_int4 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_int4;
@@ -9052,12 +8812,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_int4 ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_int4 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_int4 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_int4 WHERE col3='c';
@@ -9065,8 +8824,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_int4 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_int4;
@@ -9095,12 +8853,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_int4 ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_int4 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_int4 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_int4 WHERE col3='c';
@@ -9108,8 +8865,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_int4 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_int8;
@@ -9139,12 +8895,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_int8 ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_int8 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_int8 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_int8 WHERE col3='c';
@@ -9152,8 +8907,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_int8 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_int8;
@@ -9182,12 +8936,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_int8 ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_int8 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_int8 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_int8 WHERE col3='c';
@@ -9195,8 +8948,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_int8 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_int8;
@@ -9225,12 +8977,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_int8 ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_int8 SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_int8 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_int8 WHERE col3='c';
@@ -9238,8 +8989,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_int8 ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_interval;
@@ -9269,12 +9019,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_interval ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_interval SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_interval ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_interval WHERE col3='c';
@@ -9282,8 +9031,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_interval ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_interval;
@@ -9312,12 +9060,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_interval ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_interval SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_interval ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_interval WHERE col3='c';
@@ -9325,8 +9072,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_interval ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_interval;
@@ -9355,12 +9101,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_interval ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_interval SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_interval ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_interval WHERE col3='c';
@@ -9368,8 +9113,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_interval ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_numeric;
@@ -9399,12 +9143,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_numeric ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_numeric SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_numeric ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_numeric WHERE col3='c';
@@ -9412,8 +9155,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_numeric ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_numeric;
@@ -9442,12 +9184,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_numeric ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_numeric SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_numeric ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_numeric WHERE col3='c';
@@ -9455,8 +9196,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_numeric ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_numeric;
@@ -9485,12 +9225,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_numeric ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_numeric SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_numeric ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_numeric WHERE col3='c';
@@ -9498,8 +9237,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_numeric ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_text;
@@ -9529,12 +9267,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_text ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_text SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_text ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_text WHERE col3='c';
@@ -9542,8 +9279,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_text ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_text;
@@ -9572,12 +9308,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_text ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_text SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_text ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_text WHERE col3='c';
@@ -9585,8 +9320,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_text ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_drop_multicol_dml_text;
@@ -9615,12 +9349,11 @@ SELECT * FROM mpp21090_drop_multicol_dml_text ORDER BY 1,2,3;
 (2 rows)
 
 UPDATE mpp21090_drop_multicol_dml_text SET col3='c' WHERE col3 = 'b' AND col5 = 1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_drop_multicol_dml_text ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
+ 1.00 | c    |    1
 (2 rows)
 
 DELETE FROM mpp21090_drop_multicol_dml_text WHERE col3='c';
@@ -9628,8 +9361,7 @@ SELECT * FROM mpp21090_drop_multicol_dml_text ORDER BY 1,2,3;
  col2 | col3 | col5 
 ------+------+------
  0.00 | a    |    0
- 1.00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_pttab_addcol_addpt_dropcol_char;
@@ -13015,12 +12747,11 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_char ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_droplastcol_addpt_char SET col1 = '-' WHERE col2 = 'z' AND col1 = 'z';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col4 
 ------+------+------+------
+ -    | z    | b    |    1
  x    | x    | a    |    0
- z    | z    | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -13028,8 +12759,8 @@ UPDATE mpp21090_pttab_droplastcol_addpt_char SET col2 = '-' WHERE col2 = 'z' AND
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col4 
 ------+------+------+------
+ -    | -    | b    |    1
  x    | x    | a    |    0
- z    | z    | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_droplastcol_addpt_char WHERE col2 = '-';
@@ -13037,8 +12768,7 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col4 
 ------+------+------+------
  x    | x    | a    |    0
- z    | z    | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_pttab_droplastcol_addpt_decimal;
@@ -13071,29 +12801,29 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_decimal ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_droplastcol_addpt_decimal SET col1 = 1.00 WHERE col2 = 35.00 AND col1 = 35.00;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_decimal ORDER BY 1,2,3;
- col1  | col2  | col3 | col4 
--------+-------+------+------
-  2.00 |  2.00 | a    |    0
- 35.00 | 35.00 | b    |    1
+ col1 | col2  | col3 | col4 
+------+-------+------+------
+ 1.00 | 35.00 | b    |    1
+ 2.00 |  2.00 | a    |    0
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_pttab_droplastcol_addpt_decimal SET col2 = 1.00 WHERE col2 = 35.00 AND col1 = 1.00;
+ERROR:  moving tuple from partition "mpp21090_pttab_droplastcol_addpt_decimal_1_prt_partfour" to partition "mpp21090_pttab_droplastcol_addpt_decimal_1_prt_partone" not supported  (seg0 10.152.10.75:25432 pid=5459)
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_decimal ORDER BY 1,2,3;
- col1  | col2  | col3 | col4 
--------+-------+------+------
-  2.00 |  2.00 | a    |    0
- 35.00 | 35.00 | b    |    1
+ col1 | col2  | col3 | col4 
+------+-------+------+------
+ 1.00 | 35.00 | b    |    1
+ 2.00 |  2.00 | a    |    0
 (2 rows)
 
 DELETE FROM mpp21090_pttab_droplastcol_addpt_decimal WHERE col2 = 1.00;
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_decimal ORDER BY 1,2,3;
- col1  | col2  | col3 | col4 
--------+-------+------+------
-  2.00 |  2.00 | a    |    0
- 35.00 | 35.00 | b    |    1
+ col1 | col2  | col3 | col4 
+------+-------+------+------
+ 1.00 | 35.00 | b    |    1
+ 2.00 |  2.00 | a    |    0
 (2 rows)
 
 -- TEST
@@ -13127,12 +12857,11 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_int4 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_droplastcol_addpt_int4 SET col1 = 10000000 WHERE col2 = 35000000 AND col1 = 35000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col4 
 ----------+----------+------+------
+ 10000000 | 35000000 | b    |    1
  20000000 | 20000000 | a    |    0
- 35000000 | 35000000 | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -13140,8 +12869,8 @@ UPDATE mpp21090_pttab_droplastcol_addpt_int4 SET col2 = 10000000 WHERE col2 = 35
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col4 
 ----------+----------+------+------
+ 10000000 | 10000000 | b    |    1
  20000000 | 20000000 | a    |    0
- 35000000 | 35000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_droplastcol_addpt_int4 WHERE col2 = 10000000;
@@ -13149,8 +12878,7 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col4 
 ----------+----------+------+------
  20000000 | 20000000 | a    |    0
- 35000000 | 35000000 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_pttab_droplastcol_addpt_int8;
@@ -13183,29 +12911,29 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_int8 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_droplastcol_addpt_int8 SET col1 = 1000000000000000000 WHERE col2 = 3500000000000000000 AND col1 = 3500000000000000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col4 
 ---------------------+---------------------+------+------
+ 1000000000000000000 | 3500000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
- 3500000000000000000 | 3500000000000000000 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_pttab_droplastcol_addpt_int8 SET col2 = 1000000000000000000 WHERE col2 = 3500000000000000000 AND col1 = 1000000000000000000;
+ERROR:  moving tuple from partition "mpp21090_pttab_droplastcol_addpt_int8_1_prt_partfour" to partition "mpp21090_pttab_droplastcol_addpt_int8_1_prt_partone" not supported  (seg0 10.152.10.75:25432 pid=5459)
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col4 
 ---------------------+---------------------+------+------
+ 1000000000000000000 | 3500000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
- 3500000000000000000 | 3500000000000000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_droplastcol_addpt_int8 WHERE col2 = 1000000000000000000;
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col4 
 ---------------------+---------------------+------+------
+ 1000000000000000000 | 3500000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
- 3500000000000000000 | 3500000000000000000 | b    |    1
 (2 rows)
 
 -- TEST
@@ -13239,12 +12967,11 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_interval ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_droplastcol_addpt_interval SET col1 = '12 hours' WHERE col2 = '14 hours' AND col1 = '14 hours';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col4 
 ----------+----------+------+------
  01:00:00 | 01:00:00 | a    |    0
- 14:00:00 | 14:00:00 | b    |    1
+ 12:00:00 | 14:00:00 | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -13253,7 +12980,7 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col4 
 ----------+----------+------+------
  01:00:00 | 01:00:00 | a    |    0
- 14:00:00 | 14:00:00 | b    |    1
+ 12:00:00 | 12:00:00 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_droplastcol_addpt_interval WHERE col2 = '12 hours';
@@ -13261,8 +12988,7 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col4 
 ----------+----------+------+------
  01:00:00 | 01:00:00 | a    |    0
- 14:00:00 | 14:00:00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_pttab_droplastcol_addpt_numeric;
@@ -13295,29 +13021,29 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_numeric ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_droplastcol_addpt_numeric SET col1 = 1.000000 WHERE col2 = 35.000000 AND col1 = 35.000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_numeric ORDER BY 1,2,3;
-   col1    |   col2    | col3 | col4 
------------+-----------+------+------
-  2.000000 |  2.000000 | a    |    0
- 35.000000 | 35.000000 | b    |    1
+   col1   |   col2    | col3 | col4 
+----------+-----------+------+------
+ 1.000000 | 35.000000 | b    |    1
+ 2.000000 |  2.000000 | a    |    0
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_pttab_droplastcol_addpt_numeric SET col2 = 1.000000 WHERE col2 = 35.000000 AND col1 = 1.000000;
+ERROR:  moving tuple from partition "mpp21090_pttab_droplastcol_addpt_numeric_1_prt_partfour" to partition "mpp21090_pttab_droplastcol_addpt_numeric_1_prt_partone" not supported  (seg0 10.152.10.75:25432 pid=5459)
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_numeric ORDER BY 1,2,3;
-   col1    |   col2    | col3 | col4 
------------+-----------+------+------
-  2.000000 |  2.000000 | a    |    0
- 35.000000 | 35.000000 | b    |    1
+   col1   |   col2    | col3 | col4 
+----------+-----------+------+------
+ 1.000000 | 35.000000 | b    |    1
+ 2.000000 |  2.000000 | a    |    0
 (2 rows)
 
 DELETE FROM mpp21090_pttab_droplastcol_addpt_numeric WHERE col2 = 1.000000;
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_numeric ORDER BY 1,2,3;
-   col1    |   col2    | col3 | col4 
------------+-----------+------+------
-  2.000000 |  2.000000 | a    |    0
- 35.000000 | 35.000000 | b    |    1
+   col1   |   col2    | col3 | col4 
+----------+-----------+------+------
+ 1.000000 | 35.000000 | b    |    1
+ 2.000000 |  2.000000 | a    |    0
 (2 rows)
 
 -- TEST
@@ -13351,21 +13077,21 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_text ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_droplastcol_addpt_text SET col1 = 'qrstuvwxyz' WHERE col2 = 'xyz' AND col1 = 'xyz';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_text ORDER BY 1,2,3;
        col1       |       col2       | col3 | col4 
 ------------------+------------------+------+------
  abcdefghijklmnop | abcdefghijklmnop | a    |    0
- xyz              | xyz              | b    |    1
+ qrstuvwxyz       | xyz              | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_pttab_droplastcol_addpt_text SET col2 = 'qrstuvwxyz' WHERE col2 = 'xyz' AND col1 = 'qrstuvwxyz';
+ERROR:  moving tuple from partition "mpp21090_pttab_droplastcol_addpt_text_1_prt_partfour" to partition "mpp21090_pttab_droplastcol_addpt_text_1_prt_parttwo" not supported  (seg0 10.152.10.75:25432 pid=5459)
 SELECT * FROM mpp21090_pttab_droplastcol_addpt_text ORDER BY 1,2,3;
        col1       |       col2       | col3 | col4 
 ------------------+------------------+------+------
  abcdefghijklmnop | abcdefghijklmnop | a    |    0
- xyz              | xyz              | b    |    1
+ qrstuvwxyz       | xyz              | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_droplastcol_addpt_text WHERE col2 = 'qrstuvwxyz';
@@ -13373,7 +13099,7 @@ SELECT * FROM mpp21090_pttab_droplastcol_addpt_text ORDER BY 1,2,3;
        col1       |       col2       | col3 | col4 
 ------------------+------------------+------+------
  abcdefghijklmnop | abcdefghijklmnop | a    |    0
- xyz              | xyz              | b    |    1
+ qrstuvwxyz       | xyz              | b    |    1
 (2 rows)
 
 -- TEST
@@ -13406,12 +13132,11 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_char ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_dropmidcol_addpt_char SET col1 = '-' WHERE col2 = 'z' AND col1 = 'z';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
+ -    | z    | b    |    1
  x    | x    | a    |    0
- z    | z    | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -13419,8 +13144,8 @@ UPDATE mpp21090_pttab_dropmidcol_addpt_char SET col2 = '-' WHERE col2 = 'z' AND 
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
+ -    | -    | b    |    1
  x    | x    | a    |    0
- z    | z    | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_dropmidcol_addpt_char WHERE col2 = '-';
@@ -13428,8 +13153,7 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_char ORDER BY 1,2,3;
  col1 | col2 | col3 | col5 
 ------+------+------+------
  x    | x    | a    |    0
- z    | z    | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_pttab_dropmidcol_addpt_decimal;
@@ -13461,29 +13185,29 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_decimal ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_dropmidcol_addpt_decimal SET col1 = 1.00 WHERE col2 = 35.00 AND col1 = 35.00;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_decimal ORDER BY 1,2,3;
- col1  | col2  | col3 | col5 
--------+-------+------+------
-  2.00 |  2.00 | a    |    0
- 35.00 | 35.00 | b    |    1
+ col1 | col2  | col3 | col5 
+------+-------+------+------
+ 1.00 | 35.00 | b    |    1
+ 2.00 |  2.00 | a    |    0
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_pttab_dropmidcol_addpt_decimal SET col2 = 1.00 WHERE col2 = 35.00 AND col1 = 1.00;
+ERROR:  moving tuple from partition "mpp21090_pttab_dropmidcol_addpt_decimal_1_prt_partfour" to partition "mpp21090_pttab_dropmidcol_addpt_decimal_1_prt_partone" not supported  (seg0 10.152.10.75:25432 pid=5459)
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_decimal ORDER BY 1,2,3;
- col1  | col2  | col3 | col5 
--------+-------+------+------
-  2.00 |  2.00 | a    |    0
- 35.00 | 35.00 | b    |    1
+ col1 | col2  | col3 | col5 
+------+-------+------+------
+ 1.00 | 35.00 | b    |    1
+ 2.00 |  2.00 | a    |    0
 (2 rows)
 
 DELETE FROM mpp21090_pttab_dropmidcol_addpt_decimal WHERE col2 = 1.00;
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_decimal ORDER BY 1,2,3;
- col1  | col2  | col3 | col5 
--------+-------+------+------
-  2.00 |  2.00 | a    |    0
- 35.00 | 35.00 | b    |    1
+ col1 | col2  | col3 | col5 
+------+-------+------+------
+ 1.00 | 35.00 | b    |    1
+ 2.00 |  2.00 | a    |    0
 (2 rows)
 
 -- TEST
@@ -13516,12 +13240,11 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_int4 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_dropmidcol_addpt_int4 SET col1 = 10000000 WHERE col2 = 35000000 AND col1 = 35000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
+ 10000000 | 35000000 | b    |    1
  20000000 | 20000000 | a    |    0
- 35000000 | 35000000 | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -13529,8 +13252,8 @@ UPDATE mpp21090_pttab_dropmidcol_addpt_int4 SET col2 = 10000000 WHERE col2 = 350
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
+ 10000000 | 10000000 | b    |    1
  20000000 | 20000000 | a    |    0
- 35000000 | 35000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_dropmidcol_addpt_int4 WHERE col2 = 10000000;
@@ -13538,8 +13261,7 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_int4 ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  20000000 | 20000000 | a    |    0
- 35000000 | 35000000 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_pttab_dropmidcol_addpt_int8;
@@ -13571,29 +13293,29 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_int8 ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_dropmidcol_addpt_int8 SET col1 = 1000000000000000000 WHERE col2 = 3500000000000000000 AND col1 = 3500000000000000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
+ 1000000000000000000 | 3500000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
- 3500000000000000000 | 3500000000000000000 | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_pttab_dropmidcol_addpt_int8 SET col2 = 1000000000000000000 WHERE col2 = 3500000000000000000 AND col1 = 1000000000000000000;
+ERROR:  moving tuple from partition "mpp21090_pttab_dropmidcol_addpt_int8_1_prt_partfour" to partition "mpp21090_pttab_dropmidcol_addpt_int8_1_prt_partone" not supported  (seg0 10.152.10.75:25432 pid=5459)
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
+ 1000000000000000000 | 3500000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
- 3500000000000000000 | 3500000000000000000 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_dropmidcol_addpt_int8 WHERE col2 = 1000000000000000000;
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_int8 ORDER BY 1,2,3;
         col1         |        col2         | col3 | col5 
 ---------------------+---------------------+------+------
+ 1000000000000000000 | 3500000000000000000 | b    |    1
  2000000000000000000 | 2000000000000000000 | a    |    0
- 3500000000000000000 | 3500000000000000000 | b    |    1
 (2 rows)
 
 -- TEST
@@ -13626,12 +13348,11 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_interval ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_dropmidcol_addpt_interval SET col1 = '12 hours' WHERE col2 = '14 hours' AND col1 = '14 hours';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  01:00:00 | 01:00:00 | a    |    0
- 14:00:00 | 14:00:00 | b    |    1
+ 12:00:00 | 14:00:00 | b    |    1
 (2 rows)
 
 -- Update partition key
@@ -13640,7 +13361,7 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  01:00:00 | 01:00:00 | a    |    0
- 14:00:00 | 14:00:00 | b    |    1
+ 12:00:00 | 12:00:00 | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_dropmidcol_addpt_interval WHERE col2 = '12 hours';
@@ -13648,8 +13369,7 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_interval ORDER BY 1,2,3;
    col1   |   col2   | col3 | col5 
 ----------+----------+------+------
  01:00:00 | 01:00:00 | a    |    0
- 14:00:00 | 14:00:00 | b    |    1
-(2 rows)
+(1 row)
 
 -- TEST
 DROP TABLE IF EXISTS mpp21090_pttab_dropmidcol_addpt_numeric;
@@ -13681,29 +13401,29 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_numeric ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_dropmidcol_addpt_numeric SET col1 = 1.000000 WHERE col2 = 35.000000 AND col1 = 35.000000;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_numeric ORDER BY 1,2,3;
-   col1    |   col2    | col3 | col5 
------------+-----------+------+------
-  2.000000 |  2.000000 | a    |    0
- 35.000000 | 35.000000 | b    |    1
+   col1   |   col2    | col3 | col5 
+----------+-----------+------+------
+ 1.000000 | 35.000000 | b    |    1
+ 2.000000 |  2.000000 | a    |    0
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_pttab_dropmidcol_addpt_numeric SET col2 = 1.000000 WHERE col2 = 35.000000 AND col1 = 1.000000;
+ERROR:  moving tuple from partition "mpp21090_pttab_dropmidcol_addpt_numeric_1_prt_partfour" to partition "mpp21090_pttab_dropmidcol_addpt_numeric_1_prt_partone" not supported  (seg0 10.152.10.75:25432 pid=5459)
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_numeric ORDER BY 1,2,3;
-   col1    |   col2    | col3 | col5 
------------+-----------+------+------
-  2.000000 |  2.000000 | a    |    0
- 35.000000 | 35.000000 | b    |    1
+   col1   |   col2    | col3 | col5 
+----------+-----------+------+------
+ 1.000000 | 35.000000 | b    |    1
+ 2.000000 |  2.000000 | a    |    0
 (2 rows)
 
 DELETE FROM mpp21090_pttab_dropmidcol_addpt_numeric WHERE col2 = 1.000000;
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_numeric ORDER BY 1,2,3;
-   col1    |   col2    | col3 | col5 
------------+-----------+------+------
-  2.000000 |  2.000000 | a    |    0
- 35.000000 | 35.000000 | b    |    1
+   col1   |   col2    | col3 | col5 
+----------+-----------+------+------
+ 1.000000 | 35.000000 | b    |    1
+ 2.000000 |  2.000000 | a    |    0
 (2 rows)
 
 -- TEST
@@ -13736,21 +13456,21 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_text ORDER BY 1,2,3;
 
 -- Update distribution key
 UPDATE mpp21090_pttab_dropmidcol_addpt_text SET col1 = 'qrstuvwxyz' WHERE col2 = 'xyz' AND col1 = 'xyz';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_text ORDER BY 1,2,3;
        col1       |       col2       | col3 | col5 
 ------------------+------------------+------+------
  abcdefghijklmnop | abcdefghijklmnop | a    |    0
- xyz              | xyz              | b    |    1
+ qrstuvwxyz       | xyz              | b    |    1
 (2 rows)
 
 -- Update partition key
 UPDATE mpp21090_pttab_dropmidcol_addpt_text SET col2 = 'qrstuvwxyz' WHERE col2 = 'xyz' AND col1 = 'qrstuvwxyz';
+ERROR:  moving tuple from partition "mpp21090_pttab_dropmidcol_addpt_text_1_prt_partfour" to partition "mpp21090_pttab_dropmidcol_addpt_text_1_prt_parttwo" not supported  (seg0 10.152.10.75:25432 pid=5459)
 SELECT * FROM mpp21090_pttab_dropmidcol_addpt_text ORDER BY 1,2,3;
        col1       |       col2       | col3 | col5 
 ------------------+------------------+------+------
  abcdefghijklmnop | abcdefghijklmnop | a    |    0
- xyz              | xyz              | b    |    1
+ qrstuvwxyz       | xyz              | b    |    1
 (2 rows)
 
 DELETE FROM mpp21090_pttab_dropmidcol_addpt_text WHERE col2 = 'qrstuvwxyz';
@@ -13758,7 +13478,7 @@ SELECT * FROM mpp21090_pttab_dropmidcol_addpt_text ORDER BY 1,2,3;
        col1       |       col2       | col3 | col5 
 ------------------+------------------+------+------
  abcdefghijklmnop | abcdefghijklmnop | a    |    0
- xyz              | xyz              | b    |    1
+ qrstuvwxyz       | xyz              | b    |    1
 (2 rows)
 
 -- TEST

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -26,7 +26,16 @@ explain insert into constr_tab values (1,2,3);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
+         Hash Key: a
+         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+               ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+ Optimizer: legacy query optimizer
+(6 rows)
+
 explain update constr_tab set b = 10;
                            QUERY PLAN                            
 -----------------------------------------------------------------
@@ -50,21 +59,48 @@ CREATE TABLE constr_tab ( a int NOT NULL, b int, c int, d int, CHECK (a+b>5)) DI
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
+         Hash Key: a
+         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+               ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+ Optimizer: legacy query optimizer
+(6 rows)
+
 DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int NOT NULL, b int NOT NULL, c int NOT NULL, d int NOT NULL) DISTRIBUTED BY (a,b);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set b = 10;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
+         Hash Key: a, b
+         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+               ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+ Optimizer: legacy query optimizer
+(6 rows)
+
 DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int, b int, c int, d int) DISTRIBUTED BY (a);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
+         Hash Key: a
+         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+               ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+ Optimizer: legacy query optimizer
+(6 rows)
+
 -- Test ORCA fallback on "FROM ONLY"
 CREATE TABLE homer (a int, b int, c int)
 DISTRIBUTED BY (a)

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -33,7 +33,16 @@ INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
+         Hash Key: a
+         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+               ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+ Optimizer: legacy query optimizer
+(6 rows)
+
 explain update constr_tab set b = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
                            QUERY PLAN                            
@@ -63,7 +72,16 @@ INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
+         Hash Key: a
+         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+               ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+ Optimizer: legacy query optimizer
+(6 rows)
+
 DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int NOT NULL, b int NOT NULL, c int NOT NULL, d int NOT NULL) DISTRIBUTED BY (a,b);
 INSERT INTO constr_tab VALUES(1,5,3,4);
@@ -73,7 +91,16 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set b = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
+         Hash Key: a, b
+         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+               ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
+ Optimizer: legacy query optimizer
+(6 rows)
+
 DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int, b int, c int, d int) DISTRIBUTED BY (a);
 INSERT INTO constr_tab VALUES(1,5,3,4);

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -1279,23 +1279,21 @@ insert into TblUp4 values(1,2);
 -- end_ignore
 -- planner does not support updates on distribution keys
 update TblUp1 set a=100 where a not in (select a from TblUp3);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select * from TblUp1;
- a | b 
----+---
- 1 | 2
- 3 | 4
- 5 | 6
+  a  | b 
+-----+---
+   1 | 2
+ 100 | 4
+ 100 | 6
 (3 rows)
 
 update TblUp2 set a=100 where a not in (select a from TblUp4);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select * from TblUp2;
- a | b 
----+---
- 1 | 2
- 3 | 4
- 5 | 6
+  a  | b 
+-----+---
+   1 | 2
+ 100 | 4
+ 100 | 6
 (3 rows)
 
 --

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -984,9 +984,12 @@ SELECT a FROM dml_union_r UNION SELECT a FROM dml_union_s ORDER BY 1 LIMIT 1;
 (1 row)
 
 UPDATE dml_union_r SET a = (SELECT a FROM dml_union_r UNION SELECT a FROM dml_union_s ORDER BY 1 LIMIT 1);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+     1
+(1 row)
+
 rollback;
 -- @description union_update_test2: Update distribution column with UNION
 begin;
@@ -997,11 +1000,18 @@ SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 (1 row)
 
 UPDATE dml_union_r SET a = (SELECT a FROM dml_union_r UNION ALL SELECT a FROM dml_union_s ORDER BY 1 LIMIT 1);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+     1
+(1 row)
+
 SELECT DISTINCT(a) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ a 
+---
+ 1
+(1 row)
+
 rollback;
 -- @description union_update_test3: Update distribution column with INTERSECT
 begin;
@@ -1018,9 +1028,12 @@ SELECT COUNT(*) FROM (SELECT * FROM (SELECT a FROM dml_union_r order by a limit 
 (1 row)
 
 UPDATE dml_union_r SET a = ( SELECT * FROM (SELECT a FROM dml_union_r order by a limit 1) foo INTERSECT SELECT a FROM dml_union_s);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM dml_union_r WHERE a = 1;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+   120
+(1 row)
+
 rollback;
 -- @description union_update_test4: Update distribution column with INTERSECT
 begin;
@@ -1037,9 +1050,12 @@ SELECT COUNT(*) FROM (SELECT * FROM (SELECT a FROM dml_union_r ORDER BY 1 limit 
 (1 row)
 
 UPDATE dml_union_r SET a = ( SELECT * FROM (SELECT a FROM dml_union_r ORDER BY 1 limit 1) foo INTERSECT ALL SELECT a FROM dml_union_s);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM dml_union_r WHERE a = 1;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+   120
+(1 row)
+
 rollback;
 -- @description union_update_test5: Update distribution column with EXCEPT
 begin;
@@ -1056,37 +1072,52 @@ SELECT COUNT(*) FROM (SELECT * FROM (SELECT a FROM dml_union_r limit 1) foo EXCE
 (1 row)
 
 UPDATE dml_union_r SET a = ( SELECT * FROM (SELECT a FROM dml_union_r limit 1) foo EXCEPT SELECT a FROM dml_union_s);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT SUM(a) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ sum 
+-----
+    
+(1 row)
+
 rollback;
 -- @description union_update_test6: Update distribution column with EXCEPT
 begin;
 UPDATE dml_union_r SET a = ( SELECT * FROM (SELECT a FROM dml_union_r limit 1) foo EXCEPT ALL SELECT a FROM dml_union_s);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT DISTINCT(a) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ a 
+---
+  
+(1 row)
+
 rollback;
 -- @description union_update_test7: NULL values to distribution key
 begin;
 UPDATE dml_union_r SET a = (SELECT NULL UNION SELECT NULL)::int;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT DISTINCT(a) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ a 
+---
+  
+(1 row)
+
 rollback;
 -- @description union_update_test8: NULL values to distribution key
 begin;
 UPDATE dml_union_r SET a = (SELECT NULL INTERSECT SELECT NULL)::int;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT DISTINCT(a) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ a 
+---
+  
+(1 row)
+
 rollback;
 -- @description union_update_test9: NULL values to distribution key
 begin;
 UPDATE dml_union_r SET a = (SELECT NULL INTERSECT ALL SELECT NULL)::int;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT DISTINCT(a) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ a 
+---
+  
+(1 row)
+
 rollback;
 -- @description union_update_test10: NULL values to distribution key
 begin;
@@ -1097,9 +1128,12 @@ SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 (1 row)
 
 UPDATE dml_union_r SET a = (SELECT NULL EXCEPT SELECT NULL)::int;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r; 
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+     0
+(1 row)
+
 rollback;
 -- @description union_update_test11: NULL values to text
 begin;
@@ -1257,7 +1291,7 @@ SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 (1 row)
 
 UPDATE dml_union_r SET a = dml_union_s.a FROM dml_union_s WHERE dml_union_r.b in (SELECT b FROM dml_union_r UNION SELECT b FROM dml_union_s);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  multiple updates to a row by the same query is not allowed  (seg2 10.152.10.75:25434 pid=18097)
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 rollback;
@@ -1273,107 +1307,107 @@ UPDATE dml_union_r SET a = dml_union_r.a WHERE b in (SELECT b FROM dml_union_r I
 SELECT DISTINCT(a) FROM dml_union_r;
   a  
 -----
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
-  31
-  32
-  33
-  34
-  35
-  36
-  37
-  38
-  39
-  40
-  41
-  42
-  43
-  44
-  45
-  46
-  47
-  48
   49
-  50
-  51
-  52
-  53
-  54
-  55
-  56
-  57
-  58
-  59
-  60
-  61
-  62
-  63
-  64
-  65
-  66
-  67
-  68
-  69
-  70
-  71
+  35
+  30
+  13
+  37
+  33
   72
-  73
-  74
-  75
-  76
-  77
-  78
-  79
-  80
-  81
-  82
-  83
-  84
-  85
+  17
+   1
+  48
+  51
+  31
   86
-  87
-  88
-  89
-  90
+  34
+  70
+   2
+  71
+  15
+  69
+  36
+  29
+  28
+  63
+  16
+  83
+  52
+  85
+  68
+  50
+  14
+  84
+  20
+  40
+   5
   91
-  92
-  93
-  94
-  95
+  56
+  42
+  19
+  18
+  57
+  54
+  22
+  89
+  75
+  53
+   6
+  39
+   7
+  77
+  76
+  41
+  38
   96
+  90
+  21
+   4
+  73
   97
-  98
-  99
- 100
     
+   3
+  88
+  55
+  87
+  74
+  23
+  78
+  24
+  67
+  66
+  11
+  10
+  60
+  45
+  27
+ 100
+  12
+  80
+  79
+  46
+  44
+  82
+  59
+  62
+  47
+  65
+  92
+  61
+   8
+  43
+  95
+  93
+  64
+  94
+  26
+  58
+  25
+  99
+  98
+   9
+  81
+  32
 (101 rows)
 
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
@@ -1401,107 +1435,107 @@ SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 SELECT DISTINCT(a) FROM dml_union_r;
   a  
 -----
-    
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
   23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
-  31
-  32
-  33
-  34
-  35
-  36
-  37
-  38
-  39
-  40
-  41
-  42
-  43
-  44
-  45
-  46
-  47
-  48
-  49
-  50
-  51
-  52
-  53
-  54
-  55
-  56
-  57
-  58
-  59
-  60
-  61
-  62
-  63
-  64
-  65
-  66
-  67
-  68
-  69
-  70
-  71
-  72
-  73
-  74
-  75
-  76
-  77
   78
-  79
-  80
-  81
-  82
-  83
-  84
-  85
-  86
-  87
-  88
-  89
-  90
-  91
-  92
-  93
-  94
-  95
-  96
-  97
-  98
-  99
+  24
+  67
+  66
+  11
+  10
+  60
+  45
+  27
  100
+  12
+  80
+  79
+  46
+  44
+  82
+  59
+  62
+  47
+  65
+  92
+  61
+   8
+  43
+  95
+  93
+  64
+  94
+  26
+  58
+  25
+  99
+  98
+   9
+  81
+  32
+  49
+  35
+  30
+  13
+  37
+  33
+  72
+  17
+   1
+  48
+  51
+  31
+  86
+  34
+  70
+   2
+  71
+  15
+  69
+  36
+  29
+  28
+  63
+  16
+  83
+  52
+  85
+  68
+  50
+  14
+  84
+  20
+  40
+   5
+  91
+  56
+  42
+  19
+  18
+  57
+  54
+  22
+  89
+  75
+  53
+   6
+  39
+   7
+  77
+  76
+  41
+  38
+  96
+  90
+  21
+   4
+  73
+  97
+    
+   3
+  88
+  55
+  87
+  74
 (101 rows)
 
 rollback;
@@ -1520,11 +1554,18 @@ SELECT COUNT(*) FROM dml_union_r WHERE a = 0;
 (1 row)
 
 UPDATE dml_union_r SET a = 0 WHERE a in (SELECT a FROM dml_union_r UNION ALL SELECT a FROM dml_union_s);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(*) FROM dml_union_r WHERE a = 0;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+   115
+(1 row)
+
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+     1
+(1 row)
+
 rollback;
 -- @description union_update_test24: Update distribution column to constant value with UNION/INTERSECT/EXCEPT within dml_union_sub-query
 begin;
@@ -1541,11 +1582,18 @@ SELECT COUNT(*) FROM dml_union_r WHERE a = 0;
 (1 row)
 
 UPDATE dml_union_r SET a = 0 WHERE a in (SELECT a FROM dml_union_r INTERSECT ALL SELECT a FROM dml_union_s);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+     1
+(1 row)
+
 SELECT COUNT(*) FROM dml_union_r WHERE a = 0;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+   115
+(1 row)
+
 rollback;
 -- @description union_update_test25: Update distribution column to constant value with UNION/INTERSECT/EXCEPT within dml_union_sub-query
 begin;
@@ -1562,11 +1610,18 @@ SELECT COUNT(*) FROM dml_union_r WHERE a = 0;
 (1 row)
 
 UPDATE dml_union_r SET a = 0 WHERE a in (SELECT a FROM dml_union_r EXCEPT ALL SELECT a FROM dml_union_s);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+   100
+(1 row)
+
 SELECT COUNT(*) FROM dml_union_r WHERE a = 0;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ count 
+-------
+     0
+(1 row)
+
 rollback;
 -- @description union_update_test26: Negative Tests Update the partition key to an out of dml_union_range value with no default partition
 begin;
@@ -1621,7 +1676,7 @@ SELECT COUNT(DISTINCT(b)) FROM dml_union_s;
 (1 row)
 
 UPDATE dml_union_s SET b = (SELECT NULL UNION SELECT NULL)::numeric;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  null value in column "b" violates not-null constraint  (seg1 10.152.10.75:25433 pid=19531)
 --SELECT COUNT(DISTINCT(b)) FROM dml_union_s;
 --SELECT DISTINCT(b) FROM dml_union_s;
 -- @description union_update_test30: Negative Tests  more than one row returned by a sub-query used as an expression
@@ -1645,7 +1700,7 @@ SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 (1 row)
 
 UPDATE dml_union_r SET a = ( SELECT a FROM dml_union_r UNION ALL SELECT a FROM dml_union_s);
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  more than one row returned by a subquery used as an expression
 reset optimizer_segments;
 --SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 -- @description union_update_test31: Negative Tests  more than one row returned by a sub-query used as an expression

--- a/src/test/regress/expected/rules.out
+++ b/src/test/regress/expected/rules.out
@@ -239,34 +239,42 @@ select * from rtest_v1 where b isnull;
 
 -- let attribute a differ (must be done on rtest_t1 - see above)
 update rtest_t1 set a = a + 10 where b isnull;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 delete from rtest_v1 where b isnull;
 select * from rtest_v1;
- a | b 
----+---
-(0 rows)
+ a | b
+---+----
+ 1 | 21
+ 2 | 22
+ 3 | 23
+(3 rows)
 
 -- now updates with constant expression
 update rtest_v1 set b = 42 where a = 2;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select * from rtest_v1;
- a | b 
----+---
-(0 rows)
+ a | b
+---+----
+ 1 | 21
+ 3 | 23
+ 2 | 42
+(3 rows)
 
 update rtest_v1 set b = 99 where b = 42;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select * from rtest_v1;
- a | b 
----+---
-(0 rows)
+ a | b
+---+----
+ 1 | 21
+ 3 | 23
+ 2 | 99
+(3 rows)
 
 update rtest_v1 set b = 88 where b < 50;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select * from rtest_v1;
- a | b 
----+---
-(0 rows)
+ a | b
+---+----
+ 2 | 99
+ 1 | 88
+ 3 | 88
+(3 rows)
 
 delete from rtest_v1;
 insert into rtest_v1 select rtest_t2.a, rtest_t3.b
@@ -282,13 +290,12 @@ select * from rtest_v1;
 
 -- updates in a mergejoin
 update rtest_v1 set b = rtest_t2.b from rtest_t2 where rtest_v1.a = rtest_t2.a;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select * from rtest_v1;
  a | b  
 ---+----
- 1 | 31
- 2 | 32
- 3 | 33
+ 1 | 21
+ 2 | 22
+ 3 | 23
 (3 rows)
 
 insert into rtest_v1 select * from rtest_t3;
@@ -367,30 +374,24 @@ select * from rtest_admin;
 (3 rows)
 
 update rtest_person set pname = 'jwieck' where pdesc = 'Jan Wieck';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- Note: use ORDER BY here to ensure consistent output across all systems.
 -- The above UPDATE affects two rows with equal keys, so they could be
 -- updated in either order depending on the whim of the local qsort().
 select * from rtest_admin order by pname, sysname;
- pname | sysname 
--------+---------
- bm    | neptun
- jw    | notjw
- jw    | orion
+ pname  | sysname 
+--------+---------
+ bm     | pluto
+ jwieck | notjw
+ jwieck | orion
 (3 rows)
 
 delete from rtest_system where sysname = 'orion';
-ERROR:  Cannot parallelize that DELETE yet
-DETAIL:  Passage of data from one segment to another is not yet supported during DELETE operations.
-HINT:  The WHERE condition must specify equality between corresponding DISTRIBUTED BY columns of the target table and all joined tables.
 select * from rtest_interface;
  sysname | ifname 
 ---------+--------
- neptun  | eth0
  notjw   | eth0
- orion   | eth0
- orion   | eth1
-(4 rows)
+ pluto   | eth0
+(2 rows)
 
 select * from rtest_admin;
  pname | sysname 
@@ -406,9 +407,7 @@ select * from rtest_admin;
 insert into rtest_emp values ('wiecc', '5000.00');
 insert into rtest_emp values ('gates', '80000.00');
 update rtest_emp set ename = 'wiecx' where ename = 'wiecc';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 update rtest_emp set ename = 'wieck', salary = '6000.00' where ename = 'wiecx';
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 update rtest_emp set salary = '7000.00' where ename = 'wieck';
 delete from rtest_emp where ename = 'gates';
 select ename, who = current_user as "matches user", action, newsal, oldsal from rtest_emplog order by ename, action, newsal;
@@ -417,7 +416,9 @@ select ename, who = current_user as "matches user", action, newsal, oldsal from 
  gates                | t            | fired      |      $0.00 | $80,000.00
  gates                | t            | hired      | $80,000.00 |      $0.00
  wiecc                | t            | hired      |  $5,000.00 |      $0.00
-(3 rows)
+ wieck                | t            | honored    |  $6,000.00 |  $5,000.00
+ wieck                | t            | honored    |  $7,000.00 |  $6,000.00
+(5 rows)
 
 insert into rtest_empmass values ('meyer', '4000.00');
 insert into rtest_empmass values ('maier', '5000.00');

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -2,7 +2,6 @@
 -- UPDATE ... SET <col> = DEFAULT;
 --
 CREATE TABLE update_test (
-	e   INT DEFAULT 1,
     a   INT DEFAULT 10,
     b   INT,
     c   TEXT
@@ -100,3 +99,203 @@ SELECT a, b, char_length(c) FROM update_test;
 (2 rows)
 
 DROP TABLE update_test;
+--
+-- text types. We should support the following updates.
+--
+drop table tab1;
+ERROR:  table "tab1" does not exist
+drop table tab2;
+ERROR:  table "tab2" does not exist
+CREATE TABLE tab1 (a varchar(15), b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a varchar(15), b integer) DISTRIBUTED BY (a);
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+drop table tab1;
+drop table tab2;
+CREATE TABLE tab1 (a text, b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a text, b integer) DISTRIBUTED BY (a);
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+drop table tab1;
+drop table tab2;
+CREATE TABLE tab1 (a varchar, b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a varchar, b integer) DISTRIBUTED BY (a);
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+drop table tab1;
+drop table tab2;
+CREATE TABLE tab1 (a char(15), b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a char(15), b integer) DISTRIBUTED BY (a);
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+drop table tab1;
+drop table tab2;
+DROP TABLE IF EXISTS update_distr_key; 
+NOTICE:  table "update_distr_key" does not exist, skipping
+CREATE TABLE update_distr_key (a int, b int) DISTRIBUTED BY (a); 
+INSERT INTO update_distr_key select i, i* 10 from generate_series(0, 9) i; 
+UPDATE update_distr_key SET a = 5 WHERE b = 10; 
+SELECT * from update_distr_key; 
+ a | b  
+---+----
+ 3 | 30
+ 4 | 40
+ 5 | 50
+ 6 | 60
+ 7 | 70
+ 5 | 10
+ 8 | 80
+ 9 | 90
+ 0 |  0
+ 2 | 20
+(10 rows)
+
+DROP TABLE update_distr_key;
+-- below cases is to test multi-hash-cols
+CREATE TABLE tab3(c1 int, c2 int, c3 int, c4 int, c5 int) DISTRIBUTED BY (c1, c2, c3);
+CREATE TABLE tab5(c1 int, c2 int, c3 int, c4 int, c5 int) DISTRIBUTED BY (c1, c2, c3, c4, c5);
+INSERT INTO tab3 SELECT i, i, i, i, i FROM generate_series(1, 10)i;
+INSERT INTO tab5 SELECT i, i, i, i, i FROM generate_series(1, 10)i;
+-- test tab3
+SELECT gp_segment_id, * FROM tab3;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  1 |  1 |  1 |  1 |  1
+             0 |  2 |  2 |  2 |  2 |  2
+             0 |  3 |  3 |  3 |  3 |  3
+             0 |  4 |  4 |  4 |  4 |  4
+             0 |  5 |  5 |  5 |  5 |  5
+             0 |  6 |  6 |  6 |  6 |  6
+             0 |  7 |  7 |  7 |  7 |  7
+             0 |  8 |  8 |  8 |  8 |  8
+             0 |  9 |  9 |  9 |  9 |  9
+             0 | 10 | 10 | 10 | 10 | 10
+(10 rows)
+
+UPDATE tab3 set c1 = 9 where c4 = 1;
+SELECT gp_segment_id, * FROM tab3;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             2 |  9 |  1 |  1 |  1 |  1
+             0 |  2 |  2 |  2 |  2 |  2
+             0 |  3 |  3 |  3 |  3 |  3
+             0 |  4 |  4 |  4 |  4 |  4
+             0 |  5 |  5 |  5 |  5 |  5
+             0 |  6 |  6 |  6 |  6 |  6
+             0 |  7 |  7 |  7 |  7 |  7
+             0 |  8 |  8 |  8 |  8 |  8
+             0 |  9 |  9 |  9 |  9 |  9
+             0 | 10 | 10 | 10 | 10 | 10
+(10 rows)
+
+UPDATE tab3 set (c1,c2) = (5,6) where c4 = 1;
+SELECT gp_segment_id, * FROM tab3;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  2 |  2 |  2 |  2 |  2
+             0 |  3 |  3 |  3 |  3 |  3
+             0 |  4 |  4 |  4 |  4 |  4
+             0 |  5 |  5 |  5 |  5 |  5
+             0 |  6 |  6 |  6 |  6 |  6
+             0 |  7 |  7 |  7 |  7 |  7
+             0 |  8 |  8 |  8 |  8 |  8
+             0 |  9 |  9 |  9 |  9 |  9
+             0 | 10 | 10 | 10 | 10 | 10
+             1 |  5 |  6 |  1 |  1 |  1
+(10 rows)
+
+UPDATE tab3 set (c1,c2,c3) = (3,2,1) where c4 = 1;
+SELECT gp_segment_id, * FROM tab3;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  2 |  2 |  2 |  2 |  2
+             0 |  3 |  3 |  3 |  3 |  3
+             0 |  4 |  4 |  4 |  4 |  4
+             0 |  5 |  5 |  5 |  5 |  5
+             0 |  6 |  6 |  6 |  6 |  6
+             0 |  7 |  7 |  7 |  7 |  7
+             0 |  8 |  8 |  8 |  8 |  8
+             0 |  9 |  9 |  9 |  9 |  9
+             0 | 10 | 10 | 10 | 10 | 10
+             0 |  3 |  2 |  1 |  1 |  1
+(10 rows)
+
+-- test tab5
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             2 |  2 |  2 |  2 |  2 |  2
+             2 |  5 |  5 |  5 |  5 |  5
+             2 |  6 |  6 |  6 |  6 |  6
+             2 |  9 |  9 |  9 |  9 |  9
+             0 |  1 |  1 |  1 |  1 |  1
+             0 |  4 |  4 |  4 |  4 |  4
+             0 |  8 |  8 |  8 |  8 |  8
+             1 |  3 |  3 |  3 |  3 |  3
+             1 |  7 |  7 |  7 |  7 |  7
+             1 | 10 | 10 | 10 | 10 | 10
+(10 rows)
+
+UPDATE tab5 set c1 = 1000 where c4 = 1;
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id |  c1  | c2 | c3 | c4 | c5 
+---------------+------+----+----+----+----
+             1 |    3 |  3 |  3 |  3 |  3
+             1 |    7 |  7 |  7 |  7 |  7
+             1 |   10 | 10 | 10 | 10 | 10
+             2 |    2 |  2 |  2 |  2 |  2
+             2 |    5 |  5 |  5 |  5 |  5
+             2 |    6 |  6 |  6 |  6 |  6
+             2 |    9 |  9 |  9 |  9 |  9
+             2 | 1000 |  1 |  1 |  1 |  1
+             0 |    4 |  4 |  4 |  4 |  4
+             0 |    8 |  8 |  8 |  8 |  8
+(10 rows)
+
+UPDATE tab5 set (c1,c2) = (9,10) where c4 = 1;
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  4 |  4 |  4 |  4 |  4
+             0 |  8 |  8 |  8 |  8 |  8
+             1 |  3 |  3 |  3 |  3 |  3
+             1 |  7 |  7 |  7 |  7 |  7
+             1 | 10 | 10 | 10 | 10 | 10
+             1 |  9 | 10 |  1 |  1 |  1
+             2 |  2 |  2 |  2 |  2 |  2
+             2 |  5 |  5 |  5 |  5 |  5
+             2 |  6 |  6 |  6 |  6 |  6
+             2 |  9 |  9 |  9 |  9 |  9
+(10 rows)
+
+UPDATE tab5 set (c1,c2,c4) = (5,8,6) where c4 = 1;
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  4 |  4 |  4 |  4 |  4
+             0 |  8 |  8 |  8 |  8 |  8
+             0 |  5 |  8 |  1 |  6 |  1
+             2 |  2 |  2 |  2 |  2 |  2
+             2 |  5 |  5 |  5 |  5 |  5
+             2 |  6 |  6 |  6 |  6 |  6
+             2 |  9 |  9 |  9 |  9 |  9
+             1 |  3 |  3 |  3 |  3 |  3
+             1 |  7 |  7 |  7 |  7 |  7
+             1 | 10 | 10 | 10 | 10 | 10
+(10 rows)
+
+UPDATE tab5 set (c1,c2,c3,c4,c5) = (1,2,3,0,6) where c5 = 1;
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             2 |  2 |  2 |  2 |  2 |  2
+             2 |  5 |  5 |  5 |  5 |  5
+             2 |  6 |  6 |  6 |  6 |  6
+             2 |  9 |  9 |  9 |  9 |  9
+             0 |  4 |  4 |  4 |  4 |  4
+             0 |  8 |  8 |  8 |  8 |  8
+             1 |  3 |  3 |  3 |  3 |  3
+             1 |  7 |  7 |  7 |  7 |  7
+             1 | 10 | 10 | 10 | 10 | 10
+             1 |  1 |  2 |  3 |  0 |  6
+(10 rows)
+
+-- clean up
+drop table tab3;
+drop table tab5;

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -205,7 +205,6 @@ NOTICE:  table "update_distr_key" does not exist, skipping
 CREATE TEMP TABLE update_distr_key (a int, b int) DISTRIBUTED BY (a);
 INSERT INTO update_distr_key select i, i* 10 from generate_series(0, 9) i;
 UPDATE update_distr_key SET a = 5 WHERE b = 10;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 SELECT * from update_distr_key;
  a | b  
 ---+----
@@ -214,7 +213,7 @@ SELECT * from update_distr_key;
  4 | 40
  6 | 60
  8 | 80
- 1 | 10
+ 5 | 10
  3 | 30
  5 | 50
  7 | 70
@@ -222,3 +221,252 @@ SELECT * from update_distr_key;
 (10 rows)
 
 DROP TABLE update_distr_key;
+-- Update distribution key
+-- start_ignore
+drop table if exists r;
+NOTICE:  table "r" does not exist, skipping
+drop table if exists s;
+NOTICE:  table "s" does not exist, skipping
+drop table if exists update_dist;
+NOTICE:  table "update_dist" does not exist, skipping
+drop table if exists ao_table;
+NOTICE:  table "ao_table" does not exist, skipping
+drop table if exists aoco_table;
+NOTICE:  table "aoco_table" does not exist, skipping
+drop table if exists p_1;
+NOTICE:  table "p_1" does not exist, skipping
+drop table if exists p_2;
+NOTICE:  table "p_2" does not exist, skipping
+drop table if exists subpartition_1;
+NOTICE:  table "subpartition_1" does not exist, skipping
+-- end_ignore
+-- Update normal table distribution key
+create table update_dist(a int) distributed by (a);
+insert into update_dist values(1);
+update update_dist set a=0 where a=1;
+select * from update_dist;
+ a 
+---
+ 0
+(1 row)
+
+-- Update distribution key with join
+create table r (a int, b int) distributed by (a);
+create table s (a int, b int) distributed by (a);
+insert into r select generate_series(1, 5), generate_series(1, 5) * 2;
+insert into s select generate_series(1, 5), generate_series(1, 5) * 2;
+select * from r;
+ a | b  
+---+----
+ 3 |  6
+ 4 |  8
+ 5 | 10
+ 1 |  2
+ 2 |  4
+(5 rows)
+
+select * from s;
+ a | b  
+---+----
+ 1 |  2
+ 2 |  4
+ 3 |  6
+ 4 |  8
+ 5 | 10
+(5 rows)
+
+update r set a = r.a + 1 from s where r.a = s.a;
+select * from r;
+ a | b  
+---+----
+ 4 |  6
+ 5 |  8
+ 6 | 10
+ 3 |  4
+ 2 |  2
+(5 rows)
+
+update r set a = r.a + 1 where a in (select a from s);
+select * from r;
+ a | b  
+---+----
+ 6 | 10
+ 5 |  6
+ 6 |  8
+ 4 |  4
+ 3 |  2
+(5 rows)
+
+-- Update redistribution
+delete from r;
+delete from s;
+insert into r select generate_series(1, 5), generate_series(1, 5);
+insert into s select generate_series(1, 5), generate_series(1, 5) * 2;
+select * from r;
+ a | b 
+---+---
+ 3 | 3
+ 4 | 4
+ 5 | 5
+ 1 | 1
+ 2 | 2
+(5 rows)
+
+select * from s;
+ a | b  
+---+----
+ 3 |  6
+ 4 |  8
+ 5 | 10
+ 1 |  2
+ 2 |  4
+(5 rows)
+
+update r set a = r.a + 1 from s where r.b = s.b;
+select * from r;
+ a | b 
+---+---
+ 1 | 1
+ 3 | 3
+ 5 | 5
+ 5 | 4
+ 3 | 2
+(5 rows)
+
+update r set a = r.a + 1 where b in (select b from s);
+select * from r;
+ a | b 
+---+---
+ 1 | 1
+ 3 | 3
+ 5 | 5
+ 6 | 4
+ 4 | 2
+(5 rows)
+
+-- Update hash aggreate group by
+delete from r;
+delete from s;
+insert into r select generate_series(1, 5), generate_series(1, 5) * 2;
+insert into s select generate_series(1, 5), generate_series(1, 5);
+select * from r;
+ a | b  
+---+----
+ 1 |  2
+ 2 |  4
+ 3 |  6
+ 4 |  8
+ 5 | 10
+(5 rows)
+
+select * from s;
+ a | b 
+---+---
+ 3 | 3
+ 4 | 4
+ 5 | 5
+ 1 | 1
+ 2 | 2
+(5 rows)
+
+update s set a = s.a + 1 where exists (select 1 from r where s.a = r.b);
+select * from s;
+ a | b 
+---+---
+ 1 | 1
+ 3 | 3
+ 5 | 5
+ 3 | 2
+ 5 | 4
+(5 rows)
+
+-- Update ao table distribution key
+create table ao_table (a int, b int) WITH (appendonly=true) distributed by (a);
+insert into ao_table select g, g from generate_series(1, 5) g;
+select * from ao_table;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+(5 rows)
+
+update ao_table set a = a + 1 where b = 3;
+select * from ao_table;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 4 | 4
+ 5 | 5
+ 4 | 3
+(5 rows)
+
+-- Update aoco table distribution key
+create table aoco_table (a int, b int) WITH (appendonly=true, orientation=column) distributed by (a);
+insert into aoco_table select g,g from generate_series(1, 5) g;
+select * from aoco_table;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+(5 rows)
+
+update aoco_table set a = a + 1 where b = 3;
+select * from aoco_table;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 4 | 4
+ 5 | 5
+ 4 | 3
+(5 rows)
+
+-- Update prepare
+delete from s;
+insert into s select generate_series(1, 5), generate_series(1, 5);
+select * from r;
+ a | b  
+---+----
+ 1 |  2
+ 2 |  4
+ 3 |  6
+ 4 |  8
+ 5 | 10
+(5 rows)
+
+select * from s;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+(5 rows)
+
+prepare update_s(int) as update s set a = s.a + $1 where exists (select 1 from r where s.a = r.b);
+execute update_s(10);
+select * from s;
+ a  | b 
+----+---
+  1 | 1
+ 14 | 4
+  3 | 3
+  5 | 5
+ 12 | 2
+(5 rows)
+
+-- start_ignore
+drop table r;
+drop table s;
+drop table update_dist;
+drop table ao_table;
+drop table aoco_table;
+-- end_ignore

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -232,3 +232,246 @@ SELECT * from update_distr_key;
 (10 rows)
 
 DROP TABLE update_distr_key;
+-- Update distribution key
+-- start_ignore
+drop table if exists r;
+NOTICE:  table "r" does not exist, skipping
+drop table if exists s;
+NOTICE:  table "s" does not exist, skipping
+drop table if exists update_dist;
+NOTICE:  table "update_dist" does not exist, skipping
+drop table if exists ao_table;
+NOTICE:  table "ao_table" does not exist, skipping
+drop table if exists aoco_table;
+NOTICE:  table "aoco_table" does not exist, skipping
+-- end_ignore
+-- Update normal table distribution key
+create table update_dist(a int) distributed by (a);
+insert into update_dist values(1);
+update update_dist set a=0 where a=1;
+select * from update_dist;
+ a 
+---
+ 0
+(1 row)
+
+-- Update distribution key with join
+create table r (a int, b int) distributed by (a);
+create table s (a int, b int) distributed by (a);
+insert into r select generate_series(1, 5), generate_series(1, 5) * 2;
+insert into s select generate_series(1, 5), generate_series(1, 5) * 2;
+select * from r;
+ a | b  
+---+----
+ 1 |  2
+ 2 |  4
+ 3 |  6
+ 4 |  8
+ 5 | 10
+(5 rows)
+
+select * from s;
+ a | b  
+---+----
+ 1 |  2
+ 2 |  4
+ 3 |  6
+ 4 |  8
+ 5 | 10
+(5 rows)
+
+update r set a = r.a + 1 from s where r.a = s.a;
+select * from r;
+ a | b  
+---+----
+ 4 |  6
+ 5 |  8
+ 6 | 10
+ 3 |  4
+ 2 |  2
+(5 rows)
+
+update r set a = r.a + 1 where a in (select a from s);
+select * from r;
+ a | b  
+---+----
+ 6 | 10
+ 3 |  2
+ 5 |  6
+ 6 |  8
+ 4 |  4
+(5 rows)
+
+-- Update redistribution
+delete from r;
+delete from s;
+insert into r select generate_series(1, 5), generate_series(1, 5);
+insert into s select generate_series(1, 5), generate_series(1, 5) * 2;
+select * from r;
+ a | b 
+---+---
+ 3 | 3
+ 4 | 4
+ 5 | 5
+ 1 | 1
+ 2 | 2
+(5 rows)
+
+select * from s;
+ a | b  
+---+----
+ 3 |  6
+ 4 |  8
+ 5 | 10
+ 1 |  2
+ 2 |  4
+(5 rows)
+
+update r set a = r.a + 1 from s where r.b = s.b;
+select * from r;
+ a | b 
+---+---
+ 3 | 3
+ 5 | 5
+ 3 | 2
+ 5 | 4
+ 1 | 1
+(5 rows)
+
+update r set a = r.a + 1 where b in (select b from s);
+select * from r;
+ a | b 
+---+---
+ 3 | 3
+ 5 | 5
+ 6 | 4
+ 4 | 2
+ 1 | 1
+(5 rows)
+
+-- Update hash aggreate group by
+delete from r;
+delete from s;
+insert into r select generate_series(1, 5), generate_series(1, 5) * 2;
+insert into s select generate_series(1, 5), generate_series(1, 5);
+select * from r;
+ a | b  
+---+----
+ 1 |  2
+ 2 |  4
+ 3 |  6
+ 4 |  8
+ 5 | 10
+(5 rows)
+
+select * from s;
+ a | b 
+---+---
+ 3 | 3
+ 4 | 4
+ 5 | 5
+ 1 | 1
+ 2 | 2
+(5 rows)
+
+update s set a = s.a + 1 where exists (select 1 from r where s.a = r.b);
+select * from s;
+ a | b 
+---+---
+ 1 | 1
+ 3 | 3
+ 5 | 5
+ 5 | 4
+ 3 | 2
+(5 rows)
+
+-- Update ao table distribution key
+create table ao_table (a int, b int) WITH (appendonly=true) distributed by (a);
+insert into ao_table select g, g from generate_series(1, 5) g;
+select * from ao_table;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+(5 rows)
+
+update ao_table set a = a + 1 where b = 3;
+select * from ao_table;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 4 | 4
+ 5 | 5
+ 4 | 3
+(5 rows)
+
+-- Update aoco table distribution key
+create table aoco_table (a int, b int) WITH (appendonly=true, orientation=column) distributed by (a);
+insert into aoco_table select g,g from generate_series(1, 5) g;
+select * from aoco_table;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+(5 rows)
+
+update aoco_table set a = a + 1 where b = 3;
+select * from aoco_table;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 4 | 4
+ 5 | 5
+ 4 | 3
+(5 rows)
+
+-- Update prepare
+delete from s;
+insert into s select generate_series(1, 5), generate_series(1, 5);
+select * from r;
+ a | b  
+---+----
+ 1 |  2
+ 2 |  4
+ 3 |  6
+ 4 |  8
+ 5 | 10
+(5 rows)
+
+select * from s;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+(5 rows)
+
+prepare update_s(int) as update s set a = s.a + $1 where exists (select 1 from r where s.a = r.b);
+execute update_s(10);
+select * from s;
+ a  | b 
+----+---
+  1 | 1
+ 14 | 4
+  3 | 3
+  5 | 5
+ 12 | 2
+(5 rows)
+
+-- start_ignore
+drop table r;
+drop table s;
+drop table update_dist;
+drop table ao_table;
+drop table aoco_table;
+-- end_ignore

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -418,11 +418,11 @@ INSERT INTO unique_tbl VALUES (4, 'five');
 BEGIN;
 -- default is immediate so this should fail right away
 UPDATE unique_tbl SET i = 1 WHERE i = 0;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 ROLLBACK;
 -- check is done at end of statement, so this should succeed
 UPDATE unique_tbl SET i = i+1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 SELECT * FROM unique_tbl;
  i |  t   
 ---+------
@@ -462,7 +462,7 @@ BEGIN;
 INSERT INTO unique_tbl VALUES (1, 'five');
 INSERT INTO unique_tbl VALUES (5, 'one');
 UPDATE unique_tbl SET i = 4 WHERE i = 2;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 UPDATE unique_tbl SET i = 2 WHERE i = 4 AND t = 'four';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 DELETE FROM unique_tbl WHERE i = 1 AND t = 'one';
@@ -614,7 +614,6 @@ DETAIL:  Key (f1)=(3) conflicts with existing key (f1)=(3).
 ALTER TABLE deferred_excl DROP CONSTRAINT deferred_excl_con;
 -- This should fail, but worth testing because of HOT updates
 UPDATE deferred_excl SET f1 = 3;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 -- In the original postgres test, both the tuples in this table will be updated
 -- (probably by HOT update) in the previous statement, and would now be equal. In
 -- greenplum, the planner does not support updating distribution keys, so we need

--- a/src/test/regress/output/constraints_optimizer.source
+++ b/src/test/regress/output/constraints_optimizer.source
@@ -418,11 +418,11 @@ INSERT INTO unique_tbl VALUES (4, 'five');
 BEGIN;
 -- default is immediate so this should fail right away
 UPDATE unique_tbl SET i = 1 WHERE i = 0;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 ROLLBACK;
 -- check is done at end of statement, so this should succeed
 UPDATE unique_tbl SET i = i+1;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 SELECT * FROM unique_tbl;
  i |  t   
 ---+------
@@ -462,7 +462,7 @@ BEGIN;
 INSERT INTO unique_tbl VALUES (1, 'five');
 INSERT INTO unique_tbl VALUES (5, 'one');
 UPDATE unique_tbl SET i = 4 WHERE i = 2;
-ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+ERROR:  UPDATE on distributed key columns is now supported in general.But disabled for current statement because result relation has update triggers. Running trigger across segment is not supported
 UPDATE unique_tbl SET i = 2 WHERE i = 4 AND t = 'four';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 DELETE FROM unique_tbl WHERE i = 1 AND t = 'one';

--- a/src/test/regress/sql/ao_create_alter_valid_table.sql
+++ b/src/test/regress/sql/ao_create_alter_valid_table.sql
@@ -39,7 +39,6 @@ create table bar_ao (a int);
 
 --invalid operations
 -- start_ignore
-update foo_ao set a=5;
 delete from foo_ao;
 -- end_ignore
 

--- a/src/test/regress/sql/bfv_dml.sql
+++ b/src/test/regress/sql/bfv_dml.sql
@@ -132,7 +132,7 @@ set optimizer_trace_fallback = on;
 -- Subquery that returns a row rather than a single scalar isn't supported
 -- in ORCA currently, so we can use that to trigger fallback.
 update update_pk_test set a=1 where row(1,2) = (SELECT 1, 2);
-
+select * from update_pk_test order by 1,2;
 reset optimizer_trace_fallback;
 
 

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -1,3 +1,13 @@
+-- start_matchsubs
+
+-- m/ERROR:  moving tuple from partition .* to partition .* not supported/
+-- s/ERROR:  moving tuple from partition .* to partition .* not supported/ERROR:  cross-partition or multi-update to a row/
+
+-- m/ERROR:  multiple updates to a row by the same query is not allowed/
+-- s/ERROR:  multiple updates to a row by the same query is not allowed/ERROR:  cross-partition or multi-update to a row/
+
+-- end_matchsubs
+
 -- First create a bunch of test tables
 SET statement_mem='250 MB';
 
@@ -1457,9 +1467,9 @@ rollback;
 --Update on table with composite distribution key
 -- This currently falls back to planner, even if ORCA is enabled. And planner can't
 -- produce plans that update distribution key columns.
-SELECT SUM(a) FROM dml_heap_pt_r;
-UPDATE dml_heap_pt_p SET a = dml_heap_pt_p.b % 2 FROM dml_heap_pt_r WHERE dml_heap_pt_p.b::int = dml_heap_pt_r.b::int and dml_heap_pt_p.a = dml_heap_pt_r.a;
-SELECT SUM(a) FROM dml_heap_pt_r;
+begin;
+UPDATE dml_heap_pt_p SET a = dml_heap_pt_p.b % 2 FROM dml_heap_pt_r WHERE dml_heap_pt_p.b::int = dml_heap_pt_r.b::int and dml_heap_pt_p.a = dml_heap_pt_r.a and dml_heap_pt_p.b = 63;
+rollback;
 
 --Update on table with composite distribution key
 begin;

--- a/src/test/regress/sql/update.sql
+++ b/src/test/regress/sql/update.sql
@@ -3,7 +3,6 @@
 --
 
 CREATE TABLE update_test (
-	e   INT DEFAULT 1,
     a   INT DEFAULT 10,
     b   INT,
     c   TEXT
@@ -60,3 +59,84 @@ UPDATE update_test SET c = repeat('x', 10000) WHERE c = 'car';
 SELECT a, b, char_length(c) FROM update_test;
 
 DROP TABLE update_test;
+
+--
+-- text types. We should support the following updates.
+--
+drop table tab1;
+drop table tab2;
+
+CREATE TABLE tab1 (a varchar(15), b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a varchar(15), b integer) DISTRIBUTED BY (a);
+
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+
+drop table tab1;
+drop table tab2;
+
+CREATE TABLE tab1 (a text, b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a text, b integer) DISTRIBUTED BY (a);
+
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+
+drop table tab1;
+drop table tab2;
+
+CREATE TABLE tab1 (a varchar, b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a varchar, b integer) DISTRIBUTED BY (a);
+
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+
+drop table tab1;
+drop table tab2;
+
+CREATE TABLE tab1 (a char(15), b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a char(15), b integer) DISTRIBUTED BY (a);
+
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+
+drop table tab1;
+drop table tab2;
+
+DROP TABLE IF EXISTS update_distr_key; 
+CREATE TABLE update_distr_key (a int, b int) DISTRIBUTED BY (a); 
+INSERT INTO update_distr_key select i, i* 10 from generate_series(0, 9) i; 
+
+UPDATE update_distr_key SET a = 5 WHERE b = 10; 
+
+SELECT * from update_distr_key; 
+
+DROP TABLE update_distr_key;
+
+-- below cases is to test multi-hash-cols
+CREATE TABLE tab3(c1 int, c2 int, c3 int, c4 int, c5 int) DISTRIBUTED BY (c1, c2, c3);
+CREATE TABLE tab5(c1 int, c2 int, c3 int, c4 int, c5 int) DISTRIBUTED BY (c1, c2, c3, c4, c5);
+
+INSERT INTO tab3 SELECT i, i, i, i, i FROM generate_series(1, 10)i;
+INSERT INTO tab5 SELECT i, i, i, i, i FROM generate_series(1, 10)i;
+
+-- test tab3
+SELECT gp_segment_id, * FROM tab3;
+UPDATE tab3 set c1 = 9 where c4 = 1;
+SELECT gp_segment_id, * FROM tab3;
+UPDATE tab3 set (c1,c2) = (5,6) where c4 = 1;
+SELECT gp_segment_id, * FROM tab3;
+UPDATE tab3 set (c1,c2,c3) = (3,2,1) where c4 = 1;
+SELECT gp_segment_id, * FROM tab3;
+
+-- test tab5
+SELECT gp_segment_id, * FROM tab5;
+UPDATE tab5 set c1 = 1000 where c4 = 1;
+SELECT gp_segment_id, * FROM tab5;
+UPDATE tab5 set (c1,c2) = (9,10) where c4 = 1;
+SELECT gp_segment_id, * FROM tab5;
+UPDATE tab5 set (c1,c2,c4) = (5,8,6) where c4 = 1;
+SELECT gp_segment_id, * FROM tab5;
+UPDATE tab5 set (c1,c2,c3,c4,c5) = (1,2,3,0,6) where c5 = 1;
+SELECT gp_segment_id, * FROM tab5;
+
+-- clean up
+drop table tab3;
+drop table tab5;
+
+


### PR DESCRIPTION
Before, we cannot update distribution column in legacy planner, because the OLD tuple
and NEW tuple maybe belong to different segments. We enable this by borrowing ORCA's
logic, namely, split each update operation into delete and insert. The delete operation is hashed
by OLD tuple attributes, and insert operation is hashed by NEW tuple attributes. This change
includes following items:
* We need push missed OLD attributes to sub plan tree so that that attribute could be passed to top Motion.
* In addition, if the result relation has oids, we also need to put oid in the targetlist.
* If result relation is partitioned, we should special treat it because resultRelations is partition tables instead of root table, but that is true for normal Insert.
* Special treats for update triggers, because trigger cannot be executed across segments.
* Special treatment in nodeModifyTable, so that it can process Insert/Delete for update purpose.
* Proper initialization of SplitUpdate.

There are still TODOs:
* We don't handle cost gracefully, because we add SplitUpdate node after plan generated. Already added a FIXME for this
* For deletion, we could optimize in just sending distribution columns instead of all columns

--------

The original PR is https://github.com/greenplum-db/gpdb/pull/4644 

We need this feature for data reorganization, so we solve some conflicts and fix several bugs and open a new one.

**Changes introduced in this PR on top of #4644 :** 
* Rebase with the master branch
* Fix conflicts of these months' commits
* on `setref.c: set_plan_refs` function, previous PR #4644 use `fix_scan_list` to correct varno; however, we have made it OUTER when we created the Var, so in this PR, we simply remove that code
* on `create_plan.c:adjust_modifytable_flow` function, on the time of PR $4644, replicated table has not merged in the repo, so in this PR, we add some code to handle the default values for replicated tables
* Fix some test cases
* We comment off a case: previous, it reports error that we cannot update hash column; now it can update hash col, but will fail on other different errors depending on the order of segment error. So it is flaky, we comment it off. (see here: kainwen/gpdb@112944b#diff-aad341c184504f68db2ebf9a3c4c05d6R1414)

Author: Xiaoran Wang <xiwang@pivotal.io>
Author: Max Yang <myang@pivotal.io>
Author: Shujie Zhang <shzhang@pivotal.io>
Author: Zhenghua Lyu <zlv@pivotal.io>