### PR TITLE
Option for analyze to collect minimal stats for temp tables

### DIFF
--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -20,6 +20,7 @@ bool			gp_statistics_use_fkeys = FALSE;
 int				gp_statistics_blocks_target = 25;
 double			gp_statistics_ndistinct_scaling_ratio_threshold = 0.10;
 double			gp_statistics_sampling_threshold = 10000;
+bool			gp_statistics_reltuples_for_temp_tables_only = FALSE;
 
 /**
  * This method estimates the number of tuples and pages in a heaptable relation. Getting the number of blocks is straightforward.

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2066,7 +2066,14 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&gp_enable_resqueue_priority,
 		true, NULL, NULL
 	},
-
+	{
+		{"gp_statistics_reltuples_for_temp_tables_only", PGC_USERSET, STATS_ANALYZE,
+			gettext_noop("This guc makes analyze collect only reltuple and relpages for temp tables."),
+			NULL
+		},
+		&gp_statistics_reltuples_for_temp_tables_only,
+		false, NULL, NULL
+	},
 	{
 		{"gp_change_tracking", PGC_SUSET, UNGROUPED,
 			gettext_noop("Allows disabling change tracking."),

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -906,6 +906,7 @@ extern bool		gp_statistics_use_fkeys;
 extern int 		gp_statistics_blocks_target;
 extern double	gp_statistics_ndistinct_scaling_ratio_threshold;
 extern double	gp_statistics_sampling_threshold;
+extern bool     gp_statistics_reltuples_for_temp_tables_only;
 
 /* Analyze tools */
 extern int gp_motion_slice_noop;

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -843,3 +843,48 @@ SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_co
 (4 rows)
 
 DROP TABLE IF EXISTS foo_stats;
+-- Test the GUC gp_statistics_reltuples_only
+SET gp_autostats_mode to NONE;
+CREATE TABLE t1 (a int, b int);
+INSERT INTO t1 SELECT i,i FROM generate_series(1,10)i;
+CREATE TEMP TABLE t1_temp AS SELECT a,b FROM t1;
+-- relpages, reltuples empty for t1_temp
+SELECT relname, relpages, reltuples FROM pg_class WHERE relname = 't1_temp';
+ relname | relpages | reltuples 
+---------+----------+-----------
+ t1_temp |        0 |         0
+(1 row)
+
+SET gp_statistics_reltuples_for_temp_tables_only TO on;
+ANALYZE t1_temp (a);
+ANALYZE t1(a);
+-- Now relpages, reltuples will have value but pg_stats will be empty for t1_temp
+-- but not for t1.
+SELECT relname, relpages, reltuples FROM pg_class WHERE relname = 't1_temp';
+ relname | relpages | reltuples 
+---------+----------+-----------
+ t1_temp |        3 |        10
+(1 row)
+
+SELECT * FROM pg_stats WHERE tablename = 't1_temp';
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+(0 rows)
+
+SELECT relname, relpages, reltuples FROM pg_class WHERE relname = 't1';
+ relname | relpages | reltuples 
+---------+----------+-----------
+ t1      |        3 |        10
+(1 row)
+
+SELECT schemaname, tablename, attname, null_frac, n_distinct, histogram_bounds FROM pg_stats WHERE tablename = 't1';
+ schemaname | tablename | attname | null_frac | n_distinct |    histogram_bounds    
+------------+-----------+---------+-----------+------------+------------------------
+ public     | t1        | a       |         0 |         -1 | {1,2,3,4,5,6,7,8,9,10}
+(1 row)
+
+-- start_ignore
+RESET gp_statistics_reltuples_for_temp_tables_only;
+RESET gp_autostats_mode;
+DROP TABLE IF EXISTS t1;
+-- end_ignore


### PR DESCRIPTION
Option for analyze to collect minimal stats for temp tables

If a user has a case where they have large external tables and their
loading process uses temp tables. ANALYZE takes a long time to run on
those tables. If we do not ANALYZE them, ORCA has no idea about size of
the tables and produced slow plans. Therefore it is better to provide at
least the size of the table which requires ANALYZE to just collect
reltuples and relpages and not rest of the stats.

We provided a GUC `gp_statistics_reltuples_for_temp_tables_only` and
when turned on ANALYZE will only collect reltuples and relpages info and
not any other statistics for temp tables.