### PR TITLE
Connectionstring overflow check

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -275,8 +275,8 @@ cdbconn_termSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc)
 }								/* cdbconn_termSegmentDescriptor */
 
 /*
- * Connect to a QE as a client via libpq.
- * returns true if connected.
+ * Connect to a QE as a client via libpq. Returns a PGconn object in
+ * segdbDesc->conn which can be tested for connection status.
  */
 void
 cdbconn_doConnect(SegmentDatabaseDescriptor *segdbDesc,

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -669,10 +669,11 @@ makeOptions(void)
  * to be passed to a qExec that is being started.  NB: Can be called in a
  * thread, so mustn't use palloc/elog/ereport/etc.
  */
-void
+bool
 build_gpqeid_param(char *buf, int bufsz,
 				   bool is_writer, int gangId, int hostSegs)
 {
+	int		len;
 #ifdef HAVE_INT64_TIMESTAMP
 #define TIMESTAMP_FORMAT INT64_FORMAT
 #else
@@ -683,9 +684,11 @@ build_gpqeid_param(char *buf, int bufsz,
 #endif
 #endif
 
-	snprintf(buf, bufsz, "%d;" TIMESTAMP_FORMAT ";%s;%d;%d",
-			 gp_session_id, PgStartTime,
-			 (is_writer ? "true" : "false"), gangId, hostSegs);
+	len = snprintf(buf, bufsz, "%d;" TIMESTAMP_FORMAT ";%s;%d;%d",
+				   gp_session_id, PgStartTime,
+				   (is_writer ? "true" : "false"), gangId, hostSegs);
+
+	return (len > 0 && len < bufsz);
 }
 
 static bool

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -107,6 +107,7 @@ create_gang_retry:
 	{
 		for (i = 0; i < size; i++)
 		{
+			bool		ret;
 			char		gpqeid[100];
 			char	   *options;
 
@@ -122,10 +123,15 @@ create_gang_retry:
 			 * early enough now some locks are taken before command line
 			 * options are recognized.
 			 */
-			build_gpqeid_param(gpqeid, sizeof(gpqeid),
-							   type == GANGTYPE_PRIMARY_WRITER,
-							   gang_id,
-							   segdbDesc->segment_database_info->hostSegs);
+			ret = build_gpqeid_param(gpqeid, sizeof(gpqeid),
+									 type == GANGTYPE_PRIMARY_WRITER,
+									 gang_id,
+									 segdbDesc->segment_database_info->hostSegs);
+
+			if (!ret)
+				ereport(ERROR,
+						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+						 errmsg("failed to construct connectionstring")));
 
 			options = makeOptions();
 

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -282,7 +282,7 @@ create_gang_retry:
 				type != GANGTYPE_PRIMARY_WRITER)
 				ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 								errmsg("failed to acquire resources on one or more segments"),
-								errdetail("segments is in recovery mode")));
+								errdetail("Segments are in recovery mode.")));
 
 			ELOG_DISPATCHER_DEBUG("createGang: gang creation failed, but retryable.");
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -103,7 +103,7 @@ extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang
 bool isPrimaryWriterGangAlive(void);
 
 Gang *buildGangDefinition(GangType type, int gang_id, int size, int content);
-void build_gpqeid_param(char *buf, int bufsz, bool is_writer, int gangId, int hostSegs);
+bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int gangId, int hostSegs);
 char *makeOptions(void);
 extern bool segment_failure_due_to_recovery(const char *error_message);
 

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -300,7 +300,7 @@ select pg_sleep(1); -- small delay to make sure the postmaster has noticed the c
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 ERROR:  failed to acquire resources on one or more segments
-DETAIL:  segments is in recovery mode
+DETAIL:  Segments are in recovery mode.
 -- Wait for the quickdie() sleep to time out, and the server to restart.
 select pg_sleep(5);
  pg_sleep 


### PR DESCRIPTION
When constructing the connectionstring for connecting to the QEs, ensure we don't overflow the assigned buffer. It should be noted that this was spotted while reading some code, not when searching for a failure. I don't think we are running into an overflow here, and even if we do it will fail the connection further on, but employing defensive programming here to improve error reporting and logging seems cheap enough that it's worth it.

Also fixed some comments nearby while at it.

@xiong-gang do you think this could improve finding errors should we ever run into an overflow here?