### PR TITLE
Add yaml, JSON explain support

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1509,10 +1509,23 @@ ExplainNode(PlanState *planstate, List *ancestors,
 	{
 		ExplainPropertyInteger("operatorMem", PlanStateOperatorMemKB(planstate), es);
 	}
+	/*
+	 * We have to forcibly clean up the instrumentation state because we
+	 * haven't done ExecutorEnd yet.  This is pretty grotty ...
+	 *
+	 * Note: contrib/auto_explain could cause instrumentation to be set up
+	 * even though we didn't ask for it here.  Be careful not to print any
+	 * instrumentation results the user didn't ask for.  But we do the
+	 * InstrEndLoop call anyway, if possible, to reduce the number of cases
+	 * auto_explain has to contend with.
+	 */
+	if (planstate->instrument)
+		InstrEndLoop(planstate->instrument);
 
 	/* GPDB_90_MERGE_FIXME: In GPDB, these are printed differently. But does that work
 	 * with the new XML/YAML EXPLAIN output */
-	if (planstate->instrument && planstate->instrument->nloops > 0)
+	if (es->analyze &&
+		planstate->instrument && planstate->instrument->nloops > 0)
 	{
  		double		nloops = planstate->instrument->nloops;
 		double		startup_sec = 1000.0 * planstate->instrument->startup / nloops;
@@ -1521,7 +1534,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 
 		if (es->format == EXPLAIN_FORMAT_TEXT)
 		{
-			if (planstate->instrument->need_timer)
+			if (es->timing)
 				appendStringInfo(es->str,
 							" (actual time=%.3f..%.3f rows=%.0f loops=%.0f)",
 								 startup_sec, total_sec, rows, nloops);
@@ -1532,7 +1545,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 		}
 		else
 		{
-			if (planstate->instrument->need_timer)
+			if (es->timing)
 			{
 				ExplainPropertyFloat("Actual Startup Time", startup_sec, 3, es);
 				ExplainPropertyFloat("Actual Total Time", total_sec, 3, es);
@@ -1543,20 +1556,18 @@ ExplainNode(PlanState *planstate, List *ancestors,
 	}
 	else if (es->analyze)
 	{
-
 		if (es->format == EXPLAIN_FORMAT_TEXT)
 			appendStringInfo(es->str, " (never executed)");
-		else if (planstate->instrument->need_timer)
-		{
-			ExplainPropertyFloat("Actual Startup Time", 0.0, 3, es);
-			ExplainPropertyFloat("Actual Total Time", 0.0, 3, es);
-		}
 		else
 		{
+			if (es->timing)
+			{
+				ExplainPropertyFloat("Actual Startup Time", 0.0, 3, es);
+				ExplainPropertyFloat("Actual Total Time", 0.0, 3, es);
+			}
 			ExplainPropertyFloat("Actual Rows", 0.0, 0, es);
 			ExplainPropertyFloat("Actual Loops", 0.0, 0, es);
 		}
-
 	}
 
 	/* in text format, first line ends here */
@@ -1804,7 +1815,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 		cdbexplain_showExecStats(planstate, es);
 
 	/* Show buffer usage */
-	if (es->buffers)
+	if (es->buffers && planstate->instrument)
 	{
 		const BufferUsage *usage = &planstate->instrument->bufusage;
 

--- a/src/test/regress/atmsort.pl
+++ b/src/test/regress/atmsort.pl
@@ -320,6 +320,19 @@ query is complex, you may need to tag it with a comment to force the
 explain.  Using this command for non-EXPLAIN statements is
 inadvisable.
 
+=item -- explain_processing_on
+
+Enables the automated processing of the explain output, removing all
+the variable fields using the `explain` perl module
+This is the default.
+
+=item -- explain_processing_off
+
+Do not process the explain output. This might result in test failures
+if the test does not replace the variable values itself.
+An example of a test that uses this is the test that validates the
+format of the explain output.
+
 =back
 
 Note that you can combine the directives for a single query, but each

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -11,6 +11,20 @@
 -- s/Total runtime: \d+\.\d+ ms/Total runtime: ##.### ms/
 -- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
 -- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
+-- m/Peak memory: \d+\w? bytes\./
+-- s/Peak memory: \d+\w? bytes\./Peak memory: ### bytes./
+-- m/Peak memory: \d+\w? bytes avg x \d+ workers, \d+\w? bytes max \(seg\d+\)./
+-- s/Peak memory: \d+\w? bytes avg x \d+ workers, \d+\w? bytes max \(seg\d+\)\./Peak memory: ### bytes avg x # workers, ### bytes max (seg#)./
+-- m/Vmem reserved: \d+\w? bytes\./
+-- s/Vmem reserved: \d+\w? bytes\./Vmem reserved: ### bytes./
+-- m/Vmem reserved: \d+\w? bytes avg x \d+ workers, \d+\w? bytes max \(seg\d+\)/
+-- s/Vmem reserved: \d+\w? bytes avg x \d+ workers, \d+\w? bytes max \(seg\d+\)/Vmem reserved: ### bytes avg x # workers, ### bytes max (seg#)/
+-- m/Total memory used across slices: \d+\w bytes./
+-- s/Total memory used across slices: \d+\w bytes./Total memory used across slices: ### bytes./
+-- m/Memory used:  \d+\w?B/
+-- s/Memory used:  \d+\w?B/Memory used: ###B/
+-- m/ORCA Memory used: peak \d+\w?B  allocated \d+\w?B  freed \d+\w?B/
+-- s/ORCA Memory used: peak \d+\w?B  allocated \d+\w?B  freed \d+\w?B/ORCA Memory used: peak ##B  allocated ##B  freed ##B/
 -- end_matchsubs
 --
 -- DEFAULT syntax
@@ -23,6 +37,8 @@ CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), locat
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "boxes_pkey" for table "boxes"
 WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
 WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
+-- Activate GUP that will show more memory information
+SET explain_memory_verbosity = 'summary';
 --- Check Explain Text format output
 -- explain_processing_off
 EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
@@ -91,16 +107,28 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Total Runtime: \d+\.\d+/Total Runtime: ##.###/
 -- m/Segments: \d+\s+/
 -- s/Segments: \d+\s+/Segments: #/
--- m/PQO version \d+\.\d+\.\d+"\s+/
--- s/PQO version \d+\.\d+\.\d+"\s+/PQO version ##.##.##"/
+-- m/PQO version \d+\.\d+\.\d+",?\s+/
+-- s/PQO version \d+\.\d+\.\d+",?\s+/PQO version ##.##.##"/
 -- m/Slice: [0-3]\s+/
 -- s/Slice: [0-3]\s+/Slice: # /
--- m/Executor Memory: \d+\s+/
--- s/Executor Memory: \d+\s+/Executor Memory: ### /
+-- m/ Memory: \d+\s+/
+-- s/ Memory: \d+\s+/ Memory: ### /
 -- m/Maximum Memory Used: \d+\s+/
 -- s/Maximum Memory Used: \d+\s+/Maximum Memory Used: ### /
 -- m/Work Maximum Memory: \d+\s+/
 -- s/Work Maximum Memory: \d+\s+/Work Maximum Memory: ### /
+-- m/Peak Memory": \d+,/
+-- s/Peak Memory": \d+,\s+/Peak Memory": ###,/
+-- m/Virtual Memory": \d+/
+-- s/Virtual Memory": \d+\s+/Virtual Memory": ###/
+-- m/Workers: \d+\s+/
+-- s/Workers: \d+\s+/Workers: ## /
+-- m/Average: \d+\s+/
+-- s/Average: \d+\s+/Average: ## /
+-- m/Total memory used across slices: \d+/
+-- s/Total memory used across slices: \d+/Total memory used across slices: ###/
+-- m/ORCA Memory Used \w+: \d+/
+-- s/ORCA Memory Used (\w+): \d+\s+/ORCA Memory Used $1: ##/
 -- end_matchsubs
 -- Check Explain YAML output
 EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
@@ -845,7 +873,7 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- m/PQO version \d+\.\d+\.\d+/
 -- s/PQO version \d+\.\d+\.\d+/PQO version ##.##.##/
 -- m/<Slice>[0-3]<\/Slice>/
--- s/<Slice>[0-3]<\/Slice>/<Slice>#<\/Slice> /
+-- s/<Slice>[0-3]<\/Slice>\s+/<Slice>#<\/Slice> /
 -- m/Executor-Memory>\d+<\//
 -- s/Executor-Memory>\d+<\/([^>]+)>\s+/Executor-Memory>###<\/$1> /
 -- m/<Maximum-Memory-Used>\d+<\/Maximum-Memory-Used>\s+/
@@ -854,6 +882,18 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- s/<Work-Maximum-Memory>\d+<\/Work-Maximum-Memory>\s+/<Work-Maximum-Memory>###<\/Work-Maximum-Memory> /
 -- m/<Workers>\d+<\/Workers>\s+/
 -- s/<Workers>\d+<\/Workers>\s+/<Workers>###<\/Workers> /
+-- m/Peak-Memory>\d+<\//
+-- s/Peak-Memory>\d+<\/([^>]+)>\s+/Peak-Memory>###<\/$1>/
+-- m/Virtual-Memory>\d+/
+-- s/Virtual-Memory>\d+<\/([^>]+)>\s+/Virtual-Memory>###<\/$1>/
+-- m/<Average>\d+<\/Average>/
+-- s/<Average>\d+<\/Average>\s+/<Average>##<\/Average>/
+-- m/<Total-memory-used-across-slices>\d+/
+-- s/(<Total-memory-used-across-slices>)\d+(<\/[^>]+>)\s*/$1###$2/
+-- m/<ORCA-Memory-Used-\w+>\d+/
+-- s/<ORCA-Memory-Used-(\w+)>\d+(<\/[^>]+>)\s+/<ORCA-Memory-Used-$1>##$2/
+-- m/>\s+\+/
+-- s/>\s+\+/>+/
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain XML output
@@ -1204,35 +1244,74 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
      <Slice-statistics>                                                    +
        <Slice>                                                             +
          <Slice>0</Slice>                                                  +
-         <Executor-Memory>123454</Executor-Memory>                         +
+         <Executor-Memory>123</Executor-Memory>                            +
+         <Global-Peak-Memory>432</Global-Peak-Memory>                      +
+         <Virtual-Memory>123543</Virtual-Memory>                           +
        </Slice>                                                            +
        <Slice>                                                             +
          <Slice>1</Slice>                                                  +
-         <Average-Executor-Memory>1312423</Average-Executor-Memory>        +
-         <Workers>3342</Workers>                                           +
-         <Maximum-Memory-Used>423</Maximum-Memory-Used>                    +
+         <Executor-Memory>                                                 +
+           <Average>123143234</Average>                                    +
+           <Workers>1</Workers>                                            +
+           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>              +
+         </Executor-Memory>                                                +
+         <Global-Peak-Memory>                                              +
+           <Average>43212</Average>                                        +
+           <Workers>2</Workers>                                            +
+           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                 +
+         </Global-Peak-Memory>                                             +
+         <Virtual-Memory>                                                  +
+           <Average>4321234123423</Average>                                +
+           <Workers>64654</Workers>                                        +
+           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
+         </Virtual-Memory>                                                 +
        </Slice>                                                            +
        <Slice>                                                             +
          <Slice>2</Slice>                                                  +
-         <Average-Executor-Memory>123123</Average-Executor-Memory>         +
-         <Workers>2</Workers>                                              +
-         <Maximum-Memory-Used>543123</Maximum-Memory-Used>                 +
-         <Work-Maximum-Memory>543</Work-Maximum-Memory>                    +
+         <Executor-Memory>                                                 +
+           <Average>123143234</Average>                                    +
+           <Workers>1</Workers>                                            +
+           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>              +
+         </Executor-Memory>                                                +
+         <Global-Peak-Memory>                                              +
+           <Average>43212</Average>                                        +
+           <Workers>2</Workers>                                            +
+           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                 +
+         </Global-Peak-Memory>                                             +
+         <Virtual-Memory>                                                  +
+           <Average>4321234123423</Average>                                +
+           <Workers>64654</Workers>                                        +
+           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
+         </Virtual-Memory>                                                 +
+         <Work-Maximum-Memory>41431</Work-Maximum-Memory>                  +
        </Slice>                                                            +
        <Slice>                                                             +
          <Slice>3</Slice>                                                  +
-         <Average-Executor-Memory>1321321</Average-Executor-Memory>        +
-         <Workers>54</Workers>                                             +
-         <Maximum-Memory-Used>324</Maximum-Memory-Used>                    +
+         <Executor-Memory>                                                 +
+           <Average>123143234</Average>                                    +
+           <Workers>1</Workers>                                            +
+           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>              +
+         </Executor-Memory>                                                +
+         <Global-Peak-Memory>                                              +
+           <Average>43212</Average>                                        +
+           <Workers>2</Workers>                                            +
+           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                 +
+         </Global-Peak-Memory>                                             +
+         <Virtual-Memory>                                                  +
+           <Average>4321234123423</Average>                                +
+           <Workers>64654</Workers>                                        +
+           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
+         </Virtual-Memory>                                                 +
        </Slice>                                                            +
      </Slice-statistics>                                                   +
+     <Total-memory-used-across-slices>123</Total-memory-used-across-slices>+
      <Statement-statistics>                                                +
-       <Memory-used>1200</Memory-used>                                   +
+       <Memory-used>1200</Memory-used>                                     +
      </Statement-statistics>                                               +
      <Settings>                                                            +
        <Optimizer>legacy query optimizer</Optimizer>                       +
      </Settings>                                                           +
-     <Total-Runtime>24.8</Total-Runtime>                                 +
+     <Total-Runtime>24.8</Total-Runtime>                                   +
    </Query>                                                                +
  </explain>
 (1 row)

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -1,10 +1,12 @@
 -- start_matchsubs
--- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
--- s/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/(actual time=10.302..10.302 rows=0 loops=1)/
+-- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
+-- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
 -- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
 -- s/\(slice\d+\)    Executor memory: (\d+)\w bytes\./\(slice\)    Executor memory: (#####)K bytes./
 -- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./\(slice\)    Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg0)./
+-- s/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./\(slice\)    Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
+-- m/Work_mem: \d+\w bytes max\./
+-- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
 -- m/Total runtime: \d+\.\d+ ms/
 -- s/Total runtime: \d+\.\d+ ms/Total runtime: ##.### ms/
 -- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
@@ -14,6 +16,7 @@
 -- DEFAULT syntax
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "apples_pkey" for table "apples"
+INSERT INTO apples(id) SELECT generate_series(1, 100000);
 CREATE TABLE locations(id int PRIMARY KEY, address text);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "locations_pkey" for table "locations"
 CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES locations(id));
@@ -58,13 +61,13 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
                            Hash Key: boxes.apple_id
                            ->  Seq Scan on boxes  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                     ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                           ->  Seq Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+                     ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=1.323..3.123 rows=9 loops=1)
+                           ->  Seq Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=1.323..3.123 rows=9 loops=1)
          ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
                ->  Seq Scan on locations  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).
-   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
+   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Work_mem: 9K bytes max.
    (slice3)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
@@ -90,6 +93,14 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Segments: \d+\s+/Segments: #/
 -- m/PQO version \d+\.\d+\.\d+"\s+/
 -- s/PQO version \d+\.\d+\.\d+"\s+/PQO version ##.##.##"/
+-- m/Slice: [0-3]\s+/
+-- s/Slice: [0-3]\s+/Slice: # /
+-- m/Executor Memory: \d+\s+/
+-- s/Executor Memory: \d+\s+/Executor Memory: ### /
+-- m/Maximum Memory Used: \d+\s+/
+-- s/Maximum Memory Used: \d+\s+/Maximum Memory Used: ### /
+-- m/Work Maximum Memory: \d+\s+/
+-- s/Work Maximum Memory: \d+\s+/Work Maximum Memory: ### /
 -- end_matchsubs
 -- Check Explain YAML output
 EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
@@ -375,6 +386,22 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
                  Actual Rows: 0                         +
                  Actual Loops: 0                        +
    Triggers:                                            +
+   Slice statistics:                                    +
+     - Slice: 0                                         +
+       Executor Memory: 386000                          +
+     - Slice: 1                                         +
+       Average Executor Memory: 59000                   +
+       Workers: 3                                       +
+       Maximum Memory Used: 59000                       +
+     - Slice: 2                                         +
+       Average Executor Memory: 1110000                 +
+       Workers: 3                                       +
+       Maximum Memory Used: 1110000                     +
+       Work Maximum Memory: 1043000                     +
+     - Slice: 3                                         +
+       Average Executor Memory: 1110000                 +
+       Workers: 3                                       +
+       Maximum Memory Used: 1110000                     +
    Statement statistics:                                +
      Memory used: 128000                                +
    Settings:                                            +
@@ -401,6 +428,16 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- s/"Memory used": \d+,?\s+/"Memory used": ####,/
 -- m/"Segments": \d+,\s+/
 -- s/"Segments": \d+,\s+/"Segments": #,/
+-- m/"Slice": [0-3],\s+/
+-- s/"Slice": [0-3],\s+/"Slice": #, /
+-- m/Executor Memory": \d+,?\s+/
+-- s/Executor Memory": \d+,?\s+/Executor Memory": ### /
+-- m/"Maximum Memory Used": \d+,?\s+/
+-- s/"Maximum Memory Used": \d+,?\s+/"Maximum Memory Used": ###, /
+-- m/"Work Maximum Memory": \d+,?\s+/
+-- s/"Work Maximum Memory": \d+,?\s+/"Work Maximum Memory": ### /
+-- m/"Workers": \d+,\s+/
+-- s/"Workers": \d+,\s+/"Workers": ##, /
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain JSON output
@@ -748,6 +785,31 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
      },                                                      +
      "Triggers": [                                           +
      ],                                                      +
+     "Slice statistics": [                                   +
+       {                                                     +
+         "Slice": 0,                                         +
+         "Executor Memory": 123546                           +
+       },                                                    +
+       {                                                     +
+         "Slice": 1,                                         +
+         "Average Executor Memory": 123546                   +
+         "Workers": 1,                                       +
+         "Maximum Memory Used": 432255                       +
+       },                                                    +
+       {                                                     +
+         "Slice": 2,                                         +
+         "Average Executor Memory": 123432                   +
+         "Workers": 2,                                       +
+         "Maximum Memory Used": 4324,                        +
+         "Work Maximum Memory": 23424                        +
+       },                                                    +
+       {                                                     +
+         "Slice": 3,                                         +
+         "Average Executor Memory": 2341                     +
+         "Workers": 3,                                       +
+         "Maximum Memory Used": 123432                       +
+       }                                                     +
+     ],                                                      +
      "Statement statistics": {                               +
        "Memory used": 12800                                  +
      },                                                      +
@@ -770,14 +832,28 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- s/Plan-Width>\d+<\/Plan-Width>\s+/Plan-Width>###<\/Plan-Width>/
 -- m/Segments>\d+<\/Segments>\s+/
 -- s/Segments>\d+<\/Segments>\s+/Segments>##<\/Segments>/
--- m/-Time>\d+\.\d+<\/[^>]+\-Time>\s+/
--- s/-Time>\d+\.\d+<\/([^>]+)\-Time>\s+/-Time>##.###<\/$1-Time>/
+-- m/Actual-Rows>\d+<\/Actual-Rows>\s+/
+-- s/Actual-Rows>\d+<\/Actual-Rows>\s+/Actual-Rows>###<\/Actual-Rows>/
+-- m/Actual-Loops>\d+<\/Actual-Loops>\s+/
+-- s/Actual-Loops>\d+<\/Actual-Loops>\s+/Actual-Loops>###<\/Actual-Loops>/
+-- m/-Time>\d+\.\d+<\/[^>]+\-Time>\s*/
+-- s/-Time>\d+\.\d+<\/([^>]+)\-Time>\s*/-Time>##.###<\/$1-Time>/
 -- m/Total-Runtime>\d+\.\d+<\/Total-Runtime>\s+/
 -- s/Total-Runtime>\d+\.\d+<\/Total-Runtime>\s+/Total-Runtime>##.###<\/Total-Runtime>/
 -- m/Memory-used>\d+<\/Memory-used>\s+/
 -- s/Memory-used>\d+<\/Memory-used>\s+/Memory-used>###<\/Memory-used>/
 -- m/PQO version \d+\.\d+\.\d+/
 -- s/PQO version \d+\.\d+\.\d+/PQO version ##.##.##/
+-- m/<Slice>[0-3]<\/Slice>/
+-- s/<Slice>[0-3]<\/Slice>/<Slice>#<\/Slice> /
+-- m/Executor-Memory>\d+<\//
+-- s/Executor-Memory>\d+<\/([^>]+)>\s+/Executor-Memory>###<\/$1> /
+-- m/<Maximum-Memory-Used>\d+<\/Maximum-Memory-Used>\s+/
+-- s/<Maximum-Memory-Used>\d+<\/Maximum-Memory-Used>\s+/<Maximum-Memory-Used>###<\/Maximum-Memory-Used> /
+-- m/<Work-Maximum-Memory>\d+<\/Work-Maximum-Memory>\s+/
+-- s/<Work-Maximum-Memory>\d+<\/Work-Maximum-Memory>\s+/<Work-Maximum-Memory>###<\/Work-Maximum-Memory> /
+-- m/<Workers>\d+<\/Workers>\s+/
+-- s/<Workers>\d+<\/Workers>\s+/<Workers>###<\/Workers> /
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain XML output
@@ -1125,6 +1201,31 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
      </Plan>                                                               +
      <Triggers>                                                            +
      </Triggers>                                                           +
+     <Slice-statistics>                                                    +
+       <Slice>                                                             +
+         <Slice>0</Slice>                                                  +
+         <Executor-Memory>123454</Executor-Memory>                         +
+       </Slice>                                                            +
+       <Slice>                                                             +
+         <Slice>1</Slice>                                                  +
+         <Average-Executor-Memory>1312423</Average-Executor-Memory>        +
+         <Workers>3342</Workers>                                           +
+         <Maximum-Memory-Used>423</Maximum-Memory-Used>                    +
+       </Slice>                                                            +
+       <Slice>                                                             +
+         <Slice>2</Slice>                                                  +
+         <Average-Executor-Memory>123123</Average-Executor-Memory>         +
+         <Workers>2</Workers>                                              +
+         <Maximum-Memory-Used>543123</Maximum-Memory-Used>                 +
+         <Work-Maximum-Memory>543</Work-Maximum-Memory>                    +
+       </Slice>                                                            +
+       <Slice>                                                             +
+         <Slice>3</Slice>                                                  +
+         <Average-Executor-Memory>1321321</Average-Executor-Memory>        +
+         <Workers>54</Workers>                                             +
+         <Maximum-Memory-Used>324</Maximum-Memory-Used>                    +
+       </Slice>                                                            +
+     </Slice-statistics>                                                   +
      <Statement-statistics>                                                +
        <Memory-used>1200</Memory-used>                                   +
      </Statement-statistics>                                               +

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -1,0 +1,72 @@
+-- start_matchsubs
+-- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
+-- s/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/(actual time=10.302..10.302 rows=0 loops=1)/
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
+-- s/\(slice\d+\)    Executor memory: (\d+)\w bytes\./\(slice\)    Executor memory: (#####)K bytes./
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
+-- s/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./\(slice\)    Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg0)./
+-- m/Total runtime: \d+\.\d+ ms/
+-- s/Total runtime: \d+\.\d+ ms/Total runtime: ##.### ms/
+-- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
+-- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
+-- end_matchsubs
+--
+-- DEFAULT syntax
+CREATE TABLE apples(id int PRIMARY KEY, type text);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "apples_pkey" for table "apples"
+CREATE TABLE locations(id int PRIMARY KEY, address text);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "locations_pkey" for table "locations"
+CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES locations(id));
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "boxes_pkey" for table "boxes"
+WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
+WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
+--- Check Explain Text output
+EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+                                                   QUERY PLAN
+------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2432.00..8569.25 rows=77900 width=84)
+   ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84)
+         Hash Cond: boxes.location_id = locations.id
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1216.00..6282.12 rows=25967 width=48)
+               Hash Key: boxes.location_id
+               ->  Hash Left Join  (cost=1216.00..4724.12 rows=25967 width=48)
+                     Hash Cond: boxes.apple_id = apples.id
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+                           Hash Key: boxes.apple_id
+                           ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
+                     ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
+                           ->  Seq Scan on apples  (cost=0.00..596.00 rows=16534 width=36)
+         ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
+               ->  Seq Scan on locations  (cost=0.00..596.00 rows=16534 width=36)
+ Optimizer: legacy query optimizer
+(15 rows)
+
+--- Check Explain Analyze Text output
+-- explain_processing_off
+EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+                                                            QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2432.00..8569.25 rows=77900 width=84) (actual time=3.936..3.936 rows=0 loops=1)
+   ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+         Hash Cond: boxes.location_id = locations.id
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+               Hash Key: boxes.location_id
+               ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+                     Hash Cond: boxes.apple_id = apples.id
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+                           Hash Key: boxes.apple_id
+                           ->  Seq Scan on boxes  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+                     ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+                           ->  Seq Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+         ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+               ->  Seq Scan on locations  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).
+   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
+   (slice3)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 34.572 ms
+(21 rows)
+
+-- explain_processing_on

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -5,6 +5,8 @@
 -- s/\(slice\d+\)    Executor memory: (\d+)\w bytes\./\(slice\)    Executor memory: (#####)K bytes./
 -- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
 -- s/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./\(slice\)    Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
+-- m/\(slice\d+\)    /
+-- s/\(slice\d+\)    /\(slice\)    /
 -- m/Work_mem: \d+\w bytes max\./
 -- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
 -- m/Total runtime: \d+\.\d+ ms/
@@ -31,64 +33,65 @@
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "apples_pkey" for table "apples"
 INSERT INTO apples(id) SELECT generate_series(1, 100000);
-CREATE TABLE locations(id int PRIMARY KEY, address text);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "locations_pkey" for table "locations"
-CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES locations(id));
+CREATE TABLE box_locations(id int PRIMARY KEY, address text);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "box_locations_pkey" for table "box_locations"
+CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES box_locations(id));
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "boxes_pkey" for table "boxes"
 WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
 WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
--- Activate GUP that will show more memory information
+-- Activate GUC that will show more memory information
 SET explain_memory_verbosity = 'summary';
 --- Check Explain Text format output
 -- explain_processing_off
-EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                                    QUERY PLAN
 ------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=2432.00..8569.25 rows=77900 width=84)
-   ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84)
-         Hash Cond: boxes.location_id = locations.id
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1216.00..6282.12 rows=25967 width=48)
+   ->  Hash Left Join  (cost=4626.75..9527.20 rows=25967 width=84)
+         Hash Cond: boxes.location_id = box_locations.id
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3410.75..7240.07 rows=25967 width=48)
                Hash Key: boxes.location_id
-               ->  Hash Left Join  (cost=1216.00..4724.12 rows=25967 width=48)
-                     Hash Cond: boxes.apple_id = apples.id
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
-                           Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
-                     ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
-                           ->  Seq Scan on apples  (cost=0.00..596.00 rows=16534 width=36)
+               ->  Hash Right Join  (cost=340.75..582.07 rows=2567 width=4)
+                     Hash Cond: apples.id = boxes.apple_id
+                     ->  Seq Scan on apples  (cost=0.00..115.60 rows=3347 width=6)
+                     ->  Hash  (cost=247.00..247.00 rows=2567 width=1)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..237.00 rows=2967 width=2)
+                                 Hash Key: boxes.apple_id
+                                 ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
          ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
-               ->  Seq Scan on locations  (cost=0.00..596.00 rows=16534 width=36)
+               ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36)
  Optimizer: legacy query optimizer
 (15 rows)
 
 -- explain_processing_on
 --- Check Explain Analyze Text output that include the slices information
 -- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                                             QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=2432.00..8569.25 rows=77900 width=84) (actual time=3.936..3.936 rows=0 loops=1)
-   ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-         Hash Cond: boxes.location_id = locations.id
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+   ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.936..3.936 rows=0 loops=1)
+         Hash Cond: boxes.location_id = box_locations.id
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.936..3.96 rows=0 loops=1)
                Hash Key: boxes.location_id
-               ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                     Hash Cond: boxes.apple_id = apples.id
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                           Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                     ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=1.323..3.123 rows=9 loops=1)
-                           ->  Seq Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=1.323..3.123 rows=9 loops=1)
-         ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-               ->  Seq Scan on locations  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).
-   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Work_mem: 9K bytes max.
-   (slice3)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
+               ->  Hash Right Join  (cost=2432.00..569.25 rows=2967 width=4) (actual time=3.936..3.936 rows=0 loops=1)
+                     Hash Cond: apples.id = boxes.apple_id
+                     ->  Seq Scan on apples  (cost=0.00..110.70 rows=3190 width=6) (never executed)
+                     ->  Hash  (cost=2437.00..247.00 rows=2967 width=2) (actual time=3.936..3.969 rows=0 loops=1)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..247.00 rows=2567 width=1) (actual time=3.96..3.96 rows=0 loops=1)
+                                 Hash Key: boxes.apple_id
+                                 ->  Seq Scan on boxes  (cost=0.00..89.00 rows=2567 width=12) (actual time=3.96..3.96 rows=0 loops=1)
+         ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.936..3.96 rows=3 loops=1)
+               ->  Seq Scan on box_locations  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.36..3.96 rows=0 loops=1)
+   (slice0)    Executor memory: 86K bytes.  Peak memory: 2K bytes.  Vmem reserved: 20K bytes.
+   (slice1)    Executor memory: 9K bytes avg x 2 workers, 9K bytes max (seg0).  Peak memory: 2K bytes avg x 3 workers, 13K bytes max (seg0).  Vmem reserved: 102K bytes avg x 3 workers, 24K bytes max (seg0).
+   (slice2)    Executor memory: 122K bytes avg x 1 workers, 2K bytes max (seg0).  Peak memory: 4K bytes avg x 3 workers, 37K bytes max (seg0).  Vmem reserved: 372K bytes avg x 3 workers, 372K bytes max (seg0).
+   (slice3)    Executor memory: 110K bytes avg x 0 workers, 1K bytes max (seg0).  Peak memory: 3K bytes avg x 3 workers, 21K bytes max (seg0).  Vmem reserved: 372K bytes avg x 3 workers, 302K bytes max (seg0).
+ Total memory used across slices: 2164K bytes 
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Total runtime: 34.572 ms
-(21 rows)
+(22 rows)
 
 -- explain_processing_on
 -- YAML Required replaces for costs and time changes
