### PR TITLE
Do not call CdbDispatchPlan() to dispatch nothing

### DIFF
--- a/src/backend/cdb/cdbsubplan.c
+++ b/src/backend/cdb/cdbsubplan.c
@@ -123,7 +123,6 @@ preprocess_initplans(QueryDesc *queryDesc)
 			if (subplan->qDispSliceId > 0)
 			{
 				sps->planstate->plan->nMotionNodes = queryDesc->plannedstmt->nMotionNodes;
-				sps->planstate->plan->dispatch = DISPATCH_PARALLEL;
 
 				/*
 				 * Adjust for the slice to execute on the QD.

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -959,7 +959,7 @@ ExecSetParamPlan(SubPlanState *node, ExprContext *econtext, QueryDesc *queryDesc
 	if (Gp_role == GP_ROLE_DISPATCH &&
 		planstate != NULL &&
 		planstate->plan != NULL &&
-		planstate->plan->dispatch == DISPATCH_PARALLEL)
+		subplan->initPlanParallel)
 		shouldDispatch = true;
 
 	planstate->state->currentSubplanLevel++;
@@ -1177,6 +1177,8 @@ PG_TRY();
 		 * exit to our error handler (below) via PG_THROW.
 		 */
 		cdbdisp_finishCommand(queryDesc->estate->dispatcherState, NULL, NULL, true);
+		/* Main plan use same estate, must reset dispatcherState  */
+		queryDesc->estate->dispatcherState = NULL;
 	}
 
 	/* Clean up the interconnect. */

--- a/src/backend/executor/test/nodeSubplan_test.c
+++ b/src/backend/executor/test/nodeSubplan_test.c
@@ -86,7 +86,7 @@ test__ExecSetParamPlan__Check_Dispatch_Results(void **state)
 	queryDesc->estate->es_sliceTable = (SliceTable *) palloc(sizeof(SliceTable));
 	
 	Gp_role = GP_ROLE_DISPATCH;
-	plan->planstate->plan->dispatch=DISPATCH_PARALLEL;
+	((SubPlan*)(plan->xprstate.expr))->initPlanParallel = true;
 
 	will_be_called(isCurrentDtxTwoPhase);
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1863,6 +1863,7 @@ _copySubPlan(const SubPlan *from)
 	COPY_NODE_FIELD(extParam);
 	COPY_SCALAR_FIELD(startup_cost);
 	COPY_SCALAR_FIELD(per_call_cost);
+	COPY_SCALAR_FIELD(initPlanParallel);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1597,6 +1597,7 @@ _outSubPlan(StringInfo str, const SubPlan *node)
 	WRITE_NODE_FIELD(extParam);
 	WRITE_FLOAT_FIELD(startup_cost, "%.2f");
 	WRITE_FLOAT_FIELD(per_call_cost, "%.2f");
+	WRITE_BOOL_FIELD(initPlanParallel); /*CDB*/
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -937,6 +937,7 @@ _readSubPlan(void)
 	READ_NODE_FIELD(extParam);
 	READ_FLOAT_FIELD(startup_cost);
 	READ_FLOAT_FIELD(per_call_cost);
+	READ_BOOL_FIELD(initPlanParallel); /*CDB*/
 
 	READ_DONE();
 }

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -744,6 +744,7 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 	splan->is_initplan = false;
 	splan->is_multirow = false;
 	splan->is_parallelized = false;
+	splan->initPlanParallel = false;
 	splan->setParam = NIL;
 	splan->parParam = NIL;
 	splan->args = NIL;

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -725,6 +725,7 @@ typedef struct SubPlan
 	/* Estimated execution costs: */
 	Cost		startup_cost;	/* one-time setup cost */
 	Cost		per_call_cost;	/* cost for each subplan evaluation */
+	bool		initPlanParallel; /* CDB: Init plan is parallelled */
 } SubPlan;
 
 /*

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1784,3 +1784,19 @@ DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;
 DROP TABLE IF EXISTS dedup_test3;
 -- end_ignore
+-- Test init/main plan are not both parallel
+create table init_main_plan_parallel (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- case 1: init plan is parallel, main plan is not.
+select relname from pg_class where exists(select * from init_main_plan_parallel);
+ relname 
+---------
+(0 rows)
+
+-- case2: init plan is not parallel, main plan is parallel
+select * from init_main_plan_parallel where exists (select * from pg_class);
+ c1 | c2 
+----+----
+(0 rows)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1902,3 +1902,19 @@ DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;
 DROP TABLE IF EXISTS dedup_test3;
 -- end_ignore
+-- Test init/main plan are not both parallel
+create table init_main_plan_parallel (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- case 1: init plan is parallel, main plan is not.
+select relname from pg_class where exists(select * from init_main_plan_parallel);
+ relname 
+---------
+(0 rows)
+
+-- case2: init plan is not parallel, main plan is parallel
+select * from init_main_plan_parallel where exists (select * from pg_class);
+ c1 | c2 
+----+----
+(0 rows)
+

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -766,3 +766,10 @@ DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;
 DROP TABLE IF EXISTS dedup_test3;
 -- end_ignore
+
+-- Test init/main plan are not both parallel
+create table init_main_plan_parallel (c1 int, c2 int);
+-- case 1: init plan is parallel, main plan is not.
+select relname from pg_class where exists(select * from init_main_plan_parallel);
+-- case2: init plan is not parallel, main plan is parallel
+select * from init_main_plan_parallel where exists (select * from pg_class);


### PR DESCRIPTION
Previously, CdbDispatchPlan might be called to dispatch nothing if
1. init plan is parallel but main plan is not. CdbDispatchPlan is
still called for main plan.
2. init plan is not parallel, CdbDispatchPlan is still called for
init plan.

The reason is DISPATCH_PARALLEL stands for the whole plan include
main plan and init plans, this commit add ways to seperately tell
which plan is parallel exactly to avoid unnecessary dispatching.