### PR TITLE
Enable gpmapreduce debugging and remove GUC in core

### DIFF
--- a/gpAux/extensions/gpmapreduce/Makefile
+++ b/gpAux/extensions/gpmapreduce/Makefile
@@ -43,10 +43,6 @@ all: submake-libpq gpmapreduce all-lib
 gpmapreduce: $(MAPREDOBJS) $(libpq_builddir)/libpq.a
 	$(CC) $(CFLAGS) $(MAPREDOBJS) $(libpq_pgport) $(LDFLAGS) $(LIBS) -o $@$(X)
 
-internal:
-	rm -f $(SRCDIR)/mapred.o $(SRCDIR)/main.o
-	$(MAKE) CFLAGS="-DINTERNAL_BUILD $(CFLAGS)" all
-
 $(SRCDIR)/yaml_scan.c: $(SRCDIR)/yaml_parse.h $(SRCDIR)/yaml_scan.l
 ifdef FLEX
 	cd $(SRCDIR) ; \

--- a/gpAux/extensions/gpmapreduce/src/main.c
+++ b/gpAux/extensions/gpmapreduce/src/main.c
@@ -66,6 +66,10 @@ void usage(char *procname, boolean full)
 			"  -p | --port <port>            database server port\n"
 			"  -U | --username <username>    database user name\n"
 			"  -W | --password               prompt for password\n"
+			"\n"
+			"Debug options:\n"
+			"  -D | --debug                  enable some debugging output\n"
+			"  -P | --print                  print-only mode, do not run jobs\n"
 			);
 	}
 }
@@ -105,18 +109,12 @@ int main (int argc, char *argv[])
 		{"port",     required_argument, 0, 'p'},
 		{"file",     required_argument, 0, 'f'},
 		{"key",      required_argument, 0, 'k'},
-#ifdef INTERNAL_BUILD
 		{"print",    no_argument,       0, 'P'},
 		{"debug",    no_argument,       0, 'D'},
-#endif
 		{0, 0, 0, 0}
 	};
 
-#ifdef INTERNAL_BUILD
 	static char* short_options = "VvWxXU:h:p:f:k:?PD";
-#else
-	static char* short_options = "VvWxXU:h:p:f:k:?";
-#endif
 
 	while (1)
 	{
@@ -158,15 +156,13 @@ int main (int argc, char *argv[])
 				global_explain_flag |= global_explain | global_analyze;
 				break;
 
-#ifdef INTERNAL_BUILD
-			case 'P':  /* --print (INTERNAL_BUILD only) */
+			case 'P':  /* --print */
 				global_print_flag = 1;
 				break;
 
-			case 'D':  /* --debug (INTERNAL_BUILD only) */
+			case 'D':  /* --debug */
 				global_debug_flag = 1;
 				break;
-#endif
 
 			case 'W':  /* --password */
 				forceprompt = true;

--- a/gpAux/extensions/gpmapreduce/src/mapred.c
+++ b/gpAux/extensions/gpmapreduce/src/mapred.c
@@ -111,19 +111,15 @@ void *mapred_malloc(int size)
 	void *m;
 	XASSERT(size > 0);
 
-#ifdef INTERNAL_BUILD
 	if (global_debug_flag && global_verbose_flag)
 		fprintf(stderr, "Allocating %d bytes: ", size);
-#endif
 
 	m = malloc(size);
 	if (!m)
 		XRAISE(MEMORY_ERROR, "Memory allocation failure");
 
-#ifdef INTERNAL_BUILD
 	if (global_debug_flag && global_verbose_flag)
 		fprintf(stderr, "%p\n", m);
-#endif
 
 	return m;
 }
@@ -135,10 +131,8 @@ void mapred_free(void *ptr)
 {
 	XASSERT(ptr);
 
-#ifdef INTERNAL_BUILD
 	if (global_debug_flag && global_verbose_flag)
 		fprintf(stderr, "Freeing memory: %p\n", ptr);
-#endif
 
 	free(ptr);
 }
