### PR TITLE
Quote all identifiers in pg_upgrade

### DIFF
--- a/contrib/pg_upgrade/dump.c
+++ b/contrib/pg_upgrade/dump.c
@@ -24,7 +24,7 @@ generate_old_dump(void)
 	/* run new pg_dumpall binary for globals */
 	exec_prog(UTILITY_LOG_FILE, NULL, true,
 			  "\"%s/pg_dumpall\" %s --schema-only --globals-only "
-			  /* GPDB_91_MERGE_FIXME "--quote-all-identifiers */ " --binary-upgrade %s -f %s",
+			  "--quote-all-identifiers --binary-upgrade %s -f %s",
 			  new_cluster.bindir, cluster_conn_opts(&old_cluster),
 			  log_opts.verbose ? "--verbose" : "",
 			  GLOBALS_DUMP_FILE);
@@ -53,7 +53,7 @@ generate_old_dump(void)
 		snprintf(log_file_name, sizeof(log_file_name), DB_DUMP_LOG_FILE_MASK, old_db->db_oid);
 
 		parallel_exec_prog(log_file_name, NULL,
-				   "\"%s/pg_dump\" %s --schema-only " /* GPDB_91_MERGE_FIXME --quote-all-identifiers " */
+				   "\"%s/pg_dump\" %s --schema-only --quote-all-identifiers "
 					  "--binary-upgrade --format=custom %s --file=\"%s\" %s",
 						 new_cluster.bindir, cluster_conn_opts(&old_cluster),
 						   log_opts.verbose ? "--verbose" : "",


### PR DESCRIPTION
Align with upstream and use `--quote-all-identifiers` when dumping the schema since we have merged the underlying functionality to do so from PostgreSQL.