### PR TITLE
Fix race condition in autovacuum test

### DIFF
--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -100,6 +100,7 @@
 #include "utils/tqual.h"
 
 #include "cdb/cdbvars.h"
+#include "utils/faultinjector.h"
 
 
 /*
@@ -1606,8 +1607,10 @@ AutoVacWorkerMain(int argc, char *argv[])
 		InitPostgres(NULL, dbid, NULL, dbname);
 		SetProcessingMode(NormalProcessing);
 		set_ps_display(dbname, false);
-		ereport(DEBUG1,
+		ereport(LOG,
 				(errmsg("autovacuum: processing database \"%s\"", dbname)));
+
+		SIMPLE_FAULT_INJECTOR(AutoVacWorkerBeforeDoAutovacuum);
 
 		if (PostAuthDelay)
 			pg_usleep(PostAuthDelay * 1000000L);

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -285,7 +285,9 @@ FaultInjector_InjectFaultNameIfSet(
 	 * some other mechanism needs to be placed to avoid flaky failures.
 	 */
 	if (IsAutoVacuumLauncherProcess() ||
-		(IsAutoVacuumWorkerProcess() && 0 != strcmp("vacuum_update_dat_frozen_xid", faultName)))
+		(IsAutoVacuumWorkerProcess() &&
+		 !(0 == strcmp("vacuum_update_dat_frozen_xid", faultName) ||
+			 0 == strcmp("auto_vac_worker_before_do_autovacuum", faultName))))
 		return FaultInjectorTypeNotSpecified;
 
 	/*

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -241,6 +241,8 @@ FI_IDENT(VacuumUpdateDatFrozenXid, "vacuum_update_dat_frozen_xid")
 FI_IDENT(CollateLocaleOsLookup, "collate_locale_os_lookup")
 /* inject fault before create resource group committing */
 FI_IDENT(CreateResourceGroupFail, "create_resource_group_fail")
+/* inject fault before auto vacuum worker calls do_autovacuum */
+FI_IDENT(AutoVacWorkerBeforeDoAutovacuum, "auto_vac_worker_before_do_autovacuum")
 #endif
 
 /*

--- a/src/test/regress/input/autovacuum-template0.source
+++ b/src/test/regress/input/autovacuum-template0.source
@@ -14,28 +14,21 @@ select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='templat
 -- track that we've updated the row in pg_database for template0
 SELECT gp_inject_fault_infinite('vacuum_update_dat_frozen_xid', 'skip', 1);
 
+-- Suspend the autovacuum worker from vacuuming before
+-- ShmemVariableCache->latestCompletedXid is expected to be updated
+SELECT gp_inject_fault_infinite('auto_vac_worker_before_do_autovacuum', 'suspend', 1);
+
 select test_consume_xids(100 * 1000000);
 select test_consume_xids(100 * 1000000);
 select test_consume_xids(10 * 1000000);
 
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, 1);
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', 1);
+
 -- wait until autovacuum worker updates pg_database
 SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
 SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
-
--- Wait until autovacuum commits the pg_database change
--- Or timeout after 30 seconds
-do $$
-begin
-  for i in 1..300 loop
-    if (select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0') then
-      raise notice 'template0 is young again';
-      return;
-    end if;
-    perform pg_sleep(0.1);
-  end loop;
-  raise notice 'FAIL: template0 is not being frozen!';
-end;
-$$;
 
 -- template0 should be young
 select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';

--- a/src/test/regress/output/autovacuum-template0.source
+++ b/src/test/regress/output/autovacuum-template0.source
@@ -20,6 +20,15 @@ NOTICE:  Success:
  t
 (1 row)
 
+-- Suspend the autovacuum worker from vacuuming before
+-- ShmemVariableCache->latestCompletedXid is expected to be updated
+SELECT gp_inject_fault_infinite('auto_vac_worker_before_do_autovacuum', 'suspend', 1);
+NOTICE:  Success:
+ gp_inject_fault_infinite 
+--------------------------
+ t
+(1 row)
+
 select test_consume_xids(100 * 1000000);
  test_consume_xids 
 -------------------
@@ -38,6 +47,21 @@ select test_consume_xids(10 * 1000000);
  
 (1 row)
 
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, 1);
+NOTICE:  Success:
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t
+(1 row)
+
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 -- wait until autovacuum worker updates pg_database
 SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
 NOTICE:  Success:
@@ -53,21 +77,6 @@ NOTICE:  Success:
  t
 (1 row)
 
--- Wait until autovacuum commits the pg_database change
--- Or timeout after 30 seconds
-do $$
-begin
-  for i in 1..300 loop
-    if (select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0') then
-      raise notice 'template0 is young again';
-      return;
-    end if;
-    perform pg_sleep(0.1);
-  end loop;
-  raise notice 'FAIL: template0 is not being frozen!';
-end;
-$$;
-NOTICE:  template0 is young again
 -- template0 should be young
 select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
  ?column? 


### PR DESCRIPTION
If autovacuum was triggered before ShmemVariableCache->latestCompletedXid is
updated by manually consuming xids then autovacuum may not vacuum template0
with a proper transaction id to compare against. We made the test more reliable
by suspending a new fault injector (auto_vac_worker_before_do_autovacuum) right
before autovacuum worker sets recentXid and starts doing the autovacuum.  This
allows us to guarantee that autovacuum is comparing against a proper xid.

We also removed the loop in the test because vacuum_update_dat_frozen_xid fault
injector ensures the pg_database table has been updated.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>