### PR TITLE
doc: Remove all mentions of filerep GUCs

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -143,9 +143,6 @@
               <xref href="#extra_float_digits"/>
             </li>
             <li>
-              <xref href="#filerep_mirrorvalidation_during_resync"/>
-            </li>
-            <li>
               <xref href="#from_collapse_limit"/>
             </li>
             <li>
@@ -2159,37 +2156,6 @@
             <row>
               <entry colname="col1">integer</entry>
               <entry colname="col2">0</entry>
-              <entry colname="col3">master<p>session</p><p>reload</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="filerep_mirrorvalidation_during_resync">
-    <title>filerep_mirrorvalidation_during_resync</title>
-    <body>
-      <p>The default setting <codeph>false</codeph> improves Greenplum Database performance during
-        incremental resynchronization of segment mirrors. Setting the value to <codeph>true</codeph>
-        enables checking for the existence of files for all relations on the segment mirror during
-        incremental resynchronization. Checking for files degrades performance of the incremental
-        resynchronization process but provides a minimal check of database objects.</p>
-      <table id="table_pfd_cyq_3s">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">Boolean </entry>
-              <entry colname="col2">false</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -279,15 +279,6 @@
               <xref href="#gp_external_enable_filter_pushdown"/>
             </li>
             <li>
-              <xref href="#gp_filerep_tcp_keepalives_count"/>
-            </li>
-            <li>
-              <xref href="#gp_filerep_tcp_keepalives_idle"/>
-            </li>
-            <li>
-              <xref href="#gp_filerep_tcp_keepalives_interval"/>
-            </li>
-            <li>
               <xref href="#gp_fts_probe_interval"/>
             </li>
             <li>
@@ -3669,98 +3660,6 @@
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">false</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="gp_filerep_tcp_keepalives_count">
-    <title>gp_filerep_tcp_keepalives_count</title>
-    <body>
-      <p>How many keepalives may be lost before the connection is considered dead. A value of 0 uses
-        the system default. If TCP_KEEPCNT is not supported, this parameter must be 0. </p>
-      <p>Use this parameter for all connections that are between a primary and mirror segment. Use
-          <codeph>tcp_keepalives_count</codeph> for settings that are not between a primary and
-        mirror segment.</p>
-      <table id="gp_filerep_tcp_keepalives_count_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">number of lost keepalives</entry>
-              <entry colname="col2">2</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="gp_filerep_tcp_keepalives_idle">
-    <title>gp_filerep_tcp_keepalives_idle</title>
-    <body>
-      <p>Number of seconds between sending keepalives on an otherwise idle connection. A value of 0
-        uses the system default. If TCP_KEEPIDLE is not supported, this parameter must be 0.</p>
-      <p>Use this parameter for all connections that are between a primary and mirror segment. Use
-          <codeph>tcp_keepalives_idle</codeph> for settings that are not between a primary and
-        mirror segment.</p>
-      <table id="gp_filerep_tcp_keepalives_idle_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">number of seconds</entry>
-              <entry colname="col2">1 min</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="gp_filerep_tcp_keepalives_interval">
-    <title>gp_filerep_tcp_keepalives_interval</title>
-    <body>
-      <p>How many seconds to wait for a response to a keepalive before retransmitting. A value of 0
-        uses the system default. If TCP_KEEPINTVL is not supported, this parameter must be 0.</p>
-      <p>Use this parameter for all connections that are between a primary and mirror segment. Use
-        tcp_keepalives_interval for settings that are not between a primary and mirror segment.</p>
-      <table id="gp_filerep_tcp_keepalives_interval_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">number of seconds</entry>
-              <entry colname="col2">30 sec</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>
@@ -9094,9 +8993,7 @@
     <body>
       <p>How many keepalives may be lost before the connection is considered dead. A value of 0 uses
         the system default. If TCP_KEEPCNT is not supported, this parameter must be 0. </p>
-      <p>Use this parameter for all connections that are not between a primary and mirror segment.
-        Use gp_filerep_tcp_keepalives_count for settings that are between a primary and mirror
-        segment.</p>
+      <p>Use this parameter for all connections that are not between a primary and mirror segment.</p>
       <table id="tcp_keepalives_count_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -9125,9 +9022,7 @@
     <body>
       <p>Number of seconds between sending keepalives on an otherwise idle connection. A value of 0
         uses the system default. If TCP_KEEPIDLE is not supported, this parameter must be 0.</p>
-      <p>Use this parameter for all connections that are not between a primary and mirror segment.
-        Use gp_filerep_tcp_keepalives_idle for settings that are between a primary and mirror
-        segment.</p>
+      <p>Use this parameter for all connections that are not between a primary and mirror segment.</p>
       <table id="tcp_keepalives_idle_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -9156,9 +9051,7 @@
     <body>
       <p>How many seconds to wait for a response to a keepalive before retransmitting. A value of 0
         uses the system default. If TCP_KEEPINTVL is not supported, this parameter must be 0.</p>
-      <p>Use this parameter for all connections that are not between a primary and mirror segment.
-        Use gp_filerep_tcp_keepalives_interval for settings that are between a primary and mirror
-        segment.</p>
+      <p>Use this parameter for all connections that are not between a primary and mirror segment.</p>
       <table id="tcp_keepalives_interval_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1605,18 +1605,6 @@
           </stentry>
         </strow>
       </simpletable>
-      <p>This parameter controls validation between Greenplum Database primary segment and standby
-        segment during incremental resynchronization.</p>
-      <simpletable frame="none" id="simpletable_mkj_z1r_3s">
-        <strow>
-          <stentry>
-            <p>
-              <xref href="guc-list.xml#filerep_mirrorvalidation_during_resync"
-                >filerep_mirrorvalidation_during_resync</xref>
-            </p>
-          </stentry>
-        </strow>
-      </simpletable>
     </body>
   </topic>
   <topic id="topic56">

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -114,9 +114,6 @@
             <topicref href="guc-list.xml#gp_external_enable_exec"/>
             <topicref href="guc-list.xml#gp_external_max_segs"/>
             <topicref href="guc-list.xml#gp_external_enable_filter_pushdown"/>
-            <topicref href="guc-list.xml#gp_filerep_tcp_keepalives_count"/>
-            <topicref href="guc-list.xml#gp_filerep_tcp_keepalives_idle"/>
-            <topicref href="guc-list.xml#gp_filerep_tcp_keepalives_interval"/>
             <topicref href="guc-list.xml#gp_fts_probe_interval"/>
             <topicref href="guc-list.xml#gp_fts_probe_retries"/>
             <topicref href="guc-list.xml#gp_fts_probe_threadcount"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -70,7 +70,6 @@
             <topicref href="guc-list.xml#escape_string_warning"/>
             <topicref href="guc-list.xml#explain_pretty_print"/>
             <topicref href="guc-list.xml#extra_float_digits"/>
-            <topicref href="guc-list.xml#filerep_mirrorvalidation_during_resync"/>
             <topicref href="guc-list.xml#from_collapse_limit"/>
             <topicref href="guc-list.xml#gp_adjust_selectivity_for_outerjoins"/>
             <topicref href="guc-list.xml#gp_analyze_relative_error"/>


### PR DESCRIPTION
The GUCs controlling filerep were removed when filerep was replaced by walrep, but the documentation hasn't caught up.  Remove mentions of filerep GUCs as they no longer exist.