### PR TITLE
Add madlib_build_gppkg job to master pipeline

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -117,6 +117,7 @@ groups:
 {% if "AA" in test_sections %}
   ## --------------------------------------------------------------------
   - gate_advanced_analytics_start
+  - madlib_build_gppkg
 {% if "centos6" in os_types %}
   - MADlib_Test_orca_centos6
   - MADlib_Test_planner_centos6
@@ -287,6 +288,7 @@ groups:
 - name: AdvancedAnalytics
   jobs:
   - gate_advanced_analytics_start
+  - madlib_build_gppkg
 {% if "centos6" in os_types %}
   - MADlib_Test_orca_centos6
   - MADlib_Test_planner_centos6
@@ -641,6 +643,13 @@ resources:
 
 {% endif %}
 {% if "AA" in test_sections %}
+- name: madlib_src
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/apache/madlib.git
+    tag_filter: rel/*
+
 - name: madlib_ci
   type: git
   source:
@@ -651,12 +660,47 @@ resources:
 - name: madlib_gppkg
   type: s3
   source:
-    access_key_id: {{bucket-access-key-id}}
-    bucket: {{madlib-gppkg-bucket}}
-    region_name: {{aws-region}}
-    secret_access_key: {{bucket-secret-access-key}}
-    regexp: {{madlib-gpdb6-centos6-gppkg}}
+    access_key_id: {{madlib-s3-access_key_id}}
+    bucket: {{madlib-gppkg-gp6-bucket-name}}
+    secret_access_key: {{madlib-s3-secret_access_key}}
+    versioned_file: bin_madlib_artifacts_centos6/madlib-master-gp6-rhel6-x86_64.gppkg
+    region_name: us-west-2
 
+- name: cmake_tar
+  type: s3
+  source:
+    access_key_id: {{madlib-s3-access_key_id}}
+    bucket: {{madlib-ppr-bucket}}
+    region_name: us-west-2
+    secret_access_key: {{madlib-s3-secret_access_key}}
+    versioned_file: {{madlib-cmake-versioned_file}}
+
+- name: pyxb
+  type: s3
+  source:
+    access_key_id: {{madlib-s3-access_key_id}}
+    bucket: {{madlib-ppr-bucket}}
+    region_name: us-west-2
+    secret_access_key: {{madlib-s3-secret_access_key}}
+    versioned_file: PyXB-1.2.6.tar.gz
+
+- name: eigen
+  type: s3
+  source:
+    access_key_id: {{madlib-s3-access_key_id}}
+    bucket: {{madlib-ppr-bucket}}
+    region_name: us-west-2
+    secret_access_key: {{madlib-s3-secret_access_key}}
+    versioned_file: 3.2.tar.gz
+
+- name: boost
+  type: s3
+  source:
+    access_key_id: {{madlib-s3-access_key_id}}
+    bucket: {{madlib-ppr-bucket}}
+    region_name: us-west-2
+    secret_access_key: {{madlib-s3-secret_access_key}}
+    versioned_file: boost_1_61_0.tar.gz
 {% endif %}
 
 - name: reduced-frequency-trigger
@@ -2276,19 +2320,52 @@ jobs:
       - compile_gpdb_centos7
 {% endif %}
 
-{% if "centos6" in os_types %}
-- name: MADlib_Test_planner_centos6
+- name: madlib_build_gppkg
   plan:
   - aggregate:
+    - get: madlib_src
+      trigger: true
     - get: madlib_ci
+    - get: cmake_tar
+    - get: pyxb
+    - get: eigen
+    - get: boost
     - get: gpdb_src
       passed: [gate_advanced_analytics_start]
     - get: bin_gpdb
       resource: bin_gpdb_centos6
       trigger: [[ test_trigger ]]
       passed: [gate_advanced_analytics_start]
+    - get: bin_gpdb_centos7
+      passed: [gate_advanced_analytics_start]
+    - get: centos-gpdb-dev-6
+  - task: build_madlib_gppkg_from_source
+    file: madlib_ci/concourse/tasks/madlib_build_gppkg_from_source.yml
+    image: centos-gpdb-dev-6
+    params:
+      TEST_OS: centos6
+      DB_TYPE: gpdb6
+      CMAKE_BUILD_TYPE: Release
+      GCC_VERSION: "gcc4"
+  - aggregate:
+    - put: madlib_gppkg
+      params:
+        file: madlib_master_artifacts/madlib-*.gppkg
+
+{% if "centos6" in os_types %}
+- name: MADlib_Test_planner_centos6
+  plan:
+  - aggregate:
+    - get: madlib_ci
+    - get: gpdb_src
+      passed: [madlib_build_gppkg]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [madlib_build_gppkg]
     - get: centos-gpdb-dev-6
     - get: madlib_gppkg
+      passed: [madlib_build_gppkg]
+      trigger: true
   - task: MADlib_Test_gppkg
     file: madlib_ci/concourse/tasks/madlib_test_gppkg.yml
     image: centos-gpdb-dev-6
@@ -2302,13 +2379,14 @@ jobs:
   - aggregate:
     - get: madlib_ci
     - get: gpdb_src
-      passed: [gate_advanced_analytics_start]
+      passed: [madlib_build_gppkg]
     - get: bin_gpdb
       resource: bin_gpdb_centos6
-      trigger: [[ test_trigger ]]
-      passed: [gate_advanced_analytics_start]
+      passed: [madlib_build_gppkg]
     - get: centos-gpdb-dev-6
     - get: madlib_gppkg
+      passed: [madlib_build_gppkg]
+      trigger: true
   - task: MADlib_Test_gppkg
     file: madlib_ci/concourse/tasks/madlib_test_gppkg.yml
     image: centos-gpdb-dev-6
@@ -2324,13 +2402,14 @@ jobs:
   - aggregate:
     - get: madlib_ci
     - get: gpdb_src
-      passed: [gate_advanced_analytics_start]
+      passed: [madlib_build_gppkg]
     - get: bin_gpdb
       resource: bin_gpdb_centos7
-      trigger: [[ test_trigger ]]
-      passed: [gate_advanced_analytics_start]
+      passed: [madlib_build_gppkg]
     - get: centos-gpdb-test-7
     - get: madlib_gppkg
+      passed: [madlib_build_gppkg]
+      trigger: true
   - task: MADlib_Test_gppkg
     file: madlib_ci/concourse/tasks/madlib_test_gppkg.yml
     image: centos-gpdb-test-7
@@ -2344,13 +2423,14 @@ jobs:
   - aggregate:
     - get: madlib_ci
     - get: gpdb_src
-      passed: [gate_advanced_analytics_start]
+      passed: [madlib_build_gppkg]
     - get: bin_gpdb
       resource: bin_gpdb_centos7
-      trigger: [[ test_trigger ]]
-      passed: [gate_advanced_analytics_start]
+      passed: [madlib_build_gppkg]
     - get: centos-gpdb-test-7
     - get: madlib_gppkg
+      passed: [madlib_build_gppkg]
+      trigger: true
   - task: MADlib_Test_gppkg
     file: madlib_ci/concourse/tasks/madlib_test_gppkg.yml
     image: centos-gpdb-test-7


### PR DESCRIPTION
The current gpdb master pipeline fetches madlib gppkg compiled against
ealier version of gpdb code, installs the gppkg and runs dev check in a
container with latest gpdb installed. If there is catalog change in gpdb,
the test will fail.

To solve this issue, we add a job build_madlib_gppkg to compile madlib
gppkg from soure and pass it to downstream dev check jobs so that madlib is
always compiled and tested against latest catalog change.

Co-authored-by: Domino Valdano <dvaldano@pivotal.io>