### PR TITLE
`gpstop -u` runs HUP commands locally when possible

### DIFF
--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -12,6 +12,7 @@ import os, sys
 import signal
 import time
 from optparse import Option, OptionGroup, OptionParser, OptionValueError, SUPPRESS_USAGE
+import socket
 
 try:
     from gppylib.gpparseopts import OptParser, OptChecker
@@ -743,9 +744,15 @@ class GpStop:
         self.pool = SighupWorkerPool(numWorkers=workers)
         dbList = self.gparray.getDbList()
         dispatch_count = 0
+        hostname = socket.gethostname()
         logger.info("Signalling all postmaster processes to reload")
         for db in dbList:
-            cmd = pg.ReloadDbConf(name="reload segment number " + str(db.getSegmentDbId())
+            if db.getSegmentHostName() == "localhost" or db.getSegmentHostName() == hostname:
+                cmd = pg.ReloadDbConf(name="reload segment number " + str(db.getSegmentDbId())
+                                      , db=db
+                                      )
+            else:
+                cmd = pg.ReloadDbConf(name="reload segment number " + str(db.getSegmentDbId())
                                   , db=db
                                   , ctxt=REMOTE
                                   , remoteHost=db.getSegmentHostName()

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -747,15 +747,15 @@ class GpStop:
         hostname = socket.gethostname()
         logger.info("Signalling all postmaster processes to reload")
         for db in dbList:
-            if db.getSegmentHostName() == "localhost" or db.getSegmentHostName() == hostname:
-                cmd = pg.ReloadDbConf(name="reload segment number " + str(db.getSegmentDbId())
-                                      , db=db
-                                      )
-            else:
-                cmd = pg.ReloadDbConf(name="reload segment number " + str(db.getSegmentDbId())
-                                  , db=db
-                                  , ctxt=REMOTE
-                                  , remoteHost=db.getSegmentHostName()
+            ctxt = REMOTE
+            remote_host = db.getSegmentHostName()
+            if db.getSegmentHostName() == hostname:
+                ctxt = LOCAL
+                remote_host = None
+            cmd = pg.ReloadDbConf(name="reload segment number " + str(db.getSegmentDbId()),
+                                  db=db,
+                                  ctxt=ctxt,
+                                  remoteHost=remote_host
                                   )
             self.pool.addCommand(cmd)
             dispatch_count = dispatch_count + 1


### PR DESCRIPTION
previously, `gpstop -u` used remote `ssh` for all hosts, all HUP commands. This PR changes to
add a conditional for when the host == localhost, and runs the command
without `ssh`. 

MOTIVATION
https://github.com/moby/moby/pull/36466 fixes an issue with AppArmor in Docker. It is not available yet in Kubernetes. It causes *different* permissions when attempting to send a signal like HUP from `ssh` vs. from localhost. This PR helps work around the issue.
