### PR TITLE
Fix syntax in START TRANSACTION documentation

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/START_TRANSACTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/START_TRANSACTION.xml
@@ -7,8 +7,9 @@
         <p id="sql_command_desc">Starts a transaction block.</p>
         <section id="section2">
             <title>Synopsis</title>
-            <codeblock id="sql_command_synopsis">START TRANSACTION [SERIALIZABLE | READ COMMITTED | READ UNCOMMITTED]
-                  [READ WRITE | READ ONLY]</codeblock>
+            <codeblock id="sql_command_synopsis">START TRANSACTION [<varname>transaction_mode</varname>] [READ WRITE | READ ONLY]</codeblock>
+            <p>where <varname>transaction_mode</varname> is one of:</p>
+            <codeblock>   ISOLATION LEVEL {SERIALIZABLE | READ COMMITTED | READ UNCOMMITTED}</codeblock>
         </section>
         <section id="section3">
             <title>Description</title>


### PR DESCRIPTION
The START TRANSACTION commands requires the ISOLATION LEVEL keywords
before the actual transaction isolation name.

@dyozie I hacked blind without testing this diff locally, but I think it's somewhat sane syntactically.