### PR TITLE
Fix shared buffer access violations

### DIFF
--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -383,13 +383,13 @@ fill_seq_with_data(Relation rel, HeapTuple tuple)
 
 	page = BufferGetPage(buf);
 
+	LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
+
 	PageInit(page, BufferGetPageSize(buf), sizeof(sequence_magic));
 	sm = (sequence_magic *) PageGetSpecialPointer(page);
 	sm->magic = SEQ_MAGIC;
 
 	/* Now insert sequence tuple */
-
-	LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
 
 	/*
 	 * Since VACUUM does not process sequences, we have to force the tuple

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -807,6 +807,12 @@ ldelete:;
 		rslot = ExecProcessReturning(resultRelInfo->ri_projectReturning,
 									 slot, planSlot);
 
+		/*
+		 * Before releasing the target tuple again, make sure rslot has a
+		 * local copy of any pass-by-reference values.
+		 */
+		ExecMaterializeSlot(rslot);
+
 		ExecClearTuple(slot);
 		if (BufferIsValid(delbuffer))
 			ReleaseBuffer(delbuffer);


### PR DESCRIPTION
The violations were caught by enabling `memory_protect_buffer_pool` GUC.  There are a few more violations, mainly due to invoking `PageInit()` on an uninitialized page that either extended or just read from disk.  They are from upstream PostgreSQL code and are being discussed here: http://www.postgresql-archive.org/Shared-buffer-access-rule-violations-td6028849.html

The PR cherry-picks an upstream commit from 9.6 to fix buffer access violation in DELETE RETURNING. 