### PR TITLE
Exclude auxiliary tables of non-leaf partitions from age calculation

### DIFF
--- a/src/backend/catalog/aoblkdir.c
+++ b/src/backend/catalog/aoblkdir.c
@@ -23,7 +23,7 @@
 #include "nodes/makefuncs.h"
 
 void
-AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child)
+AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child, bool is_part_parent)
 {
 	Relation	rel;
 	TupleDesc	tupdesc;
@@ -105,7 +105,7 @@ AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child)
 								  tupdesc,
 								  indexInfo, indexColNames,
 								  classObjectId,
-								  coloptions);
+								  coloptions, is_part_parent);
 
 	heap_close(rel, NoLock);
 }

--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -43,7 +43,8 @@ CreateAOAuxiliaryTable(
 		IndexInfo  *indexInfo,
 		List *indexColNames,
 		Oid	*classObjectId,
-		int16 *coloptions)
+		int16 *coloptions,
+		bool is_part_parent)
 {
 	char aoauxiliary_relname[NAMEDATALEN];
 	char aoauxiliary_idxname[NAMEDATALEN];
@@ -150,7 +151,7 @@ CreateAOAuxiliaryTable(
 											     true,
 												 /* valid_opts */ false,
 												 /* is_part_child */ false,
-												 /* is_part_parent */ false);
+												 is_part_parent);
 
 	/* Make this table visible, else index creation will fail */
 	CommandCounterIncrement();

--- a/src/backend/catalog/aoseg.c
+++ b/src/backend/catalog/aoseg.c
@@ -27,7 +27,7 @@
 
 
 void
-AlterTableCreateAoSegTable(Oid relOid, bool is_part_child)
+AlterTableCreateAoSegTable(Oid relOid, bool is_part_child, bool is_part_parent)
 {
 	TupleDesc	tupdesc;
 	Relation	rel;
@@ -155,7 +155,7 @@ AlterTableCreateAoSegTable(Oid relOid, bool is_part_child)
 
 	(void) CreateAOAuxiliaryTable(rel, prefix, RELKIND_AOSEGMENTS,
 								  tupdesc,
-								  NULL, NIL, NULL, NULL);
+								  NULL, NIL, NULL, NULL, is_part_parent);
 
 	heap_close(rel, NoLock);
 }

--- a/src/backend/catalog/aovisimap.c
+++ b/src/backend/catalog/aovisimap.c
@@ -23,7 +23,7 @@
 #include "utils/guc.h"
 
 void
-AlterTableCreateAoVisimapTable(Oid relOid, bool is_part_child)
+AlterTableCreateAoVisimapTable(Oid relOid, bool is_part_child, bool is_part_parent)
 {
 	Relation	rel;
 	IndexInfo  *indexInfo;
@@ -101,7 +101,8 @@ AlterTableCreateAoVisimapTable(Oid relOid, bool is_part_child)
 								  RELKIND_AOVISIMAP,
 								  tupdesc,
 								  indexInfo, indexColNames,
-								  classObjectId, coloptions);
+								  classObjectId, coloptions,
+								  is_part_parent);
 
 	heap_close(rel, NoLock);
 }

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2645,7 +2645,7 @@ IndexBuildAppendOnlyRowScan(Relation parentRelation,
 					 errmsg("Cannot create index concurrently. Create an index non-concurrently "
 					        "before creating an index concurrently in an appendonly table.")));
 
-		AlterTableCreateAoBlkdirTable(RelationGetRelid(parentRelation), false);
+		AlterTableCreateAoBlkdirTable(RelationGetRelid(parentRelation), false, false);
 
 		aoscan->blockDirectory =
 			(AppendOnlyBlockDirectory *)palloc0(sizeof(AppendOnlyBlockDirectory));
@@ -2779,7 +2779,7 @@ IndexBuildAppendOnlyColScan(Relation parentRelation,
 					 errmsg("Cannot create index concurrently. Create an index non-concurrently "
 					        "before creating an index concurrently in an appendonly table.")));
 
-		AlterTableCreateAoBlkdirTable(RelationGetRelid(parentRelation), false);
+		AlterTableCreateAoBlkdirTable(RelationGetRelid(parentRelation), false, false);
 
 		aocsscan->blockDirectory =
 			(AppendOnlyBlockDirectory *)palloc0(sizeof(AppendOnlyBlockDirectory));

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -660,12 +660,25 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace,
 	HeapTuple	tuple;
 	Datum		reloptions;
 	bool		isNull;
-	bool		is_part;
+	bool		is_part_child;
+	bool		is_part_parent;
 
 	OldHeap = heap_open(OIDOldHeap, AccessExclusiveLock);
 	OldHeapDesc = RelationGetDescr(OldHeap);
 
