### PR TITLE
Exclude root and internal parent partitions from age calculation.

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -674,8 +674,7 @@ set_frozenxids(void)
 		 * The logic here should keep consistent with function
 		 * should_have_valid_relfrozenxid().
 		 */
-								  "WHERE	(relkind = 'r' AND relstorage "
-								  "NOT IN ('x', 'f', 'v', 'a', 'c')) "
+								  "WHERE	(relkind = 'r' AND relfrozenxid != 0) "
 								  "OR (relkind IN ('t', 'o', 'b', 'm'))",
 								  old_cluster.controldata.chkpnt_nxtxid));
 		PQfinish(conn);

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -674,7 +674,7 @@ set_frozenxids(void)
 		 * The logic here should keep consistent with function
 		 * should_have_valid_relfrozenxid().
 		 */
-								  "WHERE	(relkind = 'r' AND relfrozenxid != 0) "
+								  "WHERE	(relkind = 'r' AND not relfrozenxid = 0) "
 								  "OR (relkind IN ('t', 'o', 'b', 'm'))",
 								  old_cluster.controldata.chkpnt_nxtxid));
 		PQfinish(conn);

--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -180,7 +180,8 @@ _bitmap_create_lov_heapandindex(Relation rel,
 								 ONCOMMIT_NOOP, NULL /* GP Policy */,
 								 (Datum)0, false, true,
 								 /* valid_opts */ true,
-								 /* is_part_child */ false);
+								 /* is_part_child */ false,
+								 /* is_part_parent */ false);
 	*lovHeapOid = heapid;
 
 	/*

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2181,7 +2181,9 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 	Buffer		buffer;
 	bool		all_visible_cleared = false;
 
-	Insist(RelationIsHeap(relation));
+	Assert(RelationIsHeap(relation));
+	Assert(IsBootstrapProcessingMode() ||
+		   TransactionIdIsNormal(relation->rd_rel->relfrozenxid));
 
 	if (relation->rd_rel->relhasoids)
 	{

--- a/src/backend/bootstrap/bootparse.y
+++ b/src/backend/bootstrap/bootparse.y
@@ -268,7 +268,8 @@ Boot_CreateStmt:
 													  false,
 													  true,
 													  /* valid_opts */ false,
-													  /* is_part_child */ false);
+													  /* is_part_child */ false,
+													  /* is_part_parent */ false);
 						elog(DEBUG4, "relation created with oid %u", id);
 					}
 					do_end();

--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -149,7 +149,8 @@ CreateAOAuxiliaryTable(
 												 /* use_user_acl */ false,
 											     true,
 												 /* valid_opts */ false,
-												 /* is_part_child */ false);
+												 /* is_part_child */ false,
+												 /* is_part_parent */ false);
 
 	/* Make this table visible, else index creation will fail */
 	CommandCounterIncrement();

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -262,7 +262,8 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid, Datum reloptio
 										   false,
 										   true,
 										   /* valid_opts */ false,
-										   /* is_part_child */ false);
+										   /* is_part_child */ false,
+										   /* is_part_parent */ false);
 	Assert(toast_relid != InvalidOid);
 
 	/* make the toast relation visible, else heap_open will fail */

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -262,8 +262,6 @@ int			gp_sort_flags = 0;
 int			gp_dbg_flags = 0;
 int			gp_sort_max_distinct = 20000;
 
