### PR TITLE
Backport fixes to DTM retry logic to 5X_STABLE

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1452,6 +1452,8 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
     XLogRecPtr   tfXLogRecPtr;
     XLogRecord  *tfRecord  = NULL;
 
+	SIMPLE_FAULT_INJECTOR(FinishPreparedStartOfFunction);
+
 	/*
 	 * Validate the GID, and lock the GXACT to ensure that two backends do not
 	 * try to commit the same GID at once.

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -761,6 +761,7 @@ doNotifyingCommitPrepared(void)
 		 */
 		InterruptHoldoffCount = savedInterruptHoldoffCount;
 		succeeded = false;
+		FlushErrorState();
 	}
 	PG_END_TRY();
 
@@ -811,6 +812,7 @@ doNotifyingCommitPrepared(void)
 			 */
 			InterruptHoldoffCount = savedInterruptHoldoffCount;
 			succeeded = false;
+			FlushErrorState();
 		}
 		PG_END_TRY();
 	}
@@ -867,10 +869,10 @@ retryAbortPrepared(void)
 		PG_TRY();
 		{
 			succeeded = doDispatchDtxProtocolCommand(
-				DTX_PROTOCOL_COMMAND_RETRY_ABORT_PREPARED, /* flags */ 0,
-				currentGxact->gid, currentGxact->gxid,
-				&badGangs, /* raiseError */ false,
-				&direct, NULL, 0);
+													 DTX_PROTOCOL_COMMAND_RETRY_ABORT_PREPARED, /* flags */ 0,
+													 currentGxact->gid, currentGxact->gxid,
+													 &badGangs, /* raiseError */ true,
+													 &direct, NULL, 0);
 			if (!succeeded)
 				elog(WARNING, "the distributed transaction 'Abort' broadcast "
 					 "failed to one or more segments for gid = %s.  "
@@ -883,6 +885,7 @@ retryAbortPrepared(void)
 			 */
 			InterruptHoldoffCount = savedInterruptHoldoffCount;
 			succeeded = false;
+			FlushErrorState();
 		}
 		PG_END_TRY();
 	}
@@ -979,7 +982,7 @@ doNotifyingAbort(void)
 		{
 			succeeded = doDispatchDtxProtocolCommand(dtxProtocolCommand, /* flags */ 0,
 													 currentGxact->gid, currentGxact->gxid,
-													 &badGangs, /* raiseError */ false,
+													 &badGangs, /* raiseError */ true,
 													 &direct, NULL, 0);
 		}
 		PG_CATCH();
@@ -989,6 +992,7 @@ doNotifyingAbort(void)
 			 */
 			InterruptHoldoffCount = savedInterruptHoldoffCount;
 			succeeded = false;
+			FlushErrorState();
 		}
 		PG_END_TRY();
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -751,7 +751,7 @@ doNotifyingCommitPrepared(void)
 	{
 		succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_COMMIT_PREPARED, /* flags */ 0,
 												 currentGxact->gid, currentGxact->gxid,
-												 &badGangs, /* raiseError */ false,
+												 &badGangs, /* raiseError */ true,
 												 &direct, NULL, 0);
 	}
 	PG_CATCH();