@@ -117,323 +120,350 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Maximum Memory Used: \d+\s+/Maximum Memory Used: ### /
 -- m/Work Maximum Memory: \d+\s+/
 -- s/Work Maximum Memory: \d+\s+/Work Maximum Memory: ### /
--- m/Peak Memory": \d+,/
--- s/Peak Memory": \d+,\s+/Peak Memory": ###,/
--- m/Virtual Memory": \d+/
--- s/Virtual Memory": \d+\s+/Virtual Memory": ###/
 -- m/Workers: \d+\s+/
 -- s/Workers: \d+\s+/Workers: ## /
 -- m/Average: \d+\s+/
 -- s/Average: \d+\s+/Average: ## /
 -- m/Total memory used across slices: \d+/
--- s/Total memory used across slices: \d+/Total memory used across slices: ###/
+-- s/Total memory used across slices: \d+\s*/Total memory used across slices: ###/
+-- m/Memory used: \d+/
+-- s/Memory used: \d+\s+/Memory used: ###/
 -- m/ORCA Memory Used \w+: \d+/
 -- s/ORCA Memory Used (\w+): \d+\s+/ORCA Memory Used $1: ##/
 -- end_matchsubs
 -- Check Explain YAML output
-EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                        QUERY PLAN
 ---------------------------------------------------------
- - Plan:                                                +
-     Node Type: "Gather Motion"                         +
-     Senders: 3                                         +
-     Receivers: 1                                       +
-     Slice: 3                                           +
-     Segments: 3                                        +
-     Gang Type: "primary reader"                        +
-     Startup Cost: 2432.00                              +
-     Total Cost: 8569.25                                +
-     Plan Rows: 77900                                   +
-     Plan Width: 84                                     +
-     Plans:                                             +
-       - Node Type: "Hash Join"                         +
-         Parent Relationship: "Outer"                   +
-         Slice: 3                                       +
-         Segments: 3                                    +
-         Gang Type: "primary reader"                    +
-         Join Type: "Left"                              +
-         Startup Cost: 2432.00                          +
-         Total Cost: 8569.25                            +
-         Plan Rows: 77900                               +
-         Plan Width: 84                                 +
-         Hash Cond: "boxes.location_id = locations.id"  +
-         Plans:                                         +
-           - Node Type: "Redistribute Motion"           +
-             Senders: 3                                 +
-             Receivers: 3                               +
-             Parent Relationship: "Outer"               +
-             Slice: 2                                   +
-             Segments: 3                                +
-             Gang Type: "primary reader"                +
-             Startup Cost: 1216.00                      +
-             Total Cost: 6282.12                        +
-             Plan Rows: 77900                           +
-             Plan Width: 48                             +
-             Hash Key: "boxes.location_id"              +
-             Plans:                                     +
-               - Node Type: "Hash Join"                 +
-                 Parent Relationship: "Outer"           +
-                 Slice: 2                               +
-                 Segments: 3                            +
-                 Gang Type: "primary reader"            +
-                 Join Type: "Left"                      +
-                 Startup Cost: 1216.00                  +
-                 Total Cost: 4724.12                    +
-                 Plan Rows: 77900                       +
-                 Plan Width: 48                         +
-                 Hash Cond: "boxes.apple_id = apples.id"+
-                 Plans:                                 +
-                   - Node Type: "Redistribute Motion"   +
-                     Senders: 3                         +
-                     Receivers: 3                       +
-                     Parent Relationship: "Outer"       +
-                     Slice: 1                           +
-                     Segments: 3                        +
-                     Gang Type: "primary reader"        +
-                     Startup Cost: 0.00                 +
-                     Total Cost: 2437.00                +
-                     Plan Rows: 77900                   +
-                     Plan Width: 12                     +
-                     Hash Key: "boxes.apple_id"         +
-                     Plans:                             +
-                       - Node Type: "Seq Scan"          +
-                         Parent Relationship: "Outer"   +
-                         Slice: 1                       +
-                         Segments: 3                    +
-                         Gang Type: "primary reader"    +
-                         Relation Name: "boxes"         +
-                         Alias: "boxes"                 +
-                         Startup Cost: 0.00             +
-                         Total Cost: 879.00             +
-                         Plan Rows: 77900               +
-                         Plan Width: 12                 +
-                   - Node Type: "Hash"                  +
-                     Parent Relationship: "Inner"       +
-                     Slice: 2                           +
-                     Segments: 3                        +
-                     Gang Type: "primary reader"        +
-                     Startup Cost: 596.00               +
-                     Total Cost: 596.00                 +
-                     Plan Rows: 49600                   +
-                     Plan Width: 36                     +
-                     Plans:                             +
-                       - Node Type: "Seq Scan"          +
-                         Parent Relationship: "Outer"   +
-                         Slice: 2                       +
-                         Segments: 3                    +
-                         Gang Type: "primary reader"    +
-                         Relation Name: "apples"        +
-                         Alias: "apples"                +
-                         Startup Cost: 0.00             +
-                         Total Cost: 596.00             +
-                         Plan Rows: 49600               +
-                         Plan Width: 36                 +
-           - Node Type: "Hash"                          +
-             Parent Relationship: "Inner"               +
-             Slice: 3                                   +
-             Segments: 3                                +
-             Gang Type: "primary reader"                +
-             Startup Cost: 596.00                       +
-             Total Cost: 596.00                         +
-             Plan Rows: 49600                           +
-             Plan Width: 36                             +
-             Plans:                                     +
-               - Node Type: "Seq Scan"                  +
-                 Parent Relationship: "Outer"           +
-                 Slice: 3                               +
-                 Segments: 10                           +
-                 Gang Type: "primary reader"            +
-                 Relation Name: "locations"             +
-                 Alias: "locations"                     +
-                 Startup Cost: 0.00                     +
-                 Total Cost: 596.00                     +
-                 Plan Rows: 49600                       +
-                 Plan Width: 36                         +
-   Settings:                                            +
+ - Plan:                                                  +
+     Node Type: "Gather Motion"                             +
+     Senders: 3                                             +
+     Receivers: 1                                           +
+     Slice: 3                                               +
+     Segments: 3                                            +
+     Gang Type: "primary reader"                            +
+     Startup Cost: 2432.00                                  +
+     Total Cost: 8569.25                                    +
+     Plan Rows: 77900                                       +
+     Plan Width: 84                                         +
+     Plans:                                                 +
+       - Node Type: "Hash Join"                             +
+         Parent Relationship: "Outer"                       +
+         Slice: 3                                           +
+         Segments: 3                                        +
+         Gang Type: "primary reader"                        +
+         Join Type: "Left"                                  +
+         Startup Cost: 2432.00                              +
+         Total Cost: 8569.25                                +
+         Plan Rows: 77900                                   +
+         Plan Width: 84                                     +
+         Hash Cond: "boxes.location_id = box_locations.id"  +
+         Plans:                                             +
+           - Node Type: "Redistribute Motion"               +
+             Senders: 3                                     +
+             Receivers: 3                                   +
+             Parent Relationship: "Outer"                   +
+             Slice: 2                                       +
+             Segments: 3                                    +
+             Gang Type: "primary reader"                    +
+             Startup Cost: 1216.00                          +
+             Total Cost: 6282.12                            +
+             Plan Rows: 77900                               +
+             Plan Width: 48                                 +
+             Hash Key: "boxes.location_id"                  +
+             Plans:                                         +
+               - Node Type: "Hash Join"                     +
+                 Parent Relationship: "Outer"               +
+                 Slice: 2                                   +
+                 Segments: 3                                +
+                 Gang Type: "primary reader"                +
+                 Join Type: "Left"                          +
+                 Startup Cost: 1216.00                      +
+                 Total Cost: 4724.12                        +
+                 Plan Rows: 77900                           +
+                 Plan Width: 48                             +
+                 Hash Cond: "boxes.apple_id = apples.id"    +
+                 Plans:                                     +
+                   - Node Type: "Redistribute Motion"       +
+                     Senders: 3                             +
+                     Receivers: 3                           +
+                     Parent Relationship: "Outer"           +
+                     Slice: 1                               +
+                     Segments: 3                            +
+                     Gang Type: "primary reader"            +
+                     Startup Cost: 0.00                     +
+                     Total Cost: 2437.00                    +
+                     Plan Rows: 77900                       +
+                     Plan Width: 12                         +
+                     Hash Key: "boxes.apple_id"             +
+                     Plans:                                 +
+                       - Node Type: "Seq Scan"              +
+                         Parent Relationship: "Outer"       +
+                         Slice: 1                           +
+                         Segments: 3                        +
+                         Gang Type: "primary reader"        +
+                         Relation Name: "boxes"             +
+                         Alias: "boxes"                     +
+                         Startup Cost: 0.00                 +
+                         Total Cost: 879.00                 +
+                         Plan Rows: 77900                   +
+                         Plan Width: 12                     +
+                   - Node Type: "Hash"                      +
+                     Parent Relationship: "Inner"           +
+                     Slice: 2                               +
+                     Segments: 3                            +
+                     Gang Type: "primary reader"            +
+                     Startup Cost: 596.00                   +
+                     Total Cost: 596.00                     +
+                     Plan Rows: 49600                       +
+                     Plan Width: 36                         +
+                     Plans:                                 +
+                       - Node Type: "Seq Scan"              +
+                         Parent Relationship: "Outer"       +
+                         Slice: 2                           +
+                         Segments: 3                        +
+                         Gang Type: "primary reader"        +
+                         Relation Name: "apples"            +
+                         Alias: "apples"                    +
+                         Startup Cost: 0.00                 +
+                         Total Cost: 596.00                 +
+                         Plan Rows: 49600                   +
+                         Plan Width: 36                     +
+           - Node Type: "Hash"                              +
+             Parent Relationship: "Inner"                   +
+             Slice: 3                                       +
+             Segments: 3                                    +
+             Gang Type: "primary reader"                    +
+             Startup Cost: 596.00                           +
+             Total Cost: 596.00                             +
+             Plan Rows: 49600                               +
+             Plan Width: 36                                 +
+             Plans:                                         +
+               - Node Type: "Seq Scan"                      +
+                 Parent Relationship: "Outer"               +
+                 Slice: 3                                   +
+                 Segments: 10                               +
+                 Gang Type: "primary reader"                +
+                 Relation Name: "box_locations"             +
+                 Alias: "box_locations"                     +
+                 Startup Cost: 0.00                         +
+                 Total Cost: 596.00                         +
+                 Plan Rows: 49600                           +
+                 Plan Width: 36                             +
+   Settings:                                                +
      Optimizer: "legacy query optimizer"
 (1 row)
 
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                        QUERY PLAN
 ---------------------------------------------------------
- - Plan:                                                +
-     Node Type: "Gather Motion"                         +
-     Senders: 3                                         +
-     Receivers: 1                                       +
-     Slice: 3                                           +
-     Segments: 3                                        +
-     Gang Type: "primary reader"                        +
-     Startup Cost: 2432.00                              +
-     Total Cost: 8569.25                                +
-     Plan Rows: 77901                                   +
-     Plan Width: 100                                    +
-     Actual Startup Time: 1.842                         +
-     Actual Total Time: 1.842                           +
-     Actual Rows: 50                                    +
-     Actual Loops: 3                                    +
-     Plans:                                             +
-       - Node Type: "Hash Join"                         +
-         Parent Relationship: "Outer"                   +
-         Slice: 3                                       +
-         Segments: 3                                    +
-         Gang Type: "primary reader"                    +
-         Join Type: "Left"                              +
-         Startup Cost: 2432.00                          +
-         Total Cost: 8569.25                            +
-         Plan Rows: 900                                 +
-         Plan Width: 84                                 +
-         Actual Startup Time: 0.000                     +
-         Actual Total Time: 0.000                       +
-         Actual Rows: 0                                 +
-         Actual Loops: 0                                +
-         Hash Cond: "boxes.location_id = locations.id"  +
-         Plans:                                         +
-           - Node Type: "Redistribute Motion"           +
-             Senders: 3                                 +
-             Receivers: 3                               +
-             Parent Relationship: "Outer"               +
-             Slice: 2                                   +
-             Segments: 3                                +
-             Gang Type: "primary reader"                +
-             Startup Cost: 1216.00                      +
-             Total Cost: 6282.12                        +
-             Plan Rows: 77900                           +
-             Plan Width: 48                             +
-             Actual Startup Time: 0.000                 +
-             Actual Total Time: 0.000                   +
-             Actual Rows: 0                             +
-             Actual Loops: 0                            +
-             Hash Key: "boxes.location_id"              +
-             Plans:                                     +
-               - Node Type: "Hash Join"                 +
-                 Parent Relationship: "Outer"           +
-                 Slice: 2                               +
-                 Segments: 3                            +
-                 Gang Type: "primary reader"            +
-                 Join Type: "Left"                      +
-                 Startup Cost: 1216.00                  +
-                 Total Cost: 4724.12                    +
-                 Plan Rows: 77900                       +
-                 Plan Width: 48                         +
-                 Actual Startup Time: 0.000             +
-                 Actual Total Time: 0.000               +
-                 Actual Rows: 0                         +
-                 Actual Loops: 0                        +
-                 Hash Cond: "boxes.apple_id = apples.id"+
-                 Plans:                                 +
-                   - Node Type: "Redistribute Motion"   +
-                     Senders: 3                         +
-                     Receivers: 3                       +
-                     Parent Relationship: "Outer"       +
-                     Slice: 1                           +
-                     Segments: 3                        +
-                     Gang Type: "primary reader"        +
-                     Startup Cost: 0.00                 +
-                     Total Cost: 2437.00                +
-                     Plan Rows: 77900                   +
-                     Plan Width: 12                     +
-                     Actual Startup Time: 0.000         +
-                     Actual Total Time: 0.000           +
-                     Actual Rows: 0                     +
-                     Actual Loops: 0                    +
-                     Hash Key: "boxes.apple_id"         +
-                     Plans:                             +
-                       - Node Type: "Seq Scan"          +
-                         Parent Relationship: "Outer"   +
-                         Slice: 1                       +
-                         Segments: 3                    +
-                         Gang Type: "primary reader"    +
-                         Relation Name: "boxes"         +
-                         Alias: "boxes"                 +
-                         Startup Cost: 0.00             +
-                         Total Cost: 879.00             +
-                         Plan Rows: 77900               +
-                         Plan Width: 12                 +
-                         Actual Startup Time: 0.000     +
-                         Actual Total Time: 0.000       +
-                         Actual Rows: 0                 +
-                         Actual Loops: 0                +
-                   - Node Type: "Hash"                  +
-                     Parent Relationship: "Inner"       +
-                     Slice: 2                           +
-                     Segments: 3                        +
-                     Gang Type: "primary reader"        +
-                     Startup Cost: 596.00               +
-                     Total Cost: 596.00                 +
-                     Plan Rows: 49600                   +
-                     Plan Width: 36                     +
-                     Actual Startup Time: 0.000         +
-                     Actual Total Time: 0.000           +
-                     Actual Rows: 0                     +
-                     Actual Loops: 0                    +
-                     Plans:                             +
-                       - Node Type: "Seq Scan"          +
-                         Parent Relationship: "Outer"   +
-                         Slice: 2                       +
-                         Segments: 3                    +
-                         Gang Type: "primary reader"    +
-                         Relation Name: "apples"        +
-                         Alias: "apples"                +
-                         Startup Cost: 0.00             +
-                         Total Cost: 596.00             +
-                         Plan Rows: 49600               +
-                         Plan Width: 36                 +
-                         Actual Startup Time: 0.000     +
-                         Actual Total Time: 0.000       +
-                         Actual Rows: 0                 +
-                         Actual Loops: 0                +
-           - Node Type: "Hash"                          +
-             Parent Relationship: "Inner"               +
-             Slice: 3                                   +
-             Segments: 3                                +
-             Gang Type: "primary reader"                +
-             Startup Cost: 596.00                       +
-             Total Cost: 596.00                         +
-             Plan Rows: 49600                           +
-             Plan Width: 36                             +
-             Actual Startup Time: 0.000                 +
-             Actual Total Time: 0.000                   +
-             Actual Rows: 0                             +
-             Actual Loops: 0                            +
-             Plans:                                     +
-               - Node Type: "Seq Scan"                  +
-                 Parent Relationship: "Outer"           +
-                 Slice: 3                               +
-                 Segments: 10                           +
-                 Gang Type: "primary reader"            +
-                 Relation Name: "locations"             +
-                 Alias: "locations"                     +
-                 Startup Cost: 0.00                     +
-                 Total Cost: 596.00                     +
-                 Plan Rows: 49600                       +
-                 Plan Width: 36                         +
-                 Actual Startup Time: 0.000             +
-                 Actual Total Time: 0.000               +
-                 Actual Rows: 0                         +
-                 Actual Loops: 0                        +
-   Triggers:                                            +
-   Slice statistics:                                    +
-     - Slice: 0                                         +
-       Executor Memory: 386000                          +
-     - Slice: 1                                         +
-       Average Executor Memory: 59000                   +
-       Workers: 3                                       +
-       Maximum Memory Used: 59000                       +
-     - Slice: 2                                         +
-       Average Executor Memory: 1110000                 +
-       Workers: 3                                       +
-       Maximum Memory Used: 1110000                     +
-       Work Maximum Memory: 1043000                     +
-     - Slice: 3                                         +
-       Average Executor Memory: 1110000                 +
-       Workers: 3                                       +
-       Maximum Memory Used: 1110000                     +
-   Statement statistics:                                +
-     Memory used: 128000                                +
-   Settings:                                            +
-     Optimizer: "legacy query optimizer"                +
+ - Plan:                                                  +
+     Node Type: "Gather Motion"                           +
+     Senders: 3                                           +
+     Receivers: 1                                         +
+     Slice: 3                                             +
+     Segments: 3                                          +
+     Gang Type: "primary reader"                          +
+     Startup Cost: 2432.00                                +
+     Total Cost: 8569.25                                  +
+     Plan Rows: 77901                                     +
+     Plan Width: 100                                      +
+     Actual Startup Time: 1.842                           +
+     Actual Total Time: 1.842                             +
+     Actual Rows: 50                                      +
+     Actual Loops: 3                                      +
+     Plans:                                               +
+       - Node Type: "Hash Join"                           +
+         Parent Relationship: "Outer"                     +
+         Slice: 3                                         +
+         Segments: 3                                      +
+         Gang Type: "primary reader"                      +
+         Join Type: "Left"                                +
+         Startup Cost: 2432.00                            +
+         Total Cost: 8569.25                              +
+         Plan Rows: 900                                   +
+         Plan Width: 84                                   +
+         Actual Startup Time: 0.000                       +
+         Actual Total Time: 0.000                         +
+         Actual Rows: 0                                   +
+         Actual Loops: 0                                  +
+         Hash Cond: "boxes.location_id = box_locations.id"+
+         Plans:                                           +
+           - Node Type: "Redistribute Motion"             +
+             Senders: 3                                   +
+             Receivers: 3                                 +
+             Parent Relationship: "Outer"                 +
+             Slice: 2                                     +
+             Segments: 3                                  +
+             Gang Type: "primary reader"                  +
+             Startup Cost: 1216.00                        +
+             Total Cost: 6282.12                          +
+             Plan Rows: 77900                             +
+             Plan Width: 48                               +
+             Actual Startup Time: 0.000                   +
+             Actual Total Time: 0.000                     +
+             Actual Rows: 0                               +
+             Actual Loops: 0                              +
+             Hash Key: "boxes.location_id"                +
+             Plans:                                       +
+               - Node Type: "Hash Join"                   +
+                 Parent Relationship: "Outer"             +
+                 Slice: 2                                 +
+                 Segments: 3                              +
+                 Gang Type: "primary reader"              +
+                 Join Type: "Right"                       +
+                 Startup Cost: 1216.00                    +
+                 Total Cost: 4724.12                      +
+                 Plan Rows: 77900                         +
+                 Plan Width: 48                           +
+                 Actual Startup Time: 0.000               +
+                 Actual Total Time: 0.000                 +
+                 Actual Rows: 0                           +
+                 Actual Loops: 0                          +
+                 Hash Cond: "apples.id = boxes.apple_id"  +
+                 Plans:                                   +
+                   - Node Type: "Seq Scan"                +
+                     Parent Relationship: "Outer"         +
+                     Slice: 1                             +
+                     Segments: 3                          +
+                     Gang Type: "primary reader"          +
+                     Relation Name: "apples"              +
+                     Alias: "apples"                      +
+                     Startup Cost: 0.00                   +
+                     Total Cost: 2437.00                  +
+                     Plan Rows: 77900                     +
+                     Plan Width: 12                       +
+                     Actual Startup Time: 0.000           +
+                     Actual Total Time: 0.000             +
+                     Actual Rows: 0                       +
+                     Actual Loops: 0                      +
+                   - Node Type: "Hash"                    +
+                     Parent Relationship: "Inner"         +
+                     Slice: 2                             +
+                     Segments: 3                          +
+                     Gang Type: "primary reader"          +
+                     Startup Cost: 596.00                 +
+                     Total Cost: 596.00                   +
+                     Plan Rows: 49600                     +
+                     Plan Width: 36                       +
+                     Actual Startup Time: 0.000           +
+                     Actual Total Time: 0.000             +
+                     Actual Rows: 0                       +
+                     Actual Loops: 0                      +
+                     Plans:                               +
+                       - Node Type: "Redistribute Motion" +
+                         Senders: 3                       +
+                         Receivers: 3                     +
+                         Parent Relationship: "Outer"     +
+                         Slice: 2                         +
+                         Segments: 3                      +
+                         Gang Type: "primary reader"      +
+                         Startup Cost: 0.00               +
+                         Total Cost: 596.00               +
+                         Plan Rows: 49600                 +
+                         Plan Width: 36                   +
+                         Actual Startup Time: 0.000       +
+                         Actual Total Time: 0.000         +
+                         Actual Rows: 0                   +
+                         Actual Loops: 0                  +
+                         Hash Key: "boxes.apple_id"       +
+                         Plans:                           +
+                           - Node Type: "Seq Scan"        +
+                             Parent Relationship: "Outer" +
+                             Slice: 1                     +
+                             Segments: 3                  +
+                             Gang Type: "primary reader"  +
+                             Relation Name: "boxes"       +
+                             Alias: "boxes"               +
+                             Startup Cost: 123.23         +
+                             Total Cost: 432.23           +
+                             Plan Rows: 1234              +
+                             Plan Width: 1343224          +
+                             Actual Startup Time: 12.123  +
+                             Actual Total Time: 12.123    +
+                             Actual Rows: 12312312312     +
+                             Actual Loops: 1              +
+           - Node Type: "Hash"                            +
+             Parent Relationship: "Inner"                 +
+             Slice: 3                                     +
+             Segments: 3                                  +
+             Gang Type: "primary reader"                  +
+             Startup Cost: 596.00                         +
+             Total Cost: 596.00                           +
+             Plan Rows: 49600                             +
+             Plan Width: 36                               +
+             Actual Startup Time: 0.000                   +
+             Actual Total Time: 0.000                     +
+             Actual Rows: 0                               +
+             Actual Loops: 0                              +
+             Plans:                                       +
+               - Node Type: "Seq Scan"                    +
+                 Parent Relationship: "Outer"             +
+                 Slice: 3                                 +
+                 Segments: 10                             +
+                 Gang Type: "primary reader"              +
+                 Relation Name: "box_locations"           +
+                 Alias: "box_locations"                   +
+                 Startup Cost: 0.00                       +
+                 Total Cost: 596.00                       +
+                 Plan Rows: 49600                         +
+                 Plan Width: 36                           +
+                 Actual Startup Time: 0.000               +
+                 Actual Total Time: 0.000                 +
+                 Actual Rows: 0                           +
+                 Actual Loops: 0                          +
+   Triggers:                                              +
+   Slice statistics:                                      +
+     - Slice: 0                                           +
+       Executor Memory: 3900                            +
+       Global Peak Memory: 21768                        +
+       Virtual Memory: 20971                            +
+     - Slice: 1                                           +
+       Executor Memory:                                   +
+         Average: 60104123                                   +
+         Workers: 32                                       +
+         Maximum Memory Used: 604                       +
+       Global Peak Memory:                                +
+         Average: 111286                                 +
+         Workers: 31                                       +
+         Maximum Memory Used: 111296                     +
+       Virtual Memory:                                    +
+         Average: 148576                                 +
+         Workers: 1                                       +
+         Maximum Memory Used: 104576                     +
+     - Slice: 2                                           +
+       Executor Memory:                                   +
+         Average: 217194                                 +
+         Workers: 31                                       +
+         Maximum Memory Used: 271944                     +
+       Global Peak Memory:                                +
+         Average: 334226                                 +
+         Workers: 1                                       +
+         Maximum Memory Used: 342256                     +
+       Virtual Memory:                                    +
+         Average: 314528                                 +
+         Workers: 33                                       +
+         Maximum Memory Used: 345728                     +
+     - Slice: 3                                           +
+       Executor Memory:                                   +
+         Average: 113528                                 +
+         Workers: 13                                       +
+         Maximum Memory Used: 113728                     +
+       Global Peak Memory:                                +
+         Average: 251952                                 +
+         Workers: 2                                       +
+         Maximum Memory Used: 251952                     +
+       Virtual Memory:                                    +
+         Average: 314578                                 +
+         Workers: 2                                       +
+         Maximum Memory Used: 3145728                     +
+   Total memory used across slices: 123545                 +
+   Statement statistics:                                  +
+     Memory used: 1280                                  +
+   Settings:                                              +
+     Optimizer: "legacy query optimizer"                  +
    Total Runtime: 2.652
 (1 row)
 
@@ -466,386 +496,434 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- s/"Work Maximum Memory": \d+,?\s+/"Work Maximum Memory": ### /
 -- m/"Workers": \d+,\s+/
 -- s/"Workers": \d+,\s+/"Workers": ##, /
