### PR TITLE
vmem fixes: Avoid integer overflow and fix compilation for fault injection

### DIFF
--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -389,16 +389,6 @@ VmemTracker_GetMaxReservedVmemChunks(void)
 }
 
 /*
- * Returns the maximum vmem consumed by current process in "MB" unit.
- */
-int64
-VmemTracker_GetMaxReservedVmemMB(void)
-{
-	Assert(maxVmemChunksTracked >= trackedVmemChunks);
-	return CHUNKS_TO_MB(maxVmemChunksTracked);
-}
-
-/*
  * Returns the maximum vmem consumed by current process in "bytes" unit.
  */
 int64
@@ -470,15 +460,6 @@ int32
 VmemTracker_GetReservedVmemChunks(void)
 {
 	return trackedVmemChunks;
-}
-
-/*
- * Returns the vmem usage of current process in "bytes" unit.
- */
-int64
-VmemTracker_GetReservedVmemBytes(void)
-{
-	return CHUNKS_TO_BYTES(trackedVmemChunks);
 }
 
 /*
@@ -669,6 +650,26 @@ VmemTracker_ResetWaiver(void)
 	waivedChunks = 0;
 }
 
+#ifdef FAULT_INJECTOR
+/*
+ * Returns the maximum vmem consumed by current process in "MB" unit.
+ */
+static int64
+VmemTracker_GetMaxReservedVmemMB(void)
+{
+	Assert(maxVmemChunksTracked >= trackedVmemChunks);
+	return CHUNKS_TO_MB(maxVmemChunksTracked);
+}
+
+/*
+ * Returns the vmem usage of current process in "bytes" unit.
+ */
+static int64
+VmemTracker_GetReservedVmemBytes(void)
+{
+	return CHUNKS_TO_BYTES(trackedVmemChunks);
+}
+
 /*
  * Returns a bunch of different vmem usage stats such as max vmem usage,
  * current vmem usage, available vmem etc.
@@ -702,6 +703,7 @@ VmemTracker_Fault(int32 reason, int64 arg)
 
 	return -1;
 }
+#endif
 
 bool
 VmemTrackerIsActivated(void)

--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -379,16 +379,6 @@ VmemTracker_ConvertVmemBytesToChunks(int64 bytes)
 }
 
 /*
- * Returns the maximum vmem consumed by current process in "chunks" unit.
- */
-int64
-VmemTracker_GetMaxReservedVmemChunks(void)
-{
-	Assert(maxVmemChunksTracked >= trackedVmemChunks);
-	return maxVmemChunksTracked;
-}
-
-/*
  * Returns the maximum vmem consumed by current process in "bytes" unit.
  */
 int64
@@ -451,15 +441,6 @@ VmemTracker_GetMaxChunksPerQuery(void)
 {
 	return IsResGroupEnabled() ?
 		ResGroupGetMaxChunksPerQuery() : maxChunksPerQuery;
-}
-
-/*
- * Returns the vmem usage of current process in "chunks" unit.
- */
-int32
-VmemTracker_GetReservedVmemChunks(void)
-{
-	return trackedVmemChunks;
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1211,7 +1211,7 @@ ResourceGroupGetQueryMemoryLimit(void)
 	if (bypassedGroup)
 	{
 		int64		bytesInMB = 1 << BITS_IN_MB;
-		int64		bytesInChunk = 1 << VmemTracker_GetChunkSizeInBits();
+		int64		bytesInChunk = (int64) 1 << VmemTracker_GetChunkSizeInBits();
 
 		/*
 		 * In bypass mode there is a hard memory limit of

--- a/src/include/utils/vmem_tracker.h
+++ b/src/include/utils/vmem_tracker.h
@@ -45,9 +45,7 @@ extern int32 VmemTracker_ConvertVmemMBToChunks(int mb);
 extern int64 VmemTracker_ConvertVmemChunksToBytes(int chunks);
 extern int32 VmemTracker_ConvertVmemBytesToChunks(int64 bytes);
 extern int32 VmemTracker_GetReservedVmemChunks(void);
-extern int64 VmemTracker_GetReservedVmemBytes(void);
 extern int64 VmemTracker_GetMaxReservedVmemChunks(void);
-extern int64 VmemTracker_GetMaxReservedVmemMB(void);
 extern int64 VmemTracker_GetMaxReservedVmemBytes(void);
 extern int64 VmemTracker_GetVmemLimitBytes(void);
 extern int32 VmemTracker_GetVmemLimitChunks(void);
@@ -63,8 +61,9 @@ extern MemoryAllocationStatus VmemTracker_ReserveVmem(int64 newly_requested);
 extern void VmemTracker_ReleaseVmem(int64 to_be_freed_requested);
 extern void VmemTracker_RequestWaiver(int64 waiver_bytes);
 extern void VmemTracker_ResetWaiver(void);
+#ifdef FAULT_INJECTOR
 extern int64 VmemTracker_Fault(int32 reason, int64 arg);
-
+#endif
 extern int32 RedZoneHandler_GetRedZoneLimitChunks(void);
 extern int32 RedZoneHandler_GetRedZoneLimitMB(void);
 extern bool RedZoneHandler_IsVmemRedZone(void);

--- a/src/include/utils/vmem_tracker.h
+++ b/src/include/utils/vmem_tracker.h
@@ -44,8 +44,6 @@ extern int32 VmemTracker_ConvertVmemChunksToMB(int chunks);
 extern int32 VmemTracker_ConvertVmemMBToChunks(int mb);
 extern int64 VmemTracker_ConvertVmemChunksToBytes(int chunks);
 extern int32 VmemTracker_ConvertVmemBytesToChunks(int64 bytes);
-extern int32 VmemTracker_GetReservedVmemChunks(void);
-extern int64 VmemTracker_GetMaxReservedVmemChunks(void);
 extern int64 VmemTracker_GetMaxReservedVmemBytes(void);
 extern int64 VmemTracker_GetVmemLimitBytes(void);
 extern int32 VmemTracker_GetVmemLimitChunks(void);


### PR DESCRIPTION
Some assorted fixes to the vmem code:

Since `VmemTracker_GetChunkSizeInBits()` returns int32, the compiler will use 32-bit integer arithmetic for the shift, even though the resulting variable is 64-bit wide. Cast the constant to int64 to ensure we don't risk a 32-bit overflow where we can store it. This matches other uses of `VmemTracker_GetChunkSizeInBits()` where we want a 64-bit result. Found by static analysis, and while unlikely to have caused issues in production it's nevertheless a good fix.

Also remove dead code and wrap fault injector code in `FAULT_INJECTOR` guards to only compile it when fault injection is turned on and move functions only used in fault injection to be static.