@@ -1052,16 +1046,6 @@ void mapred_run_document(PGconn *conn, mapred_document_t *doc)
 
 	XTRY
 	{
-
-		/*
-		 * Setting gp_mapreduce_define will disable logging of sql
-		 * statements.
-		 */
-#ifndef INTERNAL_BUILD
-		result = PQexec(conn, "set gp_mapreduce_define=true");
-		PQclear(result);
-#endif
-
 		/*
 		 * By running things within a transaction we can effectively
 		 * obscure the mapreduce sql definitions.  They could still
@@ -1150,14 +1134,6 @@ void mapred_run_document(PGconn *conn, mapred_document_t *doc)
 
 		} while (!done);
 
-		/*
-		 * Re-enable statement logging before we try running queries
-		 */
-#ifndef INTERNAL_BUILD
-		result = PQexec(conn, "set gp_mapreduce_define=false");
-		PQclear(result);
-#endif
-
 		/* objects created, execute queries */
 		mapred_run_queries(conn, doc);
 	}
@@ -1170,15 +1146,6 @@ void mapred_run_document(PGconn *conn, mapred_document_t *doc)
 	}
 	XFINALLY
 	{
-
-		/*
-		 * disable statement logging before deleting objects
-		 */
-#ifndef INTERNAL_BUILD
-		result = PQexec(conn, "set gp_mapreduce_define=true");
-		PQclear(result);
-#endif
-
 		/* Remove all the objects that we created */
 		if (global_print_flag || global_debug_flag)
 			printf("\n");

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -295,9 +295,6 @@ bool		gp_enable_fast_sri = true;
 /* Enable single-mirror pair dispatch. */
 bool		gp_enable_direct_dispatch = true;
 
-/* Disable logging while creating mapreduce objects */
-bool		gp_mapreduce_define = false;
-
 /* Force core dump on memory context error */
 bool		coredump_on_memerror = false;
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1204,7 +1204,7 @@ exec_mpp_query(const char *query_string,
 	}
 
 
-	if (log_statement != LOGSTMT_NONE && !gp_mapreduce_define)
+	if (log_statement != LOGSTMT_NONE)
 	{
 		/*
 		 * TODO need to log SELECT INTO as DDL
@@ -2829,10 +2829,6 @@ check_log_statement(List *stmt_list)
 {
 	ListCell   *stmt_item;
 
-	/* Disable statement logging during mapreduce */
-	if (gp_mapreduce_define)
-		return false;
-
 	if (log_statement == LOGSTMT_NONE)
 		return false;
 	if (log_statement == LOGSTMT_ALL)
@@ -2868,10 +2864,6 @@ check_log_statement(List *stmt_list)
 int
 check_log_duration(char *msec_str, bool was_logged)
 {
-	/* Disable statement logging during mapreduce */
-	if (gp_mapreduce_define)
-		return 0;
-
 	if (log_duration || log_min_duration_statement >= 0)
 	{
 		long		secs;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1784,18 +1784,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_mapreduce_define", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Prepare mapreduce object creation"),	/* turn off statement
-																 * logging */
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NO_RESET_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_GPDB_ADDOPT
-		},
-		&gp_mapreduce_define,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"coredump_on_memerror", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Generate core dump on memory error."),
 			NULL,

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -835,8 +835,6 @@ extern int gp_workfile_bytes_to_checksum;
 /* The type of work files that HashJoin should use */
 extern int gp_workfile_type_hashjoin;
 
-/* Disable logging while creating mapreduce views */
-extern bool gp_mapreduce_define;
 extern bool coredump_on_memerror;
 
 /*


### PR DESCRIPTION
The `gp_mapred_define` GUC was intended to control statement logging during gpmapreduce debugging, but it could only be twiddled in the gpmapreduce code with a specialized debug build. This hardly seems worth to keep an extension GUC in core for, with tests for it in reasonably hot codepaths, so remove it.

While at it, enable the debugging tools in gpmapreduce from normal builds since they are harmless and could potentially be useful.