### PR TITLE
Remove Insist from appendonly directory

### DIFF
--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -491,15 +491,11 @@ HasLockForSegmentFileDrop(Relation aorel)
 #ifdef USE_ASSERT_CHECKING
 			acquireResult = LockRelationNoWait(aorel, ShareUpdateExclusiveLock);
 			if (acquireResult != LOCKACQUIRE_ALREADY_HELD)
-			{
 				elog(ERROR, "Don't hold access exclusive lock during drop");
-				return false;
-			}
 #endif
 			return false;
 		default:
-			Insist(false);
-			return false;
+			elog(ERROR, "invalid LockAcquireResult");
 	}
 }
 

--- a/src/backend/access/appendonly/appendonly_visimap_udf.c
+++ b/src/backend/access/appendonly/appendonly_visimap_udf.c
@@ -263,9 +263,9 @@ gp_aovisimap_hidden_info_internal(PG_FUNCTION_ARGS, Oid aoRelOid)
 			segno = fsinfo->segno;
 		}
 		else
-		{
-			Insist(false);
-		}
+			ereport(ERROR,
+					(errmsg("invalid function context"),
+					 errdetail("Storage must be either row or column oriented.")));
 
 		MemSet(values, 0, sizeof(values));
 		MemSet(nulls, false, sizeof(nulls));

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2837,7 +2837,7 @@ appendonly_insert(AppendOnlyInsertDesc aoInsertDesc,
 	/* tableName */
 #endif
 
-	Insist(RelationIsAoRows(relation));
+	Assert(RelationIsAoRows(relation));
 
 	if (aoInsertDesc->useNoToast)
 		need_toast = false;


### PR DESCRIPTION
Insist() is replaced with either Assert() or ereport(ERROR) as appropriate.

Please refer: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/BH1IXU6vnEw