### PR TITLE
Fix 'stack_base_ptr' issue with '--enable-testutils'.

### DIFF
--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -190,7 +190,6 @@ AuxiliaryProcessMain(int argc, char *argv[])
 	char	   *progname = argv[0];
 	int			flag;
 	char	   *userDoption = NULL;
-	char		stack_base;
 
 	/*
 	 * initialize globals
@@ -198,9 +197,6 @@ AuxiliaryProcessMain(int argc, char *argv[])
 	MyProcPid = getpid();
 
 	MyStartTime = time(NULL);
-
-	/* Set up reference point for stack depth checking */
-	stack_base_ptr = &stack_base;
 
 	/*
 	 * Fire up essential subsystems: error and memory management

--- a/src/backend/main/main.c
+++ b/src/backend/main/main.c
@@ -208,12 +208,6 @@ main(int argc, char *argv[])
 	if (argc > 1 && strcmp(argv[1], "--single") == 0)
 		exit(PostgresMain(argc, argv, NULL, get_current_username(progname)));
 
-	if (strcmp(progname, "postmaster") == 0)
-	{
-		/* Called as "postmaster" */
-		exit(PostmasterMain(argc, argv));
-	}
-
 	exit(PostmasterMain(argc, argv));
 }
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -613,16 +613,12 @@ PostmasterMain(int argc, char *argv[])
 	char	   *userDoption = NULL;
 	bool		listen_addr_saved = false;
 	int			i;
-	char		stack_base;
 
 	MyProcPid = PostmasterPid = getpid();
 
 	MyStartTime = time(NULL);
 
 	IsPostmasterEnvironment = true;
-
-	/* Set up reference point for stack depth checking */
-	stack_base_ptr = &stack_base;
 
 	/*
 	 * for security, no dir or file created can be group or other accessible

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -4739,7 +4739,16 @@ uint32 gp_backtrace(void **stackAddresses, uint32 maxStackDepth)
 {
 #if defined(__i386) || defined(__x86_64__)
 
-	Assert(stack_base_ptr != NULL);
+	/*
+	 * Stack base pointer has not been initialized by PostmasterMain,
+	 * or PostgresMain/AuxiliaryProcessMain is called directly by main
+	 * rather than forked by PostmasterMain (such as when initdb).
+	 *
+	 * In this case, just return depth as 0 to indicate that we have not
+	 * stored any frame addresses.
+	 */
+	if (stack_base_ptr == NULL)
+		return 0;
 
 	/* get base pointer of current frame */
 	uint64 framePtrValue = 0;

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -51,9 +51,6 @@ extern int	postmaster_alive_fds[2];
 
 extern const char *progname;
 
-/* stack base pointer, defined in postgres.c */
-extern char *stack_base_ptr;
-
 extern int	PostmasterMain(int argc, char *argv[]);
 extern void ClosePostmasterPorts(bool am_syslogger);
 


### PR DESCRIPTION
Also revise 'stack_base_ptr' related codes to keep
the same with upstream.

This is to fix initdb failure with flag '--enable-testutils'.
No new test case is needed.