### PR TITLE
Do not automatically create an array type for child partitions

### DIFF
--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -160,7 +160,8 @@ _bitmap_create_lov_heapandindex(Relation rel,
 								 (Datum)0, true,
 								 /* valid_opts */ true,
 						 		 /* persistentTid */ NULL,
-						 		 /* persistentSerialNum */ NULL);
+								 /* persistentSerialNum */ NULL,
+								 /* is_part_child */ false);
 	*lovHeapOid = heapid;
 
 	/*

--- a/src/backend/bootstrap/bootparse.y
+++ b/src/backend/bootstrap/bootparse.y
@@ -238,7 +238,8 @@ Boot_CreateStmt:
 													  true,
 													  /* valid_opts */ false,
 						 					  		  /* persistentTid */ NULL,
-						 					  		  /* persistentSerialNum */ NULL);
+													  /* persistentSerialNum */ NULL,
+													  /* is_part_child */ false);
 						elog(DEBUG4, "relation created with oid %u", id);
 					}
 					do_end();

--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -129,7 +129,8 @@ CreateAOAuxiliaryTable(
 											     true,
 												 /* valid_opts */ false,
 											     /* persistentTid */ NULL,
-											     /* persistentSerialNum */ NULL);
+											     /* persistentSerialNum */ NULL,
+												 /* is_part_child */ false);
 
 	/* Make this table visible, else index creation will fail */
 	CommandCounterIncrement();

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -211,7 +211,8 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 										   true,
 										   /* valid_opts */ false,
 										   /* persistentTid */ NULL,
-										   /* persistentSerialNum */ NULL);
+										   /* persistentSerialNum */ NULL,
+										   /* is_part_child */ false);
 
 	/* make the toast relation visible, else index creation will fail */
 	CommandCounterIncrement();

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -754,7 +754,8 @@ make_new_heap(Oid OIDOldHeap, const char *NewName, Oid NewTableSpace,
 										  allowSystemTableModsDDL,
 										  /* valid_opts */ true,
 						 				  /* persistentTid */ NULL,
-						 				  /* persistentSerialNum */ NULL);
+										  /* persistentSerialNum */ NULL,
+										  /* is_part_child */ false);
 
 	ReleaseSysCache(tuple);
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -625,7 +625,8 @@ DefineRelation(CreateStmt *stmt, char relkind, char relstorage, bool dispatch)
 										  allowSystemTableModsDDL,
 										  valid_opts,
 										  &persistentTid,
-										  &persistentSerialNum);
+										  &persistentSerialNum,
+										  stmt->is_part_child);
 
 	StoreCatalogInheritance(relationId, stmt->inhOids);
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4828,7 +4828,8 @@ OpenIntoRel(QueryDesc *queryDesc)
 											  allowSystemTableModsDDL,
 											  /* valid_opts */ !validate_reloptions,
 						 					  &persistentTid,
-						 					  &persistentSerialNum);
+											  &persistentSerialNum,
+											  /* is_part_child */ false);
 
 	FreeTupleDesc(tupdesc);
 

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -58,7 +58,8 @@ extern Oid heap_create_with_catalog(const char *relname,
 						 bool allow_system_table_mods,
 						 bool valid_opts,
 						 ItemPointer persistentTid,
-						 int64 *persistentSerialNum);
+						 int64 *persistentSerialNum,
+						 bool is_part_child);
 
 extern void heap_drop_with_catalog(Oid relid);
 

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -7873,3 +7873,18 @@ NOTICE:  exchanged partition "other_log_ids" of relation "test_split_part" with 
 NOTICE:  dropped partition "other_log_ids" for relation "test_split_part"
 NOTICE:  CREATE TABLE will create partition "test_split_part_1_prt_New" for table "test_split_part"
 NOTICE:  CREATE TABLE will create partition "test_split_part_1_prt_other_log_ids" for table "test_split_part"
+-- Only the root partition should have automatically created an array type
+select typname, typtype from pg_type where typname like '%test_split_part%' and typtype = 'b';
+     typname      | typtype 
+------------------+---------
+ _test_split_part | b
+(1 row)
+
+select array_agg(test_split_part) from test_split_part where log_id = 500;
+   array_agg    
+----------------
+ {"(500,{10})"}
+(1 row)
+
+select array_agg(test_split_part_1_prt_other_log_ids) from test_split_part_1_prt_other_log_ids where log_id = 500;
+ERROR:  could not find array type for data type test_split_part_1_prt_other_log_ids

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -7867,3 +7867,18 @@ NOTICE:  exchanged partition "other_log_ids" of relation "test_split_part" with 
 NOTICE:  dropped partition "other_log_ids" for relation "test_split_part"
 NOTICE:  CREATE TABLE will create partition "test_split_part_1_prt_New" for table "test_split_part"
 NOTICE:  CREATE TABLE will create partition "test_split_part_1_prt_other_log_ids" for table "test_split_part"
+-- Only the root partition should have automatically created an array type
+select typname, typtype from pg_type where typname like '%test_split_part%' and typtype = 'b';
+     typname      | typtype 
+------------------+---------
+ _test_split_part | b
+(1 row)
+
+select array_agg(test_split_part) from test_split_part where log_id = 500;
+   array_agg    
+----------------
+ {"(500,{10})"}
+(1 row)
+
+select array_agg(test_split_part_1_prt_other_log_ids) from test_split_part_1_prt_other_log_ids where log_id = 500;
+ERROR:  could not find array type for data type test_split_part_1_prt_other_log_ids

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3770,3 +3770,7 @@ insert into test_split_part (log_id , f_array) select id, '{10}' from generate_s
 
 ALTER TABLE test_split_part SPLIT DEFAULT PARTITION START (201) INCLUSIVE END (301) EXCLUSIVE INTO (PARTITION "New", DEFAULT PARTITION);
 
+-- Only the root partition should have automatically created an array type
+select typname, typtype from pg_type where typname like '%test_split_part%' and typtype = 'b';
+select array_agg(test_split_part) from test_split_part where log_id = 500;
+select array_agg(test_split_part_1_prt_other_log_ids) from test_split_part_1_prt_other_log_ids where log_id = 500;


### PR DESCRIPTION
As part of the Postgres 8.3 merge, all heap tables now automatically
create an array type. The array type will usually be created with
typname '\_<heap\_name>' since the automatically created composite type
already takes the typname '<heap\_name>' first. If typname
'\_<heap_name>' is taken, the logic will continue to prepend
underscores until no collision (truncating the end if typname gets
past NAMEDATALEN of 64). This might be an oversight in upstream
Postgres since certain scenarios involving creating a large number of
heap tables with similar names could result in a lot of typname
collisions until no heap tables with similar names can be
created. This is very noticable in Greenplum heap partition tables
because Greenplum has logic to automatically name child partitions
with similar names instead of having the user name each child
partition.

To prevent typname collision failures when creating a heap partition
table with a large number of child partitions, we will now stop
automatically creating the array type for child partitions.

References:
https://www.postgresql.org/message-id/flat/20070302234016.GF3665%40fetter.org
https://github.com/postgres/postgres/commit/bc8036fc666a8f846b1d4b2f935af7edd90eb5aa