### PR TITLE
Define RELCACHE_FORCE_RELEASE for --enable-cassert.

### DIFF
--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -199,12 +199,15 @@
  */
 
 /*
- * Define this to cause pfree()'d memory to be cleared immediately, to
- * facilitate catching bugs that refer to already-freed values.
- * Right now, this gets defined automatically if --enable-cassert.
+ * Define CLOBBER_FREED_MEMORY to cause pfree()'d memory to be cleared
+ * immediately, to facilitate catching bugs that refer to already-freed
+ * values. Also, with RELCACHE_FORCE_RELEASE, relcache entries will be freed as
+ * soon as their refcount goes to zero. Right now, these get defined
+ * automatically if --enable-cassert.
  */
 #ifdef USE_ASSERT_CHECKING
 #define CLOBBER_FREED_MEMORY
+#define RELCACHE_FORCE_RELEASE
 #endif
 
 /*


### PR DESCRIPTION
Many issues are surfaced due to RELCACHE_FORCE_RELEASE, so best to enable the
same with --enable-cassert along with already enabled CLOBBER_FREED_MEMORY.

Concern existed would cause test time to increase significantly with
RELCACHE_FORCE_RELEASE. But trying it out ICG time marginally gets affected from
20mins to 21mins on my laptop. Hence enabling the same with --enable-cassert.