### PR TITLE
Remove MyProc inDropTransaction flag

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -481,7 +481,6 @@ MarkAsPreparing(TransactionId xid,
 	gxact->proc.inCommit = false;
 	gxact->proc.vacuumFlags = 0;
 	gxact->proc.serializableIsoLevel = false;
-	gxact->proc.inDropTransaction = false;
 	gxact->proc.lwWaiting = false;
 	gxact->proc.lwExclusive = false;
 	gxact->proc.lwWaitLink = NULL;

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -442,7 +442,6 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid, bool isCommit)
 			proc->inCommit = false; /* be sure this is cleared in abort */
 			proc->recoveryConflictPending = false;
 			proc->serializableIsoLevel = false;
-			proc->inDropTransaction = false;
 
 			/* Clear the subtransaction-XID cache too while holding the lock */
 			proc->subxids.nxids = 0;
@@ -479,7 +478,6 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid, bool isCommit)
 		proc->inCommit = false; /* be sure this is cleared in abort */
 		proc->recoveryConflictPending = false;
 		proc->serializableIsoLevel = false;
-		proc->inDropTransaction = false;
 
 		Assert(proc->subxids.nxids == 0);
 		Assert(proc->subxids.overflowed == false);
@@ -518,7 +516,6 @@ ProcArrayClearTransaction(PGPROC *proc, bool commit)
 	proc->vacuumFlags &= ~PROC_VACUUM_STATE_MASK;
 	proc->inCommit = false;
 	proc->serializableIsoLevel = false;
-	proc->inDropTransaction = false;
 
 	/* Clear the subtransaction-XID cache too */
 	proc->subxids.nxids = 0;
@@ -1074,45 +1071,6 @@ TransactionIdIsActive(TransactionId xid)
 		{
 			result = true;
 			break;
-		}
-	}
-
-	LWLockRelease(ProcArrayLock);
-
-	return result;
-}
-
-/*
- * Returns true if there are any UAO drop transaction active (except the current
- * one).
- *
- * If allDbs is TRUE then all backends are considered; if allDbs is FALSE
- * then only backends running in my own database are considered.
- */
-bool
-HasDropTransaction(bool allDbs)
-{
-	ProcArrayStruct *arrayP = procArray;
-	bool result = false; /* Assumes */
-	int			index;
-
-	LWLockAcquire(ProcArrayLock, LW_SHARED);
-
-	for (index = 0; index < arrayP->numProcs; index++)
-	{
-		volatile PGPROC *proc = arrayP->procs[index];
-		if (proc->pid == 0)
-			continue;			/* do not count prepared xacts */
-
-		if (allDbs || proc->databaseId == MyDatabaseId)
-		{
-			if (proc->inDropTransaction && proc != MyProc)
-			{
-				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG3),
-						(errmsg("Found drop transaction: database %d, pid %d, xid %d, xmin %d",
-								proc->databaseId, proc->pid, proc->xid, proc->xmin)));
-				result = true;
-			}
 		}
 	}
 

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -380,7 +380,6 @@ InitProcess(void)
 	MyProc->localDistribXactData.state = LOCALDISTRIBXACT_STATE_NONE;
 	MyProc->xmin = InvalidTransactionId;
 	MyProc->serializableIsoLevel = false;
-	MyProc->inDropTransaction = false;
 	MyProc->pid = MyProcPid;
 	/* backendId, databaseId and roleId will be filled in later */
 	MyProc->backendId = InvalidBackendId;
@@ -581,7 +580,6 @@ InitAuxiliaryProcess(void)
 	MyProc->localDistribXactData.state = LOCALDISTRIBXACT_STATE_NONE;
 	MyProc->xmin = InvalidTransactionId;
 	MyProc->serializableIsoLevel = false;
-	MyProc->inDropTransaction = false;
 	MyProc->databaseId = InvalidOid;
 	MyProc->roleId = InvalidOid;
     MyProc->mppLocalProcessSerial = 0;

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -176,8 +176,6 @@ struct PGPROC
 
 	bool serializableIsoLevel; /* true if proc has serializable isolation level set */
 