+-- m/Peak Memory": \d+,/
+-- s/Peak Memory": \d+,\s+/Peak Memory": ###,/
+-- m/Virtual Memory": \d+/
+-- s/Virtual Memory": \d+\s+/Virtual Memory": ###/
+-- m/"Average": \d+,\s+/
+-- s/"Average": \d+,\s+/"Average": ##, /
+-- m/"Total memory used across slices": \d+,/
+-- s/"Total memory used across slices": \d+,\s*/"Total memory used across slices": ###,/
+-- m/"ORCA Memory Used \w+": \d+,?/
+-- s/"ORCA Memory Used (\w+)": \d+,?\s+/"ORCA Memory Used $1": ##/
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain JSON output
-EXPLAIN (FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                           QUERY PLAN
 --------------------------------------------------------------
- [                                                           +
-   {                                                         +
-     "Plan": {                                               +
-       "Node Type": "Gather Motion",                         +
-       "Senders": 3,                                         +
-       "Receivers": 1,                                       +
-       "Slice": 3,                                           +
-       "Segments": 3,                                        +
-       "Gang Type": "primary reader",                        +
-       "Startup Cost": 242.00,                               +
-       "Total Cost": 859.25,                                 +
-       "Plan Rows": 7790,                                    +
-       "Plan Width": 10,                                     +
-       "Plans": [                                            +
-         {                                                   +
-           "Node Type": "Hash Join",                         +
-           "Parent Relationship": "Outer",                   +
-           "Slice": 3,                                       +
-           "Segments": 3,                                    +
-           "Gang Type": "primary reader",                    +
-           "Join Type": "Left",                              +
-           "Startup Cost": 242.00,                           +
-           "Total Cost": 859.25,                             +
-           "Plan Rows": 7700,                                +
-           "Plan Width": 10,                                 +
-           "Hash Cond": "boxes.location_id = locations.id",  +
-           "Plans": [                                        +
-             {                                               +
-               "Node Type": "Redistribute Motion",           +
-               "Senders": 3,                                 +
-               "Receivers": 3,                               +
-               "Parent Relationship": "Outer",               +
-               "Slice": 2,                                   +
-               "Segments": 3,                                +
-               "Gang Type": "primary reader",                +
-               "Startup Cost": 121.00,                       +
-               "Total Cost": 628.12,                         +
-               "Plan Rows": 7790,                            +
-               "Plan Width": 4,                              +
-               "Hash Key": "boxes.location_id",              +
-               "Plans": [                                    +
-                 {                                           +
-                   "Node Type": "Hash Join",                 +
-                   "Parent Relationship": "Outer",           +
-                   "Slice": 2,                               +
-                   "Segments": 3,                            +
-                   "Gang Type": "primary reader",            +
-                   "Join Type": "Left",                      +
-                   "Startup Cost": 1216.00,                  +
-                   "Total Cost": 4724.12,                    +
-                   "Plan Rows": 77900,                       +
-                   "Plan Width": 48,                         +
-                   "Hash Cond": "boxes.apple_id = apples.id",+
-                   "Plans": [                                +
-                     {                                       +
-                       "Node Type": "Redistribute Motion",   +
-                       "Senders": 3,                         +
-                       "Receivers": 3,                       +
-                       "Parent Relationship": "Outer",       +
-                       "Slice": 1,                           +
-                       "Segments": 3,                        +
-                       "Gang Type": "primary reader",        +
-                       "Startup Cost": 0.00,                 +
-                       "Total Cost": 2437.00,                +
-                       "Plan Rows": 77900,                   +
-                       "Plan Width": 12,                     +
-                       "Hash Key": "boxes.apple_id",         +
-                       "Plans": [                            +
-                         {                                   +
-                           "Node Type": "Seq Scan",          +
-                           "Parent Relationship": "Outer",   +
-                           "Slice": 1,                       +
-                           "Segments": 3,                    +
-                           "Gang Type": "primary reader",    +
-                           "Relation Name": "boxes",         +
-                           "Alias": "boxes",                 +
-                           "Startup Cost": 0.00,             +
-                           "Total Cost": 879.00,             +
-                           "Plan Rows": 77900,               +
-                           "Plan Width": 12                  +
-                         }                                   +
-                       ]                                     +
-                     },                                      +
-                     {                                       +
-                       "Node Type": "Hash",                  +
-                       "Parent Relationship": "Inner",       +
-                       "Slice": 2,                           +
-                       "Segments": 3,                        +
-                       "Gang Type": "primary reader",        +
-                       "Startup Cost": 596.00,               +
-                       "Total Cost": 596.00,                 +
-                       "Plan Rows": 49600,                   +
-                       "Plan Width": 36,                     +
-                       "Plans": [                            +
-                         {                                   +
-                           "Node Type": "Seq Scan",          +
-                           "Parent Relationship": "Outer",   +
-                           "Slice": 2,                       +
-                           "Segments": 3,                    +
-                           "Gang Type": "primary reader",    +
-                           "Relation Name": "apples",        +
-                           "Alias": "apples",                +
-                           "Startup Cost": 0.00,             +
-                           "Total Cost": 596.00,             +
-                           "Plan Rows": 49600,               +
-                           "Plan Width": 36                  +
-                         }                                   +
-                       ]                                     +
-                     }                                       +
-                   ]                                         +
-                 }                                           +
-               ]                                             +
-             },                                              +
-             {                                               +
-               "Node Type": "Hash",                          +
-               "Parent Relationship": "Inner",               +
-               "Slice": 3,                                   +
-               "Segments": 3,                                +
-               "Gang Type": "primary reader",                +
-               "Startup Cost": 596.00,                       +
-               "Total Cost": 596.00,                         +
-               "Plan Rows": 49600,                           +
-               "Plan Width": 36,                             +
-               "Plans": [                                    +
-                 {                                           +
-                   "Node Type": "Seq Scan",                  +
-                   "Parent Relationship": "Outer",           +
-                   "Slice": 3,                               +
-                   "Segments": 10,                           +
-                   "Gang Type": "primary reader",            +
-                   "Relation Name": "locations",             +
-                   "Alias": "locations",                     +
-                   "Startup Cost": 0.00,                     +
-                   "Total Cost": 596.00,                     +
-                   "Plan Rows": 49600,                       +
-                   "Plan Width": 36                          +
-                 }                                           +
-               ]                                             +
-             }                                               +
-           ]                                                 +
-         }                                                   +
-       ]                                                     +
-     },                                                      +
-     "Settings": {                                           +
-       "Optimizer": "legacy query optimizer"                 +
-     }                                                       +
-   }                                                         +
+ [                                                             +
+   {                                                           +
+     "Plan": {                                                 +
+       "Node Type": "Gather Motion",                           +
+       "Senders": 3,                                           +
+       "Receivers": 1,                                         +
+       "Slice": 3,                                             +
+       "Segments": 3,                                          +
+       "Gang Type": "primary reader",                          +
+       "Startup Cost": 242.00,                                 +
+       "Total Cost": 859.25,                                   +
+       "Plan Rows": 7790,                                      +
+       "Plan Width": 10,                                       +
+       "Plans": [                                              +
+         {                                                     +
+           "Node Type": "Hash Join",                           +
+           "Parent Relationship": "Outer",                     +
+           "Slice": 3,                                         +
+           "Segments": 3,                                      +
+           "Gang Type": "primary reader",                      +
+           "Join Type": "Left",                                +
+           "Startup Cost": 242.00,                             +
+           "Total Cost": 859.25,                               +
+           "Plan Rows": 7700,                                  +
+           "Plan Width": 10,                                   +
+           "Hash Cond": "boxes.location_id = box_locations.id",+
+           "Plans": [                                          +
+             {                                                 +
+               "Node Type": "Redistribute Motion",             +
+               "Senders": 3,                                   +
+               "Receivers": 3,                                 +
+               "Parent Relationship": "Outer",                 +
+               "Slice": 2,                                     +
+               "Segments": 3,                                  +
+               "Gang Type": "primary reader",                  +
+               "Startup Cost": 121.00,                         +
+               "Total Cost": 628.12,                           +
+               "Plan Rows": 7790,                              +
+               "Plan Width": 4,                                +
+               "Hash Key": "boxes.location_id",                +
+               "Plans": [                                      +
+                 {                                             +
+                   "Node Type": "Hash Join",                   +
+                   "Parent Relationship": "Outer",             +
+                   "Slice": 2,                                 +
+                   "Segments": 3,                              +
+                   "Gang Type": "primary reader",              +
+                   "Join Type": "Right",                       +
+                   "Startup Cost": 1216.00,                    +
+                   "Total Cost": 4724.12,                      +
+                   "Plan Rows": 77900,                         +
+                   "Plan Width": 48,                           +
+                   "Hash Cond": "apples.id = boxes.apple_id",  +
+                   "Plans": [                                  +
+                     {                                         +
+                       "Node Type": "Seq Scan",                +
+                       "Parent Relationship": "Outer",         +
+                       "Slice": 1,                             +
+                       "Segments": 3,                          +
+                       "Gang Type": "primary reader",          +
+                       "Relation Name": "apples",              +
+                       "Alias": "apples",                      +
+                       "Startup Cost": 0.00,                   +
+                       "Total Cost": 2437.00,                  +
+                       "Plan Rows": 77900,                     +
+                       "Plan Width": 12,                       +
+                     },                                        +
+                     {                                         +
+                       "Node Type": "Hash",                    +
+                       "Parent Relationship": "Inner",         +
+                       "Slice": 2,                             +
+                       "Segments": 3,                          +
+                       "Gang Type": "primary reader",          +
+                       "Startup Cost": 596.00,                 +
+                       "Total Cost": 596.00,                   +
+                       "Plan Rows": 49600,                     +
+                       "Plan Width": 36,                       +
+                       "Plans": [                              +
+                         {                                     +
+                           "Node Type": "Redistribute Motion", +
+                           "Senders": 3,                       +
+                           "Receivers": 3,                     +
+                           "Parent Relationship": "Outer",     +
+                           "Slice": 1,                         +
+                           "Segments": 3,                      +
+                           "Gang Type": "primary reader",      +
+                           "Startup Cost": 0.10,               +
+                           "Total Cost": 27.00,              +
+                           "Plan Rows": 770,                 +
+                           "Plan Width": 2,                   +
+                           "Hash Key": "boxes.apple_id",       +
+                           "Plans": [                          +
+                             {                                 +
+                               "Node Type": "Seq Scan",        +
+                               "Parent Relationship": "Outer", +
+                               "Slice": 1,                     +
+                               "Segments": 3,                  +
+                               "Gang Type": "primary reader",  +
+                               "Relation Name": "boxes",       +
+                               "Alias": "boxes",               +
+                               "Startup Cost": 120.00,        +
+                               "Total Cost": 89.00,           +
+                               "Plan Rows": 7700,             +
+                               "Plan Width": 2                +
+                             }                                 +
+                           ]                                   +
+                         }                                     +
+                       ]                                       +
+                     }                                         +
+                   ]                                           +
+                 }                                             +
+               ]                                               +
+             },                                                +
+             {                                                 +
+               "Node Type": "Hash",                            +
+               "Parent Relationship": "Inner",                 +
+               "Slice": 3,                                     +
+               "Segments": 3,                                  +
+               "Gang Type": "primary reader",                  +
+               "Startup Cost": 596.00,                         +
+               "Total Cost": 596.00,                           +
+               "Plan Rows": 49600,                             +
+               "Plan Width": 36,                               +
+               "Plans": [                                      +
+                 {                                             +
+                   "Node Type": "Seq Scan",                    +
+                   "Parent Relationship": "Outer",             +
+                   "Slice": 3,                                 +
+                   "Segments": 10,                             +
+                   "Gang Type": "primary reader",              +
+                   "Relation Name": "box_locations",           +
+                   "Alias": "box_locations",                   +
+                   "Startup Cost": 0.00,                       +
+                   "Total Cost": 596.00,                       +
+                   "Plan Rows": 49600,                         +
+                   "Plan Width": 36                            +
+                 }                                             +
+               ]                                               +
+             }                                                 +
+           ]                                                   +
+         }                                                     +
+       ]                                                       +
+     },                                                        +
+     "Settings": {                                             +
+       "Optimizer": "legacy query optimizer"                   +
+     }                                                         +
+   }                                                           +
  ]
 (1 row)
 
 -- explain_processing_on
 --- Check Explain Analyze JSON output that include the slices information
 -- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                           QUERY PLAN
 --------------------------------------------------------------
- [                                                           +
-   {                                                         +
-     "Plan": {                                               +
-       "Node Type": "Gather Motion",                         +
-       "Senders": 3,                                         +
-       "Receivers": 1,                                       +
-       "Slice": 3,                                           +
-       "Segments": 3,                                        +
-       "Gang Type": "primary reader",                        +
-       "Startup Cost": 2432.00,                              +
-       "Total Cost": 8569.25,                                +
-       "Plan Rows": 77900,                                   +
-       "Plan Width": 84,                                     +
-       "Actual Startup Time": 5.415,                         +
-       "Actual Total Time": 5.415,                           +
-       "Actual Rows": 0,                                     +
-       "Actual Loops": 1,                                    +
-       "Plans": [                                            +
-         {                                                   +
-           "Node Type": "Hash Join",                         +
-           "Parent Relationship": "Outer",                   +
-           "Slice": 3,                                       +
-           "Segments": 10,                                   +
-           "Gang Type": "primary reader",                    +
-           "Join Type": "Left",                              +
-           "Startup Cost": 2432.00,                          +
-           "Total Cost": 8569.25,                            +
-           "Plan Rows": 77900,                               +
-           "Plan Width": 84,                                 +
-           "Actual Startup Time": 0.000,                     +
-           "Actual Total Time": 0.000,                       +
-           "Actual Rows": 0,                                 +
-           "Actual Loops": 0,                                +
-           "Hash Cond": "boxes.location_id = locations.id",  +
-           "Plans": [                                        +
-             {                                               +
-               "Node Type": "Redistribute Motion",           +
-               "Senders": 3,                                 +
-               "Receivers": 3,                               +
-               "Parent Relationship": "Outer",               +
-               "Slice": 2,                                   +
-               "Segments": 3,                                +
-               "Gang Type": "primary reader",                +
-               "Startup Cost": 1216.00,                      +
-               "Total Cost": 6282.12,                        +
-               "Plan Rows": 77900,                           +
-               "Plan Width": 48,                             +
-               "Actual Startup Time": 0.000,                 +
-               "Actual Total Time": 0.000,                   +
-               "Actual Rows": 0,                             +
-               "Actual Loops": 0,                            +
-               "Hash Key": "boxes.location_id",              +
-               "Plans": [                                    +
-                 {                                           +
-                   "Node Type": "Hash Join",                 +
-                   "Parent Relationship": "Outer",           +
-                   "Slice": 2,                               +
-                   "Segments": 3,                            +
-                   "Gang Type": "primary reader",            +
-                   "Join Type": "Left",                      +
-                   "Startup Cost": 1216.00,                  +
-                   "Total Cost": 4724.12,                    +
-                   "Plan Rows": 77900,                       +
-                   "Plan Width": 48,                         +
-                   "Actual Startup Time": 0.000,             +
-                   "Actual Total Time": 0.000,               +
-                   "Actual Rows": 0,                         +
-                   "Actual Loops": 0,                        +
-                   "Hash Cond": "boxes.apple_id = apples.id",+
-                   "Plans": [                                +
-                     {                                       +
-                       "Node Type": "Redistribute Motion",   +
-                       "Senders": 3,                         +
-                       "Receivers": 3,                       +
-                       "Parent Relationship": "Outer",       +
-                       "Slice": 1,                           +
-                       "Segments": 3,                        +
-                       "Gang Type": "primary reader",        +
-                       "Startup Cost": 0.00,                 +
-                       "Total Cost": 2437.00,                +
-                       "Plan Rows": 77900,                   +
-                       "Plan Width": 12,                     +
-                       "Actual Startup Time": 0.000,         +
-                       "Actual Total Time": 0.000,           +
-                       "Actual Rows": 0,                     +
-                       "Actual Loops": 0,                    +
-                       "Hash Key": "boxes.apple_id",         +
-                       "Plans": [                            +
-                         {                                   +
-                           "Node Type": "Seq Scan",          +
-                           "Parent Relationship": "Outer",   +
-                           "Slice": 1,                       +
-                           "Segments": 3,                    +
-                           "Gang Type": "primary reader",    +
-                           "Relation Name": "boxes",         +
-                           "Alias": "boxes",                 +
-                           "Startup Cost": 0.00,             +
-                           "Total Cost": 879.00,             +
-                           "Plan Rows": 77900,               +
-                           "Plan Width": 12,                 +
-                           "Actual Startup Time": 0.000,     +
-                           "Actual Total Time": 0.000,       +
-                           "Actual Rows": 0,                 +
-                           "Actual Loops": 0                 +
-                         }                                   +
-                       ]                                     +
-                     },                                      +
-                     {                                       +
-                       "Node Type": "Hash",                  +
-                       "Parent Relationship": "Inner",       +
-                       "Slice": 2,                           +
-                       "Segments": 3,                        +
-                       "Gang Type": "primary reader",        +
-                       "Startup Cost": 596.00,               +
-                       "Total Cost": 596.00,                 +
-                       "Plan Rows": 49600,                   +
-                       "Plan Width": 36,                     +
-                       "Actual Startup Time": 0.000,         +
-                       "Actual Total Time": 0.000,           +
-                       "Actual Rows": 0,                     +
-                       "Actual Loops": 0,                    +
-                       "Plans": [                            +
-                         {                                   +
-                           "Node Type": "Seq Scan",          +
-                           "Parent Relationship": "Outer",   +
-                           "Slice": 2,                       +
-                           "Segments": 3,                    +
-                           "Gang Type": "primary reader",    +
-                           "Relation Name": "apples",        +
-                           "Alias": "apples",                +
-                           "Startup Cost": 0.00,             +
-                           "Total Cost": 596.00,             +
-                           "Plan Rows": 49600,               +
-                           "Plan Width": 36,                 +
-                           "Actual Startup Time": 0.000,     +
-                           "Actual Total Time": 0.000,       +
-                           "Actual Rows": 0,                 +
-                           "Actual Loops": 0                 +
-                         }                                   +
-                       ]                                     +
-                     }                                       +
-                   ]                                         +
-                 }                                           +
-               ]                                             +
-             },                                              +
-             {                                               +
-               "Node Type": "Hash",                          +
-               "Parent Relationship": "Inner",               +
-               "Slice": 3,                                   +
-               "Segments": 3,                                +
-               "Gang Type": "primary reader",                +
-               "Startup Cost": 596.00,                       +
-               "Total Cost": 596.00,                         +
-               "Plan Rows": 49600,                           +
-               "Plan Width": 36,                             +
-               "Actual Startup Time": 0.000,                 +
-               "Actual Total Time": 0.000,                   +
-               "Actual Rows": 0,                             +
-               "Actual Loops": 0,                            +
-               "Plans": [                                    +
-                 {                                           +
-                   "Node Type": "Seq Scan",                  +
-                   "Parent Relationship": "Outer",           +
-                   "Slice": 3,                               +
-                   "Segments": 3,                            +
-                   "Gang Type": "primary reader",            +
-                   "Relation Name": "locations",             +
-                   "Alias": "locations",                     +
-                   "Startup Cost": 0.00,                     +
-                   "Total Cost": 59.00,                      +
-                   "Plan Rows": 4960,                        +
-                   "Plan Width": 1,                          +
-                   "Actual Startup Time": 5.000,             +
-                   "Actual Total Time": 10.000,              +
-                   "Actual Rows": 5,                         +
-                   "Actual Loops": 1                         +
-                 }                                           +
-               ]                                             +
-             }                                               +
-           ]                                                 +
-         }                                                   +
-       ]                                                     +
-     },                                                      +
-     "Triggers": [                                           +
-     ],                                                      +
-     "Slice statistics": [                                   +
-       {                                                     +
-         "Slice": 0,                                         +
-         "Executor Memory": 123546                           +
-       },                                                    +
-       {                                                     +
-         "Slice": 1,                                         +
-         "Average Executor Memory": 123546                   +
-         "Workers": 1,                                       +
-         "Maximum Memory Used": 432255                       +
-       },                                                    +
-       {                                                     +
-         "Slice": 2,                                         +
-         "Average Executor Memory": 123432                   +
-         "Workers": 2,                                       +
-         "Maximum Memory Used": 4324,                        +
-         "Work Maximum Memory": 23424                        +
-       },                                                    +
-       {                                                     +
-         "Slice": 3,                                         +
-         "Average Executor Memory": 2341                     +
-         "Workers": 3,                                       +
-         "Maximum Memory Used": 123432                       +
-       }                                                     +
-     ],                                                      +
-     "Statement statistics": {                               +
-       "Memory used": 12800                                  +
-     },                                                      +
-     "Settings": {                                           +
-       "Optimizer": "legacy query optimizer"                 +
-     },                                                      +
-     "Total Runtime": 28.324                                 +
-   }                                                         +
+ [                                                             +
+   {                                                           +
+     "Plan": {                                                 +
+       "Node Type": "Gather Motion",                           +
+       "Senders": 3,                                           +
+       "Receivers": 1,                                         +
+       "Slice": 3,                                             +
+       "Segments": 3,                                          +
+       "Gang Type": "primary reader",                          +
+       "Startup Cost": 2432.00,                                +
+       "Total Cost": 8569.25,                                  +
+       "Plan Rows": 77900,                                     +
+       "Plan Width": 84,                                       +
+       "Actual Startup Time": 5.415,                           +
+       "Actual Total Time": 5.415,                             +
+       "Actual Rows": 0,                                       +
+       "Actual Loops": 1,                                      +
+       "Plans": [                                              +
+         {                                                     +
+           "Node Type": "Hash Join",                           +
+           "Parent Relationship": "Outer",                     +
+           "Slice": 3,                                         +
+           "Segments": 10,                                     +
+           "Gang Type": "primary reader",                      +
+           "Join Type": "Left",                                +
+           "Startup Cost": 2432.00,                            +
+           "Total Cost": 8569.25,                              +
+           "Plan Rows": 77900,                                 +
+           "Plan Width": 84,                                   +
+           "Actual Startup Time": 0.000,                       +
+           "Actual Total Time": 0.000,                         +
+           "Actual Rows": 0,                                   +
+           "Actual Loops": 0,                                  +
+           "Hash Cond": "boxes.location_id = box_locations.id",+
+           "Plans": [                                          +
+             {                                                 +
+               "Node Type": "Redistribute Motion",             +
+               "Senders": 3,                                   +
+               "Receivers": 3,                                 +
+               "Parent Relationship": "Outer",                 +
+               "Slice": 2,                                     +
+               "Segments": 3,                                  +
+               "Gang Type": "primary reader",                  +
+               "Startup Cost": 1216.00,                        +
+               "Total Cost": 6282.12,                          +
+               "Plan Rows": 77900,                             +
+               "Plan Width": 48,                               +
+               "Actual Startup Time": 0.000,                   +
+               "Actual Total Time": 0.000,                     +
+               "Actual Rows": 0,                               +
+               "Actual Loops": 0,                              +
+               "Hash Key": "boxes.location_id",                +
+               "Plans": [                                      +
+                 {                                             +
+                   "Node Type": "Hash Join",                   +
+                   "Parent Relationship": "Outer",             +
+                   "Slice": 2,                                 +
+                   "Segments": 3,                              +
+                   "Gang Type": "primary reader",              +
+                   "Join Type": "Right",                       +
+                   "Startup Cost": 1216.00,                    +
+                   "Total Cost": 4724.12,                      +
+                   "Plan Rows": 77900,                         +
+                   "Plan Width": 48,                           +
+                   "Actual Startup Time": 0.000,               +
+                   "Actual Total Time": 0.000,                 +
+                   "Actual Rows": 0,                           +
+                   "Actual Loops": 0,                          +
+                   "Hash Cond": "apples.id = boxes.apple_id",  +
+                   "Plans": [                                  +
+                     {                                         +
+                       "Node Type": "Seq Scan",                +
+                       "Parent Relationship": "Outer",         +
+                       "Slice": 1,                             +
+                       "Segments": 3,                          +
+                       "Gang Type": "primary reader",          +
+                       "Relation Name": "apples",              +
+                       "Alias": "apples",                      +
+                       "Startup Cost": 0.00,                   +
+                       "Total Cost": 2437.00,                  +
+                       "Plan Rows": 77900,                     +
+                       "Plan Width": 12,                       +
+                       "Actual Startup Time": 0.000,           +
+                       "Actual Total Time": 0.000,             +
+                       "Actual Rows": 0,                       +
+                       "Actual Loops": 0,                      +
+                     },                                        +
+                     {                                         +
+                       "Node Type": "Hash",                    +
+                       "Parent Relationship": "Inner",         +
+                       "Slice": 2,                             +
+                       "Segments": 3,                          +
+                       "Gang Type": "primary reader",          +
+                       "Startup Cost": 596.00,                 +
+                       "Total Cost": 596.00,                   +
+                       "Plan Rows": 49600,                     +
+                       "Plan Width": 36,                       +
+                       "Actual Startup Time": 0.000,           +
+                       "Actual Total Time": 0.000,             +
+                       "Actual Rows": 0,                       +
+                       "Actual Loops": 0,                      +
+                       "Plans": [                              +
+                         {                                     +
+                           "Node Type": "Redistribute Motion", +
+                           "Senders": 3,                       +
+                           "Receivers": 3,                     +
+                           "Parent Relationship": "Outer",     +
+                           "Slice": 2,                         +
+                           "Segments": 3,                      +
+                           "Gang Type": "primary reader",      +
+                           "Startup Cost": 0.00,               +
+                           "Total Cost": 596.00,               +
+                           "Plan Rows": 49600,                 +
+                           "Plan Width": 36,                   +
+                           "Actual Startup Time": 0.000,       +
+                           "Actual Total Time": 0.000,         +
+                           "Actual Rows": 0,                   +
+                           "Actual Loops": 0,                  +
+                           "Hash Key": "boxes.apple_id",       +
+                           "Plans": [                          +
+                             {                                 +
+                               "Node Type": "Seq Scan",        +
+                               "Parent Relationship": "Outer", +
+                               "Slice": 1,                     +
+                               "Segments": 3,                  +
+                               "Gang Type": "primary reader",  +
+                               "Relation Name": "boxes",       +
+                               "Alias": "boxes",               +
+                               "Startup Cost": 0.10,           +
+                               "Total Cost": 829.00,           +
+                               "Plan Rows": 7900,             +
+                               "Plan Width": 2,               +
+                               "Actual Startup Time": 0.020,   +
+                               "Actual Total Time": 0.030,     +
+                               "Actual Rows": 4,               +
+                               "Actual Loops": 1               +
+                             }                                 +
+                           ]                                   +
+                         }                                     +
+                       ]                                       +
+                     }                                         +
+                   ]                                           +
+                 }                                             +
+               ]                                               +
+             },                                                +
+             {                                                 +
+               "Node Type": "Hash",                            +
+               "Parent Relationship": "Inner",                 +
+               "Slice": 3,                                     +
+               "Segments": 3,                                  +
+               "Gang Type": "primary reader",                  +
+               "Startup Cost": 596.00,                         +
+               "Total Cost": 596.00,                           +
+               "Plan Rows": 49600,                             +
+               "Plan Width": 36,                               +
+               "Actual Startup Time": 0.000,                   +
+               "Actual Total Time": 0.000,                     +
+               "Actual Rows": 0,                               +
+               "Actual Loops": 0,                              +
+               "Plans": [                                      +
+                 {                                             +
+                   "Node Type": "Seq Scan",                    +
+                   "Parent Relationship": "Outer",             +
+                   "Slice": 3,                                 +
+                   "Segments": 3,                              +
+                   "Gang Type": "primary reader",              +
+                   "Relation Name": "box_locations",           +
+                   "Alias": "box_locations",                   +
+                   "Startup Cost": 0.00,                       +
+                   "Total Cost": 59.00,                        +
+                   "Plan Rows": 4960,                          +
+                   "Plan Width": 1,                            +
+                   "Actual Startup Time": 5.000,               +
+                   "Actual Total Time": 10.000,                +
+                   "Actual Rows": 5,                           +
+                   "Actual Loops": 1                           +
+                 }                                             +
+               ]                                               +
+             }                                                 +
+           ]                                                   +
+         }                                                     +
+       ]                                                       +
+     },                                                        +
+     "Triggers": [                                             +
+     ],                                                        +
+     "Slice statistics": [                                     +
+       {                                                       +
+         "Slice": 0,                                           +
+         "Executor Memory": 123546,                            +
+         "Global Peak Memory": 21896,                          +
+         "Virtual Memory": 20952                               +
+       },                                                      +
+       {                                                       +
+         "Slice": 1,                                           +
+         "Executor Memory": {                                  +
+           "Average": 6004,                                   +
+           "Workers": 1,                                       +
+           "Maximum Memory Used": 6104                        +
+         },                                                    +
+         "Global Peak Memory": {                               +
+           "Average": 111896,                                 +
+           "Workers": 2,                                       +
+           "Maximum Memory Used": 11896                      +
+         },                                                    +
+         "Virtual Memory": {                                   +
+           "Average": 10486,                                 +
+           "Workers": 3,                                       +
+           "Maximum Memory Used": 1046                      +
+         }                                                     +
+       },                                                      +
+       {                                                       +
+         "Slice": 2,                                           +
+         "Executor Memory": {                                  +
+           "Average": 21944,                                 +
+           "Workers": 1,                                       +
+           "Maximum Memory Used": 2174                      +
+         },                                                    +
+         "Global Peak Memory": {                               +
+           "Average": 334256,                                 +
+           "Workers": 3,                                       +
+           "Maximum Memory Used": 334256                      +
+         },                                                    +
+         "Virtual Memory": {                                   +
+           "Average": 31428,                                 +
+           "Workers": 1,                                       +
+           "Maximum Memory Used": 315728                      +
+         }                                                     +
+       },                                                      +
+       {                                                       +
+         "Slice": 3,                                           +
+         "Executor Memory": {                                  +
+           "Average": 1138,                                 +
+           "Workers": 1,                                       +
+           "Maximum Memory Used": 15728                      +
+         },                                                    +
+         "Global Peak Memory": {                               +
+           "Average": 265152,                                 +
+           "Workers": 2,                                       +
+           "Maximum Memory Used": 265952                      +
+         },                                                    +
+         "Virtual Memory": {                                   +
+           "Average": 345728,                                 +
+           "Workers": 1,                                       +
+           "Maximum Memory Used": 314528                      +
+         }                                                     +
+       }                                                       +
+     ],                                                        +
+     "Total memory used across slices": 1,                  +
+     "Statement statistics": {                                 +
+       "Memory used": 1800                                    +
+     },                                                        +
+     "Settings": {                                             +
+       "Optimizer": "legacy query optimizer"                   +
+     },                                                        +
+     "Total Runtime": 28.324                                   +
+   }                                                           +
  ]
 (1 row)
 
@@ -897,7 +975,7 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain XML output
-EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                  QUERY PLAN
 ----------------------------------------------------------------------------
  <explain xmlns="http://www.postgresql.org/2009/explain">                  +
@@ -925,7 +1003,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
            <Total-Cost>8569.25</Total-Cost>                                +
            <Plan-Rows>77900</Plan-Rows>                                    +
            <Plan-Width>84</Plan-Width>                                     +
-           <Hash-Cond>boxes.location_id = locations.id</Hash-Cond>         +
+           <Hash-Cond>boxes.location_id = box_locations.id</Hash-Cond>     +
            <Plans>                                                         +
              <Plan>                                                        +
                <Node-Type>Redistribute Motion</Node-Type>                  +
@@ -947,41 +1025,25 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                    <Slice>2</Slice>                                        +
                    <Segments>3</Segments>                                  +
                    <Gang-Type>primary reader</Gang-Type>                   +
-                   <Join-Type>Left</Join-Type>                             +
+                   <Join-Type>Right</Join-Type>                            +
                    <Startup-Cost>1216.00</Startup-Cost>                    +
                    <Total-Cost>4724.12</Total-Cost>                        +
                    <Plan-Rows>77900</Plan-Rows>                            +
                    <Plan-Width>48</Plan-Width>                             +
-                   <Hash-Cond>boxes.apple_id = apples.id</Hash-Cond>       +
+                   <Hash-Cond>apples.id = boxes.apple_id</Hash-Cond>       +
                    <Plans>                                                 +
                      <Plan>                                                +
-                       <Node-Type>Redistribute Motion</Node-Type>          +
-                       <Senders>3</Senders>                                +
-                       <Receivers>3</Receivers>                            +
+                       <Node-Type>Seq Scan</Node-Type>                     +
                        <Parent-Relationship>Outer</Parent-Relationship>    +
                        <Slice>1</Slice>                                    +
                        <Segments>3</Segments>                              +
                        <Gang-Type>primary reader</Gang-Type>               +
+                       <Relation-Name>apples</Relation-Name>               +
+                       <Alias>apples</Alias>                               +
                        <Startup-Cost>0.00</Startup-Cost>                   +
                        <Total-Cost>2437.00</Total-Cost>                    +
                        <Plan-Rows>77900</Plan-Rows>                        +
                        <Plan-Width>12</Plan-Width>                         +
-                       <Hash-Key>boxes.apple_id</Hash-Key>                 +
-                       <Plans>                                             +
-                         <Plan>                                            +
-                           <Node-Type>Seq Scan</Node-Type>                 +
-                           <Parent-Relationship>Outer</Parent-Relationship>+
-                           <Slice>1</Slice>                                +
-                           <Segments>3</Segments>                          +
-                           <Gang-Type>primary reader</Gang-Type>           +
-                           <Relation-Name>boxes</Relation-Name>            +
-                           <Alias>boxes</Alias>                            +
-                           <Startup-Cost>0.00</Startup-Cost>               +
-                           <Total-Cost>879.00</Total-Cost>                 +
-                           <Plan-Rows>77900</Plan-Rows>                    +
-                           <Plan-Width>12</Plan-Width>                     +
-                         </Plan>                                           +
-                       </Plans>                                            +
                      </Plan>                                               +
                      <Plan>                                                +
                        <Node-Type>Hash</Node-Type>                         +
@@ -994,20 +1056,36 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                        <Plan-Rows>49600</Plan-Rows>                        +
                        <Plan-Width>36</Plan-Width>                         +
                        <Plans>                                             +
-                         <Plan>                                            +
-                           <Node-Type>Seq Scan</Node-Type>                 +
-                           <Parent-Relationship>Outer</Parent-Relationship>+
-                           <Slice>2</Slice>                                +
-                           <Segments>4</Segments>                          +
-                           <Gang-Type>primary reader</Gang-Type>           +
-                           <Relation-Name>apples</Relation-Name>           +
-                           <Alias>apples</Alias>                           +
-                           <Startup-Cost>1.00</Startup-Cost>               +
-                           <Total-Cost>5.00</Total-Cost>                 +
-                           <Plan-Rows>490</Plan-Rows>                    +
-                           <Plan-Width>6</Plan-Width>                     +
-                         </Plan>                                           +
-                       </Plans>                                            +
+                         <Plan>                                                +
+                           <Node-Type>Redistribute Motion</Node-Type>          +
+                           <Senders>3</Senders>                                +
+                           <Receivers>3</Receivers>                            +
+                           <Parent-Relationship>Outer</Parent-Relationship>    +
+                           <Slice>1</Slice>                                    +
+                           <Segments>3</Segments>                              +
+                           <Gang-Type>primary reader</Gang-Type>               +
+                           <Startup-Cost>0.00</Startup-Cost>                   +
+                           <Total-Cost>2437.00</Total-Cost>                    +
+                           <Plan-Rows>77900</Plan-Rows>                        +
+                           <Plan-Width>12</Plan-Width>                         +
+                           <Hash-Key>boxes.apple_id</Hash-Key>                 +
+                           <Plans>                                             +
+                             <Plan>                                            +
+                               <Node-Type>Seq Scan</Node-Type>                 +
+                               <Parent-Relationship>Outer</Parent-Relationship>+
+                               <Slice>1</Slice>                                +
+                               <Segments>3</Segments>                          +
+                               <Gang-Type>primary reader</Gang-Type>           +
+                               <Relation-Name>boxes</Relation-Name>            +
+                               <Alias>boxes</Alias>                            +
+                               <Startup-Cost>0.00</Startup-Cost>               +
+                               <Total-Cost>879.00</Total-Cost>                 +
+                               <Plan-Rows>77900</Plan-Rows>                    +
+                               <Plan-Width>12</Plan-Width>                     +
+                             </Plan>                                           +
+                           </Plans>                                            +
+                         </Plan>                                               +
+                       </Plans>                                                +
                      </Plan>                                               +
                    </Plans>                                                +
                  </Plan>                                                   +
@@ -1030,8 +1108,8 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                    <Slice>3</Slice>                                        +
                    <Segments>3</Segments>                                  +
                    <Gang-Type>primary reader</Gang-Type>                   +
-                   <Relation-Name>locations</Relation-Name>                +
-                   <Alias>locations</Alias>                                +
+                   <Relation-Name>box_locations</Relation-Name>                +
+                   <Alias>box_locations</Alias>                                +
                    <Startup-Cost>0.00</Startup-Cost>                       +
                    <Total-Cost>596.00</Total-Cost>                         +
                    <Plan-Rows>49600</Plan-Rows>                            +
@@ -1053,7 +1131,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
 -- explain_processing_on
 -- explain_processing_off
 -- Check Explain Analyze XML output
-EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                  QUERY PLAN
 ----------------------------------------------------------------------------
  <explain xmlns="http://www.postgresql.org/2009/explain">                  +
@@ -1089,7 +1167,7 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
            <Actual-Total-Time>0.000</Actual-Total-Time>                    +
            <Actual-Rows>0</Actual-Rows>                                    +
            <Actual-Loops>0</Actual-Loops>                                  +
-           <Hash-Cond>boxes.location_id = locations.id</Hash-Cond>         +
+           <Hash-Cond>boxes.location_id = box_locations.id</Hash-Cond>         +
            <Plans>                                                         +
              <Plan>                                                        +
                <Node-Type>Redistribute Motion</Node-Type>                  +
@@ -1115,7 +1193,7 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
                    <Slice>2</Slice>                                        +
                    <Segments>3</Segments>                                  +
                    <Gang-Type>primary reader</Gang-Type>                   +
-                   <Join-Type>Left</Join-Type>                             +
+                   <Join-Type>Right</Join-Type>                            +
                    <Startup-Cost>1216.00</Startup-Cost>                    +
                    <Total-Cost>4724.12</Total-Cost>                        +
                    <Plan-Rows>77900</Plan-Rows>                            +
@@ -1124,16 +1202,16 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
                    <Actual-Total-Time>0.000</Actual-Total-Time>            +
                    <Actual-Rows>0</Actual-Rows>                            +
                    <Actual-Loops>0</Actual-Loops>                          +
-                   <Hash-Cond>boxes.apple_id = apples.id</Hash-Cond>       +
+                   <Hash-Cond>apples.id = boxes.apple_id</Hash-Cond>       +
                    <Plans>                                                 +
                      <Plan>                                                +
-                       <Node-Type>Redistribute Motion</Node-Type>          +
-                       <Senders>3</Senders>                                +
-                       <Receivers>3</Receivers>                            +
+                       <Node-Type>Seq Scan</Node-Type>                     +
                        <Parent-Relationship>Outer</Parent-Relationship>    +
                        <Slice>1</Slice>                                    +
                        <Segments>3</Segments>                              +
                        <Gang-Type>primary reader</Gang-Type>               +
+                       <Relation-Name>apples</Relation-Name>               +
+                       <Alias>apples</Alias>                               +
                        <Startup-Cost>0.00</Startup-Cost>                   +
                        <Total-Cost>2437.00</Total-Cost>                    +
                        <Plan-Rows>77900</Plan-Rows>                        +
@@ -1142,26 +1220,6 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
                        <Actual-Total-Time>0.000</Actual-Total-Time>        +
                        <Actual-Rows>0</Actual-Rows>                        +
                        <Actual-Loops>0</Actual-Loops>                      +
-                       <Hash-Key>boxes.apple_id</Hash-Key>                 +
-                       <Plans>                                             +
-                         <Plan>                                            +
-                           <Node-Type>Seq Scan</Node-Type>                 +
-                           <Parent-Relationship>Outer</Parent-Relationship>+
-                           <Slice>1</Slice>                                +
-                           <Segments>3</Segments>                          +
-                           <Gang-Type>primary reader</Gang-Type>           +
-                           <Relation-Name>boxes</Relation-Name>            +
-                           <Alias>boxes</Alias>                            +
-                           <Startup-Cost>0.00</Startup-Cost>               +
-                           <Total-Cost>879.00</Total-Cost>                 +
-                           <Plan-Rows>77900</Plan-Rows>                    +
-                           <Plan-Width>12</Plan-Width>                     +
-                           <Actual-Startup-Time>0.000</Actual-Startup-Time>+
-                           <Actual-Total-Time>0.000</Actual-Total-Time>    +
-                           <Actual-Rows>0</Actual-Rows>                    +
-                           <Actual-Loops>0</Actual-Loops>                  +
-                         </Plan>                                           +
-                       </Plans>                                            +
                      </Plan>                                               +
                      <Plan>                                                +
                        <Node-Type>Hash</Node-Type>                         +
@@ -1179,13 +1237,13 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
                        <Actual-Loops>0</Actual-Loops>                      +
                        <Plans>                                             +
                          <Plan>                                            +
-                           <Node-Type>Seq Scan</Node-Type>                 +
+                           <Node-Type>Redistribute Motion</Node-Type>      +
+                           <Senders>3</Senders>                            +
+                           <Receivers>3</Receivers>                        +
                            <Parent-Relationship>Outer</Parent-Relationship>+
                            <Slice>2</Slice>                                +
                            <Segments>3</Segments>                          +
                            <Gang-Type>primary reader</Gang-Type>           +
-                           <Relation-Name>apples</Relation-Name>           +
-                           <Alias>apples</Alias>                           +
                            <Startup-Cost>0.00</Startup-Cost>               +
                            <Total-Cost>596.00</Total-Cost>                 +
                            <Plan-Rows>49600</Plan-Rows>                    +
@@ -1194,8 +1252,28 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
                            <Actual-Total-Time>0.000</Actual-Total-Time>    +
                            <Actual-Rows>0</Actual-Rows>                    +
                            <Actual-Loops>0</Actual-Loops>                  +
-                         </Plan>                                           +
-                       </Plans>                                            +
+                           <Hash-Key>boxes.apple_id</Hash-Key>                 +
+                           <Plans>                                             +
+                             <Plan>                                            +
+                               <Node-Type>Seq Scan</Node-Type>                 +
+                               <Parent-Relationship>Outer</Parent-Relationship>+
+                               <Slice>1</Slice>                                +
+                               <Segments>3</Segments>                          +
+                               <Gang-Type>primary reader</Gang-Type>           +
+                               <Relation-Name>boxes</Relation-Name>            +
+                               <Alias>boxes</Alias>                            +
+                               <Startup-Cost>0.00</Startup-Cost>               +
+                               <Total-Cost>879.00</Total-Cost>                 +
+                               <Plan-Rows>77900</Plan-Rows>                    +
+                               <Plan-Width>12</Plan-Width>                     +
+                               <Actual-Startup-Time>0.000</Actual-Startup-Time>+
+                               <Actual-Total-Time>0.000</Actual-Total-Time>    +
+                               <Actual-Rows>0</Actual-Rows>                    +
+                               <Actual-Loops>0</Actual-Loops>                  +
+                             </Plan>                                           +
+                           </Plans>                                            +
+                         </Plan>                                               +
+                       </Plans>                                                +
                      </Plan>                                               +
                    </Plans>                                                +
                  </Plan>                                                   +
@@ -1222,8 +1300,8 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
                    <Slice>3</Slice>                                        +
                    <Segments>1</Segments>                                  +
                    <Gang-Type>primary reader</Gang-Type>                   +
-                   <Relation-Name>locations</Relation-Name>                +
-                   <Alias>locations</Alias>                                +
+                   <Relation-Name>box_locations</Relation-Name>                +
+                   <Alias>box_locations</Alias>                                +
                    <Startup-Cost>0.00</Startup-Cost>                       +
                    <Total-Cost>596.00</Total-Cost>                         +
                    <Plan-Rows>49600</Plan-Rows>                            +
@@ -1283,7 +1361,6 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
            <Workers>64654</Workers>                                        +
            <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
          </Virtual-Memory>                                                 +
-         <Work-Maximum-Memory>41431</Work-Maximum-Memory>                  +
        </Slice>                                                            +
        <Slice>                                                             +
          <Slice>3</Slice>                                                  +
@@ -1317,3 +1394,7 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
 (1 row)
 
 -- explain_processing_on
+-- Cleanup
+DROP TABLE boxes;
+DROP TABLE apples;
+DROP TABLE box_locations;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -1,10 +1,12 @@
 -- start_matchsubs
--- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
--- s/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/(actual time=10.302..10.302 rows=0 loops=1)/
+-- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
+-- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
 -- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
 -- s/\(slice\d+\)    Executor memory: (\d+)\w bytes\./\(slice\)    Executor memory: (#####)K bytes./
 -- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./\(slice\)    Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg0)./
+-- s/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./\(slice\)    Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
+-- m/Work_mem: \d+\w bytes max\./
+-- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
 -- m/Total runtime: \d+\.\d+ ms/
 -- s/Total runtime: \d+\.\d+ ms/Total runtime: ##.### ms/
 -- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
@@ -14,6 +16,7 @@
 -- DEFAULT syntax
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "apples_pkey" for table "apples"
+INSERT INTO apples(id) SELECT generate_series(1, 100000);
 CREATE TABLE locations(id int PRIMARY KEY, address text);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "locations_pkey" for table "locations"
 CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES locations(id));
@@ -57,13 +60,13 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
                            Hash Key: boxes.apple_id
                            ->  Table Scan on boxes  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                     ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                           ->  Table Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+                     ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=1.323..3.123 rows=9 loops=1)
+                           ->  Table Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=1.323..3.123 rows=9 loops=1)
          ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
                ->  Table Scan on locations  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).
