### PR TITLE
Support Nested Loop Index plans using nest params

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.66.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.67.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.66.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.67.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13346,7 +13346,7 @@ int
 main ()
 {
 
-return strncmp("2.66.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.67.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13356,7 +13356,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.66.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.67.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.66.0@gpdb/stable
+orca/v2.67.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.66.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.67.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/executor/nodeBitmapTableScan.c
+++ b/src/backend/executor/nodeBitmapTableScan.c
@@ -96,11 +96,6 @@ ExecBitmapTableScan(BitmapTableScanState *node)
 	TupleTableSlot *slot = DynamicScan_GetNextTuple(scanState, BitmapTableScanBeginPartition,
 			BitmapTableScanEndPartition, BitmapTableScanReScanPartition, BitmapTableScanFetchNext);
 
-	if (TupIsNull(slot) && !scanState->ps.delayEagerFree)
-	{
-		ExecEagerFreeBitmapTableScan(node);
-	}
-
 	return slot;
 }
 

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -503,7 +503,8 @@ CConfigParamMapping::PbsPack
 	}
 
 	// enable nested loop index plans using nest params
-	pbs->FExchangeSet(EopttraceEnableNestLoopParams);
+	// instead of outer reference as in the case with GPDB 4/5
+	pbs->FExchangeSet(EopttraceIndexedNLJOuterRefAsParams);
 
 	return pbs;
 }

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -415,11 +415,7 @@ CConfigParamMapping::PbsPack
 		}
 	}
 
-	// disable index-join if the corresponding GUC is turned off
-	// GPDB_91_MERGE_FIXME - Disabling index scans under nested loop joins,
-	// as the executor now expects a Param, rather than a Var with an OUTER
-	// table reference for rescans.
-	/*if (!optimizer_enable_indexjoin) */
+	if (!optimizer_enable_indexjoin)
 	{
 		CBitSet *pbsIndexJoin = CXform::PbsIndexJoinXforms(pmp);
 		pbs->Union(pbsIndexJoin);
@@ -505,6 +501,9 @@ CConfigParamMapping::PbsPack
 	{
 		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfJoinAssociativity));
 	}
+
+	// enable nested loop index plans using nest params
+	pbs->FExchangeSet(EopttraceEnableNestLoopParams);
 
 	return pbs;
 }

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -690,6 +690,9 @@ namespace gpdxl
 			// hash a DXL datum with GPDB's hash function
 			ULONG UlCdbHash(DrgPdxldatum *pdrgpdxldatum);
 
+			// translate nest loop colrefs to GPDB nestparams
+			List *TranslateNestLoopParamList(DrgPdxlcr *pdrgdxlcrOuterRefs, CDXLTranslateContext *dxltrctxLeft, CDXLTranslateContext *dxltrctxRight);
+
 	};
 }
 

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -437,7 +437,7 @@ select * from Tbl23383_partitioned where c='1';
 drop table Tbl23383_partitioned;
 -- end_ignore
 reset enable_seqscan;
--- when optimizer is on PG exception raised during DXL->PlStmt translation for IndexScan query
+-- negative test: due to non compatible cast and CXformGet2TableScan disabled no index plan possible, fallback to planner
 -- start_ignore
 drop table if exists tbl_ab;
 NOTICE:  table "tbl_ab" does not exist, skipping

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -22,30 +22,34 @@ CREATE TABLE bfv_tab1 (
 create index bfv_tab1_idx1 on bfv_tab1 using btree(unique1);
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..431.01 rows=1 width=256)
-   Hash Cond: bfv_tab1.unique1 = "Values".column1 AND bfv_tab1.stringu1::text = "Values".column2
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=244)
-         ->  Table Scan on bfv_tab1  (cost=0.00..431.00 rows=1 width=244)
-   ->  Hash  (cost=0.00..0.00 rows=1 width=12)
-         ->  Values Scan on "Values"  (cost=0.00..0.00 rows=1 width=12)
- Optimizer: PQO version 2.55.21
-(7 rows)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=256)
+   ->  Nested Loop  (cost=0.00..2.00 rows=1 width=256)
+         Join Filter: true
+         ->  Result  (cost=0.00..0.00 rows=1 width=12)
+               ->  Values Scan on "Values"  (cost=0.00..0.00 rows=1 width=12)
+         ->  Index Scan using bfv_tab1_idx1 on bfv_tab1  (cost=0.00..2.00 rows=1 width=244)
+               Index Cond: unique1 = "Values".column1
+               Filter: stringu1::text = "Values".column2
+ Optimizer: PQO version 2.64.0
+(9 rows)
 
 set gp_enable_relsize_collection=on;
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..431.01 rows=1 width=256)
-   Hash Cond: bfv_tab1.unique1 = "Values".column1 AND bfv_tab1.stringu1::text = "Values".column2
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=244)
-         ->  Table Scan on bfv_tab1  (cost=0.00..431.00 rows=1 width=244)
-   ->  Hash  (cost=0.00..0.00 rows=1 width=12)
-         ->  Values Scan on "Values"  (cost=0.00..0.00 rows=1 width=12)
- Optimizer: PQO version 2.55.21
-(7 rows)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=256)
+   ->  Nested Loop  (cost=0.00..2.00 rows=1 width=256)
+         Join Filter: true
+         ->  Result  (cost=0.00..0.00 rows=1 width=12)
+               ->  Values Scan on "Values"  (cost=0.00..0.00 rows=1 width=12)
+         ->  Index Scan using bfv_tab1_idx1 on bfv_tab1  (cost=0.00..2.00 rows=1 width=244)
+               Index Cond: unique1 = "Values".column1
+               Filter: stringu1::text = "Values".column2
+ Optimizer: PQO version 2.64.0
+(9 rows)
 
 reset gp_enable_relsize_collection;
 --start_ignore
@@ -437,10 +441,10 @@ select disable_xform('CXformGet2TableScan');
 
 -- end_ignore
 explain select * from tbl_ab where b::oid=1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=8)
-   ->  Seq Scan on tbl_ab  (cost=0.00..0.00 rows=1 width=8)
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1176.25 rows=87 width=8)
+   ->  Seq Scan on tbl_ab  (cost=0.00..1176.25 rows=29 width=8)
          Filter: b::oid = 1::oid
  Settings:  optimizer=on
  Optimizer status: legacy query optimizer
@@ -481,16 +485,16 @@ set seq_page_cost=10000000;
 set enable_indexscan=on;
 set enable_nestloop=on;
 explain select * from nestloop_x as x, nestloop_y as y where x.i + x.j < y.j;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324041.51 rows=56 width=16)
-   ->  Nested Loop  (cost=0.00..1324041.51 rows=19 width=16)
-         Join Filter: (nestloop_x.i + nestloop_x.j) < nestloop_y.j
-         ->  Table Scan on nestloop_x  (cost=0.00..431.00 rows=7 width=8)
-         ->  Materialize  (cost=0.00..431.00 rows=7 width=8)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=8)
-                     ->  Table Scan on nestloop_y  (cost=0.00..431.00 rows=3 width=8)
- Optimizer: PQO version 2.55.21
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..543.01 rows=56 width=16)
+   ->  Nested Loop  (cost=0.00..543.01 rows=19 width=16)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=8)
+               ->  Table Scan on nestloop_x  (cost=0.00..431.00 rows=7 width=8)
+         ->  Index Scan using nestloop_y_idx on nestloop_y  (cost=0.00..112.01 rows=1 width=8)
+               Index Cond: j > (nestloop_x.i + nestloop_x.j)
+ Optimizer: PQO version 2.64.0
 (8 rows)
 
 select * from nestloop_x as x, nestloop_y as y where x.i + x.j < y.j;
@@ -508,16 +512,16 @@ select * from nestloop_x as x, nestloop_y as y where x.i + x.j < y.j;
 (9 rows)
 
 explain select * from nestloop_x as x, nestloop_y as y where y.j > x.i + x.j + 2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324041.51 rows=56 width=16)
-   ->  Nested Loop  (cost=0.00..1324041.51 rows=19 width=16)
-         Join Filter: nestloop_y.j > (nestloop_x.i + nestloop_x.j + 2)
-         ->  Table Scan on nestloop_x  (cost=0.00..431.00 rows=7 width=8)
-         ->  Materialize  (cost=0.00..431.00 rows=7 width=8)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=8)
-                     ->  Table Scan on nestloop_y  (cost=0.00..431.00 rows=3 width=8)
- Optimizer: PQO version 2.55.21
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..543.01 rows=56 width=16)
+   ->  Nested Loop  (cost=0.00..543.01 rows=19 width=16)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=8)
+               ->  Table Scan on nestloop_x  (cost=0.00..431.00 rows=7 width=8)
+         ->  Index Scan using nestloop_y_idx on nestloop_y  (cost=0.00..112.01 rows=1 width=8)
+               Index Cond: j > (nestloop_x.i + nestloop_x.j + 2)
+ Optimizer: PQO version 2.64.0
 (8 rows)
 
 select * from nestloop_x as x, nestloop_y as y where y.j > x.i + x.j + 2;
@@ -533,6 +537,7 @@ drop table nestloop_x, nestloop_y;
 SET enable_seqscan = OFF;
 SET enable_indexscan = ON;
 DROP TABLE IF EXISTS bpchar_ops;
+NOTICE:  table "bpchar_ops" does not exist, skipping
 CREATE TABLE bpchar_ops(id INT8, v char(10)) DISTRIBUTED BY(id);
 CREATE INDEX bpchar_ops_btree_idx ON bpchar_ops USING btree(v bpchar_pattern_ops);
 INSERT INTO bpchar_ops VALUES (0, 'row');

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -423,7 +423,7 @@ select * from Tbl23383_partitioned where c='1';
 drop table Tbl23383_partitioned;
 -- end_ignore
 reset enable_seqscan;
