### PR TITLE
gpperfmon: fix long query text cannot load into queries_history

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmondb.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmondb.h
@@ -4,6 +4,7 @@
 #include "apr_general.h"
 #include "apr_md5.h"
 #include "apr_hash.h"
+#include "cdb/cdbcsv.h"
 
 /**
  * Validate the the gpperfmon database is correct and
@@ -96,6 +97,13 @@ int find_token_in_config_string(char*, char**, const char*);
 void process_line_in_hadoop_cluster_info(apr_pool_t*, apr_hash_t*, char*, char*, char*);
 int get_hadoop_hosts_and_add_to_hosts(apr_pool_t*, apr_hash_t*, mmon_options_t*);
 apr_status_t truncate_file(char*, apr_pool_t*);
+
+/**
+ * MPP-29418 workaround copy/external issue that csv line with like breaks cannot
+ * exceed gp_max_csv_line_length, here we substruct 1K for fixed length columns for
+ * data load safety
+ */
+#define HARVEST_CSV_SAFEGUARD (1024)
 
 #endif /* GPMONDB_H */
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -21,6 +21,7 @@
 #include "access/url.h"
 #include "access/xlog_internal.h"
 #include "cdb/cdbappendonlyam.h"
+#include "cdb/cdbcsv.h"
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbfilerep.h"
 #include "cdb/cdbsreh.h"
@@ -3642,7 +3643,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_GPDB_ADDOPT
 		},
 		&gp_max_csv_line_length,
-		1 * 1024 * 1024, 32 * 1024, 4 * 1024 * 1024, NULL, NULL
+		1 * 1024 * 1024, 32 * 1024, MAX_GP_MAX_CSV_LINE_LENGTH, NULL, NULL
 	},
 
 	/*

--- a/src/include/cdb/cdbcsv.h
+++ b/src/include/cdb/cdbcsv.h
@@ -1,0 +1,21 @@
+/*-------------------------------------------------------------------------
+ *
+ * cdbcsv.h
+ *	  Header file for copy/external table process csv file format
+ *
+ * Portions Copyright (c) 2005-2008, Greenplum inc
+ * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
+ *
+ *
+ * IDENTIFICATION
+ *	    src/include/cdb/cdbcsv.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef CDBCSV_H
+#define CDBCSV_H
+
+#define MAX_GP_MAX_CSV_LINE_LENGTH (4 * 1024 * 1024)
+
+#endif   /* CDBCSV_H */


### PR DESCRIPTION
A known issue in copy.c blocks gpperfmon harvest long query
into queries_history. If the query text contains line breaks, and
the line length exceeds gp_max_csv_line_length, external table
fail and return an error `data too long`.

This workaround makes gpperfmon can harvest long query with line
breaks in GPDB 5X.
1. When doing harvesting, raise the gp_max_csv_line_length to
maximum legal value in session level.
2. For query longer than gp_max_csv_line_length, it means it can't be
loaded with line breaks as CSV format. This workaround just
replaces line breaks in query text with space to prevent load
failure. It may lead long query statement changed when load to
history table, but it is still better than fail to load or truncate
the query text.

For master branch we don't need this fix because merge work had
refined copy.c, it no more suffers from gp_max_csv_line_length.

Co-authored-by: Hao Wang haowang@pivotal.io
Co-authored-by: Teng Zhang tezhang@pivotal.io