### PR TITLE
Add missing break in switch.

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -293,6 +293,7 @@ restrict_and_check_grant(bool is_grant, AclMode avail_goptions, bool all_privs,
 			break;
 		case ACL_KIND_EXTPROTOCOL:
 			whole_mask = ACL_ALL_RIGHTS_EXTPROTOCOL;
+			break;
 		case ACL_KIND_TYPE:
 			whole_mask = ACL_ALL_RIGHTS_TYPE;
 			break;

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -788,6 +788,7 @@ acldefault(GrantObjectType objtype, Oid ownerId)
 		case ACL_OBJECT_EXTPROTOCOL:
 			world_default = ACL_NO_RIGHTS;
 			owner_default = ACL_ALL_RIGHTS_EXTPROTOCOL;
+			break;
 		case ACL_OBJECT_DOMAIN:
 		case ACL_OBJECT_TYPE:
 			world_default = ACL_USAGE;

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -2807,6 +2807,8 @@ log_line_prefix(StringInfo buf, ErrorData *edata)
 						if (subXid >= FirstNormalTransactionId)
 							appendStringInfo(buf, ", sx%u, ", subXid);
 					}
+
+					break;
 				}
 			case 'e':
 				appendStringInfoString(buf, unpack_sql_state(edata->sqlerrcode));

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1320,6 +1320,7 @@ ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increme
 						costThesholdOvercommitted = true;
 					}
 				}
+				break;
 
 			case RES_MEMORY_LIMIT:
 				{

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -198,6 +198,7 @@ ALTER PROTOCOL demoprot_untrusted OWNER TO extprotu; -- should fail. protocol is
 GRANT SELECT ON PROTOCOL demoprot_untrusted TO extprotu; -- should fail. protocol is not trusted
 GRANT SELECT ON PROTOCOL demoprot TO extprotu;
 GRANT INSERT ON PROTOCOL demoprot TO extprotu;
+SELECT ptcname, ptcacl FROM PG_EXTPROTOCOL WHERE ptcname = 'demoprot';
 SET SESSION AUTHORIZATION extprotu;
 
 CREATE WRITABLE EXTERNAL TABLE ext_w(a int) location('demoprot://demoprotfile.txt') format 'text'; -- should succeed

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -248,6 +248,12 @@ ERROR:  protocol "demoprot_untrusted" is not trusted
 HINT:  Only superusers may use untrusted protocols.
 GRANT SELECT ON PROTOCOL demoprot TO extprotu;
 GRANT INSERT ON PROTOCOL demoprot TO extprotu;
+SELECT ptcname, ptcacl FROM PG_EXTPROTOCOL WHERE ptcname = 'demoprot';
+ ptcname  |                  ptcacl                  
+----------+------------------------------------------
+ demoprot | {gpadmin=ar/gpadmin,extprotu=ar/gpadmin}
+(1 row)
+
 SET SESSION AUTHORIZATION extprotu;
 CREATE WRITABLE EXTERNAL TABLE ext_w(a int) location('demoprot://demoprotfile.txt') format 'text'; -- should succeed
 -- For tables using custom protocol should have dependency


### PR DESCRIPTION
These were detected by compiler option -Wimplicit-fallthrough (gcc 7.x).
Some of these issues are introduced by git merge during postgres merge.

We've seen similar cases (missing break) several times so we probably
want this compiler option as the default in the future after we modify
code to remove all or most false alarms. Before that, we will need to
run with this option locally during postgres merge.