--- when optimizer is on PG exception raised during DXL->PlStmt translation for IndexScan query
+-- negative test: due to non compatible cast and CXformGet2TableScan disabled no index plan possible, fallback to planner
 -- start_ignore
 drop table if exists tbl_ab;
 NOTICE:  table "tbl_ab" does not exist, skipping

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -124,7 +124,7 @@ insert into mpp23195_t2 values (1);
 select find_operator('select * from mpp23195_t1,mpp23195_t2 where mpp23195_t1.i < mpp23195_t2.i;', 'Dynamic Index Scan');
  find_operator 
 ---------------
- ['false']
+ ['true']
 (1 row)
 
 select * from mpp23195_t1,mpp23195_t2 where mpp23195_t1.i < mpp23195_t2.i;

--- a/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
+++ b/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
@@ -11,16 +11,18 @@ insert into co_nestloop_idxscan.bar values (1);
 create index foo_id_idx on co_nestloop_idxscan.foo(id);
 -- test with hash join
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
-         Hash Cond: foo.id = bar.id
-         ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-               ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 2.55.21
-(7 rows)
+   ->  Nested Loop  (cost=0.00..862.00 rows=1 width=8)
+         Join Filter: true
+         ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+         ->  Bitmap Table Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+               Recheck Cond: id = bar.id
+               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: id = bar.id
+ Optimizer: PQO version 2.64.0
+(9 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 
@@ -33,16 +35,18 @@ set optimizer_enable_hashjoin = off;
 set enable_hashjoin=off;
 set enable_nestloop=on;
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324033.35 rows=1 width=8)
-   ->  Nested Loop  (cost=0.00..1324033.35 rows=1 width=8)
-         Join Filter: foo.id = bar.id
-         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-               ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Nested Loop  (cost=0.00..862.00 rows=1 width=8)
+         Join Filter: true
          ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 2.55.21
-(7 rows)
+         ->  Bitmap Table Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+               Recheck Cond: id = bar.id
+               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: id = bar.id
+ Optimizer: PQO version 2.64.0
+(9 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 
@@ -56,16 +60,18 @@ set enable_seqscan = off;
 -- Known_opt_diff: OPT-929
 -- end_ignore
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324033.35 rows=1 width=8)
-   ->  Nested Loop  (cost=0.00..1324033.35 rows=1 width=8)
-         Join Filter: foo.id = bar.id
-         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-               ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Nested Loop  (cost=0.00..862.00 rows=1 width=8)
+         Join Filter: true
          ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 2.55.21
-(7 rows)
+         ->  Bitmap Table Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+               Recheck Cond: id = bar.id
+               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: id = bar.id
+ Optimizer: PQO version 2.64.0
+(9 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -71,19 +71,20 @@ analyze t1;
 -- Simple positive cases
 --
 explain select * from t, pt where tid = ptid;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.02 rows=18 width=50)
-   ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-         Hash Cond: pt.ptid = t.tid
-         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.01 rows=18 width=50)
+   ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+               ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+         ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                     Filter: pt.ptid = t.tid
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                           ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
-(10 rows)
+                     Partitions selected: 6 (out of 6)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
+                     Index Cond: ptid = $0
+ Optimizer: PQO version 2.64.0
+(11 rows)
 
 select * from t, pt where tid = ptid;
  dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -109,19 +110,20 @@ select * from t, pt where tid = ptid;
 (18 rows)
 
 explain select * from t, pt where tid + 1 = ptid;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.02 rows=18 width=50)
-   ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-         Hash Cond: pt.ptid = (t.tid + 1)
-         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.01 rows=18 width=50)
+   ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+               ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+         ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                     Filter: pt.ptid = (t.tid + 1)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                           ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
-(10 rows)
+                     Partitions selected: 6 (out of 6)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
+                     Index Cond: ptid = ($0 + 1)
+ Optimizer: PQO version 2.64.0
+(11 rows)
 
 select * from t, pt where tid + 1 = ptid;
  dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -147,20 +149,21 @@ select * from t, pt where tid + 1 = ptid;
 (18 rows)
 
 explain select * from t, pt where tid = ptid and t1 = 'hello' || tid;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.01 rows=9 width=50)
-   ->  Hash Join  (cost=0.00..862.01 rows=3 width=50)
-         Hash Cond: pt.ptid = t.tid
-         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..458.01 rows=9 width=50)
+   ->  Nested Loop  (cost=0.00..458.00 rows=3 width=50)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=19)
+               ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+                     Filter: t1 = ('hello'::text || tid::text)
+         ->  Sequence  (cost=0.00..27.00 rows=3 width=31)
                ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                     Filter: pt.ptid = t.tid
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=19)
-                           ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
-                                 Filter: t1 = ('hello'::text || tid::text)
- Optimizer: PQO version 2.55.21
-(11 rows)
+                     Partitions selected: 6 (out of 6)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..27.00 rows=3 width=31)
+                     Index Cond: ptid = $0
+ Optimizer: PQO version 2.64.0
+(12 rows)
 
 select * from t, pt where tid = ptid and t1 = 'hello' || tid;
  dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -186,19 +189,21 @@ select * from t, pt where tid = ptid and t1 = 'hello' || tid;
 (18 rows)
 
 explain select * from t, pt where t1 = pt1 and ptid = tid;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.02 rows=2 width=50)
-   ->  Hash Join  (cost=0.00..862.01 rows=1 width=50)
-         Hash Cond: pt.pt1 = t.t1 AND pt.ptid = t.tid
-         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..437.00 rows=2 width=50)
+   ->  Nested Loop  (cost=0.00..437.00 rows=1 width=50)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+               ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+         ->  Sequence  (cost=0.00..6.00 rows=1 width=31)
                ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                     Filter: pt.ptid = t.tid
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                           ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
-(10 rows)
+                     Partitions selected: 6 (out of 6)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=31)
+                     Index Cond: pt1 = $1
+                     Filter: ptid = $0
+ Optimizer: PQO version 2.64.0
+(12 rows)
 
 select * from t, pt where t1 = pt1 and ptid = tid;
  dist | tid |   t1   | t2  | dist |  pt1   |  pt2  |    pt3    | ptid 
@@ -296,21 +301,22 @@ select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello'
 -- group-by on top
 --
 explain select count(*) from t, pt where tid = ptid;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..862.01 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.01 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..862.01 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..862.01 rows=6 width=1)
-                     Hash Cond: pt.ptid = t.tid
-                     ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=4)
-                     ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..485.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.00 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..485.00 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..485.00 rows=6 width=1)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                           ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Sequence  (cost=0.00..54.00 rows=3 width=1)
                            ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                 Filter: pt.dist = t.tid
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                       ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.55.21
-(12 rows)
+                                 Partitions selected: 6 (out of 6)
+                           ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=1)
+                                 Index Cond: ptid = $0
+ Optimizer: PQO version 2.64.0
+(13 rows)
 
 select count(*) from t, pt where tid = ptid;
  count 
@@ -322,24 +328,25 @@ select count(*) from t, pt where tid = ptid;
 -- window function on top
 --
 explain select *, rank() over (order by ptid,pt1) from t, pt where tid = ptid;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- WindowAgg  (cost=0.00..862.03 rows=6 width=64)
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..485.02 rows=6 width=64)
    Order By: pt.ptid, pt.pt1
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.02 rows=18 width=50)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.02 rows=18 width=50)
          Merge Key: pt.ptid, pt.pt1
-         ->  Sort  (cost=0.00..862.02 rows=6 width=50)
+         ->  Sort  (cost=0.00..485.02 rows=6 width=50)
                Sort Key: pt.ptid, pt.pt1
-               ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-                     Hash Cond: pt.ptid = t.tid
-                     ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-                     ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+               ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+                           ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+                     ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                            ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                 Filter: pt.ptid = t.tid
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                                       ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
-(15 rows)
+                                 Partitions selected: 6 (out of 6)
+                           ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
+                                 Index Cond: ptid = $0
+ Optimizer: PQO version 2.64.0
+(16 rows)
 
 select *, rank() over (order by ptid,pt1) from t, pt where tid = ptid;
  dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid | rank 
@@ -370,28 +377,30 @@ select *, rank() over (order by ptid,pt1) from t, pt where tid = ptid;
 explain select * from t, pt where tid = ptid
 	  union all
 	  select * from t, pt where tid + 2 = ptid;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1724.03 rows=36 width=50)
-   ->  Append  (cost=0.00..1724.02 rows=12 width=50)
-         ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-               Hash Cond: dpe_single.pt.ptid = dpe_single.t.tid
-               ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-               ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..970.02 rows=36 width=50)
+   ->  Append  (cost=0.00..970.01 rows=12 width=50)
+         ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+                     ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+               ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                      ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                           Filter: dpe_single.pt.ptid = dpe_single.t.tid
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                                 ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
-         ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-               Hash Cond: dpe_single.pt.ptid = (dpe_single.t.tid + 2)
-               ->  Dynamic Table Scan on pt (dynamic scan id: 2)  (cost=0.00..431.00 rows=18 width=31)
-               ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                           Partitions selected: 6 (out of 6)
+                     ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
+                           Index Cond: ptid = $0
+         ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+                     ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+               ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                      ->  Partition Selector for pt (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                           Filter: dpe_single.pt.ptid = (dpe_single.t.tid + 2)
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                                 ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
-(19 rows)
+                           Partitions selected: 6 (out of 6)
+                     ->  Dynamic Index Scan on pt (dynamic scan id: 2)  (cost=0.00..54.00 rows=3 width=31)
+                           Index Cond: ptid = ($1 + 2)
+ Optimizer: PQO version 2.64.0
+(21 rows)
 
 select * from t, pt where tid = ptid
 	  union all
@@ -444,30 +453,32 @@ explain select count(*) from
 	  union all
 	  select * from t, pt where tid + 2 = ptid
 	  ) foo;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1724.02 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1724.02 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1724.02 rows=1 width=8)
