### PR TITLE
Support FORCE QUOTE * on external tables

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/COPY.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/COPY.xml
@@ -33,7 +33,7 @@ COPY {table [(<varname>column</varname> [, ...])] | (<varname>query</varname>)} 
         [NULL [ AS ] 'null string']
         [ESCAPE [ AS ] '<varname>escape</varname>' | 'OFF']
         [CSV [QUOTE [ AS ] 'quote'] 
-             [FORCE QUOTE column [, ...]] ]
+             [FORCE QUOTE column [, ...]] | * ]
       [IGNORE EXTERNAL PARTITIONS ]</codeblock>
     </section>
     <section id="section3">
@@ -275,8 +275,9 @@ COPY {table [(<varname>column</varname> [, ...])] | (<varname>query</varname>)} 
         <plentry>
           <pt>FORCE QUOTE</pt>
           <pd>In <codeph>CSV COPY TO</codeph> mode, forces quoting to be used for all
-              non-<codeph>NULL</codeph> values in each specified column. <codeph>NULL</codeph>
-            output is never quoted.</pd>
+              non-<codeph>NULL</codeph> values in each specified column. If <codeph>*</codeph>
+              is specified then non-<codeph>NULL</codeph> values will be quoted in all columns.
+              <codeph>NULL</codeph> output is never quoted. </pd>
         </plentry>
         <plentry>
           <pt>FORCE NOT NULL</pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
@@ -85,7 +85,7 @@ CREATE WRITABLE EXTERNAL [TEMPORARY | TEMP] TABLE <varname>table_name</varname>
                [([QUOTE [AS] '<varname>quote</varname>'] 
                [DELIMITER [AS] '<varname>delimiter</varname>']
                [NULL [AS] '<varname>null string</varname>']
-               [FORCE QUOTE <varname>column</varname> [, ...]] ]
+               [FORCE QUOTE <varname>column</varname> [, ...]] | * ]
                [ESCAPE [AS] '<varname>escape</varname>'] )]
            | 'AVRO' 
            | 'PARQUET'
@@ -106,7 +106,7 @@ CREATE WRITABLE EXTERNAL [TEMPORARY | TEMP] TABLE <varname>table_name</varname>
                [([QUOTE [AS] '<varname>quote</varname>'] 
                [DELIMITER [AS] '<varname>delimiter</varname>']
                [NULL [AS] '<varname>null string</varname>']
-               [FORCE QUOTE <varname>column</varname> [, ...]] ]
+               [FORCE QUOTE <varname>column</varname> [, ...]] | * ]
                [ESCAPE [AS] '<varname>escape</varname>'] )]
 
 CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varname>
@@ -120,7 +120,7 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
                [([QUOTE [AS] '<varname>quote</varname>'] 
                [DELIMITER [AS] '<varname>delimiter</varname>']
                [NULL [AS] '<varname>null string</varname>']
-               [FORCE QUOTE <varname>column</varname> [, ...]] ]
+               [FORCE QUOTE <varname>column</varname> [, ...]] | * ]
                [ESCAPE [AS] '<varname>escape</varname>'] )]
            | 'CUSTOM' (Formatter=<varname>&lt;formatter specifications&gt;</varname>)
     [ ENCODING '<varname>write_encoding</varname>' ]
@@ -422,8 +422,9 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
         <plentry>
           <pt>FORCE QUOTE</pt>
           <pd>In <codeph>CSV</codeph> mode for writable external tables, forces quoting to be used
-            for all non-<codeph>NULL</codeph> values in each specified column. <codeph>NULL</codeph>
-            output is never quoted.</pd>
+            for all non-<codeph>NULL</codeph> values in each specified column. If <codeph>*</codeph>
+            is specified then non-<codeph>NULL</codeph> values will be quoted in all columns.
+            <codeph>NULL</codeph> output is never quoted.</pd>
         </plentry>
         <plentry>
           <pt>FILL MISSING FIELDS</pt>

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -168,8 +168,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 				Oid			userid = GetUserId();
 				HeapTuple	tuple;
 