-	bool inDropTransaction; /* true if proc is in vacuum drop transaction */
-
 	/*
 	 * Information for resource group
 	 */

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -73,7 +73,6 @@ extern int	CountUserBackends(Oid roleid);
 extern bool CountOtherDBBackends(Oid databaseId,
 					 int *nbackends, int *nprepared);
 extern bool HasSerializableBackends(bool allDbs);
-extern bool HasDropTransaction(bool allDbs);
 
 extern void XidCacheRemoveRunningXids(TransactionId xid,
 						  int nxids, const TransactionId *xids,

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -82,17 +82,26 @@ gp_inject_fault
 t              
 (1 row)
 
--- Only one AO table can be in drop phase at a time. VACUUM on
--- crash_before_cleanup_phase will end up skipping the drop phase because
--- previous VACUUM on crash_before_segmentfile_drop is suspended in drop
--- phase. This results in segment file 1 remaining in drop pending state which
--- results in segment file 1 not being scheduled for any new inserts.
+-- VACUUM on crash_before_cleanup_phase will end up skipping the drop
+-- phase after not being able to acquire AccessExclusiveLock because
+-- we make session 3 hold AccessShareLock. This results in segment
+-- file 1 remaining in drop pending state which results in segment
+-- file 1 not being scheduled for any new inserts.
 3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 1, -1, 0, 2);
 gp_inject_fault
 ---------------
 t              
 (1 row)
+3:BEGIN;
+BEGIN
+3:SELECT count(*) FROM crash_before_cleanup_phase;
+count
+-----
+7    
+(1 row)
 1&:VACUUM crash_before_cleanup_phase;  <waiting ...>
+3:END;
+END
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
 gp_wait_until_triggered_fault
 -----------------------------

--- a/src/test/isolation2/input/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/input/uao/vacuum_cleanup.source
@@ -1,11 +1,7 @@
--- @Description Test that when there is a parallel vacuum going on in drop phase, the age of
+-- @Description Test that when AO vacuum skips drop phase, the age of
 -- the AO/AOCS table gets reduced correctly.
 
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
-
-1: create table ao_@orientation@_vacuum_cleanup1(a int, b int) with(appendonly=true, orientation=@orientation@);
-1: insert into ao_@orientation@_vacuum_cleanup1 select 1, i from generate_series(1, 100) i;
-1: update ao_@orientation@_vacuum_cleanup1 set b = b + 1;
 
 -- The age of the table is 1 after the following statement
 2: create table ao_@orientation@_vacuum_cleanup2(a int, b int) with(appendonly=true, orientation=@orientation@);
@@ -18,30 +14,24 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 2: update ao_@orientation@_vacuum_cleanup2 set b = b + 1;
 2: update ao_@orientation@_vacuum_cleanup2 set b = b + 1;
 
-
-1: select gp_inject_fault_infinite('vacuum_relation_open_relation_during_drop_phase', 'suspend', 2);
-
-2&: vacuum ao_@orientation@_vacuum_cleanup1;
-
-1: select wait_for_trigger_fault((select current_database()), 'vacuum_relation_open_relation_during_drop_phase', 2);
-
 1: set vacuum_freeze_min_age = 0;
 -- Check the age of the table just before vacuum (use BETWEEN to mask minor
 -- differences that might happen if e.g. autovacuum kicks in)
-1: select age(relfrozenxid) between 9 and 11, regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+1: select age(relfrozenxid) between 7 and 9, regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+
+-- Hold AccessShareLock to make AO VACUUM skip drop phase
+2: begin;
+2: select count(*) from ao_@orientation@_vacuum_cleanup2;
 1: vacuum ao_@orientation@_vacuum_cleanup2;
 
 -- The age should be smaller now. All the xids before the first
 -- vacuum were frozen. The relfrozenxid will be the xid of the last
 -- transaction before the vacuum (in this case it is the update statement)
-1: select age(relfrozenxid) < 9, regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
-
-1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 2);
-2<:
+1: select age(relfrozenxid) < 7, regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+2: end;
 
 -- Check that drop phase is skipped, but still the cleanup phase is performed
 -- when there are concurrent serializable transactions
-
 1: create table ao_@orientation@_vacuum_cleanup3(a int, b int) with(appendonly=true, orientation=@orientation@);
 1: insert into ao_@orientation@_vacuum_cleanup3 select i, i from generate_series(1, 100) i;
 1: delete from ao_@orientation@_vacuum_cleanup3;