-               ->  Append  (cost=0.00..1724.02 rows=12 width=1)
-                     ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-                           Hash Cond: dpe_single.pt.ptid = dpe_single.t.tid
-                           ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-                           ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..970.01 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..970.01 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..970.01 rows=1 width=8)
+               ->  Append  (cost=0.00..970.01 rows=12 width=1)
+                     ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+                           Join Filter: true
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+                                 ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+                           ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                                  ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                       Filter: dpe_single.pt.ptid = dpe_single.t.tid
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                                             ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
-                     ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-                           Hash Cond: dpe_single.pt.ptid = (dpe_single.t.tid + 2)
-                           ->  Dynamic Table Scan on pt (dynamic scan id: 2)  (cost=0.00..431.00 rows=18 width=31)
-                           ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                       Partitions selected: 6 (out of 6)
+                                 ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
+                                       Index Cond: ptid = $0
+                     ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+                           Join Filter: true
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+                                 ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+                           ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                                  ->  Partition Selector for pt (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                       Filter: dpe_single.pt.ptid = (dpe_single.t.tid + 2)
-                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                                             ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
-(21 rows)
+                                       Partitions selected: 6 (out of 6)
+                                 ->  Dynamic Index Scan on pt (dynamic scan id: 2)  (cost=0.00..54.00 rows=3 width=31)
+                                       Index Cond: ptid = ($1 + 2)
+ Optimizer: PQO version 2.64.0
+(23 rows)
 
 select count(*) from
 	( select * from t, pt where tid = ptid
@@ -486,19 +497,20 @@ set enable_hashjoin=off;
 set enable_nestloop=on;
 set enable_mergejoin=off;
 explain select * from t, pt where tid = ptid;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.02 rows=18 width=50)
-   ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-         Hash Cond: pt.ptid = t.tid
-         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.01 rows=18 width=50)
+   ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+               ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+         ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                     Filter: pt.ptid = t.tid
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                           ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
-(10 rows)
+                     Partitions selected: 6 (out of 6)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
+                     Index Cond: ptid = $0
+ Optimizer: PQO version 2.64.0
+(11 rows)
 
 select * from t, pt where tid = ptid;
  dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -532,24 +544,21 @@ set enable_indexscan=on;
 set enable_bitmapscan=off;
 set enable_hashjoin=off;
 explain select * from t, pt where tid = ptid and pt1 = 'hello0';
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..434.00 rows=1 width=50)
-   ->  Hash Join  (cost=0.00..434.00 rows=1 width=50)
-         Hash Cond: t.tid = pt.ptid
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=19)
-               Hash Key: t.tid
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..434.00 rows=1 width=50)
+   ->  Nested Loop  (cost=0.00..434.00 rows=1 width=50)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
                ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
-         ->  Hash  (cost=3.00..3.00 rows=1 width=31)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.00 rows=1 width=31)
-                     Hash Key: pt.ptid
-                     ->  Sequence  (cost=0.00..3.00 rows=1 width=31)
-                           ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                 Partitions selected: 6 (out of 6)
-                           ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..3.00 rows=1 width=31)
-                                 Index Cond: pt1 = 'hello0'::text
- Optimizer: PQO version 2.55.21
-(15 rows)
+         ->  Sequence  (cost=0.00..3.00 rows=1 width=31)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                     Partitions selected: 6 (out of 6)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..3.00 rows=1 width=31)
+                     Index Cond: pt1 = 'hello0'::text
+                     Filter: $0 = ptid
+ Optimizer: PQO version 2.64.0
+(12 rows)
 
 select * from t, pt where tid = ptid and pt1 = 'hello0';
  dist | tid |   t1   | t2  | dist |  pt1   |  pt2  |    pt3    | ptid 
@@ -565,19 +574,20 @@ set enable_indexscan=on;
 set enable_seqscan=off;
 set enable_hashjoin=off;
 explain select * from t, pt where tid = ptid;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.02 rows=18 width=50)
-   ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-         Hash Cond: pt.ptid = t.tid
-         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.01 rows=18 width=50)
+   ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+               ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+         ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                     Filter: pt.ptid = t.tid
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                           ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
-(10 rows)
+                     Partitions selected: 6 (out of 6)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
+                     Index Cond: ptid = $0
+ Optimizer: PQO version 2.64.0
+(11 rows)
 
 select * from t, pt where tid = ptid;
  dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -612,17 +622,17 @@ set enable_nestloop=off;
 explain select * from t, pt where t1 = pt1;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.01 rows=2 width=50)
-   ->  Hash Join  (cost=0.00..862.01 rows=1 width=50)
-         Hash Cond: pt.pt1 = t.t1
-         ->  Sequence  (cost=0.00..431.00 rows=18 width=31)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..437.00 rows=2 width=50)
+   ->  Nested Loop  (cost=0.00..437.00 rows=1 width=50)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+               ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+         ->  Sequence  (cost=0.00..6.00 rows=1 width=31)
                ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                      Partitions selected: 6 (out of 6)
-               ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-         ->  Hash  (cost=431.00..431.00 rows=2 width=19)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                     ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=31)
+                     Index Cond: pt1 = $0
+ Optimizer: PQO version 2.64.0
 (11 rows)
 
 select * from t, pt where t1 = pt1;
@@ -633,18 +643,20 @@ select * from t, pt where t1 = pt1;
 (2 rows)
 
 explain select * from t, pt where tid < ptid;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324044.90 rows=36 width=50)
-   ->  Nested Loop  (cost=0.00..1324044.89 rows=12 width=50)
-         Join Filter: t.tid < pt.ptid
-         ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-               Filter: t.tid < pt.ptid
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                     ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
-         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
- Optimizer: PQO version 2.55.21
-(9 rows)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..539.02 rows=36 width=50)
+   ->  Nested Loop  (cost=0.00..539.01 rows=12 width=50)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+               ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
+         ->  Sequence  (cost=0.00..108.01 rows=6 width=31)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                     Partitions selected: 6 (out of 6)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..108.01 rows=6 width=31)
+                     Index Cond: ptid > $0
+ Optimizer: PQO version 2.64.0
+(11 rows)
 
 select * from t, pt where tid < ptid;
  dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -736,19 +748,20 @@ select * from t, pt where tid < ptid;
 -- cascading joins
 --
 explain select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..1293.03 rows=12 width=69)
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=0.00..916.02 rows=12 width=69)
    Hash Cond: t1.t2 = t.t2
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.02 rows=18 width=50)
-         ->  Hash Join  (cost=0.00..862.01 rows=6 width=50)
-               Hash Cond: pt.ptid = t1.tid
-               ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
-               ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.01 rows=18 width=50)
+         ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
+                     ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=19)
+               ->  Sequence  (cost=0.00..54.00 rows=3 width=31)
                      ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                           Filter: pt.ptid = t1.tid
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
-                                 ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=19)
+                           Partitions selected: 6 (out of 6)
+                     ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
+                           Index Cond: ptid = $0
    ->  Hash  (cost=431.00..431.00 rows=1 width=19)
          ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
                ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19)
@@ -800,22 +813,23 @@ select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
 -- explain analyze
 --
 explain analyze select * from t, pt where tid = ptid;
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.02 rows=18 width=50) (actual time=2.055..2.088 rows=18 loops=1)
-   ->  Hash Join  (cost=0.00..862.01 rows=6 width=50) (actual time=1.407..1.795 rows=9 loops=1)
-         Hash Cond: pt.ptid = t.tid
-         (seg0)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
-         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31) (actual time=0.019..0.028 rows=9 loops=1)
-               Partitions scanned:  Avg 2.0 (out of 6) x 3 workers.  Max 2 parts (seg0).
-         ->  Hash  (cost=100.00..100.00 rows=34 width=4) (actual time=0.980..0.980 rows=2 loops=1)
-               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4) (actual time=0.972..0.975 rows=2 loops=1)
-                     Filter: pt.ptid = t.tid
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19) (actual time=0.956..0.957 rows=2 loops=1)
-                           ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19) (actual time=0.013..0.015 rows=2 loops=1)
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.01 rows=18 width=50) (actual time=0.750..0.755 rows=18 loops=1)
+   ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50) (actual time=0.313..0.524 rows=9 loops=1)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19) (actual time=0.208..0.358 rows=2 loops=1)
+               ->  Table Scan on t  (cost=0.00..431.00 rows=1 width=19) (actual time=0.020..0.021 rows=2 loops=1)
+         ->  Sequence  (cost=0.00..54.00 rows=3 width=31) (actual time=0.048..0.075 rows=4 loops=2)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4) (never executed)
+                     Partitions selected: 6 (out of 6)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31) (actual time=0.046..0.073 rows=4 loops=2)
+                     Index Cond: ptid = $0
+                     Partitions scanned:  Avg 6.0 (out of 6) x 3 workers of 2 scans.  Max 6 parts (seg0).
    (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 165K bytes avg x 3 workers, 167K bytes max (seg0).
-   (slice2)    Executor memory: 4323K bytes avg x 3 workers, 4323K bytes max (seg0).  Work_mem: 1K bytes max.
+   (slice1)    Executor memory: 60K bytes avg x 3 workers, 62K bytes max (seg0).
+   (slice2)    Executor memory: 155K bytes avg x 3 workers, 155K bytes max (seg0).
+   (slice3)    
  Memory used:  128000kB
  Optimizer: PQO version 2.55.21
  Total runtime: 2.810 ms
@@ -826,15 +840,15 @@ explain analyze select * from t, pt where tid = ptid;
 -- not projection capable.
 --
 explain select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt1.dist;
-                                                                                               QUERY PLAN                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..434.02 rows=9 width=62)
    Merge Key: pt1.dist
-   ->  Sort  (cost=0.00..434.01 rows=3 width=62)
+   ->  Sort  (cost=0.00..434.02 rows=3 width=62)
          Sort Key: pt1.dist
-         ->  Hash Join  (cost=0.00..434.01 rows=3 width=62)
+         ->  Hash Join  (cost=0.00..434.02 rows=3 width=62)
                Hash Cond: pt1.ptid = pt.ptid
-               ->  Dynamic Table Scan on pt1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=18 width=31)
+               ->  Dynamic Table Scan on pt1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=36 width=31)
                ->  Hash  (cost=100.00..100.00 rows=34 width=4)
                      ->  Partition Selector for pt1 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
                            Filter: pt1.ptid = pt.ptid