-	is_part = !rel_needs_long_lock(OIDOldHeap);
+	is_part_child = !rel_needs_long_lock(OIDOldHeap);
+
+	/*
+	 * Check pg_inherits to determine if the OldHeap relation is a non-leaf
+	 * (parent) in a partition hierarchy.  This can be avoided for tables that
+	 * should have valid relfrozenxid based on relkind and relstorage.
+	 */
+	if (should_have_valid_relfrozenxid(OldHeap->rd_rel->relkind,
+									   OldHeap->rd_rel->relstorage,
+									   false))
+		is_part_parent = !TransactionIdIsValid(OldHeap->rd_rel->relfrozenxid);
+	else
+		is_part_parent = rel_is_parent(OIDOldHeap);
 
 	/*
 	 * Note that the NewHeap will not receive any of the defaults or
@@ -722,8 +735,8 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace,
 										  false,
 										  /* allowSystemTableModsDDL */ true,
 										  /* valid_opts */ true,
-										  /* is_part_child */ false,
-										  /* is_part_parent */ false);
+										  is_part_child,
+										  is_part_parent);
 	Assert(OIDNewHeap != InvalidOid);
 
 	ReleaseSysCache(tuple);
@@ -757,15 +770,16 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace,
 									 &isNull);
 		if (isNull)
 			reloptions = (Datum) 0;
-		AlterTableCreateToastTable(OIDNewHeap, reloptions, is_part, true /* is_create */);
+		AlterTableCreateToastTable(OIDNewHeap, reloptions, true /* is_create */,
+								   is_part_child, is_part_parent);
 
 		ReleaseSysCache(tuple);
 	}
-	AlterTableCreateAoSegTable(OIDNewHeap, is_part);
-	AlterTableCreateAoVisimapTable(OIDNewHeap, is_part);
+	AlterTableCreateAoSegTable(OIDNewHeap, is_part_child, is_part_parent);
+	AlterTableCreateAoVisimapTable(OIDNewHeap, is_part_child, is_part_parent);
 
     if (createAoBlockDirectory)
-	    AlterTableCreateAoBlkdirTable(OIDNewHeap, is_part);
+	    AlterTableCreateAoBlkdirTable(OIDNewHeap, is_part_child, is_part_parent);
 
 	CacheInvalidateRelcacheByRelid(OIDNewHeap);
 

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -410,6 +410,7 @@ intorel_initplan(struct QueryDesc *queryDesc, int eflags)
 	create->postCreate = NULL;
 	create->deferredStmts = NULL;
 	create->is_part_child = false;
+	create->is_part_parent = false;
 	create->is_add_part = false;
 	create->is_split_part = false;
 	create->buildAoBlkdir = false;
@@ -448,10 +449,10 @@ intorel_initplan(struct QueryDesc *queryDesc, int eflags)
 
 	(void) heap_reloptions(RELKIND_TOASTVALUE, toast_options, true);
 
-	AlterTableCreateToastTable(intoRelationId, toast_options, false, true);
-	AlterTableCreateAoSegTable(intoRelationId, false);
+	AlterTableCreateToastTable(intoRelationId, toast_options, true, false, false);
+	AlterTableCreateAoSegTable(intoRelationId, false, false);
 	/* don't create AO block directory here, it'll be created when needed. */
-	AlterTableCreateAoVisimapTable(intoRelationId, false);
+	AlterTableCreateAoVisimapTable(intoRelationId, false, false);
 
 	/*
 	 * Finally we can open the target table

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5216,7 +5216,18 @@ ATAddToastIfNeeded(List **wqueue)
 		{
 			bool is_part = !rel_needs_long_lock(tab->relid);
 
-			AlterTableCreateToastTable(tab->relid, (Datum) 0, is_part, false /* is_create */);
+			/*
+			 * FIXME: we've passed false as is_part_parent to make_new_heap().
+			 * So it seems ok to pass false for is_part_parent here but is that
+			 * right?  E.g. what happens when a partitioned table goes through
+			 * this code path?  All non-leaf nodes suddenly get a valid
+			 * relfrozenxid, when they shouldn't?  How about creating a new
+			 * function to scan pg_inherits to determine, given a master
+			 * relation's OID, whether an auxiliary table needs valid
+			 * relfrozenxid or not?
+			 */
+			AlterTableCreateToastTable(tab->relid, (Datum) 0,
+									   false /* is_create */, is_part, false);
 		}
 	}
 }
