### PR TITLE
WIP: Remove FIXME for planner's SplitUpdate feature

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -21,6 +21,7 @@
 #include "parser/parse_expr.h"	/* for expr_type() */
 #include "parser/parse_oper.h"	/* for compatible_oper_opid() */
 #include "utils/relcache.h"		/* RelationGetPartitioningKey() */
+#include "optimizer/cost.h"
 #include "optimizer/tlist.h"	/* get_sortgroupclause_tle() */
 #include "optimizer/planmain.h"
 #include "optimizer/predtest.h"
@@ -1214,10 +1215,6 @@ add_absent_targetlist_mutator(Plan *plan,
 
 	Assert(is_plan_node(node));
 
-	/*
-	 * GPDB_90_MERGE_FIXME: We also need to change width and cost here. But since the plan has been
-	 * generated at this stage, it is not clear how we could recalculate the cost.
-	 */
 	if (node->type >= T_SeqScan && node->type <=T_WorkTableScan)
 	{
 		Scan		*scan;
@@ -1702,11 +1699,13 @@ make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan, RangeTblEntr
 
 	/*
 	 * Now the plan tree has been determined, we have no choice, so use the
-	 * cost of lower plan node directly.
+	 * cost of lower plan node directly, plus the cpu_tuple_cost of each row
+	 * TODO: width here is incorrect, until we merge upstream commit 3fc6e2d
 	 */
 	splitupdate->plan.startup_cost = subplan->startup_cost;
 	splitupdate->plan.total_cost = subplan->total_cost;
 	splitupdate->plan.plan_rows = 2 * subplan->plan_rows;
+	splitupdate->plan.total_cost += (splitupdate->plan.plan_rows * cpu_tuple_cost);
 	splitupdate->plan.plan_width = subplan->plan_width;
 
 	/* we need an motion node above the SplitUpdate, so mark it as strewn */

--- a/src/backend/executor/nodeSplitUpdate.c
+++ b/src/backend/executor/nodeSplitUpdate.c
@@ -74,13 +74,21 @@ SplitTupleTableSlot(List *targetList, SplitUpdate *plannode, SplitUpdateState *n
 		else if (((int)tle->resno) < plannode->ctidColIdx)
 		{
 			/* Old and new values */
-			delete_values[resno] = values[deleteAtt->data.int_value-1];
-			delete_nulls[resno] = nulls[deleteAtt->data.int_value-1];
+			if (deleteAtt != NULL)
+			{
+				delete_values[resno] = values[deleteAtt->data.int_value-1];
+				delete_nulls[resno] = nulls[deleteAtt->data.int_value-1];
+			}
+			else
+			{
+				delete_nulls[resno] = true;
+			}
 
 			insert_values[resno] = values[insertAtt->data.int_value-1];
 			insert_nulls[resno] = nulls[insertAtt->data.int_value-1];
 
-			deleteAtt = deleteAtt->next;
+			if(deleteAtt != NULL)
+			    deleteAtt = deleteAtt->next;
 			insertAtt = insertAtt->next;
 		}
 		else

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6405,6 +6405,28 @@ make_modifytable(PlannerInfo *root, CmdType operation, bool canSetTag,
 	Assert(returningLists == NIL ||
 		   list_length(resultRelations) == list_length(returningLists));
 
+
+
+	node->plan.lefttree = NULL;
+	node->plan.righttree = NULL;
+	node->plan.qual = NIL;
+	/* setrefs.c will fill in the targetlist, if needed */
+	node->plan.targetlist = NIL;
+
+	node->operation = operation;
+	node->canSetTag = canSetTag;
+	node->resultRelations = resultRelations;
+	node->resultRelIndex = -1;	/* will be set correctly in setrefs.c */
+	node->plans = subplans;
+	node->returningLists = returningLists;
+	node->rowMarks = rowMarks;
+	node->epqParam = epqParam;
+	node->action_col_idxes = NIL;
+	node->ctid_col_idxes = NIL;
+	node->oid_col_idxes = NIL;
+
+	adjust_modifytable_flow(root, node);
+
 	/*
 	 * Compute cost as sum of subplan costs.
 	 */
@@ -6426,26 +6448,6 @@ make_modifytable(PlannerInfo *root, CmdType operation, bool canSetTag,
 		plan->plan_width = rint(total_size / plan->plan_rows);
 	else
 		plan->plan_width = 0;
-
-	node->plan.lefttree = NULL;
-	node->plan.righttree = NULL;
-	node->plan.qual = NIL;
-	/* setrefs.c will fill in the targetlist, if needed */
-	node->plan.targetlist = NIL;
-
-	node->operation = operation;
-	node->canSetTag = canSetTag;
-	node->resultRelations = resultRelations;
-	node->resultRelIndex = -1;	/* will be set correctly in setrefs.c */
-	node->plans = subplans;
-	node->returningLists = returningLists;
-	node->rowMarks = rowMarks;
-	node->epqParam = epqParam;
-	node->action_col_idxes = NIL;
-	node->ctid_col_idxes = NIL;
-	node->oid_col_idxes = NIL;
-
-	adjust_modifytable_flow(root, node);
 
 	return node;
 }

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -296,6 +296,17 @@ SELECT gp_segment_id, * FROM tab5;
              1 |  1 |  2 |  3 |  0 |  6
 (10 rows)
 
+EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
+                      QUERY PLAN
+------------------------------------------------------
+ Update on tab3
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: (c1 + 1), c2, c3
+         ->  Split
+               ->  Seq Scan on tab3
+ Optimizer: legacy query optimizer
+(6 rows)
+
 -- clean up
 drop table tab3;
 drop table tab5;

--- a/src/test/regress/sql/update.sql
+++ b/src/test/regress/sql/update.sql
@@ -135,6 +135,8 @@ SELECT gp_segment_id, * FROM tab5;
 UPDATE tab5 set (c1,c2,c3,c4,c5) = (1,2,3,0,6) where c5 = 1;
 SELECT gp_segment_id, * FROM tab5;
 
+EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
+
 -- clean up
 drop table tab3;
 drop table tab5;


### PR DESCRIPTION
This fixs the following TODOs left in 73801e8d
1) Correct cost calculation for SplitUpdate plan. This will not help generating
a better plan because we have no choice other than simply adding the
SplitUpdate node.
2) Only send distribution columns for delete execution instead of all columns.

Co-authored-by: Shujie Zhang <shzhang@pivotal.io>
Co-authored-by: Alexandra Wang <leiwangcheme@gmail.com>
Signed-off-by: Alexandra Wang <leiwangcheme@gmail.com>