@@ -863,17 +877,16 @@ select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt
 (9 rows)
 
 explain select count(*) from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0';
-                                                                                               QUERY PLAN                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..434.01 rows=1 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..434.01 rows=1 width=8)
          ->  Aggregate  (cost=0.00..434.01 rows=1 width=8)
                ->  Hash Join  (cost=0.00..434.01 rows=3 width=1)
                      Hash Cond: pt1.ptid = pt.ptid
-                     ->  Dynamic Table Scan on pt1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=18 width=4)
+                     ->  Dynamic Table Scan on pt1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=36 width=4)
                      ->  Hash  (cost=100.00..100.00 rows=34 width=4)
                            ->  Partition Selector for pt1 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                 Filter: pt1.dist = pt.ptid
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.00 rows=1 width=4)
                                        ->  Result  (cost=0.00..3.00 rows=1 width=4)
                                              ->  Sequence  (cost=0.00..3.00 rows=1 width=11)

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -84,16 +84,18 @@ CREATE TABLE mpp22263 (
 create index mpp22263_idx1 on mpp22263 using btree(unique1);
 explain select * from mpp22263, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
 WHERE mpp22263.unique1 = v.i and mpp22263.stringu1 = v.j;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..431.01 rows=1 width=256)
-   Hash Cond: mpp22263.unique1 = "Values".column1 AND mpp22263.stringu1::text = "Values".column2
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=244)
-         ->  Table Scan on mpp22263  (cost=0.00..431.00 rows=1 width=244)
-   ->  Hash  (cost=0.00..0.00 rows=1 width=12)
-         ->  Values Scan on "Values"  (cost=0.00..0.00 rows=1 width=12)
- Optimizer: PQO version 2.55.21
-(7 rows)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=256)
+   ->  Nested Loop  (cost=0.00..2.00 rows=1 width=256)
+         Join Filter: true
+         ->  Result  (cost=0.00..0.00 rows=1 width=12)
+               ->  Values Scan on "Values"  (cost=0.00..0.00 rows=1 width=12)
+         ->  Index Scan using mpp22263_idx1 on mpp22263  (cost=0.00..2.00 rows=1 width=244)
+               Index Cond: unique1 = "Values".column1
+               Filter: stringu1::text = "Values".column2
+ Optimizer: PQO version 2.64.0
+(9 rows)
 
 -- atmsort.pm masks out differences in the Filter line, so just memorizing
 -- the output of the above EXPLAIN isn't enough to catch a faulty Filter line.
@@ -104,9 +106,11 @@ select * from mpp22263, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
 WHERE mpp22263.unique1 = v.i and mpp22263.stringu1 = v.j;
   $$) as et
 WHERE et like '%Filter: %';
- et 
-----
-(0 rows)
+                           et                            
+---------------------------------------------------------
+         Join Filter: true
+               Filter: stringu1::text = "Values".column2
+(2 rows)
 
 --
 -- Join condition in explain plan should represent constants with proper

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -3428,30 +3428,29 @@ select * from orca.r left outer join orca.s on (r.a=s.c and r.b<s.d) where s.d i
 -- explain Hash Join with 'IS NOT DISTINCT FROM' join condition
 -- force_explain
 explain  select * from orca.r, orca.s where r.a is not distinct from s.c;
-                                   QUERY PLAN
+                                   QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..862.01 rows=30 width=16)
-   ->  Hash Join  (cost=0.00..862.00 rows=15 width=16)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=30 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=10 width=16)
          Hash Cond: NOT s.c IS DISTINCT FROM r.a
-         ->  Table Scan on s  (cost=0.00..431.00 rows=15 width=8)
-         ->  Hash  (cost=431.00..431.00 rows=10 width=8)
-               ->  Table Scan on r  (cost=0.00..431.00 rows=10 width=8)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.602
-(8 rows)
+         ->  Table Scan on s  (cost=0.00..431.00 rows=10 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=7 width=8)
+               ->  Table Scan on r  (cost=0.00..431.00 rows=7 width=8)
+ Optimizer: PQO version 2.64.0
+(7 rows)
 
 -- explain Hash Join with equality join condition
 -- force_explain
 explain select * from orca.r, orca.s where r.a = s.c;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=30 width=16)
-   ->  Hash Join  (cost=0.00..862.00 rows=10 width=16)
-         Hash Cond: s.c = r.a
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..491.01 rows=30 width=16)
+   ->  Nested Loop  (cost=0.00..491.00 rows=10 width=16)
+         Join Filter: true
          ->  Table Scan on s  (cost=0.00..431.00 rows=10 width=8)
-         ->  Hash  (cost=431.00..431.00 rows=7 width=8)
-               ->  Table Scan on r  (cost=0.00..431.00 rows=7 width=8)
- Optimizer: PQO version 2.55.21
+         ->  Index Scan using r_a on r  (cost=0.00..60.00 rows=1 width=8)
+               Index Cond: a = s.c
+ Optimizer: PQO version 2.64.0
 (7 rows)
 
 -- sort
@@ -9620,31 +9619,43 @@ WHERE tq.sym = tt.symbol AND
       tt.event_ts <  tq.end_ts
 GROUP BY 1
 ORDER BY 1 asc ;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=352568.33..352570.83 rows=1000 width=16)
-   Merge Key: (tt.event_ts / 100000 / 5 * 5)
-   ->  Sort  (cost=352568.33..352570.83 rows=334 width=16)
-         Sort Key: (tt.event_ts / 100000 / 5 * 5)
-         ->  HashAggregate  (cost=352508.50..352518.50 rows=334 width=16)
-               Group Key: (tt.event_ts / 100000 / 5 * 5)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=352466.00..352493.50 rows=334 width=16)
-                     Hash Key: (tt.event_ts / 100000 / 5 * 5)
-                     ->  HashAggregate  (cost=352466.00..352473.50 rows=334 width=16)
-                           Group Key: tt.event_ts / 100000 / 5 * 5
-                           ->  Hash Join  (cost=604.00..352296.76 rows=11283 width=8)
-                                 Hash Cond: tq.sym::bpchar = tt.symbol
-                                 Join Filter: tt.event_ts >= tq.ets AND tt.event_ts < tq.end_ts AND plusone(tq.bid_price) < tt.trade_price
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1424.00 rows=13600 width=98)
-                                       Hash Key: tq.sym
-                                       ->  Append  (cost=0.00..608.00 rows=13600 width=98)
-                                             ->  Seq Scan on my_tq_agg_opt_part_1_prt_p1 tq  (cost=0.00..304.00 rows=6800 width=98)
-                                             ->  Seq Scan on my_tq_agg_opt_part_1_prt_p2 tq  (cost=0.00..304.00 rows=6800 width=98)
-                                 ->  Hash  (cost=324.00..324.00 rows=7467 width=108)
-                                       ->  Seq Scan on my_tt_agg_opt tt  (cost=0.00..324.00 rows=7467 width=108)
- Optimizer: legacy query optimizer
-(21 rows)
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=0.00..1305.01 rows=1 width=16)
+   Group Key: (share0_ref2.event_ts / 100000 / 5 * 5)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1305.01 rows=1 width=16)
+         Merge Key: (share0_ref2.event_ts / 100000 / 5 * 5)
+         ->  Result  (cost=0.00..1305.01 rows=1 width=16)
+               ->  GroupAggregate  (cost=0.00..1305.01 rows=1 width=16)
+                     Group Key: (share0_ref2.event_ts / 100000 / 5 * 5)
+                     ->  Sort  (cost=0.00..1305.01 rows=1 width=8)
+                           Sort Key: (share0_ref2.event_ts / 100000 / 5 * 5)
+                           ->  Result  (cost=0.00..1305.01 rows=1 width=8)
+                                 ->  Sequence  (cost=0.00..1305.01 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                                                   ->  Table Scan on my_tt_agg_opt  (cost=0.00..431.00 rows=1 width=62)
+                                       ->  Sequence  (cost=0.00..874.01 rows=1 width=8)
+                                             ->  Partition Selector for my_tq_agg_opt_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                                   Partitions selected: 2 (out of 2)
+                                             ->  Result  (cost=0.00..874.01 rows=1 width=8)
+                                                   ->  Append  (cost=0.00..874.01 rows=1 width=8)
+                                                         ->  Nested Loop  (cost=0.00..437.00 rows=1 width=132)
+                                                               Join Filter: true
+                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=62)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=62)
+                                                               ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=70)
+                                                                     Index Cond: ets <= share0_ref2.event_ts AND end_ts > share0_ref2.event_ts
+                                                                     Filter: sym::bpchar = share0_ref2.symbol AND plusone(bid_price) < share0_ref2.trade_price
+                                                         ->  Nested Loop  (cost=0.00..437.00 rows=1 width=132)
+                                                               Join Filter: true
+                                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=62)
+                                                                     ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=62)
+                                                               ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=70)
+                                                                     Index Cond: ets <= share0_ref3.event_ts
+                                                                     Filter: sym::bpchar = share0_ref3.symbol AND plusone(bid_price) < share0_ref3.trade_price AND share0_ref3.event_ts < end_ts
+ Optimizer: PQO version 2.64.0
+(34 rows)
 
 reset optimizer_segments;
 reset optimizer_enable_constant_expression_evaluation;
@@ -9718,15 +9729,15 @@ explain select id, comment from idxscan_outer as o join idxscan_inner as i on o.
 where ordernum between 10 and 20;
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..887716.68 rows=3 width=9)
-   ->  Nested Loop  (cost=0.00..887716.68 rows=1 width=9)
-         Join Filter: idxscan_outer.id = idxscan_inner.productid
-         ->  Index Scan using idxscan_inner_ordernum_key on idxscan_inner  (cost=0.00..4.91 rows=1 width=9)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..435.91 rows=3 width=9)
+   ->  Nested Loop  (cost=0.00..435.91 rows=1 width=9)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
+               ->  Table Scan on idxscan_outer  (cost=0.00..431.00 rows=3 width=4)
+         ->  Index Scan using idxscan_inner_ordernum_key on idxscan_inner  (cost=0.00..4.91 rows=1 width=5)
                Index Cond: ordernum >= 10 AND ordernum <= 20