@@ -799,10 +799,10 @@ doNotifyingCommitPrepared(void)
 		PG_TRY();
 		{
 			succeeded = doDispatchDtxProtocolCommand(
-					DTX_PROTOCOL_COMMAND_RETRY_COMMIT_PREPARED, /* flags */ 0,
-					currentGxact->gid, currentGxact->gxid,
-					&badGangs, /* raiseError */ false,
-					&direct, NULL, 0);
+													 DTX_PROTOCOL_COMMAND_RETRY_COMMIT_PREPARED, /* flags */ 0,
+													 currentGxact->gid, currentGxact->gxid,
+													 &badGangs, /* raiseError */ true,
+													 &direct, NULL, 0);
 		}
 		PG_CATCH();
 		{

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -227,6 +227,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault after persistent state change is permanently stored during first pass */
 	_("finish_prepared_transaction_abort_pass2_aborting_create_needed"),
 		/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
+	_("finish_prepared_start_of_function"),
+		/* inject fault at the start of finish prepare step executed by QEs */
 	_("filerep_verification"),
 	    /* inject fault to start verification */
 	_("twophase_transaction_commit_prepared"),

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4735,7 +4735,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&dtx_phase2_retry_count,
-		2, 0, 10, NULL, NULL
+		2, 0, 15, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -136,6 +136,8 @@ typedef enum FaultInjectorIdentifier_e {
 	FinishPreparedTransactionAbortPass2AbortingCreateNeeded,	
 		/* abort: create pending => aborting create */
 
+	FinishPreparedStartOfFunction,
+
 	FileRepVerification,
 		/* trigger filerep verification for testing */
 	

--- a/src/test/regress/expected/dtm_retry.out
+++ b/src/test/regress/expected/dtm_retry.out
@@ -1,0 +1,188 @@
+-- Check if retry logic handles errors correctly.  The retry logic had
+-- a bug where error state wasn't cleaned up correctly during retries,
+-- leading to PANIC due to ERRORDATA_STACK_SIZE exeeded.
+set dtx_phase2_retry_count = 11;
+-- Set a fault on one of the QEs such that an error is raised exactly
+-- 10 times at the beginning of 2nd phase of 2PC.
+-- ERRORDATA_STACK_SIZE is defined as 10.  By erroring out 10 times,
+-- the error handling logic in QD gets invoked 10 times.  If error
+-- state is not cleaned up before each retry, it is suffice to return
+-- an error 10 times to hit the above mentioned PANIC.
+--
+-- COMMIT_PREPARED
+--
+create extension if not exists gp_inject_fault;
+select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+begin;
+create table dtm_retry_table (a int) distributed by (a);
+-- Expected behavior is QD makes 11 attempts to commit and the last
+-- one succeeds.
+end;
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+-- Reset all faults.
+select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+NOTICE:  Success:
+ gp_inject_fault_infinite 
+--------------------------
+ t
+ t
+ t
+ t
+ t
+ t
+ t
+ t
+(8 rows)
+
+-- Verify that the table got created properly on all segments.
+insert into dtm_retry_table select * from generate_series(1,12);
+--
+-- ABORT_SOME_PREPARED
+--
+-- Let content 0 primary error out during prepare.  This leads to
+-- abort_some_prepared broadcast in 2nd phase.
+select gp_inject_fault('start_prepare', 'error', dbid)
+from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- Let content 1 primary, which had successfully prepared the
+-- transaction, report error 10 times upon receiving
+-- abort_some_prepared request.
+select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+begin;
+truncate table dtm_retry_table;
+-- Expected behavior: QD's 11th attempt to broadcast
+-- abort_some_prepared message succeeds.
+end;
+WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1532027571-0000000036.  Retrying ... try 0
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+ERROR:  fault triggered, fault name:'start_prepare' fault type:'error'
+-- Verify that the table wasn't truncated due to prevous transaction
+-- being aborted.
+select count(*) = 12 from dtm_retry_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Reset all faults.
+select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+NOTICE:  Success:
+ gp_inject_fault_infinite 
+--------------------------
+ t
+ t
+ t
+ t
+ t
+ t
+ t
+ t
+(8 rows)
+
+--
+-- ABORT_PREPARED
+--
+-- After successful prepare, QD should error out, leading to
+-- abort_prepared broadcast in 2nd phase.
+select gp_inject_fault('dtm_broadcast_prepare', 'error', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- Let content 0 primary error out 10 times during second phase.
+select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+begin;
+truncate table dtm_retry_table;
+-- Expected behavior: QD's 11th attempt to broadcast
+-- abort_prepared message succeeds.
+end;
+WARNING:  the distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+NOTICE:  Releasing segworker groups to retry broadcast.
+ERROR:  fault triggered, fault name:'dtm_broadcast_prepare' fault type:'error'
+-- Verify that the table wasn't truncated due to prevous transaction
+-- being aborted.
+select count(*) = 12 from dtm_retry_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Reset all faults.
+select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+NOTICE:  Success:
+ gp_inject_fault_infinite 
+--------------------------
+ t
+ t
+ t
+ t
+ t
+ t
+ t
+ t
+(8 rows)
+

--- a/src/test/regress/expected/dtm_retry.out
+++ b/src/test/regress/expected/dtm_retry.out
@@ -12,11 +12,11 @@ set dtx_phase2_retry_count = 11;
 -- COMMIT_PREPARED
 --
 create extension if not exists gp_inject_fault;
-select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+select gp_inject_fault_new('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -48,6 +48,13 @@ NOTICE:  Releasing segworker group to retry broadcast.
 -- Reset all faults.
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
 NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
  t
@@ -67,22 +74,22 @@ insert into dtm_retry_table select * from generate_series(1,12);
 --
 -- Let content 0 primary error out during prepare.  This leads to
 -- abort_some_prepared broadcast in 2nd phase.
-select gp_inject_fault('start_prepare', 'error', dbid)
+select gp_inject_fault_new('start_prepare', 'error', dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
 -- Let content 1 primary, which had successfully prepared the
 -- transaction, report error 10 times upon receiving
 -- abort_some_prepared request.
-select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+select gp_inject_fault_new('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -91,7 +98,7 @@ truncate table dtm_retry_table;
 -- Expected behavior: QD's 11th attempt to broadcast
 -- abort_some_prepared message succeeds.
 end;
-WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid = 1532027571-0000000036.  Retrying ... try 0
+WARNING:  the distributed transaction 'Abort [Prepared]' broadcast failed to one or more segments for gid DUMMY
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
@@ -101,7 +108,8 @@ NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
-ERROR:  fault triggered, fault name:'start_prepare' fault type:'error'
+NOTICE:  Releasing segworker groups to retry broadcast.
+ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid DUMMY
 -- Verify that the table wasn't truncated due to prevous transaction
 -- being aborted.
 select count(*) = 12 from dtm_retry_table;
@@ -112,6 +120,13 @@ select count(*) = 12 from dtm_retry_table;
 
 -- Reset all faults.
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
 NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
@@ -130,20 +145,20 @@ NOTICE:  Success:
 --
 -- After successful prepare, QD should error out, leading to
 -- abort_prepared broadcast in 2nd phase.
-select gp_inject_fault('dtm_broadcast_prepare', 'error', dbid)
+select gp_inject_fault_new('dtm_broadcast_prepare', 'error', dbid)
 from gp_segment_configuration where role = 'p' and content = -1;
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
 -- Let content 0 primary error out 10 times during second phase.
-select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+select gp_inject_fault_new('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
 NOTICE:  Success:
- gp_inject_fault 
------------------
+ gp_inject_fault_new 
+---------------------
  t
 (1 row)
 
@@ -153,6 +168,7 @@ truncate table dtm_retry_table;
 -- abort_prepared message succeeds.
 end;
 WARNING:  the distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
@@ -173,6 +189,13 @@ select count(*) = 12 from dtm_retry_table;
 
 -- Reset all faults.
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
 NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -54,6 +54,10 @@ test: query_finish_pending
 
 test: gpdiffcheck gptokencheck gp_hashagg sequence_gp tidscan co_nestloop_idxscan dml_in_udf
 
+# The test must be run by itself as it injects a fault on QE to fail
+# at the 2nd phase of 2PC.
+test: dtm_retry
+
 test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 distributed_transactions olap_group olap_window_seq sirv_functions appendonly alter_distpol_dropped query_finish
 
 # 'partition' runs for a long time, so try to keep it together with other

--- a/src/test/regress/sql/dtm_retry.sql
+++ b/src/test/regress/sql/dtm_retry.sql
@@ -1,0 +1,72 @@
+-- Check if retry logic handles errors correctly.  The retry logic had
+-- a bug where error state wasn't cleaned up correctly during retries,
+-- leading to PANIC due to ERRORDATA_STACK_SIZE exeeded.
+set dtx_phase2_retry_count = 11;
+-- Set a fault on one of the QEs such that an error is raised exactly
+-- 10 times at the beginning of 2nd phase of 2PC.
+-- ERRORDATA_STACK_SIZE is defined as 10.  By erroring out 10 times,
+-- the error handling logic in QD gets invoked 10 times.  If error
+-- state is not cleaned up before each retry, it is suffice to return
+-- an error 10 times to hit the above mentioned PANIC.
+
+--
+-- COMMIT_PREPARED
+--
+create extension if not exists gp_inject_fault;
+select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
+begin;
+create table dtm_retry_table (a int) distributed by (a);
+-- Expected behavior is QD makes 11 attempts to commit and the last
+-- one succeeds.
+end;
+-- Reset all faults.
+select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+-- Verify that the table got created properly on all segments.
+insert into dtm_retry_table select * from generate_series(1,12);
+
+--
+-- ABORT_SOME_PREPARED
+--
+-- Let content 0 primary error out during prepare.  This leads to
+-- abort_some_prepared broadcast in 2nd phase.
+select gp_inject_fault('start_prepare', 'error', dbid)
+from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
+-- Let content 1 primary, which had successfully prepared the
+-- transaction, report error 10 times upon receiving
+-- abort_some_prepared request.
+select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
+begin;
+truncate table dtm_retry_table;
+-- Expected behavior: QD's 11th attempt to broadcast
+-- abort_some_prepared message succeeds.
+end;
+-- Verify that the table wasn't truncated due to prevous transaction
+-- being aborted.
+select count(*) = 12 from dtm_retry_table;
+
+-- Reset all faults.
+select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+
+--
+-- ABORT_PREPARED
+--
+-- After successful prepare, QD should error out, leading to
+-- abort_prepared broadcast in 2nd phase.
+select gp_inject_fault('dtm_broadcast_prepare', 'error', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;
+-- Let content 0 primary error out 10 times during second phase.
+select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
+begin;
+truncate table dtm_retry_table;
+-- Expected behavior: QD's 11th attempt to broadcast
+-- abort_prepared message succeeds.
+end;
+-- Verify that the table wasn't truncated due to prevous transaction
+-- being aborted.
+select count(*) = 12 from dtm_retry_table;
+
+-- Reset all faults.
+select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;

--- a/src/test/regress/sql/dtm_retry.sql
+++ b/src/test/regress/sql/dtm_retry.sql
@@ -13,7 +13,7 @@ set dtx_phase2_retry_count = 11;
 -- COMMIT_PREPARED
 --
 create extension if not exists gp_inject_fault;
-select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+select gp_inject_fault_new('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
 begin;
 create table dtm_retry_table (a int) distributed by (a);
@@ -30,12 +30,12 @@ insert into dtm_retry_table select * from generate_series(1,12);
 --
 -- Let content 0 primary error out during prepare.  This leads to
 -- abort_some_prepared broadcast in 2nd phase.
-select gp_inject_fault('start_prepare', 'error', dbid)
+select gp_inject_fault_new('start_prepare', 'error', dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
 -- Let content 1 primary, which had successfully prepared the
 -- transaction, report error 10 times upon receiving
 -- abort_some_prepared request.
-select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+select gp_inject_fault_new('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
 begin;
 truncate table dtm_retry_table;
@@ -54,10 +54,10 @@ select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configurat
 --
 -- After successful prepare, QD should error out, leading to
 -- abort_prepared broadcast in 2nd phase.
-select gp_inject_fault('dtm_broadcast_prepare', 'error', dbid)
+select gp_inject_fault_new('dtm_broadcast_prepare', 'error', dbid)
 from gp_segment_configuration where role = 'p' and content = -1;
 -- Let content 0 primary error out 10 times during second phase.
-select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
+select gp_inject_fault_new('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
 begin;
 truncate table dtm_retry_table;


### PR DESCRIPTION
This PR pulls DTM retry logic error handling fixes from master.  Please refer to individual commit messages for more details.
  * Let dispatcher raise error when a DTM broadcast fails
  * Test case for DTM retry error handling
  * Fix dtm_retry test according to new faultinjector changes
  * Flush error state before making a retry attempt in DTM