### PR TITLE
Assorted node function fixups

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3797,8 +3797,8 @@ _copyIndexStmt(IndexStmt *from)
 	COPY_NODE_FIELD(options);
 	COPY_NODE_FIELD(whereClause);
 	COPY_NODE_FIELD(excludeOpNames);
-	COPY_SCALAR_FIELD(is_part_child);
 	COPY_SCALAR_FIELD(indexOid);
+	COPY_SCALAR_FIELD(is_part_child);
 	COPY_SCALAR_FIELD(unique);
 	COPY_SCALAR_FIELD(primary);
 	COPY_SCALAR_FIELD(isconstraint);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1463,8 +1463,8 @@ _equalIndexStmt(IndexStmt *a, IndexStmt *b)
 	COMPARE_NODE_FIELD(options);
 	COMPARE_NODE_FIELD(whereClause);
 	COMPARE_NODE_FIELD(excludeOpNames);
-	COMPARE_SCALAR_FIELD(is_part_child);
 	COMPARE_SCALAR_FIELD(indexOid);
+	COMPARE_SCALAR_FIELD(is_part_child);
 	COMPARE_SCALAR_FIELD(unique);
 	COMPARE_SCALAR_FIELD(primary);
 	COMPARE_SCALAR_FIELD(isconstraint);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1471,7 +1471,7 @@ _equalIndexStmt(IndexStmt *a, IndexStmt *b)
 	COMPARE_SCALAR_FIELD(deferrable);
 	COMPARE_SCALAR_FIELD(initdeferred);
 	COMPARE_SCALAR_FIELD(concurrent);
-	/* GPDB_90_MERGE_FIXME: should we compare altconname? */
+	COMPARE_STRING_FIELD(altconname);
 	COMPARE_SCALAR_FIELD(is_split_part);
 
 	return true;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2629,8 +2629,8 @@ _outIndexStmt(StringInfo str, IndexStmt *node)
 
 	WRITE_NODE_FIELD(whereClause);
 	WRITE_NODE_FIELD(excludeOpNames);
-	WRITE_BOOL_FIELD(is_part_child);
 	WRITE_OID_FIELD(indexOid);
+	WRITE_BOOL_FIELD(is_part_child);
 	WRITE_BOOL_FIELD(unique);
 	WRITE_BOOL_FIELD(primary);
 	WRITE_BOOL_FIELD(isconstraint);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2638,7 +2638,7 @@ _outIndexStmt(StringInfo str, IndexStmt *node)
 	WRITE_BOOL_FIELD(initdeferred);
 	WRITE_BOOL_FIELD(concurrent);
 	WRITE_STRING_FIELD(altconname);
-	/* GPDB_90_MERGE_FIXME: should we write is_split_part? */
+	WRITE_BOOL_FIELD(is_split_part);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -834,6 +834,7 @@ _readIndexStmt(void)
 	READ_BOOL_FIELD(initdeferred);
 	READ_BOOL_FIELD(concurrent);
 	READ_STRING_FIELD(altconname);
+	READ_BOOL_FIELD(is_split_part);
 
 	READ_DONE();
 }

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -825,8 +825,8 @@ _readIndexStmt(void)
 	READ_NODE_FIELD(options);
 	READ_NODE_FIELD(whereClause);
 	READ_NODE_FIELD(excludeOpNames);
-	READ_BOOL_FIELD(is_part_child);
 	READ_OID_FIELD(indexOid);
+	READ_BOOL_FIELD(is_part_child);
 	READ_BOOL_FIELD(unique);
 	READ_BOOL_FIELD(primary);
 	READ_BOOL_FIELD(isconstraint);


### PR DESCRIPTION
A few fixes that came out of looking at 9.0 merge fixmes.

The `is_split_part member` is compared in `_equalIndexStmt()`, and is copied in `_copyIndexStmt()`, so we should include it in the read and write functions as well.

The `altconname` member defines an alternative name for the index if another name for a constraint was requested. Including it in the comparison is mostly for correctness, as the index name is compared, even if few (if any) situations would fail on this being omitted.

`IndexStmt` is defined in `src/include/nodes/parsenodes.h` with `indexOid` before the `is_part_child` member. Reorder the node functions to match the definition.