### PR TITLE
Convert Insist to ereport on backend/storage

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -478,9 +478,7 @@ count_usable_fds(int max_to_probe, int *usable_fds, int *already_open)
 		{
 			/* Expect EMFILE or ENFILE, else it's fishy */
 			if (errno != EMFILE && errno != ENFILE)
-			{
-				insist_log(false, "dup(0) failed after %d successes: %m", used);
-			}
+				ereport(WARNING, (errmsg("dup(0) failed after %d successes: %m", used)));
 			break;
 		}
 

--- a/src/backend/storage/file/gp_compress.c
+++ b/src/backend/storage/file/gp_compress.c
@@ -46,7 +46,7 @@ int gp_trycompress_new(
 	 PGFunction     compressor,
 	 CompressionState *compressionState)
 {
-	Insist(PointerIsValid(compressor));
+	Assert(PointerIsValid(compressor));
 
 	gp_trycompress_generic(sourceData, sourceLen, compressedBuffer,
 						   compressedBufferWithOverrrunLen, compressedLen,

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -900,11 +900,10 @@ LockAcquireExtended(const LOCKTAG *locktag,
 	}
 	else if (proclock->holdMask & LOCKBIT_ON(lockmode))
 	{
-		elog(LOG, "lock %s on object %u/%u/%u is already held",
+		ereport(ERROR, (errmsg("lock %s on object %u/%u/%u is already held",
 			 lockMethodTable->lockModeNames[lockmode],
 			 lock->tag.locktag_field1, lock->tag.locktag_field2,
-			 lock->tag.locktag_field3);
-		Insist(false);
+			 lock->tag.locktag_field3)));
 	}
 
 	if (MyProc == lockHolderProcPtr)
@@ -4019,13 +4018,10 @@ lock_twophase_recover(TransactionId xid, uint16 info,
 	 * We shouldn't already hold the desired lock.
 	 */
 	if (proclock->holdMask & LOCKBIT_ON(lockmode))
-	{
-		elog(LOG, "lock %s on object %u/%u/%u is already held",
+		ereport(ERROR, (errmsg("lock %s on object %u/%u/%u is already held",
 			 lockMethodTable->lockModeNames[lockmode],
 			 lock->tag.locktag_field1, lock->tag.locktag_field2,
-			 lock->tag.locktag_field3);
-		Insist(false);
-	}
+			 lock->tag.locktag_field3)));
 
 	/*
 	 * We ignore any possible conflicts and just grant ourselves the lock. Not


### PR DESCRIPTION
converted insist_log to ereport to match upstream
Changed the log level on lock.c from LOG to ERROR so that ereport will halt the execution without using Insist

Please refer: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/BH1IXU6vnEw