-bool		gp_setwith_alter_storage = FALSE;
-
 bool		gp_enable_tablespace_auto_mkdir = FALSE;
 
 /* Enable check for compatibility of encoding and locale in createdb */

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -1398,6 +1398,7 @@ swap_relation_files(Oid r1, Oid r2, bool target_is_pg_class,
 	 */
 	if (TransactionIdIsValid(relform1->relfrozenxid))
 	{
+		Assert(TransactionIdIsNormal(frozenXid));
 		relform1->relfrozenxid = frozenXid;
 		/*
 		 * Don't know partition parent or not here but passing false is perfect

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -813,7 +813,8 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId, char relstorage, boo
 										  true,
 										  allowSystemTableModsDDL,
 										  valid_opts,
-										  stmt->is_part_child);
+										  stmt->is_part_child,
+										  stmt->is_part_parent);
 
 	/*
 	 * Give a warning if you use OIDS=TRUE on user tables. We do this after calling

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13104,11 +13104,10 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 				if (pg_strcasecmp(reorg_str, def->defname) != 0)
 				{
 					/* MPP-7770: disable changing storage options for now */
-					if (!gp_setwith_alter_storage)
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("option \"%s\" not supported",
-								 		def->defname)));
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("option \"%s\" not supported",
+									def->defname)));
 
 					if (pg_strcasecmp(def->defname, "appendonly") == 0)
 					{
@@ -13671,12 +13670,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		 * needed because the same tuple has to be updated again
 		 */
 		CommandCounterIncrement();
-	}
-
-	if (gp_setwith_alter_storage)
-	{
-		RemoveAttributeEncodingsByRelid(tarrelid);
-		cloneAttributeEncoding(tmprelid, tarrelid, nattr);
 	}
 
 	/* now, reindex */

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1595,14 +1595,16 @@ vac_update_datfrozenxid(void)
 	{
 		Form_pg_class classForm = (Form_pg_class) GETSTRUCT(classTup);
 
-		if (!should_have_valid_relfrozenxid(classForm->relkind,
-											classForm->relstorage))
-		{
-			Assert(!TransactionIdIsValid(classForm->relfrozenxid));
+		if (!TransactionIdIsValid(classForm->relfrozenxid))
 			continue;
-		}
 
 		Assert(TransactionIdIsNormal(classForm->relfrozenxid));
+		/*
+		 * Don't know partition parent or not here but passing false is perfect
+		 * for assertion, as valid relfrozenxid means it shouldn't be parent.
+		 */
+		Assert(should_have_valid_relfrozenxid(classForm->relkind,
+											  classForm->relstorage, false));
 
 		if (TransactionIdPrecedes(classForm->relfrozenxid, newFrozenXid))
 			newFrozenXid = classForm->relfrozenxid;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4047,7 +4047,8 @@ OpenIntoRel(QueryDesc *queryDesc)
 											  true,
 											  allowSystemTableModsDDL,
 											  /* valid_opts */ !validate_reloptions,
-											  /* is_part_child */ false);
+											  /* is_part_child */ false,
+											  /* is_part_parent */ false);
 	Assert(intoRelationId != InvalidOid);
 
 	FreeTupleDesc(tupdesc);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3477,6 +3477,7 @@ CopyCreateStmtFields(CreateStmt *from, CreateStmt *newnode)
 	/* postCreate omitted (why?) */
 	COPY_NODE_FIELD(deferredStmts);
 	COPY_SCALAR_FIELD(is_part_child);
+	COPY_SCALAR_FIELD(is_part_parent);
 	COPY_SCALAR_FIELD(is_add_part);
 	COPY_SCALAR_FIELD(is_split_part);
 	COPY_SCALAR_FIELD(ownerid);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -712,6 +712,7 @@ _outCreateStmt_common(StringInfo str, CreateStmt *node)
 	/* postCreate - for analysis, QD only */
 	/* deferredStmts - for analysis, QD only */
 	WRITE_BOOL_FIELD(is_part_child);
+	WRITE_BOOL_FIELD(is_part_parent);
 	WRITE_BOOL_FIELD(is_add_part);
 	WRITE_BOOL_FIELD(is_split_part);
 	WRITE_OID_FIELD(ownerid);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2542,6 +2542,7 @@ _outCreateStmt(StringInfo str, CreateStmt *node)
 	/* postCreate omitted */
 	WRITE_NODE_FIELD(deferredStmts);
 	WRITE_BOOL_FIELD(is_part_child);
+	WRITE_BOOL_FIELD(is_part_parent);
 	WRITE_BOOL_FIELD(is_add_part);
 	WRITE_BOOL_FIELD(is_split_part);
 	WRITE_OID_FIELD(ownerid);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1139,6 +1139,7 @@ _readCreateStmt_common(CreateStmt *local_node)
 	/* postCreate - for analysis, QD only */
 	/* deferredStmts - for analysis, QD only */
 	READ_BOOL_FIELD(is_part_child);
+	READ_BOOL_FIELD(is_part_parent);
 	READ_BOOL_FIELD(is_add_part);
 	READ_BOOL_FIELD(is_split_part);
 	READ_OID_FIELD(ownerid);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2249,6 +2249,7 @@ _readCreateStmt(void)
 	/* postCreate omitted */
 	READ_NODE_FIELD(deferredStmts);
 	READ_BOOL_FIELD(is_part_child);
+	READ_BOOL_FIELD(is_part_parent);
 	READ_BOOL_FIELD(is_add_part);
 	READ_BOOL_FIELD(is_split_part);
 	READ_OID_FIELD(ownerid);

--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -781,6 +781,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 		if (newSub)
 			newSub->parentRel = copyObject(pBy->parentRel);
 
+		stmt->is_part_parent = true;
 		make_child_node(cxt, stmt, relname, curPby, (Node *) newSub,
 						pRuleCatalog, pPostCreate, pConstraint, pStoreAttr,
 						prtstr, bQuiet, colencs);

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -2851,14 +2851,16 @@ RelationSetNewRelfilenode(Relation relation, TransactionId freezeXid)
 		classform->relpages = 0;	/* it's empty until further notice */
 		classform->reltuples = 0;
 	}
