### PR TITLE
pg_dump: disable unused pre-7.3 dump code

### DIFF
--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -589,7 +589,9 @@ extern void parseOidArray(const char *str, Oid *array, int arraysize);
 
 extern void sortDumpableObjects(DumpableObject **objs, int numObjs);
 extern void sortDumpableObjectsByTypeName(DumpableObject **objs, int numObjs);
+#if 0 /* GPDB_100_MERGE_FIXME: we don't support pre-7.3 dumps. */
 extern void sortDumpableObjectsByTypeOid(DumpableObject **objs, int numObjs);
+#endif
 
 
 /*

--- a/src/bin/pg_dump/pg_dump_sort.c
+++ b/src/bin/pg_dump/pg_dump_sort.c
@@ -19,6 +19,7 @@
 
 static const char *modulename = gettext_noop("sorter");
 
+#if 0 /* GPDB_100_MERGE_FIXME: we don't support pre-7.3 dumps. This disappears in PG10. */
 /*
  * Sort priority for object types when dumping a pre-7.3 database.
  * Objects are sorted by priority levels, and within an equal priority level
@@ -61,8 +62,8 @@ static const int oldObjectTypePriority[] =
 	11,							/* DO_BLOB_DATA */
 	2,							/* DO_COLLATION */
 	3,							/* DO_EXTPROTOCOL */
-	/* GPDB_84_MERGE_FIXME: missing DO_TYPE_STORAGE_OPTIONS? */
 };
+#endif
 
 /*
  * Sort priority for object types when dumping newer databases.
@@ -210,6 +211,7 @@ DOTypeNameCompare(const void *p1, const void *p2)
 }
 
 
+#if 0 /* GPDB_100_MERGE_FIXME: we don't support pre-7.3 dumps. This disappears in PG10. */
 /*
  * Sort the given objects into a type/OID-based ordering
  *
@@ -239,6 +241,7 @@ DOTypeOidCompare(const void *p1, const void *p2)
 
 	return oidcmp(obj1->catId.oid, obj2->catId.oid);
 }
+#endif
 
 
 /*


### PR DESCRIPTION
Remove the the unused pre-7.3 priority table; it has been out of sync for a while now and we don't want to accidentally make use of it in the future. It'll disappear in the 10.x merge with upstream.

Co-authored-by: Nadeem Ghani <nghani@pivotal.io>
Co-authored-by: Jim Doty <jdoty@pivotal.io>