### PR TITLE
Fix queries which involve UNION of setops

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -91,6 +91,14 @@ typedef struct
 } grouped_window_ctx;
 
 static void parse_analyze_error_callback(void *parsestate);     /*CDB*/
+/* Working state for transformSetOperationTree_internal */
+typedef struct
+{
+	int			ncols;
+	List	  **leaftypes;
+	List	  **leaftypmods;
+} setop_types_ctx;
+
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
 static Query *transformInsertStmt(ParseState *pstate, InsertStmt *stmt);
 static List *transformInsertRow(ParseState *pstate, List *exprlist,
@@ -110,6 +118,9 @@ static Query *transformSelectStmt(ParseState *pstate, SelectStmt *stmt);
 static Query *transformValuesClause(ParseState *pstate, SelectStmt *stmt);
 static Query *transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt);
 static Node *transformSetOperationTree(ParseState *pstate, SelectStmt *stmt);
+static Node *transformSetOperationTree_internal(ParseState *pstate, SelectStmt *stmt,
+												setop_types_ctx *setop_types);
+static void coerceSetOpTypes(ParseState *pstate, Node *sop, List *coltypes, List *coltypmods);
 static void getSetColTypes(ParseState *pstate, Node *node,
 			   List **colTypes, List **colTypmods);
 static void applyColumnNames(List *dst, List *src);
