### PR TITLE
Change from IMMUTABLE to VOLATILE, conform to the upstream

### DIFF
--- a/src/backend/commands/proclang.c
+++ b/src/backend/commands/proclang.c
@@ -184,7 +184,7 @@ CreateProceduralLanguage(CreatePLangStmt *stmt)
 											false,		/* isWindowFunc */
 											false,		/* security_definer */
 											true,		/* isStrict */
-											PROVOLATILE_IMMUTABLE, // GPDB_90_MERGE_FIXME: why is this is IMMUTABLE in GPDB, when it's VOLATILE in the upstream?
+											PROVOLATILE_VOLATILE,
 											buildoidvector(funcargtypes, 1),
 											PointerGetDatum(NULL),
 											PointerGetDatum(NULL),


### PR DESCRIPTION
Chang from IMMUTABLE to VOLATILE, conform to the upstream

Spotted by Heikki Linnakangas.

The mistake is introduced by this [commit](https://github.com/greenplum-db/gpdb/commit/cacb2839ac869b3f0ab9e9fc4b152f7d83e71673#diff-647cb7e5bf5ede8a26c758bde206154fR200)