### PR TITLE
Updating ports in sample configs to match best practices

### DIFF
--- a/gpMgmt/doc/gpconfigs/gpinitsystem_config
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_config
@@ -14,7 +14,7 @@ SEG_PREFIX=gpseg
 
 #### Base number by which primary segment port numbers 
 #### are calculated.
-PORT_BASE=20000
+PORT_BASE=6000
 
 #### File system location(s) where primary segment data directories 
 #### will be created. The number of locations in the list dictate
@@ -49,15 +49,15 @@ ENCODING=UNICODE
 
 #### Base number by which mirror segment port numbers 
 #### are calculated.
-#MIRROR_PORT_BASE=21000
+#MIRROR_PORT_BASE=7000
 
 #### Base number by which primary file replication port 
 #### numbers are calculated.
-#REPLICATION_PORT_BASE=22000
+#REPLICATION_PORT_BASE=8000
 
 #### Base number by which mirror file replication port 
 #### numbers are calculated. 
-#MIRROR_REPLICATION_PORT_BASE=23000
+#MIRROR_REPLICATION_PORT_BASE=9000
 
 #### File system location(s) where mirror segment data directories 
 #### will be created. The number of mirror locations must equal the

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_singlenode
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_singlenode
@@ -40,7 +40,7 @@ SEG_PREFIX=gpsne
 # started on a segment host. The base port number will be 
 # incremented by one for each segment instance started on a host. 
 
-PORT_BASE=20000
+PORT_BASE=6000
 
 
 # This specifies the data storage location(s) where the script will 

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_test
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_test
@@ -14,7 +14,7 @@ SEG_PREFIX=gpseg
 
 #### Base number by which primary segment port numbers 
 #### are calculated.
-PORT_BASE=19000
+PORT_BASE=6000
 
 #### File system location(s) where primary segment data directories 
 #### will be created. The number of locations in the list dictate
@@ -49,15 +49,15 @@ ENCODING=UNICODE
 
 #### Base number by which mirror segment port numbers 
 #### are calculated.
-MIRROR_PORT_BASE=20000
+MIRROR_PORT_BASE=7000
 
 #### Base number by which primary file replication port 
 #### numbers are calculated.
-REPLICATION_PORT_BASE=21000
+REPLICATION_PORT_BASE=8000
 
 #### Base number by which mirror file replication port 
 #### numbers are calculated. 
-MIRROR_REPLICATION_PORT_BASE=22000
+MIRROR_REPLICATION_PORT_BASE=9000
 
 #### File system location(s) where mirror segment data directories 
 #### will be created. The number of mirror locations must equal the


### PR DESCRIPTION
Best practice for Greenplum currently is to set net.ipv4.ip_local_port_range = 10000 65535 and we should be setting the ports that the segment nodes use outside of that range. This updates the configs we ship to match that best practice.