### PR TITLE
Fix pxf unittest compilation

### DIFF
--- a/gpAux/extensions/pxf/test/pxffilters_test.c
+++ b/gpAux/extensions/pxf/test/pxffilters_test.c
@@ -22,7 +22,9 @@
 #include <setjmp.h>
 
 #include "cmockery.h"
-#include "c.h"
+
+#include "postgres.h"
+#include "utils/memutils.h"
 
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */
 #define UNIT_TESTING


### PR DESCRIPTION
The compilation failed on OSX/clag with the error "implicit declaration of
function 'MemoryContextInit' is invalid".