-				tuple = SearchSysCache1(AUTHOID,
-										ObjectIdGetDatum(userid));
+				tuple = SearchSysCache1(AUTHOID, ObjectIdGetDatum(userid));
 				if (!HeapTupleIsValid(tuple))
 					ereport(ERROR,
 							(errcode(ERRCODE_UNDEFINED_OBJECT),
@@ -271,13 +270,11 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 					}
 				}
 				else
-				{
 					ereport(ERROR,
 							(errcode(ERRCODE_INTERNAL_ERROR),
-						  errmsg("internal error in DefineExternalRelation. "
-								 "protocol is %d, writable is %d",
-								 uri->protocol, iswritable)));
-				}
+							 errmsg("internal error in DefineExternalRelation"),
+							 errdetail("Protocol is %d, writable is %d",
+									   uri->protocol, iswritable)));
 
 				ReleaseSysCache(tuple);
 			}
@@ -335,7 +332,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 		if (dencoding)
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("conflicting or redundant ENCODING specification")));
+					 errmsg("conflicting or redundant ENCODING specification")));
 		dencoding = defel;
 	}
 
@@ -351,8 +348,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 				pg_valid_client_encoding(encoding_name) < 0)
 				ereport(ERROR,
 						(errcode(ERRCODE_UNDEFINED_OBJECT),
-						 errmsg("%d is not a valid encoding code",
-								encoding)));
+						 errmsg("%d is not a valid encoding code", encoding)));
 		}
 		else if (IsA(dencoding->arg, String))
 		{
@@ -396,9 +392,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 							 errmsg("number of locations (%d) exceeds the number of segments (%d)",
 									list_length(exttypeDesc->location_list),
 									getgpsegmentCount()),
-							 errhint("The table cannot be queried until cluster "
-									 "is expanded so that there are at least as "
-									 "many segments as locations.")));
+							 errhint("The table cannot be queried until cluster is expanded so that there are at least as many segments as locations.")));
 			}
 		}
 	}
