### PR TITLE
Fix external schema bug in fast_match

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -426,7 +426,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_00_gpload_formatOpts_setup(self):
         "0  gpload setup"
-        for num in range(1,33):
+        for num in range(1,34):
            f = open(mkpath('query%d.sql' % num),'w')
            f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n"+"\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
            f.close()
@@ -690,6 +690,13 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         copy_data('external_file_08.txt','data_file.txt')
         write_config_file(mode='update',reuse_flag='false',fast_match='true',file='data_file.txt')
         self.doTest(32)
+    def test_33_gpload_reuse_table_merge_mode_with_fast_match_and_external_schema(self):
+        "33  gpload update mode with fast match and external schema"
+        file = mkpath('setup.sql')
+        runfile(file)
+        copy_data('external_file_04.txt','data_file.txt')
+        write_config_file(mode='merge',reuse_flag='true',fast_match='true',file='data_file.txt',externalSchema='test')
+        self.doTest(33)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(GPLoad_FormatOpts_TestCase)

--- a/gpMgmt/bin/gpload_test/gpload2/query33.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query33.ans
@@ -1,0 +1,20 @@
+2018-07-24 06:14:29|INFO|gpload session started 2018-07-24 06:14:29
+2018-07-24 06:14:29|INFO|setting schema 'public' for table 'texttable'
+2018-07-24 06:14:29|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-07-24 06:14:29|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-07-24 06:14:29|INFO|did not find an external table to reuse. creating test.ext_gpload_reusable_d2e95f76_8f08_11e8_8c76_0242ac110002
+2018-07-24 06:14:29|INFO|running time: 0.40 seconds
+2018-07-24 06:14:29|INFO|rows Inserted          = 16
+2018-07-24 06:14:29|INFO|rows Updated           = 0
+2018-07-24 06:14:29|INFO|data formatting errors = 0
+2018-07-24 06:14:29|INFO|gpload succeeded
+2018-07-24 06:14:30|INFO|gpload session started 2018-07-24 06:14:30
+2018-07-24 06:14:30|INFO|setting schema 'public' for table 'texttable'
+2018-07-24 06:14:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-07-24 06:14:30|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-07-24 06:14:30|INFO|reusing external table test.ext_gpload_reusable_d2e95f76_8f08_11e8_8c76_0242ac110002
+2018-07-24 06:14:30|INFO|running time: 0.31 seconds
+2018-07-24 06:14:30|INFO|rows Inserted          = 0
+2018-07-24 06:14:30|INFO|rows Updated           = 16
+2018-07-24 06:14:30|INFO|data formatting errors = 0
+2018-07-24 06:14:30|INFO|gpload succeeded


### PR DESCRIPTION
- The results of fast_match SQL don't include shema name, so we need
add shema name to extSchemaTable for fast_match
- Remove locationStr which is unused