### PR TITLE
Misc commits in iteration_9 branch 

### DIFF
--- a/contrib/xlogdump/xlogdump.c
+++ b/contrib/xlogdump/xlogdump.c
@@ -542,7 +542,9 @@ dumpXLogRecord(XLogRecord *record, bool header_only)
 		case RM_SEQ_ID:
 			print_rmgr_seq(curRecPtr, record, info);
 			break;
-
+		case RM_BITMAP_ID:
+			print_rmgr_bitmap(curRecPtr, record, info);
+			break;
 		case RM_APPEND_ONLY_ID:
 			print_rmgr_ao(curRecPtr, record, info);
 			break;

--- a/contrib/xlogdump/xlogdump_rmgr.h
+++ b/contrib/xlogdump/xlogdump_rmgr.h
@@ -76,6 +76,7 @@ void print_rmgr_hash(XLogRecPtr, XLogRecord *, uint8);
 void print_rmgr_gin(XLogRecPtr, XLogRecord *, uint8);
 void print_rmgr_gist(XLogRecPtr, XLogRecord *, uint8);
 void print_rmgr_seq(XLogRecPtr, XLogRecord *, uint8);
+void print_rmgr_bitmap(XLogRecPtr cur, XLogRecord *record, uint8 info);
 void print_rmgr_ao(XLogRecPtr, XLogRecord *, uint8);
 
 #endif /* __XLOGDUMP_RMGR_H__ */

--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -2497,7 +2497,7 @@ _bitmap_doinsert(Relation rel, ItemPointerData ht_ctid, Datum *attdata,
 
 	/* insert this new tuple into the bitmap index. */
 	inserttuple(rel, metabuf, tidOffset, ht_ctid, tupDesc, attdata, nulls, 
-				lovHeap, lovIndex, scanKeys, scanDesc, true);
+				lovHeap, lovIndex, scanKeys, scanDesc, RelationNeedsWAL(rel));
 
 	index_endscan(scanDesc);
 	_bitmap_close_lov_heapandindex(lovHeap, lovIndex, RowExclusiveLock);


### PR DESCRIPTION
These 2 commits should be committed to master separately:
* support bitmap index in xlogdump
* disable WALrep for temp bitmap index
