### PR TITLE
Attempt to unbreak snmp support compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ addons:
     - g++-6
     - python-dev
     - python-yaml
+    - libsnmp-dev
 
 ## ----------------------------------------------------------------------
 ## Build tools
@@ -90,7 +91,7 @@ before_script:
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --with-apr-config=${TRAVIS_BUILD_DIR}/tools/bin/apr-1-config --disable-orca --disable-gpcloud --enable-pxf --enable-mapreduce --with-perl
+  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --with-apr-config=${TRAVIS_BUILD_DIR}/tools/bin/apr-1-config --disable-orca --disable-gpcloud --enable-pxf --enable-mapreduce --with-perl --enable-snmp
 
   - make
   - make install

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -38,7 +38,6 @@
 #include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbtm.h"
 #include "cdb/cdbutil.h"
-#include "pg_config.h"
 
 /*
  * GUC variables

--- a/src/backend/postmaster/alertseverity.c
+++ b/src/backend/postmaster/alertseverity.c
@@ -12,15 +12,6 @@
  *
  *-------------------------------------------------------------------------
  */
-#if !defined(_XOPEN_SOURCE) || _XOPEN_SOURCE<600
-#undef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 600
-#endif
-#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE<200112L
-#undef _POSIX_C_SOURCE
-/* Define to activate features from IEEE Stds 1003.1-2001 */
-#define _POSIX_C_SOURCE 200112L
-#endif
 #include "postgres.h"
 #include "pg_config.h"  /* Adding this helps eclipse see that USE_SNMP is set */
 

--- a/src/backend/postmaster/alertseverity.c
+++ b/src/backend/postmaster/alertseverity.c
@@ -13,7 +13,6 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
-#include "pg_config.h"  /* Adding this helps eclipse see that USE_SNMP is set */
 
 #include <fcntl.h>
 #include <signal.h>

--- a/src/backend/postmaster/sendalert.c
+++ b/src/backend/postmaster/sendalert.c
@@ -13,7 +13,6 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
-#include "pg_config.h"  /* Adding this helps eclipse see that USE_SNMP is set */
 
 #include <fcntl.h>
 #include <signal.h>

--- a/src/backend/postmaster/sendalert.c
+++ b/src/backend/postmaster/sendalert.c
@@ -12,15 +12,6 @@
  *
  *-------------------------------------------------------------------------
  */
-#if !defined(_XOPEN_SOURCE) || _XOPEN_SOURCE<600
-#undef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 600
-#endif
-#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE<200112L
-#undef _POSIX_C_SOURCE
-/* Define to activate features from IEEE Stds 1003.1-2001 */
-#define _POSIX_C_SOURCE 200112L
-#endif
 #include "postgres.h"
 #include "pg_config.h"  /* Adding this helps eclipse see that USE_SNMP is set */
 
@@ -59,6 +50,8 @@ extern int	PostPortNumber;
 #endif
 
 #ifdef USE_SNMP
+#include <sys/types.h>
+
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/definitions.h>
 #include <net-snmp/types.h>


### PR DESCRIPTION
Commit 3b3adb2 most likely broke compilation of the SNMP related code, as it required feature test
macros to enable <sys/types.h>.  There however seems to be little reason for the feature test macros here either, so remove and try to unbreak the build.  Also enable snmp in Travis CI so we get a heads up the next time we break it.

Also fix bogus inclusions of pg_config.h spotted while in there.