### PR TITLE
Fix duplicate distributed keys for CTAS

### DIFF
--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -4595,6 +4595,12 @@ select test();
  
 (1 row)
 
+-- Test duplicate distribute keys
+CREATE TABLE qp_misc_jiras.ctas_dup_dk_src (col1 int, col2 int);
+CREATE TABLE qp_misc_jiras.ctas_dup_dk as SELECT distinct col2 as c1, col2 as c2 from qp_misc_jiras.ctas_dup_dk_src;
+ERROR:  duplicate DISTRIBUTED BY column 'c1'
+SELECT distinct col2 c1, col2 c2 into qp_misc_jiras.ctas_dup_dk_1 from qp_misc_jiras.ctas_dup_dk_src;
+ERROR:  duplicate DISTRIBUTED BY column 'c1'
 -- start_ignore
 drop schema qp_misc_jiras cascade;
 NOTICE:  drop cascades to table qp_misc_jiras._tbl10050_test

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -4624,6 +4624,10 @@ select test();
  
 (1 row)
 
+-- Test duplicate distribute keys
+CREATE TABLE qp_misc_jiras.ctas_dup_dk_src (col1 int, col2 int);
+CREATE TABLE qp_misc_jiras.ctas_dup_dk as SELECT distinct col2 as c1, col2 as c2 from qp_misc_jiras.ctas_dup_dk_src;
+SELECT distinct col2 c1, col2 c2 into qp_misc_jiras.ctas_dup_dk_1 from qp_misc_jiras.ctas_dup_dk_src;
 -- start_ignore
 drop schema qp_misc_jiras cascade;
 NOTICE:  drop cascades to table qp_misc_jiras._tbl10050_test

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -2590,6 +2590,12 @@ select test();
 select test();
 select test();
 select test();
+
+-- Test duplicate distribute keys
+CREATE TABLE qp_misc_jiras.ctas_dup_dk_src (col1 int, col2 int);
+CREATE TABLE qp_misc_jiras.ctas_dup_dk as SELECT distinct col2 as c1, col2 as c2 from qp_misc_jiras.ctas_dup_dk_src;
+SELECT distinct col2 c1, col2 c2 into qp_misc_jiras.ctas_dup_dk_1 from qp_misc_jiras.ctas_dup_dk_src;
+
 -- start_ignore
 drop schema qp_misc_jiras cascade;
 -- end_ignore


### PR DESCRIPTION
To keep it consistent with the "Create table" syntax, CTAS should also
disallow duplicate distributed keys, otherwise backup and restore will
mess up.