-         ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
-                     ->  Table Scan on idxscan_outer  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.55.21
+               Filter: idxscan_outer.id = productid
+ Optimizer: PQO version 2.64.0
 (9 rows)
 
 select id, comment from idxscan_outer as o join idxscan_inner as i on o.id = i.productid
@@ -9774,10 +9785,10 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "index_test_pkey"
 insert into orca.index_test select i,i%2,i%3,i%4,i%5 from generate_series(1,100) i;
 -- force_explain
 explain select * from orca.index_test where a = 5;
-                                       QUERY PLAN
+                                       QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..3.00 rows=1 width=20)
-   ->  Index Scan using index_test_pkey on index_test  (cost=0.00..3.00 rows=1 width=20)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=20)
+   ->  Index Scan using index_test_pkey on index_test  (cost=0.00..2.00 rows=1 width=20)
          Index Cond: a = 5
  Settings:  optimizer=on
  Optimizer status: PQO version 1.602
@@ -9785,10 +9796,10 @@ explain select * from orca.index_test where a = 5;
 
 -- force_explain
 explain select * from orca.index_test where c = 5;
-                                       QUERY PLAN
+                                       QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..3.00 rows=1 width=20)
-   ->  Index Scan using index_test_pkey on index_test  (cost=0.00..3.00 rows=1 width=20)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=20)
+   ->  Index Scan using index_test_pkey on index_test  (cost=0.00..2.00 rows=1 width=20)
          Index Cond: c = 5
  Settings:  optimizer=on
  Optimizer status: PQO version 1.602
@@ -9796,10 +9807,10 @@ explain select * from orca.index_test where c = 5;
 
 -- force_explain
 explain select * from orca.index_test where a = 5 and c = 5;
-                                       QUERY PLAN
+                                       QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..3.00 rows=1 width=20)
-   ->  Index Scan using index_test_pkey on index_test  (cost=0.00..3.00 rows=1 width=20)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=20)
+   ->  Index Scan using index_test_pkey on index_test  (cost=0.00..2.00 rows=1 width=20)
          Index Cond: a = 5 AND c = 5
  Settings:  optimizer=on
  Optimizer status: PQO version 1.602
@@ -9889,10 +9900,10 @@ CREATE TABLE btree_test as SELECT * FROM generate_series(1,100) as a distributed
 CREATE INDEX btree_test_index ON btree_test(a);
 EXPLAIN SELECT * FROM btree_test WHERE a in (1, 47);
 INFO:  GPORCA failed to produce a plan, falling back to planner
-                                 QUERY PLAN
+                                 QUERY PLAN                                 
 ----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.25 rows=2 width=4)
-   ->  Seq Scan on btree_test  (cost=0.00..4.25 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.25 rows=2 width=4)
+   ->  Seq Scan on btree_test  (cost=0.00..2.25 rows=1 width=4)
          Filter: a = ANY ('{1,47}'::integer[])
  Settings:  optimizer=on; optimizer_metadata_caching=on
  Optimizer status: legacy query optimizer
@@ -9900,10 +9911,10 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('2', 47);
 INFO:  GPORCA failed to produce a plan, falling back to planner
-                                 QUERY PLAN
+                                 QUERY PLAN                                 
 ----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.25 rows=2 width=4)
-   ->  Seq Scan on btree_test  (cost=0.00..4.25 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.25 rows=2 width=4)
+   ->  Seq Scan on btree_test  (cost=0.00..2.25 rows=1 width=4)
          Filter: a = ANY ('{2,47}'::integer[])
  Settings:  optimizer=on; optimizer_metadata_caching=on
  Optimizer status: legacy query optimizer
@@ -9911,10 +9922,10 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2');
 INFO:  GPORCA failed to produce a plan, falling back to planner
-                                 QUERY PLAN
+                                 QUERY PLAN                                 
 ----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.25 rows=2 width=4)
-   ->  Seq Scan on btree_test  (cost=0.00..4.25 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.25 rows=2 width=4)
+   ->  Seq Scan on btree_test  (cost=0.00..2.25 rows=1 width=4)
          Filter: a = ANY ('{1,2}'::integer[])
  Settings:  optimizer=on; optimizer_metadata_caching=on
  Optimizer status: legacy query optimizer
@@ -9922,10 +9933,10 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2', 47);
 INFO:  GPORCA failed to produce a plan, falling back to planner
-                                 QUERY PLAN
+                                 QUERY PLAN                                 
 ----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.38 rows=3 width=4)
-   ->  Seq Scan on btree_test  (cost=0.00..4.38 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.38 rows=3 width=4)
+   ->  Seq Scan on btree_test  (cost=0.00..2.38 rows=1 width=4)
          Filter: a = ANY ('{1,2,47}'::integer[])
  Settings:  optimizer=on; optimizer_metadata_caching=on
  Optimizer status: legacy query optimizer
@@ -9935,7 +9946,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 CREATE TABLE bitmap_test as SELECT * FROM generate_series(1,100) as a distributed randomly;
 CREATE INDEX bitmap_index ON bitmap_test USING BITMAP(a);
 EXPLAIN SELECT * FROM bitmap_test WHERE a in (1);
-                                   QUERY PLAN
+                                   QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..204.38 rows=1 width=4)
    ->  Bitmap Table Scan on bitmap_test  (cost=0.00..204.38 rows=1 width=4)
@@ -9947,7 +9958,7 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in (1);
 (7 rows)
 
 EXPLAIN SELECT * FROM bitmap_test WHERE a in (1, 47);
-                                   QUERY PLAN
+                                   QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..408.76 rows=3 width=4)
    ->  Bitmap Table Scan on bitmap_test  (cost=0.00..408.76 rows=1 width=4)
@@ -9959,7 +9970,7 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in (1, 47);
 (7 rows)
 
 EXPLAIN SELECT * FROM bitmap_test WHERE a in ('2', 47);
-                                   QUERY PLAN
+                                   QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..408.76 rows=3 width=4)
    ->  Bitmap Table Scan on bitmap_test  (cost=0.00..408.76 rows=1 width=4)
@@ -10010,32 +10021,32 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 LOG:  Planner produced plan :0
                                                                    QUERY PLAN                                                                   
 ------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=10489.33..21118.58 rows=40897 width=28)
-   ->  Append  (cost=10489.33..21118.58 rows=13633 width=28)
-         ->  HashAggregate  (cost=10489.33..10909.06 rows=9328 width=28)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=10128.79..20306.02 rows=40897 width=28)
+   ->  Append  (cost=10128.79..20306.02 rows=13633 width=28)
+         ->  HashAggregate  (cost=10128.79..10408.61 rows=9328 width=28)
                Group Key: "rollup".unnamed_attr_2, "rollup".unnamed_attr_1, "rollup"."grouping", "rollup"."group_id"
-               ->  Subquery Scan on "rollup"  (cost=8552.10..10424.75 rows=1435 width=28)
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=8552.10..10381.70 rows=1435 width=28)
+               ->  Subquery Scan on "rollup"  (cost=8552.10..10074.98 rows=1435 width=28)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=8552.10..10031.93 rows=1435 width=28)
                            Hash Key: "rollup".unnamed_attr_2, "rollup".unnamed_attr_1, (Grouping), group_id()
-                           ->  GroupAggregate  (cost=8552.10..10295.60 rows=1435 width=28)
+                           ->  GroupAggregate  (cost=8552.10..9945.83 rows=1435 width=28)
                                  Group Key: "rollup"."grouping", "rollup"."group_id"
-                                 ->  Subquery Scan on "rollup"  (cost=8552.10..10134.17 rows=2153 width=28)
-                                       ->  GroupAggregate  (cost=8552.10..10069.60 rows=2153 width=28)
+                                 ->  Subquery Scan on "rollup"  (cost=8552.10..9822.06 rows=2153 width=28)
+                                       ->  GroupAggregate  (cost=8552.10..9757.49 rows=2153 width=28)
                                              Group Key: "rollup".unnamed_attr_2, "rollup"."grouping", "rollup"."group_id"
-                                             ->  Subquery Scan on "rollup"  (cost=8552.10..9843.60 rows=2870 width=28)
-                                                   ->  GroupAggregate  (cost=8552.10..9757.50 rows=2870 width=28)
+                                             ->  Subquery Scan on "rollup"  (cost=8552.10..9585.30 rows=2870 width=28)
+                                                   ->  GroupAggregate  (cost=8552.10..9499.20 rows=2870 width=28)
                                                          Group Key: share0_ref1.b, share0_ref1.a
                                                          ->  Sort  (cost=8552.10..8767.35 rows=28700 width=8)
                                                                Sort Key: share0_ref1.b, share0_ref1.a
                                                                ->  Shared Scan (share slice:id 1:0)  (cost=1391.50..1494.60 rows=28700 width=8)
                                                                      ->  Materialize  (cost=0.00..1391.50 rows=28700 width=8)
                                                                            ->  Seq Scan on foo  (cost=0.00..961.00 rows=28700 width=8)
-         ->  HashAggregate  (cost=9886.65..10080.37 rows=4305 width=28)
+         ->  HashAggregate  (cost=9639.11..9768.26 rows=4305 width=28)
                Group Key: "rollup".unnamed_attr_1, "rollup".unnamed_attr_2, "rollup"."grouping", "rollup"."group_id"
-               ->  Subquery Scan on "rollup"  (cost=8552.10..9822.07 rows=1435 width=28)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=8552.10..9779.02 rows=1435 width=28)
+               ->  Subquery Scan on "rollup"  (cost=8552.10..9585.30 rows=1435 width=28)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=8552.10..9542.25 rows=1435 width=28)
                            Hash Key: share0_ref2.a, share0_ref2.b, (Grouping), group_id()
