### PR TITLE
Check that sed is successful in gpinitsystem

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1246,18 +1246,18 @@ CREATE_QD_DB () {
 		$ECHO "#Greenplum specific configuration parameters for Master instance database" >> ${GP_DIR}/$PG_CONF
 		$ECHO "#------------------------------------------------------------------------" >> ${GP_DIR}/$PG_CONF
 		LOG_MSG "[INFO]:-Setting the Master port to $GP_PORT"
-		SED_PG_CONF ${GP_DIR}/$PG_CONF "$PORT_TXT" port=$GP_PORT 0
+		SED_PG_CONF ${GP_DIR}/$PG_CONF "$PORT_TXT" port=$GP_PORT
 		ERROR_CHK $? "set Master port=$GP_PORT in $PG_CONF" 2
 		LOG_MSG "[INFO]:-Completed setting the Master port to $MASTER_PORT"
 		LOG_MSG "[INFO]:-Setting the Master listen addresses to '*'"
-		SED_PG_CONF ${GP_DIR}/$PG_CONF "$LISTEN_ADR_TXT" listen_addresses=\'*\' 0
+		SED_PG_CONF ${GP_DIR}/$PG_CONF "$LISTEN_ADR_TXT" listen_addresses=\'*\'
 		ERROR_CHK $? "set Master listen addresses to '*' in $PG_CONF" 2
 		LOG_MSG "[INFO]:-Completed setting the listen addresses to '*'"
 		LOG_MSG "[INFO]:-Setting Master logging option"
-		SED_PG_CONF ${GP_DIR}/$PG_CONF "$LOG_STATEMENT_TXT" log_statement=all 0
+		SED_PG_CONF ${GP_DIR}/$PG_CONF "$LOG_STATEMENT_TXT" log_statement=all
 		ERROR_CHK $? "set log_statement=all in ${GP_DIR}/$PG_CONF" 1
 		LOG_MSG "[INFO]:-Setting Master instance check point segments"
-		SED_PG_CONF ${GP_DIR}/$PG_CONF "$CHKPOINT_SEG_TXT" "checkpoint_segments=$CHECK_POINT_SEGMENTS" 0
+		SED_PG_CONF ${GP_DIR}/$PG_CONF "$CHKPOINT_SEG_TXT" "checkpoint_segments=$CHECK_POINT_SEGMENTS"
 		ERROR_CHK $? "set checkpoint_segments=$CHECK_POINT_SEGMENTS in ${GP_DIR}/$PG_CONF" 1
 		
 		if [  x"" != x"$PG_CONF_ADD_FILE" ]; then
@@ -1266,7 +1266,7 @@ CREATE_QD_DB () {
 						do
 						LOG_MSG "[INFO]:-Adding config $NEW_PARAM to Master"
 						SEARCH_TXT=`$ECHO $NEW_PARAM |$CUT -d"=" -f1`
-						SED_PG_CONF ${GP_DIR}/$PG_CONF $SEARCH_TXT $NEW_PARAM 0
+						SED_PG_CONF ${GP_DIR}/$PG_CONF $SEARCH_TXT $NEW_PARAM
 						ERROR_CHK $? "set $NEW_PARAM ${GP_DIR}/$PG_CONF" 1
 				done
 		fi

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -372,13 +372,6 @@ SED_PG_CONF () {
 					$RM -f ${FILENAME}.bak1
 				fi
 				$SED -i'.bak2' -e "s/^#${SEARCH_TXT}/${SEARCH_TXT}/" $FILENAME
-				SED_DIFF=`diff $FILENAME.bak2 $FILENAME`
-				if [ x"" == x"$SED_DIFF" ]; then
-					ERROR_EXIT "[FATAL]:-Failed to replace $SEARCH_TXT in $FILENAME" 2
-				else
-					LOG_MSG "[INFO]:-Replaced line in $FILENAME"
-					$RM -f ${FILENAME}.bak2
-				fi
 			fi
 	else
 		# trap DEBUG will always be called first, when other traps are triggered.

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -348,7 +348,6 @@ SED_PG_CONF () {
 	FILENAME=$1;shift
 	SEARCH_TXT=$1;shift
 	SUB_TXT="$1";shift
-	KEEP_PREV=$1;shift
 	SED_HOST=$1
 	if [ x"" == x"$SED_HOST" ]; then
 			if [ `$GREP -c "${SEARCH_TXT}[ ]*=" $FILENAME` -gt 1 ]; then
@@ -364,11 +363,7 @@ SED_PG_CONF () {
 					LOG_MSG "[INFO]:-Appended line $SUB_TXT to $FILENAME"
 				fi
 			else
-				if [ $KEEP_PREV -eq 0 ];then
-					$SED -i'.bak1' -e "s/${SEARCH_TXT}/${SUB_TXT} #${SEARCH_TXT}/" $FILENAME
-				else
-					$SED -i'.bak1' -e "s/${SEARCH_TXT}.*/${SUB_TXT}/" $FILENAME
-				fi
+				$SED -i'.bak1' -e "s/${SEARCH_TXT}.*/${SUB_TXT}/" $FILENAME
 				SED_DIFF=`diff $FILENAME.bak1 $FILENAME`
 				if [ x"" == x"$SED_DIFF" ]; then
 					ERROR_EXIT "[FATAL]:-Failed to replace $SEARCH_TXT in $FILENAME" 2
@@ -406,11 +401,7 @@ SED_PG_CONF () {
 				LOG_MSG "[INFO]:-Appended line $SUB_TXT to $FILENAME on $SED_HOST" 1
 			fi
 		else
-			if [ $KEEP_PREV -eq 0 ];then
-				$ECHO "s/${SEARCH_TXT}/${SUB_TXT} #${SEARCH_TXT}/" > $SED_TMP_FILE
-			else
-				$ECHO "s/${SEARCH_TXT}.*/${SUB_TXT}/" > $SED_TMP_FILE
-			fi
+			$ECHO "s/${SEARCH_TXT}/${SUB_TXT} #${SEARCH_TXT}/" > $SED_TMP_FILE
 			$CAT $SED_TMP_FILE | $TRUSTED_SHELL ${SED_HOST} $DD of=$SED_TMP_FILE > /dev/null 2>&1
 			$TRUSTED_SHELL $SED_HOST "sed -i'.bak1' -f $SED_TMP_FILE $FILENAME" > /dev/null 2>&1
 			if [ $RETVAL -ne 0 ]; then

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -369,17 +369,17 @@ SED_PG_CONF () {
 				else
 					$SED -i'.bak1' -e "s/${SEARCH_TXT}.*/${SUB_TXT}/" $FILENAME
 				fi
-				RETVAL=$?
-				if [ $RETVAL -ne 0 ]; then
+				SED_DIFF=`diff $FILENAME.bak1 $FILENAME`
+				if [ x"" == x"$SED_DIFF" ]; then
 					ERROR_EXIT "[FATAL]:-Failed to replace $SEARCH_TXT in $FILENAME" 2
 				else
 					LOG_MSG "[INFO]:-Replaced line in $FILENAME"
 					$RM -f ${FILENAME}.bak1
 				fi
 				$SED -i'.bak2' -e "s/^#${SEARCH_TXT}/${SEARCH_TXT}/" $FILENAME
-				RETVAL=$?
-				if [ $RETVAL -ne 0 ]; then
-					ERROR_EXIT "[FATAL]:-Failed to replace #$SEARCH_TXT in $FILENAME" 2
+				SED_DIFF=`diff $FILENAME.bak2 $FILENAME`
+				if [ x"" == x"$SED_DIFF" ]; then
+					ERROR_EXIT "[FATAL]:-Failed to replace $SEARCH_TXT in $FILENAME" 2
 				else
 					LOG_MSG "[INFO]:-Replaced line in $FILENAME"
 					$RM -f ${FILENAME}.bak2

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -156,11 +156,11 @@ PROCESS_QE () {
         $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO \"#----------------------\" >> ${GP_DIR}/$PG_CONF"
         RETVAL=$?
         PARA_EXIT $RETVAL "Update ${GP_DIR}/$PG_CONF file"
-        SED_PG_CONF ${GP_DIR}/$PG_CONF "$PORT_TXT" port=$GP_PORT 0 $GP_HOSTADDRESS
+        SED_PG_CONF ${GP_DIR}/$PG_CONF "$PORT_TXT" port=$GP_PORT $GP_HOSTADDRESS
         PARA_EXIT $RETVAL "Update port number to $GP_PORT"
-        SED_PG_CONF ${GP_DIR}/$PG_CONF "$LISTEN_ADR_TXT" listen_addresses=\'*\' 0 $GP_HOSTADDRESS
+        SED_PG_CONF ${GP_DIR}/$PG_CONF "$LISTEN_ADR_TXT" listen_addresses=\'*\' $GP_HOSTADDRESS
         PARA_EXIT $RETVAL "Update listen address"
-        SED_PG_CONF ${GP_DIR}/$PG_CONF "$CHKPOINT_SEG_TXT" checkpoint_segments=$CHECK_POINT_SEGMENTS 0 $GP_HOSTADDRESS
+        SED_PG_CONF ${GP_DIR}/$PG_CONF "$CHKPOINT_SEG_TXT" checkpoint_segments=$CHECK_POINT_SEGMENTS $GP_HOSTADDRESS
         PARA_EXIT $RETVAL "Update checkpoint segments"
 
         if [ x"" != x"$PG_CONF_ADD_FILE" ]; then
@@ -169,7 +169,7 @@ PROCESS_QE () {
 	        do
 	            LOG_MSG "[INFO][$INST_COUNT]:-Adding config $NEW_PARAM to segment"
 	            SEARCH_TXT=`$ECHO $NEW_PARAM |$CUT -d"=" -f1`
-	            SED_PG_CONF ${GP_DIR}/$PG_CONF $SEARCH_TXT $NEW_PARAM 0 $GP_HOSTADDRESS
+	            SED_PG_CONF ${GP_DIR}/$PG_CONF $SEARCH_TXT $NEW_PARAM $GP_HOSTADDRESS
 	            PARA_EXIT $RETVAL "Update $PG_CONF $SEARCH_TXT $NEW_PARAM"
 	        done
         fi


### PR DESCRIPTION
Previously, the sed command was returning 0 whether or not it performed a
successful substitution, so checking the return value was causing it to silently
fail.

This commit modifies the function to diff the old and new versions of the file
instead, to explicitly check that the file is modified.

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>
Co-authored-by: Nadeem Ghani <nghani@pivotal.io>