@@ -119,9 +130,6 @@ static Query *transformDeclareCursorStmt(ParseState *pstate,
 static Query *transformExplainStmt(ParseState *pstate,
 					 ExplainStmt *stmt);
 static bool isSimplyUpdatableQuery(Query *query);
-static bool isSetopLeaf(SelectStmt *stmt);
-static int collectSetopTypes(ParseState *pstate, SelectStmt *stmt,
-							 List **types, List **typmods);
 static void transformLockingClause(ParseState *pstate, Query *qry, LockingClause *lc);
 static bool check_parameter_resolution_walker(Node *node, ParseState *pstate);
 
@@ -1925,7 +1933,6 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 			   *sv_rtable;
 	RangeTblEntry *jrte;
 	int			tllen;
-	List	   *colTypes, *colTypmods;
 
 	qry->commandType = CMD_SELECT;
 
@@ -1975,129 +1982,6 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
-	}
-
-	/*
-	 * Before transforming the subtrees, we collect all the data types
-	 * and typmods by searching their targetList (ResTarget) or valuesClause.
-	 * This is necessary because choosing column types in leaf query
-	 * without knowing whole of tree may result in a wrong type. And this
-	 * situation goes an error that is against user's instinct. Instead,
-	 * we want to look at all the leavs at one time, and decide each column
-	 * types. The resjunk columns are not interesting, because type coercion
-	 * between queries is done only for each non-resjunk column in set operations.
-	 */
-	colTypes = NIL;
-	colTypmods = NIL;
-	pstate->p_setopTypes = NIL;
-	pstate->p_setopTypmods = NIL;
-	collectSetopTypes(pstate, stmt, &colTypes, &colTypmods);
-	Insist(list_length(colTypes) == list_length(colTypmods));
-	forboth (lct, colTypes, lcm, colTypmods)
-	{
-		List	   *types = (List *) lfirst(lct);
-		List	   *typmods = (List *) lfirst(lcm);
-		ListCell   *lct2, *lcm2;
-		Oid			ptype;
-		int32		ptypmod;
-		Oid			restype;
-		int32		restypmod;
-		bool		allsame, hasnontext;
-		char	   *context;
-
-		Insist(list_length(types) == list_length(typmods));
-
-		context = (stmt->op == SETOP_UNION ? "UNION" :
-				   stmt->op == SETOP_INTERSECT ? "INTERSECT" :
-				   "EXCEPT");
-		allsame = true;
-		hasnontext = false;
-		ptype = linitial_oid(types);
-		ptypmod = linitial_int(typmods);
-		forboth (lct2, types, lcm2, typmods)
-		{
-			Oid		ntype = lfirst_oid(lct2);
-			int32	ntypmod = lfirst_int(lcm2);
-
-			/*
-			 * In the first iteration, ntype and ptype is the same element,
-			 * but we ignore it as it's not a big problem here.
-			 */
-			if (!(ntype == ptype && ntypmod == ptypmod))
-			{
-				/* if any is different, false */
-				allsame = false;
-			}
-			/*
-			 * MPP-15619 - backwards compatibility with existing view definitions.
-			 *
-			 * Historically we would cast UNKNOWN to text for most union queries,
-			 * but there are many union cases where this historical behavior
-			 * resulted in unacceptable errors (MPP-11377).
-			 * To handle this we added additional code to resolve to a
-			 * consistent cast for unions, which is generally better and
-			 * handles more cases.  However, in order to deal with backwards
-			 * compatibility we have to deliberately hamstring this code and
-			 * cast UNKNOWN to text if the other colums are STRING_TYPE
-			 * even when some other datatype (such as name) might actually
-			 * be more natural.  This captures the set of views that
-			 * we previously supported prior to the fix for MPP-11377 and
-			 * thus is the set of views that we must not treat differently.
-			 * This might be removed when we are ready to change view definition.
-			 */
-			if (ntype != UNKNOWNOID &&
-				STRING_TYPE != TypeCategory(getBaseType(ntype)))
-				hasnontext = true;
-		}
-
-		/*
-		 * Backward compatibility; Unfortunately, we cannot change
-		 * the old behavior of the part which was working without ERROR,
-		 * mostly for the view definition. See comments above for detail.
-		 * Setting InvalidOid for this column, the column type resolution
-		 * will be falling back to the old process.
-		 */
-		if (!hasnontext)
-		{
-			restype = InvalidOid;
-			restypmod = -1;
-		}
-		else
-		{
-			/*
-			 * Even if the types are all the same, we resolve the type
-			 * by select_common_type(), which casts domains to base types.
-			 * Ideally, the domain types should be preserved, but to keep
-			 * compatibility with older GPDB views, currently we don't change it.
-			 * This restriction will be solved once upgrade/view issues get clean.
-			 * See MPP-7509 for the issue.
-			 */
-			restype = select_common_type(types, context);
-			/*
-			 * If there's no common type, the last resort is TEXT.
-			 * See also select_common_type().
-			 */
-			if (restype == UNKNOWNOID)
-			{
-				restype = TEXTOID;
-				restypmod = -1;
-			}
-			else
-			{
-				/*
-				 * Essentially we preserve typmod only when all elements
-				 * are identical, otherwise default (-1).
-				 */
-				if (allsame)
-					restypmod = ptypmod;
-				else
-					restypmod = -1;
-			}
-		}
-
-		pstate->p_setopTypes = lappend_oid(pstate->p_setopTypes, restype);
-		pstate->p_setopTypmods = lappend_int(pstate->p_setopTypmods, restypmod);
-		pstate->p_propagateSetopTypes = true; /* once p_setopTypes are set, we allow pstate to propagate setop types */
 	}
 
 	/*
@@ -2274,6 +2158,152 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 static Node *
 transformSetOperationTree(ParseState *pstate, SelectStmt *stmt)
 {
+	setop_types_ctx ctx;
+	Node	   *top;
+	List	   *selected_types;
+	List	   *selected_typmods;
+	int			i;
+
+	/*
+	 * Transform all the subtrees.
+	 */
+	ctx.ncols = -1;
+	ctx.leaftypes = NULL;
+	ctx.leaftypmods = NULL;
+	top = transformSetOperationTree_internal(pstate, stmt, &ctx);
+	Assert(ctx.ncols >= 0);
+
+	/*
+	 * We have now transformed all the subtrees, and collected all the
+	 * data types and typmods of the columns from each leaf node.
+	 *
+	 * In PostgreSQL, we also choose the result type for each subtree as we
+	 * recurse, but in GPDB, we do that here as a separate pass. That way, we
+	 * have can make the decision globally based on every leaf, rather
+	 * separately for each subtree.
+	 *
+	 * There are also some hacks to more leniently coerce between types, to
+	 * make some cases not error out.
+	 */
+	selected_types = NIL;
+	selected_typmods = NIL;
+	for (i = 0; i < ctx.ncols; i++)
+	{
+		List	   *types = ctx.leaftypes[i];
+		List	   *typmods = ctx.leaftypmods[i];
+		ListCell   *lct2, *lcm2;
+		Oid			ptype;
+		int32		ptypmod;
+		Oid			restype;
+		int32		restypmod;
+		bool		allsame, hasnontext;
+		char	   *context;
+
+		Insist(list_length(types) == list_length(typmods));
+
+		context = (stmt->op == SETOP_UNION ? "UNION" :
+				   stmt->op == SETOP_INTERSECT ? "INTERSECT" :
+				   "EXCEPT");
+		allsame = true;
+		hasnontext = false;
+		ptype = linitial_oid(types);
+		ptypmod = linitial_int(typmods);
+		forboth (lct2, types, lcm2, typmods)
+		{
+			Oid			ntype = lfirst_oid(lct2);
+			int32		ntypmod = lfirst_int(lcm2);
+
+			/*
+			 * In the first iteration, ntype and ptype is the same element,
+			 * but we ignore it as it's not a big problem here.
+			 */
+			if (!(ntype == ptype && ntypmod == ptypmod))
+			{
+				/* if any is different, false */
+				allsame = false;
+			}
+			/*
+			 * MPP-15619 - backwards compatibility with existing view definitions.
+			 *
+			 * Historically we would cast UNKNOWN to text for most union queries,
+			 * but there are many union cases where this historical behavior
+			 * resulted in unacceptable errors (MPP-11377).
+			 * To handle this we added additional code to resolve to a
+			 * consistent cast for unions, which is generally better and
+			 * handles more cases.  However, in order to deal with backwards
+			 * compatibility we have to deliberately hamstring this code and
+			 * cast UNKNOWN to text if the other colums are STRING_TYPE
+			 * even when some other datatype (such as name) might actually
+			 * be more natural.  This captures the set of views that
+			 * we previously supported prior to the fix for MPP-11377 and
+			 * thus is the set of views that we must not treat differently.
+			 * This might be removed when we are ready to change view definition.
+			 */
+			if (ntype != UNKNOWNOID &&
+				STRING_TYPE != TypeCategory(getBaseType(ntype)))
+				hasnontext = true;
+		}
+
+		/*
+		 * Backward compatibility; Unfortunately, we cannot change
+		 * the old behavior of the part which was working without ERROR,
+		 * mostly for the view definition. See comments above for detail.
+		 * Setting InvalidOid for this column, the column type resolution
+		 * will be falling back to the old process.
+		 */
+		if (!hasnontext)
+		{
+			restype = InvalidOid;
+			restypmod = -1;
+		}
+		else
+		{
+			/*
+			 * Even if the types are all the same, we resolve the type
+			 * by select_common_type(), which casts domains to base types.
+			 * Ideally, the domain types should be preserved, but to keep
+			 * compatibility with older GPDB views, currently we don't change it.
+			 * This restriction will be solved once upgrade/view issues get clean.
+			 * See MPP-7509 for the issue.
+			 */
+			restype = select_common_type(types, context);
+			/*
+			 * If there's no common type, the last resort is TEXT.
+			 * See also select_common_type().
+			 */
+			if (restype == UNKNOWNOID)
+			{
+				restype = TEXTOID;
+				restypmod = -1;
+			}
+			else
+			{
+				/*
+				 * Essentially we preserve typmod only when all elements
+				 * are identical, otherwise default (-1).
+				 */
+				if (allsame)
+					restypmod = ptypmod;
+				else
+					restypmod = -1;
+			}
+		}
+
+		selected_types = lappend_oid(selected_types, restype);
+		selected_typmods = lappend_int(selected_typmods, restypmod);
+	}
+
+	coerceSetOpTypes(pstate, top, selected_types, selected_typmods);
+
+	return top;
+}
+
+static Node *
+transformSetOperationTree_internal(ParseState *pstate, SelectStmt *stmt,
+								   setop_types_ctx *setop_types)
+{
+	bool		isLeaf;
+
 	Assert(stmt && IsA(stmt, SelectStmt));
 
 	/* Guard against stack overflow due to overly complex set-expressions */
@@ -2294,7 +2324,28 @@ transformSetOperationTree(ParseState *pstate, SelectStmt *stmt)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("SELECT FOR UPDATE/SHARE is not allowed with UNION/INTERSECT/EXCEPT")));
 