-                           ->  GroupAggregate  (cost=8552.10..9692.92 rows=1435 width=28)
+                           ->  GroupAggregate  (cost=8552.10..9456.15 rows=1435 width=28)
                                  Group Key: share0_ref2.a
                                  ->  Sort  (cost=8552.10..8767.35 rows=28700 width=8)
                                        Sort Key: share0_ref2.a, share0_ref2.b
@@ -10146,14 +10157,13 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 -- end_ignore
 -- Query should not fallback to planner
 explain select * from foo where b in ('1', '2');
-                                  QUERY PLAN
+                                  QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=12)
-         Filter: b::text = ANY ('{1,2}'::character varying[]::text[])
- Settings:  optimizer=on; optimizer_metadata_caching=on
- Optimizer status: PQO version 2.1
-(5 rows)
+         Filter: b::text = ANY ('{1,2}'::text[])
+ Optimizer: PQO version 2.64.0
+(4 rows)
 
 set optimizer_enable_ctas = off;
 set log_statement='none';
@@ -10212,13 +10222,13 @@ INSERT INTO csq_cast_param_inner VALUES
 	(11, '11'),
 	(101, '12');
 EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
-                                                   QUERY PLAN
+                                                   QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.56 rows=2 width=4)
    ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
          ->  Table Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
                Filter: (SubPlan 1)
-               SubPlan 1
+               SubPlan 1  (slice2; segments: 3)
                  ->  Result  (cost=0.00..431.00 rows=2 width=4)
                        ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
@@ -10238,13 +10248,13 @@ DROP CAST (myint as int8);
 CREATE FUNCTION myint_numeric(myint) RETURNS numeric AS 'int4_numeric' LANGUAGE INTERNAL STRICT IMMUTABLE;
 CREATE CAST (myint AS numeric) WITH FUNCTION myint_numeric(myint) AS IMPLICIT;
 EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
-                                                   QUERY PLAN
+                                                   QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.56 rows=2 width=4)
    ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
          ->  Table Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
                Filter: (SubPlan 1)
-               SubPlan 1
+               SubPlan 1  (slice2; segments: 3)
                  ->  Result  (cost=0.00..431.00 rows=2 width=4)
                        ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2600,28 +2600,28 @@ explain (costs off) SELECT a.* FROM a LEFT JOIN b ON a.b_id = b.id;
                          QUERY PLAN                         
 ------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Hash Left Join
-         Hash Cond: a.b_id = b.id
+   ->  Nested Loop Left Join
+         Join Filter: true
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: a.b_id
                ->  Table Scan on a
-         ->  Hash
-               ->  Table Scan on b
- Optimizer: PQO version 2.55.21
+         ->  Index Scan using b_pkey on b
+               Index Cond: id = a.b_id
+ Optimizer: PQO version 2.64.0
 (9 rows)
 
 explain (costs off) SELECT b.* FROM b LEFT JOIN c ON b.c_id = c.id;
                          QUERY PLAN                         
 ------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Hash Left Join
-         Hash Cond: b.c_id = c.id
+   ->  Nested Loop Left Join
+         Join Filter: true
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: b.c_id
                ->  Table Scan on b
-         ->  Hash
-               ->  Table Scan on c
- Optimizer: PQO version 2.55.21
+         ->  Index Scan using c_pkey on c
+               Index Cond: id = b.c_id
+ Optimizer: PQO version 2.64.0
 (9 rows)
 
 explain (costs off)
@@ -2638,14 +2638,14 @@ explain (costs off)
          ->  Hash
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Hash Key: b.id
-                     ->  Hash Left Join
-                           Hash Cond: b.c_id = c.id
+                     ->  Nested Loop Left Join
+                           Join Filter: true
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: b.c_id
                                  ->  Table Scan on b
-                           ->  Hash
-                                 ->  Table Scan on c
- Optimizer: PQO version 2.55.21
+                           ->  Index Scan using c_pkey on c
+                                 Index Cond: id = b.c_id
+ Optimizer: PQO version 2.64.0
 (17 rows)
 
 -- check optimization of outer join within another special join
@@ -2660,12 +2660,12 @@ select id from a where id in (
          Hash Cond: a.id = b.id
          ->  Table Scan on a
          ->  Hash
-               ->  Hash Left Join
-                     Hash Cond: b.id = c.id
+               ->  Nested Loop Left Join
+                     Join Filter: true
                      ->  Table Scan on b
-                     ->  Hash
-                           ->  Table Scan on c
- Optimizer: PQO version 2.55.21
+                     ->  Index Scan using c_pkey on c
+                           Index Cond: id = b.id
+ Optimizer: PQO version 2.64.0
 (11 rows)
 
 rollback;
@@ -2689,12 +2689,12 @@ explain (costs off)
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Left Join
-         Hash Cond: parent.k = child.k
+   ->  Nested Loop Left Join
+         Join Filter: true
          ->  Table Scan on parent
-         ->  Hash
-               ->  Table Scan on child
- Optimizer: PQO version 2.55.21
+         ->  Index Scan using child_k_key on child
+               Index Cond: k = parent.k
+ Optimizer: PQO version 2.64.0
 (7 rows)
 
 -- this case is not

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -293,23 +293,19 @@ INSERT INTO barrescan values(5008);
 CREATE FUNCTION foorescan(int) RETURNS setof foorescan AS 'SELECT * FROM foorescan WHERE fooid = $1;' LANGUAGE SQL;
 --invokes ExecReScanFunctionScan with chgParam != NULL
 SELECT f.* FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) ORDER BY 1,2;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  SQL function "foorescan" statement 1
+ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"  (entry db 127.0.0.1:15432 pid=2755)
+CONTEXT:  SQL function "foorescan" during startup
 SELECT b.fooid, max(f.foosubid) FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) GROUP BY b.fooid ORDER BY 1,2;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  SQL function "foorescan" statement 1
+ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"  (entry db 127.0.0.1:15432 pid=2755)
+CONTEXT:  SQL function "foorescan" during startup
 CREATE VIEW fooview1 AS SELECT f.* FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) ORDER BY 1,2;
 SELECT * FROM fooview1 AS fv WHERE fv.fooid = 5004;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  SQL function "foorescan" statement 1
+ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"  (entry db 127.0.0.1:15432 pid=2755)
+CONTEXT:  SQL function "foorescan" during startup
 CREATE VIEW fooview2 AS SELECT b.fooid, max(f.foosubid) AS maxsubid FROM barrescan b, foorescan f WHERE f.fooid = b.fooid AND b.fooid IN (SELECT fooid FROM foorescan(b.fooid)) GROUP BY b.fooid ORDER BY 1,2;
 SELECT * FROM fooview2 AS fv WHERE fv.maxsubid = 5;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  SQL function "foorescan" statement 1
+ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"  (entry db 127.0.0.1:15432 pid=2755)
+CONTEXT:  SQL function "foorescan" during startup
 DROP VIEW vw_foorescan;
 DROP VIEW fooview1;
 DROP VIEW fooview2;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -110,7 +110,6 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
                                                ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                                      ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
                                                            ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                                                 Filter: NOT csq_t2.y IS NULL
                                                                  Partitions selected: 4 (out of 4)
                                                            ->  Dynamic Table Scan on csq_t2 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: PQO version 2.55.21
@@ -134,10 +133,10 @@ NOTICE:  table "mrs_t1" does not exist, skipping
 create table mrs_t1(x int) distributed by (x);
 insert into mrs_t1 select generate_series(1,20);
 explain select * from mrs_t1 where exists (select x from mrs_t1 where x < -1);
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1293.00 rows=20 width=4)
-   ->  Nested Loop Semi Join  (cost=0.00..1293.00 rows=10 width=4)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=20 width=4)
+   ->  Nested Loop Semi Join  (cost=0.00..1293.00 rows=7 width=4)
          Join Filter: true
          ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
@@ -156,10 +155,10 @@ select * from mrs_t1 where exists (select x from mrs_t1 where x < -1) order by 1
 (0 rows)
 
 explain select * from mrs_t1 where exists (select x from mrs_t1 where x = 1);
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1293.00 rows=20 width=4)
-   ->  Nested Loop Semi Join  (cost=0.00..1293.00 rows=10 width=4)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=20 width=4)
+   ->  Nested Loop Semi Join  (cost=0.00..1293.00 rows=7 width=4)
          Join Filter: true
          ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
@@ -278,12 +277,11 @@ insert into csq_d1 select * from csq_m1;
 explain select array(select x from csq_m1); -- no initplan
                           QUERY PLAN                          
 --------------------------------------------------------------
- Result  (cost=1.01..1.02 rows=1 width=0)
+ Result  (cost=1.00..1.01 rows=1 width=0)
    InitPlan 1 (returns $0)
-     ->  Seq Scan on csq_m1  (cost=0.00..1.01 rows=1 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: legacy query optimizer
-(5 rows)
+     ->  Seq Scan on csq_m1  (cost=0.00..1.00 rows=1 width=4)
+ Optimizer: legacy query optimizer
+(4 rows)
 
 select array(select x from csq_m1); -- {1}
  ?column? 
@@ -296,7 +294,7 @@ explain select array(select x from csq_d1); -- initplan
 ------------------------------------------------------------------------------------
  Result  (cost=1.01..1.02 rows=1 width=0)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.01 rows=1 width=4)
+     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
            ->  Seq Scan on csq_d1  (cost=0.00..1.01 rows=1 width=4)
  Settings:  optimizer=on; optimizer_segments=3
  Optimizer status: legacy query optimizer
@@ -407,32 +405,31 @@ select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
 -- outer plan node is master-only and CSQ has distributed relation
 --
 explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- broadcast motion
