### PR TITLE
Fix misplaced right paren bugs in pgstatfuncs.c.

### DIFF
--- a/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/backend/utils/adt/pgstatfuncs.c
@@ -645,7 +645,6 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 		bool		nulls[19];
 		HeapTuple	tuple;
 		PgBackendStatus *beentry;
-		SockAddr	zero_clientaddr;
 
 		MemSet(values, 0, sizeof(values));
 		MemSet(nulls, 0, sizeof(nulls));
@@ -686,6 +685,8 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 		/* Values only available to same user or superuser */
 		if (superuser() || beentry->st_userid == GetUserId())
 		{
+			SockAddr	zero_clientaddr;
+
 			switch (beentry->st_state)
 			{
 				case STATE_IDLE:
@@ -744,7 +745,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 			/* A zeroed client addr means we don't know */
 			memset(&zero_clientaddr, 0, sizeof(zero_clientaddr));
 			if (memcmp(&(beentry->st_clientaddr), &zero_clientaddr,
-					   sizeof(zero_clientaddr) == 0))
+					   sizeof(zero_clientaddr)) == 0)
 			{
 				nulls[11] = true;
 				nulls[12] = true;


### PR DESCRIPTION
This backports a133bf7031ad5b62281b21dbd6b2097d3d400f0d from upstream, not because there is an immediate rush with backporting it but because it shows up as a compiler warning and an annnoying Coverity defect. Patch applied cleanly with `git cherry-pick`.
```
commit a133bf7031ad5b62281b21dbd6b2097d3d400f0d
Author: Kevin Grittner <kgrittn@postgresql.org>
Date:   Fri Dec 27 15:26:24 2013 -0600

    Fix misplaced right paren bugs in pgstatfuncs.c.

    The bug would only show up if the C sockaddr structure contained
    zero in the first byte for a valid address; otherwise it would
    fail to fail, which is probably why it went unnoticed for so long.

    Patch submitted by Joel Jacobson after seeing an article by Andrey
    Karpov in which he reports finding this through static code
    analysis using PVS-Studio.  While I was at it I moved a definition
    of a local variable referenced in the buggy code to a more local
    context.

    Backpatch to all supported branches.
```