### PR TITLE
Add Oracle Enterprise Linux 7 to UD regression tests

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -127,7 +127,6 @@ groups:
   - regression_tests_gphdfs_hadoop_centos
   - regression_tests_gphdfs_mapr_centos
   - regression_tests_gphdfs_hadoop_oracle
-  - regression_tests_gphdfs_mapr_oracle
   - gate_ud_end
 {% endif %}
 {% if "AA" in test_sections %}
@@ -289,7 +288,6 @@ groups:
   - regression_tests_gphdfs_hadoop_centos
   - regression_tests_gphdfs_mapr_centos
   - regression_tests_gphdfs_hadoop_oracle
-  - regression_tests_gphdfs_mapr_oracle
   - gate_ud_end
 
 {% endif %}
@@ -3364,40 +3362,6 @@ jobs:
       TARGET_OS: centos
       TARGET_OS_VERSION: 6
 
-- name: regression_tests_gphdfs_mapr_oracle
-  ensure:
-    <<: *set_failed
-  on_success:
-    <<: *ccp_destroy
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gate_ud_start]
-    - get: bin_gpdb
-      passed: [gate_ud_start]
-      trigger: [[ test_trigger ]]
-      resource: bin_gpdb_centos7
-    - get: ccp_src
-    - get: oracle-gpdb-test-7
-  - put: terraform
-    params:
-      <<: *ccp_default_params
-      vars:
-        <<: *ccp_default_vars
-        number_of_nodes: 1
-        PLATFORM: centos7
-        instance_type: n1-standard-4
-  - task: gen_and_initialize_mapr
-    file: gpdb_src/concourse/tasks/gen_mapr.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-  - task: regression_tests_gphdfs_mapr
-    file: gpdb_src/concourse/tasks/regression_tests_gphdfs_mapr.yml
-    image: oracle-gpdb-test-7
-    params:
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 7
-
 - name: gate_ud_end
   plan:
   - aggregate:
@@ -3407,7 +3371,6 @@ jobs:
       - regression_tests_gphdfs_hadoop_centos
       - regression_tests_gphdfs_mapr_centos
       - regression_tests_gphdfs_hadoop_oracle
-      - regression_tests_gphdfs_mapr_oracle
       trigger: true
     - get: bin_gpdb_centos6
       passed:
@@ -3417,7 +3380,6 @@ jobs:
     - get: bin_gpdb_centos7
       passed:
       - regression_tests_gphdfs_hadoop_oracle
-      - regression_tests_gphdfs_mapr_oracle
 
 {% endif %}
 {% if "AA" in test_sections %}
@@ -3686,7 +3648,6 @@ jobs:
       - regression_tests_gphdfs_hadoop_centos
       - regression_tests_gphdfs_mapr_centos
       - regression_tests_gphdfs_hadoop_oracle
-      - regression_tests_gphdfs_mapr_oracle
       - regression_tests_pxf
       - DPM_backup-restore_ddboost_part1
       - DPM_backup-restore_ddboost_part2

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -126,6 +126,8 @@ groups:
   - regression_tests_pxf
   - regression_tests_gphdfs_hadoop_centos
   - regression_tests_gphdfs_mapr_centos
+  - regression_tests_gphdfs_hadoop_oracle
+  - regression_tests_gphdfs_mapr_oracle
   - gate_ud_end
 {% endif %}
 {% if "AA" in test_sections %}
@@ -286,6 +288,8 @@ groups:
   - regression_tests_pxf
   - regression_tests_gphdfs_hadoop_centos
   - regression_tests_gphdfs_mapr_centos
+  - regression_tests_gphdfs_hadoop_oracle
+  - regression_tests_gphdfs_mapr_oracle
   - gate_ud_end
 
 {% endif %}
@@ -3309,6 +3313,23 @@ jobs:
       TARGET_OS: centos
       TARGET_OS_VERSION: 6
 