-	if (isSetopLeaf(stmt))
+	/*
+	 * If an internal node of a set-op tree has ORDER BY, UPDATE, or LIMIT
+	 * clauses attached, we need to treat it like a leaf node to generate an
+	 * independent sub-Query tree.	Otherwise, it can be represented by a
+	 * SetOperationStmt node underneath the parent Query.
+	 */
+	if (stmt->op == SETOP_NONE)
+	{
+		Assert(stmt->larg == NULL && stmt->rarg == NULL);
+		isLeaf = true;
+	}
+	else
+	{
+		Assert(stmt->larg != NULL && stmt->rarg != NULL);
+		if (stmt->sortClause || stmt->limitOffset || stmt->limitCount ||
+			stmt->lockingClause)
+			isLeaf = true;
+		else
+			isLeaf = false;
+	}
+
+	if (isLeaf)
 	{
 		/* Process leaf SELECT */
 		Query	   *selectQuery;
@@ -2342,12 +2393,124 @@ transformSetOperationTree(ParseState *pstate, SelectStmt *stmt)
 		/* assume new rte is at end */
 		rtr->rtindex = list_length(pstate->p_rtable);
 		Assert(rte == rt_fetch(rtr->rtindex, pstate->p_rtable));
+
+		/*
+		 * Remember the datatype of each column to the lists in
+		 * 'setop_types'.
+		 */
+		{
+			List	   *coltypes;
+			List	   *coltypmods;
+			ListCell   *lc_types;
+			ListCell   *lc_typmods;
+			int			i;
+
+			getSetColTypes(pstate, (Node *) rtr, &coltypes, &coltypmods);
+			if (setop_types->ncols == -1)
+			{
+				setop_types->ncols = list_length(coltypes);
+				setop_types->leaftypes = (List **) palloc0(setop_types->ncols * sizeof(List *));
+				setop_types->leaftypmods = (List **) palloc0(setop_types->ncols * sizeof(List *));
+			}
+			i = 0;
+			forboth(lc_types, coltypes, lc_typmods, coltypmods)
+			{
+				Oid			coltype = lfirst_oid(lc_types);
+				int			coltypmod = lfirst_int(lc_typmods);
+
+				setop_types->leaftypes[i] = lappend_oid(setop_types->leaftypes[i], coltype);
+				setop_types->leaftypmods[i] = lappend_int(setop_types->leaftypmods[i], coltypmod);
+				i++;
+
+				/*
+				 * It's possible that this leaf query has a differnet number
+				 * of columns than the previous ones. That's an error, but
+				 * we don't throw it here because we don't have the context
+				 * needed for a good error message. We don't know which
+				 * operation of the setop tree is the one where the number
+				 * of columns between the left and right branches differ.
+				 * Therefore, just return here as if nothing happened, and
+				 * we'll catch that error in the parent instead.
+				 */
+				if (i == setop_types->ncols)
+					break;
+			}
+		}
 		return (Node *) rtr;
 	}
 	else
 	{
 		/* Process an internal node (set operation node) */
 		SetOperationStmt *op = makeNode(SetOperationStmt);
+		List	   *lcoltypes;
+		List	   *rcoltypes;
+		List	   *lcoltypmods;
+		List	   *rcoltypmods;
+		const char *context;
+		int			i;
+
+		context = (stmt->op == SETOP_UNION ? "UNION" :
+				   (stmt->op == SETOP_INTERSECT ? "INTERSECT" :
+					"EXCEPT"));
+
+		op->op = stmt->op;
+		op->all = stmt->all;
+
+		/*
+		 * Recursively transform the child nodes.
+		 */
+		op->larg = transformSetOperationTree_internal(pstate, stmt->larg,
+													  setop_types);
+		op->rarg = transformSetOperationTree_internal(pstate, stmt->rarg,
+													  setop_types);
+
+		/*
+		 * Verify that the two children have the same number of non-junk
+		 * columns, and determine the types of the merged output columns.
+		 */
+		getSetColTypes(pstate, op->larg, &lcoltypes, &lcoltypmods);
+		getSetColTypes(pstate, op->rarg, &rcoltypes, &rcoltypmods);
+		if (list_length(lcoltypes) != list_length(rcoltypes))
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("each %s query must have the same number of columns",
+						context)));
+
+		/*
+		 * In PostgreSQL, we select the common type for each column here.
+		 * In GPDB, we do that as a separate pass, after we have collected
+		 * information on the types of each leaf node first.
+		 *
+		 * But fill the lists with invalid types for now. These will be
+		 * replaced with the real values in the second pass, but in the
+		 * meanwhile, we we need something with the right length, for the
+		 * check above, that checks that each subtree has the same number of
+		 * columns.
+		 */
+		op->colTypes = NIL;
+		op->colTypmods = NIL;
+		for (i = 0; i < list_length(lcoltypes); i++)
+		{
+			op->colTypes = lappend_oid(op->colTypes, InvalidOid);
+			op->colTypmods = lappend_oid(op->colTypmods, -1);
+		}
+
+		return (Node *) op;
+	}
+}
+
+/*
+ * Label every SetOperationStmt in the tree with the given datatypes.
+ */
+static void
+coerceSetOpTypes(ParseState *pstate, Node *sop,
+				 List *preselected_coltypes, List *preselected_coltypmods)
+{
+	if (IsA(sop, RangeTblRef))
+		return;
+	else
+	{
+		SetOperationStmt *op = (SetOperationStmt *) sop;
 		List	   *lcoltypes;
 		List	   *rcoltypes;
 		List	   *lcoltypmods;
@@ -2360,48 +2523,32 @@ transformSetOperationTree(ParseState *pstate, SelectStmt *stmt)
 		ListCell   *mcm;
 		const char *context;
 
-		context = (stmt->op == SETOP_UNION ? "UNION" :
-				   (stmt->op == SETOP_INTERSECT ? "INTERSECT" :
-					"EXCEPT"));
+		Assert(IsA(op, SetOperationStmt));
 
-		op->op = stmt->op;
-		op->all = stmt->all;
+		context = (op->op == SETOP_UNION ? "UNION" :
+				   op->op == SETOP_INTERSECT ? "INTERSECT" :
+				   "EXCEPT");
 
-		/*
-		 * Recursively transform the child nodes.
-		 */
-		op->larg = transformSetOperationTree(pstate, stmt->larg);
-		op->rarg = transformSetOperationTree(pstate, stmt->rarg);
+		/* Recurse to determine the children's types first */
+		coerceSetOpTypes(pstate, op->larg, preselected_coltypes, preselected_coltypmods);
+		coerceSetOpTypes(pstate, op->rarg, preselected_coltypes, preselected_coltypmods);
 
-		/*
-		 * Verify that the two children have the same number of non-junk
-		 * columns, and determine the types of the merged output columns.
-		 * At one time in past, this information was used to deduce
-		 * common data type, but now we don't; predict it beforehand,
-		 * since in some cases transformation of individual leaf query
-		 * hides what type the column should be from the whole of tree view.
-		 */
 		getSetColTypes(pstate, op->larg, &lcoltypes, &lcoltypmods);
 		getSetColTypes(pstate, op->rarg, &rcoltypes, &rcoltypmods);
 		Assert(list_length(lcoltypes) == list_length(rcoltypes));
 		Assert(list_length(lcoltypes) == list_length(lcoltypmods));
 		Assert(list_length(rcoltypes) == list_length(rcoltypmods));
+		Assert(list_length(lcoltypes) == list_length(preselected_coltypes));
+		Assert(list_length(lcoltypes) == list_length(preselected_coltypmods));
 
 		op->colTypes = NIL;
 		op->colTypmods = NIL;
-		/* We should have predicted types and typmods up to now */
-		Assert(pstate->p_setopTypes && pstate->p_setopTypmods);
-		Assert(list_length(pstate->p_setopTypes) ==
-			   list_length(pstate->p_setopTypmods));
-		Assert(list_length(pstate->p_setopTypes) ==
-			   list_length(lcoltypes));
-
-		/* Iterate each column with tree candidates */
-		lct = list_head(lcoltypes);
-		rct = list_head(rcoltypes);
+		/* don't have a "foreach6", so chase four of the lists by hand */
 		lcm = list_head(lcoltypmods);
 		rcm = list_head(rcoltypmods);
-		forboth(mct, pstate->p_setopTypes, mcm, pstate->p_setopTypmods)
+		mct = list_head(preselected_coltypes);
+		mcm = list_head(preselected_coltypmods);
+		forboth(lct, lcoltypes, rct, rcoltypes)
 		{
 			Oid			lcoltype = lfirst_oid(lct);
 			Oid			rcoltype = lfirst_oid(rct);
@@ -2427,163 +2574,11 @@ transformSetOperationTree(ParseState *pstate, SelectStmt *stmt)
 			/* Set final decision */
 			op->colTypes = lappend_oid(op->colTypes, rescoltype);
 			op->colTypmods = lappend_int(op->colTypmods, rescoltypmod);
-			lct = lnext(lct);
 			lcm = lnext(lcm);
-			rct = lnext(rct);
 			rcm = lnext(rcm);
+			mct = lnext(mct);
+			mcm = lnext(mcm);
 		}
-
-		return (Node *) op;
-	}
-}
-
-/*
- * isSetopLeaf
- *  returns true if the statement is set operation tree leaf.
- */
-static bool
-isSetopLeaf(SelectStmt *stmt)
-{
-	Assert(stmt && IsA(stmt, SelectStmt));
-	/*
-	 * If an internal node of a set-op tree has ORDER BY, UPDATE, or LIMIT
-	 * clauses attached, we need to treat it like a leaf node to generate an
-	 * independent sub-Query tree.	Otherwise, it can be represented by a
-	 * SetOperationStmt node underneath the parent Query.
-	 */
-	if (stmt->op == SETOP_NONE)
-	{
-		Assert(stmt->larg == NULL && stmt->rarg == NULL);
-		return true;
-	}
-	else
-	{
-		Assert(stmt->larg != NULL && stmt->rarg != NULL);
-		if (stmt->sortClause || stmt->limitOffset || stmt->limitCount ||
-			stmt->lockingClause)
-			return true;
-		else
-			return false;
-	}
-}
-
-/*
- * collectSetopTypes
- *  transforms the statement partially and collect data type oid
- * and typmod from targetlist recursively. In set operations, the
- * final data type should be determined from the total tree view,
- * so we traverse the tree and collect types naively (without coercing)
- * and use the information for later column type decision.
- * types and typmods are output parameter, and the returned values
- * are List of List which contain column number of elements as the
- * first dimension, and leaf number of elements as the second dimension.
- * Returns the number of non-junk columns.
- */
-static int
-collectSetopTypes(ParseState *pstate, SelectStmt *stmt,
-				  List **types, List **typmods)
-{
-	if (isSetopLeaf(stmt))
-	{
-		ParseState	   *parentstate = pstate;
-		SelectStmt	   *select_stmt = stmt;
-		List		   *tlist, *temp_tlist;
-		ListCell	   *lc, *lct, *lcm;
-		int				tlist_length;
-
-		/* Copy them just in case */
-		pstate = make_parsestate(parentstate);
-		stmt = copyObject(select_stmt);
-
-		if (stmt->valuesLists)
-		{
-			/* in VALUES query, we can transform all */
-			tlist = transformValuesClause(pstate, stmt)->targetList;
-		}
-		else
-		{
-			/* transform only tragetList */
-			transformFromClause(pstate, stmt->fromClause);
-			tlist = transformTargetList(pstate, stmt->targetList);
-		}
-
-		/* Filter out junk columns. */
-		temp_tlist = NIL;
-		foreach (lc, tlist)
-		{
-			TargetEntry	   *tle = (TargetEntry *) lfirst(lc);
-
-			if (tle->resjunk)
-				continue;
-			temp_tlist = lappend(temp_tlist, tle);
-		}
-		tlist = temp_tlist;
-		tlist_length = list_length(tlist);
-
-		if (*types == NIL)
-		{
-			Assert(*typmods == NIL);
-			/* Construct List of List for numbers of tlist */
-			foreach(lc, tlist)
-			{
-				*types = lappend(*types, NIL);
-				*typmods = lappend(*typmods, NIL);
-			}
-		}
-		else if (list_length(*types) != tlist_length)
-		{
-			/*
-			 * Must be an error in later process.
-			 * Nothing to do in this preprocess (not an assert.)
-			 */
-			free_parsestate(pstate);
-			pfree(stmt);
-			return tlist_length;
-		}
-		lct = list_head(*types);
-		lcm = list_head(*typmods);
-		foreach (lc, tlist)
-		{
-			TargetEntry	   *tle = (TargetEntry *) lfirst(lc);
-			List		   *typelist = (List *) lfirst(lct);
-			List		   *typmodlist = (List *) lfirst(lcm);
-
-			/* Keep back to the original List */
-			lfirst(lct) = lappend_oid(typelist, exprType((Node *) tle->expr));
-			lfirst(lcm) = lappend_int(typmodlist, exprTypmod((Node *) tle->expr));
-
-			lct = lnext(lct);
-			lcm = lnext(lcm);
-		}
-		/* They're not needed anymore */
-		free_parsestate(pstate);
-		pfree(stmt);
-
-		return tlist_length;
-	}
-	else
-	{
-		int			lnum, rnum;
-		const char *context;
-
-		/* just recurse to the leaf */
-		lnum = collectSetopTypes(pstate, stmt->larg, types, typmods);
-		rnum = collectSetopTypes(pstate, stmt->rarg, types, typmods);
-
-		context = (stmt->op == SETOP_UNION ? "UNION" :
-				   (stmt->op == SETOP_INTERSECT ? "INTERSECT" :
-					"EXCEPT"));
-		/*
-		 * We need to report error here before doing anything with the
-		 * collected result.
-		 */
-		if (lnum != rnum)
-			ereport(ERROR,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("each %s query must have the same number of columns",
-							context)));
-
-		return lnum;
 	}
 }
 

