### PR TITLE
Set required statement_mem in qp_dml_joins test.

### DIFF
--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -1,4 +1,5 @@
 -- First create a bunch of test tables
+SET statement_mem='250 MB';
 CREATE TABLE dml_ao_check_r (
 	a int default 100 CHECK( a between 1 and 105),
 	b float8 CONSTRAINT rcheck_b CHECK( b <> 0.00 and b IS NOT NULL),

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -1,4 +1,5 @@
 -- First create a bunch of test tables
+SET statement_mem='250 MB';
 CREATE TABLE dml_ao_check_r (
 	a int default 100 CHECK( a between 1 and 105),
 	b float8 CONSTRAINT rcheck_b CHECK( b <> 0.00 and b IS NOT NULL),

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -1,4 +1,5 @@
 -- First create a bunch of test tables
+SET statement_mem='250 MB';
 
 CREATE TABLE dml_ao_check_r (
 	a int default 100 CHECK( a between 1 and 105),


### PR DESCRIPTION
This has been annoying from long time, as always fails with planner. It was
fixed earlier in CI by setting the statement_mem but ideally it to have it in
tests to pass anywhere and not just in CI.

Fixes #4668.