### PR TITLE
Fix some steps of building gp with gporca.

### DIFF
--- a/README.CentOS.bash
+++ b/README.CentOS.bash
@@ -24,6 +24,7 @@ sudo yum install -y \
     xerces-c-devel \
     zlib-devel
 
+sudo pip install -U pip
 sudo pip install conan
 sudo pip install -r python-dependencies.txt
 sudo pip install -r python-developer-dependencies.txt

--- a/README.linux.md
+++ b/README.linux.md
@@ -9,7 +9,7 @@
 - If you want to link cmake3 to cmake, run:
 
   ```bash
-    sudo ln -sf ../../bin/cmake3 /usr/local/bin/cmake
+    sudo ln -sf /usr/bin/cmake3 /usr/local/bin/cmake
   ```
 
 - Make sure that you add `/usr/local/lib` and `/usr/local/lib64` to
@@ -57,7 +57,9 @@ Use dependency script for CentOS.
 ## Common Platform Tasks:
 
 Make sure that you add `/usr/local/lib` to `/etc/ld.so.conf`,
-then run command `ldconfig`.
+then run command `ldconfig`. After build the optimizer, run
+`ldconfig` again to make sure necessary links and cache have
+been created for these shared libraries.
 
 1. ORCA requires [CMake](https://cmake.org) 3.x; make sure you have it installed.
    Installation instructions vary, please check the CMake website.

--- a/python-developer-dependencies.txt
+++ b/python-developer-dependencies.txt
@@ -3,7 +3,6 @@ Jinja2==2.10
 parse-type==0.4.2
 pexpect==4.4.0
 PSI==0.3b2
-pysql==0.16
 PyYAML==3.12
 ptyprocess==0.5.2
 six==1.11.0


### PR DESCRIPTION
When follow the building guide to build gp in centos7, meet some
problems.
 * Remove some unnecessary python packages from develop-dependencies.txt,
PyYAML-3.12,enum34-1.1.6,six-1.11.0 have installed by installing conan.
parse_type-0.4.2 has isntalled by installing behave in dependences.ext.
 * Remove pysql from develop-dependencies.txt since it would meet a error
"install_script 'pysql_w32_postinst.py' not found in scripts" when
execute "pip install pysql".
 * Use absolute-path to rename cmake3 to cmake.
 * Add /usr/local/lib to LD_LIBRARY_PATH to avoid "configure: error: Your
ORCA version is expected to be 2.67.XXX"

Signed-off-by: zhanggang <zhanggang@cmss.chinamobile.com>