-   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
+   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Work_mem: 12343K bytes max.
    (slice3)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
  Memory used:  128000kB
  Total runtime: 34.572 ms
@@ -88,6 +91,14 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Segments: \d+\s+/Segments: #/
 -- m/PQO version \d+\.\d+\.\d+"\s+/
 -- s/PQO version \d+\.\d+\.\d+"\s+/PQO version ##.##.##"/
+-- m/Slice: [0-3]\s+/
+-- s/Slice: [0-3]\s+/Slice: # /
+-- m/Executor Memory: \d+\s+/
+-- s/Executor Memory: \d+\s+/Executor Memory: ### /
+-- m/Maximum Memory Used: \d+\s+/
+-- s/Maximum Memory Used: \d+\s+/Maximum Memory Used: ### /
+-- m/Work Maximum Memory: \d+\s+/
+-- s/Work Maximum Memory: \d+\s+/Work Maximum Memory: ### /
 -- end_matchsubs
 -- Check Explain YAML output
 EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
@@ -373,6 +384,22 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
                  Actual Rows: 0                         +
                  Actual Loops: 0                        +
    Triggers:                                            +
+   Slice statistics:                                    +
+     - Slice: 0                                         +
+       Executor Memory: 386000                          +
+     - Slice: 1                                         +
+       Average Executor Memory: 59000                   +
+       Workers: 3                                       +
+       Maximum Memory Used: 59000                       +
+     - Slice: 2                                         +
+       Average Executor Memory: 1110000                 +
+       Workers: 3                                       +
+       Maximum Memory Used: 1110000                     +
+       Work Maximum Memory: 1043000                     +
+     - Slice: 3                                         +
+       Average Executor Memory: 1110000                 +
+       Workers: 3                                       +
+       Maximum Memory Used: 1110000                     +
    Statement statistics:                                +
      Memory used: 128000                                +
    Settings:                                            +
@@ -399,6 +426,16 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- s/"Memory used": \d+,?\s+/"Memory used": ####,/
 -- m/"Segments": \d+,\s+/
 -- s/"Segments": \d+,\s+/"Segments": #,/
+-- m/"Slice": [0-3],\s+/
+-- s/"Slice": [0-3],\s+/"Slice": #, /
+-- m/Executor Memory": \d+,?\s+/
+-- s/Executor Memory": \d+,?\s+/Executor Memory": ### /
+-- m/"Maximum Memory Used": \d+,?\s+/
+-- s/"Maximum Memory Used": \d+,?\s+/"Maximum Memory Used": ###, /
+-- m/"Work Maximum Memory": \d+,?\s+/
+-- s/"Work Maximum Memory": \d+,?\s+/"Work Maximum Memory": ### /
+-- m/"Workers": \d+,\s+/
+-- s/"Workers": \d+,\s+/"Workers": ##, /
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain JSON output
@@ -746,6 +783,31 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
      },                                                      +
      "Triggers": [                                           +
      ],                                                      +
+     "Slice statistics": [                                   +
+       {                                                     +
+         "Slice": 0,                                         +
+         "Executor Memory": 123546                           +
+       },                                                    +
+       {                                                     +
+         "Slice": 1,                                         +
+         "Average Executor Memory": 123546                   +
+         "Workers": 1,                                       +
+         "Maximum Memory Used": 432255                       +
+       },                                                    +
+       {                                                     +
+         "Slice": 2,                                         +
+         "Average Executor Memory": 123432                   +
+         "Workers": 2,                                       +
+         "Maximum Memory Used": 4324,                        +
+         "Work Maximum Memory": 23424                        +
+       },                                                    +
+       {                                                     +
+         "Slice": 3,                                         +
+         "Average Executor Memory": 2341                     +
+         "Workers": 3,                                       +
+         "Maximum Memory Used": 123432                       +
+       }                                                     +
+     ],                                                      +
      "Statement statistics": {                               +
        "Memory used": 12800                                  +
      },                                                      +
@@ -768,14 +830,28 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- s/Plan-Width>\d+<\/Plan-Width>\s+/Plan-Width>###<\/Plan-Width>/
 -- m/Segments>\d+<\/Segments>\s+/
 -- s/Segments>\d+<\/Segments>\s+/Segments>##<\/Segments>/
--- m/-Time>\d+\.\d+<\/[^>]+\-Time>\s+/
--- s/-Time>\d+\.\d+<\/([^>]+)\-Time>\s+/-Time>##.###<\/$1-Time>/
+-- m/Actual-Rows>\d+<\/Actual-Rows>\s+/
+-- s/Actual-Rows>\d+<\/Actual-Rows>\s+/Actual-Rows>###<\/Actual-Rows>/
+-- m/Actual-Loops>\d+<\/Actual-Loops>\s+/
+-- s/Actual-Loops>\d+<\/Actual-Loops>\s+/Actual-Loops>###<\/Actual-Loops>/
+-- m/-Time>\d+\.\d+<\/[^>]+\-Time>\s*/
+-- s/-Time>\d+\.\d+<\/([^>]+)\-Time>\s*/-Time>##.###<\/$1-Time>/
 -- m/Total-Runtime>\d+\.\d+<\/Total-Runtime>\s+/
 -- s/Total-Runtime>\d+\.\d+<\/Total-Runtime>\s+/Total-Runtime>##.###<\/Total-Runtime>/
 -- m/Memory-used>\d+<\/Memory-used>\s+/
 -- s/Memory-used>\d+<\/Memory-used>\s+/Memory-used>###<\/Memory-used>/
 -- m/PQO version \d+\.\d+\.\d+/
 -- s/PQO version \d+\.\d+\.\d+/PQO version ##.##.##/
+-- m/<Slice>[0-3]<\/Slice>/
+-- s/<Slice>[0-3]<\/Slice>/<Slice>#<\/Slice> /
+-- m/Executor-Memory>\d+<\//
+-- s/Executor-Memory>\d+<\/([^>]+)>\s+/Executor-Memory>###<\/$1> /
+-- m/<Maximum-Memory-Used>\d+<\/Maximum-Memory-Used>\s+/
+-- s/<Maximum-Memory-Used>\d+<\/Maximum-Memory-Used>\s+/<Maximum-Memory-Used>###<\/Maximum-Memory-Used> /
+-- m/<Work-Maximum-Memory>\d+<\/Work-Maximum-Memory>\s+/
+-- s/<Work-Maximum-Memory>\d+<\/Work-Maximum-Memory>\s+/<Work-Maximum-Memory>###<\/Work-Maximum-Memory> /
+-- m/<Workers>\d+<\/Workers>\s+/
+-- s/<Workers>\d+<\/Workers>\s+/<Workers>###<\/Workers> /
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain XML output
@@ -1123,6 +1199,31 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
      </Plan>                                                               +
      <Triggers>                                                            +
      </Triggers>                                                           +
+     <Slice-statistics>                                                    +
+       <Slice>                                                             +
+         <Slice>0</Slice>                                                  +
+         <Executor-Memory>123454</Executor-Memory>                         +
+       </Slice>                                                            +
+       <Slice>                                                             +
+         <Slice>1</Slice>                                                  +
+         <Average-Executor-Memory>1312423</Average-Executor-Memory>        +
+         <Workers>3342</Workers>                                           +
+         <Maximum-Memory-Used>423</Maximum-Memory-Used>                    +
+       </Slice>                                                            +
+       <Slice>                                                             +
+         <Slice>2</Slice>                                                  +
+         <Average-Executor-Memory>123123</Average-Executor-Memory>         +
+         <Workers>2</Workers>                                              +
+         <Maximum-Memory-Used>543123</Maximum-Memory-Used>                 +
+         <Work-Maximum-Memory>543</Work-Maximum-Memory>                    +
+       </Slice>                                                            +
+       <Slice>                                                             +
+         <Slice>3</Slice>                                                  +
+         <Average-Executor-Memory>1321321</Average-Executor-Memory>        +
+         <Workers>54</Workers>                                             +
+         <Maximum-Memory-Used>324</Maximum-Memory-Used>                    +
+       </Slice>                                                            +
+     </Slice-statistics>                                                   +
      <Statement-statistics>                                                +
        <Memory-used>1200</Memory-used>                                   +
      </Statement-statistics>                                               +

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -11,6 +11,20 @@
 -- s/Total runtime: \d+\.\d+ ms/Total runtime: ##.### ms/
 -- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
 -- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
+-- m/Peak memory: \d+\w? bytes\./
+-- s/Peak memory: \d+\w? bytes\./Peak memory: ### bytes./
+-- m/Peak memory: \d+\w? bytes avg x \d+ workers, \d+\w? bytes max \(seg\d+\)./
+-- s/Peak memory: \d+\w? bytes avg x \d+ workers, \d+\w? bytes max \(seg\d+\)\./Peak memory: ### bytes avg x # workers, ### bytes max (seg#)./
+-- m/Vmem reserved: \d+\w? bytes\./
+-- s/Vmem reserved: \d+\w? bytes\./Vmem reserved: ### bytes./
+-- m/Vmem reserved: \d+\w? bytes avg x \d+ workers, \d+\w? bytes max \(seg\d+\)/
+-- s/Vmem reserved: \d+\w? bytes avg x \d+ workers, \d+\w? bytes max \(seg\d+\)/Vmem reserved: ### bytes avg x # workers, ### bytes max (seg#)/
+-- m/Total memory used across slices: \d+\w bytes./
+-- s/Total memory used across slices: \d+\w bytes./Total memory used across slices: ### bytes./
+-- m/Memory used:  \d+\w?B/
+-- s/Memory used:  \d+\w?B/Memory used: ###B/
+-- m/ORCA Memory used: peak \d+\w?B  allocated \d+\w?B  freed \d+\w?B/
+-- s/ORCA Memory used: peak \d+\w?B  allocated \d+\w?B  freed \d+\w?B/ORCA Memory used: peak ##B  allocated ##B  freed ##B/
 -- end_matchsubs
 --
 -- DEFAULT syntax
@@ -23,6 +37,8 @@ CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), locat
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "boxes_pkey" for table "boxes"
 WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
 WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
+-- Activate GUP that will show more memory information
+SET explain_memory_verbosity = 'summary';
 --- Check Explain Text format output
 -- explain_processing_off
 EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
@@ -64,11 +80,14 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
                            ->  Table Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=1.323..3.123 rows=9 loops=1)
          ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
                ->  Table Scan on locations  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).
-   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Work_mem: 12343K bytes max.
-   (slice3)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
- Memory used:  128000kB
+   (slice0)    Executor memory: 386K bytes.  Peak memory: 42342K bytes.  Vmem reserved: 123432K bytes.
+   (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Peak memory: 1234532 bytes avg x 2 workers, 123 bytes max (seg0).  Vmem reserved: 100 bytes avg x 3 workers, 123k bytes max (seg0).
+   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Peak memory: 543 bytes avg x 2 workers, 312 bytes max (seg0).  Vmem reserved: 1234243 bytes avg x 1 workers, 312 bytes max (seg0).  Work_mem: 9K bytes max.
+   (slice3)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Peak memory: 534 bytes avg x 1 workers, 5433 bytes max (seg0).  Vmem reserved: 423K bytes avg x 2 workers, 4K bytes max (seg0).
+ Total memory used across slices: 100K bytes.
+ Memory used:  1280kB
+ ORCA Memory used: peak 50kB  allocated 100kB  freed 0B
+ Optimizer: PQO version 2.54.0
  Total runtime: 34.572 ms
 (21 rows)
 
@@ -89,16 +108,24 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Total Runtime: \d+\.\d+/Total Runtime: ##.###/
 -- m/Segments: \d+\s+/
 -- s/Segments: \d+\s+/Segments: #/
--- m/PQO version \d+\.\d+\.\d+"\s+/
--- s/PQO version \d+\.\d+\.\d+"\s+/PQO version ##.##.##"/
+-- m/PQO version \d+\.\d+\.\d+",?\s+/
+-- s/PQO version \d+\.\d+\.\d+",?\s+/PQO version ##.##.##"/
 -- m/Slice: [0-3]\s+/
 -- s/Slice: [0-3]\s+/Slice: # /
--- m/Executor Memory: \d+\s+/
--- s/Executor Memory: \d+\s+/Executor Memory: ### /
+-- m/ Memory: \d+\s+/
+-- s/ Memory: \d+\s+/ Memory: ### /
 -- m/Maximum Memory Used: \d+\s+/
 -- s/Maximum Memory Used: \d+\s+/Maximum Memory Used: ### /
 -- m/Work Maximum Memory: \d+\s+/
 -- s/Work Maximum Memory: \d+\s+/Work Maximum Memory: ### /
+-- m/Workers: \d+\s+/
+-- s/Workers: \d+\s+/Workers: ## /
+-- m/Average: \d+\s+/
+-- s/Average: \d+\s+/Average: ## /
+-- m/Total memory used across slices: \d+/
+-- s/Total memory used across slices: \d+/Total memory used across slices: ###/
+-- m/ORCA Memory Used \w+: \d+/
+-- s/ORCA Memory Used (\w+): \d+\s+/ORCA Memory Used $1: ##/
 -- end_matchsubs
 -- Check Explain YAML output
 EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
@@ -387,21 +414,54 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
    Slice statistics:                                    +
      - Slice: 0                                         +
        Executor Memory: 386000                          +
+       Global Peak Memory: 12343                        +
+       Virtual Memory: 5432                             +
      - Slice: 1                                         +
-       Average Executor Memory: 59000                   +
-       Workers: 3                                       +
-       Maximum Memory Used: 59000                       +
+       Executor Memory:                                 +
+         Average: 59000                                +
+         Workers: 3                                    +
+         Maximum Memory Used: 59000                    +
+       Global Peak Memory:                              +
+         Average: 59000                                +
+         Workers: 3                                    +
+         Maximum Memory Used: 59000                    +
+       Virtual Memory:                                  +
+         Average: 59000                                +
+         Workers: 3                                    +
+         Maximum Memory Used: 59000                    +
      - Slice: 2                                         +
-       Average Executor Memory: 1110000                 +
-       Workers: 3                                       +
-       Maximum Memory Used: 1110000                     +
+       Executor Memory:                                 +
+         Average: 59000                                +
+         Workers: 3                                    +
+         Maximum Memory Used: 59000                    +
+       Global Peak Memory:                              +
+         Average: 59000                                +
+         Workers: 3                                    +
+         Maximum Memory Used: 59000                    +
+       Virtual Memory:                                  +
+         Average: 59000                                +
+         Workers: 3                                    +
+         Maximum Memory Used: 59000                    +
        Work Maximum Memory: 1043000                     +
      - Slice: 3                                         +
-       Average Executor Memory: 1110000                 +
-       Workers: 3                                       +
-       Maximum Memory Used: 1110000                     +
+       Executor Memory:                                 +
+         Average: 59000                                +
+         Workers: 3                                    +
+         Maximum Memory Used: 59000                    +
+       Global Peak Memory:                              +
+         Average: 59000                                +
+         Workers: 3                                    +
+         Maximum Memory Used: 59000                    +
+       Virtual Memory:                                  +
+         Average: 59000                                +
+         Workers: 3                                    +
+         Maximum Memory Used: 59000                    +
+   Total memory used across slices: 13211               +
    Statement statistics:                                +
      Memory used: 128000                                +
+     ORCA Memory Used Peak: 14                          +
+     ORCA Memory Used Allocated: 13                     +
+     ORCA Memory Used Freed: 12                         +
    Settings:                                            +
      Optimizer: "PQO version 1.2.3"                     +
    Total Runtime: 2.652
@@ -436,6 +496,16 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- s/"Work Maximum Memory": \d+,?\s+/"Work Maximum Memory": ### /
 -- m/"Workers": \d+,\s+/
 -- s/"Workers": \d+,\s+/"Workers": ##, /
+-- m/Peak Memory": \d+,/
+-- s/Peak Memory": \d+,\s+/Peak Memory": ###,/
+-- m/Virtual Memory": \d+/
+-- s/Virtual Memory": \d+\s+/Virtual Memory": ###/
+-- m/"Average": \d+,\s+/
+-- s/"Average": \d+,\s+/"Average": ##, /
+-- m/"Total memory used across slices": \d+,/
+-- s/"Total memory used across slices": \d+,/"Total memory used across slices": ###,/
+-- m/"ORCA Memory Used \w+": \d+,?/
+-- s/"ORCA Memory Used (\w+)": \d+,?\s+/"ORCA Memory Used $1": ##/
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain JSON output
@@ -786,33 +856,75 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
      "Slice statistics": [                                   +
        {                                                     +
          "Slice": 0,                                         +
-         "Executor Memory": 123546                           +
+         "Executor Memory": 123546,                          +
+         "Global Peak Memory": 14612,                        +
+         "Virtual Memory": 1235                              +
        },                                                    +
        {                                                     +
          "Slice": 1,                                         +
-         "Average Executor Memory": 123546                   +
-         "Workers": 1,                                       +
-         "Maximum Memory Used": 432255                       +
+         "Executor Memory": {                                +
+           "Average": 12314,                                 +
+           "Workers": 12314,                                 +
+           "Maximum Memory Used": 12314,                     +
+         },                                                  +
+         "Global Peak Memory": {                             +
+           "Average": 12314,                                 +
+           "Workers": 12314,                                 +
+           "Maximum Memory Used": 12314,                     +
+         },                                                  +
+         "Virtual Memory": {                                 +
+           "Average": 12314,                                 +
+           "Workers": 12314,                                 +
+           "Maximum Memory Used": 12314,                     +
+         }                                                   +
        },                                                    +
        {                                                     +
          "Slice": 2,                                         +
-         "Average Executor Memory": 123432                   +
-         "Workers": 2,                                       +
-         "Maximum Memory Used": 4324,                        +
+         "Executor Memory": {                                +
+           "Average": 12314,                                 +
+           "Workers": 12314,                                 +
+           "Maximum Memory Used": 12314,                     +
+         },                                                  +
+         "Global Peak Memory": {                             +
+           "Average": 12314,                                 +
+           "Workers": 12314,                                 +
+           "Maximum Memory Used": 12314,                     +
+         },                                                  +
+         "Virtual Memory": {                                 +
+           "Average": 12314,                                 +
+           "Workers": 12314,                                 +
+           "Maximum Memory Used": 12314,                     +
+         },                                                  +
          "Work Maximum Memory": 23424                        +
        },                                                    +
        {                                                     +
          "Slice": 3,                                         +
-         "Average Executor Memory": 2341                     +
-         "Workers": 3,                                       +
-         "Maximum Memory Used": 123432                       +
+         "Executor Memory": {                                +
+           "Average": 12314,                                 +
+           "Workers": 12314,                                 +
+           "Maximum Memory Used": 12314,                     +
+         },                                                  +
+         "Global Peak Memory": {                             +
+           "Average": 12314,                                 +
+           "Workers": 12314,                                 +
+           "Maximum Memory Used": 12314,                     +
+         },                                                  +
+         "Virtual Memory": {                                 +
+           "Average": 12314,                                 +
+           "Workers": 12314,                                 +
+           "Maximum Memory Used": 12314,                     +
+         }                                                   +
        }                                                     +
      ],                                                      +
+     "Total memory used across slices": 13213,               +
      "Statement statistics": {                               +
        "Memory used": 12800                                  +
+       "ORCA Memory Used Peak": 12423,                       +
+       "ORCA Memory Used Allocated": 12312,                  +
+       "ORCA Memory Used Freed": 15                          +
      },                                                      +
      "Settings": {                                           +
-       "Optimizer": "PQO version 1.2.3"                      +
+       "Optimizer": "PQO version 1.2.3",                     +
      },                                                      +
      "Total Runtime": 28.324                                 +
    }                                                         +
