### PR TITLE
Remove FIXME for unsupported features

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -553,7 +553,7 @@ gpdb::OidExprCollation
 	{
 		if (pnodeExpr && IsA(pnodeExpr, List))
 		{
-			// GDPB_91_MERGE_FIXME: collation
+			// GPORCA currently does not support collations, so infer them using type defaults
 			List *exprlist = (List *) pnodeExpr;
 			ListCell   *lc;
 
@@ -1899,7 +1899,7 @@ gpdb::PvarMakeVar
 {
 	GP_WRAP_START;
 	{
-		// GPDB_91_MERGE_FIXME: collation
+		// GPORCA currently does not support collations, so infer them using type defaults
 		Oid collation = OidTypeCollation(vartype);
 		return makeVar(varno, varattno, vartype, vartypmod, collation, varlevelsup);
 	}
@@ -2957,7 +2957,7 @@ gpdb::PexprEvaluate
 {
 	GP_WRAP_START;
 	{
-		// GPDB_91_MERGE_FIXME: collation
+		// GPORCA currently does not support collations, so infer them using type defaults
 		return evaluate_expr(pexpr, oidResultType, iTypeMod, InvalidOid);
 	}
 	GP_WRAP_END;

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1272,7 +1272,7 @@ CTranslatorDXLToPlStmt::PplanFunctionScanFromDXLTVF
 
 		pfuncscan->funccoltypes = gpdb::PlAppendOid(pfuncscan->funccoltypes, oidType);
 		pfuncscan->funccoltypmods = gpdb::PlAppendInt(pfuncscan->funccoltypmods, typMod);
-		// GDPB_91_MERGE_FIXME: collation
+		// GPORCA currently does not support collations, so infer them using type defaults
 		pfuncscan->funccolcollations = gpdb::PlAppendOid(pfuncscan->funccolcollations, typCollation);
 	}
 

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -559,9 +559,9 @@ CTranslatorRelcacheToDXL::Pmdrel
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
 	}
 
-	// GPDB_91_MERGE_FIXME - Orca does not support foreign data
 	if (RelationIsForeign(rel))
 	{
+		// GPORCA does not support foreign data wrappers
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Foreign Data"));
 	}
 

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -882,28 +882,18 @@ exprCollation(const Node *expr)
 			break;
 
 		case T_DMLActionExpr:
-			coll = InvalidOid;	/* GPDB_91_MERGE_FIXME: ORCA only expression */
-			break;
 		case T_PartSelectedExpr:
-			coll = InvalidOid;	/* GPDB_91_MERGE_FIXME: ORCA only expression */
-			break;
 		case T_PartDefaultExpr:
-			coll = InvalidOid;	/* GPDB_91_MERGE_FIXME: ORCA only expression */
-			break;
 		case T_PartBoundExpr:
-			coll = InvalidOid;	/* GPDB_91_MERGE_FIXME: ORCA only expression */
-			break;
 		case T_PartBoundInclusionExpr:
-			coll = InvalidOid;	/* GPDB_91_MERGE_FIXME: ORCA only expression */
-			break;
 		case T_PartBoundOpenExpr:
-			coll = InvalidOid;	/* GPDB_91_MERGE_FIXME: ORCA only expression */
-			break;
 		case T_PartListRuleExpr:
-			coll = InvalidOid;	/* GPDB_91_MERGE_FIXME: ORCA only expression */
-			break;
 		case T_PartListNullTestExpr:
-			coll = InvalidOid;	/* GPDB_91_MERGE_FIXME: ORCA only expression */
+			/*
+			 * ORCA currently does not support collation,
+			 * so return invalid oid for ORCA only expressions
+			 */
+			coll = InvalidOid;
 			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(expr));


### PR DESCRIPTION
GPORCA does not support collation and foreign data wrappers right now and will fallback to planner. So removing FIXMEs related to this.