-	if (should_have_valid_relfrozenxid(relation->rd_rel->relkind,
-									   relation->rd_rel->relstorage))
+
+	if (TransactionIdIsValid(classform->relfrozenxid))
 	{
 		classform->relfrozenxid = freezeXid;
-	}
-	else
-	{
-		classform->relfrozenxid = InvalidTransactionId;
+		/*
+		 * Don't know partition parent or not here but passing false is perfect
+		 * for assertion, as valid relfrozenxid means it shouldn't be parent.
+		 */
+		Assert(should_have_valid_relfrozenxid(classform->relkind,
+											  classform->relstorage, false));
 	}
 
 	simple_heap_update(pg_class, &tuple->t_self, tuple);

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -2854,6 +2854,7 @@ RelationSetNewRelfilenode(Relation relation, TransactionId freezeXid)
 
 	if (TransactionIdIsValid(classform->relfrozenxid))
 	{
+		Assert(TransactionIdIsNormal(freezeXid));
 		classform->relfrozenxid = freezeXid;
 		/*
 		 * Don't know partition parent or not here but passing false is perfect

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -801,17 +801,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_setwith_alter_storage", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Let SET WITH alter the storage options."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_setwith_alter_storage,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"gp_enable_preunique", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable 2-phase duplicate removal."),
 			gettext_noop("If true, planner may choose to remove duplicates in "

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -62,29 +62,30 @@ extern Relation heap_create(const char *relname,
 			bool allow_system_table_mods);
 
 extern Oid heap_create_with_catalog(const char *relname,
-						 Oid relnamespace,
-						 Oid reltablespace,
-						 Oid relid,
-						 Oid reltypeid,
-						 Oid reloftypeid,
-						 Oid ownerid,
-						 TupleDesc tupdesc,
-						 List *cooked_constraints,
-						 Oid relam,
-						 char relkind,
-						 char relpersistence,
-						 char relstorage,
-						 bool shared_relation,
-						 bool mapped_relation,
-						 bool oidislocal,
-						 int oidinhcount,
-						 OnCommitAction oncommit,
-                         const struct GpPolicy *policy,    /* MPP */
-						 Datum reloptions,
-						 bool use_user_acl,
-						 bool allow_system_table_mods,
-						 bool valid_opts,
-						 bool is_part_child);
+									Oid relnamespace,
+									Oid reltablespace,
+									Oid relid,
+									Oid reltypeid,
+									Oid reloftypeid,
+									Oid ownerid,
+									TupleDesc tupdesc,
+									List *cooked_constraints,
+									Oid relam,
+									char relkind,
+									char relpersistence,
+									char relstorage,
+									bool shared_relation,
+									bool mapped_relation,
+									bool oidislocal,
+									int oidinhcount,
+									OnCommitAction oncommit,
+									const struct GpPolicy *policy,    /* MPP */
+									Datum reloptions,
+									bool use_user_acl,
+									bool allow_system_table_mods,
+									bool valid_opts,
+									bool is_part_child,
+									bool is_part_parent);
 
 extern void heap_drop_with_catalog(Oid relid);
 
@@ -166,6 +167,7 @@ extern void MetaTrackDropObject(Oid		classid,
 		|| ((relkind) == RELKIND_SEQUENCE) \
 		|| ((relkind) == RELKIND_VIEW)) 
 
-extern bool should_have_valid_relfrozenxid(char relkind, char relstorage);
-
+extern bool should_have_valid_relfrozenxid(char relkind,
+										   char relstorage,
+										   bool is_partition_parent);
 #endif   /* HEAP_H */

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -783,10 +783,6 @@ extern bool gp_dynamic_partition_pruning;
  */
 extern bool gp_cte_sharing;
 
-/* MPP-7770: disallow altering storage using SET WITH */
-
-extern bool	gp_setwith_alter_storage;
-
 /* Priority for the segworkers relative to the postmaster's priority */
 extern int gp_segworker_relative_priority;
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1687,6 +1687,9 @@ typedef struct CreateStmt
 								 * interior or leaf parts of the new table.  Not marked for a
 								 * a partition root or ordinary table.
 								 */
+	bool        is_part_parent; /* CDB: Marked during analysis for top and interior
+								 * parent of partition tables which don't contain
+								 * any data */
 	bool		is_add_part;	/* CDB: is create adding a part to a partition? */
 	bool		is_split_part;	/* CDB: is create spliting a part? */
 	Oid			ownerid;		/* OID of the role to own this. if InvalidOid, GetUserId() */

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -205,34 +205,32 @@ alter table pg_class set distributed by (relname);
 ERROR:  permission denied: "pg_class" is a system catalog
 alter table pg_class set with(appendonly = true);
 ERROR:  permission denied: "pg_class" is a system catalog
