### PR TITLE
Fix header file inclusion for PG_PRINTF_ATTRIBUTE in gpmapreduce

### DIFF
--- a/gpAux/extensions/gpmapreduce/include/mapred.h
+++ b/gpAux/extensions/gpmapreduce/include/mapred.h
@@ -1,6 +1,8 @@
 #ifndef MAPRED_H
 #define MAPRED_H
 
+#include <postgres_fe.h>
+
 #ifndef YAML_H
 #include <yaml.h>
 #endif

--- a/gpAux/extensions/gpmapreduce/src/mapred.c
+++ b/gpAux/extensions/gpmapreduce/src/mapred.c
@@ -6,7 +6,6 @@
 #include <stdarg.h>
 #include <unistd.h>     /* for file "access" test */
 #include <errno.h>
-#include "pg_config_manual.h"
 
 #define scalarfree(x)							\
 	do {										\

--- a/gpAux/extensions/gpmapreduce/src/parse.c
+++ b/gpAux/extensions/gpmapreduce/src/parse.c
@@ -7,7 +7,6 @@
 #include <yaml.h>
 
 #include <stdarg.h>
-#include "pg_config_manual.h"
 
 int mapred_parse_error(mapred_parser_t *parser, char *fmt, ...)
 	__attribute__((format(PG_PRINTF_ATTRIBUTE, 2, 3)));


### PR DESCRIPTION
Commit 8e60838c22735fcacabc125170fc1d removed `PG_PRINTF_ATTRIBUTE`  from `pg_config_manual.h`, which exposed the fact that gpmapreduce was erroneously including that header instead of the correct one. Instead include `postgres_fe.h` for now, as gpmapreduce is client side tool and not a separated extension, to fix compilation.