### PR TITLE
.gitignore generated dev pipelines

### DIFF
--- a/concourse/pipelines/.gitignore
+++ b/concourse/pipelines/.gitignore
@@ -1,0 +1,1 @@
+gpdb-dev-*.yml


### PR DESCRIPTION
Generated dev pipelines should be included in .gitignore. It's too
easy to accidentally add a generated dev pipeline to a commit.

Authored-by: Jason Vigil <jvigil@pivotal.io>