--- a/src/backend/parser/parse_node.c
+++ b/src/backend/parser/parse_node.c
@@ -47,9 +47,6 @@ make_parsestate(ParseState *parentParseState)
 
 	pstate->parentParseState = parentParseState;
 
-	/* disable propagateSetopTypes by default */
-	pstate->p_propagateSetopTypes = false;
-
 	/* Fill in fields that don't start at null/false/zero */
 	pstate->p_next_resno = 1;
 
@@ -57,11 +54,6 @@ make_parsestate(ParseState *parentParseState)
 	{
 		pstate->p_sourcetext = parentParseState->p_sourcetext;
 		pstate->p_variableparams = parentParseState->p_variableparams;
-		if (parentParseState->p_propagateSetopTypes)
-		{
-			pstate->p_setopTypes = parentParseState->p_setopTypes;
-			pstate->p_setopTypmods = parentParseState->p_setopTypmods;
-		}
 	}
 
 	return pstate;

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -96,9 +96,6 @@ typedef struct ParseState
 	struct HTAB *p_namecache;  /* parse state object name cache */
 	bool        p_hasTblValueExpr;
 	bool        p_hasDynamicFunction; /* function w/unstable return type */
-	List	   *p_setopTypes;		/* predicated types on Setop */
-	List	   *p_setopTypmods;		/* predicated typmods on Setop */
-	bool        p_propagateSetopTypes;      /* if possible to propagate types on Setop */
 } ParseState;
 
 /* Support for parser_errposition_callback function */

