### PR TITLE
Remove hardcoded versionstring in xlogdump

### DIFF
--- a/contrib/xlogdump/Makefile
+++ b/contrib/xlogdump/Makefile
@@ -21,10 +21,7 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-# GPDB_90_MERGE_FIXME: Force majorversion to 9.0. Revert this once we bump the
-# version number from 8.5devel to 9.0devel.
-majorversion=90
-#majorversion=`echo $(PG_VERSION) | sed -e 's/^\([0-9]*\)\.\([0-9]*\).*/\1\2/g'`
+majorversion=`echo $(PG_VERSION) | sed -e 's/^\([0-9]*\)\.\([0-9]*\).*/\1\2/g'`
 
 xlogdump_oid2name.o: oid2name.txt
 


### PR DESCRIPTION
We are well past the 8.5devel version, so go back to using the actual version from `PG_VERSION` rather than hardcoding. This removes a FIXME that was added during the 9.0 merge cycle due to 9.0 being labelled 8.5 in upstream for some time before it was renamed.