@@ -14722,6 +14733,36 @@ rel_get_table_oid(Relation rel)
 		heap_close(deprel, AccessShareLock);
 	}
 	return toid;
+}
+
+/*
+ * Check if a relation is a parent in partition hierarchy by probing
+ * pg_inherits catalog table.
+ */
+bool
+rel_is_parent(Oid relid)
+{
+	Relation inhrel;
+	ScanKeyData scankey;
+	SysScanDesc sscan;
+	bool is_parent = false;
+
+	ScanKeyInit(&scankey,
+				Anum_pg_inherits_inhparent,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(relid));
+
+	inhrel = heap_open(InheritsRelationId, AccessShareLock);
+
+	sscan = systable_beginscan(inhrel, InheritsParentIndexId,
+							   true, SnapshotNow, 1, &scankey);
+
+	if (systable_getnext(sscan))
+		is_parent = true;
+
+	systable_endscan(sscan);
+	heap_close(inhrel, AccessShareLock);
+	return is_parent;
 }
 
 /*

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -704,16 +704,30 @@ standard_ProcessUtility(Node *parsetree,
 
 							AlterTableCreateToastTable(relOid,
 													   toast_options,
-													   cstmt->is_part_child,
-													   true);
+													   true,
+ 													   cstmt->is_part_child,
+													   cstmt->is_part_parent);
+							/*
+							 * If the master relation is a non-leaf relation in
+							 * a partition hierarchy, then this auxiliary
+							 * relation, like its master relation, will not
+							 * contain any data.  Therefore, like the master
+							 * relation, exclude this auxiliary table from
+							 * database age calculation, by passing master
+							 * relation's is_part_parent flag.
+							 */
 							AlterTableCreateAoSegTable(relOid,
-													   cstmt->is_part_child);
+													   cstmt->is_part_child,
+													   cstmt->is_part_parent);
 
 							if (cstmt->buildAoBlkdir)
-								AlterTableCreateAoBlkdirTable(relOid, cstmt->is_part_child);
+								AlterTableCreateAoBlkdirTable(relOid,
+															  cstmt->is_part_child,
+															  cstmt->is_part_parent);
 
 							AlterTableCreateAoVisimapTable(relOid,
-														   cstmt->is_part_child);
+														   cstmt->is_part_child,
+														   cstmt->is_part_parent);
 						}
 
 						if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/include/catalog/aoblkdir.h
+++ b/src/include/catalog/aoblkdir.h
@@ -25,6 +25,7 @@
 #define Anum_pg_aoblkdir_firstrownum   3
 #define Anum_pg_aoblkdir_minipage      4
 
-extern void AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child);
+extern void AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child,
+										  bool is_part_parent);
 
 #endif

--- a/src/include/catalog/aocatalog.h
+++ b/src/include/catalog/aocatalog.h
@@ -27,6 +27,7 @@ extern bool CreateAOAuxiliaryTable(
 		IndexInfo  *indexInfo,
 		List *indexColNames,
 		Oid	*classObjectId,
-		int16 *coloptions);
+		int16 *coloptions,
+		bool is_part_parent);
 
 #endif   /* AOCATALOG_H */

--- a/src/include/catalog/aoseg.h
+++ b/src/include/catalog/aoseg.h
@@ -20,6 +20,7 @@
 /*
  * aoseg.c prototypes
  */
-extern void AlterTableCreateAoSegTable(Oid relOid, bool is_part_child);
+extern void AlterTableCreateAoSegTable(Oid relOid, bool is_part_child,
+									   bool is_part_parent);
 
 #endif   /* AOSEG_H */

--- a/src/include/catalog/aovisimap.h
+++ b/src/include/catalog/aovisimap.h
@@ -23,6 +23,7 @@
 #define Anum_pg_aovisimap_firstrownum   2
 #define Anum_pg_aovisimap_visimap       3
 
-extern void AlterTableCreateAoVisimapTable(Oid relOid, bool is_part_child);
+extern void AlterTableCreateAoVisimapTable(Oid relOid, bool is_part_child,
+										   bool is_part_parent);
 
 #endif

--- a/src/include/catalog/toasting.h
+++ b/src/include/catalog/toasting.h
@@ -18,7 +18,8 @@
  * toasting.c prototypes
  */
 extern void AlterTableCreateToastTable(Oid relOid, Datum reloptions,
-									   bool is_part_child, bool is_create);
+									   bool is_create, bool is_part_child,
+									   bool is_part_parent);
 extern void BootstrapToastTable(char *relName,
 					Oid toastOid, Oid toastIndexOid);
 

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -109,6 +109,7 @@ extern void AtEOSubXact_on_commit_actions(bool isCommit,
 							  SubTransactionId mySubid,
 							  SubTransactionId parentSubid);
 
