### PR TITLE
Backport fault injector improvements from master to 5X_STABLE

### DIFF
--- a/contrib/gp_inject_fault/gp_inject_fault--1.0.sql
+++ b/contrib/gp_inject_fault/gp_inject_fault--1.0.sql
@@ -3,6 +3,46 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_fault_inject" to load this file. \quit
 
+CREATE FUNCTION gp_inject_fault_new(
+  faultname text,
+  type text,
+  ddl text,
+  database text,
+  tablename text,
+  start_occurrence int4,
+  end_occurrence int4,
+  extra_arg int4,
+  db_id int4)
+RETURNS boolean
+AS 'MODULE_PATHNAME'
+LANGUAGE C VOLATILE STRICT NO SQL;
+
+-- Simpler version, trigger only one time, occurrence start at 1 and
+-- end at 1, no sleep and no ddl/database/tablename.  If you are
+-- porting a test from master, replace gp_inject_fault() from master
+-- with gp_inject_fault_new().
+CREATE FUNCTION gp_inject_fault_new(
+  faultname text,
+  type text,
+  db_id int4)
+RETURNS boolean
+AS $$ select gp_inject_fault_new($1, $2, '', '', '', 1, 1, 0, $3) $$
+LANGUAGE SQL;
+
+-- Old version, always trigger until fault is reset.  This is kept to
+-- avoid modifications to existing tests.  This is identical to the
+-- newly introduced *_infinite() version in master.
+CREATE FUNCTION gp_inject_fault(
+  faultname text,
+  type text,
+  db_id int4)
+RETURNS boolean
+AS $$ select gp_inject_fault_new($1, $2, '', '', '', 1, -1, 0, $3) $$
+LANGUAGE SQL;
+
+-- Old version, always trigger until fault is reset.  The old
+-- interface accepted (1) number of occurrences after which the fault
+-- will take affect and (2) sleeptime which maps to extraArg.
 CREATE FUNCTION gp_inject_fault(
   faultname text,
   type text,
@@ -13,15 +53,26 @@ CREATE FUNCTION gp_inject_fault(
   sleeptime int4,
   db_id int4)
 RETURNS boolean
-AS 'MODULE_PATHNAME'
-LANGUAGE C VOLATILE STRICT NO SQL;
+AS $$ select gp_inject_fault_new($1, $2, $3, $4, $5, $6, -1, $7, $8) $$
+LANGUAGE SQL;
 
--- Simpler version, for convenience in the common case of 1 occurrence,
--- no sleep, and no ddl/database/tablename.
-CREATE FUNCTION gp_inject_fault(
+-- Simpler version, always trigger until fault is reset.
+CREATE FUNCTION gp_inject_fault_infinite(
   faultname text,
   type text,
   db_id int4)
 RETURNS boolean
-AS $$ select gp_inject_fault($1, $2, '', '', '', 1, 0, $3) $$
+AS $$ select gp_inject_fault_new($1, $2, '', '', '', 1, -1, 0, $3) $$
 LANGUAGE SQL;
+
+-- Simpler version to avoid confusion for wait_until_triggered fault.
+-- occurrence in call below defines wait until number of times the
+-- fault hits.
+CREATE FUNCTION gp_wait_until_triggered_fault(
+  faultname text,
+  numtimestriggered int4,
+  db_id int4)
+RETURNS boolean
+AS $$ select gp_inject_fault_new($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3) $$
+LANGUAGE SQL;
+

--- a/gpMgmt/bin/gppylib/programs/clsInjectFault.py
+++ b/gpMgmt/bin/gppylib/programs/clsInjectFault.py
@@ -55,8 +55,9 @@ class GpInjectFaultProgram:
         result.append( toNonNoneString(self.options.ddlStatement))
         result.append( toNonNoneString(self.options.databaseName))
         result.append( toNonNoneString(self.options.tableName))
-        result.append( toNonNoneString(self.options.numOccurrences))
-        result.append( toNonNoneString(self.options.sleepTimeSeconds))
+        result.append( toNonNoneString(self.options.numOccurrences)) # startOccurrence
+        result.append('-1') # endOccurrence
+        result.append( toNonNoneString(self.options.sleepTimeSeconds)) # extraArg
         return '\n'.join(result)
 
     #

--- a/gpMgmt/bin/gppylib/programs/clsInjectFault.py
+++ b/gpMgmt/bin/gppylib/programs/clsInjectFault.py
@@ -40,6 +40,15 @@ class GpInjectFaultProgram:
     #
     def __init__(self, options):
         self.options = options
+        # "-o 0" means the fault should be triggered indefinitely.
+        # Otherwise, the fault should be triggered exactly once.
+        if self.options.numOccurrences == 0:
+            self.options.endOccurrence = -1
+            self.options.numOccurrences = 1 # startOccurrence
+        else:
+            self.options.endOccurrence = self.options.numOccurrences
+            if self.options.numOccurrences < 0:
+                raise Exception("invalid value for -o option %s", self.options.numOccurrences)
 
     #
     # Build the fault transition message.  Fault options themselves will NOT be validated by the
@@ -56,7 +65,7 @@ class GpInjectFaultProgram:
         result.append( toNonNoneString(self.options.databaseName))
         result.append( toNonNoneString(self.options.tableName))
         result.append( toNonNoneString(self.options.numOccurrences)) # startOccurrence
-        result.append('-1') # endOccurrence
+        result.append( toNonNoneString(self.options.endOccurrence)) # endOccurrence
         result.append( toNonNoneString(self.options.sleepTimeSeconds)) # extraArg
         return '\n'.join(result)
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -3282,8 +3282,9 @@ processTransitionRequest_faultInject(void * inputBuf, int *offsetPtr, int length
 	char *ddlStatement = readNextStringFromString(inputBuf, offsetPtr, length);
 	char *databaseName = readNextStringFromString(inputBuf, offsetPtr, length);
 	char *tableName = readNextStringFromString(inputBuf, offsetPtr, length);
-	int numOccurrences = readIntFromString(inputBuf, offsetPtr, length, &wasRead);
-	int sleepTimeSeconds = readIntFromString(inputBuf, offsetPtr, length, &wasRead);
+	int startOccurrence = readIntFromString(inputBuf, offsetPtr, length, &wasRead);
+	int endOccurrence = readIntFromString(inputBuf, offsetPtr, length, &wasRead);
+	int extraArg = readIntFromString(inputBuf, offsetPtr, length, &wasRead);
 	FaultInjectorEntry_s	faultInjectorEntry;
 
 	init_ps_display("filerep fault inject process", "", "", "");
@@ -3296,8 +3297,8 @@ processTransitionRequest_faultInject(void * inputBuf, int *offsetPtr, int length
 		goto exit;
 	}
 
-	elog(DEBUG1, "FAULT INJECTED: Name %s Type %s, DDL %s, DB %s, Table %s, NumOccurrences %d  SleepTime %d",
-		 faultName, type, ddlStatement, databaseName, tableName, numOccurrences, sleepTimeSeconds );
+	elog(DEBUG1, "FAULT INJECTED: Name %s Type %s, DDL %s, DB %s, Table %s, StartOccurrence %d, EndOccurrence %d, extraArg %d",
+		 faultName, type, ddlStatement, databaseName, tableName, startOccurrence, endOccurrence, extraArg);
 
 	strlcpy(faultInjectorEntry.faultName, faultName, sizeof(faultInjectorEntry.faultName));
 	faultInjectorEntry.faultInjectorIdentifier = FaultInjectorIdentifierStringToEnum(faultName);
@@ -3319,13 +3320,18 @@ processTransitionRequest_faultInject(void * inputBuf, int *offsetPtr, int length
 		goto exit;
 	}
 
-	faultInjectorEntry.sleepTime = sleepTimeSeconds;
-	if (sleepTimeSeconds < 0 || sleepTimeSeconds > 7200) {
-		ereport(COMMERROR, (errcode(ERRCODE_PROTOCOL_VIOLATION),
-							errmsg("invalid sleep time, allowed range [0, 7200 sec]")));
+	faultInjectorEntry.extraArg = extraArg;
 
-		appendStringInfo(buf, "Failure: invalid sleep time, allowed range [0, 7200 sec]");
-		goto exit;
+	if (faultInjectorEntry.faultInjectorType == FaultInjectorTypeSleep)
+	{
+		if (extraArg < 0 || extraArg > 7200) {
+			ereport(COMMERROR,
+					(errcode(ERRCODE_PROTOCOL_VIOLATION),
+					 errmsg("invalid sleep time, allowed range [0, 7200 sec]")));
+
+			appendStringInfo(buf, "Failure: invalid sleep time, allowed range [0, 7200 sec]");
+			goto exit;
+		}
 	}
 
 	faultInjectorEntry.ddlStatement = FaultInjectorDDLStringToEnum(ddlStatement);
@@ -3341,15 +3347,28 @@ processTransitionRequest_faultInject(void * inputBuf, int *offsetPtr, int length
 
 	snprintf(faultInjectorEntry.tableName, sizeof(faultInjectorEntry.tableName), "%s", tableName);
 
-	faultInjectorEntry.occurrence = numOccurrences;
-	if (numOccurrences > 1000) {
-		ereport(COMMERROR, (errcode(ERRCODE_PROTOCOL_VIOLATION),
-							errmsg("invalid occurrence number, allowed range [1, 1000]")));
+	if (startOccurrence > 1000)
+	{
+		ereport(COMMERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("invalid start occurrence number, allowed range [1, 1000]")));
 
-		appendStringInfo(buf, "Failure: invalid occurrence number, allowed range [1, 1000]");
+		appendStringInfo(buf, "Failure: invalid start occurrence number, allowed range [1, 1000]");
 		goto exit;
 	}
 
+	if (endOccurrence != INFINITE_END_OCCURRENCE && endOccurrence < startOccurrence)
+	{
+		ereport(COMMERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("invalid end occurrence number, allowed range [startOccurrence, ] or -1")));
+
+		appendStringInfo(buf, "Failure: invalid end occurrence number, allowed range [startOccurrence, ] or -1");
+		goto exit;
+	}
+
+	faultInjectorEntry.startOccurrence = startOccurrence;
+	faultInjectorEntry.endOccurrence = endOccurrence;
 
 	if (FaultInjector_SetFaultInjection(&faultInjectorEntry) == STATUS_OK) {
 		if (faultInjectorEntry.faultInjectorType == FaultInjectorTypeStatus) {

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -15,6 +15,8 @@
 
 #define FAULT_NAME_MAX_LENGTH	256
 
+#define INFINITE_END_OCCURRENCE -1
+
 /*
  *
  */
@@ -354,7 +356,7 @@ typedef struct FaultInjectorEntry_s {
 	
 	FaultInjectorType_e		faultInjectorType;
 	
-	int						sleepTime;
+	int						extraArg;
 		/* in seconds, in use if fault injection type is sleep */
 		
 	DDLStatement_e			ddlStatement;
@@ -363,7 +365,8 @@ typedef struct FaultInjectorEntry_s {
 	
 	char					tableName[NAMEDATALEN];
 	
-	volatile	int			occurrence;
+	volatile	int			startOccurrence;
+	volatile	int			endOccurrence;
 	volatile	 int	numTimesTriggered;
 	volatile	FaultInjectorState_e	faultInjectorState;
 

--- a/src/test/fsync/expected/bgwriter_checkpoint.out
+++ b/src/test/fsync/expected/bgwriter_checkpoint.out
@@ -214,7 +214,7 @@ select dirty_buffers() from gp_dist_random('gp_id')
 -- fsync_test1 and fsync_test2 tables. `num times hit` is corresponding
 -- to the number of files synced by `fsync_counter` fault type.
 select gp_inject_fault('fsync_counter', 'status', '', '', '', 0, 0, 2::smallint);
-NOTICE:  Success: fault name:'fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' occurrence:'-1' sleep time:'0' fault injection state:'triggered'  num times hit:'5'
+NOTICE:  Success: fault name:'fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'5'
  gp_inject_fault 
 -----------------
  t

--- a/src/test/fsync/input/setup.source
+++ b/src/test/fsync/input/setup.source
@@ -1,15 +1,4 @@
 create or replace function dirty_buffers() returns setof record as
  '@abs_builddir@/fsync_helper@DLSUFFIX@', 'dirty_buffers'
   LANGUAGE C VOLATILE STRICT NO SQL;
-CREATE FUNCTION gp_inject_fault(
-  faultname text,
-  type text,
-  ddl text,
-  database text,
-  tablename text,
-  numoccurrences int4,
-  sleeptime int4,
-  db_id smallint)
-RETURNS boolean
-AS '$libdir/gp_inject_fault'
-LANGUAGE C VOLATILE STRICT NO SQL;
+create extension if not exists gp_inject_fault;

--- a/src/test/fsync/output/setup.source
+++ b/src/test/fsync/output/setup.source
@@ -1,15 +1,4 @@
 create or replace function dirty_buffers() returns setof record as
  '@abs_builddir@/fsync_helper@DLSUFFIX@', 'dirty_buffers'
   LANGUAGE C VOLATILE STRICT NO SQL;
-CREATE FUNCTION gp_inject_fault(
-  faultname text,
-  type text,
-  ddl text,
-  database text,
-  tablename text,
-  numoccurrences int4,
-  sleeptime int4,
-  db_id smallint)
-RETURNS boolean
-AS '$libdir/gp_inject_fault'
-LANGUAGE C VOLATILE STRICT NO SQL;
+create extension if not exists gp_inject_fault;

--- a/src/test/heap_checksum/input/setup.source
+++ b/src/test/heap_checksum/input/setup.source
@@ -1,14 +1,3 @@
 CREATE OR REPLACE FUNCTION invalidate_buffers(Oid, Oid, Oid) RETURNS BOOL AS '@abs_builddir@/heap_checksum_helper@DLSUFFIX@', 'invalidate_buffers'
 LANGUAGE C VOLATILE STRICT NO SQL;
-CREATE FUNCTION gp_inject_fault(
-  faultname text,
-  type text,
-  ddl text,
-  database text,
-  tablename text,
-  numoccurrences int4,
-  sleeptime int4,
-  db_id smallint)
-RETURNS boolean
-AS '$libdir/gp_inject_fault'
-LANGUAGE C VOLATILE STRICT NO SQL;
+create extension if not exists gp_inject_fault;

--- a/src/test/heap_checksum/output/setup.source
+++ b/src/test/heap_checksum/output/setup.source
@@ -1,14 +1,3 @@
 CREATE OR REPLACE FUNCTION invalidate_buffers(Oid, Oid, Oid) RETURNS BOOL AS '@abs_builddir@/heap_checksum_helper@DLSUFFIX@', 'invalidate_buffers'
 LANGUAGE C VOLATILE STRICT NO SQL;
-CREATE FUNCTION gp_inject_fault(
-  faultname text,
-  type text,
-  ddl text,
-  database text,
-  tablename text,
-  numoccurrences int4,
-  sleeptime int4,
-  db_id smallint)
-RETURNS boolean
-AS '$libdir/gp_inject_fault'
-LANGUAGE C VOLATILE STRICT NO SQL;
+create extension if not exists gp_inject_fault;

--- a/src/test/isolation2/expected/resgroup/resgroup_assign_slot_fail.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_assign_slot_fail.out
@@ -26,9 +26,9 @@ gp_inject_fault
 ---------------
 t              
 (1 row)
-SELECT gp_inject_fault('resgroup_assigned_on_master', 'error', 1);
-gp_inject_fault
----------------
+SELECT gp_inject_fault_new('resgroup_assigned_on_master', 'error', 1);
+gp_inject_fault_new 
+--------------------
 t              
 (1 row)
 -- end_ignore

--- a/src/test/isolation2/sql/resgroup/resgroup_assign_slot_fail.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_assign_slot_fail.sql
@@ -14,7 +14,7 @@ CREATE ROLE role_test RESOURCE GROUP rg_test;
 2: SET ROLE role_test;
 -- start_ignore
 SELECT gp_inject_fault('resgroup_assigned_on_master', 'reset', 1);
-SELECT gp_inject_fault('resgroup_assigned_on_master', 'error', 1);
+SELECT gp_inject_fault_new('resgroup_assigned_on_master', 'error', 1);
 -- end_ignore
 2: BEGIN;
 2: BEGIN;

--- a/src/test/regress/expected/cursor.out
+++ b/src/test/regress/expected/cursor.out
@@ -89,7 +89,7 @@ DECLARE cursor_c2 CURSOR FOR SELECT * FROM cursor_writer_reader WHERE b=666 ORDE
 SAVEPOINT x;
 UPDATE cursor_writer_reader SET b=333 WHERE b=666;
 select gp_inject_fault('qe_got_snapshot_and_interconnect', 'status', 2);
-NOTICE:  Success: fault name:'qe_got_snapshot_and_interconnect' fault type:'suspend' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'triggered'  num times hit:'1'
+NOTICE:  Success: fault name:'qe_got_snapshot_and_interconnect' fault type:'suspend' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t

--- a/src/test/regress/expected/gporca_faults.out
+++ b/src/test/regress/expected/gporca_faults.out
@@ -16,10 +16,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
+select gp_inject_fault_new('opt_relcache_translator_catalog_access', 'interrupt', 1);
 NOTICE:  Success:
- gp_inject_fault
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -57,10 +57,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
+select gp_inject_fault_new('opt_relcache_translator_catalog_access', 'interrupt', 1);
 NOTICE:  Success:
- gp_inject_fault
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 

--- a/src/test/regress/expected/gporca_faults_optimizer.out
+++ b/src/test/regress/expected/gporca_faults_optimizer.out
@@ -16,10 +16,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
+select gp_inject_fault_new('opt_relcache_translator_catalog_access', 'interrupt', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -53,10 +53,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
+select gp_inject_fault_new('opt_relcache_translator_catalog_access', 'interrupt', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 

--- a/src/test/regress/expected/qp_executor.out
+++ b/src/test/regress/expected/qp_executor.out
@@ -5,7 +5,6 @@ create table cf_executor_test (a integer);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into cf_executor_test select a from generate_series(1,100) a;
-set log_min_messages=debug5;
 --end_ignore
 set debug_print_slice_table=on;
 select count(*) from cf_executor_test;
@@ -51,7 +50,6 @@ select * from cf_executor_test limit 0;
 (0 rows)
 
 --start_ignore
-reset log_min_messages;
 reset debug_print_slice_table;
 drop table cf_executor_test;
 --end_ignore

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -151,17 +151,15 @@ create table _tmp_table2 as select i as c1, 0 as c2 from generate_series(0, 10) 
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- make one QE sleep before reading command
-select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 50, 2::smallint);
+select gp_inject_fault_new('before_read_command', 'sleep', '', '', '', 1, 1, 50, 2::smallint);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
-begin;
 select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;
 ERROR:  division by zero  (seg0 slice1 172.17.0.2:25433 pid=31180)
-end;
 select gp_inject_fault('before_read_command', 'reset', 2);
 NOTICE:  Success:
  gp_inject_fault 

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -48,6 +48,23 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into testsisc select i, i % 1000, i % 100000, i % 75 from
 (select generate_series(1, nsegments * 50000) as i from 
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar; 
+-- Reset the fault here otherwise it interferes with
+-- execshare_input_next fault below, when gp_enable_mk_sort is turned
+-- back on later in the test.
+select gp_inject_fault('execsort_mksort_mergeruns', 'status', 2);
+NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('execsort_mksort_mergeruns', 'reset', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 set gp_resqueue_print_operator_memory_limits=on;
 set statement_mem='2MB';
 set gp_enable_mk_sort=off;
@@ -112,21 +129,13 @@ LIMIT 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'1'
+NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
 (1 row)
 
 reset gp_enable_mk_sort;
--- Disable faultinjectors
-select gp_inject_fault('execsort_mksort_mergeruns', 'reset', 2);
-NOTICE:  Success:
- gp_inject_fault 
------------------
- t
-(1 row)
-
 select gp_inject_fault('execshare_input_next', 'reset', 2);
 NOTICE:  Success:
  gp_inject_fault 

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -32,7 +32,7 @@ select DISTINCT S from (select row_number() over(partition by i1 order by i2) AS
 (1 row)
 
 select gp_inject_fault('execsort_mksort_mergeruns', 'status', 2);
-NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -77,7 +77,7 @@ LIMIT 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -112,7 +112,7 @@ LIMIT 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t

--- a/src/test/regress/expected/query_finish_pending_optimizer.out
+++ b/src/test/regress/expected/query_finish_pending_optimizer.out
@@ -32,7 +32,7 @@ select DISTINCT S from (select row_number() over(partition by i1 order by i2) AS
 (1 row)
 
 select gp_inject_fault('execsort_mksort_mergeruns', 'status', 2);
-NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -48,6 +48,23 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into testsisc select i, i % 1000, i % 100000, i % 75 from
 (select generate_series(1, nsegments * 50000) as i from 
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar; 
+-- Reset the fault here otherwise it interferes with
+-- execshare_input_next fault below, when gp_enable_mk_sort is turned
+-- back on later in the test.
+select gp_inject_fault('execsort_mksort_mergeruns', 'status', 2);
+NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('execsort_mksort_mergeruns', 'reset', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 set gp_resqueue_print_operator_memory_limits=on;
 set statement_mem='2MB';
 set gp_enable_mk_sort=off;
@@ -77,7 +94,7 @@ LIMIT 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'set'  num times hit:'0'
+NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0'
  gp_inject_fault 
 -----------------
  t
@@ -112,21 +129,13 @@ LIMIT 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'set'  num times hit:'0'
+NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0'
  gp_inject_fault 
 -----------------
  t
 (1 row)
 
 reset gp_enable_mk_sort;
--- Disable faultinjectors
-select gp_inject_fault('execsort_mksort_mergeruns', 'reset', 2);
-NOTICE:  Success:
- gp_inject_fault 
------------------
- t
-(1 row)
-
 select gp_inject_fault('execshare_input_next', 'reset', 2);
 NOTICE:  Success:
  gp_inject_fault 

--- a/src/test/regress/expected/query_finish_pending_optimizer.out
+++ b/src/test/regress/expected/query_finish_pending_optimizer.out
@@ -151,17 +151,15 @@ create table _tmp_table2 as select i as c1, 0 as c2 from generate_series(0, 10) 
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- make one QE sleep before reading command
-select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 50, 2::smallint);
+select gp_inject_fault_new('before_read_command', 'sleep', '', '', '', 1, 1, 50, 2::smallint);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
-begin;
 select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;
 ERROR:  division by zero  (seg0 slice1 172.17.0.2:25433 pid=31180)
-end;
 select gp_inject_fault('before_read_command', 'reset', 2);
 NOTICE:  Success:
  gp_inject_fault 

--- a/src/test/regress/expected/segspace.out
+++ b/src/test/regress/expected/segspace.out
@@ -36,10 +36,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('exec_hashjoin_new_batch', 'interrupt', 2);
+select gp_inject_fault_new('exec_hashjoin_new_batch', 'interrupt', 2);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -52,7 +52,7 @@ SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE 
 ERROR:  canceling MPP operation  (seg0 slice2 127.0.0.1:25432 pid=26876)
 rollback;
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -100,10 +100,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('exec_hashjoin_new_batch', 'interrupt', 2);
+select gp_inject_fault_new('exec_hashjoin_new_batch', 'interrupt', 2);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -113,7 +113,7 @@ SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE 
 ERROR:  canceling MPP operation  (seg0 127.0.0.1:25432 pid=26876)
 rollback;
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -157,10 +157,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('exec_hashjoin_new_batch', 'interrupt', 2);
+select gp_inject_fault_new('exec_hashjoin_new_batch', 'interrupt', 2);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -172,7 +172,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 ERROR:  canceling MPP operation  (seg0 127.0.0.1:25432 pid=26876)
 rollback;
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -226,10 +226,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('workfile_write_failure', 'error', 2);
+select gp_inject_fault_new('workfile_write_failure', 'error', 2);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -242,7 +242,7 @@ update foo set j=m.cc1 from (
   where t1.i1 = t2.i2 ) as m;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice3 127.0.0.1:25432 pid=3175)
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -297,10 +297,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('workfile_write_failure', 'error', 2);
+select gp_inject_fault_new('workfile_write_failure', 'error', 2);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -311,7 +311,7 @@ delete from testsisc using (
 ) src  where testsisc.i1 = src.i;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 127.0.0.1:25432 pid=3143)
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -357,10 +357,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('workfile_write_failure', 'error', 2);
-NOTICE:  Success:
- gp_inject_fault 
------------------
+select gp_inject_fault_new('workfile_write_failure', 'error', 2);
+NOTICE:  Success: 
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -375,7 +375,7 @@ select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used
 (1 row)
 
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -413,10 +413,10 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('workfile_write_failure', 'error', 2);
+select gp_inject_fault_new('workfile_write_failure', 'error', 2);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -426,7 +426,7 @@ select * from
 where x.a = ctesisc.i1) y;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice1 127.0.0.1:25432 pid=3175)
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -26,7 +26,7 @@ NOTICE:  Success:
 SELECT COUNT(t1.*) FROM test_zlib_hashjoin AS t1, test_zlib_hashjoin AS t2 WHERE t1.i1=t2.i2;
 ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=2829)
 select gp_inject_fault('workfile_creation_failure', 'status', 2);
-NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -60,7 +60,7 @@ NOTICE:  Success:
 SELECT MAX(i1) FROM test_zlib_hagg GROUP BY i2;
 ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=2829)
 select gp_inject_fault('workfile_creation_failure', 'status', 2);
-NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t
@@ -126,7 +126,7 @@ select * from t1;
 (0 rows)
 
 select gp_inject_fault('workfile_creation_failure', 'status', 2);
-NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'0' fault injection state:'completed'  num times hit:'1'
+NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1'
  gp_inject_fault 
 -----------------
  t

--- a/src/test/regress/input/autovacuum-template0.source
+++ b/src/test/regress/input/autovacuum-template0.source
@@ -22,12 +22,12 @@ select test_consume_xids(100 * 1000000);
 select test_consume_xids(100 * 1000000);
 select test_consume_xids(10 * 1000000);
 
--- Wait until autovacuum is triggered
-SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'wait_until_triggered', 1);
+-- Wait until autovacuum is triggered at least once
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, 1);
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', 1);
 
 -- wait until autovacuum worker updates pg_database
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'wait_until_triggered', 1);
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
 SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
 
 -- template0 should be young

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -172,8 +172,9 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 -- when creating reader gang, an error reported and only current gang is cleaned.
 select cleanupAllGangs();
 
--- segment 0 report an error when get a request 
-select gp_inject_fault('send_qe_details_init_backend', 'error', 2);
+-- Segment 0 should report an error upon getting a request.  The
+-- _new() API ensures that the fault is triggered exactly once.
+select gp_inject_fault_new('send_qe_details_init_backend', 'error', 2);
 
 -- expect failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
@@ -303,7 +304,8 @@ DROP TABLE foo_test;
 --
 \c
 select gp_inject_fault('gang_created', 'reset', 1);
-select gp_inject_fault('gang_created', 'error', 1);
+-- The _new() API ensures that the fault is triggered exactly once.
+select gp_inject_fault_new('gang_created', 'error', 1);
 select 1 from gp_dist_random('gp_id') limit 1;
 -- if previous gang is not destroyed, snapshot collision would happen
 select 1 from gp_dist_random('gp_id') limit 1;

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -978,10 +978,12 @@ COPY COPY_ON_SEGMENT_CHECK_TOW_DSITKEY FROM '/tmp/COPY_ON_SEGMENT_CHECK_TOW_DSIT
 -- COPY FROM ON SEGMENT DISTRIBUTED RANDOMLY
 CREATE TABLE COPY_ON_SEGMENT_DIST_RANDOMLY(a int) DISTRIBUTED RANDOMLY;
 -- Test COPY FROM ON SEGMENT processed overflow
-CREATE EXTENSION gp_inject_fault;
-SELECT gp_inject_fault('copy_from_high_processed', 'reset', '', '', '', 1, 0, 1);
-SELECT gp_inject_fault('copy_from_high_processed', 'skip', '', '', '', 1, 0, 1);
+CREATE EXTENSION if not exists gp_inject_fault;
+SELECT gp_inject_fault('copy_from_high_processed', 'reset', 1);
+-- The _new() API ensures that the fault is triggered only once.
+SELECT gp_inject_fault_new('copy_from_high_processed', 'skip', 1);
 COPY COPY_ON_SEGMENT_DIST_RANDOMLY FROM PROGRAM 'echo <SEGID>' ON SEGMENT;
+SELECT gp_inject_fault('copy_from_high_processed', 'reset', 1);
 
 -- COPY FROM ON SEGMENT partitoned table
 CREATE TABLE COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED(a int) DISTRIBUTED BY (a) PARTITION BY range(a) ( START (0) END (10) EVERY (5));

--- a/src/test/regress/output/autovacuum-template0.source
+++ b/src/test/regress/output/autovacuum-template0.source
@@ -47,11 +47,11 @@ select test_consume_xids(10 * 1000000);
  
 (1 row)
 
--- Wait until autovacuum is triggered
-SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'wait_until_triggered', 1);
+-- Wait until autovacuum is triggered at least once
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_wait_until_triggered_fault 
+-------------------------------
  t
 (1 row)
 
@@ -63,10 +63,10 @@ NOTICE:  Success:
 (1 row)
 
 -- wait until autovacuum worker updates pg_database
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'wait_until_triggered', 1);
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_wait_until_triggered_fault 
+-------------------------------
  t
 (1 row)
 

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -287,11 +287,12 @@ select cleanupAllGangs();
  t
 (1 row)
 
--- segment 0 report an error when get a request 
-select gp_inject_fault('send_qe_details_init_backend', 'error', 2);
+-- Segment 0 should report an error upon getting a request.  The
+-- _new() API ensures that the fault is triggered exactly once.
+select gp_inject_fault_new('send_qe_details_init_backend', 'error', 2);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -531,10 +532,11 @@ NOTICE:  Success:
  t
 (1 row)
 
-select gp_inject_fault('gang_created', 'error', 1);
+-- The _new() API ensures that the fault is triggered exactly once.
+select gp_inject_fault_new('gang_created', 'error', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1094,23 +1094,31 @@ CONTEXT:  COPY copy_on_segment_check_tow_dsitkey, line 1: "0,0"
 -- COPY FROM ON SEGMENT DISTRIBUTED RANDOMLY
 CREATE TABLE COPY_ON_SEGMENT_DIST_RANDOMLY(a int) DISTRIBUTED RANDOMLY;
 -- Test COPY FROM ON SEGMENT processed overflow
-CREATE EXTENSION gp_inject_fault;
-SELECT gp_inject_fault('copy_from_high_processed', 'reset', '', '', '', 1, 0, 1);
+CREATE EXTENSION if not exists gp_inject_fault;
+SELECT gp_inject_fault('copy_from_high_processed', 'reset', 1);
 NOTICE:  Success:
  gp_inject_fault 
 -----------------
  t
 (1 row)
 
-SELECT gp_inject_fault('copy_from_high_processed', 'skip', '', '', '', 1, 0, 1);
+-- The _new() API ensures that the fault is triggered only once.
+SELECT gp_inject_fault_new('copy_from_high_processed', 'skip', 1);
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
 COPY COPY_ON_SEGMENT_DIST_RANDOMLY FROM PROGRAM 'echo <SEGID>' ON SEGMENT;
 NOTICE:  Copied 4294967285 lines
+SELECT gp_inject_fault('copy_from_high_processed', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 -- COPY FROM ON SEGMENT partitoned table
 CREATE TABLE COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED(a int) DISTRIBUTED BY (a) PARTITION BY range(a) ( START (0) END (10) EVERY (5));
 INSERT INTO COPY_ON_SEGMENT_CHECK_DISTKEY_PARTIONED SELECT generate_series(0,9);

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -1152,8 +1152,6 @@ PG_FUNCTION_INFO_V1(hasBackendsExist);
 Datum
 hasBackendsExist(PG_FUNCTION_ARGS)
 {
-	const char *walreceiver = "walreceiver";
-
 	int beid;
 	int32 result;
 	int timeout = PG_GETARG_INT32(0);
@@ -1171,9 +1169,8 @@ hasBackendsExist(PG_FUNCTION_ARGS)
 		for (beid = 1; beid <= tot_backends; beid++)
 		{
 			PgBackendStatus *beentry = pgstat_fetch_stat_beentry(beid);
-			if (beentry && beentry->st_procpid >0 && beentry->st_procpid != pid
-					&& strncmp(walreceiver, beentry->st_appname, strlen(walreceiver)) /* exclude the WALREP process*/
-				)
+			if (beentry && beentry->st_procpid >0 && beentry->st_procpid != pid &&
+				beentry->st_session_id == gp_session_id)
 				result++;
 		}
 		if (result == 0 || timeout == 0)

--- a/src/test/regress/sql/gporca_faults.sql
+++ b/src/test/regress/sql/gporca_faults.sql
@@ -12,7 +12,7 @@ INSERT INTO foo VALUES (1,1);
 
 -- test interruption requests to optimization
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
-select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
+select gp_inject_fault_new('opt_relcache_translator_catalog_access', 'interrupt', 1);
 select count(*) from foo;
 
 -- Ensure that ORCA is not called on any process other than the master QD
@@ -27,7 +27,7 @@ $$ LANGUAGE plpgsql VOLATILE;
 EXPLAIN SELECT * FROM func1_nosql_vol(5), foo;
 
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
-select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
+select gp_inject_fault_new('opt_relcache_translator_catalog_access', 'interrupt', 1);
 SELECT * FROM func1_nosql_vol(5), foo;
 
 -- The fault should *not* be hit above when optimizer = off, to reset it now.

--- a/src/test/regress/sql/qp_executor.sql
+++ b/src/test/regress/sql/qp_executor.sql
@@ -2,7 +2,6 @@
 drop table if exists cf_executor_test;
 create table cf_executor_test (a integer);
 insert into cf_executor_test select a from generate_series(1,100) a;
-set log_min_messages=debug5;
 --end_ignore
 
 set debug_print_slice_table=on;
@@ -23,7 +22,6 @@ select * from cf_executor_test limit null;
 select * from cf_executor_test limit 0;
 
 --start_ignore
-reset log_min_messages;
 reset debug_print_slice_table;
 drop table cf_executor_test;
 --end_ignore

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -1,3 +1,4 @@
+
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 
 drop table if exists _tmp_table;
@@ -71,11 +72,9 @@ create table _tmp_table1 as select i as c1, i as c2 from generate_series(1, 10) 
 create table _tmp_table2 as select i as c1, 0 as c2 from generate_series(0, 10) i;
 
 -- make one QE sleep before reading command
-select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 50, 2::smallint);
+select gp_inject_fault_new('before_read_command', 'sleep', '', '', '', 1, 1, 50, 2::smallint);
 
-begin;
 select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;
-end;
 
 select gp_inject_fault('before_read_command', 'reset', 2);
 drop table _tmp_table1;

--- a/src/test/regress/sql/segspace.sql
+++ b/src/test/regress/sql/segspace.sql
@@ -34,7 +34,7 @@ ANALYZE segspace_test_hj_skew;
 
 -- enable the fault injector
 select gp_inject_fault('exec_hashjoin_new_batch', 'reset', 2);
-select gp_inject_fault('exec_hashjoin_new_batch', 'interrupt', 2);
+select gp_inject_fault_new('exec_hashjoin_new_batch', 'interrupt', 2);
 
 set gp_workfile_type_hashjoin=buffile;
 set statement_mem=2048;
@@ -74,7 +74,7 @@ set gp_hashjoin_metadata_memory_percent=0;
 
 -- enable the fault injector
 select gp_inject_fault('exec_hashjoin_new_batch', 'reset', 2);
-select gp_inject_fault('exec_hashjoin_new_batch', 'interrupt', 2);
+select gp_inject_fault_new('exec_hashjoin_new_batch', 'interrupt', 2);
 
 begin;
 
@@ -114,7 +114,7 @@ set gp_hashjoin_metadata_memory_percent=0;
 
 -- enable the fault injector
 select gp_inject_fault('exec_hashjoin_new_batch', 'reset', 2);
-select gp_inject_fault('exec_hashjoin_new_batch', 'interrupt', 2);
+select gp_inject_fault_new('exec_hashjoin_new_batch', 'interrupt', 2);
 
 begin;
 
@@ -160,7 +160,7 @@ set gp_cte_sharing=on;
 
 -- enable the fault injector
 select gp_inject_fault('workfile_write_failure', 'reset', 2);
-select gp_inject_fault('workfile_write_failure', 'error', 2);
+select gp_inject_fault_new('workfile_write_failure', 'error', 2);
 
 -- LEAK in UPDATE: update with sisc xslice sort
 update foo set j=m.cc1 from (
@@ -210,7 +210,7 @@ set statement_mem=1024; -- 1mb for 3 segment to get leak.
 
 -- enable the fault injector
 select gp_inject_fault('workfile_write_failure', 'reset', 2);
-select gp_inject_fault('workfile_write_failure', 'error', 2);
+select gp_inject_fault_new('workfile_write_failure', 'error', 2);
 
 -- LEAK in DELETE with APPEND ONLY tables
 delete from testsisc using (
@@ -246,7 +246,7 @@ create table foo (c int, d int);
 
 -- enable the fault injector
 select gp_inject_fault('workfile_write_failure', 'reset', 2);
-select gp_inject_fault('workfile_write_failure', 'error', 2);
+select gp_inject_fault_new('workfile_write_failure', 'error', 2);
 
 -- expect to see leak if we hit error
 update foo set d = i1 from (select i1,i2 from testsort order by i2) x;
@@ -279,7 +279,7 @@ create table foo (c int, d int);
 
 -- enable the fault injector
 select gp_inject_fault('workfile_write_failure', 'reset', 2);
-select gp_inject_fault('workfile_write_failure', 'error', 2);
+select gp_inject_fault_new('workfile_write_failure', 'error', 2);
 
 update foo set d = i1 from (with ctesisc as (select * from testsisc order by i2)
 select * from

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_alter/aoco_alter_scenario_test/aocoAlterColumn.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_alter/aoco_alter_scenario_test/aocoAlterColumn.py
@@ -97,7 +97,7 @@ class AOCOAlterColumn(MPPTestCase):
         # Inject Fault to put one primary in panic
         self.fileutil.inject_fault(f='postmaster', y='reset',  seg_id=primary_dbid)
         self.fileutil.inject_fault(f='postmaster', y='panic',  seg_id=primary_dbid)
-        state=self.fileutil.check_fault_status(fault_name='postmaster', status='triggered')
+        state=self.fileutil.check_fault_status(fault_name='postmaster')
         self.log_segment_state()
         # Recover the down segments
         self.recover_seg()

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/__init__.py
@@ -253,7 +253,7 @@ class SuspendCheckpointCrashRecovery(MPPTestCase):
                 self.wait_till_all_sqls_done(6 + 1)
                 trigger_count = 6
             fault_type = self.get_faults_before_executing_trigger_sqls(pass_num, cluster_state, test_type, ddl_type, aborting_create_needed=False)
-            fault_hit = self.fileutil.check_fault_status(fault_name=fault_type, status="triggered", num_times_hit=trigger_count)
+            fault_hit = self.fileutil.check_fault_status(fault_name=fault_type, num_times_hit=trigger_count)
             if not fault_hit:
                raise Exception('Fault not hit expected number of times')
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/__init__.py
@@ -325,7 +325,7 @@ class FilerepTestCase(MPPTestCase):
         first_mirror_dbid = first_mirror_dbid.split('\n')[3].strip()
 
         tinctest.logger.info("\n Injecting faults on first mirror")
-        flag = self.util.check_fault_status(fault_name='fileRep_is_operation_completed', status='triggered', max_cycle=100);
+        flag = self.util.check_fault_status(fault_name='fileRep_is_operation_completed', max_cycle=100);
         if not flag:
             raise Exception("Fault fileRep_is_operation_completed didn't trigger")   
  

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/fts/fts_transitions/__init__.py
@@ -180,7 +180,7 @@ class FtsTransitions(MPPTestCase):
         self.start_db_with_no_rc_check()
 
     def check_fault_status(self, fault_name, seg_id=None, role=None):
-        status = self.fileutil.check_fault_status(fault_name = fault_name, status ='triggered', max_cycle=20, role=role, seg_id=seg_id)
+        status = self.fileutil.check_fault_status(fault_name = fault_name, max_cycle=20, role=role, seg_id=seg_id)
         self.assertTrue(status, 'The fault is not triggered in the time expected')
 
     def cluster_state(self):

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/lib/base.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/lib/base.py
@@ -48,7 +48,7 @@ class BaseClass(MPPTestCase):
         tinctest.logger.info('Successfully reset fault_name : %s fault_type : %s  occurence : %s ' % (fault_name, type, occurence))
 
     def check_fault_status(self, fault_name, seg_id=None, role=None):
-        status = self.filereputil.check_fault_status(fault_name = fault_name, status ='triggered', max_cycle=20, role=role, seg_id=seg_id)
+        status = self.filereputil.check_fault_status(fault_name = fault_name, max_cycle=20, role=role, seg_id=seg_id)
         self.assertTrue(status, 'The fault is not triggered in the time expected')
 
     def incremental_recoverseg(self):

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/__init__.py
@@ -60,7 +60,7 @@ class PgtwoPhaseClass(MPPTestCase):
         @param fault_type : type of fault to ne suspended
         '''
         if fault_type == 'end_prepare_two_phase_sleep':
-            self.filereputil.inject_fault(f='end_prepare_two_phase_sleep', sleeptime='1000', y='sleep', r='primary', p=self.port)
+            self.filereputil.inject_fault(f='end_prepare_two_phase_sleep', sleeptime='1000', y='sleep', r='primary', p=self.port, o='0')
             tinctest.logger.info('Injected fault to sleep in end_prepare_two_phase')
 
         elif fault_type == 'abort':
@@ -184,7 +184,7 @@ class PgtwoPhaseClass(MPPTestCase):
         if fault_type == None:
             return self.get_trigger_status_old(trigger_count);
 
-        return self.filereputil.check_fault_status(fault_name=fault_type, status="triggered", seg_id='1', num_times_hit=trigger_count);
+        return self.filereputil.check_fault_status(fault_name=fault_type, seg_id='1', num_times_hit=trigger_count);
 
     def check_trigger_sql_hang(self, test_dir, fault_type = None):
         '''

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/transaction_management/crashrecovery/test_crashrecovery.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/transaction_management/crashrecovery/test_crashrecovery.py
@@ -109,7 +109,7 @@ class CrashRecovery_2PC(TINCTestCase):
         self.proc = cmd.runNoWait()
         tinctest.logger.info("runNoWait: %s, pid: %d" % (cmd.cmdStr, self.proc.pid))
 
-        commitBlocked = self.filereputil.check_fault_status(fault_name='dtm_xlog_distributed_commit', status="triggered", seg_id='1', num_times_hit=1);
+        commitBlocked = self.filereputil.check_fault_status(fault_name='dtm_xlog_distributed_commit', seg_id='1', num_times_hit=1);
 
         # Shutdown of primary (and mirror) should happen only after
         # the commit is blocked due to suspend fault.

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/__init__.py
@@ -38,11 +38,8 @@ class Reindex():
 
         return self.util.inject_fault(f=fault_, m=mode_ , y=operation_, r =prim_mirr_, seg_id= seg_id_, H='ALL', table=table_)
 
-    def check_fault_status(self, fault_name_ = None, status_ = None, seg_id_ = 1, max_cycle_=10):
-        if (fault_name_ is None or status_ is None):
-            raise Exception('Incorrect parameters provided for inject fault')
-
-        return self.util.check_fault_status(fault_name=fault_name_, status=status_, seg_id=seg_id_, max_cycle=max_cycle_)
+    def check_fault_status(self, fault_name_ = None, seg_id_ = 1, max_cycle_=10):
+        return self.util.check_fault_status(fault_name=fault_name_, seg_id=seg_id_, max_cycle=max_cycle_)
 
     def do_gpcheckcat(self):
         dbstate = GpdbVerify()

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/scenario/test_scenario.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/scenario/test_scenario.py
@@ -57,7 +57,7 @@ class drop_obj(SQLTestCase):
     def setUp(self):
         super(drop_obj, self).setUp()
         self.util = Reindex()
-        self.util.check_fault_status(fault_name_ = "reindex_db", status_ = "triggered", seg_id_ = 1,  max_cycle_ = 20)
+        self.util.check_fault_status(fault_name_ = "reindex_db", seg_id_ = 1, max_cycle_ = 20)
 
     def tearDown(self):
         self.util.inject_fault(operation_ = "reset", fault_ = "reindex_db", mode_ = "async", prim_mirr_ = "primary", seg_id_ = 1)
@@ -90,7 +90,7 @@ class add_index(SQLTestCase):
     def setUp(self):
         super(add_index, self).setUp()
         self.util = Reindex()
-        self.util.check_fault_status(fault_name_ = "reindex_relation", status_ = "triggered", seg_id_ = 1,  max_cycle_ = 20)
+        self.util.check_fault_status(fault_name_ = "reindex_relation", seg_id_ = 1, max_cycle_ = 20)
 
     def tearDown(self):
         self.util.inject_fault(operation_ = "reset", fault_ = "reindex_relation", mode_ = "async", prim_mirr_ = "primary", seg_id_ = 1)
@@ -151,7 +151,7 @@ class insert_tup_gpfastseq(SQLTestCase):
     def setUp(self):
         super(insert_tup_gpfastseq, self).setUp()
         self.util = Reindex()
-        self.util.check_fault_status(fault_name_ = "reindex_relation", status_ = "triggered", seg_id_ = 1,  max_cycle_ = 20)
+        self.util.check_fault_status(fault_name_ = "reindex_relation", seg_id_ = 1, max_cycle_ = 20)
 
     def tearDown(self):
         self.util.inject_fault(operation_ = "reset", fault_ = "reindex_relation", mode_ = "async", prim_mirr_ = "primary", seg_id_ = 1)
@@ -192,7 +192,7 @@ class reset_fault(SQLTestCase):
         ans = False
         while ctr < 10:
             ctr += 1
-            ans = self.util.check_fault_status(fault_name_ = "reindex_relation", status_ = "triggered", seg_id_ = 1,  max_cycle_ = 20)
+            ans = self.util.check_fault_status(fault_name_ = "reindex_relation", seg_id_ = 1, max_cycle_ = 20)
             if ans == True:
                 ans2=self.util.inject_fault(operation_ = "reset", fault_ = "reindex_relation", mode_ = "async", prim_mirr_ = "primary", seg_id_ = 1)
                 if ans2[0] == True:

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/test_crossexec.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/test_crossexec.py
@@ -80,7 +80,7 @@ class test_crossexec(SQLTestCase):
         triggered = False
         filereputil = Filerepe2e_Util()
         while poll < 10 and not triggered:
-            status = 'triggered'
+            status = 'completed'
             (ok, out) = filereputil.inject_fault(f=fault_name, y='status', seg_id='1')
             for line in out.splitlines():
                 if line.find(fault_name) > 0 and line.find(status) > 0:

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/basebackup/test_xlog_cleanup.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/basebackup/test_xlog_cleanup.py
@@ -58,7 +58,7 @@ class basebackup_cases(mpp.gpdb.tests.storage.walrepl.run.StandbyRunMixin, MPPTe
 
     def wait_triggered(self, fault_name):
 
-        search = "fault injection state:'triggered'"
+        search = "fault injection state:'completed'"
         for i in walrepl.polling(10, 3):
             result = self.fault_status(fault_name)
             stdout = result.stdout

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/lib/fault.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/lib/fault.py
@@ -38,7 +38,7 @@ class Gpfault(object):
 
     def wait_triggered(self, fault_name):
 
-        search = "fault injection state:'triggered'"
+        search = "fault injection state:'completed'"
         for i in walrepl.polling(10, 3):
             result = self.fault_status(fault_name)
             stdout = result.stdout

--- a/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
+++ b/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
@@ -109,27 +109,28 @@ class Filerepe2e_Util():
             return (ok,out)
        
     
-    def check_fault_status(self,fault_name = None, status = None, max_cycle=20, role='primary', seg_id=None, num_times_hit = None):
-        ''' 
+    def check_fault_status(self,fault_name = None, max_cycle=20, role='primary', seg_id=None, num_times_hit = None):
+        '''
         Check whether a fault is triggered. Poll till the fault is triggered
         @param name : Fault name
-        @param status : Status to be checked - triggered/completed
         @param seg_id : db_id of the segment
         '''
-        if (not fault_name) or (not status) :
-            self.fail("Need a value for fault_name and status to continue")
-    
+        if not fault_name:
+            self.fail("Need a value for fault_name to continue")
+
         poll =0
         while(poll < max_cycle):
             (ok, out) = self.inject_fault(f=fault_name, y='status', r=role, seg_id=seg_id)
             poll +=1
             for line in out.splitlines():
-                if line.find(fault_name) > 0 and line.find(status) > 0 :
-                    if num_times_hit and line.find("num times hit:'%d'" % num_times_hit) < 0 :
+                if (line.find(fault_name) > 0 and
+                    (line.find("completed") > 0 or
+                     line.find("triggered") > 0)):
+                    if num_times_hit and line.find("num times hit:'%d'" % num_times_hit) < 0:
                         tinctest.logger.info('Fault not hit num of times %d line %s ' % (num_times_hit,line))
                         continue
                     if num_times_hit:
-                        tinctest.logger.info('Fault %s is %s num_times_hit %d' % (fault_name,status, num_times_hit))
+                        tinctest.logger.info('Fault %s is triggered num_times_hit %d' % (fault_name, num_times_hit))
                     poll = 0 
                     return True
             #sleep a while before start polling again


### PR DESCRIPTION
Faultinjector on master is enhanced with ability to specify the exact number of times a fault can trigger.  This patch set imports the enhancement and adjusts ICW and TINC tests accordingly.

Notable differences, specific to 5X_STABLE:
* Backward compatibility: The new faultinjector interface is suffixed with `_new()`.  E.g. `gp_inject_fault_new()`.  The meaning of existing faultinjector interface is unchanged in order to minimize changes to existing tests.  Existing interface is just a wrapper over the new interface.
* To backport a test that uses new functionality from master, replace `gp_inject_fault()` with `gp_inject_fault_new()`.