### PR TITLE
docs - add best practices page for resource groups

### DIFF
--- a/gpdb-doc/dita/best_practices/best-practices.ditamap
+++ b/gpdb-doc/dita/best_practices/best-practices.ditamap
@@ -9,6 +9,7 @@
         <topicref href="sysconfig.xml"/>
         <topicref href="schema.xml"/>
         <topicref href="workloads.xml"/>
+        <topicref href="resgroups.xml"/>
         <topicref href="maintenance.xml">
             <topicref href="analyze.xml"/>
             <topicref href="bloat.xml"/>

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -143,10 +143,9 @@ gp_seg_memory = total_gp_memory / number_of_active_primary_segments
           group for the workload and the time of day.</li>
         <li>Use the <codeph>gptoolkit</codeph> views to examine resource group resource
             usage and to monitor how the groups are working.</li>
-        <li otherprops="pivotal">A Greenplum Database workload is a resource group with
-          special assignment capabilities. Consider using Pivotal Greenplum Command Center
-          to create and manage workloads, and to define the criteria under which Command
-          Center dynamically assigns a transaction to a workload.</li>
+        <li otherprops="pivotal">Consider using Pivotal Greenplum Command Center
+          to create and manage resource groups, and to define the criteria under which
+          Command Center dynamically assigns a transaction to a resource group.</li>
       </ul>
     </section>
     <section id="section113x" xml:lang="en">

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_hhc_z5w_r4">
+  <title>Memory and Resource Management with Resource Groups</title>
+  <shortdesc>Managing Greenplum Database resources with resource groups</shortdesc>
+  <body>
+    <p>Memory, CPU, and concurrent transaction management have a significant impact on
+      performance in a Greenplum Database cluster. Resource groups are a newer resource
+      management scheme that enforce memory, CPU, and concurrent transaction limits in
+      Greenplum Database.</p>
+    <ul id="ul_agm_sbl_zt">
+      <li>
+        <xref href="#topic_hhc_z5w_r4/section_r52_rbl_zt" format="dita"/>
+      </li>
+      <li>
+        <xref href="#topic_hhc_z5w_r4/section_upm_rbl_zt" format="dita"/>
+      </li>
+      <li>
+        <xref href="#topic_hhc_z5w_r4/configuring_rg" format="dita"/>
+      </li>
+      <li>
+        <xref href="#topic_hhc_z5w_r4/section113x" format="dita"/>
+      </li>
+      <li>
+        <xref href="#topic_hhc_z5w_r4/section177x" format="dita"/>
+      </li>
+    </ul>
+    <section id="section_r52_rbl_zt">
+      <title>Configuring Memory for Greenplum Database</title>
+      <p>While it is not always possible to increase system memory, you can avoid
+        many out-of-memory conditions by configuring resource groups to manage expected
+        workloads. </p>
+      <p>The following operating system and Greenplum Database memory settings are
+        significant when you manage your Greenplum Database resources with resource groups:</p>
+      <ul id="ul_xv2_phn_1s">
+        <li>
+          <b>vm.overcommit_memory</b>
+          <p>This Linux kernel parameter, set in <codeph>/etc/sysctl.conf</codeph>,
+            identifies the method that the operating system uses to determine how
+            much memory can be allocated to processes. <codeph>vm.overcommit_memory</codeph> must always be set to 2 for Greenplum Database systems.
+          </p>
+        </li>
+        <li>
+          <b>vm.overcommit_ratio</b>
+          <p>This Linux kernel parameter, set in <codeph>/etc/sysctl.conf</codeph>, 
+            identifies the percentage of RAM that is used for application processes;
+            the remainder is reserved for the operating system. The operating system
+            default value (50 on Red Hat) is a good starting point for Greenplum
+            Database clusters employing resource group-based resource management. If
+            your memory utilization is too low, increase the value; if your memory or
+            swap usage is too high, decrease the setting.</p>
+        </li>
+        <li>
+          <b>gp_resource_group_memory_limit</b>
+          <p>The percentage of system memory to allocate to Greenplum Database. The
+            default value is .7 (70%).</p> 
+        </li>
+        <li>
+          <b>gp_workfile_limit_files_per_query</b>
+          <p>Set <codeph>gp_workfile_limit_files_per_query</codeph> to limit the maximum number of
+            temporary spill files (workfiles) allowed per query. Spill files are created when a
+            query requires more memory than it is allocated. When the limit is exceeded the query is
+            terminated. The default is zero, which allows an unlimited number of spill files and may
+            fill up the file system. </p>
+        </li>
+        <li>
+          <p>
+            <b>gp_workfile_compress_algorithm</b>
+          </p>
+          <p>If there are numerous spill files then set
+              <codeph>gp_workfile_compress_algorithm</codeph> to compress the spill files.
+            Compressing spill files may help to avoid overloading the disk subsystem with IO
+            operations. </p>
+        </li>
+      </ul>
+      <p>Other considerations:</p>
+      <ul id="ul_xv2_phn_2z">
+        <li>Do not configure the operating system to use huge pages. </li>
+        <li>When you configure resource group memory, consider memory requirements
+           for mirror segments that become primary segments during a failure to ensure
+           that database operations can continue when primary segments or segment hosts
+           fail.
+        </li>
+      </ul>
+    </section>
+    <section id="section_upm_rbl_zt">
+      <title>Example Memory Configuration Calculations</title>
+      <p>This section provides example memory calculations for a Greenplum Database system with
+        the following specifications:</p>
+      <ul id="ul_q4x_g1g_zt">
+        <li>Total RAM = 256GB </li>
+        <li>Swap = 64GB </li>
+        <li>8 primary segments and 8 mirror segments per host, in blocks of 4 hosts.</li>
+        <li>Maximum number of primaries per host during failure is 11.</li>
+      </ul>
+      <p>The usable memory available on a host is a function of 
+        the amount of RAM and swap space configured for the system, as well as the
+        <codeph>vm.overcommit_ratio</codeph> system parameter setting:</p>
+        <codeblock>
+total_node_usable_memory = RAM * (vm.overcommit_ratio / 100) + Swap
+                         = 256GB * (50/100) + 64GB
+                         = 192GB</codeblock>
+      <p>Assuming the default <codeph>gp_resource_group_memory_limit</codeph> value (.7),
+        the memory allocated to a Greenplum Database host with the example configuration is:</p>
+        <codeblock>
+total_gp_memory = total_node_usable_memory * gp_resource_group_memory_limit
+                = 192GB * .7
+                = 134.4GB</codeblock>
+      <p>The memory available to a Greenplum Database segment on a segment host is a function
+        of the memory reserved for Greenplum on the host and the number of active primary
+        segments on the host:</p>
+        <codeblock>
+gp_seg_memory = total_gp_memory / number_of_active_primary_segments
+              = 134.4GB / 11
+              = 12.2GB</codeblock>
+    </section>
+    <section id="configuring_rg">
+      <title>Configuring Resource Groups</title>
+      <p>Greenplum Database resource groups provide a powerful mechanism for managing the workload
+        of the cluster. You can use resource groups to limit both the number of concurrent
+        active queries and the amount of CPU and memory that can be consumed by queries
+        running in the resource group.</p>
+      <ul id="ul_svy_b3n_1s">
+        <li>A transaction submitted by any Greenplum Database role with
+            <codeph>SUPERUSER</codeph> privileges runs under the default resource
+            group named <codeph>admin_group</codeph>. Keep this in mind when
+            scheduling and running Greenplum administration utilities.</li>
+        <li>Ensure that each role is assigned a resource group. If you do not assign
+            a resource group to a role, queries submitted by the role are handled by the
+            default resource group named <codeph>default_group</codeph>.</li>
+        <li>Use the <codeph>CONCURRENCY</codeph> resource group parameter to limit the
+            number of active queries that members of a particular resource group can run
+            concurrently.</li>
+        <li>Use the <codeph>MEMORY_LIMIT</codeph> and <codeph>MEMORY_SHARED_QUOTA</codeph>
+            parameters to control the maximum amount of memory that queries running in the
+           resource group can consume.</li>
+        <li>When you specify a <codeph>memory_spill_ratio</codeph> in your session,
+            individual queries running in the session can allocate more than their "share"
+           of memory, which reduces the memory available for other queries running in the
+           resource group.</li>
+        <li>Greenplum Database assigns unreserved memory (100 - (sum of all resource
+          group <codeph>MEMORY_LIMIT</codeph>s) to a global shared memory pool. This
+          memory is available to all queries on a first-come, first-served basis.</li>
+        <li>Alter resource groups dynamically to match the real requirements of the
+          group for the workload and the time of day.</li>
+        <li>Use the <codeph>gptoolkit</codeph> views to examine resource group resource
+            usage and to monitor how the groups are working.</li>
+      </ul>
+    </section>
+    <section id="section113x" xml:lang="en">
+      <title>Low Memory Queries</title>
+      <p>A low <codeph>memory_spill_ratio</codeph> setting (for example, in the 0-2% range)
+        has been shown to increase the performance of queries with low memory requirements.
+        Use the <codeph>memory_spill_ratio</codeph> server configuration parameter to override
+        the setting on a per-query basis. For example:
+        <codeblock>SET memory_spill_ratio=0;</codeblock></p>
+    </section>
+    <section id="section177x" xml:lang="en">
+      <title>Administrative Utilities and admin_group Concurrency</title>
+      <p>The default resource group for database transactions initiated by Greenplum
+        Database <codeph>SUPERUSER</codeph>s is the group named <codeph>admin_group</codeph>.
+        The default <codeph>CONCURRENCY</codeph> value for the <codeph>admin_group</codeph>
+        resource group is 10.</p>
+      <p>Certain Greenplum Database administrative utilities may use more than one
+        <codeph>CONCURRENCY</codeph> slot at runtime; for example, <codeph>gpbackup</codeph>
+        that you invoke with the <codeph>--jobs</codeph> option. If the utility(s) you run
+        require more concurrent transactions than that configured for <codeph>admin_group</codeph>,
+        consider temporarily increasing the group's <codeph>MEMORY_LIMIT</codeph> and
+        <codeph>CONCURRENCY</codeph> values to meet the utility's requirement, making sure to
+        return these parameters back to their original settings when the utility completes.
+        <note>Memory allocation changes that you initiate with <codeph>ALTER RESOURCE GROUP</codeph>
+        may not take affect immediately due to resource consumption by currently running
+        queries. Be sure to alter resource group parameters in advance of your maintenance
+        window.</note></p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_hhc_z5w_r4">
   <title>Memory and Resource Management with Resource Groups</title>
-  <shortdesc>Managing Greenplum Database resources with resource groups</shortdesc>
+  <shortdesc>Managing Greenplum Database resources with resource groups.</shortdesc>
   <body>
     <p>Memory, CPU, and concurrent transaction management have a significant impact on
       performance in a Greenplum Database cluster. Resource groups are a newer resource
@@ -31,7 +31,7 @@
         many out-of-memory conditions by configuring resource groups to manage expected
         workloads. </p>
       <p>The following operating system and Greenplum Database memory settings are
-        significant when you manage your Greenplum Database resources with resource groups:</p>
+        significant when you manage Greenplum Database resources with resource groups:</p>
       <ul id="ul_xv2_phn_1s">
         <li>
           <b>vm.overcommit_memory</b>
@@ -90,8 +90,8 @@
       <ul id="ul_q4x_g1g_zt">
         <li>Total RAM = 256GB </li>
         <li>Swap = 64GB </li>
-        <li>8 primary segments and 8 mirror segments per host, in blocks of 4 hosts.</li>
-        <li>Maximum number of primaries per host during failure is 11.</li>
+        <li>8 primary segments and 8 mirror segments per host, in blocks of 4 hosts</li>
+        <li>Maximum number of primaries per host during failure is 11</li>
       </ul>
       <p>The usable memory available on a host is a function of 
         the amount of RAM and swap space configured for the system, as well as the
@@ -117,9 +117,8 @@ gp_seg_memory = total_gp_memory / number_of_active_primary_segments
     <section id="configuring_rg">
       <title>Configuring Resource Groups</title>
       <p>Greenplum Database resource groups provide a powerful mechanism for managing the workload
-        of the cluster. You can use resource groups to limit both the number of concurrent
-        active queries and the amount of CPU and memory that can be consumed by queries
-        running in the resource group.</p>
+        of the cluster. Consider these general guidelines when you configure resource groups
+        for your system:</p>
       <ul id="ul_svy_b3n_1s">
         <li>A transaction submitted by any Greenplum Database role with
             <codeph>SUPERUSER</codeph> privileges runs under the default resource
@@ -145,6 +144,10 @@ gp_seg_memory = total_gp_memory / number_of_active_primary_segments
           group for the workload and the time of day.</li>
         <li>Use the <codeph>gptoolkit</codeph> views to examine resource group resource
             usage and to monitor how the groups are working.</li>
+        <li otherprops="pivotal">A Greenplum Database workload is a resource group with
+          special assignment capabilities. Consider using Pivotal Greenplum Command Center
+          to create and manage workloads, and to define the criteria under which Command
+          Center dynamically assigns a transaction to a workload.</li>
       </ul>
     </section>
     <section id="section113x" xml:lang="en">
@@ -162,7 +165,7 @@ gp_seg_memory = total_gp_memory / number_of_active_primary_segments
         The default <codeph>CONCURRENCY</codeph> value for the <codeph>admin_group</codeph>
         resource group is 10.</p>
       <p>Certain Greenplum Database administrative utilities may use more than one
-        <codeph>CONCURRENCY</codeph> slot at runtime; for example, <codeph>gpbackup</codeph>
+        <codeph>CONCURRENCY</codeph> slot at runtime, such as <codeph>gpbackup</codeph>
         that you invoke with the <codeph>--jobs</codeph> option. If the utility(s) you run
         require more concurrent transactions than that configured for <codeph>admin_group</codeph>,
         consider temporarily increasing the group's <codeph>MEMORY_LIMIT</codeph> and

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -108,11 +108,14 @@ total_gp_memory = total_node_usable_memory * gp_resource_group_memory_limit
                 = 134.4GB</codeblock>
       <p>The memory available to a Greenplum Database segment on a segment host is a function
         of the memory reserved for Greenplum on the host and the number of active primary
-        segments on the host:</p>
+        segments on the host. On cluster startup:</p>
         <codeblock>
 gp_seg_memory = total_gp_memory / number_of_active_primary_segments
-              = 134.4GB / 11
-              = 12.2GB</codeblock>
+              = 134.4GB / 8
+              = 16.8GB</codeblock>
+      <p>Note that when 3 mirror segments switch to primary segments, the per-segment
+        memory is still 16.8GB. Total memory usage on the segment host may approach:
+        <codeblock>total_gp_memory_with_primaries = 16.8GB * 11 = 184.8GB</codeblock></p>
     </section>
     <section id="configuring_rg">
       <title>Configuring Resource Groups</title>
@@ -133,10 +136,6 @@ gp_seg_memory = total_gp_memory / number_of_active_primary_segments
         <li>Use the <codeph>MEMORY_LIMIT</codeph> and <codeph>MEMORY_SHARED_QUOTA</codeph>
             parameters to control the maximum amount of memory that queries running in the
            resource group can consume.</li>
-        <li>When you specify a <codeph>memory_spill_ratio</codeph> in your session,
-            individual queries running in the session can allocate more than their "share"
-           of memory, which reduces the memory available for other queries running in the
-           resource group.</li>
         <li>Greenplum Database assigns unreserved memory (100 - (sum of all resource
           group <codeph>MEMORY_LIMIT</codeph>s) to a global shared memory pool. This
           memory is available to all queries on a first-come, first-served basis.</li>

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -13,10 +13,10 @@
         <xref href="#topic_hhc_z5w_r4/section_r52_rbl_zt" format="dita"/>
       </li>
       <li>
-        <xref href="#topic_hhc_z5w_r4/section_upm_rbl_zt" format="dita"/>
+        <xref href="#topic_hhc_z5w_r4/configuring_rg" format="dita"/>
       </li>
       <li>
-        <xref href="#topic_hhc_z5w_r4/configuring_rg" format="dita"/>
+        <xref href="#topic_hhc_z5w_r4/section_upm_rbl_zt" format="dita"/>
       </li>
       <li>
         <xref href="#topic_hhc_z5w_r4/section113x" format="dita"/>
@@ -83,6 +83,37 @@
         </li>
       </ul>
     </section>
+    <section id="configuring_rg">
+      <title>Configuring Resource Groups</title>
+      <p>Greenplum Database resource groups provide a powerful mechanism for managing the workload
+        of the cluster. Consider these general guidelines when you configure resource groups
+        for your system:</p>
+      <ul id="ul_svy_b3n_1s">
+        <li>A transaction submitted by any Greenplum Database role with
+            <codeph>SUPERUSER</codeph> privileges runs under the default resource
+            group named <codeph>admin_group</codeph>. Keep this in mind when
+            scheduling and running Greenplum administration utilities.</li>
+        <li>Ensure that you assign each non-admin role a resource group. If you do not assign
+            a resource group to a role, queries submitted by the role are handled by the
+            default resource group named <codeph>default_group</codeph>.</li>
+        <li>Use the <codeph>CONCURRENCY</codeph> resource group parameter to limit the
+            number of active queries that members of a particular resource group can run
+            concurrently.</li>
+        <li>Use the <codeph>MEMORY_LIMIT</codeph> and <codeph>MEMORY_SHARED_QUOTA</codeph>
+            parameters to control the maximum amount of memory that queries running in the
+           resource group can consume.</li>
+        <li>Greenplum Database assigns unreserved memory (100 - (sum of all resource
+          group <codeph>MEMORY_LIMIT</codeph>s) to a global shared memory pool. This
+          memory is available to all queries on a first-come, first-served basis.</li>
+        <li>Alter resource groups dynamically to match the real requirements of the
+          group for the workload and the time of day.</li>
+        <li>Use the <codeph>gptoolkit</codeph> views to examine resource group resource
+            usage and to monitor how the groups are working.</li>
+        <li otherprops="pivotal">Consider using Pivotal Greenplum Command Center
+          to create and manage resource groups, and to define the criteria under which
+          Command Center dynamically assigns a transaction to a resource group.</li>
+      </ul>
+    </section>
     <section id="section_upm_rbl_zt">
       <title>Example Memory Configuration Calculations</title>
       <p>This section provides example memory calculations for a Greenplum Database system with
@@ -116,37 +147,6 @@ gp_seg_memory = total_gp_memory / number_of_active_primary_segments
       <p>Note that when 3 mirror segments switch to primary segments, the per-segment
         memory is still 16.8GB. Total memory usage on the segment host may approach:
         <codeblock>total_gp_memory_with_primaries = 16.8GB * 11 = 184.8GB</codeblock></p>
-    </section>
-    <section id="configuring_rg">
-      <title>Configuring Resource Groups</title>
-      <p>Greenplum Database resource groups provide a powerful mechanism for managing the workload
-        of the cluster. Consider these general guidelines when you configure resource groups
-        for your system:</p>
-      <ul id="ul_svy_b3n_1s">
-        <li>A transaction submitted by any Greenplum Database role with
-            <codeph>SUPERUSER</codeph> privileges runs under the default resource
-            group named <codeph>admin_group</codeph>. Keep this in mind when
-            scheduling and running Greenplum administration utilities.</li>
-        <li>Ensure that you assign each non-admin role a resource group. If you do not assign
-            a resource group to a role, queries submitted by the role are handled by the
-            default resource group named <codeph>default_group</codeph>.</li>
-        <li>Use the <codeph>CONCURRENCY</codeph> resource group parameter to limit the
-            number of active queries that members of a particular resource group can run
-            concurrently.</li>
-        <li>Use the <codeph>MEMORY_LIMIT</codeph> and <codeph>MEMORY_SHARED_QUOTA</codeph>
-            parameters to control the maximum amount of memory that queries running in the
-           resource group can consume.</li>
-        <li>Greenplum Database assigns unreserved memory (100 - (sum of all resource
-          group <codeph>MEMORY_LIMIT</codeph>s) to a global shared memory pool. This
-          memory is available to all queries on a first-come, first-served basis.</li>
-        <li>Alter resource groups dynamically to match the real requirements of the
-          group for the workload and the time of day.</li>
-        <li>Use the <codeph>gptoolkit</codeph> views to examine resource group resource
-            usage and to monitor how the groups are working.</li>
-        <li otherprops="pivotal">Consider using Pivotal Greenplum Command Center
-          to create and manage resource groups, and to define the criteria under which
-          Command Center dynamically assigns a transaction to a resource group.</li>
-      </ul>
     </section>
     <section id="section113x" xml:lang="en">
       <title>Low Memory Queries</title>

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -125,7 +125,7 @@ gp_seg_memory = total_gp_memory / number_of_active_primary_segments
             <codeph>SUPERUSER</codeph> privileges runs under the default resource
             group named <codeph>admin_group</codeph>. Keep this in mind when
             scheduling and running Greenplum administration utilities.</li>
-        <li>Ensure that each role is assigned a resource group. If you do not assign
+        <li>Ensure that you assign each non-admin role a resource group. If you do not assign
             a resource group to a role, queries submitted by the role are handled by the
             default resource group named <codeph>default_group</codeph>.</li>
         <li>Use the <codeph>CONCURRENCY</codeph> resource group parameter to limit the


### PR DESCRIPTION
create a best practices page for resource groups
- base level of content, tried to provide info parallel to what is discussed on resource queue best practices page
- add a section describing admin utilities and admin_group resource group concurrency

doc review site link:
- http://docs-gpdb-review-staging.cfapps.io/review/best_practices/resgroups.html