@@ -789,6 +783,7 @@ transformFormatOpts(char formattype, List *formatOpts, int numcols, bool iswrita
 	Datum		result;
 	char	   *format_str;
 	char	   *formatter = NULL;
+	StringInfoData cfbuf;
 
 	CopyState cstate = palloc0(sizeof(CopyStateData));
 
@@ -821,7 +816,7 @@ transformFormatOpts(char formattype, List *formatOpts, int numcols, bool iswrita
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
-				errmsg("formatter option only valid for custom formatters")));
+						 errmsg("formatter option only valid for custom formatters")));
 			}
 			else
 				elog(ERROR, "option \"%s\" not recognized",
@@ -843,19 +838,15 @@ transformFormatOpts(char formattype, List *formatOpts, int numcols, bool iswrita
 						   false /* is_copy */);
 
 		/*
-		 * build the format option string that will get stored in the catalog.
-		 */
-		StringInfoData cfbuf;
-
-		initStringInfo(&cfbuf);
-
-		/*
+		 * Build the format option string that will get stored in the catalog.
+		 *
 		 * NOTE: These are intentionally not escaped "correctly"! For
 		 * historical reasons, these options are stored in a weird format
 		 * that looks like they're SQL literals, but the escaping is
 		 * different. See comments in escape_fmtopts_string(), in
 		 * src/bin/pg_dump/dumputils.c.
 		 */
+		initStringInfo(&cfbuf);
 		appendStringInfo(&cfbuf, "delimiter '%s'", cstate->delim);
 		appendStringInfo(&cfbuf, " null '%s'", cstate->null_print);
 		appendStringInfo(&cfbuf, " escape '%s'", cstate->escape);

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -812,7 +812,6 @@ transformFormatOpts(char formattype, List *formatOpts, int numcols, bool iswrita
 				strcmp(defel->defname, "escape") == 0 ||
 				strcmp(defel->defname, "force_not_null") == 0 ||
 				strcmp(defel->defname, "force_quote") == 0 ||
-				/* GPDB_90_MERGE_FIXME: add 'force_quote_all' here */
 				strcmp(defel->defname, "fill_missing_fields") == 0 ||
 				strcmp(defel->defname, "newline") == 0)
 			{
@@ -907,6 +906,9 @@ transformFormatOpts(char formattype, List *formatOpts, int numcols, bool iswrita
 				is_first_col = false;
 			}
 		}
+
+		if (cstate->force_quote_all)
+			appendStringInfo(&cfbuf, " force quote *");
 
 		if (cstate->eol_str)
 			appendStringInfo(&cfbuf, " newline '%s'", cstate->eol_str);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -5282,6 +5282,10 @@ format_opt_item:
 			{
 				$$ = makeDefElem("force_quote", (Node *)$3);
 			}
+			| FORCE QUOTE '*'
+			{
+				$$ = makeDefElem("force_quote", (Node *)makeNode(A_Star));
+			}
 			| FILL MISSING FIELDS
 			{
 				$$ = makeDefElem("fill_missing_fields", (Node *)makeInteger(TRUE));

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -1464,17 +1464,21 @@ CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_csv4 (a int, b text) EXECUTE 'cat > @
 -- Create writable external table with force quote
 CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_csv5 (a int, b text) EXECUTE 'cat > @abs_srcdir@/data/wet_csv5.tbl' FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"' FORCE QUOTE b);
 
+CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_csv6 (a int, b text, c text) EXECUTE 'cat > @abs_srcdir@/data/wet_csv6.tbl' FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ' QUOTE AS '"' FORCE QUOTE *);
+
 INSERT INTO tbl_wet_csv1 VALUES (generate_series(1,256), 'test_1');
 INSERT INTO tbl_wet_csv2 VALUES (generate_series(1,256), 'test_2');
 INSERT INTO tbl_wet_csv3 VALUES (generate_series(1,256), 'test_3');
 INSERT INTO tbl_wet_csv4 VALUES (generate_series(1,256), 'test_4');
 INSERT INTO tbl_wet_csv5 VALUES (generate_series(1,256), 'test_5');
+INSERT INTO tbl_wet_csv6 VALUES (generate_series(1,256), 'test_6', 'test_6_1');
 
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv1;
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv2;
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv3;
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv4;
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv5;
+DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv6;
 
 -- start_ignore
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_text1;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -2816,16 +2816,19 @@ CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_csv3 (a int, b text) EXECUTE 'cat > @
 CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_csv4 (a int, b text) EXECUTE 'cat > @abs_srcdir@/data/wet_csv4.tbl' FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '''');
 -- Create writable external table with force quote
 CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_csv5 (a int, b text) EXECUTE 'cat > @abs_srcdir@/data/wet_csv5.tbl' FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"' FORCE QUOTE b);
+CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_csv6 (a int, b text, c text) EXECUTE 'cat > @abs_srcdir@/data/wet_csv6.tbl' FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ' QUOTE AS '"' FORCE QUOTE *);
 INSERT INTO tbl_wet_csv1 VALUES (generate_series(1,256), 'test_1');
 INSERT INTO tbl_wet_csv2 VALUES (generate_series(1,256), 'test_2');
 INSERT INTO tbl_wet_csv3 VALUES (generate_series(1,256), 'test_3');
 INSERT INTO tbl_wet_csv4 VALUES (generate_series(1,256), 'test_4');
 INSERT INTO tbl_wet_csv5 VALUES (generate_series(1,256), 'test_5');
+INSERT INTO tbl_wet_csv6 VALUES (generate_series(1,256), 'test_6', 'test_6_1');
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv1;
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv2;
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv3;
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv4;
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv5;
+DROP EXTERNAL TABLE IF EXISTS tbl_wet_csv6;
 -- start_ignore
 DROP EXTERNAL TABLE IF EXISTS tbl_wet_text1;
 NOTICE:  table "tbl_wet_text1" does not exist, skipping


### PR DESCRIPTION
`FORCE QUOTE *` was added in PostgreSQL 9.0 as a shorthand for `FORCE QUOTE <column_1 .. column_n>` in the `COPY` command, where all columns of a relation are added for forced quoting. External tables use copy and copy options under the hood, so they too should support `*` to quote all columns. This resolves a FIXME added during the 9.0 merge.

Also cleans up some related code a little and adds `FORCE QUOTE *` to the `COPY` portion of the docs.