### PR TITLE
Added a GPDB_92_MERGE_FIXME to avoid compilation failure

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -776,7 +776,8 @@ CDXLNode *
 CTranslatorQueryToDXL::PdxlnCTAS()
 {
 	GPOS_ASSERT(CMD_SELECT == m_pquery->commandType);
-	GPOS_ASSERT(NULL != m_pquery->intoClause);
+	// GPDB_92_MERGE_FIXME: we should plumb through the intoClause
+//	GPOS_ASSERT(NULL != m_pquery->intoClause);
 
 	m_fCTASQuery = true;
 	CDXLNode *pdxlnQuery = PdxlnFromQueryInternal();


### PR DESCRIPTION
Query node now doesnot have intoClause, it has been commented during the
92 merge, so doing the same to fix compilation issues with assert /
debug enabled.