-                                                                                                     QUERY PLAN                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..1293.00 rows=2 width=4)
+                                                                                                                                                                 QUERY PLAN                                                                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
-         Filter: CASE WHEN NOT csq_d1.x IS NULL THEN CASE WHEN "ColRef_0018" = "ColRef_0017" THEN NULL::boolean WHEN NOT "ColRef_0018" IS NULL THEN false ELSE true END ELSE NULL::boolean END OR csq_d1.x < (-100)
+         Filter: CASE WHEN NOT csq_d1.x IS NULL THEN CASE WHEN (pg_catalog.sum((sum((CASE WHEN csq_m1.x IS NULL THEN 1 ELSE 0 END))))) = (count((count()))) THEN NULL::boolean WHEN NOT (pg_catalog.sum((sum((CASE WHEN csq_m1.x IS NULL THEN 1 ELSE 0 END))))) IS NULL THEN false ELSE true END ELSE NULL::boolean END OR csq_d1.x < (-100)
          ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
                ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
                      Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..1293.00 rows=1 width=30)
-                           Hash Key: csq_d1.gp_segment_id
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
+                           Hash Key: csq_d1.ctid, csq_d1.gp_segment_id
                            ->  Result  (cost=0.00..1293.00 rows=1 width=30)
                                  ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
                                        Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-                                       ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=3 width=18)
+                                       ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=18)
                                              Join Filter: csq_d1.x = csq_m1.x OR csq_m1.x IS NULL
                                              ->  Sort  (cost=0.00..431.00 rows=1 width=14)
                                                    Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
                                                    ->  Table Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                                             ->  Result  (cost=0.00..431.00 rows=5 width=8)
-                                                   ->  Materialize  (cost=0.00..431.00 rows=5 width=4)
-                                                         ->  Broadcast Motion 1:2  (slice1)  (cost=0.00..431.00 rows=9 width=4)
-                                                               ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
-(23 rows)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                                         ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=3 width=4)
+                                                               ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.64.0
+(22 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
  x 
@@ -466,6 +463,7 @@ select count(*) from csq_t1 t1 where a > ( select avg(a)::int from csq_t1 t2 whe
 --
 CREATE OR REPLACE FUNCTION csq_f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL CONTAINS SQL;
 DROP TABLE IF EXISTS csq_r;
+NOTICE:  table "csq_r" does not exist, skipping
 CREATE TABLE csq_r(a int) distributed by (a);
 INSERT INTO csq_r VALUES (1);
 -- subqueries shouldn't be pulled into a join if the from clause has a function call
@@ -569,10 +567,10 @@ SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1);
 explain SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..862.00 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Table Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a < ((subplan))
-         SubPlan 1
+         Filter: a < ((SubPlan 1))
+         SubPlan 1  (slice1; segments: 3)
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on; optimizer_segments=3
@@ -588,10 +586,10 @@ SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
 explain SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..862.00 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Table Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a <= ((subplan))
-         SubPlan 1
+         Filter: a <= ((SubPlan 1))
+         SubPlan 1  (slice1; segments: 3)
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on; optimizer_segments=3
@@ -609,16 +607,16 @@ SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
 explain SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1724.00 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1724.00 rows=1 width=4)
    ->  Table Scan on csq_r  (cost=0.00..1724.00 rows=1 width=4)
-         Filter: (subplan)
-         SubPlan 1
-           ->  Nested Loop  (cost=0.00..862.00 rows=2 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Nested Loop  (cost=0.00..862.00 rows=1 width=4)
                  Join Filter: true
                  ->  Result  (cost=0.00..0.00 rows=1 width=4)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
-                 ->  Materialize  (cost=0.00..431.00 rows=2 width=1)
-                       ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=2 width=1)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                              ->  Table Scan on csq_r  (cost=0.00..431.00 rows=1 width=1)
  Settings:  optimizer=on; optimizer_segments=3
  Optimizer status: PQO version 1.621
@@ -810,10 +808,10 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.t=t1.t and t1.i = 1);
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..862.00 rows=1 width=19)
-   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=19)
-         Hash Cond: public.csq_pullup.t = public.csq_pullup.t
-         ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=19)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
+   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=17)
+         Hash Cond: subselect_gp.csq_pullup.t = subselect_gp.csq_pullup.t
+         ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Result  (cost=0.00..431.00 rows=1 width=4)
                      ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=4)
@@ -835,12 +833,12 @@ select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where 
 explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.i=t1.i + 1);
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..862.00 rows=1 width=19)
-   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=19)
-         Hash Cond: public.csq_pullup.i = (public.csq_pullup.i + 1)
-         ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=19)
-         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-               ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=2 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
+   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=17)
+         Hash Cond: subselect_gp.csq_pullup.i = (subselect_gp.csq_pullup.i + 1)
+         ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                      ->  Result  (cost=0.00..431.00 rows=1 width=4)
                            ->  Result  (cost=0.00..431.00 rows=1 width=4)
                                  ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=4)
@@ -870,15 +868,14 @@ analyze subselect_t2;
 explain select * from subselect_t1 where x in (select y from subselect_t2);
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..862.00 rows=2 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
    ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
          Hash Cond: subselect_t1.x = subselect_t2.y
          ->  Table Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-               ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
-(8 rows)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.64.0
+(7 rows)
 
 select * from subselect_t1 where x in (select y from subselect_t2);
  x 
@@ -893,16 +890,16 @@ select * from subselect_t1 where x in (select y from subselect_t2);
 explain select * from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1293.00 rows=2 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Hash Join  (cost=0.00..1293.00 rows=1 width=4)
-         Hash Cond: "outer".y = subselect_t1.x
+         Hash Cond: subselect_gp.subselect_t2.y = subselect_t1.x
          ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
-               Group Key: y
-               ->  Sort  (cost=0.00..862.00 rows=3 width=4)
-                     Sort Key: y
-                     ->  Append  (cost=0.00..862.00 rows=3 width=4)
-                           ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=2 width=4)
-                           ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=2 width=4)
+               Group Key: subselect_gp.subselect_t2.y
+               ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+                     Sort Key: subselect_gp.subselect_t2.y
+                     ->  Append  (cost=0.00..862.00 rows=2 width=4)
+                           ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Table Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on; optimizer_segments=3
@@ -920,16 +917,15 @@ explain select count(*) from subselect_t1 where x in (select y from subselect_t2
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..862.00 rows=1 width=8)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
          ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
                ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
                      Hash Cond: subselect_t1.x = subselect_t2.y
                      ->  Table Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-                           ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
-(10 rows)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.64.0
+(9 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2);
  count 
@@ -944,17 +940,17 @@ explain select count(*) from subselect_t1 where x in (select y from subselect_t2
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
          ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
                ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
-                     Hash Cond: "outer".y = subselect_t1.x
+                     Hash Cond: subselect_gp.subselect_t2.y = subselect_t1.x
                      ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
-                           Group Key: y
-                           ->  Sort  (cost=0.00..862.00 rows=3 width=4)
-                                 Sort Key: y
-                                 ->  Append  (cost=0.00..862.00 rows=3 width=4)
-                                       ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=2 width=4)
-                                       ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=2 width=4)
+                           Group Key: subselect_gp.subselect_t2.y
+                           ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+                                 Sort Key: subselect_gp.subselect_t2.y
+                                 ->  Append  (cost=0.00..862.00 rows=2 width=4)
+                                       ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                            ->  Table Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on; optimizer_segments=3
@@ -1045,8 +1041,8 @@ explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
 explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
 union all
 select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
-                  QUERY PLAN                   
------------------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=4)
    One-Time Filter: false
  Settings:  optimizer=on; optimizer_segments=3
@@ -1085,17 +1081,17 @@ where t1.a = foo.a;
 insert into t1 values (1);
 insert into t2 values (1);
 explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
-                                                  QUERY PLAN
+                                                  QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1293.00 rows=1 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=1)
          Filter: (SubPlan 1)
          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=4)
-         SubPlan 1
+         SubPlan 1  (slice0)
            ->  Limit  (cost=0.00..431.00 rows=1 width=4)
                  ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                       Filter: $1 = 1
+                       Filter: t1.a = 1
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
@@ -1104,17 +1100,17 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
 (14 rows)
 
 explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
-                                                  QUERY PLAN
+                                                  QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1293.00 rows=1 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=1)
          Filter: (SubPlan 1)
          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=4)
-         SubPlan 1
+         SubPlan 1  (slice0)
            ->  Limit  (cost=0.00..431.00 rows=1 width=4)
                  ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                       Filter: $1 = 1
+                       Filter: t1.a = 1
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
@@ -1428,31 +1424,30 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
   WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL) ORDER BY 2;
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=1 width=12)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+ Result  (cost=0.00..862.00 rows=3 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=7 width=4)
          Merge Key: subselect_gp.subselect_tbl.f1
-         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+         ->  Sort  (cost=0.00..862.00 rows=3 width=4)
                Sort Key: subselect_gp.subselect_tbl.f1
                ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=4)
                      Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
-                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  Hash Key: subselect_gp.subselect_tbl.f2
-                                 ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: PQO version 2.34.1
-(14 rows)
+                                 ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: PQO version 2.64.0
+(13 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
   WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE
     f2 IN (SELECT f1 FROM SUBSELECT_TBL)) ORDER BY 2;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1293.00 rows=1 width=12)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=4)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1293.00 rows=2 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=5 width=4)
          Merge Key: subselect_gp.subselect_tbl.f1
-         ->  Sort  (cost=0.00..1293.00 rows=1 width=4)
+         ->  Sort  (cost=0.00..1293.00 rows=2 width=4)
                Sort Key: subselect_gp.subselect_tbl.f1
                ->  Hash Join  (cost=0.00..1293.00 rows=2 width=4)
                      Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
@@ -1479,11 +1474,11 @@ EXPLAIN SELECT '' AS three, f1, f2
                          WHERE f3 IS NOT NULL) ORDER BY 2,3;
                                                                              QUERY PLAN                                                                              
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=11.20..11.22 rows=8 width=8)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000009.64..10000000009.64 rows=4 width=8)
    Merge Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
-   ->  Sort  (cost=11.20..11.22 rows=3 width=8)
+   ->  Sort  (cost=10000000009.64..10000000009.64 rows=2 width=8)
          Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
-         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=3.38..11.08 rows=3 width=8)
+         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10000000009.61 rows=2 width=8)
                Join Filter: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2 AND subselect_gp.subselect_tbl.f2 = subselect_gp.subselect_tbl.f3::integer
                ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=8)
                ->  Materialize  (cost=3.38..3.59 rows=7 width=12)