--- MPP-7770: allow testing of changing storage for now
-set gp_setwith_alter_storage = true;
 alter table pg_class set with(appendonly = true);
 ERROR:  permission denied: "pg_class" is a system catalog
 -- WITH clause
 create table atsdb (i int, j text) distributed by (j);
 insert into atsdb select i, i::text from generate_series(1, 10) i;
 alter table atsdb set with(appendonly = true);
+ERROR:  option "appendonly" not supported
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
- relname | ?column? |    reloptions     
----------+----------+-------------------
- atsdb   | t        | {appendonly=true}
-(1 row)
+ relname | ?column? | reloptions 
+---------+----------+------------
+(0 rows)
 
 select * from atsdb;
  i  | j  
 ----+----
   1 | 1
-  3 | 3
-  5 | 5
+  4 | 4
   7 | 7
+  2 | 2
+  5 | 5
+  8 | 8
+  3 | 3
+  6 | 6
   9 | 9
  10 | 10
-  2 | 2
-  4 | 4
-  6 | 6
-  8 | 8
 (10 rows)
 
 drop table atsdb;
@@ -358,12 +356,12 @@ select * from distcheck where rel = 'atsdb';
 
 alter table atsdb drop column n;
 alter table atsdb set with(appendonly = true, compresslevel = 3);
+ERROR:  option "appendonly" not supported
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
- relname | ?column? |            reloptions             
----------+----------+-----------------------------------
- atsdb   | t        | {appendonly=true,compresslevel=3}
-(1 row)
+ relname | ?column? | reloptions 
+---------+----------+------------
+(0 rows)
 
 select * from distcheck where rel = 'atsdb';
   rel  | attname 
@@ -485,122 +483,121 @@ select * from distcheck where rel = 'atsdb';
 
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
- relname | ?column? |            reloptions             
----------+----------+-----------------------------------
- atsdb   | t        | {appendonly=true,compresslevel=3}
-(1 row)
+ relname | ?column? | reloptions 
+---------+----------+------------
+(0 rows)
 
 select * from atsdb;
   j  |  t  
 -----+-----
-  10 | 11
-  12 | 13
   14 | 15
-  16 | 17
-  18 | 19
-  30 | 31
-  32 | 33
-  34 | 35
-  36 | 37
-  38 | 39
-  50 | 51
-  52 | 53
-  54 | 55
-  56 | 57
-  58 | 59
-  70 | 71
-  72 | 73
-  74 | 75
-  76 | 77
-  78 | 79
-  90 | 91
-  92 | 93
-  94 | 95
-  96 | 97
-  98 | 99
- 100 | 101
-   2 | 3
-   4 | 5
-   6 | 7
-   8 | 9
-  20 | 21
-  22 | 23
-  24 | 25
-  26 | 27
-  28 | 29
-  40 | 41
-  42 | 43
-  44 | 45
-  46 | 47
-  48 | 49
-  60 | 61
-  62 | 63
-  64 | 65
-  66 | 67
-  68 | 69
-  80 | 81
-  82 | 83
-  84 | 85
-  86 | 87
-  88 | 89
-   3 | 4
-   5 | 6
-   7 | 8
-  19 | 20
-  21 | 22
-  23 | 24
-  25 | 26
-  27 | 28
-  39 | 40
-  41 | 42
-  43 | 44
-  45 | 46
-  47 | 48
-  59 | 60
-  61 | 62
-  63 | 64
-  65 | 66
-  67 | 68
-  79 | 80
-  81 | 82
-  83 | 84
-  85 | 86
-  87 | 88
-   9 | 10
-  11 | 12
-  13 | 14
   15 | 16
-  17 | 18
-  29 | 30
   31 | 32
   33 | 34
-  35 | 36
+  36 | 37
   37 | 38
+  48 | 49
+  52 | 53
+  70 | 71
+  84 | 85
+  85 | 86
+   2 | 3
+  16 | 17
+  29 | 30
+  34 | 35
   49 | 50
-  51 | 52
-  53 | 54
-  55 | 56
-  57 | 58
-  69 | 70
+  68 | 69
   71 | 72
+  83 | 84
+  13 | 14
+  17 | 18
+  28 | 29
+  30 | 31
+  35 | 36
+  50 | 51
+  51 | 52
+  63 | 64
+  69 | 70
+  72 | 73
+  86 | 87
+   3 | 4
+   6 | 7
+  18 | 19
+  20 | 21
+  42 | 43
+  53 | 54
   73 | 74
-  75 | 76
+  76 | 77
   77 | 78
-  89 | 90
+  88 | 89
+  90 | 91
   91 | 92
-  93 | 94
-  95 | 96
+   5 | 6
+  19 | 20
+  22 | 23
+  38 | 39
+  40 | 41
+  41 | 42
+  54 | 55
+  55 | 56
+  74 | 75
+  87 | 88
   97 | 98
