### PR TITLE
Add test case for UNION of setop queries

### DIFF
--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -1869,6 +1869,22 @@ UNION SELECT 300, 300)
               2
 (1 row)
 
+CREATE TABLE t1_setop(a int) DISTRIBUTED BY (a);
+CREATE TABLE t2_setop(a int) DISTRIBUTED BY (a);
+INSERT INTO t1_setop VALUES (1), (2), (3);
+INSERT INTO t2_setop VALUES (3), (4), (5);
+(SELECT a FROM t1_setop EXCEPT SELECT a FROM t2_setop ORDER BY a)
+UNION
+(SELECT a FROM t2_setop EXCEPT SELECT a FROM t1_setop ORDER BY a)
+ORDER BY a;
+ a 
+---
+ 1
+ 2
+ 4
+ 5
+(4 rows)
+
 --
 -- Clean up
 --

--- a/src/test/regress/sql/union_gp.sql
+++ b/src/test/regress/sql/union_gp.sql
@@ -511,6 +511,15 @@ UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select c1 from T_random) order by 1;', 'APPEND');
 
+CREATE TABLE t1_setop(a int) DISTRIBUTED BY (a);
+CREATE TABLE t2_setop(a int) DISTRIBUTED BY (a);
+INSERT INTO t1_setop VALUES (1), (2), (3);
+INSERT INTO t2_setop VALUES (3), (4), (5);
+(SELECT a FROM t1_setop EXCEPT SELECT a FROM t2_setop ORDER BY a)
+UNION
+(SELECT a FROM t2_setop EXCEPT SELECT a FROM t1_setop ORDER BY a)
+ORDER BY a;
+
 --
 -- Clean up
 --


### PR DESCRIPTION
Queries of the form would fail due to a tripped assertion
```
explain (select a from foo except select a from foo order by a) UNION (select a from foo except select a from foo order by a);
FATAL:  Unexpected internal error (analyze.c:2393)
DETAIL:  FailedAssertion("!(pstate->p_setopTypes && pstate->p_setopTypmods)", File: "analyze.c", Line: 2393)
HINT:  Process 98860 will wait for gp_debug_linger=120 seconds before termination.
```

The commit 352362a which refactored the way the types of the columns are
determined in UNION queries fixes the issue. This test is to ensure that the
issue is fixed.