### PR TITLE
Remove CdbPathLocus hack to query segment catalogs

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -1112,16 +1112,6 @@ cdbpath_motion_for_join(PlannerInfo *root,
 		return cdbpathlocus_join(outer.locus, inner.locus);
 
 	/*
-	 * Kludge used internally for querying catalogs on segment dbs. Each QE
-	 * will join the catalogs that are local to its own segment. The catalogs
-	 * don't have partitioning keys.  No motion needed.
-	 */
-	else if (CdbPathLocus_IsStrewn(outer.locus) &&
-			 CdbPathLocus_IsStrewn(inner.locus) &&
-			 cdbpathlocus_querysegmentcatalogs)
-		return outer.locus;
-
-	/*
 	 * Both sources are partitioned.  Redistribute or replicate one or both.
 	 */
 	else

--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -33,18 +33,6 @@ static List *cdb_build_distribution_pathkeys(PlannerInfo *root,
 								int nattrs,
 								AttrNumber *attrs);
 
-
-/*
- * This flag controls the policy type returned from
- * cdbpathlocus_from_baserel() for non-partitioned tables.
- * It's a kludge put in to allow us to do
- * distributed queries on catalog tables, like pg_class
- * and pg_statistic.
- * To use it, simply set it to true before running a catalog query, then set
- * it back to false.
- */
-bool		cdbpathlocus_querysegmentcatalogs = false;
-
 /*
  * Are two pathkeys equal?
  *
@@ -336,10 +324,6 @@ cdbpathlocus_from_baserel(struct PlannerInfo *root,
 	{
 		CdbPathLocus_MakeSegmentGeneral(&result);
 	}
-	/* Kludge used internally for querying catalogs on segment dbs */
-	else if (cdbpathlocus_querysegmentcatalogs)
-		CdbPathLocus_MakeStrewn(&result);
-
 	/* Normal catalog access */
 	else
 		CdbPathLocus_MakeEntry(&result);

--- a/src/include/cdb/cdbpathlocus.h
+++ b/src/include/cdb/cdbpathlocus.h
@@ -24,18 +24,6 @@ struct PlannerInfo;				/* defined in relation.h */
 
 
 /*
- * This flag controls the policy type returned from
- * cdbpathlocus_from_baserel() for non-partitioned tables.
- * It's a kludge put in to allow us to do
- * distributed queries on catalog tables, like pg_class
- * and pg_statistic.
- * To use it, simply set it to true before running a catalog query, then set
- * it back to false.
- */
-extern bool cdbpathlocus_querysegmentcatalogs;
-
-
-/*
  * CdbLocusType
  */
 typedef enum CdbLocusType


### PR DESCRIPTION
This kludge was put in place to allow for queries against segment
catalogs to extract statistics for ANALYZE. With the rewritten
analyze we no longer need this, and since the on-switch has been
removed it's essentially just dead code anyways. Remove.