### PR TITLE
Save git root, submodule and changelog information.

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -88,6 +88,25 @@ function build_gppkg() {
   popd
 }
 
+function git_info() {
+  pushd ${GPDB_SRC_PATH}
+
+  "${CWDIR}/git_info.bash" | tee ${GREENPLUM_INSTALL_DIR}/etc/git-info.json
+
+  PREV_TAG=$(git describe --tags --abbrev=0 @^)
+
+  cat > ${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt <<-EOF
+	======================================================================
+	Git log since previous release tag (${PREV_TAG})
+	----------------------------------------------------------------------
+
+	EOF
+
+  git log --abbrev-commit --date=relative "${PREV_TAG}..@" | tee -a ${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt
+
+  popd
+}
+
 function unittest_check_gpdb() {
   pushd ${GPDB_SRC_PATH}
     source ${GREENPLUM_INSTALL_DIR}/greenplum_path.sh
@@ -172,6 +191,7 @@ function _main() {
   # the source tree and hence needs to be copied over.
   rsync -au gpaddon_src/ ${GPDB_SRC_PATH}/gpAux/${ADDON_DIR}
   build_gpdb "${BLD_TARGET_OPTION[@]}"
+  git_info
   build_gppkg
   if [ "${TARGET_OS}" != "win32" ] ; then
       # Don't unit test when cross compiling. Tests don't build because they

--- a/concourse/scripts/git_info.bash
+++ b/concourse/scripts/git_info.bash
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -uo pipefail
+
+# ----------------------------------------------------------------------
+# Check for prerequisite utilities
+# ----------------------------------------------------------------------
+
+PREREQ_COMMANDS="git"
+
+for COMMAND in ${PREREQ_COMMANDS}; do
+    type "${COMMAND}" >/dev/null 2>&1 || { echo >&2 "Required command line utility \"${COMMAND}\" is not available.  Aborting."; exit 1; }
+done
+
+# ----------------------------------------------------------------------
+# Retrieve root URI and commit SHA1
+# ----------------------------------------------------------------------
+
+URI=$( git remote -v | grep "fetch" | grep "origin" | awk '{print $2}' )
+SHA1=$( git rev-parse HEAD )
+
+# ----------------------------------------------------------------------
+# Generate root JSON record
+# ----------------------------------------------------------------------
+
+echo -n "
+{\"root\": {
+  \"uri\": \"${URI}\",
+  \"sha1\": \"${SHA1}\"},
+  \"submodules\": ["
+
+# ----------------------------------------------------------------------
+# Generate submodule records
+# ----------------------------------------------------------------------
+
+submodules=$( git submodule status )
+submodule_count=$( git submodule status | wc -l | tr -d ' ' )
+
+COUNTER=0
+IFS=$'\n'
+
+for line in $submodules; do
+    SOURCE_PATH=$( echo "${line}" | cut -d " " -f3 )
+    SHA1=$( echo "${line}" | cut -d " " -f2 )
+    TAG=$( echo "${line}" | cut -d " " -f4 )
+    COUNTER=$((COUNTER+1))
+
+echo -n "
+     {\"source_path\": \"${SOURCE_PATH}\",
+      \"sha1\": \"${SHA1}\",
+      \"tag\": \"${TAG//[)(]/}\"}"
+
+    if [ "${COUNTER}" != "${submodule_count}" ]; then
+        echo -n ","
+    fi
+done
+
+echo "]}"


### PR DESCRIPTION
The following information will be saved in
${GREENPLUM_INSTALL_DIR}/etc/git-info.json:

* Root repo (uri, sha1)
* Submodules (submodule source path, sha1, tag)

Save git commits since last release tag into
${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt

Example: git-info.json
```
{"root": {
  "uri": "https://github.com/foobar/gpdb.git",
  "sha1": "3ad9999c30a1989d7cae17a0625fbea4a1d1105f"},
  "submodules": [
     {"source_path": "gpAux/extensions/googletest",
      "sha1": "ec499991675c25b9827aacd08c02433cccde7780",
      "tag": "null"},
     {"source_path": "gpAux/extensions/pgbouncer/source",
      "sha1": "23a15bd999934e833eb59bdd5c9bc7dd498eae88",
      "tag": "null"},
     {"source_path": "gpAux/extensions/postgis-2.0.3/source",
      "sha1": "4fefce57cbd999906db60070434611228294bef3",
      "tag": "null"},
     {"source_path": "gpMgmt/bin/pythonSrc/ext",
      "sha1": "19a8896e9cb300f9999f788d1989d1c0e10641e4",
      "tag": "null"},
     {"source_path": "src/bin/gpfdist/ext",
      "sha1": "96f7f1b0b776edb419299997ba0a576007f64dd7",
      "tag": "null"}]}```
