### PR TITLE
Update kernel.sem setting to be consistent with 5.9.0 doc

### DIFF
--- a/README.linux.md
+++ b/README.linux.md
@@ -95,7 +95,7 @@ then run command `ldconfig`.
   kernel.shmmax = 500000000
   kernel.shmmni = 4096
   kernel.shmall = 4000000000
-  kernel.sem = 250 512000 100 2048
+  kernel.sem = 500 1024000 200 4096
   kernel.sysrq = 1
   kernel.core_uses_pid = 1
   kernel.msgmnb = 65536

--- a/concourse/scripts/behave_gpdb.bash
+++ b/concourse/scripts/behave_gpdb.bash
@@ -36,7 +36,7 @@ function gpcheck_setup() {
         kernel.shmmax = 500000000
         kernel.shmmni = 4096
         kernel.shmall = 4000000000
-        kernel.sem = 250 512000 100 2048
+        kernel.sem = 500 1024000 200 4096
         kernel.sysrq = 1
         kernel.core_uses_pid = 1
         kernel.msgmnb = 65536

--- a/gpMgmt/doc/gpconfigs/gpcheck.cnf
+++ b/gpMgmt/doc/gpconfigs/gpcheck.cnf
@@ -6,7 +6,7 @@ xfs_mount_options = rw,noatime,inode64,allocsize=16m
 sysctl.kernel.shmmax = 500000000
 sysctl.kernel.shmmni = 4096
 sysctl.kernel.shmall = 4000000000
-sysctl.kernel.sem = 250 512000 100 2048
+sysctl.kernel.sem = 500 1024000 200 4096
 sysctl.kernel.sysrq = 1
 sysctl.kernel.core_uses_pid = 1
 sysctl.kernel.msgmnb = 65536

--- a/gpdb-doc/dita/install_guide/prep_os_install_gpdb.xml
+++ b/gpdb-doc/dita/install_guide/prep_os_install_gpdb.xml
@@ -191,7 +191,7 @@ SELinuxstatus: disabled</codeblock>
               <codeblock>kernel.shmmax = 500000000
 kernel.shmmni = 4096
 kernel.shmall = 4000000000
-kernel.sem = 250 512000 100 2048
+kernel.sem = 500 1024000 200 4096
 kernel.sysrq = 1
 kernel.core_uses_pid = 1
 kernel.msgmnb = 65536

--- a/src/tools/vagrant/centos/vagrant-configure-os.sh
+++ b/src/tools/vagrant/centos/vagrant-configure-os.sh
@@ -15,7 +15,7 @@ sudo bash -c 'printf "# GPDB-Specific Settings\n\n"                    >> /etc/s
 sudo bash -c 'printf "kernel.shmmax = 500000000\n"                     >> /etc/sysctl.d/gpdb.conf'
 sudo bash -c 'printf "kernel.shmmni = 4096\n"                          >> /etc/sysctl.d/gpdb.conf'
 sudo bash -c 'printf "kernel.shmall = 4000000000\n"                    >> /etc/sysctl.d/gpdb.conf'
-sudo bash -c 'printf "kernel.sem = 250 512000 100 2048\n"              >> /etc/sysctl.d/gpdb.conf'
+sudo bash -c 'printf "kernel.sem = 500 1024000 200 4096\n"             >> /etc/sysctl.d/gpdb.conf'
 sudo bash -c 'printf "kernel.sysrq = 1\n"                              >> /etc/sysctl.d/gpdb.conf'
 sudo bash -c 'printf "kernel.core_uses_pid = 1\n"                      >> /etc/sysctl.d/gpdb.conf'
 sudo bash -c 'printf "kernel.msgmnb = 65536\n"                         >> /etc/sysctl.d/gpdb.conf'


### PR DESCRIPTION
Between GPDB 5.8.0 and 5.9.0, the recommended Linux System Settings changed for kernel.sem.
https://gpdb.docs.pivotal.io/580/install_guide/prep_os_install_gpdb.html#topic3
https://gpdb.docs.pivotal.io/590/install_guide/prep_os_install_gpdb.html#topic3

However, the gpdb repository had references to the kernel.sem parameter, as well as a couple other parameters, which seem to be inconsistent. (See comment below)

Co-authored-by: @amilkh