### PR TITLE
Remove GPDB_92_MERGE_FIXME in cdbpath.c

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -1480,10 +1480,7 @@ cdbpath_dedup_fixup_baserel(Path *path, CdbpathDedupFixupContext *ctx)
 	}
 
 	/* Add these vars to the rel's list of result columns. */
-	/* GPDB_92_MERGE_FIXME: set create_new_ph as true or false?
-	 * I'm setting it as safe value true here.
-	 */
-	add_vars_to_targetlist(ctx->root, rowid_vars, ctx->distinct_on_rowid_relids, true);
+	add_vars_to_targetlist(ctx->root, rowid_vars, ctx->distinct_on_rowid_relids, false);
 
 	/* Recalculate width of the rel's result rows. */
 	set_rel_width(ctx->root, rel);


### PR DESCRIPTION
Remove GPDB_92_MERGE_FIXME in cdbpath.c and change create_new_ph from
'true' to false.

When the function 'add_vars_to_targetlist' is called. The param 'create_new_ph'
should be true before deconstruct_jointree, and false after that. The funtion
'cdbpath_dedup_fixup_baserel' is always called after deconstruct_jointree. So
it should be false.