### PR TITLE
gpload: Wait for gpfdist to exit after kill

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2815,6 +2815,7 @@ class gpload:
 
                     else:
                         os.kill(a.pid, signal.SIGKILL)
+                        os.waitpid(a.pid, 0)
                 except OSError:
                     pass
         self.log(self.LOG, 'terminating all threads')


### PR DESCRIPTION
gpload will kill all gpfdist processes after finished loading. Without
waiting these processes will become zombies and sometimes causes
gpload to hang.