+   4 | 5
+   7 | 8
+  21 | 22
+  39 | 40
+  56 | 57
+  57 | 58
+  75 | 76
+  89 | 90
+  96 | 97
+  12 | 13
+  23 | 24
+  26 | 27
+  27 | 28
+  43 | 44
+  58 | 59
+  60 | 61
+  65 | 66
+  82 | 83
+  93 | 94
   99 | 100
+   8 | 9
+   9 | 10
+  25 | 26
+  32 | 33
+  46 | 47
+  47 | 48
+  59 | 60
+  62 | 63
+  64 | 65
+  78 | 79
+  80 | 81
+  81 | 82
+  92 | 93
+  94 | 95
+  95 | 96
+ 100 | 101
  101 | 102
+  10 | 11
+  11 | 12
+  24 | 25
+  44 | 45
+  45 | 46
+  61 | 62
+  66 | 67
+  67 | 68
+  79 | 80
+  98 | 99
 (100 rows)
 
 -- validate parameters
 alter table atsdb set with (appendonly = ff);
-ERROR:  invalid value for boolean option "appendonly": ff
+ERROR:  option "appendonly" not supported
 alter table atsdb set with (reorganize = true);
 alter table atsdb set with (fgdfgef = asds);
-ERROR:  unrecognized parameter "fgdfgef"
+ERROR:  option "fgdfgef" not supported
 alter table atsdb set with(reorganize = true, reorganize = false) distributed
 randomly;
 ERROR:  "reorganize" specified more than once
@@ -700,21 +697,12 @@ select * from atsdb order by 1, 2, 3;
 (9 rows)
 
 alter table atsdb set with(appendonly = true);
+ERROR:  option "appendonly" not supported
 select relname, a.blocksize, compresslevel, compresstype, checksum from pg_class c, pg_appendonly a where
 relname  like 'atsdb%' and c.oid = a.relid order by 1;
-    relname    | blocksize | compresslevel | compresstype | checksum 
----------------+-----------+---------------+--------------+----------
- atsdb         |     32768 |             0 |              | t
- atsdb_1_prt_1 |     32768 |             0 |              | t
- atsdb_1_prt_2 |     32768 |             0 |              | t
- atsdb_1_prt_3 |     32768 |             0 |              | t
- atsdb_1_prt_4 |     32768 |             0 |              | t
- atsdb_1_prt_5 |     32768 |             0 |              | t
- atsdb_1_prt_6 |     32768 |             0 |              | t
- atsdb_1_prt_7 |     32768 |             0 |              | t
- atsdb_1_prt_8 |     32768 |             0 |              | t
- atsdb_1_prt_9 |     32768 |             0 |              | t
-(10 rows)
+ relname | blocksize | compresslevel | compresstype | checksum 
+---------+-----------+---------------+--------------+----------
+(0 rows)
 
 select * from atsdb order by 1, 2, 3;
  i  | j  | k 
@@ -835,6 +823,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into mpp5746 select array[i], i from generate_series(1, 100) i;
 alter table mpp5746 set with (reorganize=true, appendonly = true);
+ERROR:  option "appendonly" not supported
 select * from mpp5746 order by 1;
    c   |  t  
 -------+-----
@@ -1047,6 +1036,7 @@ select * from mpp5746 order by 1;
 (100 rows)
 
 alter table mpp5746 set with (reorganize=true, appendonly = false);
+ERROR:  option "appendonly" not supported
 select * from mpp5746 order by 1;
    c   
 -------
@@ -1171,32 +1161,33 @@ insert into mpp5738 select i, i+1, i+2, i from generate_series(1, 10) i;
 select * from mpp5738;
  a  | b  | c  | d  
 ----+----+----+----
-  1 |  2 |  3 |  1
   3 |  4 |  5 |  3
-  5 |  6 |  7 |  5
-  7 |  8 |  9 |  7
-  9 | 10 | 11 |  9
-  2 |  3 |  4 |  2
   4 |  5 |  6 |  4
+  5 |  6 |  7 |  5
   6 |  7 |  8 |  6
+  7 |  8 |  9 |  7
+  1 |  2 |  3 |  1
+  2 |  3 |  4 |  2
   8 |  9 | 10 |  8
+  9 | 10 | 11 |  9
  10 | 11 | 12 | 10
 (10 rows)
 
 alter table mpp5738 alter partition for(rank(1)) set with (appendonly=true);
 NOTICE:  altering table "mpp5738_1_prt_1" (partition for rank 1 of relation "mpp5738")
+ERROR:  option "appendonly" not supported
 select * from mpp5738;
  a  | b  | c  | d  
 ----+----+----+----
   1 |  2 |  3 |  1
