### PR TITLE
ORCA should not fallback when ONLY clause is used with external tables

### DIFF
--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -141,3 +141,38 @@ SELECT * FROM homer;
  4 | 3 | 44
 (4 rows)
 
+-- ORCA should not fallback when ONLY clause is used on external tables
+-- start_ignore
+DROP TABLE IF EXISTS t1;
+NOTICE:  table "t1" does not exist, skipping
+DROP TABLE IF EXISTS ext_table_no_fallback;
+NOTICE:  table "ext_table_no_fallback" does not exist, skipping
+CREATE TABLE heap_t1 (a int, b int) DISTRIBUTED BY (b);
+CREATE EXTERNAL TABLE ext_table_no_fallback (a int, b int) LOCATION ('gpfdist://myhost:8080/test.csv') FORMAT 'CSV';
+-- end_ignore
+EXPLAIN SELECT * FROM ext_table_no_fallback;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..11000.00 rows=1000000 width=8)
+   ->  External Scan on ext_table_no_fallback  (cost=0.00..11000.00 rows=333334 width=8)
+ Optimizer: legacy query optimizer
+(3 rows)
+
+EXPLAIN SELECT * FROM ONLY ext_table_no_fallback;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..11000.00 rows=1000000 width=8)
+   ->  External Scan on ext_table_no_fallback  (cost=0.00..11000.00 rows=333334 width=8)
+ Optimizer: legacy query optimizer
+(3 rows)
+
+EXPLAIN INSERT INTO heap_t1 SELECT * FROM ONLY ext_table_no_fallback;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Insert on heap_t1  (cost=0.00..11000.00 rows=333334 width=8)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..11000.00 rows=333334 width=8)
+         Hash Key: ext_table_no_fallback.b
+         ->  External Scan on ext_table_no_fallback  (cost=0.00..11000.00 rows=333334 width=8)
+ Optimizer: legacy query optimizer
+(5 rows)
+

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -170,3 +170,39 @@ SELECT * FROM homer;
  4 | 3 | 44
 (4 rows)
 
+-- ORCA should not fallback when ONLY clause is used on external tables
+-- start_ignore
+DROP TABLE IF EXISTS t1;
+NOTICE:  table "t1" does not exist, skipping
+DROP TABLE IF EXISTS ext_table_no_fallback;
+NOTICE:  table "ext_table_no_fallback" does not exist, skipping
+CREATE TABLE heap_t1 (a int, b int) DISTRIBUTED BY (b);
+CREATE EXTERNAL TABLE ext_table_no_fallback (a int, b int) LOCATION ('gpfdist://myhost:8080/test.csv') FORMAT 'CSV';
+-- end_ignore
+EXPLAIN SELECT * FROM ext_table_no_fallback;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..472.74 rows=1000000 width=8)
+   ->  External Scan on ext_table_no_fallback  (cost=0.00..437.97 rows=333334 width=8)
+ Optimizer: PQO version 2.67.0
+(3 rows)
+
+EXPLAIN SELECT * FROM ONLY ext_table_no_fallback;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..472.74 rows=1000000 width=8)
+   ->  External Scan on ext_table_no_fallback  (cost=0.00..437.97 rows=333334 width=8)
+ Optimizer: PQO version 2.67.0
+(3 rows)
+
+EXPLAIN INSERT INTO heap_t1 SELECT * FROM ONLY ext_table_no_fallback;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Insert  (cost=0.00..16080.27 rows=333334 width=8)
+   ->  Result  (cost=0.00..455.27 rows=333334 width=12)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..451.27 rows=333334 width=8)
+               Hash Key: ext_table_no_fallback.b
+               ->  External Scan on ext_table_no_fallback  (cost=0.00..437.97 rows=333334 width=8)
+ Optimizer: PQO version 2.67.0
+(6 rows)
+

--- a/src/test/regress/sql/qp_orca_fallback.sql
+++ b/src/test/regress/sql/qp_orca_fallback.sql
@@ -74,3 +74,14 @@ SELECT * FROM homer;
 
 DELETE FROM ONLY homer WHERE a = 3;
 SELECT * FROM homer;
+
+-- ORCA should not fallback when ONLY clause is used on external tables
+-- start_ignore
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS ext_table_no_fallback;
+CREATE TABLE heap_t1 (a int, b int) DISTRIBUTED BY (b);
+CREATE EXTERNAL TABLE ext_table_no_fallback (a int, b int) LOCATION ('gpfdist://myhost:8080/test.csv') FORMAT 'CSV';
+-- end_ignore
+EXPLAIN SELECT * FROM ext_table_no_fallback;
+EXPLAIN SELECT * FROM ONLY ext_table_no_fallback;
+EXPLAIN INSERT INTO heap_t1 SELECT * FROM ONLY ext_table_no_fallback;


### PR DESCRIPTION
As part of commit a3f7f4d71, fallback was introduced if the query
contained ONLY clause for relations. However, it should exclude external
tables as they as well invoke PdxlnFromRelation for query to dxl
translation. For external tables inh is set to false always.
This commit fixes the issue by excluding external tables from the check
of ONLY clause, and adds relevant test cases.