### PR TITLE
Fix gp_max_csv_line_length does not work in INSERT INTO ... SELECT ...

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3399,6 +3399,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_max_csv_line_length", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Maximum allowed length of a csv input data row in bytes"),
 			NULL,
+			GUC_GPDB_ADDOPT
 		},
 		&gp_max_csv_line_length,
 		1 * 1024 * 1024, 32 * 1024, 4 * 1024 * 1024,

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -1617,3 +1617,45 @@ SELECT * FROM encoding_issue2 WHERE num = 5;
 
 DROP EXTERNAL TABLE encoding_issue;
 DROP EXTERNAL TABLE encoding_issue2;
+
+-- --------------------------------------
+-- gp_max_csv_line_length
+-- --------------------------------------
+
+CREATE OR REPLACE FUNCTION random_string(length integer) RETURNS text AS
+$$
+declare
+  chars text[] := '{0,1,2,3,4,5,6,7,8,9,A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z}';
+  result text := '';
+  line text := '';
+  i integer := 0;
+  j integer := 0;
+  nloops integer := length / 1024;
+  c char := '';
+begin
+  for i in 1..nloops loop
+    line = '';
+    c = chars[1+random()*(array_length(chars, 1)-1)];
+    for j in 1..1024 loop
+      line = line || c;
+    end loop;
+    result = result || line || E'\n';
+  end loop;
+  return result;
+end;
+$$ LANGUAGE plpgsql;
+
+CREATE EXTERNAL TABLE gp_max_csv_line_length_issue (word text)
+LOCATION ('file://@hostname@/tmp/long_text.csv')
+FORMAT 'CSV';
+
+CREATE TABLE gp_max_csv_line_length_target (word text);
+
+COPY (SELECT random_string(3*1024*1024)) TO '/tmp/long_text.csv' WITH CSV;
+
+SET gp_max_csv_line_length TO 4194304;
+INSERT INTO gp_max_csv_line_length_target SELECT * FROM gp_max_csv_line_length_issue;
+
+DROP TABLE gp_max_csv_line_length_target;
+DROP EXTERNAL TABLE gp_max_csv_line_length_issue;
+DROP FUNCTION random_string(integer);

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -2927,3 +2927,40 @@ SELECT * FROM encoding_issue2 WHERE num = 5;
 
 DROP EXTERNAL TABLE encoding_issue;
 DROP EXTERNAL TABLE encoding_issue2;
+-- --------------------------------------
+-- gp_max_csv_line_length
+-- --------------------------------------
+CREATE OR REPLACE FUNCTION random_string(length integer) RETURNS text AS
+$$
+declare
+  chars text[] := '{0,1,2,3,4,5,6,7,8,9,A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z}';
+  result text := '';
+  line text := '';
+  i integer := 0;
+  j integer := 0;
+  nloops integer := length / 1024;
+  c char := '';
+begin
+  for i in 1..nloops loop
+    line = '';
+    c = chars[1+random()*(array_length(chars, 1)-1)];
+    for j in 1..1024 loop
+      line = line || c;
+    end loop;
+    result = result || line || E'\n';
+  end loop;
+  return result;
+end;
+$$ LANGUAGE plpgsql;
+CREATE EXTERNAL TABLE gp_max_csv_line_length_issue (word text)
+LOCATION ('file://mdw.dev.gpcc/tmp/long_text.csv')
+FORMAT 'CSV';
+CREATE TABLE gp_max_csv_line_length_target (word text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'word' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+COPY (SELECT random_string(3*1024*1024)) TO '/tmp/long_text.csv' WITH CSV;
+SET gp_max_csv_line_length TO 4194304;
+INSERT INTO gp_max_csv_line_length_target SELECT * FROM gp_max_csv_line_length_issue;
+DROP TABLE gp_max_csv_line_length_target;
+DROP EXTERNAL TABLE gp_max_csv_line_length_issue;
+DROP FUNCTION random_string(integer);


### PR DESCRIPTION
gp_max_csv_line_length is a session level GUC. When change it in
session, it affects statement like select * from <external_table>.
But it does not work for INSERT INTO table SELECT * FROM <external_table>.
For such statement, the scan of external table happens in a QE backend
process, not the QD.
This fix add GUC_GPDB_ADDOPT so that setting this GUC in session level
can affect both QD and QE process.