+extern bool rel_is_parent(Oid relid);
 extern bool rel_needs_long_lock(Oid relid);
 extern Oid  rel_partition_get_master(Oid relid);
 

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -720,6 +720,125 @@ NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5" for table "sto_a
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_subothers" for table "sto_ao_ao_1_prt_5"
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_sub1" for table "sto_ao_ao_1_prt_5"
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_sub2" for table "sto_ao_ao_1_prt_5"
+-- Non-leaf (empty) partitions along with their auxiliary tables
+-- should have relfrozenxid = 0.  Select the names of those tables
+-- within this partition hierarchy whose aoseg auxiliary tables have
+-- relfrozenxid = 0.
+select c1.relname from pg_appendonly a, pg_class c1, pg_class c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.segrelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao_1_prt_2
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+-- Same query as above but obtain relnames from segments.
+select c2.gp_segment_id, c1.relname from pg_appendonly a, pg_class c1,
+gp_dist_random('pg_class') c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.segrelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+(18 rows)
+
+-- Same two queries as above but for visimap auxiliary table.
+select c1.relname from pg_appendonly a, pg_class c1, pg_class c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.visimaprelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao_1_prt_2
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+-- Obtain relnames from segments whose visimap tables have relfrozenxid = 0.
+select c2.gp_segment_id, c1.relname from pg_appendonly a, pg_class c1,
+gp_dist_random('pg_class') c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.visimaprelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+(18 rows)
+
+-- Same validation toast - select all relnames whose toast tables have relfrozenxid = 0.
+select c1.relname from pg_class c1, pg_class c2 where c1.relname like 'sto_ao_ao%' and
+c2.relfrozenxid = 0 and c1.reltoastrelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao_1_prt_2
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+-- Obtain relnames from segments whose toast tables have relfrozenxid = 0.
+select c2.gp_segment_id, c1.relname from pg_class c1, gp_dist_random('pg_class') c2 where
+c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and c1.reltoastrelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+(18 rows)
+
 create table exh_ao_ao (like sto_ao_ao) with (appendonly=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- Exchange default sub-partition, should fail
@@ -736,8 +855,84 @@ ERROR:  Cannot specify a name, rank, or value for a DEFAULT partition in this co
 -- Exchange a partition that has sub partitions, should fail.
 alter table sto_ao_ao exchange partition for ('2008-01-01') with table exh_ao_ao;
 ERROR:  cannot EXCHANGE PARTITION for relation "sto_ao_ao" -- partition has children
-drop table sto_ao_ao;
-drop table exh_ao_ao;
+-- Alter table that causes rewrite.  Then validate that auxiliary
+-- tables of non-leaf partitions still have relfrozenxid = 0.
+alter table sto_ao_ao alter column col4 type bigint;
+-- aoseg
+select c1.relname from pg_appendonly a, pg_class c1, pg_class c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.segrelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_2
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+select c2.gp_segment_id, c1.relname from pg_appendonly a, pg_class c1,
+gp_dist_random('pg_class') c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.segrelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+(18 rows)
+
+-- toast
+select c1.relname from pg_class c1, pg_class c2 where c1.relname like 'sto_ao_ao%' and
+c2.relfrozenxid = 0 and c1.reltoastrelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_2
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+select c2.gp_segment_id, c1.relname from pg_class c1, gp_dist_random('pg_class') c2 where
+c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and c1.reltoastrelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+(18 rows)
+
 -- XXX: not yet: VALIDATE parameter
 -- Exchange a partition with an external table; ensure that we require to use
 -- WITHOUT VALIDATION and that the new partition won't be included in TRUNCATE

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -724,6 +724,125 @@ NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5" for table "sto_a
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_subothers" for table "sto_ao_ao_1_prt_5"
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_sub1" for table "sto_ao_ao_1_prt_5"
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_sub2" for table "sto_ao_ao_1_prt_5"
+-- Non-leaf (empty) partitions along with their auxiliary tables
+-- should have relfrozenxid = 0.  Select the names of those tables
+-- within this partition hierarchy whose aoseg auxiliary tables have
+-- relfrozenxid = 0.
+select c1.relname from pg_appendonly a, pg_class c1, pg_class c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.segrelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao_1_prt_2
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+-- Same query as above but obtain relnames from segments.
+select c2.gp_segment_id, c1.relname from pg_appendonly a, pg_class c1,
+gp_dist_random('pg_class') c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.segrelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+(18 rows)
+
+-- Same two queries as above but for visimap auxiliary table.
+select c1.relname from pg_appendonly a, pg_class c1, pg_class c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.visimaprelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao_1_prt_2
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+-- Obtain relnames from segments whose visimap tables have relfrozenxid = 0.
+select c2.gp_segment_id, c1.relname from pg_appendonly a, pg_class c1,
+gp_dist_random('pg_class') c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.visimaprelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+(18 rows)
+
+-- Same validation toast - select all relnames whose toast tables have relfrozenxid = 0.
+select c1.relname from pg_class c1, pg_class c2 where c1.relname like 'sto_ao_ao%' and
+c2.relfrozenxid = 0 and c1.reltoastrelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao_1_prt_2
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+-- Obtain relnames from segments whose toast tables have relfrozenxid = 0.
+select c2.gp_segment_id, c1.relname from pg_class c1, gp_dist_random('pg_class') c2 where
+c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and c1.reltoastrelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+(18 rows)
+
 create table exh_ao_ao (like sto_ao_ao) with (appendonly=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- Exchange default sub-partition, should fail
@@ -740,8 +859,84 @@ ERROR:  Cannot specify a name, rank, or value for a DEFAULT partition in this co
 -- Exchange a partition that has sub partitions, should fail.
 alter table sto_ao_ao exchange partition for ('2008-01-01') with table exh_ao_ao;
 ERROR:  cannot EXCHANGE PARTITION for relation "sto_ao_ao" -- partition has children
-drop table sto_ao_ao;
-drop table exh_ao_ao;
+-- Alter table that causes rewrite.  Then validate that auxiliary
+-- tables of non-leaf partitions still have relfrozenxid = 0.
+alter table sto_ao_ao alter column col4 type bigint;
+-- aoseg
+select c1.relname from pg_appendonly a, pg_class c1, pg_class c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.segrelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_2
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+select c2.gp_segment_id, c1.relname from pg_appendonly a, pg_class c1,
+gp_dist_random('pg_class') c2 where
+c1.oid = a.relid and c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and a.segrelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+(18 rows)
+
+-- toast
+select c1.relname from pg_class c1, pg_class c2 where c1.relname like 'sto_ao_ao%' and
+c2.relfrozenxid = 0 and c1.reltoastrelid = c2.oid;
+        relname         
+------------------------
+ sto_ao_ao
+ sto_ao_ao_1_prt_others
+ sto_ao_ao_1_prt_2
+ sto_ao_ao_1_prt_3
+ sto_ao_ao_1_prt_4
+ sto_ao_ao_1_prt_5
+(6 rows)
+
+select c2.gp_segment_id, c1.relname from pg_class c1, gp_dist_random('pg_class') c2 where
+c1.relname like 'sto_ao_ao%' and c2.relfrozenxid = 0 and c1.reltoastrelid = c2.oid;
+ gp_segment_id |        relname         
+---------------+------------------------
+             0 | sto_ao_ao
+             0 | sto_ao_ao_1_prt_others
+             0 | sto_ao_ao_1_prt_2
+             0 | sto_ao_ao_1_prt_3
+             0 | sto_ao_ao_1_prt_4
+             0 | sto_ao_ao_1_prt_5
+             1 | sto_ao_ao
+             1 | sto_ao_ao_1_prt_others
+             1 | sto_ao_ao_1_prt_2
+             1 | sto_ao_ao_1_prt_3
+             1 | sto_ao_ao_1_prt_4
+             1 | sto_ao_ao_1_prt_5
+             2 | sto_ao_ao
+             2 | sto_ao_ao_1_prt_others
+             2 | sto_ao_ao_1_prt_2
+             2 | sto_ao_ao_1_prt_3
+             2 | sto_ao_ao_1_prt_4
+             2 | sto_ao_ao_1_prt_5
+(18 rows)
+
 -- XXX: not yet: VALIDATE parameter
 -- Exchange a partition with an external table; ensure that we require to use
 -- WITHOUT VALIDATION and that the new partition won't be included in TRUNCATE


### PR DESCRIPTION
This is a follow-up to 44f9776071c3ecbfbcf6015f66207157916665e9.  The `is_part_parent` flag is reused during auxiliary table creation to identify auxiliary tables corresponding to non-leaf partitions.

Thanks to @ylew-zdata for letting us know that the auxiliary tables need to be handled.

I'm not too happy with this patch, mainly because it is not clear how various alter commands and cluster that rewrite a table will behave under this change.  A better option to determine if a table is non-leaf is to scan pg_inherits.  That way, we don't need to dispatch `is_part_parent`/`child` flags to segments as `pg_inherits` is available on segments.  But that's for another day.