--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -164,7 +164,7 @@ select 1 union (select distinct 10 from (select 1, 3.0 union select distinct 2, 
 (2 rows)
 
 select 1 union (select distinct '10' from (select 1, 3.0 union select distinct 2, null::integer) as foo);
-ERROR:  UNION/INTERSECT/EXCEPT could not convert type text to integer
+ERROR:  UNION types integer and text cannot be matched
 select distinct a from (select 'A' union select 'B') as foo(a);
  a 
 ---

--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -1863,6 +1863,22 @@ UNION SELECT 300, 300)
               2
 (1 row)
 
+CREATE TABLE t1_setop(a int) DISTRIBUTED BY (a);
+CREATE TABLE t2_setop(a int) DISTRIBUTED BY (a);
+INSERT INTO t1_setop VALUES (1), (2), (3);
+INSERT INTO t2_setop VALUES (3), (4), (5);
+(SELECT a FROM t1_setop EXCEPT SELECT a FROM t2_setop ORDER BY a)
+UNION
+(SELECT a FROM t2_setop EXCEPT SELECT a FROM t1_setop ORDER BY a)
+ORDER BY a;
+ a 
+---
+ 1
+ 2
+ 4
+ 5
+(4 rows)
+
 --
 -- Clean up
 --

--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -562,7 +562,6 @@ order by 1;
 -- N-ary UNION ALL explain
 --
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -576,29 +575,12 @@ UNION ALL
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 2: explain
-        ^
-QUERY:  EXPLAIN 
-explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select a1 from T_a1)
-UNION ALL
-(select b1 from T_b2)
-UNION ALL
-(select c1 from T_random)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -612,29 +594,12 @@ UNION ALL
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 2: explain
-        ^
-QUERY:  EXPLAIN 
-explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select b1 from T_b2)
-UNION ALL
-(select a1 from T_a1)
-UNION ALL
-(select c1 from T_random)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -648,29 +613,12 @@ UNION ALL
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 2: explain
-        ^
-QUERY:  EXPLAIN 
-explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select c1 from T_random)
-UNION ALL
-(select a1 from T_a1)
-UNION ALL
-(select b1 from T_b2)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -684,27 +632,11 @@ UNION ALL
 (select b1 from T_b2)
 order by 1;'
 , 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 2: explain
