### PR TITLE
Fix Path for ICG used in ORCA pipeline

### DIFF
--- a/concourse/scripts/builds/GpBuild.py
+++ b/concourse/scripts/builds/GpBuild.py
@@ -49,7 +49,7 @@ class GpBuild(GpdbBuildBase):
         if option == 'world':
             return self.run_install_check_with_command('make installcheck-world')
         else:
-            return self.run_install_check_with_command('make -C src/test installcheck-good')
+            return self.run_install_check_with_command('make -C src/test/regress installcheck-good')
 
     def run_install_check_with_command(self, make_command):
         return subprocess.call([


### PR DESCRIPTION
Currently the code runs the ICG test with path src/test:
```
bchaudhary ~/workspace/gpdb [fix-icg-path]: make -C src/test/ installcheck-good
make: Nothing to be done for `installcheck-good'.
```

But with the recent changes in gpdb, it appears that this path should be `src/test/regress`, so updating the scripts. 
```
bchaudhary ~/workspace/gpdb [fix-icg-path]: make -C src/test/regress installcheck-good
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C ../../../src/port all
rm -rf ./testtablespace ./testtablespace_otherloc
./checkinc.py
mkdir ./testtablespace ./testtablespace_otherloc
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C  hooktest
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C  query_info_hook_test
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C ../backend submake-errcodes
make[1]: Nothing to be done for `all'.
make[1]: Nothing to be done for `all'.
make[2]: Nothing to be done for `submake-errcodes'.
Greenplum INCLUDEDIR:    /usr/local/gpdb/include
Greenplum PKGINCLUDEDIR: /usr/local/gpdb/include/postgresql
Checking includes...
Include files are ok
../../../src/test/regress/pg_regress --inputdir=. --psqldir='/usr/local/gpdb/bin'   --dlpath=. --init-file=./init_file   --schedule=./parallel_schedule --schedule=./greenplum_schedule --ao-dir=uao
(using postmaster on Bhuvneshs-MacBook-Pro.local, port 15432)
============== dropping database "regression"         ==============
DROP DATABASE
============== creating database "regression"         ==============
CREATE DATABASE
ALTER DATABASE
============== checking optimizer status              ==============
Optimizer enabled. Using optimizer answer files whenever possible
============== checking gp_resource_manager status    ==============
Resource group disabled. Using default answer files
============== running regression test queries        ==============
test tablespace               ... ok (1.46 sec)  (diff:0.11 sec)
parallel group (18 tests):
...
```