### PR TITLE
Update the version of pylint in python-dependencies.txt

### DIFF
--- a/python-dependencies.txt
+++ b/python-dependencies.txt
@@ -11,6 +11,5 @@ paramiko==1.18.1
 parse==1.8.2
 psutil==4.0.0
 pycrypto==2.6.1
-pylint==0.21.0
 setuptools==36.6.0
 unittest2==0.5.1


### PR DESCRIPTION
When build depends by run "make", meet an error "pkg_resources.DistributionNotFound: 
The 'pylint<1.9.0,>=1.8.1' distribution was not found and is required by conan". This commit
update the version of pylint from 0.21.0 to 1.8.4