-  3 |  4 |  5 |  3
-  5 |  6 |  7 |  5
-  7 |  8 |  9 |  7
-  9 | 10 | 11 |  9
   2 |  3 |  4 |  2
+  3 |  4 |  5 |  3
   4 |  5 |  6 |  4
+  5 |  6 |  7 |  5
   6 |  7 |  8 |  6
+  7 |  8 |  9 |  7
   8 |  9 | 10 |  8
+  9 | 10 | 11 |  9
  10 | 11 | 12 | 10
 (10 rows)
 
@@ -1312,10 +1303,8 @@ create table abc (a int, b int, c int) distributed by (a);
 Alter table abc set distributed randomly;
 Alter table abc set with (reorganize=false) distributed randomly;
 WARNING:  distribution policy of relation "abc" already set to DISTRIBUTED RANDOMLY
-HINT:  Use ALTER TABLE "abc" SET WITH (REORGANIZE=TRUE) DISTRIBUTED RANDOMLY to force a random redistribution
+HINT:  Use ALTER TABLE "abc" SET WITH (REORGANIZE=TRUE) DISTRIBUTED RANDOMLY to force a random redistribution.
 drop table abc;
--- MPP-7770: disable changing storage options (default, for now)
-set gp_setwith_alter_storage = false;
 -- disallow, so fails
 create table atsdb (i int, j text) distributed by (j);
 alter table atsdb set with(appendonly = true);

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -47,6 +47,33 @@ NOTICE:  CREATE TABLE will create partition "region_1_prt_region3_2_prt_europe" 
 NOTICE:  CREATE TABLE will create partition "region_1_prt_region3_2_prt_mideast" for table "region_1_prt_region3"
 NOTICE:  CREATE TABLE will create partition "region_1_prt_region3_2_prt_australia" for table "region_1_prt_region3"
 NOTICE:  CREATE TABLE will create partition "region_1_prt_region3_2_prt_antarctica" for table "region_1_prt_region3"
+-- root and internal parent partitions should have relfrozenxid as 0
+select relname from pg_class where relkind = 'r' and relname like 'region%' and relfrozenxid=0;
+       relname        
+----------------------
+ region
+ region_1_prt_region1
+ region_1_prt_region2
+ region_1_prt_region3
+(4 rows)
+
+select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'region%' and relfrozenxid=0;
+ gp_segment_id |       relname        
+---------------+----------------------
+             1 | region
+             1 | region_1_prt_region1
+             1 | region_1_prt_region2
+             1 | region_1_prt_region3
+             2 | region
+             2 | region_1_prt_region1
+             2 | region_1_prt_region2
+             2 | region_1_prt_region3
+             0 | region
+             0 | region_1_prt_region1
+             0 | region_1_prt_region2
+             0 | region_1_prt_region3
+(12 rows)
+
 create unique index region_pkey on region(r_regionkey);
 NOTICE:  building index for child partition "region_1_prt_region1"
 NOTICE:  building index for child partition "region_1_prt_region1_2_prt_africa"
@@ -7818,7 +7845,37 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sales_pkey" for 
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sales_1_prt_aa_pkey" for table "sales_1_prt_aa"
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sales_1_prt_bb_pkey" for table "sales_1_prt_bb"
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sales_1_prt_cc_pkey" for table "sales_1_prt_cc"
+-- root partition (and only root) should have relfrozenxid as 0
+select relname from pg_class where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+ relname 
+---------
+ sales
+(1 row)
+
+select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+ gp_segment_id | relname 
+---------------+---------
+             1 | sales
+             2 | sales
+             0 | sales
+(3 rows)
+
 alter table sales add column tax float;
+-- root partition (and only root) continues to have relfrozenxid as 0
+select relname from pg_class where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+ relname 
+---------
+ sales
+(1 row)
+
+select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+ gp_segment_id | relname 
+---------------+---------
+             2 | sales
+             0 | sales
+             1 | sales
+(3 rows)
+
 alter table sales drop column tax;
 create table newpart(like sales);
 alter table newpart add constraint partable_pkey primary key(pkid, option3);

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -47,6 +47,33 @@ NOTICE:  CREATE TABLE will create partition "region_1_prt_region3_2_prt_europe" 
 NOTICE:  CREATE TABLE will create partition "region_1_prt_region3_2_prt_mideast" for table "region_1_prt_region3"
 NOTICE:  CREATE TABLE will create partition "region_1_prt_region3_2_prt_australia" for table "region_1_prt_region3"
 NOTICE:  CREATE TABLE will create partition "region_1_prt_region3_2_prt_antarctica" for table "region_1_prt_region3"