-        ^
-QUERY:  EXPLAIN 
-explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select d1 from T_constant)
-UNION ALL
-(select c1 from T_random)
-UNION ALL
-(select a1 from T_a1)
-UNION ALL
-(select b1 from T_b2)
-order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 --
 -- N-ary UNION results
 --
@@ -908,7 +840,6 @@ order by 1;
 -- N-ary UNION explain
 --
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
@@ -922,29 +853,12 @@ UNION
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 2: explain
-        ^
-QUERY:  EXPLAIN 
-explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select a1 from T_a1)
-UNION
-(select b1 from T_b2)
-UNION
-(select c1 from T_random)
-UNION
-(select d1 from T_constant)
-order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
@@ -958,29 +872,12 @@ UNION
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 2: explain
-        ^
-QUERY:  EXPLAIN 
-explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select b1 from T_b2)
-UNION
-(select a1 from T_a1)
-UNION
-(select c1 from T_random)
-UNION
-(select d1 from T_constant)
-order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
@@ -994,29 +891,12 @@ UNION
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 2: explain
-        ^
-QUERY:  EXPLAIN 
-explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select c1 from T_random)
-UNION
-(select a1 from T_a1)
-UNION
-(select b1 from T_b2)
-UNION
-(select d1 from T_constant)
-order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
@@ -1030,27 +910,11 @@ UNION
 (select b1 from T_b2)
 order by 1;'
 , 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 2: explain
