### PR TITLE
Delete useless comment

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -1260,10 +1260,6 @@ CreateExtension(CreateExtensionStmt *stmt)
 							stmt->extname)));
 	}
 
-	/* We want to promote user to superuser in QE when creating extension */
-	/* GPDB_91_MERGE_FIXME: I don't see any such promotion here. But this is doing
-	 * something else important. Update comment.
-	 */
 	if (Gp_role == GP_ROLE_EXECUTE)
 	{
 		switch (stmt->create_ext_state)


### PR DESCRIPTION
The confusing comment is spotted by Asim R P, and he gaves another comment on it.

After quering the author about the confusing comment,  the confusing comment could be deleted.
