### PR TITLE
docs - add missing gp-specific options to pg_dump

### DIFF
--- a/gpdb-doc/dita/utility_guide/client_utilities/pg_dump.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/pg_dump.xml
@@ -301,6 +301,16 @@
               regular PostgreSQL system.</pd>
           </plentry>
           <plentry>
+            <pt>--function-oids <varname>oids</varname></pt>
+            <pd>Dump the function(s) specified in the <varname>oids</varname> list of
+              object identifiers.</pd>
+          </plentry>
+          <plentry>
+            <pt>--relation-oids <varname>oids</varname></pt>
+            <pd>Dump the relation(s) specified in the <varname>oids</varname> list of
+              object identifiers.</pd>
+          </plentry>
+          <plentry>
             <pt>-Z 0..9 | --compress=0..9</pt>
             <pd>Specify the compression level to use in archive formats that support compression.
               Currently only the <varname>custom</varname> archive format supports compression.</pd>


### PR DESCRIPTION
pg_dump command line help includes the following 2 options that are missing from the docs:

   --function-oids            dump only function(s) of given list of oids
   --relation-oids             dump only relation(s) of given list of oids

these options were added in mid 2016 and are used by the minirepro tool.

add these these options to the pg_dump doc reference page unless there are any objections ...