### PR TITLE
Add GUC to force redistribute on insert on randomly distributed tables

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -356,6 +356,13 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elem[] =
 		&optimizer_array_constraints,
 		false, // m_fNegate
 		GPOS_WSZ_LIT("Allows the constraint framework to derive array constraints in the optimizer.")
+		},
+
+		{
+		EopttraceForceRedistributeOnInsertOnRandomDistrTables,
+		&optimize_force_random_distribution_on_insert,
+		false, // m_fNegate
+		GPOS_WSZ_LIT("Force redistribute motion on insert on randomly distributed tables.")
 		}
 };
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -451,6 +451,7 @@ bool		optimizer_array_constraints;
 bool		optimizer_cte_inlining;
 bool		optimizer_enable_space_pruning;
 bool		optimizer_enable_associativity;
+bool		optimize_force_random_distribution_on_insert;
 
 /* Analyze related GUCs for Optimizer */
 bool		optimizer_analyze_root_partition;
@@ -3082,6 +3083,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&gp_resource_group_bypass,
 		false,
 		check_gp_resource_group_bypass, NULL, NULL
+	},
+
+	{
+		{"optimize_force_random_distribution_on_insert", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Force random redistribution on insert on randomly distributed tables."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimize_force_random_distribution_on_insert,
+		true,
+		NULL, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -505,6 +505,7 @@ extern bool optimizer_array_constraints;
 extern bool optimizer_cte_inlining;
 extern bool optimizer_enable_space_pruning;
 extern bool optimizer_enable_associativity;
+extern bool optimize_force_random_distribution_on_insert;
 
 /* Analyze related GUCs for Optimizer */
 extern bool optimizer_analyze_root_partition;

--- a/src/test/regress/expected/bfv_dd_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_optimizer.out
@@ -1111,6 +1111,7 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 insert into dd_random select g, g%15 from generate_series(1, 100) g;
 INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 -- non hash distributed tables

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -259,6 +259,7 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 insert into boolean values ('t', 1);
 INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 alter table boolean set distributed by (boo, b);
@@ -922,7 +923,9 @@ INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1232388"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select Ta.key, Ta.value from public.zoompp7620 as Ta  limit 7500 "
+CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from pg_catalog.gp_dist_random('pg_catalog.pg_class') c where c.oid=46779"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.key , (case when pg_column_size(Ta.value) > 1024 then NULL else Ta.value  end) as value, (case when Ta.value is NULL then false else true end) from public.zoompp7620 as Ta  limit 30000 "
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 insert into mpp7620 values (200, 200);
@@ -932,9 +935,11 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE c
 insert into zoompp7620 select * from mpp7620 where key=200;
 INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
+INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to ALL contents
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
@@ -966,15 +971,15 @@ explain select * from (select * from mpp7620 where key=200) ss where key =200;
 (5 rows)
 
 explain insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Insert  (cost=0.00..431.03 rows=1 width=4)
-   ->  Result  (cost=0.00..431.00 rows=1 width=20)
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-               ->  Table Scan on mpp7620  (cost=0.00..431.00 rows=1 width=4)
-                     Filter: key = 200
- Settings:  optimizer=on
- Optimizer status: PQO version 1.624
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Insert  (cost=0.00..431.02 rows=1 width=4)
+   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+         ->  Result  (cost=0.00..431.00 rows=1 width=16)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Table Scan on mpp7620  (cost=0.00..431.00 rows=1 width=4)
+                           Filter: key = 200
+ Optimizer: PQO version 2.67.0
 (7 rows)
 
 explain select key from mpp7620 where mpp7620.key=200;


### PR DESCRIPTION
If the GUC optimize_force_random_distribution_on_insert is set, force a redistribute
motion before executing insert on randomly distributed table. This will ensure
random data distribution across all the segments, otherwise the data may be
inserted into only 1 segment or a few depending on the data distribution fed to
Insert node.

This change is only relevant for ORCA. Corresponding ORCA PR: https://github.com/greenplum-db/gporca/pull/391