+-- root and internal parent partitions should have relfrozenxid as 0
+select relname from pg_class where relkind = 'r' and relname like 'region%' and relfrozenxid=0;
+       relname        
+----------------------
+ region
+ region_1_prt_region1
+ region_1_prt_region2
+ region_1_prt_region3
+(4 rows)
+
+select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'region%' and relfrozenxid=0;
+ gp_segment_id |       relname        
+---------------+----------------------
+             1 | region
+             1 | region_1_prt_region1
+             1 | region_1_prt_region2
+             1 | region_1_prt_region3
+             0 | region
+             0 | region_1_prt_region1
+             0 | region_1_prt_region2
+             0 | region_1_prt_region3
+             2 | region
+             2 | region_1_prt_region1
+             2 | region_1_prt_region2
+             2 | region_1_prt_region3
+(12 rows)
+
 create unique index region_pkey on region(r_regionkey);
 NOTICE:  building index for child partition "region_1_prt_region1"
 NOTICE:  building index for child partition "region_1_prt_region1_2_prt_africa"
@@ -7812,7 +7839,37 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sales_pkey" for 
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sales_1_prt_aa_pkey" for table "sales_1_prt_aa"
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sales_1_prt_bb_pkey" for table "sales_1_prt_bb"
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sales_1_prt_cc_pkey" for table "sales_1_prt_cc"
+-- root partition (and only root) should have relfrozenxid as 0
+select relname from pg_class where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+ relname 
+---------
+ sales
+(1 row)
+
+select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+ gp_segment_id | relname 
+---------------+---------
+             1 | sales
+             2 | sales
+             0 | sales
+(3 rows)
+
 alter table sales add column tax float;
+-- root partition (and only root) continues to have relfrozenxid as 0
+select relname from pg_class where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+ relname 
+---------
+ sales
+(1 row)
+
+select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+ gp_segment_id | relname 
+---------------+---------
+             1 | sales
+             2 | sales
+             0 | sales
+(3 rows)
+
 alter table sales drop column tax;
 create table newpart(like sales);
 alter table newpart add constraint partable_pkey primary key(pkid, option3);

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -3588,33 +3588,6 @@ else 'Unidentify' end
 (10 rows)
 
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
-create table qp_misc_jiras.x (a int, b int) distributed by (a);
---create index xi on x(a);
-insert into qp_misc_jiras.x values (1,2), (2,3), (3,4);
-select count(*) from qp_misc_jiras.x;
- count 
--------
-     3
-(1 row)
-
-set gp_setwith_alter_storage to true;
-alter table qp_misc_jiras.x set with (appendonly=true) distributed by (b);
-insert into qp_misc_jiras.x values (4,5), (5,6);
-select count(*) from qp_misc_jiras.x;
- count 
--------
-     5
-(1 row)
-
-alter table qp_misc_jiras.x set with (appendonly=false) distributed by (a);
-insert into qp_misc_jiras.x values (6,7), (7,8);
-select count(*) from qp_misc_jiras.x;
- count 
--------
-     7
-(1 row)
-
-drop table if exists qp_misc_jiras.x cascade;
 create table qp_misc_jiras.r
     (a int, b int, c int)
     with (appendonly = true)

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -3626,33 +3626,6 @@ else 'Unidentify' end
 (16 rows)
 
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
-create table qp_misc_jiras.x (a int, b int) distributed by (a);
---create index xi on x(a);
-insert into qp_misc_jiras.x values (1,2), (2,3), (3,4);
-select count(*) from qp_misc_jiras.x;
- count 
--------
-     3
-(1 row)
-
-set gp_setwith_alter_storage to true;
-alter table qp_misc_jiras.x set with (appendonly=true) distributed by (b);
-insert into qp_misc_jiras.x values (4,5), (5,6);
-select count(*) from qp_misc_jiras.x;
- count 
--------
-     5
-(1 row)
-
-alter table qp_misc_jiras.x set with (appendonly=false) distributed by (a);
-insert into qp_misc_jiras.x values (6,7), (7,8);
-select count(*) from qp_misc_jiras.x;
- count 
--------
-     7
-(1 row)
-
-drop table if exists qp_misc_jiras.x cascade;
 create table qp_misc_jiras.r
     (a int, b int, c int)
     with (appendonly = true)

--- a/src/test/regress/input/uao_ddl/alter_ao_table_setstorage.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_setstorage.source
@@ -44,11 +44,6 @@ select * from sto_alt_uao1_setstorage;
 SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimapidxid is
 not NULL AND visimapidxid is not NULL AND relid='sto_alt_uao1_setstorage'::regclass;
 
-set gp_setwith_alter_storage = true;
-Alter Table sto_alt_uao1_setstorage
- set with (appendonly=true, compresslevel=3);
-select count(bigint_col) from sto_alt_uao1_setstorage;
-set gp_setwith_alter_storage = false;
 update sto_alt_uao1_setstorage set numeric_col = -numeric_col;
 delete from sto_alt_uao1_setstorage where numeric_col = 0;
 select * from sto_alt_uao1_setstorage;