+- name: regression_tests_gphdfs_hadoop_oracle
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_ud_start]
+    - get: bin_gpdb
+      passed: [gate_ud_start]
+      trigger: [[ test_trigger ]]
+      resource: bin_gpdb_centos7
+    - get: oracle-gpdb-test-7
+  - task: regression_tests_gphdfs
+    file: gpdb_src/concourse/tasks/regression_tests_gphdfs.yml
+    image: oracle-gpdb-test-7
+    params:
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 7
+
 - name: regression_tests_gphdfs_mapr_centos
   ensure:
     <<: *set_failed
@@ -3343,17 +3364,60 @@ jobs:
       TARGET_OS: centos
       TARGET_OS_VERSION: 6
 
+- name: regression_tests_gphdfs_mapr_oracle
+  ensure:
+    <<: *set_failed
+  on_success:
+    <<: *ccp_destroy
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_ud_start]
+    - get: bin_gpdb
+      passed: [gate_ud_start]
+      trigger: [[ test_trigger ]]
+      resource: bin_gpdb_centos7
+    - get: ccp_src
+    - get: oracle-gpdb-test-7
+  - put: terraform
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+        number_of_nodes: 1
+        PLATFORM: centos7
+        instance_type: n1-standard-4
+  - task: gen_and_initialize_mapr
+    file: gpdb_src/concourse/tasks/gen_mapr.yml
+    params:
+      <<: *ccp_gen_cluster_default_params
+  - task: regression_tests_gphdfs_mapr
+    file: gpdb_src/concourse/tasks/regression_tests_gphdfs_mapr.yml
+    image: oracle-gpdb-test-7
+    params:
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 7
+
 - name: gate_ud_end
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: &gate_ud_end
+      passed:
       - regression_tests_pxf
       - regression_tests_gphdfs_hadoop_centos
       - regression_tests_gphdfs_mapr_centos
+      - regression_tests_gphdfs_hadoop_oracle
+      - regression_tests_gphdfs_mapr_oracle
       trigger: true
     - get: bin_gpdb_centos6
-      passed: *gate_ud_end
+      passed:
+      - regression_tests_pxf
+      - regression_tests_gphdfs_hadoop_centos
+      - regression_tests_gphdfs_mapr_centos
+    - get: bin_gpdb_centos7
+      passed:
+      - regression_tests_gphdfs_hadoop_oracle
+      - regression_tests_gphdfs_mapr_oracle
 
 {% endif %}
 {% if "AA" in test_sections %}
@@ -3621,6 +3685,8 @@ jobs:
       - QP_memory-accounting
       - regression_tests_gphdfs_hadoop_centos
       - regression_tests_gphdfs_mapr_centos
+      - regression_tests_gphdfs_hadoop_oracle
+      - regression_tests_gphdfs_mapr_oracle
       - regression_tests_pxf
       - DPM_backup-restore_ddboost_part1
       - DPM_backup-restore_ddboost_part2