--- a/src/test/isolation2/output/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/output/uao/vacuum_cleanup.source
@@ -1,15 +1,8 @@
--- @Description Test that when there is a parallel vacuum going on in drop phase, the age of
+-- @Description Test that when AO vacuum skips drop phase, the age of
 -- the AO/AOCS table gets reduced correctly.
 
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE
-
-1: create table ao_@orientation@_vacuum_cleanup1(a int, b int) with(appendonly=true, orientation=@orientation@);
-CREATE
-1: insert into ao_@orientation@_vacuum_cleanup1 select 1, i from generate_series(1, 100) i;
-INSERT 100
-1: update ao_@orientation@_vacuum_cleanup1 set b = b + 1;
-UPDATE 100
 
 -- The age of the table is 1 after the following statement
 2: create table ao_@orientation@_vacuum_cleanup2(a int, b int) with(appendonly=true, orientation=@orientation@);
@@ -29,55 +22,42 @@ UPDATE 100
 2: update ao_@orientation@_vacuum_cleanup2 set b = b + 1;
 UPDATE 100
 
-
-1: select gp_inject_fault_infinite('vacuum_relation_open_relation_during_drop_phase', 'suspend', 2);
-gp_inject_fault_infinite
-------------------------
-t                       
-(1 row)
-
-2&: vacuum ao_@orientation@_vacuum_cleanup1;  <waiting ...>
-
-1: select wait_for_trigger_fault((select current_database()), 'vacuum_relation_open_relation_during_drop_phase', 2);
-wait_for_trigger_fault
-----------------------
-t                     
-(1 row)
-
 1: set vacuum_freeze_min_age = 0;
 SET
 -- Check the age of the table just before vacuum (use BETWEEN to mask minor
 -- differences that might happen if e.g. autovacuum kicks in)
-1: select age(relfrozenxid) between 9 and 11, regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+1: select age(relfrozenxid) between 7 and 9, regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
 ?column?|regexp_replace    
 --------+------------------
 t       |pg_<seg>_<oid>    
 t       |pg_aovisimap_<oid>
 (2 rows)
+
+-- Hold AccessShareLock to make AO VACUUM skip drop phase
+2: begin;
+BEGIN
+2: select count(*) from ao_@orientation@_vacuum_cleanup2;
+count
+-----
+100  
+(1 row)
 1: vacuum ao_@orientation@_vacuum_cleanup2;
 VACUUM
 
 -- The age should be smaller now. All the xids before the first
 -- vacuum were frozen. The relfrozenxid will be the xid of the last
 -- transaction before the vacuum (in this case it is the update statement)
-1: select age(relfrozenxid) < 9, regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+1: select age(relfrozenxid) < 7, regexp_replace(replace(relname, 'ao_@orientation@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','m') and relstorage not in ('x','f','v') and (relname like '%' || 'ao_@orientation@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
 ?column?|regexp_replace    
 --------+------------------
 t       |pg_<seg>_<oid>    
 t       |pg_aovisimap_<oid>
 (2 rows)
-
-1: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 2);
-gp_inject_fault
----------------
-t              
-(1 row)
-2<:  <... completed>
-VACUUM
+2: end;
+END
 
 -- Check that drop phase is skipped, but still the cleanup phase is performed
 -- when there are concurrent serializable transactions
-
 1: create table ao_@orientation@_vacuum_cleanup3(a int, b int) with(appendonly=true, orientation=@orientation@);
 CREATE
 1: insert into ao_@orientation@_vacuum_cleanup3 select i, i from generate_series(1, 100) i;


### PR DESCRIPTION
The MyProc inDropTransaction flag was used to make sure concurrent AO
vacuum would not conflict with each other during drop phase. Two
concurrent AO vacuum on same relation was possible back in 4.3 and 5X
where the different AO vacuum phases (prepare, compaction, drop,
cleanup) would interleave with each other, and having two AO vacuum
drop phases concurrently on the same AO relation was
dangerous. However, we no longer do that interleaving anymore on
6.0devel. We now hold the ShareUpdateExclusiveLock through the entire
AO vacuum which renders the inDropTransaction flag useless.