### PR TITLE
Remove gp_dev_notice_agg_cost GUC

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -899,8 +899,6 @@ cdb_grouping_planner(PlannerInfo *root,
 	if (consider_agg & AGG_1PHASE)
 	{
 		cost_1phase_aggregation(root, &ctx, &plan_1p);
-		if (gp_dev_notice_agg_cost)
-			elog(NOTICE, "1-phase cost: %.6f", plan_1p.plan_cost);
 		if (plan_info == NULL || plan_info->plan_cost > plan_1p.plan_cost)
 			plan_info = &plan_1p;
 	}
@@ -908,8 +906,6 @@ cdb_grouping_planner(PlannerInfo *root,
 	if (consider_agg & (AGG_2PHASE | AGG_2PHASE_DQA))
 	{
 		cost_2phase_aggregation(root, &ctx, &plan_2p);
-		if (gp_dev_notice_agg_cost)
-			elog(NOTICE, "2-phase cost: %.6f", plan_2p.plan_cost);
 		if (plan_info == NULL || plan_info->plan_cost > plan_2p.plan_cost)
 			plan_info = &plan_2p;
 	}
@@ -917,8 +913,6 @@ cdb_grouping_planner(PlannerInfo *root,
 	if (consider_agg & AGG_3PHASE)
 	{
 		cost_3phase_aggregation(root, &ctx, &plan_3p);
-		if (gp_dev_notice_agg_cost)
-			elog(NOTICE, "3-phase cost: %.6f", plan_3p.plan_cost);
 		if (plan_info == NULL || !enable_groupagg || plan_info->plan_cost > plan_3p.plan_cost)
 			plan_info = &plan_3p;
 	}

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -320,12 +320,6 @@ int			gp_autostats_on_change_threshold = 100000;
 bool		log_autostats = true;
 
 /* --------------------------------------------------------------------------------------------------
- * Miscellaneous developer use
- */
-
-bool		gp_dev_notice_agg_cost = false;
-
-/* --------------------------------------------------------------------------------------------------
  * Server debugging
  */
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -902,17 +902,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_dev_notice_agg_cost", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Trace aggregate costing decisions as NOTICEs."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_dev_notice_agg_cost,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"gp_enable_explain_allstat", PGC_USERSET, CLIENT_CONN_OTHER,
 			gettext_noop("Experimental feature: dump stats for all segments in EXPLAIN ANALYZE."),
 			NULL,

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -871,21 +871,6 @@ extern bool	log_autostats;
 
 
 /* --------------------------------------------------------------------------------------------------
- * Miscellaneous developer use
- */
-
-/*
- * gp_dev_notice_agg_cost (bool)
- *
- * Issue aggregation optimizer cost estimates as NOTICE level messages
- * during GPDB aggregation planning.  This is intended to facilitate
- * tuning the cost algorithm.  The presence of this switch should not
- * be published.  The name is intended to suggest that it is for developer
- * use only.
- */
-extern bool  gp_dev_notice_agg_cost;
-
-/* --------------------------------------------------------------------------------------------------
  * Server debugging
  */
 


### PR DESCRIPTION
This GUC was purely for developer use, but can just as well be replaced by the developer inserting the desired `elog()` calls when hacking.

Discussion: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/L_UX23R6goI