@@ -843,7 +955,7 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- m/PQO version \d+\.\d+\.\d+/
 -- s/PQO version \d+\.\d+\.\d+/PQO version ##.##.##/
 -- m/<Slice>[0-3]<\/Slice>/
--- s/<Slice>[0-3]<\/Slice>/<Slice>#<\/Slice> /
+-- s/<Slice>[0-3]<\/Slice>\s+/<Slice>#<\/Slice> /
 -- m/Executor-Memory>\d+<\//
 -- s/Executor-Memory>\d+<\/([^>]+)>\s+/Executor-Memory>###<\/$1> /
 -- m/<Maximum-Memory-Used>\d+<\/Maximum-Memory-Used>\s+/
@@ -852,6 +964,18 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- s/<Work-Maximum-Memory>\d+<\/Work-Maximum-Memory>\s+/<Work-Maximum-Memory>###<\/Work-Maximum-Memory> /
 -- m/<Workers>\d+<\/Workers>\s+/
 -- s/<Workers>\d+<\/Workers>\s+/<Workers>###<\/Workers> /
+-- m/Peak-Memory>\d+<\//
+-- s/Peak-Memory>\d+<\/([^>]+)>\s+/Peak-Memory>###<\/$1>/
+-- m/Virtual-Memory>\d+/
+-- s/Virtual-Memory>\d+<\/([^>]+)>\s+/Virtual-Memory>###<\/$1>/
+-- m/<Average>\d+<\/Average>/
+-- s/<Average>\d+<\/Average>\s+/<Average>##<\/Average>/
+-- m/<Total-memory-used-across-slices>\d+/
+-- s/(<Total-memory-used-across-slices>)\d+(<\/[^>]+>)\s*/$1###$2/
+-- m/<ORCA-Memory-Used-\w+>\d+/
+-- s/<ORCA-Memory-Used-(\w+)>\d+(<\/[^>]+>)\s+/<ORCA-Memory-Used-$1>##$2/
+-- m/>\s+\+/
+-- s/>\s+\+/>+/
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain XML output
@@ -1202,35 +1326,77 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
      <Slice-statistics>                                                    +
        <Slice>                                                             +
          <Slice>0</Slice>                                                  +
-         <Executor-Memory>123454</Executor-Memory>                         +
+         <Executor-Memory>123</Executor-Memory>                            +
+         <Global-Peak-Memory>432</Global-Peak-Memory>                      +
+         <Virtual-Memory>123543</Virtual-Memory>                           +
        </Slice>                                                            +
        <Slice>                                                             +
          <Slice>1</Slice>                                                  +
-         <Average-Executor-Memory>1312423</Average-Executor-Memory>        +
-         <Workers>3342</Workers>                                           +
-         <Maximum-Memory-Used>423</Maximum-Memory-Used>                    +
+         <Executor-Memory>                                                 +
+           <Average>123143234</Average>                                    +
+           <Workers>1</Workers>                                            +
+           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>              +
+         </Executor-Memory>                                                +
+         <Global-Peak-Memory>                                              +
+           <Average>43212</Average>                                        +
+           <Workers>2</Workers>                                            +
+           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                 +
+         </Global-Peak-Memory>                                             +
+         <Virtual-Memory>                                                  +
+           <Average>4321234123423</Average>                                +
+           <Workers>64654</Workers>                                        +
+           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
+         </Virtual-Memory>                                                 +
        </Slice>                                                            +
        <Slice>                                                             +
          <Slice>2</Slice>                                                  +
-         <Average-Executor-Memory>123123</Average-Executor-Memory>         +
-         <Workers>2</Workers>                                              +
-         <Maximum-Memory-Used>543123</Maximum-Memory-Used>                 +
-         <Work-Maximum-Memory>543</Work-Maximum-Memory>                    +
+         <Executor-Memory>                                                 +
+           <Average>123143234</Average>                                    +
+           <Workers>1</Workers>                                            +
+           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>              +
+         </Executor-Memory>                                                +
+         <Global-Peak-Memory>                                              +
+           <Average>43212</Average>                                        +
+           <Workers>2</Workers>                                            +
+           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                 +
+         </Global-Peak-Memory>                                             +
+         <Virtual-Memory>                                                  +
+           <Average>4321234123423</Average>                                +
+           <Workers>64654</Workers>                                        +
+           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
+         </Virtual-Memory>                                                 +
+         <Work-Maximum-Memory>41431</Work-Maximum-Memory>                  +
        </Slice>                                                            +
        <Slice>                                                             +
          <Slice>3</Slice>                                                  +
-         <Average-Executor-Memory>1321321</Average-Executor-Memory>        +
-         <Workers>54</Workers>                                             +
-         <Maximum-Memory-Used>324</Maximum-Memory-Used>                    +
+         <Executor-Memory>                                                 +
+           <Average>123143234</Average>                                    +
+           <Workers>1</Workers>                                            +
+           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>              +
+         </Executor-Memory>                                                +
+         <Global-Peak-Memory>                                              +
+           <Average>43212</Average>                                        +
+           <Workers>2</Workers>                                            +
+           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                 +
+         </Global-Peak-Memory>                                             +
+         <Virtual-Memory>                                                  +
+           <Average>4321234123423</Average>                                +
+           <Workers>64654</Workers>                                        +
+           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
+         </Virtual-Memory>                                                 +
        </Slice>                                                            +
      </Slice-statistics>                                                   +
+     <Total-memory-used-across-slices>123</Total-memory-used-across-slices>+
      <Statement-statistics>                                                +
-       <Memory-used>1200</Memory-used>                                   +
+       <Memory-used>1200</Memory-used>                                     +
+       <ORCA-Memory-Used-Peak>431234</ORCA-Memory-Used-Peak>               +
+       <ORCA-Memory-Used-Allocated>4231</ORCA-Memory-Used-Allocated>       +
+       <ORCA-Memory-Used-Freed>4332234</ORCA-Memory-Used-Freed>            +
      </Statement-statistics>                                               +
      <Settings>                                                            +
-       <Optimizer>PQO version 1.2.3</Optimizer>                           +
+       <Optimizer>PQO version 1.2.3</Optimizer>                            +
      </Settings>                                                           +
-     <Total-Runtime>24.8</Total-Runtime>                                 +
+     <Total-Runtime>24.8</Total-Runtime>                                   +
    </Query>                                                                +
  </explain>
 (1 row)

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -34,12 +34,11 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
                      Hash Cond: boxes.apple_id = apples.id
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
                            Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
+                           ->  Table Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
                      ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
-                           ->  Seq Scan on apples  (cost=0.00..596.00 rows=16534 width=36)
+                           ->  Table Scan on apples  (cost=0.00..596.00 rows=16534 width=36)
          ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
-               ->  Seq Scan on locations  (cost=0.00..596.00 rows=16534 width=36)
- Optimizer: legacy query optimizer
+               ->  Table Scan on locations  (cost=0.00..596.00 rows=16534 width=36)
 (15 rows)
 
 -- explain_processing_on