--- a/src/test/regress/output/uao_ddl/alter_ao_table_setstorage.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_setstorage.source
@@ -81,16 +81,6 @@ not NULL AND visimapidxid is not NULL AND relid='sto_alt_uao1_setstorage'::regcl
               1
 (1 row)
 
-set gp_setwith_alter_storage = true;
-Alter Table sto_alt_uao1_setstorage
- set with (appendonly=true, compresslevel=3);
-select count(bigint_col) from sto_alt_uao1_setstorage;
- count 
--------
-     3
-(1 row)
-
-set gp_setwith_alter_storage = false;
 update sto_alt_uao1_setstorage set numeric_col = -numeric_col;
 delete from sto_alt_uao1_setstorage where numeric_col = 0;
 select * from sto_alt_uao1_setstorage;
@@ -104,7 +94,7 @@ set gp_select_invisible=true;
 select count(*) from sto_alt_uao1_setstorage;
  count 
 -------
-     6
+     9
 (1 row)
 
 set gp_select_invisible=false;

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -140,9 +140,6 @@ drop table atsdb, atsdb_1, atsdb_2;
 alter table pg_class set distributed by (relname);
 alter table pg_class set with(appendonly = true);
 
--- MPP-7770: allow testing of changing storage for now
-set gp_setwith_alter_storage = true;
-
 alter table pg_class set with(appendonly = true);
 
 -- WITH clause
@@ -371,10 +368,6 @@ create table abc (a int, b int, c int) distributed by (a);
 Alter table abc set distributed randomly;
 Alter table abc set with (reorganize=false) distributed randomly;
 drop table abc;
-
-
--- MPP-7770: disable changing storage options (default, for now)
-set gp_setwith_alter_storage = false;
 
 -- disallow, so fails
 create table atsdb (i int, j text) distributed by (j);

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -25,6 +25,10 @@ subpartition by list (r_name) subpartition template
 	partition region3 start (5) end (8)
 );
 
+-- root and internal parent partitions should have relfrozenxid as 0
+select relname from pg_class where relkind = 'r' and relname like 'region%' and relfrozenxid=0;
+select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'region%' and relfrozenxid=0;
+
 create unique index region_pkey on region(r_regionkey);
 
 copy region from stdin with delimiter '|';
@@ -3755,7 +3759,15 @@ distributed by (pkid) partition by range (option3)
 	partition cc start(201) end (300)
 );
 
+-- root partition (and only root) should have relfrozenxid as 0
+select relname from pg_class where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+
 alter table sales add column tax float;
+-- root partition (and only root) continues to have relfrozenxid as 0
+select relname from pg_class where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'sales%' and relfrozenxid=0;
+
 alter table sales drop column tax;
 
 create table newpart(like sales);

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -2212,32 +2212,6 @@ else 'Unidentify' end
 ;
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
 
-create table qp_misc_jiras.x (a int, b int) distributed by (a);
-
-
---create index xi on x(a);
-
-insert into qp_misc_jiras.x values (1,2), (2,3), (3,4);
-
-select count(*) from qp_misc_jiras.x;
-
-set gp_setwith_alter_storage to true;
-
-alter table qp_misc_jiras.x set with (appendonly=true) distributed by (b);
-
-insert into qp_misc_jiras.x values (4,5), (5,6);
-
-select count(*) from qp_misc_jiras.x;
-
-
-alter table qp_misc_jiras.x set with (appendonly=false) distributed by (a);
-
-insert into qp_misc_jiras.x values (6,7), (7,8);
-
-select count(*) from qp_misc_jiras.x;
-
-drop table if exists qp_misc_jiras.x cascade;
-
 create table qp_misc_jiras.r
     (a int, b int, c int)
     with (appendonly = true)


### PR DESCRIPTION
Root partition and internal parent partitions do not contain any data. But since
currently these tables still have valid relfrozenxid, their age keeps
growing. The problem it poses is to bring the age down need to run vacuum on
root, which trickles down and vacuum's each and every child partition as
well. Instead, if only leaf if getting modified those can be vacuumed in
isolation and bring the age down and avoid the overhead of vacuuming the full
hierarchy.

So, similar to AO, CO, external tables, etc.. for root and parent partitions
record relfrozenxid as 0 (InvalidTransaction) during table creation. This works
since these tables will never store any xids. This would skip them from age
calculation hence eliminate the forced need for vacuum on them. Ideally, same can be
achieved by defining root and internal parent partition as AO tables but its lot
more work and ddls need modifications.

** This PR also contains commit removing guc gp_setwith_alter_storage and corresponding tests. In future when the feature is fully implemented and verified can be exposed and no guc is needed.