### PR TITLE
Update gpsd and minirepro util to capture HLL counter as a bytea[]

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -121,7 +121,8 @@ def dumpStats(cur):
             rowTypes = types + [vals[3] + '[]'] * 4
         for val, typ in zip(vals[5:], rowTypes):
             i = i + 1
-            if i == 9 and (val == 5 or val == 6):
+            str_val = "'%s'" % val
+            if i == 9 and (val == 98 or val == 99):
                 hll = True
 
             if val is None:
@@ -130,7 +131,7 @@ def dumpStats(cur):
                 val = val.replace("'", "''").replace('\\', '\\\\')
                 val = "E'" + val + "'"
             if i == 21 and hll == True:
-                rowVals.append('\t{0}::{1}'.format(val, 'bytea[]'))
+                rowVals.append('\t{0}::{1}'.format(str_val, 'bytea[]'))
             else:
                 rowVals.append('\t{0}::{1}'.format(val, typ))
         print pstring.format(vals[0], vals[2], ',\n'.join(rowVals))

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -258,7 +258,8 @@ def dump_stats(cur, oid_str, f_out):
             rowTypes = types + [vals[3] + '[]'] * 4
         for val, typ in zip(vals[5:], rowTypes):
             i = i + 1
-            if i == 9 and (val == 5 or val == 6):
+            str_val = "'%s'" % val
+            if i == 9 and (val == 98 or val == 99):
                 hll = True
 
             if val is None:
@@ -266,7 +267,7 @@ def dump_stats(cur, oid_str, f_out):
             elif isinstance(val, (str, unicode)) and val[0] == '{':
                 val = "E'%s'" % E(val)
             if i == 21 and hll == True:
-                rowVals.append('\t{0}::{1}'.format(val, 'bytea[]'))
+                rowVals.append('\t{0}::{1}'.format(str_val, 'bytea[]'))
             else:
                 rowVals.append('\t{0}::{1}'.format(val, typ))
 


### PR DESCRIPTION
Prior to this commit, the minirepro and gpsd util, captured the hll counter from the pg_statistic table as `int[]` instead of a `bytea[]`, which caused errors while trying to load it.
This PR fixes this issue.