-        ^
-QUERY:  EXPLAIN 
-explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select d1 from T_constant)
-UNION
-(select c1 from T_random)
-UNION
-(select a1 from T_a1)
-UNION
-(select b1 from T_b2)
-order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 --
 -- Binary UNION ALL results
 --
@@ -1522,63 +1386,39 @@ select count_operator('(select * from T_b2) UNION ALL (select * from T_random) o
               1
 (1 row)
 
-select count_operator('explain
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select a1 from T_a1) UNION ALL (select d1 from T_constant) order by 1;', 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 1: EXPLAIN explain
-                ^
-QUERY:  EXPLAIN explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select a1 from T_a1) UNION ALL (select d1 from T_constant) order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
-select count_operator('explain
+ count_operator 
+----------------
+              2
+(1 row)
+
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select d1 from T_constant) UNION ALL (select a1 from T_a1) order by 1;', 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 1: EXPLAIN explain
-                ^
-QUERY:  EXPLAIN explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select d1 from T_constant) UNION ALL (select a1 from T_a1) order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
-select count_operator('explain
+ count_operator 
+----------------
+              2
+(1 row)
+
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select c1 from T_random) UNION ALL (select d1 from T_constant) order by 1;', 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 1: EXPLAIN explain
-                ^
-QUERY:  EXPLAIN explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select c1 from T_random) UNION ALL (select d1 from T_constant) order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 select count_operator('with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -1980,63 +1820,39 @@ select count_operator('(select * from T_b2) UNION (select * from T_random) order
               1
 (1 row)
 
-select count_operator('explain
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select a1 from T_a1) UNION (select d1 from T_constant) order by 1;', 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 1: EXPLAIN explain
-                ^
-QUERY:  EXPLAIN explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select a1 from T_a1) UNION (select d1 from T_constant) order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
-select count_operator('explain
+ count_operator 
+----------------
+              2
+(1 row)
+
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select a1 from T_a1) order by 1;', 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 1: EXPLAIN explain
-                ^
-QUERY:  EXPLAIN explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select d1 from T_constant) UNION (select a1 from T_a1) order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
-select count_operator('explain
+ count_operator 
+----------------
+              2
+(1 row)
+
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select c1 from T_random) UNION (select d1 from T_constant) order by 1;', 'APPEND');
-ERROR:  plpy.SPIError: syntax error at or near "explain"
-LINE 1: EXPLAIN explain
-                ^
-QUERY:  EXPLAIN explain
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select c1 from T_random) UNION (select d1 from T_constant) order by 1;
-CONTEXT:  Traceback (most recent call last):
-  PL/Python function "count_operator", line 2, in <module>
-    rv = plpy.execute('EXPLAIN ' + query)
-PL/Python function "count_operator"
+ count_operator 
+----------------
+              2
+(1 row)
+
 select count_operator('with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200

--- a/src/test/regress/sql/union_gp.sql
+++ b/src/test/regress/sql/union_gp.sql
@@ -156,7 +156,6 @@ order by 1;
 --
 
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -172,7 +171,6 @@ order by 1;'
 , 'APPEND');
 
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -188,7 +186,6 @@ order by 1;'
 , 'APPEND');
 
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -204,7 +201,6 @@ order by 1;'
 , 'APPEND');
 
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -280,7 +276,6 @@ order by 1;
 --
 
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
@@ -296,7 +291,6 @@ order by 1;'
 , 'APPEND');
 
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
@@ -312,7 +306,6 @@ order by 1;'
 , 'APPEND');
 
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
@@ -328,7 +321,6 @@ order by 1;'
 , 'APPEND');
 
 select count_operator('
-explain
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
@@ -403,21 +395,21 @@ select count_operator('(select * from T_a1) UNION ALL (select * from T_random) o
 
 select count_operator('(select * from T_b2) UNION ALL (select * from T_random) order by 1;', 'APPEND');
 
-select count_operator('explain
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select a1 from T_a1) UNION ALL (select d1 from T_constant) order by 1;', 'APPEND');
 
-select count_operator('explain
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select d1 from T_constant) UNION ALL (select a1 from T_a1) order by 1;', 'APPEND');
 
-select count_operator('explain
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -490,21 +482,21 @@ select count_operator('(select * from T_a1) UNION (select * from T_random) order
 
 select count_operator('(select * from T_b2) UNION (select * from T_random) order by 1;', 'APPEND');
 
-select count_operator('explain
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select a1 from T_a1) UNION (select d1 from T_constant) order by 1;', 'APPEND');
 
-select count_operator('explain
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select a1 from T_a1) order by 1;', 'APPEND');
 
-select count_operator('explain
+select count_operator('
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200

--- a/src/test/regress/sql/union_gp.sql
+++ b/src/test/regress/sql/union_gp.sql
@@ -509,6 +509,15 @@ UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select c1 from T_random) order by 1;', 'APPEND');
 
+CREATE TABLE t1_setop(a int) DISTRIBUTED BY (a);
+CREATE TABLE t2_setop(a int) DISTRIBUTED BY (a);
+INSERT INTO t1_setop VALUES (1), (2), (3);
+INSERT INTO t2_setop VALUES (3), (4), (5);
+(SELECT a FROM t1_setop EXCEPT SELECT a FROM t2_setop ORDER BY a)
+UNION
+(SELECT a FROM t2_setop EXCEPT SELECT a FROM t1_setop ORDER BY a)
+ORDER BY a;
+
 --
 -- Clean up
 --


### PR DESCRIPTION
Queries which involved a UNION of queries which were set operations and had an order by clause would error out as follows:
```
explain (select a from foo except select a from foo order by a) UNION (select a from foo except select a from foo order by a);
FATAL:  Unexpected internal error (analyze.c:2393)
DETAIL:  FailedAssertion("!(pstate->p_setopTypes && pstate->p_setopTypmods)", File: "analyze.c", Line: 2393)
HINT:  Process 98860 will wait for gp_debug_linger=120 seconds before termination.
```
This PR cherry-picks commit 352362a655c5ae3bfeff6bd3c6507a0add3c2f50 from master to fix the issue.
This PR also cherry-picks the commit 01536f8d944aa0f84fc454b03b2fdfbf6c054438 to fix the expected answer file for union_gp test.