### PR TITLE
support fast_match option in gpload config file

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -95,7 +95,7 @@ d = mkpath('config')
 if not os.path.exists(d):
     os.mkdir(d)
 
-def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None,staging_table=None):
+def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None,staging_table=None,fast_match='false'):
 
     f = open(mkpath('config/config_file'),'w')
     f.write("VERSION: 1.0.0.1")
@@ -177,6 +177,7 @@ def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',
         f.write("\n    - SCHEMA: "+externalSchema)
     f.write("\n   PRELOAD:")
     f.write("\n    - REUSE_TABLES: "+reuse_flag)
+    f.write("\n    - FAST_MATCH: "+fast_match)
     if staging_table:
         f.write("\n    - STAGING_TABLE: "+staging_table)
     f.write("\n")
@@ -436,7 +437,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_00_gpload_formatOpts_setup(self):
         "0  gpload setup"
-        for num in range(1,30):
+        for num in range(1,33):
            f = open(mkpath('query%d.sql' % num),'w')
            f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n"+"\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
            f.close()
@@ -679,6 +680,27 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         copy_data('external_file_14.txt','data_file.txt')
         write_config_file(mode='insert',reuse_flag='true',file='data_file.txt',log_errors=True, error_limit='100')
         self.doTest(29)
+
+    def test_30_gpload_reuse_table_update_mode_with_fast_match(self):
+        "30  gpload update mode with fast match"
+        #drop_tables()
+        copy_data('external_file_04.txt','data_file.txt')
+        write_config_file(mode='update',reuse_flag='true',fast_match='true',file='data_file.txt')
+        self.doTest(30)
+
+    def test_31_gpload_reuse_table_update_mode_with_fast_match_and_different_columns_number(self):
+        "31 gpload update mode with fast match and differenct columns number) "
+        psql_run(cmd="ALTER TABLE texttable ADD column n8 text",dbname='reuse_gptest')
+        copy_data('external_file_08.txt','data_file.txt')
+        write_config_file(mode='update',reuse_flag='true',fast_match='true',file='data_file.txt')
+        self.doTest(31)
+
+    def test_32_gpload_update_mode_without_reuse_table_with_fast_match(self):
+        "32  gpload update mode when reuse table is false and fast match is true"
+        drop_tables()
+        copy_data('external_file_08.txt','data_file.txt')
+        write_config_file(mode='update',reuse_flag='false',fast_match='true',file='data_file.txt')
+        self.doTest(32)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(GPLoad_FormatOpts_TestCase)

--- a/gpMgmt/bin/gpload_test/gpload2/query30.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query30.ans
@@ -1,0 +1,20 @@
+2017-04-10 07:07:08|INFO|gpload session started 2017-04-10 07:07:08
+2017-04-10 07:07:08|INFO|setting schema 'public' for table 'texttable'
+2017-04-10 07:07:08|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2017-04-10 07:07:08|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2017-04-10 07:07:08|INFO|did not find an external table to reuse. creating ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
+2017-04-10 07:07:08|INFO|running time: 0.08 seconds
+2017-04-10 07:07:08|INFO|rows Inserted          = 0
+2017-04-10 07:07:08|INFO|rows Updated           = 32
+2017-04-10 07:07:08|INFO|data formatting errors = 0
+2017-04-10 07:07:08|INFO|gpload succeeded
+2017-04-10 07:07:08|INFO|gpload session started 2017-04-10 07:07:08
+2017-04-10 07:07:08|INFO|setting schema 'public' for table 'texttable'
+2017-04-10 07:07:08|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2017-04-10 07:07:08|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2017-04-10 07:07:08|INFO|reusing external table ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
+2017-04-10 07:07:09|INFO|running time: 0.08 seconds
+2017-04-10 07:07:09|INFO|rows Inserted          = 0
+2017-04-10 07:07:09|INFO|rows Updated           = 32
+2017-04-10 07:07:09|INFO|data formatting errors = 0
+2017-04-10 07:07:09|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query31.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query31.ans
@@ -1,0 +1,26 @@
+2018-07-20 09:06:30|INFO|gpload session started 2018-07-20 09:06:30
+2018-07-20 09:06:30|INFO|setting schema 'public' for table 'texttable'
+2018-07-20 09:06:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-07-20 09:06:30|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
+2018-07-20 09:06:30|INFO|reusing external table ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
+2018-07-20 09:06:30|ERROR|ERROR:  column "n8" does not exist
+LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
+                                                             ^
+ encountered while running INSERT INTO staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0 ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
+2018-07-20 09:06:30|INFO|rows Inserted          = 0
+2018-07-20 09:06:30|INFO|rows Updated           = 0
+2018-07-20 09:06:30|INFO|data formatting errors = 0
+2018-07-20 09:06:30|INFO|gpload failed
+2018-07-20 09:06:30|INFO|gpload session started 2018-07-20 09:06:30
+2018-07-20 09:06:30|INFO|setting schema 'public' for table 'texttable'
+2018-07-20 09:06:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-07-20 09:06:30|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
+2018-07-20 09:06:30|INFO|reusing external table ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
+2018-07-20 09:06:30|ERROR|ERROR:  column "n8" does not exist
+LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
+                                                             ^
+ encountered while running INSERT INTO staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0 ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
+2018-07-20 09:06:30|INFO|rows Inserted          = 0
+2018-07-20 09:06:30|INFO|rows Updated           = 0
+2018-07-20 09:06:30|INFO|data formatting errors = 0
+2018-07-20 09:06:30|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query32.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query32.ans
@@ -1,0 +1,18 @@
+2018-07-20 09:11:14|INFO|gpload session started 2018-07-20 09:11:14
+2018-07-20 09:11:14|INFO|setting schema 'public' for table 'texttable'
+2018-07-20 09:11:14|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-07-20 09:11:14|WARN|fast_match is ignored when reuse_tables is false!
+2018-07-20 09:11:14|INFO|running time: 0.28 seconds
+2018-07-20 09:11:14|INFO|rows Inserted          = 0
+2018-07-20 09:11:14|INFO|rows Updated           = 34
+2018-07-20 09:11:14|INFO|data formatting errors = 0
+2018-07-20 09:11:14|INFO|gpload succeeded
+2018-07-20 09:11:14|INFO|gpload session started 2018-07-20 09:11:14
+2018-07-20 09:11:14|INFO|setting schema 'public' for table 'texttable'
+2018-07-20 09:11:14|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-07-20 09:11:14|WARN|fast_match is ignored when reuse_tables is false!
+2018-07-20 09:11:14|INFO|running time: 0.29 seconds
+2018-07-20 09:11:14|INFO|rows Inserted          = 0
+2018-07-20 09:11:14|INFO|rows Updated           = 34
+2018-07-20 09:11:14|INFO|data formatting errors = 0
+2018-07-20 09:11:14|INFO|gpload succeeded


### PR DESCRIPTION
- Add fast_match option in gpload config file. If both reuse_tables
and fast_match are true, gpload will make fast match external
table(without checking columns). If reuse_tables is false and
fast_match is true, it will print warning message.