--- a/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
+++ b/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
@@ -30,7 +30,7 @@ function setup_gpadmin_user() {
 
 function _main() {
 	time configure
-        sed -i s/1024/unlimited/ /etc/security/limits.d/90-nproc.conf
+	sed -i s/1024/unlimited/ /etc/security/limits.d/90-nproc.conf
 	time install_gpdb
 	time setup_gpadmin_user
 	time gen_env

--- a/concourse/scripts/regression_tests_gphdfs.bash
+++ b/concourse/scripts/regression_tests_gphdfs.bash
@@ -57,7 +57,7 @@ function gen_env(){
 
 		\${HADOOP_HOME}/bin/hdfs namenode -format -force
 		\${HADOOP_HOME}/sbin/start-dfs.sh
-	else		
+	else
 		export HADOOP_HOME=/opt/mapr/hadoop/hadoop-2.7.0
 		wget -O \${HADOOP_HOME}/share/hadoop/common/lib/parquet-hadoop-bundle-1.8.1.jar http://central.maven.org/maven2/org/apache/parquet/parquet-hadoop-bundle/1.8.1/parquet-hadoop-bundle-1.8.1.jar
 	fi
@@ -93,10 +93,10 @@ function install_mapr_client() {
 }
 
 function run_regression_test() {
-  # Add symlink for oracle7 compatibility
-  if [ "$TARGET_OS_VERSION" == "7" ] ; then
-    ln -s /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.191-2.6.15.4.0.1.el7_5.x86_64  /usr/lib/jvm/java-1.7.0-openjdk.x86_64
-  fi
+	# Add symlink for oracle7 compatibility
+	if [ "$TARGET_OS_VERSION" == "7" ] ; then
+		ln -s /usr/lib/jvm/java-1.7.0-openjdk /usr/lib/jvm/java-1.7.0-openjdk.x86_64
+	fi
 	su - gpadmin -c "bash /home/gpadmin/run_regression_test.sh $(pwd)"
 }
 
@@ -128,11 +128,7 @@ function _main() {
 	time setup_gpadmin_user
 	time install_mapr_client
 	time configure
-  if [ "$TARGET_OS_VERSION" == "7" ] ; then
-	  sed -i s/4096/unlimited/ /etc/security/limits.d/20-nproc.conf
-  else
-	  sed -i s/1024/unlimited/ /etc/security/limits.d/90-nproc.conf
-  fi
+	sed -i s/\(1024\|4096\)/unlimited/ /etc/security/limits.d/*-nproc.conf
 	time install_gpdb
 	time make_cluster
 	time copy_jar_to_mapr_host

--- a/concourse/scripts/regression_tests_gphdfs.bash
+++ b/concourse/scripts/regression_tests_gphdfs.bash
@@ -93,6 +93,10 @@ function install_mapr_client() {
 }
 
 function run_regression_test() {
+  # Add symlink for oracle7 compatibility
+  if [ "$TARGET_OS_VERSION" == "7" ] ; then
+    ln -s /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.191-2.6.15.4.0.1.el7_5.x86_64  /usr/lib/jvm/java-1.7.0-openjdk.x86_64
+  fi
 	su - gpadmin -c "bash /home/gpadmin/run_regression_test.sh $(pwd)"
 }
 
@@ -124,7 +128,11 @@ function _main() {
 	time setup_gpadmin_user
 	time install_mapr_client
 	time configure
-	sed -i s/1024/unlimited/ /etc/security/limits.d/90-nproc.conf
+  if [ "$TARGET_OS_VERSION" == "7" ] ; then
+	  sed -i s/4096/unlimited/ /etc/security/limits.d/20-nproc.conf
+  else
+	  sed -i s/1024/unlimited/ /etc/security/limits.d/90-nproc.conf
+  fi
 	time install_gpdb
 	time make_cluster
 	time copy_jar_to_mapr_host


### PR DESCRIPTION
We are adding support for OEL 7 (Oracle Enterprise Linux) which is analogous to Centos 7. These tests were previously running on Centos 6, so there were some necessary adjustments (see [here](https://access.redhat.com/solutions/406663) for reference).
Current state:
`regression_tests_gphdfs_hadoop_oracle` is passing
`regression_tests_gphdfs_mapr_oracle` is failing and requires investigation from the UD team as to why.

Dev Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/dev:add_UD_tests_oracle

Setting dev pipeline:
```
./concourse/pipelines/gen_pipeline.py -a 'UD'
```
followed by
```
fly -t gpdb-dev \
  set-pipeline \
  -p dev:add_UD_tests_oracle \
  -c ~/workspace/gpdb5/concourse/pipelines/gpdb-dev-pivotal.yml \
  -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
  -l ~/workspace/continuous-integration/secrets/gpdb_5X_STABLE-ci-secrets.dev.yml \
  -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \
  -v gpdb-git-branch=add_UD_tests_oracle \
  -v gpdb-git-remote=https://github.com/pivotal-pa-toolsmiths/gpdb.git \
```