### PR TITLE
Backport to 5X: Fix gpconfig read from file

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -448,7 +448,7 @@ def get_gucs_from_files(gucname):
     commands = []
     for host in hosts:
         for seg in host.dbs:
-            command = GpReadConfig("readConfig", host, seg, gucname)
+            command = GpReadConfig("readConfig", seg, gucname)
             commands.append(command)
             pool.addCommand(command)
 

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -8,7 +8,7 @@ TODO: docs!
 """
 import os, pickle, base64, time
 
-import re
+import re, socket
 
 from gppylib.gplog import *
 from gppylib.db import dbconn
@@ -1724,8 +1724,7 @@ class GpRecoverSeg(Command):
        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
 
 class GpReadConfig(Command):
-    def __init__(self, name, host, seg, guc_name, ctxt=LOCAL, remote_host=None):
-        self.host = host
+    def __init__(self, name, seg, guc_name):
         self.seg_db_id = seg.getSegmentDbId()
         self.seg_content_id = seg.getSegmentContentId()
         self.guc_name = guc_name
@@ -1733,6 +1732,11 @@ class GpReadConfig(Command):
         cat_path = findCmdInPath('cat')
 
         cmdStr = "%s %s/postgresql.conf" % (cat_path, seg.getSegmentDataDirectory())
+        ctxt = LOCAL
+        remote_host = None
+        if seg.hostname != socket.gethostname():
+            ctxt = REMOTE
+            remote_host = seg.hostname
         Command.__init__(self, name, cmdStr, ctxt, remote_host)
 
     def get_guc_value(self):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gp.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gp.py
@@ -36,7 +36,6 @@ class GpConfig(GpTestCase):
         seg = self.gparray.master
         seg = self.gparray.master
         args = dict(name="my_command",
-                    host="host",
                     seg=seg,
                     guc_name="statement_mem",)
         subject = GpReadConfig(**args)
@@ -46,10 +45,29 @@ class GpConfig(GpTestCase):
     @patch("gppylib.commands.base.Command.__init__", create=False)
     @patch("gppylib.commands.base.Command.get_results", return_value=CommandResult(0, "#statement_mem = 100\nstatement_mem = 200", "", True, False))
     @patch("gppylib.commands.base.Command.run")
-    def test_GpReadConfig_returns_selected_guc(self, mock_run, mock_results, mock_init):
+    @patch("socket.gethostname", return_value="mdw")
+    def test_GpReadConfig_returns_selected_guc(self, mock_hostname, mock_run, mock_results, mock_init):
         seg = self.gparray.master
         args = dict(name="my_command",
-                    host="host",
+                    seg=seg,
+                    guc_name="statement_mem",
+        )
+
+        subject = GpReadConfig(**args)
+        init_args = mock_init.call_args_list
+        self.assertEquals(init_args[0][0][3], 1) # ctxt.LOCAL
+        self.assertEquals(init_args[0][0][4], None)
+
+        subject.run(validateAfter=True)
+        self.assertEquals('200', subject.get_guc_value())
+
+    @patch("gppylib.commands.base.Command.__init__", create=False)
+    @patch("gppylib.commands.base.Command.get_results", return_value=CommandResult(0, "statement_mem=100\n statement_mem=200 #blah", "", True, False))
+    @patch("gppylib.commands.base.Command.run")
+    @patch("socket.gethostname", return_value="mdw")
+    def test_GpReadConfig_returns_selected_guc_with_whitespace_before_key(self, mock_hostname, mock_run, mock_results, mock_init):
+        seg = self.gparray.master
+        args = dict(name="my_command",
                     seg=seg,
                     guc_name="statement_mem",
         )
@@ -60,17 +78,20 @@ class GpConfig(GpTestCase):
         self.assertEquals('200', subject.get_guc_value())
 
     @patch("gppylib.commands.base.Command.__init__", create=False)
-    @patch("gppylib.commands.base.Command.get_results", return_value=CommandResult(0, "statement_mem=100\n statement_mem=200 #blah", "", True, False))
+    @patch("gppylib.commands.base.Command.get_results", return_value=CommandResult(0, "#statement_mem = 100\nstatement_mem = 200", "", True, False))
     @patch("gppylib.commands.base.Command.run")
-    def test_GpReadConfig_returns_selected_guc_with_whitespace_before_key(self, mock_run, mock_results, mock_init):
-        seg = self.gparray.master
+    @patch("socket.gethostname", return_value="mdw")
+    def test_GpReadConfig_returns_selected_guc_on_remote_segment(self, mock_hostname, mock_run, mock_results, mock_init):
+        seg = self.gparray.segments[0].primaryDB
         args = dict(name="my_command",
-                    host="host",
                     seg=seg,
                     guc_name="statement_mem",
         )
 
         subject = GpReadConfig(**args)
+        init_args = mock_init.call_args_list
+        self.assertEquals(init_args[0][0][3], 2) # ctxt.REMOTE
+        self.assertEquals(init_args[0][0][4], "sdw1")
 
         subject.run(validateAfter=True)
         self.assertEquals('200', subject.get_guc_value())


### PR DESCRIPTION
The --file flag was broken because the command to read from segment
postgresql.conf was being run locally instead of remotely.

As part of backport, we also modified `test_GpReadConfig_returns_selected_guc_on_remote_segment` to use `gparray.segments` instead of `gparray.segmentPairs`.

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>
Co-authored-by: Nadeem Ghani <nghani@pivotal.io>
(cherry picked from commit 2f0799843d67ec76fbced2f21b52f6cf80a140f9)