@@ -1522,19 +1517,18 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
   WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1) ORDER BY 2,3;
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=1 width=16)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+ Result  (cost=0.00..862.00 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
          Merge Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
-         ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+         ->  Sort  (cost=0.00..862.00 rows=3 width=8)
                Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f2
                ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
                      Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f1 AND subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
-                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-                           ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=8)
- Settings:  optimizer=on
- Optimizer status: PQO version 2.34.1
-(12 rows)
+                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=8)
+                           ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: PQO version 2.64.0
+(11 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
   FROM SUBSELECT_TBL upper
@@ -1542,21 +1536,20 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
     (SELECT f2 FROM SUBSELECT_TBL WHERE CAST(upper.f2 AS float) = f3) ORDER BY 2,3;
                                                                                     QUERY PLAN                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=1 width=20)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+ Result  (cost=0.00..862.00 rows=3 width=20)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=8 width=12)
          Merge Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f3
-         ->  Sort  (cost=0.00..862.00 rows=1 width=12)
+         ->  Sort  (cost=0.00..862.00 rows=3 width=12)
                Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f3
                ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=12)
                      Hash Cond: subselect_gp.subselect_tbl.f2::double precision = subselect_gp.subselect_tbl.f3 AND subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2
-                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=16)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=16)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=12)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=12)
                                  Hash Key: subselect_gp.subselect_tbl.f2
-                                 ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=1 width=12)
- Settings:  optimizer=on
- Optimizer status: PQO version 2.34.1
-(14 rows)
+                                 ->  Table Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=12)
+ Optimizer: PQO version 2.64.0
+(13 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
   FROM SUBSELECT_TBL upper
@@ -1571,7 +1564,7 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
                Sort Key: subselect_gp.subselect_tbl.f1, subselect_gp.subselect_tbl.f3
                ->  Table Scan on subselect_tbl  (cost=0.00..1324033.89 rows=3 width=12)
                      Filter: (SubPlan 1)
-                     SubPlan 1
+                     SubPlan 1  (slice2; segments: 3)
                        ->  Result  (cost=0.00..431.00 rows=4 width=4)
                              ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
                                    ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
@@ -1586,17 +1579,17 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
                      WHERE f3 IS NOT NULL) ORDER BY 2;
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=2.13..2.14 rows=4 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=6.67..6.69 rows=8 width=4)
    Merge Key: subselect_gp.subselect_tbl.f1
-   ->  Sort  (cost=2.13..2.14 rows=2 width=4)
+   ->  Sort  (cost=6.67..6.69 rows=3 width=4)
          Sort Key: subselect_gp.subselect_tbl.f1
-         ->  Hash Semi Join  (cost=3.33..6.49 rows=2 width=4)
+         ->  Hash Semi Join  (cost=3.33..6.55 rows=3 width=4)
                Hash Cond: subselect_gp.subselect_tbl.f1 = subselect_gp.subselect_tbl.f2 AND subselect_gp.subselect_tbl.f2 = subselect_gp.subselect_tbl.f3::integer
                ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=8)
                ->  Hash  (cost=3.22..3.22 rows=3 width=12)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.22 rows=3 width=12)
                            Hash Key: subselect_gp.subselect_tbl.f2
-                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+                           ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=12)
                                  Filter: f3 IS NOT NULL
  Settings:  optimizer=on
  Optimizer status: legacy query optimizer
@@ -1609,115 +1602,115 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.06 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..864.06 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..864.06 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..864.06 rows=34 width=1)
-                     Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
-                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
-                     ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                           ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                 Group Key: public.tenk1.hundred
-                                 ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                       Sort Key: public.tenk1.hundred
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                             Hash Key: public.tenk1.hundred
-                                             ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                   Group Key: public.tenk1.hundred
-                                                   ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
- Optimizer: PQO version 2.55.21
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..631.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..631.98 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..631.98 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..631.98 rows=34 width=1)
+                     Join Filter: true
+                     ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                           Group Key: public.tenk1.hundred
+                           ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                 Sort Key: public.tenk1.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                       Hash Key: public.tenk1.hundred
+                                       ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                             Group Key: public.tenk1.hundred
+                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                     ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=1)
+                           Index Cond: unique1 = public.tenk1.hundred
+ Optimizer: PQO version 2.64.0
 (17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.10 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..631.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..631.98 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
                Group Key: public.tenk1.ten
-               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
+               ->  Sort  (cost=0.00..631.98 rows=4 width=4)
                      Sort Key: public.tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..631.98 rows=4 width=4)
                            Hash Key: public.tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
+                           ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
                                  Group Key: public.tenk1.ten
-                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
+                                 ->  Sort  (cost=0.00..631.98 rows=34 width=4)
                                        Sort Key: public.tenk1.ten
-                                       ->  Hash Join  (cost=0.00..864.10 rows=34 width=4)
-                                             Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
-                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                         Group Key: public.tenk1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: public.tenk1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                                     Hash Key: public.tenk1.hundred
-                                                                     ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                                           Group Key: public.tenk1.hundred
-                                                                           ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
- Optimizer: PQO version 2.55.21
+                                       ->  Nested Loop  (cost=0.00..631.98 rows=34 width=4)
+                                             Join Filter: true
+                                             ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                   Group Key: public.tenk1.hundred
+                                                   ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                                         Sort Key: public.tenk1.hundred
+                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                               Hash Key: public.tenk1.hundred
+                                                               ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                                     Group Key: public.tenk1.hundred
+                                                                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                                             ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=4)
+                                                   Index Cond: unique1 = public.tenk1.hundred
+ Optimizer: PQO version 2.64.0
 (26 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.06 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..864.06 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..864.06 rows=1 width=8)
-               ->  Hash Semi Join  (cost=0.00..864.06 rows=34 width=1)
-                     Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
-                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
-                     ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                           ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                 Group Key: public.tenk1.hundred
-                                 ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                       Sort Key: public.tenk1.hundred
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                             Hash Key: public.tenk1.hundred
-                                             ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                   Group Key: public.tenk1.hundred
-                                                   ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
- Optimizer: PQO version 2.55.21
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..631.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..631.98 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..631.98 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..631.98 rows=34 width=1)
+                     Join Filter: true
+                     ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                           Group Key: public.tenk1.hundred
+                           ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                 Sort Key: public.tenk1.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                       Hash Key: public.tenk1.hundred
+                                       ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                             Group Key: public.tenk1.hundred
+                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                     ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=1)
+                           Index Cond: unique1 = public.tenk1.hundred
+ Optimizer: PQO version 2.64.0
 (17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.10 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..631.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..631.98 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
                Group Key: public.tenk1.ten
-               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
+               ->  Sort  (cost=0.00..631.98 rows=4 width=4)
                      Sort Key: public.tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..631.98 rows=4 width=4)
                            Hash Key: public.tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
+                           ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
                                  Group Key: public.tenk1.ten
-                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
+                                 ->  Sort  (cost=0.00..631.98 rows=34 width=4)
                                        Sort Key: public.tenk1.ten
-                                       ->  Hash Semi Join  (cost=0.00..864.10 rows=34 width=4)
-                                             Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
-                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                         Group Key: public.tenk1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: public.tenk1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                                     Hash Key: public.tenk1.hundred
-                                                                     ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                                           Group Key: public.tenk1.hundred
-                                                                           ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
- Optimizer: PQO version 2.55.21
+                                       ->  Nested Loop  (cost=0.00..631.98 rows=34 width=4)
+                                             Join Filter: true
+                                             ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                   Group Key: public.tenk1.hundred
+                                                   ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                                         Sort Key: public.tenk1.hundred
+                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                               Hash Key: public.tenk1.hundred
+                                                               ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                                     Group Key: public.tenk1.hundred
+                                                                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                                             ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=4)
+                                                   Index Cond: unique1 = public.tenk1.hundred
+ Optimizer: PQO version 2.64.0
 (26 rows)
 
 --
@@ -1727,16 +1720,16 @@ EXPLAIN select count(distinct ss.ten) from
 -- we should see 2 subplans in the explain
 --
 EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
-                                                 QUERY PLAN
+                                                 QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..865.54 rows=1 width=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..865.54 rows=1 width=1)
-         ->  Limit  (cost=0.00..865.54 rows=1 width=1)
-               ->  Result  (cost=0.00..865.54 rows=3353 width=1)
-                     ->  Result  (cost=0.00..865.53 rows=6137 width=8)
-                           ->  Hash Left Join  (cost=0.00..865.49 rows=6137 width=8)
+ Limit  (cost=0.00..865.44 rows=1 width=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..865.44 rows=1 width=1)
+         ->  Limit  (cost=0.00..865.44 rows=1 width=1)
+               ->  Result  (cost=0.00..865.44 rows=3361 width=1)
+                     ->  Result  (cost=0.00..865.44 rows=3361 width=8)
+                           ->  Hash Left Join  (cost=0.00..865.41 rows=3361 width=8)
                                  Hash Cond: tenk2.unique1 = tenk1.unique1
-                                 ->  Table Scan on tenk2  (cost=0.00..431.51 rows=3353 width=4)
+                                 ->  Table Scan on tenk2  (cost=0.00..431.51 rows=3361 width=4)
                                  ->  Hash  (cost=431.96..431.96 rows=3319 width=12)
                                        ->  HashAggregate  (cost=0.00..431.96 rows=3319 width=12)
                                              Group Key: tenk1.unique1

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -192,7 +192,7 @@ drop table Tbl23383_partitioned;
 
 reset enable_seqscan;
 
--- when optimizer is on PG exception raised during DXL->PlStmt translation for IndexScan query
+-- negative test: due to non compatible cast and CXformGet2TableScan disabled no index plan possible, fallback to planner
 
 -- start_ignore
 drop table if exists tbl_ab;


### PR DESCRIPTION
Translate nestparams passed from ORCA to create the nestparams node in Nested Loop joins.

This feature can be enabled by setting the trace flag EopttraceEnableNestLoopParams.

Co-authored-by: Abhijit Subramanya <asubramanya@pivotal.io>
Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>