@@ -57,17 +56,16 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
                      Hash Cond: boxes.apple_id = apples.id
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
                            Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+                           ->  Table Scan on boxes  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
                      ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                           ->  Seq Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+                           ->  Table Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
          ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-               ->  Seq Scan on locations  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+               ->  Table Scan on locations  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).
    (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
    (slice3)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: legacy query optimizer
  Total runtime: 34.572 ms
 (21 rows)
 
@@ -157,7 +155,7 @@ EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.
                      Plan Width: 12                     +
                      Hash Key: "boxes.apple_id"         +
                      Plans:                             +
-                       - Node Type: "Seq Scan"          +
+                       - Node Type: "Table Scan"        +
                          Parent Relationship: "Outer"   +
                          Slice: 1                       +
                          Segments: 3                    +
@@ -178,7 +176,7 @@ EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.
                      Plan Rows: 49600                   +
                      Plan Width: 36                     +
                      Plans:                             +
-                       - Node Type: "Seq Scan"          +
+                       - Node Type: "Table Scan"        +
                          Parent Relationship: "Outer"   +
                          Slice: 2                       +
                          Segments: 3                    +
@@ -199,7 +197,7 @@ EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.
              Plan Rows: 49600                           +
              Plan Width: 36                             +
              Plans:                                     +
-               - Node Type: "Seq Scan"                  +
+               - Node Type: "Table Scan"                +
                  Parent Relationship: "Outer"           +
                  Slice: 3                               +
                  Segments: 10                           +
@@ -211,7 +209,7 @@ EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.
                  Plan Rows: 49600                       +
                  Plan Width: 36                         +
    Settings:                                            +
-     Optimizer: "legacy query optimizer"
+     Optimizer: "PQO version 1.2.3"
 (1 row)
 
 --- Check Explain Analyze YAML output that include the slices information
@@ -301,7 +299,7 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
                      Actual Loops: 0                    +
                      Hash Key: "boxes.apple_id"         +
                      Plans:                             +
-                       - Node Type: "Seq Scan"          +
+                       - Node Type: "Table Scan"        +
                          Parent Relationship: "Outer"   +
                          Slice: 1                       +
                          Segments: 3                    +
@@ -330,7 +328,7 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
                      Actual Rows: 0                     +
                      Actual Loops: 0                    +
                      Plans:                             +
-                       - Node Type: "Seq Scan"          +
+                       - Node Type: "Table Scan"        +
                          Parent Relationship: "Outer"   +
                          Slice: 2                       +
                          Segments: 3                    +
@@ -359,7 +357,7 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
              Actual Rows: 0                             +
              Actual Loops: 0                            +
              Plans:                                     +
-               - Node Type: "Seq Scan"                  +
+               - Node Type: "Table Scan"                +
                  Parent Relationship: "Outer"           +
                  Slice: 3                               +
                  Segments: 10                           +
@@ -378,7 +376,7 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
    Statement statistics:                                +
      Memory used: 128000                                +
    Settings:                                            +
-     Optimizer: "legacy query optimizer"                +
+     Optimizer: "PQO version 1.2.3"                     +
    Total Runtime: 2.652
 (1 row)
 
@@ -476,7 +474,7 @@ EXPLAIN (FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.
                        "Hash Key": "boxes.apple_id",         +
                        "Plans": [                            +
                          {                                   +
-                           "Node Type": "Seq Scan",          +
+                           "Node Type": "Table Scan",        +
                            "Parent Relationship": "Outer",   +
                            "Slice": 1,                       +
                            "Segments": 3,                    +
@@ -502,7 +500,7 @@ EXPLAIN (FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.
                        "Plan Width": 36,                     +
                        "Plans": [                            +
                          {                                   +
-                           "Node Type": "Seq Scan",          +
+                           "Node Type": "Table Scan",        +
                            "Parent Relationship": "Outer",   +
                            "Slice": 2,                       +
                            "Segments": 3,                    +
@@ -532,7 +530,7 @@ EXPLAIN (FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.
                "Plan Width": 36,                             +
                "Plans": [                                    +
                  {                                           +
-                   "Node Type": "Seq Scan",                  +
+                   "Node Type": "Table Scan",                +
                    "Parent Relationship": "Outer",           +
                    "Slice": 3,                               +
                    "Segments": 10,                           +
@@ -551,7 +549,7 @@ EXPLAIN (FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.
        ]                                                     +
      },                                                      +
      "Settings": {                                           +
-       "Optimizer": "legacy query optimizer"                 +
+       "Optimizer": "PQO version 1.2.3"                      +
      }                                                       +
    }                                                         +
  ]
@@ -652,7 +650,7 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
                        "Hash Key": "boxes.apple_id",         +
                        "Plans": [                            +
                          {                                   +
-                           "Node Type": "Seq Scan",          +
+                           "Node Type": "Table Scan",        +
                            "Parent Relationship": "Outer",   +
                            "Slice": 1,                       +
                            "Segments": 3,                    +
@@ -686,7 +684,7 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
                        "Actual Loops": 0,                    +
                        "Plans": [                            +
                          {                                   +
-                           "Node Type": "Seq Scan",          +
+                           "Node Type": "Table Scan",        +
                            "Parent Relationship": "Outer",   +
                            "Slice": 2,                       +
                            "Segments": 3,                    +
@@ -724,7 +722,7 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
                "Actual Loops": 0,                            +
                "Plans": [                                    +
                  {                                           +
-                   "Node Type": "Seq Scan",                  +
+                   "Node Type": "Table Scan",                +
                    "Parent Relationship": "Outer",           +
                    "Slice": 3,                               +
                    "Segments": 3,                            +
@@ -752,7 +750,7 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
        "Memory used": 12800                                  +
      },                                                      +
      "Settings": {                                           +
-       "Optimizer": "legacy query optimizer"                 +
+       "Optimizer": "PQO version 1.2.3"                      +
      },                                                      +
      "Total Runtime": 28.324                                 +
    }                                                         +
@@ -853,7 +851,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                        <Hash-Key>boxes.apple_id</Hash-Key>                 +
                        <Plans>                                             +
                          <Plan>                                            +
-                           <Node-Type>Seq Scan</Node-Type>                 +
+                           <Node-Type>Table Scan</Node-Type>               +
                            <Parent-Relationship>Outer</Parent-Relationship>+
                            <Slice>1</Slice>                                +
                            <Segments>3</Segments>                          +
@@ -879,7 +877,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                        <Plan-Width>36</Plan-Width>                         +
                        <Plans>                                             +
                          <Plan>                                            +
-                           <Node-Type>Seq Scan</Node-Type>                 +
+                           <Node-Type>Table Scan</Node-Type>               +
                            <Parent-Relationship>Outer</Parent-Relationship>+
                            <Slice>2</Slice>                                +
                            <Segments>4</Segments>                          +
@@ -909,7 +907,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                <Plan-Width>36</Plan-Width>                                 +
                <Plans>                                                     +
                  <Plan>                                                    +
-                   <Node-Type>Seq Scan</Node-Type>                         +
+                   <Node-Type>Table Scan</Node-Type>                       +
                    <Parent-Relationship>Outer</Parent-Relationship>        +
                    <Slice>3</Slice>                                        +
                    <Segments>3</Segments>                                  +
@@ -928,7 +926,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
        </Plans>                                                            +
      </Plan>                                                               +
      <Settings>                                                            +
-       <Optimizer>legacy query optimizer</Optimizer>                       +
+       <Optimizer>PQO version 1.2.3</Optimizer>                           +
      </Settings>                                                           +
    </Query>                                                                +
  </explain>
@@ -1029,7 +1027,7 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
                        <Hash-Key>boxes.apple_id</Hash-Key>                 +
                        <Plans>                                             +
                          <Plan>                                            +
-                           <Node-Type>Seq Scan</Node-Type>                 +
+                           <Node-Type>Table Scan</Node-Type>               +
                            <Parent-Relationship>Outer</Parent-Relationship>+
                            <Slice>1</Slice>                                +
                            <Segments>3</Segments>                          +
@@ -1063,7 +1061,7 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
                        <Actual-Loops>0</Actual-Loops>                      +
                        <Plans>                                             +
                          <Plan>                                            +
-                           <Node-Type>Seq Scan</Node-Type>                 +
+                           <Node-Type>Table Scan</Node-Type>               +
                            <Parent-Relationship>Outer</Parent-Relationship>+
                            <Slice>2</Slice>                                +
                            <Segments>3</Segments>                          +
@@ -1101,7 +1099,7 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
                <Actual-Loops>0</Actual-Loops>                              +
                <Plans>                                                     +
                  <Plan>                                                    +
-                   <Node-Type>Seq Scan</Node-Type>                         +
+                   <Node-Type>Table Scan</Node-Type>                       +
                    <Parent-Relationship>Outer</Parent-Relationship>        +
                    <Slice>3</Slice>                                        +
                    <Segments>1</Segments>                                  +
@@ -1129,7 +1127,7 @@ EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id 
        <Memory-used>1200</Memory-used>                                   +
      </Statement-statistics>                                               +
      <Settings>                                                            +
-       <Optimizer>legacy query optimizer</Optimizer>                       +
+       <Optimizer>PQO version 1.2.3</Optimizer>                           +
      </Settings>                                                           +
      <Total-Runtime>24.8</Total-Runtime>                                 +
    </Query>                                                                +

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -5,6 +5,8 @@
 -- s/\(slice\d+\)    Executor memory: (\d+)\w bytes\./\(slice\)    Executor memory: (#####)K bytes./
 -- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
 -- s/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./\(slice\)    Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
+-- m/\(slice\d+\)    /
+-- s/\(slice\d+\)    /\(slice\)    /
 -- m/Work_mem: \d+\w bytes max\./
 -- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
 -- m/Total runtime: \d+\.\d+ ms/
@@ -31,59 +33,61 @@
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "apples_pkey" for table "apples"
 INSERT INTO apples(id) SELECT generate_series(1, 100000);
-CREATE TABLE locations(id int PRIMARY KEY, address text);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "locations_pkey" for table "locations"
-CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES locations(id));
+CREATE TABLE box_locations(id int PRIMARY KEY, address text);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "box_locations_pkey" for table "box_locations"
+CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES box_locations(id));
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "boxes_pkey" for table "boxes"
 WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
 WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
--- Activate GUP that will show more memory information
+-- Activate GUC that will show more memory information
 SET explain_memory_verbosity = 'summary';
 --- Check Explain Text format output
 -- explain_processing_off
-EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                                    QUERY PLAN
 ------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=2432.00..8569.25 rows=77900 width=84)
-   ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84)
-         Hash Cond: boxes.location_id = locations.id
+   ->  Nested Loop Left Join  (cost=2432.00..8569.25 rows=25967 width=84)
+         Join Filter: true
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1216.00..6282.12 rows=25967 width=48)
                Hash Key: boxes.location_id
-               ->  Hash Left Join  (cost=1216.00..4724.12 rows=25967 width=48)
-                     Hash Cond: boxes.apple_id = apples.id
+               ->  Nested Loop Left Join  (cost=1216.00..4724.12 rows=25967 width=48)
+                     Join Filter: true
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
                            Hash Key: boxes.apple_id
                            ->  Table Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
-                     ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
-                           ->  Table Scan on apples  (cost=0.00..596.00 rows=16534 width=36)
-         ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
-               ->  Table Scan on locations  (cost=0.00..596.00 rows=16534 width=36)
+                     ->  Index Scan using apples_pkey on apples  (cost=11.123..11.123 rows=0 width=1)
+                           Index Cond: id = boxes.apple_id
+         ->  Index Scan using box_locations_pkey on box_locations  (cost=22.234..32.231 rows=1 width=0)
+               Index Cond: id = boxes.location_id
 (15 rows)
 
 -- explain_processing_on
 --- Check Explain Analyze Text output that include the slices information
 -- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                                             QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=2432.00..8569.25 rows=77900 width=84) (actual time=3.936..3.936 rows=0 loops=1)
-   ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-         Hash Cond: boxes.location_id = locations.id
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2432.00..8569.25 rows=77900 width=84) (actual time=3.936..3.936 rows=1 loops=1)
+   ->  Nested Loop Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.36..3.96 rows=1 loops=1)
+         Join Filter: true
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.936..3.96 rows=0 loops=1)
                Hash Key: boxes.location_id
-               ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                     Hash Cond: boxes.apple_id = apples.id
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+               ->  Nested Loop Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.936..3.916 rows=1 loops=1)
+                     Join Filter: true
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.96..3.936 rows=0 loops=1)
                            Hash Key: boxes.apple_id
-                           ->  Table Scan on boxes  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-                     ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=1.323..3.123 rows=9 loops=1)
-                           ->  Table Scan on apples  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=1.323..3.123 rows=9 loops=1)
-         ->  Hash  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
-               ->  Table Scan on locations  (cost=2432.00..8569.25 rows=25967 width=84) (never executed)
+                           ->  Table Scan on boxes  (cost=1.123..11.322 rows=1 width=0) (actual time=11.222..11.222 rows=1 loops=1)
+                     ->  Index Scan using apples_pkey on apples  (cost=12.321..12.123 rows=3 width=3) (never executed)
+                           Index Cond: id = boxes.apple_id
+         ->  Index Scan using box_locations_pkey on box_locations  (cost=12.123..12.321 rows=32 width=321) (never executed)
+               Index Cond: id = boxes.location_id
    (slice0)    Executor memory: 386K bytes.  Peak memory: 42342K bytes.  Vmem reserved: 123432K bytes.
    (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Peak memory: 1234532 bytes avg x 2 workers, 123 bytes max (seg0).  Vmem reserved: 100 bytes avg x 3 workers, 123k bytes max (seg0).
-   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Peak memory: 543 bytes avg x 2 workers, 312 bytes max (seg0).  Vmem reserved: 1234243 bytes avg x 1 workers, 312 bytes max (seg0).  Work_mem: 9K bytes max.
+   (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Peak memory: 543 bytes avg x 2 workers, 312 bytes max (seg0).  Vmem reserved: 1234243 bytes avg x 1 workers, 312 bytes max (seg0).
    (slice3)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Peak memory: 534 bytes avg x 1 workers, 5433 bytes max (seg0).  Vmem reserved: 423K bytes avg x 2 workers, 4K bytes max (seg0).
+   (slice4)    
+   (slice5)    
  Total memory used across slices: 100K bytes.
  Memory used:  1280kB
  ORCA Memory used: peak 50kB  allocated 100kB  freed 0B
@@ -123,348 +127,319 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- m/Average: \d+\s+/
 -- s/Average: \d+\s+/Average: ## /
 -- m/Total memory used across slices: \d+/
--- s/Total memory used across slices: \d+/Total memory used across slices: ###/
+-- s/Total memory used across slices: \d+\s*/Total memory used across slices: ###/
+-- m/Memory used: \d+/
+-- s/Memory used: \d+\s+/Memory used: ###/
 -- m/ORCA Memory Used \w+: \d+/
 -- s/ORCA Memory Used (\w+): \d+\s+/ORCA Memory Used $1: ##/
 -- end_matchsubs
 -- Check Explain YAML output
-EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                        QUERY PLAN
----------------------------------------------------------
- - Plan:                                                +
-     Node Type: "Gather Motion"                         +
-     Senders: 3                                         +
-     Receivers: 1                                       +
-     Slice: 3                                           +
-     Segments: 3                                        +
-     Gang Type: "primary reader"                        +
-     Startup Cost: 2432.00                              +
-     Total Cost: 8569.25                                +
-     Plan Rows: 77900                                   +
-     Plan Width: 84                                     +
-     Plans:                                             +
-       - Node Type: "Hash Join"                         +
-         Parent Relationship: "Outer"                   +
-         Slice: 3                                       +
-         Segments: 3                                    +
-         Gang Type: "primary reader"                    +
-         Join Type: "Left"                              +
-         Startup Cost: 2432.00                          +
-         Total Cost: 8569.25                            +
-         Plan Rows: 77900                               +
-         Plan Width: 84                                 +
-         Hash Cond: "boxes.location_id = locations.id"  +
-         Plans:                                         +
-           - Node Type: "Redistribute Motion"           +
-             Senders: 3                                 +
-             Receivers: 3                               +
-             Parent Relationship: "Outer"               +
-             Slice: 2                                   +
-             Segments: 3                                +
-             Gang Type: "primary reader"                +
-             Startup Cost: 1216.00                      +
-             Total Cost: 6282.12                        +
-             Plan Rows: 77900                           +
-             Plan Width: 48                             +
-             Hash Key: "boxes.location_id"              +
-             Plans:                                     +
-               - Node Type: "Hash Join"                 +
-                 Parent Relationship: "Outer"           +
-                 Slice: 2                               +
-                 Segments: 3                            +
-                 Gang Type: "primary reader"            +
-                 Join Type: "Left"                      +
-                 Startup Cost: 1216.00                  +
-                 Total Cost: 4724.12                    +
-                 Plan Rows: 77900                       +
-                 Plan Width: 48                         +
-                 Hash Cond: "boxes.apple_id = apples.id"+
-                 Plans:                                 +
-                   - Node Type: "Redistribute Motion"   +
-                     Senders: 3                         +
-                     Receivers: 3                       +
-                     Parent Relationship: "Outer"       +
-                     Slice: 1                           +
-                     Segments: 3                        +
-                     Gang Type: "primary reader"        +
-                     Startup Cost: 0.00                 +
-                     Total Cost: 2437.00                +
-                     Plan Rows: 77900                   +
-                     Plan Width: 12                     +
-                     Hash Key: "boxes.apple_id"         +
-                     Plans:                             +
-                       - Node Type: "Table Scan"        +
-                         Parent Relationship: "Outer"   +
-                         Slice: 1                       +
-                         Segments: 3                    +
-                         Gang Type: "primary reader"    +
-                         Relation Name: "boxes"         +
-                         Alias: "boxes"                 +
-                         Startup Cost: 0.00             +
-                         Total Cost: 879.00             +
-                         Plan Rows: 77900               +
-                         Plan Width: 12                 +
-                   - Node Type: "Hash"                  +
-                     Parent Relationship: "Inner"       +
-                     Slice: 2                           +
-                     Segments: 3                        +
-                     Gang Type: "primary reader"        +
-                     Startup Cost: 596.00               +
-                     Total Cost: 596.00                 +
-                     Plan Rows: 49600                   +
-                     Plan Width: 36                     +
-                     Plans:                             +
-                       - Node Type: "Table Scan"        +
-                         Parent Relationship: "Outer"   +
-                         Slice: 2                       +
-                         Segments: 3                    +
-                         Gang Type: "primary reader"    +
-                         Relation Name: "apples"        +
-                         Alias: "apples"                +
-                         Startup Cost: 0.00             +
-                         Total Cost: 596.00             +
-                         Plan Rows: 49600               +
-                         Plan Width: 36                 +
-           - Node Type: "Hash"                          +
-             Parent Relationship: "Inner"               +
-             Slice: 3                                   +
-             Segments: 3                                +
-             Gang Type: "primary reader"                +
-             Startup Cost: 596.00                       +
-             Total Cost: 596.00                         +
-             Plan Rows: 49600                           +
-             Plan Width: 36                             +
-             Plans:                                     +
-               - Node Type: "Table Scan"                +
-                 Parent Relationship: "Outer"           +
-                 Slice: 3                               +
-                 Segments: 10                           +
-                 Gang Type: "primary reader"            +
-                 Relation Name: "locations"             +
-                 Alias: "locations"                     +
-                 Startup Cost: 0.00                     +
-                 Total Cost: 596.00                     +
-                 Plan Rows: 49600                       +
-                 Plan Width: 36                         +
-   Settings:                                            +
-     Optimizer: "PQO version 1.2.3"
+-------------------------------------------------------
+ - Plan:                                              +
+     Node Type: "Gather Motion"                       +
+     Senders: 3                                       +
+     Receivers: 1                                     +
+     Slice: 3                                         +
+     Segments: 3                                      +
+     Gang Type: "primary reader"                      +
+     Startup Cost: 2432.00                            +
+     Total Cost: 8569.25                              +
+     Plan Rows: 77900                                 +
+     Plan Width: 84                                   +
+     Plans:                                           +
+       - Node Type: "Nested Loop"                     +
+         Parent Relationship: "Outer"                 +
+         Slice: 3                                     +
+         Segments: 3                                  +
+         Gang Type: "primary reader"                  +
+         Join Type: "Left"                            +
+         Startup Cost: 2432.00                        +
+         Total Cost: 8569.25                          +
+         Plan Rows: 77900                             +
+         Plan Width: 84                               +
+         Join Filter: "true"                          +
+         Plans:                                       +
+           - Node Type: "Redistribute Motion"         +
+             Senders: 3                               +
+             Receivers: 3                             +
+             Parent Relationship: "Outer"             +
+             Slice: 2                                 +
+             Segments: 3                              +
+             Gang Type: "primary reader"              +
+             Startup Cost: 1216.00                    +
+             Total Cost: 6282.12                      +
+             Plan Rows: 77900                         +
+             Plan Width: 48                           +
+             Hash Key: "boxes.location_id"            +
+             Plans:                                   +
+               - Node Type: "Nested Loop"             +
+                 Parent Relationship: "Outer"         +
+                 Slice: 2                             +
+                 Segments: 3                          +
+                 Gang Type: "primary reader"          +
+                 Join Type: "Left"                    +
+                 Startup Cost: 1216.00                +
+                 Total Cost: 4724.12                  +
+                 Plan Rows: 77900                     +
+                 Plan Width: 48                       +
+                 Join Filter: "true"                  +
+                 Plans:                               +
+                   - Node Type: "Redistribute Motion" +
+                     Senders: 3                       +
+                     Receivers: 3                     +
+                     Parent Relationship: "Outer"     +
+                     Slice: 1                         +
+                     Segments: 3                      +
+                     Gang Type: "primary reader"      +
+                     Startup Cost: 0.00               +
+                     Total Cost: 2437.00              +
+                     Plan Rows: 77900                 +
+                     Plan Width: 12                   +
+                     Hash Key: "boxes.apple_id"       +
+                     Plans:                           +
+                       - Node Type: "Table Scan"      +
+                         Parent Relationship: "Outer" +
+                         Slice: 1                     +
+                         Segments: 3                  +
+                         Gang Type: "primary reader"  +
+                         Relation Name: "boxes"       +
+                         Alias: "boxes"               +
+                         Startup Cost: 0.00           +
+                         Total Cost: 879.00           +
+                         Plan Rows: 77900             +
+                         Plan Width: 12               +
+                   - Node Type: "Index Scan"          +
+                     Parent Relationship: "Inner"     +
+                     Slice: 2                         +
+                     Segments: 3                      +
+                     Gang Type: "primary reader"      +
+                     Scan Direction: "Forward"        +
+                     Index Name: "apples_pkey"        +
+                     Relation Name: "apples"          +
+                     Alias: "apples"                  +
+                     Startup Cost: 0.02               +
+                     Total Cost: 1.00                 +
+                     Plan Rows: 13                    +
+                     Plan Width: 43213                +
+                     Index Cond: "id = boxes.apple_id"+
+           - Node Type: "Index Scan"                  +
+             Parent Relationship: "Inner"             +
+             Slice: 3                                 +
+             Segments: 3                              +
+             Gang Type: "primary reader"              +
+             Scan Direction: "Forward"                +
+             Index Name: "box_locations_pkey"         +
+             Relation Name: "box_locations"           +
+             Alias: "box_locations"                   +
+             Startup Cost: 1.00                       +
+             Total Cost: 3.00                         +
+             Plan Rows: 2                             +
+             Plan Width: 56                           +
+             Index Cond: "id = boxes.location_id"     +
+   Settings:                                          +
+     Optimizer: "PQO version 2.1.0"
 (1 row)
 
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
-                       QUERY PLAN
----------------------------------------------------------
- - Plan:                                                +
-     Node Type: "Gather Motion"                         +
-     Senders: 3                                         +
-     Receivers: 1                                       +
-     Slice: 3                                           +
-     Segments: 3                                        +
-     Gang Type: "primary reader"                        +
-     Startup Cost: 2432.00                              +
-     Total Cost: 8569.25                                +
-     Plan Rows: 77901                                   +
-     Plan Width: 100                                    +
-     Actual Startup Time: 1.842                         +
-     Actual Total Time: 1.842                           +
-     Actual Rows: 50                                    +
-     Actual Loops: 3                                    +
-     Plans:                                             +
-       - Node Type: "Hash Join"                         +
-         Parent Relationship: "Outer"                   +
-         Slice: 3                                       +
-         Segments: 3                                    +
-         Gang Type: "primary reader"                    +
-         Join Type: "Left"                              +
-         Startup Cost: 2432.00                          +
-         Total Cost: 8569.25                            +
-         Plan Rows: 900                                 +
-         Plan Width: 84                                 +
-         Actual Startup Time: 0.000                     +
-         Actual Total Time: 0.000                       +
-         Actual Rows: 0                                 +
-         Actual Loops: 0                                +
-         Hash Cond: "boxes.location_id = locations.id"  +
-         Plans:                                         +
-           - Node Type: "Redistribute Motion"           +
-             Senders: 3                                 +
-             Receivers: 3                               +
-             Parent Relationship: "Outer"               +
-             Slice: 2                                   +
-             Segments: 3                                +
-             Gang Type: "primary reader"                +
-             Startup Cost: 1216.00                      +
-             Total Cost: 6282.12                        +
-             Plan Rows: 77900                           +
-             Plan Width: 48                             +
-             Actual Startup Time: 0.000                 +
-             Actual Total Time: 0.000                   +
-             Actual Rows: 0                             +
-             Actual Loops: 0                            +
-             Hash Key: "boxes.location_id"              +
-             Plans:                                     +
-               - Node Type: "Hash Join"                 +
-                 Parent Relationship: "Outer"           +
-                 Slice: 2                               +
-                 Segments: 3                            +
-                 Gang Type: "primary reader"            +
-                 Join Type: "Left"                      +
-                 Startup Cost: 1216.00                  +
-                 Total Cost: 4724.12                    +
-                 Plan Rows: 77900                       +
-                 Plan Width: 48                         +
-                 Actual Startup Time: 0.000             +
-                 Actual Total Time: 0.000               +
-                 Actual Rows: 0                         +
-                 Actual Loops: 0                        +
-                 Hash Cond: "boxes.apple_id = apples.id"+
-                 Plans:                                 +
-                   - Node Type: "Redistribute Motion"   +
-                     Senders: 3                         +
-                     Receivers: 3                       +
-                     Parent Relationship: "Outer"       +
-                     Slice: 1                           +
-                     Segments: 3                        +
-                     Gang Type: "primary reader"        +
-                     Startup Cost: 0.00                 +
-                     Total Cost: 2437.00                +
-                     Plan Rows: 77900                   +
-                     Plan Width: 12                     +
-                     Actual Startup Time: 0.000         +
-                     Actual Total Time: 0.000           +
-                     Actual Rows: 0                     +
-                     Actual Loops: 0                    +
-                     Hash Key: "boxes.apple_id"         +
-                     Plans:                             +
-                       - Node Type: "Table Scan"        +
-                         Parent Relationship: "Outer"   +
-                         Slice: 1                       +
-                         Segments: 3                    +
-                         Gang Type: "primary reader"    +
-                         Relation Name: "boxes"         +
-                         Alias: "boxes"                 +
-                         Startup Cost: 0.00             +
-                         Total Cost: 879.00             +
-                         Plan Rows: 77900               +
-                         Plan Width: 12                 +
-                         Actual Startup Time: 0.000     +
-                         Actual Total Time: 0.000       +
-                         Actual Rows: 0                 +
-                         Actual Loops: 0                +
-                   - Node Type: "Hash"                  +
-                     Parent Relationship: "Inner"       +
-                     Slice: 2                           +
-                     Segments: 3                        +
-                     Gang Type: "primary reader"        +
-                     Startup Cost: 596.00               +
-                     Total Cost: 596.00                 +
-                     Plan Rows: 49600                   +
-                     Plan Width: 36                     +
-                     Actual Startup Time: 0.000         +
-                     Actual Total Time: 0.000           +
-                     Actual Rows: 0                     +
-                     Actual Loops: 0                    +
-                     Plans:                             +
-                       - Node Type: "Table Scan"        +
-                         Parent Relationship: "Outer"   +
-                         Slice: 2                       +
-                         Segments: 3                    +
-                         Gang Type: "primary reader"    +
-                         Relation Name: "apples"        +
-                         Alias: "apples"                +
-                         Startup Cost: 0.00             +
-                         Total Cost: 596.00             +
-                         Plan Rows: 49600               +
-                         Plan Width: 36                 +
-                         Actual Startup Time: 0.000     +
-                         Actual Total Time: 0.000       +
-                         Actual Rows: 0                 +
-                         Actual Loops: 0                +
-           - Node Type: "Hash"                          +
-             Parent Relationship: "Inner"               +
-             Slice: 3                                   +
-             Segments: 3                                +
-             Gang Type: "primary reader"                +
-             Startup Cost: 596.00                       +
-             Total Cost: 596.00                         +
-             Plan Rows: 49600                           +
-             Plan Width: 36                             +
-             Actual Startup Time: 0.000                 +
-             Actual Total Time: 0.000                   +
-             Actual Rows: 0                             +
-             Actual Loops: 0                            +
-             Plans:                                     +
-               - Node Type: "Table Scan"                +
-                 Parent Relationship: "Outer"           +
-                 Slice: 3                               +
-                 Segments: 10                           +
-                 Gang Type: "primary reader"            +
-                 Relation Name: "locations"             +
-                 Alias: "locations"                     +
-                 Startup Cost: 0.00                     +
-                 Total Cost: 596.00                     +
-                 Plan Rows: 49600                       +
-                 Plan Width: 36                         +
-                 Actual Startup Time: 0.000             +
-                 Actual Total Time: 0.000               +
-                 Actual Rows: 0                         +
-                 Actual Loops: 0                        +
-   Triggers:                                            +
-   Slice statistics:                                    +
-     - Slice: 0                                         +
-       Executor Memory: 386000                          +
-       Global Peak Memory: 12343                        +
-       Virtual Memory: 5432                             +
-     - Slice: 1                                         +
-       Executor Memory:                                 +
-         Average: 59000                                +
-         Workers: 3                                    +
-         Maximum Memory Used: 59000                    +
-       Global Peak Memory:                              +
-         Average: 59000                                +
-         Workers: 3                                    +
-         Maximum Memory Used: 59000                    +
-       Virtual Memory:                                  +
-         Average: 59000                                +
-         Workers: 3                                    +
-         Maximum Memory Used: 59000                    +
-     - Slice: 2                                         +
-       Executor Memory:                                 +
-         Average: 59000                                +
-         Workers: 3                                    +
-         Maximum Memory Used: 59000                    +
-       Global Peak Memory:                              +
-         Average: 59000                                +
-         Workers: 3                                    +
-         Maximum Memory Used: 59000                    +
-       Virtual Memory:                                  +
-         Average: 59000                                +
-         Workers: 3                                    +
-         Maximum Memory Used: 59000                    +
-       Work Maximum Memory: 1043000                     +
-     - Slice: 3                                         +
-       Executor Memory:                                 +
-         Average: 59000                                +
-         Workers: 3                                    +
-         Maximum Memory Used: 59000                    +
-       Global Peak Memory:                              +
-         Average: 59000                                +
-         Workers: 3                                    +
-         Maximum Memory Used: 59000                    +
-       Virtual Memory:                                  +
-         Average: 59000                                +
-         Workers: 3                                    +
-         Maximum Memory Used: 59000                    +
-   Total memory used across slices: 13211               +
-   Statement statistics:                                +
-     Memory used: 128000                                +
-     ORCA Memory Used Peak: 14                          +
-     ORCA Memory Used Allocated: 13                     +
-     ORCA Memory Used Freed: 12                         +
-   Settings:                                            +
-     Optimizer: "PQO version 1.2.3"                     +
-   Total Runtime: 2.652
+EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
+                       QUERY PLAN                      
+-------------------------------------------------------
+ - Plan:                                              +
+     Node Type: "Gather Motion"                       +
+     Senders: 3                                       +
+     Receivers: 1                                     +
+     Slice: 3                                         +
+     Segments: 3                                      +
+     Gang Type: "primary reader"                      +
+     Startup Cost: 2432.00                            +
+     Total Cost: 8569.25                              +
+     Plan Rows: 77901                                 +
+     Plan Width: 100                                  +
+     Actual Startup Time: 1.842                       +
+     Actual Total Time: 1.842                         +
+     Actual Rows: 50                                  +
+     Actual Loops: 3                                  +
+     Plans:                                           +
+       - Node Type: "Nested Loop"                     +
+         Parent Relationship: "Outer"                 +
+         Slice: 3                                     +
+         Segments: 3                                  +
+         Gang Type: "primary reader"                  +
+         Join Type: "Left"                            +
+         Startup Cost: 2432.00                        +
+         Total Cost: 8569.25                          +
+         Plan Rows: 900                               +
+         Plan Width: 84                               +
+         Actual Startup Time: 0.000                   +
+         Actual Total Time: 0.000                     +
+         Actual Rows: 0                               +
+         Actual Loops: 0                              +
+         Join Filter: "true"                          +
+         Rows Removed by Join Filter: 0               +
+         Plans:                                       +
+           - Node Type: "Redistribute Motion"         +
+             Senders: 3                               +
+             Receivers: 3                             +
+             Parent Relationship: "Outer"             +
+             Slice: 2                                 +
+             Segments: 3                              +
+             Gang Type: "primary reader"              +
+             Startup Cost: 1216.00                    +
+             Total Cost: 6282.12                      +
+             Plan Rows: 77900                         +
+             Plan Width: 48                           +
+             Actual Startup Time: 0.000               +
+             Actual Total Time: 0.000                 +
+             Actual Rows: 0                           +
+             Actual Loops: 0                          +
+             Hash Key: "boxes.location_id"            +
+             Plans:                                   +
+               - Node Type: "Nested Loop"             +
+                 Parent Relationship: "Outer"         +
+                 Slice: 2                             +
+                 Segments: 3                          +
+                 Gang Type: "primary reader"          +
+                 Join Type: "Left"                    +
+                 Startup Cost: 1216.00                +
+                 Total Cost: 4724.12                  +
+                 Plan Rows: 77900                     +
+                 Plan Width: 48                       +
+                 Actual Startup Time: 0.000           +
+                 Actual Total Time: 0.000             +
+                 Actual Rows: 0                       +
+                 Actual Loops: 1                      +
+                 Join Filter: "true"                  +
+                 Rows Removed by Join Filter: 0       +
+                 Plans:                               +
+                   - Node Type: "Redistribute Motion" +
+                     Senders: 3                       +
+                     Receivers: 3                     +
+                     Parent Relationship: "Outer"     +
+                     Slice: 1                         +
+                     Segments: 3                      +
+                     Gang Type: "primary reader"      +
+                     Startup Cost: 0.00               +
+                     Total Cost: 2437.00              +
+                     Plan Rows: 77900                 +
+                     Plan Width: 11                   +
+                     Actual Startup Time: 0.040       +
+                     Actual Total Time: 0.000         +
+                     Actual Rows: 0                   +
+                     Actual Loops: 0                  +
+                     Hash Key: "boxes.apple_id"       +
+                     Plans:                           +
+                       - Node Type: "Table Scan"      +
+                         Parent Relationship: "Outer" +
+                         Slice: 1                     +
+                         Segments: 3                  +
+                         Gang Type: "primary reader"  +
+                         Relation Name: "boxes"       +
+                         Alias: "boxes"               +
+                         Startup Cost: 0.00           +
+                         Total Cost: 879.00           +
+                         Plan Rows: 77900             +
+                         Plan Width: 13               +
+                         Actual Startup Time: 0.010   +
+                         Actual Total Time: 0.000     +
+                         Actual Rows: 0               +
+                         Actual Loops: 0              +
+                   - Node Type: "Index Scan"          +
+                     Parent Relationship: "Inner"     +
+                     Slice: 2                         +
+                     Segments: 3                      +
+                     Gang Type: "primary reader"      +
+                     Scan Direction: "Forward"        +
+                     Index Name: "apples_pkey"        +
+                     Relation Name: "apples"          +
+                     Alias: "apples"                  +
+                     Startup Cost: 0.10               +
+                     Total Cost: 2.20                 +
+                     Plan Rows: 1123                  +
+                     Plan Width: 43                   +
+                     Actual Startup Time: 0.010       +
+                     Actual Total Time: 0.030         +
+                     Actual Rows: 10                  +
+                     Actual Loops: 11                 +
+                     Index Cond: "id = boxes.apple_id"+
+                     Rows Removed by Index Recheck: 0 +
+           - Node Type: "Index Scan"                  +
+             Parent Relationship: "Inner"             +
+             Slice: 3                                 +
+             Segments: 3                              +
+             Gang Type: "primary reader"              +
+             Scan Direction: "Forward"                +
+             Index Name: "box_locations_pkey"         +
+             Relation Name: "box_locations"           +
+             Alias: "box_locations"                   +
+             Startup Cost: 0.10                       +
+             Total Cost: 2.10                         +
+             Plan Rows: 123                           +
+             Plan Width: 1233                         +
+             Actual Startup Time: 1.000               +
+             Actual Total Time: 2.000                 +
+             Actual Rows: 3                           +
+             Actual Loops: 4                          +
+             Index Cond: "id = boxes.location_id"     +
+             Rows Removed by Index Recheck: 0         +
+   Triggers:                                          +
+   Slice statistics:                                  +
+     - Slice: 0                                       +
+       Executor Memory: 386000                        +
+       Global Peak Memory: 12343                      +
+       Virtual Memory: 5432                           +
+     - Slice: 1                                       +
+       Executor Memory:                               +
+         Average: 59000                               +
+         Workers: 3                                   +
+         Maximum Memory Used: 59000                   +
+       Global Peak Memory:                            +
+         Average: 59000                               +
+         Workers: 3                                   +
+         Maximum Memory Used: 59000                   +
+       Virtual Memory:                                +
+         Average: 59000                               +
+         Workers: 3                                   +
+         Maximum Memory Used: 59000                   +
+     - Slice: 2                                       +
+       Executor Memory:                               +
+         Average: 59000                               +
+         Workers: 3                                   +
+         Maximum Memory Used: 59000                   +
+       Global Peak Memory:                            +
+         Average: 59000                               +
+         Workers: 3                                   +
+         Maximum Memory Used: 59000                   +
+       Virtual Memory:                                +
+         Average: 59000                               +
+         Workers: 3                                   +
+         Maximum Memory Used: 59000                   +
+     - Slice: 3                                       +
+       Executor Memory:                               +
+         Average: 59000                               +
+         Workers: 3                                   +
+         Maximum Memory Used: 59000                   +
+       Global Peak Memory:                            +
+         Average: 59000                               +
+         Workers: 3                                   +
+         Maximum Memory Used: 59000                   +
+       Virtual Memory:                                +
+         Average: 59000                               +
+         Workers: 3                                   +
+         Maximum Memory Used: 59000                   +
+     - Slice: 4                                       +
+     - Slice: 5                                       +
+   Total memory used across slices: 13211             +
+   Statement statistics:                              +
+     Memory used: 1200                                +
+     ORCA Memory Used Peak: 14                        +
+     ORCA Memory Used Allocated: 13                   +
+     ORCA Memory Used Freed: 12                       +
+   Settings:                                          +
+     Optimizer: "PQO version 1.2.3"                   +
+   Total Runtime: 2.61
 (1 row)
 
 -- explain_processing_on
@@ -503,431 +478,392 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- m/"Average": \d+,\s+/
 -- s/"Average": \d+,\s+/"Average": ##, /
 -- m/"Total memory used across slices": \d+,/
--- s/"Total memory used across slices": \d+,/"Total memory used across slices": ###,/
+-- s/"Total memory used across slices": \d+,\s*/"Total memory used across slices": ###,/
 -- m/"ORCA Memory Used \w+": \d+,?/
 -- s/"ORCA Memory Used (\w+)": \d+,?\s+/"ORCA Memory Used $1": ##/
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain JSON output
-EXPLAIN (FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                           QUERY PLAN
 --------------------------------------------------------------
- [                                                           +
-   {                                                         +
-     "Plan": {                                               +
-       "Node Type": "Gather Motion",                         +
-       "Senders": 3,                                         +
-       "Receivers": 1,                                       +
-       "Slice": 3,                                           +
-       "Segments": 3,                                        +
-       "Gang Type": "primary reader",                        +
-       "Startup Cost": 242.00,                               +
-       "Total Cost": 859.25,                                 +
-       "Plan Rows": 7790,                                    +
-       "Plan Width": 10,                                     +
-       "Plans": [                                            +
-         {                                                   +
-           "Node Type": "Hash Join",                         +
-           "Parent Relationship": "Outer",                   +
-           "Slice": 3,                                       +
-           "Segments": 3,                                    +
-           "Gang Type": "primary reader",                    +
-           "Join Type": "Left",                              +
-           "Startup Cost": 242.00,                           +
-           "Total Cost": 859.25,                             +
-           "Plan Rows": 7700,                                +
-           "Plan Width": 10,                                 +
-           "Hash Cond": "boxes.location_id = locations.id",  +
-           "Plans": [                                        +
-             {                                               +
-               "Node Type": "Redistribute Motion",           +
-               "Senders": 3,                                 +
-               "Receivers": 3,                               +
-               "Parent Relationship": "Outer",               +
-               "Slice": 2,                                   +
-               "Segments": 3,                                +
-               "Gang Type": "primary reader",                +
-               "Startup Cost": 121.00,                       +
-               "Total Cost": 628.12,                         +
-               "Plan Rows": 7790,                            +
-               "Plan Width": 4,                              +
-               "Hash Key": "boxes.location_id",              +
-               "Plans": [                                    +
-                 {                                           +
-                   "Node Type": "Hash Join",                 +
-                   "Parent Relationship": "Outer",           +
-                   "Slice": 2,                               +
-                   "Segments": 3,                            +
-                   "Gang Type": "primary reader",            +
-                   "Join Type": "Left",                      +
-                   "Startup Cost": 1216.00,                  +
-                   "Total Cost": 4724.12,                    +
-                   "Plan Rows": 77900,                       +
-                   "Plan Width": 48,                         +
-                   "Hash Cond": "boxes.apple_id = apples.id",+
-                   "Plans": [                                +
-                     {                                       +
-                       "Node Type": "Redistribute Motion",   +
-                       "Senders": 3,                         +
-                       "Receivers": 3,                       +
-                       "Parent Relationship": "Outer",       +
-                       "Slice": 1,                           +
-                       "Segments": 3,                        +
-                       "Gang Type": "primary reader",        +
-                       "Startup Cost": 0.00,                 +
-                       "Total Cost": 2437.00,                +
-                       "Plan Rows": 77900,                   +
-                       "Plan Width": 12,                     +
-                       "Hash Key": "boxes.apple_id",         +
-                       "Plans": [                            +
-                         {                                   +
-                           "Node Type": "Table Scan",        +
-                           "Parent Relationship": "Outer",   +
-                           "Slice": 1,                       +
-                           "Segments": 3,                    +
-                           "Gang Type": "primary reader",    +
-                           "Relation Name": "boxes",         +
-                           "Alias": "boxes",                 +
-                           "Startup Cost": 0.00,             +
-                           "Total Cost": 879.00,             +
-                           "Plan Rows": 77900,               +
-                           "Plan Width": 12                  +
-                         }                                   +
-                       ]                                     +
-                     },                                      +
-                     {                                       +
-                       "Node Type": "Hash",                  +
-                       "Parent Relationship": "Inner",       +
-                       "Slice": 2,                           +
-                       "Segments": 3,                        +
-                       "Gang Type": "primary reader",        +
-                       "Startup Cost": 596.00,               +
-                       "Total Cost": 596.00,                 +
-                       "Plan Rows": 49600,                   +
-                       "Plan Width": 36,                     +
-                       "Plans": [                            +
-                         {                                   +
-                           "Node Type": "Table Scan",        +
-                           "Parent Relationship": "Outer",   +
-                           "Slice": 2,                       +
-                           "Segments": 3,                    +
-                           "Gang Type": "primary reader",    +
-                           "Relation Name": "apples",        +
-                           "Alias": "apples",                +
-                           "Startup Cost": 0.00,             +
-                           "Total Cost": 596.00,             +
-                           "Plan Rows": 49600,               +
-                           "Plan Width": 36                  +
-                         }                                   +
-                       ]                                     +
-                     }                                       +
-                   ]                                         +
-                 }                                           +
-               ]                                             +
-             },                                              +
-             {                                               +
-               "Node Type": "Hash",                          +
-               "Parent Relationship": "Inner",               +
-               "Slice": 3,                                   +
-               "Segments": 3,                                +
-               "Gang Type": "primary reader",                +
-               "Startup Cost": 596.00,                       +
-               "Total Cost": 596.00,                         +
-               "Plan Rows": 49600,                           +
-               "Plan Width": 36,                             +
-               "Plans": [                                    +
-                 {                                           +
-                   "Node Type": "Table Scan",                +
-                   "Parent Relationship": "Outer",           +
-                   "Slice": 3,                               +
-                   "Segments": 10,                           +
-                   "Gang Type": "primary reader",            +
-                   "Relation Name": "locations",             +
-                   "Alias": "locations",                     +
-                   "Startup Cost": 0.00,                     +
-                   "Total Cost": 596.00,                     +
-                   "Plan Rows": 49600,                       +
-                   "Plan Width": 36                          +
-                 }                                           +
-               ]                                             +
-             }                                               +
-           ]                                                 +
-         }                                                   +
-       ]                                                     +
-     },                                                      +
-     "Settings": {                                           +
-       "Optimizer": "PQO version 1.2.3"                      +
-     }                                                       +
-   }                                                         +
+ [                                                        +
+   {                                                      +
+     "Plan": {                                            +
+       "Node Type": "Gather Motion",                      +
+       "Senders": 3,                                      +
+       "Receivers": 1,                                    +
+       "Slice": 3,                                        +
+       "Segments": 3,                                     +
+       "Gang Type": "primary reader",                     +
+       "Startup Cost": 242.00,                            +
+       "Total Cost": 859.25,                              +
+       "Plan Rows": 7790,                                 +
+       "Plan Width": 10,                                  +
+       "Plans": [                                         +
+         {                                                +
+           "Node Type": "Nested Loop",                    +
+           "Parent Relationship": "Outer",                +
+           "Slice": 3,                                    +
+           "Segments": 3,                                 +
+           "Gang Type": "primary reader",                 +
+           "Join Type": "Left",                           +
+           "Startup Cost": 242.00,                        +
+           "Total Cost": 859.25,                          +
+           "Plan Rows": 7700,                             +
+           "Plan Width": 10,                              +
+           "Join Filter": "true",                         +
+           "Plans": [                                     +
+             {                                            +
+               "Node Type": "Redistribute Motion",        +
+               "Senders": 3,                              +
+               "Receivers": 3,                            +
+               "Parent Relationship": "Outer",            +
+               "Slice": 2,                                +
+               "Segments": 3,                             +
+               "Gang Type": "primary reader",             +
+               "Startup Cost": 121.00,                    +
+               "Total Cost": 628.12,                      +
+               "Plan Rows": 7790,                         +
+               "Plan Width": 4,                           +
+               "Hash Key": "boxes.location_id",           +
+               "Plans": [                                 +
+                 {                                        +
+                   "Node Type": "Nested Loop",            +
+                   "Parent Relationship": "Outer",        +
+                   "Slice": 2,                            +
+                   "Segments": 3,                         +
+                   "Gang Type": "primary reader",         +
+                   "Join Type": "Left",                   +
+                   "Startup Cost": 1216.00,               +
+                   "Total Cost": 4724.12,                 +
+                   "Plan Rows": 77900,                    +
+                   "Plan Width": 48,                      +
+                   "Join Filter": "true",                 +
+                   "Plans": [                             +
+                     {                                    +
+                       "Node Type": "Redistribute Motion",+
+                       "Senders": 3,                      +
+                       "Receivers": 3,                    +
+                       "Parent Relationship": "Outer",    +
+                       "Slice": 1,                        +
+                       "Segments": 3,                     +
+                       "Gang Type": "primary reader",     +
+                       "Startup Cost": 0.00,              +
+                       "Total Cost": 2437.00,             +
+                       "Plan Rows": 77900,                +
+                       "Plan Width": 12,                  +
+                       "Hash Key": "boxes.apple_id",      +
+                       "Plans": [                         +
+                         {                                +
+                           "Node Type": "Table Scan",     +
+                           "Parent Relationship": "Outer",+
+                           "Slice": 1,                    +
+                           "Segments": 3,                 +
+                           "Gang Type": "primary reader", +
+                           "Relation Name": "boxes",      +
+                           "Alias": "boxes",              +
+                           "Startup Cost": 0.00,          +
+                           "Total Cost": 879.00,          +
+                           "Plan Rows": 77900,            +
+                           "Plan Width": 12               +
+                         }                                +
+                       ]                                  +
+                     },                                   +
+                     {                                    +
+                       "Node Type": "Index Scan",         +
+                       "Parent Relationship": "Inner",    +
+                       "Slice": 2,                        +
+                       "Segments": 3,                     +
+                       "Gang Type": "primary reader",     +
+                       "Scan Direction": "Forward",       +
+                       "Index Name": "apples_pkey",       +
+                       "Relation Name": "apples",         +
+                       "Alias": "apples",                 +
+                       "Startup Cost": 1.00,              +
+                       "Total Cost": 2.20,                +
+                       "Plan Rows": 3,                    +
+                       "Plan Width": 4,                   +
+                       "Index Cond": "id = boxes.apple_id"+
+                     }                                    +
+                   ]                                      +
+                 }                                        +
+               ]                                          +
+             },                                           +
+             {                                            +
+               "Node Type": "Index Scan",                 +
+               "Parent Relationship": "Inner",            +
+               "Slice": 3,                                +
+               "Segments": 3,                             +
+               "Gang Type": "primary reader",             +
+               "Scan Direction": "Forward",               +
+               "Index Name": "box_locations_pkey",        +
+               "Relation Name": "box_locations",          +
+               "Alias": "box_locations",                  +
+               "Startup Cost": 0.10,                      +
+               "Total Cost": 2.20,                        +
+               "Plan Rows": 3,                            +
+               "Plan Width": 4,                           +
+               "Index Cond": "id = boxes.location_id"     +
+             }                                            +
+           ]                                              +
+         }                                                +
+       ]                                                  +
+     },                                                   +
+     "Settings": {                                        +
+       "Optimizer": "PQO version 2.1.0"                   +
+     }                                                    +
+   }                                                      +
  ]
 (1 row)
 
 -- explain_processing_on
 --- Check Explain Analyze JSON output that include the slices information
 -- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                           QUERY PLAN
---------------------------------------------------------------
- [                                                           +
-   {                                                         +
-     "Plan": {                                               +
-       "Node Type": "Gather Motion",                         +
-       "Senders": 3,                                         +
-       "Receivers": 1,                                       +
-       "Slice": 3,                                           +
-       "Segments": 3,                                        +
-       "Gang Type": "primary reader",                        +
-       "Startup Cost": 2432.00,                              +
-       "Total Cost": 8569.25,                                +
-       "Plan Rows": 77900,                                   +
-       "Plan Width": 84,                                     +
-       "Actual Startup Time": 5.415,                         +
-       "Actual Total Time": 5.415,                           +
-       "Actual Rows": 0,                                     +
-       "Actual Loops": 1,                                    +
-       "Plans": [                                            +
-         {                                                   +
-           "Node Type": "Hash Join",                         +
-           "Parent Relationship": "Outer",                   +
-           "Slice": 3,                                       +
-           "Segments": 10,                                   +
-           "Gang Type": "primary reader",                    +
-           "Join Type": "Left",                              +
-           "Startup Cost": 2432.00,                          +
-           "Total Cost": 8569.25,                            +
-           "Plan Rows": 77900,                               +
-           "Plan Width": 84,                                 +
-           "Actual Startup Time": 0.000,                     +
-           "Actual Total Time": 0.000,                       +
-           "Actual Rows": 0,                                 +
-           "Actual Loops": 0,                                +
-           "Hash Cond": "boxes.location_id = locations.id",  +
-           "Plans": [                                        +
-             {                                               +
-               "Node Type": "Redistribute Motion",           +
-               "Senders": 3,                                 +
-               "Receivers": 3,                               +
-               "Parent Relationship": "Outer",               +
-               "Slice": 2,                                   +
-               "Segments": 3,                                +
-               "Gang Type": "primary reader",                +
-               "Startup Cost": 1216.00,                      +
-               "Total Cost": 6282.12,                        +
-               "Plan Rows": 77900,                           +
-               "Plan Width": 48,                             +
-               "Actual Startup Time": 0.000,                 +
-               "Actual Total Time": 0.000,                   +
-               "Actual Rows": 0,                             +
-               "Actual Loops": 0,                            +
-               "Hash Key": "boxes.location_id",              +
-               "Plans": [                                    +
-                 {                                           +
-                   "Node Type": "Hash Join",                 +
-                   "Parent Relationship": "Outer",           +
-                   "Slice": 2,                               +
-                   "Segments": 3,                            +
-                   "Gang Type": "primary reader",            +
-                   "Join Type": "Left",                      +
-                   "Startup Cost": 1216.00,                  +
-                   "Total Cost": 4724.12,                    +
-                   "Plan Rows": 77900,                       +
-                   "Plan Width": 48,                         +
-                   "Actual Startup Time": 0.000,             +
-                   "Actual Total Time": 0.000,               +
-                   "Actual Rows": 0,                         +
-                   "Actual Loops": 0,                        +
-                   "Hash Cond": "boxes.apple_id = apples.id",+
-                   "Plans": [                                +
-                     {                                       +
-                       "Node Type": "Redistribute Motion",   +
-                       "Senders": 3,                         +
-                       "Receivers": 3,                       +
-                       "Parent Relationship": "Outer",       +
-                       "Slice": 1,                           +
-                       "Segments": 3,                        +
-                       "Gang Type": "primary reader",        +
-                       "Startup Cost": 0.00,                 +
-                       "Total Cost": 2437.00,                +
-                       "Plan Rows": 77900,                   +
-                       "Plan Width": 12,                     +
-                       "Actual Startup Time": 0.000,         +
-                       "Actual Total Time": 0.000,           +
-                       "Actual Rows": 0,                     +
-                       "Actual Loops": 0,                    +
-                       "Hash Key": "boxes.apple_id",         +
-                       "Plans": [                            +
-                         {                                   +
-                           "Node Type": "Table Scan",        +
-                           "Parent Relationship": "Outer",   +
-                           "Slice": 1,                       +
-                           "Segments": 3,                    +
-                           "Gang Type": "primary reader",    +
-                           "Relation Name": "boxes",         +
-                           "Alias": "boxes",                 +
-                           "Startup Cost": 0.00,             +
-                           "Total Cost": 879.00,             +
-                           "Plan Rows": 77900,               +
-                           "Plan Width": 12,                 +
-                           "Actual Startup Time": 0.000,     +
-                           "Actual Total Time": 0.000,       +
-                           "Actual Rows": 0,                 +
-                           "Actual Loops": 0                 +
-                         }                                   +
-                       ]                                     +
-                     },                                      +
-                     {                                       +
-                       "Node Type": "Hash",                  +
-                       "Parent Relationship": "Inner",       +
-                       "Slice": 2,                           +
-                       "Segments": 3,                        +
-                       "Gang Type": "primary reader",        +
-                       "Startup Cost": 596.00,               +
-                       "Total Cost": 596.00,                 +
-                       "Plan Rows": 49600,                   +
-                       "Plan Width": 36,                     +
-                       "Actual Startup Time": 0.000,         +
-                       "Actual Total Time": 0.000,           +
-                       "Actual Rows": 0,                     +
-                       "Actual Loops": 0,                    +
-                       "Plans": [                            +
-                         {                                   +
-                           "Node Type": "Table Scan",        +
-                           "Parent Relationship": "Outer",   +
-                           "Slice": 2,                       +
-                           "Segments": 3,                    +
-                           "Gang Type": "primary reader",    +
-                           "Relation Name": "apples",        +
-                           "Alias": "apples",                +
-                           "Startup Cost": 0.00,             +
-                           "Total Cost": 596.00,             +
-                           "Plan Rows": 49600,               +
-                           "Plan Width": 36,                 +
-                           "Actual Startup Time": 0.000,     +
-                           "Actual Total Time": 0.000,       +
-                           "Actual Rows": 0,                 +
-                           "Actual Loops": 0                 +
-                         }                                   +
-                       ]                                     +
-                     }                                       +
-                   ]                                         +
-                 }                                           +
-               ]                                             +
-             },                                              +
-             {                                               +
-               "Node Type": "Hash",                          +
-               "Parent Relationship": "Inner",               +
-               "Slice": 3,                                   +
-               "Segments": 3,                                +
-               "Gang Type": "primary reader",                +
-               "Startup Cost": 596.00,                       +
-               "Total Cost": 596.00,                         +
-               "Plan Rows": 49600,                           +
-               "Plan Width": 36,                             +
-               "Actual Startup Time": 0.000,                 +
-               "Actual Total Time": 0.000,                   +
-               "Actual Rows": 0,                             +
-               "Actual Loops": 0,                            +
-               "Plans": [                                    +
-                 {                                           +
-                   "Node Type": "Table Scan",                +
-                   "Parent Relationship": "Outer",           +
-                   "Slice": 3,                               +
-                   "Segments": 3,                            +
-                   "Gang Type": "primary reader",            +
-                   "Relation Name": "locations",             +
-                   "Alias": "locations",                     +
-                   "Startup Cost": 0.00,                     +
-                   "Total Cost": 59.00,                      +
-                   "Plan Rows": 4960,                        +
-                   "Plan Width": 1,                          +
-                   "Actual Startup Time": 5.000,             +
-                   "Actual Total Time": 10.000,              +
-                   "Actual Rows": 5,                         +
-                   "Actual Loops": 1                         +
-                 }                                           +
-               ]                                             +
-             }                                               +
-           ]                                                 +
-         }                                                   +
-       ]                                                     +
-     },                                                      +
-     "Triggers": [                                           +
-     ],                                                      +
-     "Slice statistics": [                                   +
-       {                                                     +
-         "Slice": 0,                                         +
-         "Executor Memory": 123546,                          +
-         "Global Peak Memory": 14612,                        +
-         "Virtual Memory": 1235                              +
-       },                                                    +
-       {                                                     +
-         "Slice": 1,                                         +
-         "Executor Memory": {                                +
-           "Average": 12314,                                 +
-           "Workers": 12314,                                 +
-           "Maximum Memory Used": 12314,                     +
-         },                                                  +
-         "Global Peak Memory": {                             +
-           "Average": 12314,                                 +
-           "Workers": 12314,                                 +
-           "Maximum Memory Used": 12314,                     +
-         },                                                  +
-         "Virtual Memory": {                                 +
-           "Average": 12314,                                 +
-           "Workers": 12314,                                 +
-           "Maximum Memory Used": 12314,                     +
-         }                                                   +
-       },                                                    +
-       {                                                     +
-         "Slice": 2,                                         +
-         "Executor Memory": {                                +
-           "Average": 12314,                                 +
-           "Workers": 12314,                                 +
-           "Maximum Memory Used": 12314,                     +
-         },                                                  +
-         "Global Peak Memory": {                             +
-           "Average": 12314,                                 +
-           "Workers": 12314,                                 +
-           "Maximum Memory Used": 12314,                     +
-         },                                                  +
-         "Virtual Memory": {                                 +
-           "Average": 12314,                                 +
-           "Workers": 12314,                                 +
-           "Maximum Memory Used": 12314,                     +
-         },                                                  +
-         "Work Maximum Memory": 23424                        +
-       },                                                    +
-       {                                                     +
-         "Slice": 3,                                         +
-         "Executor Memory": {                                +
-           "Average": 12314,                                 +
-           "Workers": 12314,                                 +
-           "Maximum Memory Used": 12314,                     +
-         },                                                  +
-         "Global Peak Memory": {                             +
-           "Average": 12314,                                 +
-           "Workers": 12314,                                 +
-           "Maximum Memory Used": 12314,                     +
-         },                                                  +
-         "Virtual Memory": {                                 +
-           "Average": 12314,                                 +
-           "Workers": 12314,                                 +
-           "Maximum Memory Used": 12314,                     +
-         }                                                   +
-       }                                                     +
-     ],                                                      +
-     "Total memory used across slices": 13213,               +
-     "Statement statistics": {                               +
-       "Memory used": 12800                                  +
-       "ORCA Memory Used Peak": 12423,                       +
-       "ORCA Memory Used Allocated": 12312,                  +
-       "ORCA Memory Used Freed": 15                          +
-     },                                                      +
-     "Settings": {                                           +
-       "Optimizer": "PQO version 1.2.3",                     +
-     },                                                      +
-     "Total Runtime": 28.324                                 +
-   }                                                         +
+------------------------------------------------------------
+ [                                                         +
+   {                                                       +
+     "Plan": {                                             +
+       "Node Type": "Gather Motion",                       +
+       "Senders": 3,                                       +
+       "Receivers": 1,                                     +
+       "Slice": 3,                                         +
+       "Segments": 3,                                      +
+       "Gang Type": "primary reader",                      +
+       "Startup Cost": 2432.00,                            +
+       "Total Cost": 8569.25,                              +
+       "Plan Rows": 77900,                                 +
+       "Plan Width": 84,                                   +
+       "Actual Startup Time": 5.415,                       +
+       "Actual Total Time": 5.415,                         +
+       "Actual Rows": 0,                                   +
+       "Actual Loops": 1,                                  +
+       "Plans": [                                          +
+         {                                                 +
+           "Node Type": "Nested Loop",                     +
+           "Parent Relationship": "Outer",                 +
+           "Slice": 3,                                     +
+           "Segments": 10,                                 +
+           "Gang Type": "primary reader",                  +
+           "Join Type": "Left",                            +
+           "Startup Cost": 2432.00,                        +
+           "Total Cost": 8569.25,                          +
+           "Plan Rows": 77900,                             +
+           "Plan Width": 84,                               +
+           "Actual Startup Time": 0.000,                   +
+           "Actual Total Time": 0.000,                     +
+           "Actual Rows": 0,                               +
+           "Actual Loops": 1,                              +
+           "Join Filter": "true",                          +
+           "Rows Removed by Join Filter": 0,               +
+           "Plans": [                                      +
+             {                                             +
+               "Node Type": "Redistribute Motion",         +
+               "Senders": 3,                               +
+               "Receivers": 3,                             +
+               "Parent Relationship": "Outer",             +
+               "Slice": 2,                                 +
+               "Segments": 3,                              +
+               "Gang Type": "primary reader",              +
+               "Startup Cost": 1216.00,                    +
+               "Total Cost": 6282.12,                      +
+               "Plan Rows": 77900,                         +
+               "Plan Width": 48,                           +
+               "Actual Startup Time": 0.000,               +
+               "Actual Total Time": 0.000,                 +
+               "Actual Rows": 0,                           +
+               "Actual Loops": 0,                          +
+               "Hash Key": "boxes.location_id",            +
+               "Plans": [                                  +
+                 {                                         +
+                   "Node Type": "Nested Loop",             +
+                   "Parent Relationship": "Outer",         +
+                   "Slice": 2,                             +
+                   "Segments": 3,                          +
+                   "Gang Type": "primary reader",          +
+                   "Join Type": "Left",                    +
+                   "Startup Cost": 1216.00,                +
+                   "Total Cost": 4724.12,                  +
+                   "Plan Rows": 77900,                     +
+                   "Plan Width": 48,                       +
+                   "Actual Startup Time": 0.000,           +
+                   "Actual Total Time": 0.000,             +
+                   "Actual Rows": 0,                       +
+                   "Actual Loops": 2,                      +
+                   "Join Filter": "true",                  +
+                   "Rows Removed by Join Filter": 0,       +
+                   "Plans": [                              +
+                     {                                     +
+                       "Node Type": "Redistribute Motion", +
+                       "Senders": 3,                       +
+                       "Receivers": 3,                     +
+                       "Parent Relationship": "Outer",     +
+                       "Slice": 1,                         +
+                       "Segments": 3,                      +
+                       "Gang Type": "primary reader",      +
+                       "Startup Cost": 0.00,               +
+                       "Total Cost": 2437.00,              +
+                       "Plan Rows": 77900,                 +
+                       "Plan Width": 12,                   +
+                       "Actual Startup Time": 0.000,       +
+                       "Actual Total Time": 0.000,         +
+                       "Actual Rows": 0,                   +
+                       "Actual Loops": 0,                  +
+                       "Hash Key": "boxes.apple_id",       +
+                       "Plans": [                          +
+                         {                                 +
+                           "Node Type": "Table Scan",      +
+                           "Parent Relationship": "Outer", +
+                           "Slice": 1,                     +
+                           "Segments": 3,                  +
+                           "Gang Type": "primary reader",  +
+                           "Relation Name": "boxes",       +
+                           "Alias": "boxes",               +
+                           "Startup Cost": 0.00,           +
+                           "Total Cost": 879.00,           +
+                           "Plan Rows": 77900,             +
+                           "Plan Width": 12,               +
+                           "Actual Startup Time": 0.000,   +
+                           "Actual Total Time": 0.000,     +
+                           "Actual Rows": 0,               +
+                           "Actual Loops": 0               +
+                         }                                 +
+                       ]                                   +
+                     },                                    +
+                     {                                     +
+                       "Node Type": "Index Scan",          +
+                       "Parent Relationship": "Inner",     +
+                       "Slice": 2,                         +
+                       "Segments": 3,                      +
+                       "Gang Type": "primary reader",      +
+                       "Scan Direction": "Forward",        +
+                       "Index Name": "apples_pkey",        +
+                       "Relation Name": "apples",          +
+                       "Alias": "apples",                  +
+                       "Startup Cost": 0.10,               +
+                       "Total Cost": 2.20,                 +
+                       "Plan Rows": 3,                     +
+                       "Plan Width": 44,                   +
+                       "Actual Startup Time": 0.050,       +
+                       "Actual Total Time": 0.060,         +
+                       "Actual Rows": 7,                   +
+                       "Actual Loops": 8,                  +
+                       "Index Cond": "id = boxes.apple_id",+
+                       "Rows Removed by Index Recheck": 0  +
+                     }                                     +
+                   ]                                       +
+                 }                                         +
+               ]                                           +
+             },                                            +
+             {                                             +
+               "Node Type": "Index Scan",                  +
+               "Parent Relationship": "Inner",             +
+               "Slice": 3,                                 +
+               "Segments": 3,                              +
+               "Gang Type": "primary reader",              +
+               "Scan Direction": "Forward",                +
+               "Index Name": "box_locations_pkey",         +
+               "Relation Name": "box_locations",           +
+               "Alias": "box_locations",                   +
+               "Startup Cost": 0.10,                       +
+               "Total Cost": 2.10,                         +
+               "Plan Rows": 2,                             +
+               "Plan Width": 3,                           +
+               "Actual Startup Time": 0.050,               +
+               "Actual Total Time": 6.000,                 +
+               "Actual Rows": 7,                           +
+               "Actual Loops": 8,                          +
+               "Index Cond": "id = boxes.location_id",     +
+               "Rows Removed by Index Recheck": 0          +
+             }                                             +
+           ]                                               +
+         }                                                 +
+       ]                                                   +
+     },                                                    +
+     "Triggers": [                                         +
+     ],                                                    +
+     "Slice statistics": [                                 +
+       {                                                   +
+         "Slice": 0,                                       +
+         "Executor Memory": 123546,                        +
+         "Global Peak Memory": 14612,                      +
+         "Virtual Memory": 1235                            +
+       },                                                  +
+       {                                                   +
+         "Slice": 1,                                       +
+         "Executor Memory": {                              +
+           "Average": 12314,                               +
+           "Workers": 12314,                               +
+           "Maximum Memory Used": 12314,                   +
+         },                                                +
+         "Global Peak Memory": {                           +
+           "Average": 12314,                               +
+           "Workers": 12314,                               +
+           "Maximum Memory Used": 12314,                   +
+         },                                                +
+         "Virtual Memory": {                               +
+           "Average": 12314,                               +
+           "Workers": 12314,                               +
+           "Maximum Memory Used": 12314,                   +
+         }                                                 +
+       },                                                  +
+       {                                                   +
+         "Slice": 2,                                       +
+         "Executor Memory": {                              +
+           "Average": 12314,                               +
+           "Workers": 12314,                               +
+           "Maximum Memory Used": 12314,                   +
+         },                                                +
+         "Global Peak Memory": {                           +
+           "Average": 12314,                               +
+           "Workers": 12314,                               +
+           "Maximum Memory Used": 12314,                   +
+         },                                                +
+         "Virtual Memory": {                               +
+           "Average": 12314,                               +
+           "Workers": 12314,                               +
+           "Maximum Memory Used": 12314,                   +
+         }                                                 +
+       },                                                  +
+       {                                                   +
+         "Slice": 3,                                       +
+         "Executor Memory": {                              +
+           "Average": 12314,                               +
+           "Workers": 12314,                               +
+           "Maximum Memory Used": 12314,                   +
+         },                                                +
+         "Global Peak Memory": {                           +
+           "Average": 12314,                               +
+           "Workers": 12314,                               +
+           "Maximum Memory Used": 12314,                   +
+         },                                                +
+         "Virtual Memory": {                               +
+           "Average": 12314,                               +
+           "Workers": 12314,                               +
+           "Maximum Memory Used": 12314                    +
+         }                                                 +
+       },                                                  +
+       {                                                   +
+         "Slice": 4                                        +
+       },                                                  +
+       {                                                   +
+         "Slice": 5                                        +
+       }                                                   +
+     ],                                                    +
+     "Total memory used across slices": 13213,             +
+     "Statement statistics": {                             +
+       "Memory used": 1800                                 +
+       "ORCA Memory Used Peak": 12423,                     +
+       "ORCA Memory Used Allocated": 12312,                +
+       "ORCA Memory Used Freed": 15                        +
+     },                                                    +
+     "Settings": {                                         +
+       "Optimizer": "PQO version 1.2.3",                   +
+     },                                                    +
+     "Total Runtime": 28.324                               +
+   }                                                       +
  ]
 (1 row)
 
@@ -979,7 +915,7 @@ EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- end_matchsubs
 -- explain_processing_off
 -- Check Explain XML output
-EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                  QUERY PLAN
 ----------------------------------------------------------------------------
  <explain xmlns="http://www.postgresql.org/2009/explain">                  +
@@ -997,7 +933,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
        <Plan-Width>84</Plan-Width>                                         +
        <Plans>                                                             +
          <Plan>                                                            +
-           <Node-Type>Hash Join</Node-Type>                                +
+           <Node-Type>Nested Loop</Node-Type>                              +
            <Parent-Relationship>Outer</Parent-Relationship>                +
            <Slice>3</Slice>                                                +
            <Segments>3</Segments>                                          +
@@ -1007,7 +943,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
            <Total-Cost>8569.25</Total-Cost>                                +
            <Plan-Rows>77900</Plan-Rows>                                    +
            <Plan-Width>84</Plan-Width>                                     +
-           <Hash-Cond>boxes.location_id = locations.id</Hash-Cond>         +
+           <Join-Filter>true</Join-Filter>                                 +
            <Plans>                                                         +
              <Plan>                                                        +
                <Node-Type>Redistribute Motion</Node-Type>                  +
@@ -1024,7 +960,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                <Hash-Key>boxes.location_id</Hash-Key>                      +
                <Plans>                                                     +
                  <Plan>                                                    +
-                   <Node-Type>Hash Join</Node-Type>                        +
+                   <Node-Type>Nested Loop</Node-Type>                      +
                    <Parent-Relationship>Outer</Parent-Relationship>        +
                    <Slice>2</Slice>                                        +
                    <Segments>3</Segments>                                  +
@@ -1034,7 +970,7 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                    <Total-Cost>4724.12</Total-Cost>                        +
                    <Plan-Rows>77900</Plan-Rows>                            +
                    <Plan-Width>48</Plan-Width>                             +
-                   <Hash-Cond>boxes.apple_id = apples.id</Hash-Cond>       +
+                   <Join-Filter>true</Join-Filter>                         +
                    <Plans>                                                 +
                      <Plan>                                                +
                        <Node-Type>Redistribute Motion</Node-Type>          +
@@ -1044,10 +980,10 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                        <Slice>1</Slice>                                    +
                        <Segments>3</Segments>                              +
                        <Gang-Type>primary reader</Gang-Type>               +
-                       <Startup-Cost>0.00</Startup-Cost>                   +
+                       <Startup-Cost>0.10</Startup-Cost>                   +
                        <Total-Cost>2437.00</Total-Cost>                    +
                        <Plan-Rows>77900</Plan-Rows>                        +
-                       <Plan-Width>12</Plan-Width>                         +
+                       <Plan-Width>22</Plan-Width>                         +
                        <Hash-Key>boxes.apple_id</Hash-Key>                 +
                        <Plans>                                             +
                          <Plan>                                            +
@@ -1058,75 +994,55 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
                            <Gang-Type>primary reader</Gang-Type>           +
                            <Relation-Name>boxes</Relation-Name>            +
                            <Alias>boxes</Alias>                            +
-                           <Startup-Cost>0.00</Startup-Cost>               +
+                           <Startup-Cost>0.01</Startup-Cost>               +
                            <Total-Cost>879.00</Total-Cost>                 +
                            <Plan-Rows>77900</Plan-Rows>                    +
-                           <Plan-Width>12</Plan-Width>                     +
+                           <Plan-Width>42</Plan-Width>                     +
                          </Plan>                                           +
                        </Plans>                                            +
                      </Plan>                                               +
                      <Plan>                                                +
-                       <Node-Type>Hash</Node-Type>                         +
+                       <Node-Type>Index Scan</Node-Type>                   +
                        <Parent-Relationship>Inner</Parent-Relationship>    +
                        <Slice>2</Slice>                                    +
                        <Segments>3</Segments>                              +
                        <Gang-Type>primary reader</Gang-Type>               +
-                       <Startup-Cost>596.00</Startup-Cost>                 +
-                       <Total-Cost>596.00</Total-Cost>                     +
-                       <Plan-Rows>49600</Plan-Rows>                        +
-                       <Plan-Width>36</Plan-Width>                         +
-                       <Plans>                                             +
-                         <Plan>                                            +
-                           <Node-Type>Table Scan</Node-Type>               +
-                           <Parent-Relationship>Outer</Parent-Relationship>+
-                           <Slice>2</Slice>                                +
-                           <Segments>4</Segments>                          +
-                           <Gang-Type>primary reader</Gang-Type>           +
-                           <Relation-Name>apples</Relation-Name>           +
-                           <Alias>apples</Alias>                           +
-                           <Startup-Cost>1.00</Startup-Cost>               +
-                           <Total-Cost>5.00</Total-Cost>                 +
-                           <Plan-Rows>490</Plan-Rows>                    +
-                           <Plan-Width>6</Plan-Width>                     +
-                         </Plan>                                           +
-                       </Plans>                                            +
+                       <Scan-Direction>Forward</Scan-Direction>            +
+                       <Index-Name>apples_pkey</Index-Name>                +
+                       <Relation-Name>apples</Relation-Name>               +
+                       <Alias>apples</Alias>                               +
+                       <Startup-Cost>0.10</Startup-Cost>                   +
+                       <Total-Cost>2.20</Total-Cost>                       +
+                       <Plan-Rows>3</Plan-Rows>                            +
+                       <Plan-Width>5</Plan-Width>                          +
+                       <Index-Cond>id = boxes.apple_id</Index-Cond>        +
                      </Plan>                                               +
                    </Plans>                                                +
                  </Plan>                                                   +
                </Plans>                                                    +
              </Plan>                                                       +
              <Plan>                                                        +
-               <Node-Type>Hash</Node-Type>                                 +
+               <Node-Type>Index Scan</Node-Type>                           +
                <Parent-Relationship>Inner</Parent-Relationship>            +
                <Slice>3</Slice>                                            +
                <Segments>3</Segments>                                      +
                <Gang-Type>primary reader</Gang-Type>                       +
-               <Startup-Cost>596.00</Startup-Cost>                         +
-               <Total-Cost>596.00</Total-Cost>                             +
-               <Plan-Rows>49600</Plan-Rows>                                +
-               <Plan-Width>36</Plan-Width>                                 +
-               <Plans>                                                     +
-                 <Plan>                                                    +
-                   <Node-Type>Table Scan</Node-Type>                       +
-                   <Parent-Relationship>Outer</Parent-Relationship>        +
-                   <Slice>3</Slice>                                        +
-                   <Segments>3</Segments>                                  +
-                   <Gang-Type>primary reader</Gang-Type>                   +
-                   <Relation-Name>locations</Relation-Name>                +
-                   <Alias>locations</Alias>                                +
-                   <Startup-Cost>0.00</Startup-Cost>                       +
-                   <Total-Cost>596.00</Total-Cost>                         +
-                   <Plan-Rows>49600</Plan-Rows>                            +
-                   <Plan-Width>36</Plan-Width>                             +
-                 </Plan>                                                   +
-               </Plans>                                                    +
+               <Scan-Direction>Forward</Scan-Direction>                    +
+               <Index-Name>box_locations_pkey</Index-Name>                 +
+               <Relation-Name>box_locations</Relation-Name>                +
+               <Alias>box_locations</Alias>                                +
+               <Startup-Cost>0.50</Startup-Cost>                           +
+               <Total-Cost>2.40</Total-Cost>                               +
+               <Plan-Rows>3</Plan-Rows>                                    +
+               <Plan-Width>2</Plan-Width>                                  +
+               <Index-Cond>id = boxes.location_id</Index-Cond>             +
              </Plan>                                                       +
            </Plans>                                                        +
          </Plan>                                                           +
        </Plans>                                                            +
      </Plan>                                                               +
      <Settings>                                                            +
-       <Optimizer>PQO version 1.2.3</Optimizer>                           +
+       <Optimizer>PQO version 1.2.3</Optimizer>                            +
      </Settings>                                                           +
    </Query>                                                                +
  </explain>
@@ -1135,270 +1051,255 @@ EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.a
 -- explain_processing_on
 -- explain_processing_off
 -- Check Explain Analyze XML output
-EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                  QUERY PLAN
-----------------------------------------------------------------------------
- <explain xmlns="http://www.postgresql.org/2009/explain">                  +
-   <Query>                                                                 +
-     <Plan>                                                                +
-       <Node-Type>Gather Motion</Node-Type>                                +
-       <Senders>3</Senders>                                                +
-       <Receivers>1</Receivers>                                            +
-       <Slice>3</Slice>                                                    +
-       <Segments>3</Segments>                                              +
-       <Gang-Type>primary reader</Gang-Type>                               +
-       <Startup-Cost>2432.00</Startup-Cost>                                +
-       <Total-Cost>8569.25</Total-Cost>                                    +
-       <Plan-Rows>77900</Plan-Rows>                                        +
-       <Plan-Width>84</Plan-Width>                                         +
-       <Actual-Startup-Time>2.978</Actual-Startup-Time>                    +
-       <Actual-Total-Time>2.978</Actual-Total-Time>                        +
-       <Actual-Rows>0</Actual-Rows>                                        +
-       <Actual-Loops>1</Actual-Loops>                                      +
-       <Plans>                                                             +
-         <Plan>                                                            +
-           <Node-Type>Hash Join</Node-Type>                                +
-           <Parent-Relationship>Outer</Parent-Relationship>                +
-           <Slice>3</Slice>                                                +
-           <Segments>3</Segments>                                          +
-           <Gang-Type>primary reader</Gang-Type>                           +
-           <Join-Type>Left</Join-Type>                                     +
-           <Startup-Cost>2432.00</Startup-Cost>                            +
-           <Total-Cost>8569.25</Total-Cost>                                +
-           <Plan-Rows>77900</Plan-Rows>                                    +
-           <Plan-Width>84</Plan-Width>                                     +
-           <Actual-Startup-Time>0.000</Actual-Startup-Time>                +
-           <Actual-Total-Time>0.000</Actual-Total-Time>                    +
-           <Actual-Rows>0</Actual-Rows>                                    +
-           <Actual-Loops>0</Actual-Loops>                                  +
-           <Hash-Cond>boxes.location_id = locations.id</Hash-Cond>         +
-           <Plans>                                                         +
-             <Plan>                                                        +
-               <Node-Type>Redistribute Motion</Node-Type>                  +
-               <Senders>3</Senders>                                        +
-               <Receivers>3</Receivers>                                    +
-               <Parent-Relationship>Outer</Parent-Relationship>            +
-               <Slice>2</Slice>                                            +
-               <Segments>3</Segments>                                      +
-               <Gang-Type>primary reader</Gang-Type>                       +
-               <Startup-Cost>1216.00</Startup-Cost>                        +
-               <Total-Cost>6282.12</Total-Cost>                            +
-               <Plan-Rows>77900</Plan-Rows>                                +
-               <Plan-Width>48</Plan-Width>                                 +
-               <Actual-Startup-Time>0.000</Actual-Startup-Time>            +
-               <Actual-Total-Time>0.000</Actual-Total-Time>                +
-               <Actual-Rows>0</Actual-Rows>                                +
-               <Actual-Loops>0</Actual-Loops>                              +
-               <Hash-Key>boxes.location_id</Hash-Key>                      +
-               <Plans>                                                     +
-                 <Plan>                                                    +
-                   <Node-Type>Hash Join</Node-Type>                        +
-                   <Parent-Relationship>Outer</Parent-Relationship>        +
-                   <Slice>2</Slice>                                        +
-                   <Segments>3</Segments>                                  +
-                   <Gang-Type>primary reader</Gang-Type>                   +
-                   <Join-Type>Left</Join-Type>                             +
-                   <Startup-Cost>1216.00</Startup-Cost>                    +
-                   <Total-Cost>4724.12</Total-Cost>                        +
-                   <Plan-Rows>77900</Plan-Rows>                            +
-                   <Plan-Width>48</Plan-Width>                             +
-                   <Actual-Startup-Time>0.000</Actual-Startup-Time>        +
-                   <Actual-Total-Time>0.000</Actual-Total-Time>            +
-                   <Actual-Rows>0</Actual-Rows>                            +
-                   <Actual-Loops>0</Actual-Loops>                          +
-                   <Hash-Cond>boxes.apple_id = apples.id</Hash-Cond>       +
-                   <Plans>                                                 +
-                     <Plan>                                                +
-                       <Node-Type>Redistribute Motion</Node-Type>          +
-                       <Senders>3</Senders>                                +
-                       <Receivers>3</Receivers>                            +
-                       <Parent-Relationship>Outer</Parent-Relationship>    +
-                       <Slice>1</Slice>                                    +
-                       <Segments>3</Segments>                              +
-                       <Gang-Type>primary reader</Gang-Type>               +
-                       <Startup-Cost>0.00</Startup-Cost>                   +
-                       <Total-Cost>2437.00</Total-Cost>                    +
-                       <Plan-Rows>77900</Plan-Rows>                        +
-                       <Plan-Width>12</Plan-Width>                         +
-                       <Actual-Startup-Time>0.000</Actual-Startup-Time>    +
-                       <Actual-Total-Time>0.000</Actual-Total-Time>        +
-                       <Actual-Rows>0</Actual-Rows>                        +
-                       <Actual-Loops>0</Actual-Loops>                      +
-                       <Hash-Key>boxes.apple_id</Hash-Key>                 +
-                       <Plans>                                             +
-                         <Plan>                                            +
-                           <Node-Type>Table Scan</Node-Type>               +
-                           <Parent-Relationship>Outer</Parent-Relationship>+
-                           <Slice>1</Slice>                                +
-                           <Segments>3</Segments>                          +
-                           <Gang-Type>primary reader</Gang-Type>           +
-                           <Relation-Name>boxes</Relation-Name>            +
-                           <Alias>boxes</Alias>                            +
-                           <Startup-Cost>0.00</Startup-Cost>               +
-                           <Total-Cost>879.00</Total-Cost>                 +
-                           <Plan-Rows>77900</Plan-Rows>                    +
-                           <Plan-Width>12</Plan-Width>                     +
-                           <Actual-Startup-Time>0.000</Actual-Startup-Time>+
-                           <Actual-Total-Time>0.000</Actual-Total-Time>    +
-                           <Actual-Rows>0</Actual-Rows>                    +
-                           <Actual-Loops>0</Actual-Loops>                  +
-                         </Plan>                                           +
-                       </Plans>                                            +
-                     </Plan>                                               +
-                     <Plan>                                                +
-                       <Node-Type>Hash</Node-Type>                         +
-                       <Parent-Relationship>Inner</Parent-Relationship>    +
-                       <Slice>2</Slice>                                    +
-                       <Segments>3</Segments>                              +
-                       <Gang-Type>primary reader</Gang-Type>               +
-                       <Startup-Cost>596.00</Startup-Cost>                 +
-                       <Total-Cost>596.00</Total-Cost>                     +
-                       <Plan-Rows>49600</Plan-Rows>                        +
-                       <Plan-Width>36</Plan-Width>                         +
-                       <Actual-Startup-Time>0.000</Actual-Startup-Time>    +
-                       <Actual-Total-Time>0.000</Actual-Total-Time>        +
-                       <Actual-Rows>0</Actual-Rows>                        +
-                       <Actual-Loops>0</Actual-Loops>                      +
-                       <Plans>                                             +
-                         <Plan>                                            +
-                           <Node-Type>Table Scan</Node-Type>               +
-                           <Parent-Relationship>Outer</Parent-Relationship>+
-                           <Slice>2</Slice>                                +
-                           <Segments>3</Segments>                          +
-                           <Gang-Type>primary reader</Gang-Type>           +
-                           <Relation-Name>apples</Relation-Name>           +
-                           <Alias>apples</Alias>                           +
-                           <Startup-Cost>0.00</Startup-Cost>               +
-                           <Total-Cost>596.00</Total-Cost>                 +
-                           <Plan-Rows>49600</Plan-Rows>                    +
-                           <Plan-Width>36</Plan-Width>                     +
-                           <Actual-Startup-Time>0.000</Actual-Startup-Time>+
-                           <Actual-Total-Time>0.000</Actual-Total-Time>    +
-                           <Actual-Rows>0</Actual-Rows>                    +
-                           <Actual-Loops>0</Actual-Loops>                  +
-                         </Plan>                                           +
-                       </Plans>                                            +
-                     </Plan>                                               +
-                   </Plans>                                                +
-                 </Plan>                                                   +
-               </Plans>                                                    +
-             </Plan>                                                       +
-             <Plan>                                                        +
-               <Node-Type>Hash</Node-Type>                                 +
-               <Parent-Relationship>Inner</Parent-Relationship>            +
-               <Slice>3</Slice>                                            +
-               <Segments>3</Segments>                                      +
-               <Gang-Type>primary reader</Gang-Type>                       +
-               <Startup-Cost>59.00</Startup-Cost>                         +
-               <Total-Cost>59.00</Total-Cost>                             +
-               <Plan-Rows>4960</Plan-Rows>                                +
-               <Plan-Width>36</Plan-Width>                                 +
-               <Actual-Startup-Time>0.000</Actual-Startup-Time>            +
-               <Actual-Total-Time>0.000</Actual-Total-Time>                +
-               <Actual-Rows>0</Actual-Rows>                                +
-               <Actual-Loops>0</Actual-Loops>                              +
-               <Plans>                                                     +
-                 <Plan>                                                    +
-                   <Node-Type>Table Scan</Node-Type>                       +
-                   <Parent-Relationship>Outer</Parent-Relationship>        +
-                   <Slice>3</Slice>                                        +
-                   <Segments>1</Segments>                                  +
-                   <Gang-Type>primary reader</Gang-Type>                   +
-                   <Relation-Name>locations</Relation-Name>                +
-                   <Alias>locations</Alias>                                +
-                   <Startup-Cost>0.00</Startup-Cost>                       +
-                   <Total-Cost>596.00</Total-Cost>                         +
-                   <Plan-Rows>49600</Plan-Rows>                            +
-                   <Plan-Width>36</Plan-Width>                             +
-                   <Actual-Startup-Time>1.000</Actual-Startup-Time>        +
-                   <Actual-Total-Time>10.000</Actual-Total-Time>            +
-                   <Actual-Rows>0</Actual-Rows>                            +
-                   <Actual-Loops>0</Actual-Loops>                          +
-                 </Plan>                                                   +
-               </Plans>                                                    +
-             </Plan>                                                       +
-           </Plans>                                                        +
-         </Plan>                                                           +
-       </Plans>                                                            +
-     </Plan>                                                               +
-     <Triggers>                                                            +
-     </Triggers>                                                           +
-     <Slice-statistics>                                                    +
-       <Slice>                                                             +
-         <Slice>0</Slice>                                                  +
-         <Executor-Memory>123</Executor-Memory>                            +
-         <Global-Peak-Memory>432</Global-Peak-Memory>                      +
-         <Virtual-Memory>123543</Virtual-Memory>                           +
-       </Slice>                                                            +
-       <Slice>                                                             +
-         <Slice>1</Slice>                                                  +
-         <Executor-Memory>                                                 +
-           <Average>123143234</Average>                                    +
-           <Workers>1</Workers>                                            +
-           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>              +
-         </Executor-Memory>                                                +
-         <Global-Peak-Memory>                                              +
-           <Average>43212</Average>                                        +
-           <Workers>2</Workers>                                            +
-           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                 +
-         </Global-Peak-Memory>                                             +
-         <Virtual-Memory>                                                  +
-           <Average>4321234123423</Average>                                +
-           <Workers>64654</Workers>                                        +
-           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
-         </Virtual-Memory>                                                 +
-       </Slice>                                                            +
-       <Slice>                                                             +
-         <Slice>2</Slice>                                                  +
-         <Executor-Memory>                                                 +
-           <Average>123143234</Average>                                    +
-           <Workers>1</Workers>                                            +
-           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>              +
-         </Executor-Memory>                                                +
-         <Global-Peak-Memory>                                              +
-           <Average>43212</Average>                                        +
-           <Workers>2</Workers>                                            +
-           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                 +
-         </Global-Peak-Memory>                                             +
-         <Virtual-Memory>                                                  +
-           <Average>4321234123423</Average>                                +
-           <Workers>64654</Workers>                                        +
-           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
-         </Virtual-Memory>                                                 +
-         <Work-Maximum-Memory>41431</Work-Maximum-Memory>                  +
-       </Slice>                                                            +
-       <Slice>                                                             +
-         <Slice>3</Slice>                                                  +
-         <Executor-Memory>                                                 +
-           <Average>123143234</Average>                                    +
-           <Workers>1</Workers>                                            +
-           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>              +
-         </Executor-Memory>                                                +
-         <Global-Peak-Memory>                                              +
-           <Average>43212</Average>                                        +
-           <Workers>2</Workers>                                            +
-           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                 +
-         </Global-Peak-Memory>                                             +
-         <Virtual-Memory>                                                  +
-           <Average>4321234123423</Average>                                +
-           <Workers>64654</Workers>                                        +
-           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>              +
-         </Virtual-Memory>                                                 +
-       </Slice>                                                            +
-     </Slice-statistics>                                                   +
-     <Total-memory-used-across-slices>123</Total-memory-used-across-slices>+
-     <Statement-statistics>                                                +
-       <Memory-used>1200</Memory-used>                                     +
-       <ORCA-Memory-Used-Peak>431234</ORCA-Memory-Used-Peak>               +
-       <ORCA-Memory-Used-Allocated>4231</ORCA-Memory-Used-Allocated>       +
-       <ORCA-Memory-Used-Freed>4332234</ORCA-Memory-Used-Freed>            +
-     </Statement-statistics>                                               +
-     <Settings>                                                            +
-       <Optimizer>PQO version 1.2.3</Optimizer>                            +
-     </Settings>                                                           +
-     <Total-Runtime>24.8</Total-Runtime>                                   +
-   </Query>                                                                +
+----------------------------------------------------------------------------------------
+ <explain xmlns="http://www.postgresql.org/2009/explain">                              +
+   <Query>                                                                             +
+     <Plan>                                                                            +
+       <Node-Type>Gather Motion</Node-Type>                                            +
+       <Senders>3</Senders>                                                            +
+       <Receivers>1</Receivers>                                                        +
+       <Slice>3</Slice>                                                                +
+       <Segments>3</Segments>                                                          +
+       <Gang-Type>primary reader</Gang-Type>                                           +
+       <Startup-Cost>2432.00</Startup-Cost>                                            +
+       <Total-Cost>8569.25</Total-Cost>                                                +
+       <Plan-Rows>77900</Plan-Rows>                                                    +
+       <Plan-Width>84</Plan-Width>                                                     +
+       <Actual-Startup-Time>2.978</Actual-Startup-Time>                                +
+       <Actual-Total-Time>2.978</Actual-Total-Time>                                    +
+       <Actual-Rows>0</Actual-Rows>                                                    +
+       <Actual-Loops>1</Actual-Loops>                                                  +
+       <Plans>                                                                         +
+         <Plan>                                                                        +
+           <Node-Type>Nested Loop</Node-Type>                                          +
+           <Parent-Relationship>Outer</Parent-Relationship>                            +
+           <Slice>3</Slice>                                                            +
+           <Segments>3</Segments>                                                      +
+           <Gang-Type>primary reader</Gang-Type>                                       +
+           <Join-Type>Left</Join-Type>                                                 +
+           <Startup-Cost>2432.00</Startup-Cost>                                        +
+           <Total-Cost>8569.25</Total-Cost>                                            +
+           <Plan-Rows>77900</Plan-Rows>                                                +
+           <Plan-Width>84</Plan-Width>                                                 +
+           <Actual-Startup-Time>0.000</Actual-Startup-Time>                            +
+           <Actual-Total-Time>0.000</Actual-Total-Time>                                +
+           <Actual-Rows>2</Actual-Rows>                                                +
+           <Actual-Loops>3</Actual-Loops>                                              +
+           <Join-Filter>true</Join-Filter>                                             +
+           <Rows-Removed-by-Join-Filter>0</Rows-Removed-by-Join-Filter>                +
+           <Plans>                                                                     +
+             <Plan>                                                                    +
+               <Node-Type>Redistribute Motion</Node-Type>                              +
+               <Senders>3</Senders>                                                    +
+               <Receivers>3</Receivers>                                                +
+               <Parent-Relationship>Outer</Parent-Relationship>                        +
+               <Slice>2</Slice>                                                        +
+               <Segments>3</Segments>                                                  +
+               <Gang-Type>primary reader</Gang-Type>                                   +
+               <Startup-Cost>1216.00</Startup-Cost>                                    +
+               <Total-Cost>6282.12</Total-Cost>                                        +
+               <Plan-Rows>77900</Plan-Rows>                                            +
+               <Plan-Width>48</Plan-Width>                                             +
+               <Actual-Startup-Time>0.000</Actual-Startup-Time>                        +
+               <Actual-Total-Time>0.000</Actual-Total-Time>                            +
+               <Actual-Rows>0</Actual-Rows>                                            +
+               <Actual-Loops>0</Actual-Loops>                                          +
+               <Hash-Key>boxes.location_id</Hash-Key>                                  +
+               <Plans>                                                                 +
+                 <Plan>                                                                +
+                   <Node-Type>Nested Loop</Node-Type>                                  +
+                   <Parent-Relationship>Outer</Parent-Relationship>                    +
+                   <Slice>2</Slice>                                                    +
+                   <Segments>3</Segments>                                              +
+                   <Gang-Type>primary reader</Gang-Type>                               +
+                   <Join-Type>Left</Join-Type>                                         +
+                   <Startup-Cost>1216.00</Startup-Cost>                                +
+                   <Total-Cost>4724.12</Total-Cost>                                    +
+                   <Plan-Rows>77900</Plan-Rows>                                        +
+                   <Plan-Width>48</Plan-Width>                                         +
+                   <Actual-Startup-Time>0.001</Actual-Startup-Time>                    +
+                   <Actual-Total-Time>0.000</Actual-Total-Time>                        +
+                   <Actual-Rows>5</Actual-Rows>                                        +
+                   <Actual-Loops>6</Actual-Loops>                                      +
+                   <Join-Filter>true</Join-Filter>                                     +
+                   <Rows-Removed-by-Join-Filter>0</Rows-Removed-by-Join-Filter>        +
+                   <Plans>                                                             +
+                     <Plan>                                                            +
+                       <Node-Type>Redistribute Motion</Node-Type>                      +
+                       <Senders>3</Senders>                                            +
+                       <Receivers>3</Receivers>                                        +
+                       <Parent-Relationship>Outer</Parent-Relationship>                +
+                       <Slice>1</Slice>                                                +
+                       <Segments>3</Segments>                                          +
+                       <Gang-Type>primary reader</Gang-Type>                           +
+                       <Startup-Cost>0.00</Startup-Cost>                               +
+                       <Total-Cost>2437.00</Total-Cost>                                +
+                       <Plan-Rows>77900</Plan-Rows>                                    +
+                       <Plan-Width>11</Plan-Width>                                     +
+                       <Actual-Startup-Time>0.010</Actual-Startup-Time>                +
+                       <Actual-Total-Time>0.000</Actual-Total-Time>                    +
+                       <Actual-Rows>0</Actual-Rows>                                    +
+                       <Actual-Loops>0</Actual-Loops>                                  +
+                       <Hash-Key>boxes.apple_id</Hash-Key>                             +
+                       <Plans>                                                         +
+                         <Plan>                                                        +
+                           <Node-Type>Table Scan</Node-Type>                           +
+                           <Parent-Relationship>Outer</Parent-Relationship>            +
+                           <Slice>1</Slice>                                            +
+                           <Segments>3</Segments>                                      +
+                           <Gang-Type>primary reader</Gang-Type>                       +
+                           <Relation-Name>boxes</Relation-Name>                        +
+                           <Alias>boxes</Alias>                                        +
+                           <Startup-Cost>0.00</Startup-Cost>                           +
+                           <Total-Cost>879.00</Total-Cost>                             +
+                           <Plan-Rows>77900</Plan-Rows>                                +
+                           <Plan-Width>12</Plan-Width>                                 +
+                           <Actual-Startup-Time>0.000</Actual-Startup-Time>            +
+                           <Actual-Total-Time>0.000</Actual-Total-Time>                +
+                           <Actual-Rows>0</Actual-Rows>                                +
+                           <Actual-Loops>0</Actual-Loops>                              +
+                         </Plan>                                                       +
+                       </Plans>                                                        +
+                     </Plan>                                                           +
+                     <Plan>                                                            +
+                       <Node-Type>Index Scan</Node-Type>                               +
+                       <Parent-Relationship>Inner</Parent-Relationship>                +
+                       <Slice>2</Slice>                                                +
+                       <Segments>3</Segments>                                          +
+                       <Gang-Type>primary reader</Gang-Type>                           +
+                       <Scan-Direction>Forward</Scan-Direction>                        +
+                       <Index-Name>apples_pkey</Index-Name>                            +
+                       <Relation-Name>apples</Relation-Name>                           +
+                       <Alias>apples</Alias>                                           +
+                       <Startup-Cost>0.90</Startup-Cost>                               +
+                       <Total-Cost>2.70</Total-Cost>                                   +
+                       <Plan-Rows>6</Plan-Rows>                                        +
+                       <Plan-Width>5</Plan-Width>                                      +
+                       <Actual-Startup-Time>0.400</Actual-Startup-Time>                +
+                       <Actual-Total-Time>0.300</Actual-Total-Time>                    +
+                       <Actual-Rows>2</Actual-Rows>                                    +
+                       <Actual-Loops>1</Actual-Loops>                                  +
+                       <Index-Cond>id = boxes.apple_id</Index-Cond>                    +
+                       <Rows-Removed-by-Index-Recheck>0</Rows-Removed-by-Index-Recheck>+
+                     </Plan>                                                           +
+                   </Plans>                                                            +
+                 </Plan>                                                               +
+               </Plans>                                                                +
+             </Plan>                                                                   +
+             <Plan>                                                                    +
+               <Node-Type>Index Scan</Node-Type>                                       +
+               <Parent-Relationship>Inner</Parent-Relationship>                        +
+               <Slice>3</Slice>                                                        +
+               <Segments>3</Segments>                                                  +
+               <Gang-Type>primary reader</Gang-Type>                                   +
+               <Scan-Direction>Forward</Scan-Direction>                                +
+               <Index-Name>box_locations_pkey</Index-Name>                             +
+               <Relation-Name>box_locations</Relation-Name>                            +
+               <Alias>box_locations</Alias>                                            +
+               <Startup-Cost>0.60</Startup-Cost>                                       +
+               <Total-Cost>2.04</Total-Cost>                                           +
+               <Plan-Rows>4</Plan-Rows>                                                +
+               <Plan-Width>13</Plan-Width>                                             +
+               <Actual-Startup-Time>0.020</Actual-Startup-Time>                        +
+               <Actual-Total-Time>0.010</Actual-Total-Time>                            +
+               <Actual-Rows>0</Actual-Rows>                                            +
+               <Actual-Loops>0</Actual-Loops>                                          +
+               <Index-Cond>id = boxes.location_id</Index-Cond>                         +
+               <Rows-Removed-by-Index-Recheck>0</Rows-Removed-by-Index-Recheck>        +
+             </Plan>                                                                   +
+           </Plans>                                                                    +
+         </Plan>                                                                       +
+       </Plans>                                                                        +
+     </Plan>                                                                           +
+     <Triggers>                                                                        +
+     </Triggers>                                                                       +
+     <Slice-statistics>                                                                +
+       <Slice>                                                                         +
+         <Slice>0</Slice>                                                              +
+         <Executor-Memory>123</Executor-Memory>                                        +
+         <Global-Peak-Memory>432</Global-Peak-Memory>                                  +
+         <Virtual-Memory>123543</Virtual-Memory>                                       +
+       </Slice>                                                                        +
+       <Slice>                                                                         +
+         <Slice>1</Slice>                                                              +
+         <Executor-Memory>                                                             +
+           <Average>123143234</Average>                                                +
+           <Workers>1</Workers>                                                        +
+           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>                          +
+         </Executor-Memory>                                                            +
+         <Global-Peak-Memory>                                                          +
+           <Average>43212</Average>                                                    +
+           <Workers>2</Workers>                                                        +
+           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                             +
+         </Global-Peak-Memory>                                                         +
+         <Virtual-Memory>                                                              +
+           <Average>4321234123423</Average>                                            +
+           <Workers>64654</Workers>                                                    +
+           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>                          +
+         </Virtual-Memory>                                                             +
+       </Slice>                                                                        +
+       <Slice>                                                                         +
+         <Slice>2</Slice>                                                              +
+         <Executor-Memory>                                                             +
+           <Average>123143234</Average>                                                +
+           <Workers>1</Workers>                                                        +
+           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>                          +
+         </Executor-Memory>                                                            +
+         <Global-Peak-Memory>                                                          +
+           <Average>43212</Average>                                                    +
+           <Workers>2</Workers>                                                        +
+           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                             +
+         </Global-Peak-Memory>                                                         +
+         <Virtual-Memory>                                                              +
+           <Average>4321234123423</Average>                                            +
+           <Workers>64654</Workers>                                                    +
+           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>                          +
+         </Virtual-Memory>                                                             +
+       </Slice>                                                                        +
+       <Slice>                                                                         +
+         <Slice>3</Slice>                                                              +
+         <Executor-Memory>                                                             +
+           <Average>123143234</Average>                                                +
+           <Workers>1</Workers>                                                        +
+           <Maximum-Memory-Used>5432523</Maximum-Memory-Used>                          +
+         </Executor-Memory>                                                            +
+         <Global-Peak-Memory>                                                          +
+           <Average>43212</Average>                                                    +
+           <Workers>2</Workers>                                                        +
+           <Maximum-Memory-Used>4321</Maximum-Memory-Used>                             +
+         </Global-Peak-Memory>                                                         +
+         <Virtual-Memory>                                                              +
+           <Average>4321234123423</Average>                                            +
+           <Workers>64654</Workers>                                                    +
+           <Maximum-Memory-Used>5432345</Maximum-Memory-Used>                          +
+         </Virtual-Memory>                                                             +
+       </Slice>                                                                        +
+       <Slice>                                                                         +
+         <Slice>4</Slice>                                                              +
+       </Slice>                                                                        +
+       <Slice>                                                                         +
+         <Slice>5</Slice>                                                              +
+       </Slice>                                                                        +
+     </Slice-statistics>                                                               +
+     <Total-memory-used-across-slices>123</Total-memory-used-across-slices>            +
+     <Statement-statistics>                                                            +
+       <Memory-used>1200</Memory-used>                                                 +
+       <ORCA-Memory-Used-Peak>431234</ORCA-Memory-Used-Peak>                           +
+       <ORCA-Memory-Used-Allocated>4231</ORCA-Memory-Used-Allocated>                   +
+       <ORCA-Memory-Used-Freed>4332234</ORCA-Memory-Used-Freed>                        +
+     </Statement-statistics>                                                           +
+     <Settings>                                                                        +
+       <Optimizer>PQO version 1.2.3</Optimizer>                                        +
+     </Settings>                                                                       +
+     <Total-Runtime>24.8</Total-Runtime>                                               +
+   </Query>                                                                            +
  </explain>
 (1 row)
 
 -- explain_processing_on
+-- Cleanup
+DROP TABLE boxes;
+DROP TABLE apples;
+DROP TABLE box_locations;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -25,7 +25,7 @@ test: spi_processed64bit
 test: python_processed64bit
 
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table gp_create_view window_views
-test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions
+test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
 
 test: bitmap_index gp_dump_query_oids analyze gp_owner_permission incremental_analyze
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -1,0 +1,26 @@
+-- start_matchsubs
+-- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
+-- s/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/(actual time=10.302..10.302 rows=0 loops=1)/
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
+-- s/\(slice\d+\)    Executor memory: (\d+)\w bytes\./\(slice\)    Executor memory: (#####)K bytes./
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
+-- s/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./\(slice\)    Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg0)./
+-- m/Total runtime: \d+\.\d+ ms/
+-- s/Total runtime: \d+\.\d+ ms/Total runtime: ##.### ms/
+-- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
+-- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
+-- end_matchsubs
+--
+-- DEFAULT syntax
+CREATE TABLE apples(id int PRIMARY KEY, type text);
+CREATE TABLE locations(id int PRIMARY KEY, address text);
+CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES locations(id));
+
+--- Check Explain Text output
+EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+
+--- Check Explain Analyze Text output
+-- explain_processing_off
+EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+-- explain_processing_on
+

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -16,11 +16,97 @@ CREATE TABLE apples(id int PRIMARY KEY, type text);
 CREATE TABLE locations(id int PRIMARY KEY, address text);
 CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES locations(id));
 
---- Check Explain Text output
+--- Check Explain Text format output
+-- explain_processing_off
 EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+-- explain_processing_on
 
---- Check Explain Analyze Text output
+--- Check Explain Analyze Text output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
 -- explain_processing_on
 
+-- YAML Required replaces for costs and time changes
+-- start_matchsubs
+-- m/ Loops: \d+ /
+-- s/ Loops: \d+\s+/ Loops: # /
+-- m/ Cost: \d+\.\d+ /
+-- s/ Cost: \d+\.\d+\s+/ Cost: ###.## /
+-- m/ Rows: \d+ /
+-- s/ Rows: \d+\s+/ Rows: ##### /
+-- m/ Plan Width: \d+ /
+-- s/ Plan Width: \d+\s+/ Plan Width: ## /
+-- m/ Time: \d+\.\d+ /
+-- s/ Time: \d+\.\d+\s+/ Time: ##.### /
+-- m/Total Runtime: \d+\.\d+/
+-- s/Total Runtime: \d+\.\d+/Total Runtime: ##.###/
+-- m/Segments: \d+\s+/
+-- s/Segments: \d+\s+/Segments: #/
+-- m/PQO version \d+\.\d+\.\d+"\s+/
+-- s/PQO version \d+\.\d+\.\d+"\s+/PQO version ##.##.##"/
+-- end_matchsubs
+-- Check Explain YAML output
+EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+
+--- Check Explain Analyze YAML output that include the slices information
+-- explain_processing_off
+EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+-- explain_processing_on
+
+-- JSON Required replaces for costs and time changes
+-- start_matchsubs
+-- m/ Loops": \d+,?\s+/
+-- s/ Loops": \d+,?\s+/ Loops": #, /
+-- m/ Cost": \d+\.\d+, /
+-- s/ Cost": \d+\.\d+,\s+/ Cost": ###.##, /
+-- m/ Rows": \d+, /
+-- s/ Rows": \d+,\s+/ Rows": #####, /
+-- m/"Plan Width": \d+,? /
+-- s/"Plan Width": \d+,?\s+/"Plan Width": ##, /
+-- m/ Time": \d+\.\d+, /
+-- s/ Time": \d+\.\d+,\s+/ Time": ##.###, /
+-- m/Total Runtime": \d+\.\d+,?\s+/
+-- s/Total Runtime": \d+\.\d+,?\s+/Total Runtime": ##.###,/
+-- m/"Memory used": \d+,?\s+/
+-- s/"Memory used": \d+,?\s+/"Memory used": ####,/
+-- m/"Segments": \d+,\s+/
+-- s/"Segments": \d+,\s+/"Segments": #,/
+-- end_matchsubs
+-- explain_processing_off
+-- Check Explain JSON output
+EXPLAIN (FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+-- explain_processing_on
+
+--- Check Explain Analyze JSON output that include the slices information
+-- explain_processing_off
+EXPLAIN (ANALYZE, FORMAT JSON) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+-- explain_processing_on
+
+-- XML Required replaces for costs and time changes
+-- start_matchsubs
+-- m/Cost>\d+\.\d+<\/[^>]+\-Cost>\s+/
+-- s/Cost>\d+\.\d+<\/([^>]+)\-Cost>\s+/Cost>###.##<\/$1-Cost>/
+-- m/Plan-Rows>\d+<\/Plan-Rows>\s+/
+-- s/Plan-Rows>\d+<\/Plan-Rows>\s+/Plan-Rows>###<\/Plan-Rows>/
+-- m/Plan-Width>\d+<\/Plan-Width>\s+/
+-- s/Plan-Width>\d+<\/Plan-Width>\s+/Plan-Width>###<\/Plan-Width>/
+-- m/Segments>\d+<\/Segments>\s+/
+-- s/Segments>\d+<\/Segments>\s+/Segments>##<\/Segments>/
+-- m/-Time>\d+\.\d+<\/[^>]+\-Time>\s+/
+-- s/-Time>\d+\.\d+<\/([^>]+)\-Time>\s+/-Time>##.###<\/$1-Time>/
+-- m/Total-Runtime>\d+\.\d+<\/Total-Runtime>\s+/
+-- s/Total-Runtime>\d+\.\d+<\/Total-Runtime>\s+/Total-Runtime>##.###<\/Total-Runtime>/
+-- m/Memory-used>\d+<\/Memory-used>\s+/
+-- s/Memory-used>\d+<\/Memory-used>\s+/Memory-used>###<\/Memory-used>/
+-- m/PQO version \d+\.\d+\.\d+/
+-- s/PQO version \d+\.\d+\.\d+/PQO version ##.##.##/
+-- end_matchsubs
+-- explain_processing_off
+-- Check Explain XML output
+EXPLAIN (FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+-- explain_processing_on
+
+-- explain_processing_off
+-- Check Explain Analyze XML output
+EXPLAIN (ANALYZE, FORMAT XML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN locations ON locations.id = boxes.location_id;
+-- explain_processing_on


### PR DESCRIPTION
- Add tests of the format of the output for `explain` and `explain analyze`
- Add missing YAML, JSON and XML representation of
  - Slice Output in general
- Correct one issue: Node Types for GreenPlum were not being displayed correctly on YAML, JSON and XML formats