### PR TITLE
5 x stable remove hungarian

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.68.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.69.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.68.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.69.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12402,7 +12402,7 @@ int
 main ()
 {
 
-return strncmp("2.68.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.69.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12412,7 +12412,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.68.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.69.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/contrib/orca_debug/orca_debug.cpp
+++ b/contrib/orca_debug/orca_debug.cpp
@@ -119,7 +119,7 @@ static Query *parseSQL(char *szSqlText)
 
 	List *plQueryTree = pg_parse_and_rewrite(szSqlText, NULL, 0);
 
-	if (1 != gpdb::UlListLength(plQueryTree))
+	if (1 != gpdb::ListLength(plQueryTree))
 	{
 		elog(ERROR, "problem parsing query %s", szSqlText);
 	}
@@ -149,7 +149,7 @@ static PlannedStmt *planQuery(char *szSqlText)
 
 	List *plQueryTree = pg_parse_and_rewrite(szSqlText, NULL, 0);
 
-	if (1 != gpdb::UlListLength(plQueryTree))
+	if (1 != gpdb::ListLength(plQueryTree))
 	{
 		elog(ERROR, "problem parsing query %s", szSqlText);
 	}
@@ -272,7 +272,7 @@ static int translateQueryToFile
 	Assert(pquery);
 
 	char *szXmlString = COptTasks::SzDXL(pquery);
-	int iLen = (int) gpos::clib::UlStrLen(szXmlString);
+	int iLen = (int) gpos::clib::Strlen(szXmlString);
 
 	CFileWriter fw;
 	fw.Open(szFilename, S_IRUSR | S_IWUSR);
@@ -664,14 +664,14 @@ DumpMDObjDXL(PG_FUNCTION_ARGS)
 {
 	Oid oid = gpdb::OidFromDatum(PG_GETARG_DATUM(0));
 
-	char *szDXL = COptTasks::SzMDObjs(ListMake1Oid(oid));
+	char *dxl_string = COptTasks::SzMDObjs(ListMake1Oid(oid));
 
-	if (NULL == szDXL)
+	if (NULL == dxl_string)
 	{
 		elog(ERROR, "Error dumping MD object");
 	}
 
-	PG_RETURN_TEXT_P(cstring_to_text(szDXL));
+	PG_RETURN_TEXT_P(cstring_to_text(dxl_string));
 }
 }
 
@@ -692,9 +692,9 @@ DumpRelStatsDXL(PG_FUNCTION_ARGS)
 {
 	Oid oid = gpdb::OidFromDatum(PG_GETARG_DATUM(0));
 
-	char *szDXL = COptTasks::SzRelStats(ListMake1Oid(oid));
+	char *dxl_string = COptTasks::SzRelStats(ListMake1Oid(oid));
 
-	PG_RETURN_TEXT_P(cstring_to_text(szDXL));
+	PG_RETURN_TEXT_P(cstring_to_text(dxl_string));
 }
 }
 
@@ -716,9 +716,9 @@ DumpMDCastDXL(PG_FUNCTION_ARGS)
 	Oid oidSrc = gpdb::OidFromDatum(PG_GETARG_DATUM(0));
 	Oid oidDest = gpdb::OidFromDatum(PG_GETARG_DATUM(1));
 
-	char *szDXL = COptTasks::SzMDCast(ListMake2Oid(oidSrc, oidDest));
+	char *dxl_string = COptTasks::SzMDCast(ListMake2Oid(oidSrc, oidDest));
 
-	PG_RETURN_TEXT_P(cstring_to_text(szDXL));
+	PG_RETURN_TEXT_P(cstring_to_text(dxl_string));
 }
 }
 
@@ -741,9 +741,9 @@ DumpMDScCmpDXL(PG_FUNCTION_ARGS)
 	Oid oidRight = gpdb::OidFromDatum(PG_GETARG_DATUM(1));
 	char *szCmpType = text_to_cstring(PG_GETARG_TEXT_P(2));
 	
-	char *szDXL = COptTasks::SzMDScCmp(ListMake2Oid(oidLeft, oidRight), szCmpType);
+	char *dxl_string = COptTasks::SzMDScCmp(ListMake2Oid(oidLeft, oidRight), szCmpType);
 
-	PG_RETURN_TEXT_P(cstring_to_text(szDXL));
+	PG_RETURN_TEXT_P(cstring_to_text(dxl_string));
 }
 }
 

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.68.0@gpdb/stable
+orca/v2.69.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.68.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.69.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -52,7 +52,7 @@
 #include "miscadmin.h"
 
 #ifdef USE_ORCA
-extern char *SzDXLPlan(Query *parse);
+extern char *SerializeDXLPlan(Query *parse);
 extern const char *OptVersion();
 #endif
 
@@ -226,7 +226,7 @@ ExplainDXL(Query *query, ExplainStmt *stmt, const char *queryString,
 		optimizer_enumerate_plans = true;
 
 		// optimize query using optimizer and get generated plan in DXL format
-		char *dxl = SzDXLPlan(query);
+		char *dxl = SerializeDXLPlan(query);
 
 		// restore old value of enumerate plans GUC
 		optimizer_enumerate_plans = save_enumerate;
@@ -1137,7 +1137,7 @@ explain_outNode(StringInfo str,
 
 				/* scale the number of rows by the number of segments sending data */
 				scaleFactor = nSenders;
-				
+
 				switch (pMotion->motionType)
 				{
 					case MOTIONTYPE_HASH:
@@ -1279,8 +1279,8 @@ explain_outNode(StringInfo str,
 				/* Get the range table, it should be a TableFunction */
 				rte = rt_fetch(((Scan *) plan)->scanrelid, es->rtable);
 				Assert(rte->rtekind == RTE_TABLEFUNCTION);
-				
-				/* 
+
+				/*
 				 * Lookup the function name.
 				 *
 				 * Unlike RTE_FUNCTION there should be no cases where the
@@ -1295,9 +1295,9 @@ explain_outNode(StringInfo str,
 				if (strcmp(rte->eref->aliasname, proname) != 0)
 					appendStringInfo(str, " %s",
 									 quote_identifier(rte->eref->aliasname));
-				
+
 				/* might be nice to add order by and scatter by info */
-				
+
 			}
 			break;
 		case T_FunctionScan:
@@ -1615,7 +1615,7 @@ explain_outNode(StringInfo str,
 						   str, indent, es);
 
 			/* Partitioning and ordering information */
-			
+
 		}
 		break;
 
@@ -1830,7 +1830,7 @@ explain_outNode(StringInfo str,
 
 			for (i = 0; i < indent; i++)
 				appendStringInfo(str, "  ");
-			
+
 			appendStringInfo(str, "  ->  ");
 
 			explain_outNode(str, subnode,

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -36,26 +36,26 @@ extern MemoryContext MessageContext;
 //
 //---------------------------------------------------------------------------
 PlannedStmt *
-CGPOptimizer::PplstmtOptimize
+CGPOptimizer::GPOPTOptimizedPlan
 	(
-	Query *pquery,
-	bool *pfUnexpectedFailure // output : set to true if optimizer unexpectedly failed to produce plan
+	Query *query,
+	bool *had_unexpected_failure // output : set to true if optimizer unexpectedly failed to produce plan
 	)
 {
-	SOptContext octx;
+	SOptContext gpopt_context;
 	PlannedStmt* plStmt = NULL;
 	GPOS_TRY
 	{
-		plStmt = COptTasks::PplstmtOptimize(pquery, &octx, pfUnexpectedFailure);
+		plStmt = COptTasks::GPOPTOptimizedPlan(query, &gpopt_context, had_unexpected_failure);
 		// clean up context
-		octx.Free(octx.epinQuery, octx.epinPlStmt);
+		gpopt_context.Free(gpopt_context.epinQuery, gpopt_context.epinPlStmt);
 	}
 	GPOS_CATCH_EX(ex)
 	{
 		// clone the error message before context free.
-		CHAR* szErrorMsg = octx.CloneErrorMsg(MessageContext);
+		CHAR* serialized_error_msg = gpopt_context.CloneErrorMsg(MessageContext);
 		// clean up context
-		octx.Free(octx.epinQuery, octx.epinPlStmt);
+		gpopt_context.Free(gpopt_context.epinQuery, gpopt_context.epinPlStmt);
 
 		// Special handler for a few common user-facing errors. In particular,
 		// we want to use the correct error code for these, in case an application
@@ -64,18 +64,18 @@ CGPOptimizer::PplstmtOptimize
 		// application errors.
 		if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLNotNullViolation))
 		{
-			errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
 			errfinish(errcode(ERRCODE_NOT_NULL_VIOLATION),
-				  errmsg("%s", szErrorMsg));
+				  errmsg("%s", serialized_error_msg));
 		}
 
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiOptimizerError) ||
-			NULL != szErrorMsg)
+			NULL != serialized_error_msg)
 		{
-			Assert(NULL != szErrorMsg);
-			errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+			Assert(NULL != serialized_error_msg);
+			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
 			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
-					errmsg("%s", szErrorMsg));
+					errmsg("%s", serialized_error_msg));
 		}
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
 		{
@@ -83,13 +83,13 @@ CGPOptimizer::PplstmtOptimize
 		}
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiNoAvailableMemory))
 		{
-			errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
 			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
 					errmsg("No available memory to allocate string buffer."));
 		}
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiInvalidComparisonTypeCode))
 		{
-			errstart(ERROR, ex.SzFilename(), ex.UlLine(), NULL, TEXTDOMAIN);
+			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
 			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
 					errmsg("Invalid comparison type code. Valid values are Eq, NEq, LT, LEq, GT, GEq."));
 		}
@@ -108,12 +108,12 @@ CGPOptimizer::PplstmtOptimize
 //
 //---------------------------------------------------------------------------
 char *
-CGPOptimizer::SzDXLPlan
+CGPOptimizer::SerializeDXLPlan
 	(
-	Query *pquery
+	Query *query
 	)
 {
-	return COptTasks::SzOptimize(pquery);
+	return COptTasks::Optimize(query);
 }
 
 //---------------------------------------------------------------------------
@@ -136,7 +136,7 @@ CGPOptimizer::InitGPOPT ()
 	gpos_free = gpdb::OptimizerFree;
   }
   struct gpos_init_params params =
-	{gpos_alloc, gpos_free, gpdb::FAbortRequested};
+	{gpos_alloc, gpos_free, gpdb::IsAbortRequested};
   gpos_init(&params);
   gpdxl_init();
   gpopt_init();
@@ -160,7 +160,7 @@ CGPOptimizer::TerminateGPOPT ()
 
 //---------------------------------------------------------------------------
 //	@function:
-//		PplstmtOptimize
+//		GPOPTOptimizedPlan
 //
 //	@doc:
 //		Expose GP optimizer API to C files
@@ -168,19 +168,19 @@ CGPOptimizer::TerminateGPOPT ()
 //---------------------------------------------------------------------------
 extern "C"
 {
-PlannedStmt *PplstmtOptimize
+PlannedStmt *GPOPTOptimizedPlan
 	(
-	Query *pquery,
-	bool *pfUnexpectedFailure
+	Query *query,
+	bool *had_unexpected_failure
 	)
 {
-	return CGPOptimizer::PplstmtOptimize(pquery, pfUnexpectedFailure);
+	return CGPOptimizer::GPOPTOptimizedPlan(query, had_unexpected_failure);
 }
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		SzDXLPlan
+//		SerializeDXLPlan
 //
 //	@doc:
 //		Serialize planned statement to DXL
@@ -188,12 +188,12 @@ PlannedStmt *PplstmtOptimize
 //---------------------------------------------------------------------------
 extern "C"
 {
-char *SzDXLPlan
+char *SerializeDXLPlan
 	(
-	Query *pquery
+	Query *query
 	)
 {
-	return CGPOptimizer::SzDXLPlan(pquery);
+	return CGPOptimizer::SerializeDXLPlan(query);
 }
 }
 

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -24,89 +24,89 @@ using namespace gpdxl;
 using namespace gpopt;
 
 // array mapping GUCs to traceflags
-CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elem[] =
+CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] =
 {
 		{
 		EopttracePrintQuery,
 		&optimizer_print_query,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints the optimizer's input query expression tree.")
 		},
 
 		{
 		EopttracePrintPlan,
 		&optimizer_print_plan,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints the plan expression tree produced by the optimizer.")
 		},
 
 		{
 		EopttracePrintXform,
 		&optimizer_print_xform,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints the input and output expression trees of the optimizer transformations.")
 		},
 
 		{
 		EopttracePrintXformResults,
 		&optimizer_print_xform_results,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Print input and output of xforms.")
 		},
 
 		{
 		EopttracePrintMemoAfterExploration,
 		&optimizer_print_memo_after_exploration,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints MEMO after exploration.")
 		},
 
 		{
 		EopttracePrintMemoAfterImplementation,
 		&optimizer_print_memo_after_implementation,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints MEMO after implementation.")
 		},
 
 		{
 		EopttracePrintMemoAfterOptimization,
 		&optimizer_print_memo_after_optimization,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints MEMO after optimization.")
 		},
 
 		{
 		EopttracePrintJobScheduler,
 		&optimizer_print_job_scheduler,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints jobs in scheduler on each job completion.")
 		},
 
 		{
 		EopttracePrintExpressionProperties,
 		&optimizer_print_expression_properties,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints expression properties.")
 		},
 
 		{
 		EopttracePrintGroupProperties,
 		&optimizer_print_group_properties,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints group properties.")
 		},
 
 		{
 		EopttracePrintOptimizationContext,
 		&optimizer_print_optimization_context,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints optimization context.")
 		},
 
 		{
 		EopttracePrintOptimizationStatistics,
 		&optimizer_print_optimization_stats,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Prints optimization stats.")
 		},
 
@@ -120,387 +120,387 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elem[] =
 		{
 		EopttraceDisableMotions,
 		&optimizer_enable_motions,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionBroadcast,
 		&optimizer_enable_motion_broadcast,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion broadcast nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionGather,
 		&optimizer_enable_motion_gather,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion gather nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionHashDistribute,
 		&optimizer_enable_motion_redistribute,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion hash-distribute nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionRandom,
 		&optimizer_enable_motion_redistribute,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion random nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableMotionRountedDistribute,
 		&optimizer_enable_motion_redistribute,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable motion routed-distribute nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableSort,
 		&optimizer_enable_sort,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable sort nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisableSpool,
 		&optimizer_enable_materialize,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable spool nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisablePartPropagation,
 		&optimizer_enable_partition_propagation,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable partition propagation nodes in optimizer.")
 		},
 
 		{
 		EopttraceDisablePartSelection,
 		&optimizer_enable_partition_selection,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable partition selection in optimizer.")
 		},
 
 		{
 		EopttraceDisableOuterJoin2InnerJoinRewrite,
 		&optimizer_enable_outerjoin_rewrite,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable outer join to inner join rewrite in optimizer.")
 		},
 
 		{
 		EopttraceDonotDeriveStatsForAllGroups,
 		&optimizer_enable_derive_stats_all_groups,
-		true, // m_fNegate
+		true, // m_negate_param
 		GPOS_WSZ_LIT("Disable deriving stats for all groups after exploration.")
 		},
 
 		{
 		EopttraceEnableSpacePruning,
 		&optimizer_enable_space_pruning,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable space pruning in optimizer.")
 		},
 
 		{
 		EopttraceForceMultiStageAgg,
 		&optimizer_force_multistage_agg,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Force optimizer to always pick multistage aggregates when such a plan alternative is generated.")
 		},
 
 		{
 		EopttracePrintColsWithMissingStats,
 		&optimizer_print_missing_stats,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Print columns with missing statistics.")
 		},
 
 		{
 		EopttraceEnableRedistributeBroadcastHashJoin,
 		&optimizer_enable_hashjoin_redistribute_broadcast_children,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable generating hash join plan where outer child is Redistribute and inner child is Broadcast.")
 		},
 
 		{
 		EopttraceExtractDXLStats,
 		&optimizer_extract_dxl_stats,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Extract plan stats in dxl.")
 		},
 
 		{
 		EopttraceExtractDXLStatsAllNodes,
 		&optimizer_extract_dxl_stats_all_nodes,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Extract plan stats for all physical dxl nodes.")
 		},
 
 		{
 		EopttraceDeriveStatsForDPE,
 		&optimizer_dpe_stats,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable stats derivation of partitioned tables with dynamic partition elimination.")
 		},
 
 		{
 		EopttraceEnumeratePlans,
 		&optimizer_enumerate_plans,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable plan enumeration.")
 		},
 
 		{
 		EopttraceSamplePlans,
 		&optimizer_sample_plans,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable plan sampling.")
 		},
 
 		{
 		EopttraceEnableCTEInlining,
 		&optimizer_cte_inlining,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable CTE inlining.")
 		},
 
 		{
 		EopttraceEnableConstantExpressionEvaluation,
 		&optimizer_enable_constant_expression_evaluation,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Enable constant expression evaluation in the optimizer")
 		},
 
 		{
 		EopttraceUseExternalConstantExpressionEvaluationForInts,
 		&optimizer_use_external_constant_expression_evaluation_for_ints,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Enable constant expression evaluation for integers in the optimizer")
 		},
 
 		{
 		EopttraceApplyLeftOuter2InnerUnionAllLeftAntiSemiJoinDisregardingStats,
 		&optimizer_apply_left_outer_to_union_all_disregarding_stats,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Always apply Left Outer Join to Inner Join UnionAll Left Anti Semi Join without looking at stats")
 		},
 
 		{
 		EopttraceRemoveOrderBelowDML,
 		&optimizer_remove_order_below_dml,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Remove OrderBy below a DML operation")
 		},
 
 		{
 		EopttraceDisableReplicateInnerNLJOuterChild,
 		&optimizer_enable_broadcast_nestloop_outer_child,
-		true,  // m_fNegate
+		true,  // m_negate_param
 		GPOS_WSZ_LIT("Enable plan alternatives where NLJ's outer child is replicated")
 		},
 
 		{
 		EopttraceEnforceCorrelatedExecution,
 		&optimizer_enforce_subplans,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Enforce correlated execution in the optimizer")
 		},
 
 		{
 		EopttraceForceExpandedMDQAs,
 		&optimizer_force_expanded_distinct_aggs,
-		false,  // m_fNegate
+		false,  // m_negate_param
 		GPOS_WSZ_LIT("Always pick plans that expand multiple distinct aggregates into join of single distinct aggregate in the optimizer")
 		},
 
 		{
 		EopttraceDisablePushingCTEConsumerReqsToCTEProducer,
 		&optimizer_push_requirements_from_consumer_to_producer,
-		true,  // m_fNegate
+		true,  // m_negate_param
 		GPOS_WSZ_LIT("Optimize CTE producer plan on requirements enforced on top of CTE consumer")
 		},
 
 		{
 		EopttraceDisablePruneUnusedComputedColumns,
 		&optimizer_prune_computed_columns,
-		true,  // m_fNegate
+		true,  // m_negate_param
 		GPOS_WSZ_LIT("Prune unused computed columns when pre-processing query")
 		},
 
 		{
 		EopttraceForceThreeStageScalarDQA,
 		&optimizer_force_three_stage_scalar_dqa,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Force optimizer to always pick 3 stage aggregate plan for scalar distinct qualified aggregate.")
 		},
 
 		{
 		EopttraceEnableParallelAppend,
 		&optimizer_parallel_union,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Enable parallel execution for UNION/UNION ALL queries.")
 		},
 
 		{
 		EopttraceArrayConstraints,
 		&optimizer_array_constraints,
-		false, // m_fNegate
+		false, // m_negate_param
 		GPOS_WSZ_LIT("Allows the constraint framework to derive array constraints in the optimizer.")
 		}
 };
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CConfigParamMapping::PbsPack
+//		CConfigParamMapping::PackConfigParamInBitset
 //
 //	@doc:
 //		Pack the GPDB config params into a bitset
 //
 //---------------------------------------------------------------------------
 CBitSet *
-CConfigParamMapping::PbsPack
+CConfigParamMapping::PackConfigParamInBitset
 	(
-	IMemoryPool *pmp,
-	ULONG ulXforms // number of available xforms
+	IMemoryPool *mp,
+	ULONG xform_id // number of available xforms
 	)
 {
-	CBitSet *pbs = GPOS_NEW(pmp) CBitSet(pmp, EopttraceSentinel);
+	CBitSet *traceflag_bitset = GPOS_NEW(mp) CBitSet(mp, EopttraceSentinel);
 
-	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(m_elem); ul++)
+	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(m_elements); ul++)
 	{
-		SConfigMappingElem elem = m_elem[ul];
-		GPOS_ASSERT(!pbs->FBit((ULONG) elem.m_etf) &&
+		SConfigMappingElem elem = m_elements[ul];
+		GPOS_ASSERT(!traceflag_bitset->Get((ULONG) elem.m_trace_flag) &&
 					"trace flag already set");
 
-		BOOL fVal = *elem.m_pfParam;
-		if (elem.m_fNegate)
+		BOOL value = *elem.m_is_param;
+		if (elem.m_negate_param)
 		{
 			// negate the value of config param
-			fVal = !fVal;
+			value = !value;
 		}
 
-		if (fVal)
+		if (value)
 		{
 #ifdef GPOS_DEBUG
-			BOOL fSet =
+			BOOL is_traceflag_set =
 #endif // GPOS_DEBUG
-				pbs->FExchangeSet((ULONG) elem.m_etf);
-			GPOS_ASSERT(!fSet);
+				traceflag_bitset->ExchangeSet((ULONG) elem.m_trace_flag);
+			GPOS_ASSERT(!is_traceflag_set);
 		}
 	}
 
 	// pack disable flags of xforms
-	for (ULONG ul = 0; ul < ulXforms; ul++)
+	for (ULONG ul = 0; ul < xform_id; ul++)
 	{
-		GPOS_ASSERT(!pbs->FBit(EopttraceDisableXformBase + ul) &&
+		GPOS_ASSERT(!traceflag_bitset->Get(EopttraceDisableXformBase + ul) &&
 					"xform trace flag already set");
 
 		if (optimizer_xforms[ul])
 		{
 #ifdef GPOS_DEBUG
-			BOOL fSet =
+			BOOL is_traceflag_set =
 #endif // GPOS_DEBUG
-				pbs->FExchangeSet(EopttraceDisableXformBase + ul);
-			GPOS_ASSERT(!fSet);
+				traceflag_bitset->ExchangeSet(EopttraceDisableXformBase + ul);
+			GPOS_ASSERT(!is_traceflag_set);
 		}
 	}
 
 	// disable index-join if the corresponding GUC is turned off
 	if (!optimizer_enable_indexjoin)
 	{
-		CBitSet *pbsIndexJoin = CXform::PbsIndexJoinXforms(pmp);
-		pbs->Union(pbsIndexJoin);
-		pbsIndexJoin->Release();
+		CBitSet *index_join_bitset = CXform::PbsIndexJoinXforms(mp);
+		traceflag_bitset->Union(index_join_bitset);
+		index_join_bitset->Release();
 	}
 
 	// disable bitmap scan if the corresponding GUC is turned off
 	if (!optimizer_enable_bitmapscan)
 	{
-		CBitSet *pbsBitmapScan = CXform::PbsBitmapIndexXforms(pmp);
-		pbs->Union(pbsBitmapScan);
-		pbsBitmapScan->Release();
+		CBitSet *bitmap_index_bitset = CXform::PbsBitmapIndexXforms(mp);
+		traceflag_bitset->Union(bitmap_index_bitset);
+		bitmap_index_bitset->Release();
 	}
 
 	// disable outerjoin to unionall transformation if GUC is turned off
 	if (!optimizer_enable_outerjoin_to_unionall_rewrite)
 	{
-		 pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftOuter2InnerUnionAllLeftAntiSemiJoin));
+		 traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftOuter2InnerUnionAllLeftAntiSemiJoin));
 	}
 
 	// disable Assert MaxOneRow plans if GUC is turned off
 	if (!optimizer_enable_assert_maxonerow)
 	{
-		 pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfMaxOneRow2Assert));
+		 traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfMaxOneRow2Assert));
 	}
 
 	if (!optimizer_enable_partial_index)
 	{
-		CBitSet *pbsHeterogeneousIndex = CXform::PbsHeterogeneousIndexXforms(pmp);
-		pbs->Union(pbsHeterogeneousIndex);
-		pbsHeterogeneousIndex->Release();
+		CBitSet *heterogeneous_index_bitset = CXform::PbsHeterogeneousIndexXforms(mp);
+		traceflag_bitset->Union(heterogeneous_index_bitset);
+		heterogeneous_index_bitset->Release();
 	}
 
 	if (!optimizer_enable_hashjoin)
 	{
 		// disable hash-join if the corresponding GUC is turned off
-		CBitSet *pbsHashJoin = CXform::PbsHashJoinXforms(pmp);
-		pbs->Union(pbsHashJoin);
-		pbsHashJoin->Release();
+		CBitSet *hash_join_bitste = CXform::PbsHashJoinXforms(mp);
+		traceflag_bitset->Union(hash_join_bitste);
+		hash_join_bitste->Release();
 	}
 
 	if (!optimizer_enable_dynamictablescan)
 	{
 		// disable dynamic table scan if the corresponding GUC is turned off
-		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfDynamicGet2DynamicTableScan));
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfDynamicGet2DynamicTableScan));
 	}
 
 	if (!optimizer_enable_tablescan)
 	{
 		// disable table scan if the corresponding GUC is turned off
-		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfGet2TableScan));
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfGet2TableScan));
 	}
 
 	if (!optimizer_enable_indexscan)
 	{
 		// disable index scan if the corresponding GUC is turned off
-		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexScan));
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexScan));
 	}
 
-	CBitSet *pbsJoinHeuristic = NULL;
+	CBitSet *join_heuristic_bitset = NULL;
 	switch (optimizer_join_order)
 	{
 		case JOIN_ORDER_IN_QUERY:
-			pbsJoinHeuristic = CXform::PbsJoinOrderInQueryXforms(pmp);
+			join_heuristic_bitset = CXform::PbsJoinOrderInQueryXforms(mp);
 			break;
 		case JOIN_ORDER_GREEDY_SEARCH:
-			pbsJoinHeuristic = CXform::PbsJoinOrderOnGreedyXforms(pmp);
+			join_heuristic_bitset = CXform::PbsJoinOrderOnGreedyXforms(mp);
 			break;
 		case JOIN_ORDER_EXHAUSTIVE_SEARCH:
-			pbsJoinHeuristic = GPOS_NEW(pmp) CBitSet(pmp, EopttraceSentinel);
+			join_heuristic_bitset = GPOS_NEW(mp) CBitSet(mp, EopttraceSentinel);
 			break;
 		default:
 			elog(ERROR, "Invalid value for optimizer_join_order, must \
 				 not come here");
 			break;
 	}
-	pbs->Union(pbsJoinHeuristic);
-	pbsJoinHeuristic->Release();
+	traceflag_bitset->Union(join_heuristic_bitset);
+	join_heuristic_bitset->Release();
 
 	// disable join associativity transform if the corresponding GUC
 	// is turned off independent of the join order algorithm chosen
 	if (!optimizer_enable_associativity)
 	{
-		pbs->FExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfJoinAssociativity));
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfJoinAssociativity));
 	}
 
-	return pbs;
+	return traceflag_bitset;
 }
 
 // EOF

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -51,7 +51,7 @@
 using namespace gpos;
 
 bool
-gpdb::FBoolFromDatum
+gpdb::BoolFromDatum
 	(
 	Datum d
 	)
@@ -65,7 +65,7 @@ gpdb::FBoolFromDatum
 }
 
 Datum
-gpdb::DDatumFromBool
+gpdb::DatumFromBool
 	(
 	bool b
 	)
@@ -79,7 +79,7 @@ gpdb::DDatumFromBool
 }
 
 char
-gpdb::CCharFromDatum
+gpdb::CharFromDatum
 	(
 	Datum d
 	)
@@ -93,7 +93,7 @@ gpdb::CCharFromDatum
 }
 
 Datum
-gpdb::DDatumFromChar
+gpdb::DatumFromChar
 	(
 	char c
 	)
@@ -107,7 +107,7 @@ gpdb::DDatumFromChar
 }
 
 int8
-gpdb::CInt8FromDatum
+gpdb::Int8FromDatum
 	(
 	Datum d
 	)
@@ -121,7 +121,7 @@ gpdb::CInt8FromDatum
 }
 
 Datum
-gpdb::DDatumFromInt8
+gpdb::DatumFromInt8
 	(
 	int8 i8
 	)
@@ -135,7 +135,7 @@ gpdb::DDatumFromInt8
 }
 
 uint8
-gpdb::UcUint8FromDatum
+gpdb::Uint8FromDatum
 	(
 	Datum d
 	)
@@ -149,7 +149,7 @@ gpdb::UcUint8FromDatum
 }
 
 Datum
-gpdb::DDatumFromUint8
+gpdb::DatumFromUint8
 	(
 	uint8 ui8
 	)
@@ -163,7 +163,7 @@ gpdb::DDatumFromUint8
 }
 
 int16
-gpdb::SInt16FromDatum
+gpdb::Int16FromDatum
 	(
 	Datum d
 	)
@@ -177,7 +177,7 @@ gpdb::SInt16FromDatum
 }
 
 Datum
-gpdb::DDatumFromInt16
+gpdb::DatumFromInt16
 	(
 	int16 i16
 	)
@@ -191,7 +191,7 @@ gpdb::DDatumFromInt16
 }
 
 uint16
-gpdb::UsUint16FromDatum
+gpdb::Uint16FromDatum
 	(
 	Datum d
 	)
@@ -205,7 +205,7 @@ gpdb::UsUint16FromDatum
 }
 
 Datum
-gpdb::DDatumFromUint16
+gpdb::DatumFromUint16
 	(
 	uint16 ui16
 	)
@@ -219,7 +219,7 @@ gpdb::DDatumFromUint16
 }
 
 int32
-gpdb::IInt32FromDatum
+gpdb::Int32FromDatum
 	(
 	Datum d
 	)
@@ -233,7 +233,7 @@ gpdb::IInt32FromDatum
 }
 
 Datum
-gpdb::DDatumFromInt32
+gpdb::DatumFromInt32
 	(
 	int32 i32
 	)
@@ -247,7 +247,7 @@ gpdb::DDatumFromInt32
 }
 
 uint32
-gpdb::UlUint32FromDatum
+gpdb::lUint32FromDatum
 	(
 	Datum d
 	)
@@ -261,7 +261,7 @@ gpdb::UlUint32FromDatum
 }
 
 Datum
-gpdb::DDatumFromUint32
+gpdb::DatumFromUint32
 	(
 	uint32 ui32
 	)
@@ -275,7 +275,7 @@ gpdb::DDatumFromUint32
 }
 
 int64
-gpdb::LlInt64FromDatum
+gpdb::Int64FromDatum
 	(
 	Datum d
 	)
@@ -290,7 +290,7 @@ gpdb::LlInt64FromDatum
 }
 
 Datum
-gpdb::DDatumFromInt64
+gpdb::DatumFromInt64
 	(
 	int64 i64
 	)
@@ -305,7 +305,7 @@ gpdb::DDatumFromInt64
 }
 
 uint64
-gpdb::UllUint64FromDatum
+gpdb::Uint64FromDatum
 	(
 	Datum d
 	)
@@ -319,7 +319,7 @@ gpdb::UllUint64FromDatum
 }
 
 Datum
-gpdb::DDatumFromUint64
+gpdb::DatumFromUint64
 	(
 	uint64 ui64
 	)
@@ -347,7 +347,7 @@ gpdb::OidFromDatum
 }
 
 void *
-gpdb::PvPointerFromDatum
+gpdb::PointerFromDatum
 	(
 	Datum d
 	)
@@ -361,7 +361,7 @@ gpdb::PvPointerFromDatum
 }
 
 float4
-gpdb::FpFloat4FromDatum
+gpdb::Float4FromDatum
 	(
 	Datum d
 	)
@@ -375,7 +375,7 @@ gpdb::FpFloat4FromDatum
 }
 
 float8
-gpdb::DFloat8FromDatum
+gpdb::Float8FromDatum
 	(
 	Datum d
 	)
@@ -389,7 +389,7 @@ gpdb::DFloat8FromDatum
 }
 
 Datum
-gpdb::DDatumFromPointer
+gpdb::DatumFromPointer
 	(
 	const void *p
 	)
@@ -403,7 +403,7 @@ gpdb::DDatumFromPointer
 }
 
 bool
-gpdb::FAggregateExists
+gpdb::AggregateExists
 	(
 	Oid oid
 	)
@@ -417,7 +417,7 @@ gpdb::FAggregateExists
 }
 
 Bitmapset *
-gpdb::PbmsAddMember
+gpdb::BmsAddMember
 	(
 	Bitmapset *a,
 	int x
@@ -432,7 +432,7 @@ gpdb::PbmsAddMember
 }
 
 void *
-gpdb::PvCopyObject
+gpdb::CopyObject
 	(
 	void *from
 	)
@@ -446,16 +446,16 @@ gpdb::PvCopyObject
 }
 
 Size
-gpdb::SDatumSize
+gpdb::DatumSize
 	(
 	Datum value,
-	bool typByVal,
+	bool type_by_val,
 	int iTypLen
 	)
 {
 	GP_WRAP_START;
 	{
-		return datumGetSize(value, typByVal, iTypLen);
+		return datumGetSize(value, type_by_val, iTypLen);
 	}
 	GP_WRAP_END;
 	return 0;
@@ -464,111 +464,111 @@ gpdb::SDatumSize
 void
 gpdb::DeconstructArray
 	(
-	struct ArrayType *parray,
+	struct ArrayType *array,
 	Oid elmtype,
-	int iElmlen,
+	int elmlen,
 	bool elmbyval,
-	char cElmalign,
-	Datum **ppElemSP,
+	char elmalign,
+	Datum **elemsp,
 	bool **nullsp,
-	int *piElemSP
+	int *nelemsp
 	)
 {
 	GP_WRAP_START;
 	{
-		deconstruct_array(parray, elmtype, iElmlen, elmbyval, cElmalign, ppElemSP, nullsp, piElemSP);
+		deconstruct_array(array, elmtype, elmlen, elmbyval, elmalign, elemsp, nullsp, nelemsp);
 		return;
 	}
 	GP_WRAP_END;
 }
 
 Node *
-gpdb::PnodeMutateExpressionTree
+gpdb::MutateExpressionTree
 	(
-	Node *pnode,
+	Node *node,
 	Node *(*mutator) (),
 	void *context
 	)
 {
 	GP_WRAP_START;
 	{
-		return expression_tree_mutator(pnode, mutator, context);
+		return expression_tree_mutator(node, mutator, context);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 bool
-gpdb::FWalkExpressionTree
+gpdb::WalkExpressionTree
 	(
-	Node *pnode,
+	Node *node,
 	bool (*walker) (),
 	void *context
 	)
 {
 	GP_WRAP_START;
 	{
-		return expression_tree_walker(pnode, walker, context);
+		return expression_tree_walker(node, walker, context);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 Oid
-gpdb::OidExprType
+gpdb::ExprType
 	(
-	Node *pnodeExpr
+	Node *expr
 	)
 {
 	GP_WRAP_START;
 	{
-		return exprType(pnodeExpr);
+		return exprType(expr);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 int32
-gpdb::IExprTypeMod
+gpdb::ExprTypeMod
 	(
-	Node *pnodeExpr
+	Node *expr
 	)
 {
 	GP_WRAP_START;
 	{
-		return exprTypmod(pnodeExpr);
+		return exprTypmod(expr);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 List *
-gpdb::PlExtractNodesPlan
+gpdb::ExtractNodesPlan
 	(
 	Plan *pl,
-	int iNodeTag,
-	bool descendIntoSubqueries
+	int node_tag,
+	bool descend_into_subqueries
 	)
 {
 	GP_WRAP_START;
 	{
-		return extract_nodes_plan(pl, iNodeTag, descendIntoSubqueries);
+		return extract_nodes_plan(pl, node_tag, descend_into_subqueries);
 	}
 	GP_WRAP_END;
 	return NIL;
 }
 
 List *
-gpdb::PlExtractNodesExpression
+gpdb::ExtractNodesExpression
 	(
 	Node *node,
-	int iNodeTag,
-	bool descendIntoSubqueries
+	int node_tag,
+	bool descend_into_subqueries
 	)
 {
 	GP_WRAP_START;
 	{
-		return extract_nodes_expression(node, iNodeTag, descendIntoSubqueries);
+		return extract_nodes_expression(node, node_tag, descend_into_subqueries);
 	}
 	GP_WRAP_END;
 	return NIL;
@@ -589,7 +589,7 @@ gpdb::FreeAttrStatsSlot
 }
 
 bool
-gpdb::FFuncStrict
+gpdb::FuncStrict
 	(
 	Oid funcid
 	)
@@ -604,7 +604,7 @@ gpdb::FFuncStrict
 }
 
 char
-gpdb::CFuncStability
+gpdb::FuncStability
 	(
 	Oid funcid
 	)
@@ -619,7 +619,7 @@ gpdb::CFuncStability
 }
 
 char
-gpdb::CFuncDataAccess
+gpdb::FuncDataAccess
 	(
 	Oid funcid
 	)
@@ -634,7 +634,7 @@ gpdb::CFuncDataAccess
 }
 
 bool
-gpdb::FFunctionExists
+gpdb::FunctionExists
 	(
 	Oid oid
 	)
@@ -649,7 +649,7 @@ gpdb::FFunctionExists
 }
 
 List *
-gpdb::PlFunctionOids(void)
+gpdb::FunctionOids(void)
 {
 	GP_WRAP_START;
 	{
@@ -661,7 +661,7 @@ gpdb::PlFunctionOids(void)
 }
 
 Oid
-gpdb::OidAggIntermediateResultType
+gpdb::GetAggIntermediateResultType
 	(
 	Oid aggid
 	)
@@ -676,15 +676,15 @@ gpdb::OidAggIntermediateResultType
 }
 
 Query *
-gpdb::PqueryFlattenJoinAliasVar
+gpdb::FlattenJoinAliasVar
 	(
-	Query *pquery,
-	gpos::ULONG ulQueryLevel
+	Query *query,
+	gpos::ULONG query_level
 	)
 {
 	GP_WRAP_START;
 	{
-		return flatten_join_alias_var_optimizer(pquery, ulQueryLevel);
+		return flatten_join_alias_var_optimizer(query, query_level);
 	}
 	GP_WRAP_END;
 
@@ -692,7 +692,7 @@ gpdb::PqueryFlattenJoinAliasVar
 }
 
 bool
-gpdb::FOrderedAgg
+gpdb::IsOrderedAgg
 	(
 	Oid aggid
 	)
@@ -707,7 +707,7 @@ gpdb::FOrderedAgg
 }
 
 bool
-gpdb::FAggHasPrelimFunc
+gpdb::AggHasPrelimFunc
 	(
 	Oid aggid
 	)
@@ -722,7 +722,7 @@ gpdb::FAggHasPrelimFunc
 }
 
 bool
-gpdb::FAggHasPrelimOrInvPrelimFunc
+gpdb::AggHasPrelimOrInvPrelimFunc
 	(
 	Oid aggid
 	)
@@ -737,23 +737,23 @@ gpdb::FAggHasPrelimOrInvPrelimFunc
 }
 
 Oid
-gpdb::OidAggregate
+gpdb::GetAggregate
 	(
-	const char *szAgg,
-	Oid oidType
+	const char *agg,
+	Oid type_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_aggregate */
-		return get_aggregate(szAgg, oidType);
+		return get_aggregate(agg, type_oid);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 Oid
-gpdb::OidArrayType
+gpdb::GetArrayType
 	(
 	Oid typid
 	)
@@ -768,25 +768,25 @@ gpdb::OidArrayType
 }
 
 bool
-gpdb::FGetAttrStatsSlot
+gpdb::GetAttrStatsSlot
 	(
 	AttStatsSlot *sslot,
 	HeapTuple statstuple,
-	int iReqKind,
+	int reqkind,
 	Oid reqop,
 	int flags
 	)
 {
 	GP_WRAP_START;
 	{
-		return get_attstatsslot(sslot, statstuple, iReqKind, reqop, flags);
+		return get_attstatsslot(sslot, statstuple, reqkind, reqop, flags);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 HeapTuple
-gpdb::HtAttrStats
+gpdb::GetAttStats
 	(
 	Oid relid,
 	AttrNumber attnum
@@ -802,7 +802,7 @@ gpdb::HtAttrStats
 }
 
 Oid
-gpdb::OidCommutatorOp
+gpdb::GetCommutatorOp
 	(
 	Oid opno
 	)
@@ -817,7 +817,7 @@ gpdb::OidCommutatorOp
 }
 
 char *
-gpdb::SzTriggerName
+gpdb::GetTriggerName
 	(
 	Oid triggerid
 	)
@@ -832,7 +832,7 @@ gpdb::SzTriggerName
 }
 
 Oid
-gpdb::OidTriggerRelid
+gpdb::GetTriggerRelid
 	(
 	Oid triggerid
 	)
@@ -847,7 +847,7 @@ gpdb::OidTriggerRelid
 }
 
 Oid
-gpdb::OidTriggerFuncid
+gpdb::GetTriggerFuncid
 	(
 	Oid triggerid
 	)
@@ -862,7 +862,7 @@ gpdb::OidTriggerFuncid
 }
 
 int32
-gpdb::ITriggerType
+gpdb::GetTriggerType
 	(
 	Oid triggerid
 	)
@@ -877,7 +877,7 @@ gpdb::ITriggerType
 }
 
 bool
-gpdb::FTriggerEnabled
+gpdb::IsTriggerEnabled
 	(
 	Oid triggerid
 	)
@@ -892,7 +892,7 @@ gpdb::FTriggerEnabled
 }
 
 bool
-gpdb::FTriggerExists
+gpdb::TriggerExists
 	(
 	Oid oid
 	)
@@ -907,45 +907,45 @@ gpdb::FTriggerExists
 }
 
 bool
-gpdb::FCheckConstraintExists
+gpdb::CheckConstraintExists
 	(
-	Oid oidCheckConstraint
+	Oid check_constraint_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return check_constraint_exists(oidCheckConstraint);
+		return check_constraint_exists(check_constraint_oid);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 char *
-gpdb::SzCheckConstraintName
+gpdb::GetCheckConstraintName
 	(
-	Oid oidCheckConstraint
+	Oid check_constraint_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return get_check_constraint_name(oidCheckConstraint);
+		return get_check_constraint_name(check_constraint_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Oid
-gpdb::OidCheckConstraintRelid
+gpdb::GetCheckConstraintRelid
 	(
-	Oid oidCheckConstraint
+	Oid check_constraint_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return get_check_constraint_relid(oidCheckConstraint);
+		return get_check_constraint_relid(check_constraint_oid);
 	}
 	GP_WRAP_END;
 	return 0;
@@ -954,51 +954,51 @@ gpdb::OidCheckConstraintRelid
 Node *
 gpdb::PnodeCheckConstraint
 	(
-	Oid oidCheckConstraint
+	Oid check_constraint_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return get_check_constraint_expr_tree(oidCheckConstraint);
+		return get_check_constraint_expr_tree(check_constraint_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 List *
-gpdb::PlCheckConstraint
+gpdb::GetCheckConstraintOids
 	(
-	Oid oidRel
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_constraint */
-		return get_check_constraint_oids(oidRel);
+		return get_check_constraint_oids(rel_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Node *
-gpdb::PnodePartConstraintRel
+gpdb::GetRelationPartContraints
 	(
-	Oid oidRel,
-	List **pplDefaultLevels
+	Oid rel_oid,
+	List **default_levels
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_partition, pg_partition_rule, pg_constraint */
-		return get_relation_part_constraints(oidRel, pplDefaultLevels);
+		return get_relation_part_constraints(rel_oid, default_levels);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 bool
-gpdb::FHasExternalPartition
+gpdb::HasExternalPartition
 	(
 	Oid oid
 	)
@@ -1014,7 +1014,7 @@ gpdb::FHasExternalPartition
 
 
 bool
-gpdb::FLeafPartition
+gpdb::IsLeafPartition
 	(
 	Oid oid
 	)
@@ -1029,7 +1029,7 @@ gpdb::FLeafPartition
 }
 
 Oid
-gpdb::OidRootPartition
+gpdb::GetRootPartition
 	(
 	Oid oid
 	)
@@ -1044,75 +1044,75 @@ gpdb::OidRootPartition
 }
 
 bool
-gpdb::FCastFunc
+gpdb::GetCastFunc
 	(
-	Oid oidSrc,
-	Oid oidDest, 
+	Oid src_oid,
+	Oid dest_oid,
 	bool *is_binary_coercible,
-	Oid *oidCastFunc,
+	Oid *cast_fn_oid,
 	CoercionPathType *pathtype
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_cast */
-		return get_cast_func(oidSrc, oidDest, is_binary_coercible, oidCastFunc, pathtype);
+		return get_cast_func(src_oid, dest_oid, is_binary_coercible, cast_fn_oid, pathtype);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 unsigned int
-gpdb::UlCmpt
+gpdb::GetComparisonType
 	(
-	Oid oidOp,
-	Oid oidLeft, 
-	Oid oidRight
+	Oid op_oid,
+	Oid left_oid,
+	Oid right_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_amop */
-		return get_comparison_type(oidOp, oidLeft, oidRight);
+		return get_comparison_type(op_oid, left_oid, right_oid);
 	}
 	GP_WRAP_END;
 	return CmptOther;
 }
 
 Oid
-gpdb::OidScCmp
+gpdb::GetComparisonOperator
 	(
-	Oid oidLeft, 
-	Oid oidRight,
-	unsigned int ulCmpt
+	Oid left_oid,
+	Oid right_oid,
+	unsigned int cmpt
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_amop */
-		return get_comparison_operator(oidLeft, oidRight, (CmpType) ulCmpt);
+		return get_comparison_operator(left_oid, right_oid, (CmpType) cmpt);
 	}
 	GP_WRAP_END;
 	return InvalidOid;
 }
 
 Oid
-gpdb::OidEqualityOp
+gpdb::GetEqualityOp
 	(
-	Oid oidType
+	Oid type_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_type */
-		return equality_oper_opid(oidType);
+		return equality_oper_opid(type_oid);
 	}
 	GP_WRAP_END;
 	return InvalidOid;
 }
 
 char *
-gpdb::SzFuncName
+gpdb::GetFuncName
 	(
 	Oid funcid
 	)
@@ -1127,7 +1127,7 @@ gpdb::SzFuncName
 }
 
 List *
-gpdb::PlFuncOutputArgTypes
+gpdb::GetFuncOutputArgTypes
 	(
 	Oid funcid
 	)
@@ -1142,7 +1142,7 @@ gpdb::PlFuncOutputArgTypes
 }
 
 List *
-gpdb::PlFuncArgTypes
+gpdb::GetFuncArgTypes
 	(
 	Oid funcid
 	)
@@ -1157,7 +1157,7 @@ gpdb::PlFuncArgTypes
 }
 
 bool
-gpdb::FFuncRetset
+gpdb::GetFuncRetset
 	(
 	Oid funcid
 	)
@@ -1172,7 +1172,7 @@ gpdb::FFuncRetset
 }
 
 Oid
-gpdb::OidFuncRetType
+gpdb::GetFuncRetType
 	(
 	Oid funcid
 	)
@@ -1187,7 +1187,7 @@ gpdb::OidFuncRetType
 }
 
 Oid
-gpdb::OidInverseOp
+gpdb::GetInverseOp
 	(
 	Oid opno
 	)
@@ -1202,7 +1202,7 @@ gpdb::OidInverseOp
 }
 
 RegProcedure
-gpdb::OidOpFunc
+gpdb::GetOpFunc
 	(
 	Oid opno
 	)
@@ -1217,7 +1217,7 @@ gpdb::OidOpFunc
 }
 
 char *
-gpdb::SzOpName
+gpdb::GetOpName
 	(
 	Oid opno
 	)
@@ -1232,7 +1232,7 @@ gpdb::SzOpName
 }
 
 List *
-gpdb::PlPartitionAttrs
+gpdb::GetPartitionAttrs
 	(
 	Oid oid
 	)
@@ -1264,7 +1264,7 @@ gpdb::GetOrderedPartKeysAndKinds
 }
 
 PartitionNode *
-gpdb::PpnParts
+gpdb::GetParts
 	(
 	Oid relid,
 	int2 level,
@@ -1283,7 +1283,7 @@ gpdb::PpnParts
 }
 
 List *
-gpdb::PlRelationKeys
+gpdb::GetRelationKeys
 	(
 	Oid relid
 	)
@@ -1298,7 +1298,7 @@ gpdb::PlRelationKeys
 }
 
 Oid
-gpdb::OidTypeRelid
+gpdb::GetTypeRelid
 	(
 	Oid typid
 	)
@@ -1313,7 +1313,7 @@ gpdb::OidTypeRelid
 }
 
 char *
-gpdb::SzTypeName
+gpdb::GetTypeName
 	(
 	Oid typid
 	)
@@ -1328,7 +1328,7 @@ gpdb::SzTypeName
 }
 
 int
-gpdb::UlSegmentCountGP(void)
+gpdb::GetGPSegmentCount(void)
 {
 	GP_WRAP_START;
 	{
@@ -1339,15 +1339,15 @@ gpdb::UlSegmentCountGP(void)
 }
 
 bool
-gpdb::FHeapAttIsNull
+gpdb::HeapAttIsNull
 	(
 	HeapTuple tup,
-	int iAttNum
+	int attno
 	)
 {
 	GP_WRAP_START;
 	{
-		return heap_attisnull(tup, iAttNum);
+		return heap_attisnull(tup, attno);
 	}
 	GP_WRAP_END;
 	return false;
@@ -1368,7 +1368,7 @@ gpdb::FreeHeapTuple
 }
 
 bool
-gpdb::FIndexExists
+gpdb::IndexExists
 	(
 	Oid oid
 	)
@@ -1383,7 +1383,7 @@ gpdb::FIndexExists
 }
 
 bool
-gpdb::FGreenplumDbHashable
+gpdb::IsGreenplumDbHashable
 	(
 	Oid typid
 	)
@@ -1398,52 +1398,52 @@ gpdb::FGreenplumDbHashable
 }
 
 List *
-gpdb::PlAppendElement
+gpdb::LAppend
 	(
-	List *plist,
+	List *list,
 	void *datum
 	)
 {
 	GP_WRAP_START;
 	{
-		return lappend(plist, datum);
+		return lappend(list, datum);
 	}
 	GP_WRAP_END;
 	return NIL;
 }
 
 List *
-gpdb::PlAppendInt
+gpdb::LAppendInt
 	(
-	List *plist,
+	List *list,
 	int iDatum
 	)
 {
 	GP_WRAP_START;
 	{
-		return lappend_int(plist, iDatum);
+		return lappend_int(list, iDatum);
 	}
 	GP_WRAP_END;
 	return NIL;
 }
 
 List *
-gpdb::PlAppendOid
+gpdb::LAppendOid
 	(
-	List *plist,
+	List *list,
 	Oid datum
 	)
 {
 	GP_WRAP_START;
 	{
-		return lappend_oid(plist, datum);
+		return lappend_oid(list, datum);
 	}
 	GP_WRAP_END;
 	return NIL;
 }
 
 List *
-gpdb::PlPrependElement
+gpdb::LPrepend
 	(
 	void *datum,
 	List *list
@@ -1458,7 +1458,7 @@ gpdb::PlPrependElement
 }
 
 List *
-gpdb::PlPrependInt
+gpdb::LPrependInt
 	(
 	int datum,
 	List *list
@@ -1473,7 +1473,7 @@ gpdb::PlPrependInt
 }
 
 List *
-gpdb::PlPrependOid
+gpdb::LPrependOid
 	(
 	Oid datum,
 	List *list
@@ -1488,7 +1488,7 @@ gpdb::PlPrependOid
 }
 
 List *
-gpdb::PlConcat
+gpdb::ListConcat
 	(
 	List *list1,
 	List *list2
@@ -1503,7 +1503,7 @@ gpdb::PlConcat
 }
 
 List *
-gpdb::PlCopy
+gpdb::ListCopy
 	(
 	List *list
 	)
@@ -1517,7 +1517,7 @@ gpdb::PlCopy
 }
 
 ListCell *
-gpdb::PlcListHead
+gpdb::ListHead
 	(
 	List *l
 	)
@@ -1531,7 +1531,7 @@ gpdb::PlcListHead
 }
 
 ListCell *
-gpdb::PlcListTail
+gpdb::ListTail
 	(
 	List *l
 	)
@@ -1545,7 +1545,7 @@ gpdb::PlcListTail
 }
 
 uint32
-gpdb::UlListLength
+gpdb::ListLength
 	(
 	List *l
 	)
@@ -1559,7 +1559,7 @@ gpdb::UlListLength
 }
 
 void *
-gpdb::PvListNth
+gpdb::ListNth
 	(
 	List *list,
 	int n
@@ -1574,7 +1574,7 @@ gpdb::PvListNth
 }
 
 int
-gpdb::IListNth
+gpdb::ListNthInt
 	(
 	List *list,
 	int n
@@ -1589,7 +1589,7 @@ gpdb::IListNth
 }
 
 Oid
-gpdb::OidListNth
+gpdb::ListNthOid
 	(
 	List *list,
 	int n
@@ -1604,7 +1604,7 @@ gpdb::OidListNth
 }
 
 bool
-gpdb::FMemberOid
+gpdb::ListMemberOid
 	(
 	List *list,
 	Oid oid
@@ -1619,78 +1619,78 @@ gpdb::FMemberOid
 }
 
 void
-gpdb::FreeList
+gpdb::ListFree
 	(
-	List *plist
+	List *list
 	)
 {
 	GP_WRAP_START;
 	{
-		list_free(plist);
+		list_free(list);
 		return;
 	}
 	GP_WRAP_END;
 }
 
 void
-gpdb::FreeListDeep
+gpdb::ListFreeDeep
 	(
-	List *plist
+	List *list
 	)
 {
 	GP_WRAP_START;
 	{
-		list_free_deep(plist);
+		list_free_deep(list);
 		return;
 	}
 	GP_WRAP_END;
 }
 
 bool
-gpdb::FMotionGather
+gpdb::IsMotionGather
 	(
-	const Motion *pmotion
+	const Motion *motion
 	)
 {
 	GP_WRAP_START;
 	{
-		return isMotionGather(pmotion);
+		return isMotionGather(motion);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 bool
-gpdb::FAppendOnlyPartitionTable
+gpdb::IsAppendOnlyPartitionTable
 	(
-	Oid rootOid
+	Oid root_oid
 	)
 {
 	GP_WRAP_START;
 	{
-		return rel_has_appendonly_partition(rootOid);
+		return rel_has_appendonly_partition(root_oid);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 bool
-gpdb::FMultilevelPartitionUniform
+gpdb::IsMultilevelPartitionUniform
 	(
-	Oid rootOid
+	Oid root_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_partition, pg_partition_rule, pg_constraint */
-		return rel_partitioning_is_uniform(rootOid);
+		return rel_partitioning_is_uniform(root_oid);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 TypeCacheEntry *
-gpdb::PtceLookup
+gpdb::LookupTypeCache
 	(
 	Oid type_id,
 	int flags
@@ -1706,7 +1706,7 @@ gpdb::PtceLookup
 }
 
 Value *
-gpdb::PvalMakeString
+gpdb::MakeStringValue
 	(
 	char *str
 	)
@@ -1720,7 +1720,7 @@ gpdb::PvalMakeString
 }
 
 Value *
-gpdb::PvalMakeInteger
+gpdb::MakeIntegerValue
 	(
 	long i
 	)
@@ -1734,7 +1734,7 @@ gpdb::PvalMakeInteger
 }
 
 Node *
-gpdb::PnodeMakeBoolConst
+gpdb::MakeBoolConst
 	(
 	bool value,
 	bool isnull
@@ -1749,23 +1749,23 @@ gpdb::PnodeMakeBoolConst
 }
 
 Node *
-gpdb::PnodeMakeNULLConst
+gpdb::MakeNULLConst
 	(
-	Oid oidType
+	Oid type_oid
 	)
 {
 	GP_WRAP_START;
 	{
-		return (Node *) makeNullConst(oidType, -1 /*consttypmod*/);
+		return (Node *) makeNullConst(type_oid, -1 /*consttypmod*/);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 TargetEntry *
-gpdb::PteMakeTargetEntry
+gpdb::MakeTargetEntry
 	(
-	Expr *pnodeExpr,
+	Expr *expr,
 	AttrNumber resno,
 	char *resname,
 	bool resjunk
@@ -1773,14 +1773,14 @@ gpdb::PteMakeTargetEntry
 {
 	GP_WRAP_START;
 	{
-		return makeTargetEntry(pnodeExpr, resno, resname, resjunk);
+		return makeTargetEntry(expr, resno, resname, resjunk);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Var *
-gpdb::PvarMakeVar
+gpdb::MakeVar
 	(
 	Index varno,
 	AttrNumber varattno,
@@ -1798,7 +1798,7 @@ gpdb::PvarMakeVar
 }
 
 void *
-gpdb::PvMemoryContextAllocImpl
+gpdb::MemCtxtAllocImpl
 	(
 	MemoryContext context,
 	Size size,
@@ -1816,7 +1816,7 @@ gpdb::PvMemoryContextAllocImpl
 }
 
 void *
-gpdb::PvMemoryContextAllocZeroAlignedImpl
+gpdb::MemCtxtAllocZeroAlignedImpl
 	(
 	MemoryContext context,
 	Size size,
@@ -1834,7 +1834,7 @@ gpdb::PvMemoryContextAllocZeroAlignedImpl
 }
 
 void *
-gpdb::PvMemoryContextAllocZeroImpl
+gpdb::MemCtxtAllocZeroImpl
 	(
 	MemoryContext context,
 	Size size,
@@ -1852,7 +1852,7 @@ gpdb::PvMemoryContextAllocZeroImpl
 }
 
 void *
-gpdb::PvMemoryContextReallocImpl
+gpdb::MemCtxtReallocImpl
 	(
 	void *pointer,
 	Size size,
@@ -1870,7 +1870,7 @@ gpdb::PvMemoryContextReallocImpl
 }
 
 char *
-gpdb::SzMemoryContextStrdup
+gpdb::MemCtxtStrdup
 	(
 	MemoryContext context,
 	const char *string
@@ -1915,7 +1915,7 @@ gpdb::GpdbEreportImpl
 }
 
 char *
-gpdb::SzNodeToString
+gpdb::NodeToString
 	(
 	void *obj
 	)
@@ -1929,7 +1929,7 @@ gpdb::SzNodeToString
 }
 
 Node *
-gpdb::Pnode
+gpdb::StringToNode
 	(
 	char *string
 	)
@@ -1944,7 +1944,7 @@ gpdb::Pnode
 
 
 Node *
-gpdb::PnodeTypeDefault
+gpdb::GetTypeDefault
 	(
 	Oid typid
 	)
@@ -1960,7 +1960,7 @@ gpdb::PnodeTypeDefault
 
 
 double
-gpdb::DNumericToDoubleNoOverflow
+gpdb::NumericToDoubleNoOverflow
 	(
 	Numeric num
 	)
@@ -1974,7 +1974,7 @@ gpdb::DNumericToDoubleNoOverflow
 }
 
 double
-gpdb::DConvertTimeValueToScalar
+gpdb::ConvertTimeValueToScalar
 	(
 	Datum datum,
 	Oid typid
@@ -1989,7 +1989,7 @@ gpdb::DConvertTimeValueToScalar
 }
 
 double
-gpdb::DConvertNetworkToScalar
+gpdb::ConvertNetworkToScalar
 	(
 	Datum datum,
 	Oid typid
@@ -2004,7 +2004,7 @@ gpdb::DConvertNetworkToScalar
 }
 
 bool
-gpdb::FOpHashJoinable
+gpdb::IsOpHashJoinable
 	(
 	Oid opno
 	)
@@ -2019,7 +2019,7 @@ gpdb::FOpHashJoinable
 }
 
 bool
-gpdb::FOpStrict
+gpdb::IsOpStrict
 	(
 	Oid opno
 	)
@@ -2051,7 +2051,7 @@ gpdb::GetOpInputTypes
 }
 
 bool
-gpdb::FOperatorExists
+gpdb::OperatorExists
 	(
 	Oid oid
 	)
@@ -2094,7 +2094,7 @@ gpdb::GPDBFree
 }
 
 struct varlena *
-gpdb::PvlenDetoastDatum
+gpdb::DetoastDatum
 	(
 	struct varlena * datum
 	)
@@ -2108,9 +2108,9 @@ gpdb::PvlenDetoastDatum
 }
 
 bool
-gpdb::FWalkQueryOrExpressionTree
+gpdb::WalkQueryOrExpressionTree
 	(
-	Node *pnode,
+	Node *node,
 	bool (*walker) (),
 	void *context,
 	int flags
@@ -2118,16 +2118,16 @@ gpdb::FWalkQueryOrExpressionTree
 {
 	GP_WRAP_START;
 	{
-		return query_or_expression_tree_walker(pnode, walker, context, flags);
+		return query_or_expression_tree_walker(node, walker, context, flags);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 Node *
-gpdb::PnodeMutateQueryOrExpressionTree
+gpdb::MutateQueryOrExpressionTree
 	(
-	Node *pnode,
+	Node *node,
 	Node *(*mutator) (),
 	void *context,
 	int flags
@@ -2135,14 +2135,14 @@ gpdb::PnodeMutateQueryOrExpressionTree
 {
 	GP_WRAP_START;
 	{
-		return query_or_expression_tree_mutator(pnode, mutator, context, flags);
+		return query_or_expression_tree_mutator(node, mutator, context, flags);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Query *
-gpdb::PqueryMutateQueryTree
+gpdb::MutateQueryTree
 	(
 	Query *query,
 	Node *(*mutator) (),
@@ -2159,7 +2159,7 @@ gpdb::PqueryMutateQueryTree
 }
 
 List *
-gpdb::PlMutateRangeTable
+gpdb::MutateRangeTable
 	(
 	List *rtable,
 	Node *(*mutator) (),
@@ -2176,7 +2176,7 @@ gpdb::PlMutateRangeTable
 }
 
 bool
-gpdb::FRelPartIsRoot
+gpdb::RelPartIsRoot
 	(
 	Oid relid
 	)
@@ -2190,7 +2190,7 @@ gpdb::FRelPartIsRoot
 }
 
 bool
-gpdb::FRelPartIsInterior
+gpdb::RelPartIsInterior
 	(
 	Oid relid
 	)
@@ -2204,7 +2204,7 @@ gpdb::FRelPartIsInterior
 }
 
 bool
-gpdb::FRelPartIsNone
+gpdb::RelPartIsNone
 	(
 	Oid relid
 	)
@@ -2234,13 +2234,13 @@ gpdb::FHashPartitioned
 bool
 gpdb::FHasSubclass
 	(
-	Oid oidRel
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_inherits */
-		return has_subclass(oidRel);
+		return has_subclass(rel_oid);
 	}
 	GP_WRAP_END;
 	return false;
@@ -2248,22 +2248,22 @@ gpdb::FHasSubclass
 
 
 bool
-gpdb::FHasParquetChildren
+gpdb::HasParquetChildren
 	(
-	Oid oidRel
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_inherits, pg_class */
-		return has_parquet_children(oidRel);
+		return has_parquet_children(rel_oid);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 GpPolicy *
-gpdb::Pdistrpolicy
+gpdb::GetDistributionPolicy
 	(
 	Relation rel
 	)
@@ -2278,7 +2278,7 @@ gpdb::Pdistrpolicy
 }
 
 gpos::BOOL
-gpdb::FChildPartDistributionMismatch
+gpdb::IsChildPartDistributionMismatched
 	(
 	Relation rel
 	)
@@ -2293,23 +2293,23 @@ gpdb::FChildPartDistributionMismatch
 }
 
 gpos::BOOL
-gpdb::FChildTriggers
+gpdb::ChildPartHasTriggers
 	(
 	Oid oid,
-	int triggerType
+	int trigger_type
 	)
 {
     GP_WRAP_START;
     {
 		/* catalog tables: pg_inherits, pg_trigger */
-    	return child_triggers(oid, triggerType);
+    	return child_triggers(oid, trigger_type);
     }
     GP_WRAP_END;
     return false;
 }
 
 bool
-gpdb::FRelationExists
+gpdb::RelationExists
 	(
 	Oid oid
 	)
@@ -2324,7 +2324,7 @@ gpdb::FRelationExists
 }
 
 List *
-gpdb::PlRelationOids(void)
+gpdb::GetAllRelationOids(void)
 {
 	GP_WRAP_START;
 	{
@@ -2386,7 +2386,7 @@ gpdb::CloseRelation
 }
 
 List *
-gpdb::PlRelationIndexes
+gpdb::GetRelationIndexes
 	(
 	Relation relation
 	)
@@ -2401,7 +2401,7 @@ gpdb::PlRelationIndexes
 }
 
 LogicalIndexes *
-gpdb::Plgidx
+gpdb::GetLogicalPartIndexes
 	(
 	Oid oid
 	)
@@ -2416,16 +2416,16 @@ gpdb::Plgidx
 }
 
 LogicalIndexInfo *
-gpdb::Plgidxinfo
+gpdb::GetLogicalIndexInfo
 	(
-	Oid rootOid, 
-	Oid indexOid
+	Oid root_oid,
+	Oid index_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_index */
-		return logicalIndexInfoForIndexOid(rootOid, indexOid);
+		return logicalIndexInfoForIndexOid(root_oid, index_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
@@ -2447,60 +2447,60 @@ gpdb::BuildRelationTriggers
 }
 
 Relation
-gpdb::RelGetRelation
+gpdb::GetRelation
 	(
-	Oid relationId
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: relcache */
-		return RelationIdGetRelation(relationId);
+		return RelationIdGetRelation(rel_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 ExtTableEntry *
-gpdb::Pexttable
+gpdb::GetExternalTableEntry
 	(
-	Oid relationId
+	Oid rel_oid
 	)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_exttable */
-		return GetExtTableEntry(relationId);
+		return GetExtTableEntry(rel_oid);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 TargetEntry *
-gpdb::PteMember
+gpdb::FindFirstMatchingMemberInTargetList
 	(
-	Node *pnode,
+	Node *node,
 	List *targetlist
 	)
 {
 	GP_WRAP_START;
 	{
-		return tlist_member(pnode, targetlist);
+		return tlist_member(node, targetlist);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 List *
-gpdb::PteMembers
+gpdb::FindMatchingMembersInTargetList
 	(
-	Node *pnode,
+	Node *node,
 	List *targetlist
 	)
 {
 	GP_WRAP_START;
 	{
-		return tlist_members(pnode, targetlist);
+		return tlist_members(node, targetlist);
 	}
 	GP_WRAP_END;
 
@@ -2508,7 +2508,7 @@ gpdb::PteMembers
 }
 
 bool
-gpdb::FEqual
+gpdb::Equals
 	(
 	void *p1,
 	void *p2
@@ -2523,7 +2523,7 @@ gpdb::FEqual
 }
 
 bool
-gpdb::FTypeExists
+gpdb::TypeExists
 	(
 	Oid oid
 	)
@@ -2538,7 +2538,7 @@ gpdb::FTypeExists
 }
 
 bool
-gpdb::FCompositeType
+gpdb::IsCompositeType
 	(
 	Oid typid
 	)
@@ -2553,35 +2553,35 @@ gpdb::FCompositeType
 }
 
 int
-gpdb::IValue
+gpdb::GetIntFromValue
 	(
-	Node *pnode
+	Node *node
 	)
 {
 	GP_WRAP_START;
 	{
-		return intVal(pnode);
+		return intVal(node);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 Uri *
-gpdb::PuriParseExternalTable
+gpdb::ParseExternTableUri
 	(
-	const char *szUri
+	const char *uri
 	)
 {
 	GP_WRAP_START;
 	{
-		return ParseExternalTableUri(szUri);
+		return ParseExternalTableUri(uri);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 CdbComponentDatabases *
-gpdb::PcdbComponentDatabases(void)
+gpdb::GetComponentDatabases(void)
 {
 	GP_WRAP_START;
 	{
@@ -2593,22 +2593,22 @@ gpdb::PcdbComponentDatabases(void)
 }
 
 int
-gpdb::IStrCmpIgnoreCase
+gpdb::StrCmpIgnoreCase
 	(
-	const char *sz1,
-	const char *sz2
+	const char *s1,
+	const char *s2
 	)
 {
 	GP_WRAP_START;
 	{
-		return pg_strcasecmp(sz1, sz2);
+		return pg_strcasecmp(s1, s2);
 	}
 	GP_WRAP_END;
 	return 0;
 }
 
 bool *
-gpdb::RgfRandomSegMap
+gpdb::ConstructRandomSegMap
 	(
 	int total_primaries,
 	int total_to_skip
@@ -2623,7 +2623,7 @@ gpdb::RgfRandomSegMap
 }
 
 StringInfo
-gpdb::SiMakeStringInfo(void)
+gpdb::MakeStringInfo(void)
 {
 	GP_WRAP_START;
 	{
@@ -2650,7 +2650,7 @@ gpdb::AppendStringInfo
 }
 
 int
-gpdb::IFindNodes
+gpdb::FindNodes
 	(
 	Node *node,
 	List *nodeTags
@@ -2665,11 +2665,11 @@ gpdb::IFindNodes
 }
 
 Node *
-gpdb::PnodeCoerceToCommonType
+gpdb::CoerceToCommonType
 	(
 	ParseState *pstate,
-	Node *pnode,
-	Oid oidTargetType,
+	Node *node,
+	Oid target_type,
 	const char *context
 	)
 {
@@ -2679,8 +2679,8 @@ gpdb::PnodeCoerceToCommonType
 		return coerce_to_common_type
 					(
 					pstate,
-					pnode,
-					oidTargetType,
+					node,
+					target_type,
 					context
 					);
 	}
@@ -2689,7 +2689,7 @@ gpdb::PnodeCoerceToCommonType
 }
 
 bool
-gpdb::FResolvePolymorphicType
+gpdb::ResolvePolymorphicArgType
 	(
 	int numargs,
 	Oid *argtypes,
@@ -2708,15 +2708,15 @@ gpdb::FResolvePolymorphicType
 
 // hash a const value with GPDB's hash function
 int32 
-gpdb::ICdbHash
+gpdb::CdbHashConst
 	(
-	Const *pconst,
-	int iSegments
+	Const *constant,
+	int num_segments
 	)
 {
 	GP_WRAP_START;
 	{
-		return cdbhash_const(pconst, iSegments);	
+		return cdbhash_const(constant, num_segments);
 	}
 	GP_WRAP_END;
 	return 0;
@@ -2724,15 +2724,15 @@ gpdb::ICdbHash
 
 // hash a list of const values with GPDB's hash function
 int32 
-gpdb::ICdbHashList
+gpdb::CdbHashConstList
 	(
-	List *plConsts,
-	int iSegments
+	List *constants,
+	int num_segments
 	)
 {
 	GP_WRAP_START;
 	{
-		return cdbhash_const_list(plConsts, iSegments);	
+		return cdbhash_const_list(constants, num_segments);
 	}
 	GP_WRAP_END;
 	return 0;
@@ -2742,12 +2742,12 @@ gpdb::ICdbHashList
 void
 gpdb::CheckRTPermissions
 	(
-	List *plRangeTable
+	List *rtable
 	)
 {
 	GP_WRAP_START;
 	{
-		ExecCheckRTPerms(plRangeTable);
+		ExecCheckRTPerms(rtable);
 		return;
 	}
 	GP_WRAP_END;
@@ -2780,9 +2780,9 @@ gpdb::IndexOpProperties
 
 // get oids of opfamilies for the index keys
 List *
-gpdb::PlIndexOpFamilies
+gpdb::GetIndexOpFamilies
 	(
-	Oid oidIndex
+	Oid index_oid
 	)
 {
 	GP_WRAP_START;
@@ -2790,7 +2790,7 @@ gpdb::PlIndexOpFamilies
 		/* catalog tables: pg_index */
 
 		// We return the operator families of the index keys.
-		return get_index_opfamilies(oidIndex);
+		return get_index_opfamilies(index_oid);
 	}
 	GP_WRAP_END;
 	
@@ -2799,7 +2799,7 @@ gpdb::PlIndexOpFamilies
 
 // get oids of families this operator belongs to
 List *
-gpdb::PlScOpOpFamilies
+gpdb::GetOpFamiliesForScOp
 	(
 	Oid opno
 	)
@@ -2819,19 +2819,19 @@ gpdb::PlScOpOpFamilies
 
 
 
-// Evaluates 'pexpr' and returns the result as an Expr.
-// Caller keeps ownership of 'pexpr' and takes ownership of the result
+// Evaluates 'expr' and returns the result as an Expr.
+// Caller keeps ownership of 'expr' and takes ownership of the result
 Expr *
-gpdb::PexprEvaluate
+gpdb::EvaluateExpr
 	(
-	Expr *pexpr,
-	Oid oidResultType,
-	int32 iTypeMod
+	Expr *expr,
+	Oid result_type,
+	int32 typmod
 	)
 {
 	GP_WRAP_START;
 	{
-		return evaluate_expr(pexpr, oidResultType, iTypeMod);
+		return evaluate_expr(expr, result_type, typmod);
 	}
 	GP_WRAP_END;
 	return NULL;
@@ -2839,35 +2839,35 @@ gpdb::PexprEvaluate
 
 // interpret the value of "With oids" option from a list of defelems
 bool
-gpdb::FInterpretOidsOption
+gpdb::InterpretOidsOption
 	(
-	List *plOptions
+	List *options
 	)
 {
 	GP_WRAP_START;
 	{
-		return interpretOidsOption(plOptions);
+		return interpretOidsOption(options);
 	}
 	GP_WRAP_END;
 	return false;
 }
 
 char *
-gpdb::SzDefGetString
+gpdb::DefGetString
 	(
-	DefElem *pdefelem
+	DefElem *defelem
 	)
 {
 	GP_WRAP_START;
 	{
-		return defGetString(pdefelem);
+		return defGetString(defelem);
 	}
 	GP_WRAP_END;
 	return NULL;
 }
 
 Expr *
-gpdb::PexprTransformArrayConstToArrayExpr
+gpdb::TransformArrayConstToArrayExpr
 	(
 	Const *c
 	)
@@ -2881,7 +2881,7 @@ gpdb::PexprTransformArrayConstToArrayExpr
 }
 
 Node *
-gpdb::PnodeEvalConstExpressions
+gpdb::EvalConstExpressions
 	(
 	Node *node
 	)
@@ -2895,7 +2895,7 @@ gpdb::PnodeEvalConstExpressions
 }
 
 SelectedParts *
-gpdb::SpStaticPartitionSelection
+gpdb::RunStaticPartitionSelection
 	(
 	PartitionSelector *ps
 	)
@@ -2909,7 +2909,7 @@ gpdb::SpStaticPartitionSelection
 }
 
 FaultInjectorType_e
-gpdb::OptTasksFaultInjector
+gpdb::InjectFaultInOptTasks
 	(
 	FaultInjectorIdentifier_e identifier
 	)
@@ -2926,15 +2926,15 @@ gpdb::OptTasksFaultInjector
 }
 
 gpos::ULONG
-gpdb::UlLeafPartitions
+gpdb::CountLeafPartTables
        (
-       Oid oidRelation
+       Oid rel_oid
        )
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_partition, pg_partition_rules */
-		return countLeafPartTables(oidRelation);
+		return countLeafPartTables(rel_oid);
 	}
 	GP_WRAP_END;
 
@@ -3046,7 +3046,7 @@ register_mdcache_invalidation_callbacks(void)
 
 // Has there been any catalog changes since last call?
 bool
-gpdb::FMDCacheNeedsReset
+gpdb::MDCacheNeedsReset
 		(
 			void
 		)
@@ -3102,7 +3102,7 @@ gpdb::OptimizerFree
 
 // returns true if a query cancel is requested in GPDB
 bool
-gpdb::FAbortRequested
+gpdb::IsAbortRequested
 	(
 	void
 	)

--- a/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
+++ b/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
@@ -37,41 +37,41 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CMDProviderRelcache::CMDProviderRelcache
 	(
-	IMemoryPool *pmp
+	IMemoryPool *mp
 	)
 	:
-	m_pmp(pmp)
+	m_mp(mp)
 {
-	GPOS_ASSERT(NULL != m_pmp);
+	GPOS_ASSERT(NULL != m_mp);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMDProviderRelcache::PstrObject
+//		CMDProviderRelcache::GetMDObjDXLStr
 //
 //	@doc:
 //		Returns the DXL of the requested object in the provided memory pool
 //
 //---------------------------------------------------------------------------
 CWStringBase *
-CMDProviderRelcache::PstrObject
+CMDProviderRelcache::GetMDObjDXLStr
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *md_id
 	)
 	const
 {
-	IMDCacheObject *pimdobj = CTranslatorRelcacheToDXL::Pimdobj(pmp, pmda, pmdid);
+	IMDCacheObject *md_obj = CTranslatorRelcacheToDXL::RetrieveObject(mp, md_accessor, md_id);
 
-	GPOS_ASSERT(NULL != pimdobj);
+	GPOS_ASSERT(NULL != md_obj);
 
-	CWStringDynamic *pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, pimdobj, true /*fSerializeHeaders*/, false /*findent*/);
+	CWStringDynamic *str = CDXLUtils::SerializeMDObj(m_mp, md_obj, true /*fSerializeHeaders*/, false /*findent*/);
 
 	// cleanup DXL object
-	pimdobj->Release();
+	md_obj->Release();
 
-	return pstr;
+	return str;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -35,28 +35,28 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CContextDXLToPlStmt::CContextDXLToPlStmt
 	(
-	IMemoryPool *pmp,
-	CIdGenerator *pidgtorPlan,
-	CIdGenerator *pidgtorMotion,
-	CIdGenerator *pidgtorParam,
-	List **plRTable,
-	List **plSubPlan
+	IMemoryPool *mp,
+	CIdGenerator *plan_id_counter,
+	CIdGenerator *motion_id_counter,
+	CIdGenerator *param_id_counter,
+	List **rtable_entries_list,
+	List **subplan_entries_list
 	)
 	:
-	m_pmp(pmp),
-	m_pidgtorPlan(pidgtorPlan),
-	m_pidgtorMotion(pidgtorMotion),
-	m_pidgtorParam(pidgtorParam),
-	m_pplRTable(plRTable),
-	m_plPartitionTables(NULL),
-	m_pdrgpulNumSelectors(NULL),
-	m_pplSubPlan(plSubPlan),
-	m_ulResultRelation(0),
-	m_pintocl(NULL),
-	m_pdistrpolicy(NULL)
+	m_mp(mp),
+	m_plan_id_counter(plan_id_counter),
+	m_motion_id_counter(motion_id_counter),
+	m_param_id_counter(param_id_counter),
+	m_rtable_entries_list(rtable_entries_list),
+	m_partitioned_tables_list(NULL),
+	m_num_partition_selectors_array(NULL),
+	m_subplan_entries_list(subplan_entries_list),
+	m_result_relation_index(0),
+	m_into_clause(NULL),
+	m_distribution_policy(NULL)
 {
-	m_phmulcteconsumerinfo = GPOS_NEW(m_pmp) HMUlCTEConsumerInfo(m_pmp);
-	m_pdrgpulNumSelectors = GPOS_NEW(m_pmp) DrgPul(m_pmp);
+	m_cte_consumer_info = GPOS_NEW(m_mp) HMUlCTEConsumerInfo(m_mp);
+	m_num_partition_selectors_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 }
 
 //---------------------------------------------------------------------------
@@ -69,78 +69,78 @@ CContextDXLToPlStmt::CContextDXLToPlStmt
 //---------------------------------------------------------------------------
 CContextDXLToPlStmt::~CContextDXLToPlStmt()
 {
-	m_phmulcteconsumerinfo->Release();
-	m_pdrgpulNumSelectors->Release();
+	m_cte_consumer_info->Release();
+	m_num_partition_selectors_array->Release();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlNextPlanId
+//		CContextDXLToPlStmt::GetNextPlanId
 //
 //	@doc:
 //		Get the next plan id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlNextPlanId()
+CContextDXLToPlStmt::GetNextPlanId()
 {
-	return m_pidgtorPlan->UlNextId();
+	return m_plan_id_counter->next_id();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlCurrentMotionId
+//		CContextDXLToPlStmt::GetCurrentMotionId
 //
 //	@doc:
 //		Get the current motion id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlCurrentMotionId()
+CContextDXLToPlStmt::GetCurrentMotionId()
 {
-	return m_pidgtorMotion->UlCurrentId();
+	return m_motion_id_counter->current_id();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlNextMotionId
+//		CContextDXLToPlStmt::GetNextMotionId
 //
 //	@doc:
 //		Get the next motion id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlNextMotionId()
+CContextDXLToPlStmt::GetNextMotionId()
 {
-	return m_pidgtorMotion->UlNextId();
+	return m_motion_id_counter->next_id();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlNextParamId
+//		CContextDXLToPlStmt::GetNextParamId
 //
 //	@doc:
 //		Get the next plan id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlNextParamId()
+CContextDXLToPlStmt::GetNextParamId()
 {
-	return m_pidgtorParam->UlNextId();
+	return m_param_id_counter->next_id();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::UlCurrentParamId
+//		CContextDXLToPlStmt::GetCurrentParamId
 //
 //	@doc:
 //		Get the current param id
 //
 //---------------------------------------------------------------------------
 ULONG
-CContextDXLToPlStmt::UlCurrentParamId()
+CContextDXLToPlStmt::GetCurrentParamId()
 {
-	return m_pidgtorParam->UlCurrentId();
+	return m_param_id_counter->current_id();
 }
 
 //---------------------------------------------------------------------------
@@ -154,49 +154,49 @@ CContextDXLToPlStmt::UlCurrentParamId()
 void
 CContextDXLToPlStmt::AddCTEConsumerInfo
 	(
-	ULONG ulCteId,
-	ShareInputScan *pshscan
+	ULONG cte_id,
+	ShareInputScan *share_input_scan
 	)
 {
-	GPOS_ASSERT(NULL != pshscan);
+	GPOS_ASSERT(NULL != share_input_scan);
 
-	SCTEConsumerInfo *pcteinfo = m_phmulcteconsumerinfo->PtLookup(&ulCteId);
-	if (NULL != pcteinfo)
+	SCTEConsumerInfo *cte_info = m_cte_consumer_info->Find(&cte_id);
+	if (NULL != cte_info)
 	{
-		pcteinfo->AddCTEPlan(pshscan);
+		cte_info->AddCTEPlan(share_input_scan);
 		return;
 	}
 
-	List *plPlanCTE = ListMake1(pshscan);
+	List *cte_plan = ListMake1(share_input_scan);
 
-	ULONG *pulKey = GPOS_NEW(m_pmp) ULONG(ulCteId);
+	ULONG *key = GPOS_NEW(m_mp) ULONG(cte_id);
 #ifdef GPOS_DEBUG
-	BOOL fResult =
+	BOOL result =
 #endif
-			m_phmulcteconsumerinfo->FInsert(pulKey, GPOS_NEW(m_pmp) SCTEConsumerInfo(plPlanCTE));
+			m_cte_consumer_info->Insert(key, GPOS_NEW(m_mp) SCTEConsumerInfo(cte_plan));
 
-	GPOS_ASSERT(fResult);
+	GPOS_ASSERT(result);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::PplanCTEProducer
+//		CContextDXLToPlStmt::GetCTEConsumerList
 //
 //	@doc:
 //		Return the list of GPDB plan nodes representing the CTE consumers
 //		with the given CTE identifier
 //---------------------------------------------------------------------------
 List *
-CContextDXLToPlStmt::PshscanCTEConsumer
+CContextDXLToPlStmt::GetCTEConsumerList
 	(
-	ULONG ulCteId
+	ULONG cte_id
 	)
 	const
 {
-	SCTEConsumerInfo *pcteinfo = m_phmulcteconsumerinfo->PtLookup(&ulCteId);
-	if (NULL != pcteinfo)
+	SCTEConsumerInfo *cte_info = m_cte_consumer_info->Find(&cte_id);
+	if (NULL != cte_info)
 	{
-		return pcteinfo->m_plSis;
+		return cte_info->m_cte_consumer_list;
 	}
 
 	return NULL;
@@ -204,30 +204,30 @@ CContextDXLToPlStmt::PshscanCTEConsumer
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::PlPrte
+//		CContextDXLToPlStmt::GetRTableEntriesList
 //
 //	@doc:
 //		Return the list of RangeTableEntries
 //
 //---------------------------------------------------------------------------
 List *
-CContextDXLToPlStmt::PlPrte()
+CContextDXLToPlStmt::GetRTableEntriesList()
 {
-	return (*(m_pplRTable));
+	return (*(m_rtable_entries_list));
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::PlPplanSubplan
+//		CContextDXLToPlStmt::GetSubplanEntriesList
 //
 //	@doc:
 //		Return the list of subplans generated so far
 //
 //---------------------------------------------------------------------------
 List *
-CContextDXLToPlStmt::PlPplanSubplan()
+CContextDXLToPlStmt::GetSubplanEntriesList()
 {
-	return (*(m_pplSubPlan));
+	return (*(m_subplan_entries_list));
 }
 
 //---------------------------------------------------------------------------
@@ -241,19 +241,19 @@ CContextDXLToPlStmt::PlPplanSubplan()
 void
 CContextDXLToPlStmt::AddRTE
 	(
-	RangeTblEntry *prte,
-	BOOL fResultRelation
+	RangeTblEntry *rte,
+	BOOL is_result_relation
 	)
 {
-	(* (m_pplRTable)) = gpdb::PlAppendElement((*(m_pplRTable)), prte);
+	(* (m_rtable_entries_list)) = gpdb::LAppend((*(m_rtable_entries_list)), rte);
 
-	prte->inFromCl = true;
+	rte->inFromCl = true;
 
-	if (fResultRelation)
+	if (is_result_relation)
 	{
-		GPOS_ASSERT(0 == m_ulResultRelation && "Only one result relation supported");
-		prte->inFromCl = false;
-		m_ulResultRelation = gpdb::UlListLength(*(m_pplRTable));
+		GPOS_ASSERT(0 == m_result_relation_index && "Only one result relation supported");
+		rte->inFromCl = false;
+		m_result_relation_index = gpdb::ListLength(*(m_rtable_entries_list));
 	}
 }
 
@@ -271,9 +271,9 @@ CContextDXLToPlStmt::AddPartitionedTable
 	OID oid
 	)
 {
-	if (!gpdb::FMemberOid(m_plPartitionTables, oid))
+	if (!gpdb::ListMemberOid(m_partitioned_tables_list, oid))
 	{
-		m_plPartitionTables = gpdb::PlAppendOid(m_plPartitionTables, oid);
+		m_partitioned_tables_list = gpdb::LAppendOid(m_partitioned_tables_list, oid);
 	}
 }
 
@@ -288,41 +288,41 @@ CContextDXLToPlStmt::AddPartitionedTable
 void
 CContextDXLToPlStmt::IncrementPartitionSelectors
 	(
-	ULONG ulScanId
+	ULONG scan_id
 	)
 {
 	// add extra elements to the array if necessary
-	const ULONG ulLen = m_pdrgpulNumSelectors->UlLength();
-	for (ULONG ul = ulLen; ul <= ulScanId; ul++)
+	const ULONG len = m_num_partition_selectors_array->Size();
+	for (ULONG ul = len; ul <= scan_id; ul++)
 	{
-		ULONG *pul = GPOS_NEW(m_pmp) ULONG(0);
-		m_pdrgpulNumSelectors->Append(pul);
+		ULONG *pul = GPOS_NEW(m_mp) ULONG(0);
+		m_num_partition_selectors_array->Append(pul);
 	}
 
-	ULONG *pul = (*m_pdrgpulNumSelectors)[ulScanId];
-	(*pul) ++;
+	ULONG *ul = (*m_num_partition_selectors_array)[scan_id];
+	(*ul) ++;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::PlNumPartitionSelectors
+//		CContextDXLToPlStmt::GetNumPartitionSelectorsList
 //
 //	@doc:
 //		Return list containing number of partition selectors for every scan id
 //
 //---------------------------------------------------------------------------
 List *
-CContextDXLToPlStmt::PlNumPartitionSelectors() const
+CContextDXLToPlStmt::GetNumPartitionSelectorsList() const
 {
-	List *pl = NIL;
-	const ULONG ulLen = m_pdrgpulNumSelectors->UlLength();
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	List *partition_selectors_list = NIL;
+	const ULONG len = m_num_partition_selectors_array->Size();
+	for (ULONG ul = 0; ul < len; ul++)
 	{
-		ULONG *pul = (*m_pdrgpulNumSelectors)[ul];
-		pl = gpdb::PlAppendInt(pl, *pul);
+		ULONG *num_partition_selectors = (*m_num_partition_selectors_array)[ul];
+		partition_selectors_list = gpdb::LAppendInt(partition_selectors_list, *num_partition_selectors);
 	}
 
-	return pl;
+	return partition_selectors_list;
 }
 
 //---------------------------------------------------------------------------
@@ -334,9 +334,9 @@ CContextDXLToPlStmt::PlNumPartitionSelectors() const
 //
 //---------------------------------------------------------------------------
 void
-CContextDXLToPlStmt::AddSubplan(Plan *pplan)
+CContextDXLToPlStmt::AddSubplan(Plan *plan)
 {
-	(* (m_pplSubPlan)) = gpdb::PlAppendElement((*(m_pplSubPlan)), pplan);
+	(* (m_subplan_entries_list)) = gpdb::LAppend((*(m_subplan_entries_list)), plan);
 }
 
 //---------------------------------------------------------------------------
@@ -350,15 +350,15 @@ CContextDXLToPlStmt::AddSubplan(Plan *pplan)
 void
 CContextDXLToPlStmt::AddCtasInfo
 	(
-	IntoClause *pintocl,
-	GpPolicy *pdistrpolicy
+	IntoClause *into_clause,
+	GpPolicy *distribution_policy
 	)
 {
-	GPOS_ASSERT(NULL != pintocl);
-	GPOS_ASSERT(NULL != pdistrpolicy);
+	GPOS_ASSERT(NULL != into_clause);
+	GPOS_ASSERT(NULL != distribution_policy);
 	
-	m_pintocl = pintocl;
-	m_pdistrpolicy = pdistrpolicy;
+	m_into_clause = into_clause;
+	m_distribution_policy = distribution_policy;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CMappingColIdVar.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVar.cpp
@@ -27,10 +27,10 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CMappingColIdVar::CMappingColIdVar
 	(
-	IMemoryPool *pmp
+	IMemoryPool *mp
 	)
 	:
-	m_pmp(pmp)
+	m_mp(mp)
 {
 }
 

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -43,80 +43,80 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CMappingColIdVarPlStmt::CMappingColIdVarPlStmt
 	(
-	IMemoryPool *pmp,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	CDXLTranslateContext *pdxltrctxOut,
-	CContextDXLToPlStmt *pctxdxltoplstmt
+	IMemoryPool *mp,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	CDXLTranslateContext *output_context,
+	CContextDXLToPlStmt *dxl_to_plstmt_context
 	)
 	:
-	CMappingColIdVar(pmp),
-	m_pdxltrctxbt(pdxltrctxbt),
-	m_pdrgpdxltrctx(pdrgpdxltrctx),
-	m_pdxltrctxOut(pdxltrctxOut),
-	m_pctxdxltoplstmt(pctxdxltoplstmt)
+	CMappingColIdVar(mp),
+	m_base_table_context(base_table_context),
+	m_child_contexts(child_contexts),
+	m_output_context(output_context),
+	m_dxl_to_plstmt_context(dxl_to_plstmt_context)
 {
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingColIdVarPlStmt::Pctxdxltoplstmt
+//		CMappingColIdVarPlStmt::GetDXLToPlStmtContext
 //
 //	@doc:
 //		Returns the DXL->PlStmt translation context
 //
 //---------------------------------------------------------------------------
 CContextDXLToPlStmt *
-CMappingColIdVarPlStmt::Pctxdxltoplstmt()
+CMappingColIdVarPlStmt::GetDXLToPlStmtContext()
 {
-	return m_pctxdxltoplstmt;
+	return m_dxl_to_plstmt_context;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingColIdVarPlStmt::PpdxltrctxOut
+//		CMappingColIdVarPlStmt::GetOutputContext
 //
 //	@doc:
 //		Returns the output translation context
 //
 //---------------------------------------------------------------------------
 CDXLTranslateContext *
-CMappingColIdVarPlStmt::PpdxltrctxOut()
+CMappingColIdVarPlStmt::GetOutputContext()
 {
-	return m_pdxltrctxOut;
+	return m_output_context;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingColIdVarPlStmt::PparamFromDXLNodeScId
+//		CMappingColIdVarPlStmt::ParamFromDXLNodeScId
 //
 //	@doc:
 //		Translates a DXL scalar identifier operator into a GPDB Param node
 //
 //---------------------------------------------------------------------------
 Param *
-CMappingColIdVarPlStmt::PparamFromDXLNodeScId
+CMappingColIdVarPlStmt::ParamFromDXLNodeScId
 	(
-	const CDXLScalarIdent *pdxlop
+	const CDXLScalarIdent *dxlop
 	)
 {
-	GPOS_ASSERT(NULL != m_pdxltrctxOut);
+	GPOS_ASSERT(NULL != m_output_context);
 
-	Param *pparam = NULL;
+	Param *param = NULL;
 
-	const ULONG ulColId = pdxlop->Pdxlcr()->UlID();
-	const CMappingElementColIdParamId *pmecolidparamid = m_pdxltrctxOut->Pmecolidparamid(ulColId);
+	const ULONG colid = dxlop->GetDXLColRef()->Id();
+	const CMappingElementColIdParamId *elem = m_output_context->GetParamIdMappingElement(colid);
 
-	if (NULL != pmecolidparamid)
+	if (NULL != elem)
 	{
-		pparam = MakeNode(Param);
-		pparam->paramkind = PARAM_EXEC;
-		pparam->paramid = pmecolidparamid->UlParamId();
-		pparam->paramtype = CMDIdGPDB::PmdidConvert(pmecolidparamid->PmdidType())->OidObjectId();
-		pparam->paramtypmod = pmecolidparamid->ITypeModifier();
+		param = MakeNode(Param);
+		param->paramkind = PARAM_EXEC;
+		param->paramid = elem->ParamId();
+		param->paramtype = CMDIdGPDB::CastMdid(elem->MdidType())->Oid();
+		param->paramtypmod = elem->TypeModifier();
 	}
 
-	return pparam;
+	return param;
 }
 
 //---------------------------------------------------------------------------
@@ -128,119 +128,117 @@ CMappingColIdVarPlStmt::PparamFromDXLNodeScId
 //
 //---------------------------------------------------------------------------
 Var *
-CMappingColIdVarPlStmt::PvarFromDXLNodeScId
+CMappingColIdVarPlStmt::VarFromDXLNodeScId
 	(
-	const CDXLScalarIdent *pdxlop
+	const CDXLScalarIdent *dxlop
 	)
 {
-	Index idxVarno = 0;
+	Index varno = 0;
 	AttrNumber attno = 0;
 
-	Index idxVarnoold = 0;
-	AttrNumber attnoOld = 0;
+	Index varno_old = 0;
+	AttrNumber attno_old = 0;
 
-	const ULONG ulColId = pdxlop->Pdxlcr()->UlID();
-	if (NULL != m_pdxltrctxbt)
+	const ULONG colid = dxlop->GetDXLColRef()->Id();
+	if (NULL != m_base_table_context)
 	{
 		// scalar id is used in a base table operator node
-		idxVarno = m_pdxltrctxbt->IRel();
-		attno = (AttrNumber) m_pdxltrctxbt->IAttnoForColId(ulColId);
+		varno = m_base_table_context->GetRelIndex();
+		attno = (AttrNumber) m_base_table_context->GetAttnoForColId(colid);
 
-		idxVarnoold = idxVarno;
-		attnoOld = attno;
+		varno_old = varno;
+		attno_old = attno;
 	}
 
 	// if lookup has failed in the first step, attempt lookup again using outer and inner contexts
-	if (0 == attno && NULL != m_pdrgpdxltrctx)
+	if (0 == attno && NULL != m_child_contexts)
 	{
-		GPOS_ASSERT(0 != m_pdrgpdxltrctx->UlLength());
+		GPOS_ASSERT(0 != m_child_contexts->Size());
 
-		const CDXLTranslateContext *pdxltrctxLeft = (*m_pdrgpdxltrctx)[0];
-
-		//	const CDXLTranslateContext *pdxltrctxRight
+		const CDXLTranslateContext *left_context = (*m_child_contexts)[0];
 
 		// not a base table
-		GPOS_ASSERT(NULL != pdxltrctxLeft);
+		GPOS_ASSERT(NULL != left_context);
 
 		// lookup column in the left child translation context
-		const TargetEntry *pte = pdxltrctxLeft->Pte(ulColId);
+		const TargetEntry *target_entry = left_context->GetTargetEntry(colid);
 
-		if (NULL != pte)
+		if (NULL != target_entry)
 		{
 			// identifier comes from left child
-			idxVarno = OUTER;
+			varno = OUTER;
 		}
 		else
 		{
-			const ULONG ulContexts = m_pdrgpdxltrctx->UlLength();
-			if (2 > ulContexts)
+			const ULONG num_contexts = m_child_contexts->Size();
+			if (2 > num_contexts)
 			{
 				// there are no more children. col id not found in this tree
 				// and must be an outer ref
 				return NULL;
 			}
 
-			const CDXLTranslateContext *pdxltrctxRight = (*m_pdrgpdxltrctx)[1];
+			const CDXLTranslateContext *right_context = (*m_child_contexts)[1];
 
 			// identifier must come from right child
-			GPOS_ASSERT(NULL != pdxltrctxRight);
+			GPOS_ASSERT(NULL != right_context);
 
-			pte = pdxltrctxRight->Pte(ulColId);
+			target_entry = right_context->GetTargetEntry(colid);
 
-			idxVarno = INNER;
+			varno = INNER;
 
 			// check any additional contexts if col is still not found yet
-			for (ULONG ul = 2; NULL == pte && ul < ulContexts; ul++)
+			for (ULONG ul = 2; NULL == target_entry && ul < num_contexts; ul++)
 			{
-				const CDXLTranslateContext *pdxltrctx = (*m_pdrgpdxltrctx)[ul];
-				GPOS_ASSERT(NULL != pdxltrctx);
+				const CDXLTranslateContext *context = (*m_child_contexts)[ul];
+				GPOS_ASSERT(NULL != context);
 
-				pte = pdxltrctx->Pte(ulColId);
-				if (NULL == pte)
+				target_entry = context->GetTargetEntry(colid);
+				if (NULL == target_entry)
 				{
 					continue;
 				}
 
-				Var *pv = (Var*) pte->expr;
-				idxVarno = pv->varno;
+				Var *var = (Var*) target_entry->expr;
+				varno = var->varno;
 			}
 		}
 
-		if (NULL  == pte)
+		if (NULL  == target_entry)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, ulColId);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, colid);
 		}
 
-		attno = pte->resno;
+		attno = target_entry->resno;
 
 		// find the original varno and attno for this column
-		if (IsA(pte->expr, Var))
+		if (IsA(target_entry->expr, Var))
 		{
-			Var *pv = (Var*) pte->expr;
-			idxVarnoold = pv->varnoold;
-			attnoOld = pv->varoattno;
+			Var *var = (Var*) target_entry->expr;
+			varno_old = var->varnoold;
+			attno_old = var->varoattno;
 		}
 		else
 		{
-			idxVarnoold = idxVarno;
-			attnoOld = attno;
+			varno_old = varno;
+			attno_old = attno;
 		}
 	}
 
-	Var *pvar = gpdb::PvarMakeVar
+	Var *var = gpdb::MakeVar
 						(
-						idxVarno,
+						varno,
 						attno,
-						CMDIdGPDB::PmdidConvert(pdxlop->PmdidType())->OidObjectId(),
-						pdxlop->ITypeModifier(),
+						CMDIdGPDB::CastMdid(dxlop->MdidType())->Oid(),
+						dxlop->TypeModifier(),
 						0	// varlevelsup
 						);
 
 	// set varnoold and varoattno since makeVar does not set them properly
-	pvar->varnoold = idxVarnoold;
-	pvar->varoattno = attnoOld;
+	var->varnoold = varno_old;
+	var->varoattno = attno_old;
 
-	return pvar;
+	return var;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
+++ b/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
@@ -33,16 +33,16 @@ using namespace gpos;
 //---------------------------------------------------------------------------
 CMappingElementColIdParamId::CMappingElementColIdParamId
 	(
-	ULONG ulColId,
-	ULONG ulParamId,
-	IMDId *pmdid,
-	INT iTypeModifier
+	ULONG colid,
+	ULONG paramid,
+	IMDId *mdid,
+	INT type_modifier
 	)
 	:
-	m_ulColId(ulColId),
-	m_ulParamId(ulParamId),
-	m_pmdid(pmdid),
-	m_iTypeModifier(iTypeModifier)
+	m_colid(colid),
+	m_paramid(paramid),
+	m_mdid(mdid),
+	m_type_modifier(type_modifier)
 {
 }
 

--- a/src/backend/gpopt/translate/CMappingElementColIdTE.cpp
+++ b/src/backend/gpopt/translate/CMappingElementColIdTE.cpp
@@ -33,14 +33,14 @@ using namespace gpos;
 //---------------------------------------------------------------------------
 CMappingElementColIdTE::CMappingElementColIdTE
 	(
-	ULONG ulColId,
-	ULONG ulQueryLevel,
-	TargetEntry *pte
+	ULONG colid,
+	ULONG query_level,
+	TargetEntry *target_entry
 	)
 	:
-	m_ulColId(ulColId),
-	m_ulQueryLevel(ulQueryLevel),
-	m_pte(pte)
+	m_colid(colid),
+	m_query_level(query_level),
+	m_target_entry(target_entry)
 {
 }
 

--- a/src/backend/gpopt/translate/CMappingVarColId.cpp
+++ b/src/backend/gpopt/translate/CMappingVarColId.cpp
@@ -40,97 +40,97 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CMappingVarColId::CMappingVarColId
 	(
-	IMemoryPool *pmp
+	IMemoryPool *mp
 	)
 	:
-	m_pmp(pmp)
+	m_mp(mp)
 {
-	m_pmvcmap = GPOS_NEW(m_pmp) CMVCMap(m_pmp);
+	m_gpdb_att_opt_col_mapping = GPOS_NEW(m_mp) GPDBAttOptColHashMap(m_mp);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::Pgpdbattoptcol
+//		CMappingVarColId::GetGPDBAttOptColMapping
 //
 //	@doc:
 //		Given a gpdb attribute, return the mapping info to opt col
 //
 //---------------------------------------------------------------------------
 const CGPDBAttOptCol *
-CMappingVarColId::Pgpdbattoptcol
+CMappingVarColId::GetGPDBAttOptColMapping
 	(
-	ULONG ulCurrentQueryLevel,
-	const Var *pvar,
-	EPlStmtPhysicalOpType eplsphoptype
+	ULONG current_query_level,
+	const Var *var,
+	EPlStmtPhysicalOpType plstmt_physical_op_type
 	)
 	const
 {
-	GPOS_ASSERT(NULL != pvar);
-	GPOS_ASSERT(ulCurrentQueryLevel >= pvar->varlevelsup);
+	GPOS_ASSERT(NULL != var);
+	GPOS_ASSERT(current_query_level >= var->varlevelsup);
 
 	// absolute query level of var
-	ULONG ulAbsQueryLevel = ulCurrentQueryLevel - pvar->varlevelsup;
+	ULONG abs_query_level = current_query_level - var->varlevelsup;
 
 	// extract varno
-	ULONG ulVarNo = pvar->varno;
-	if (EpspotWindow == eplsphoptype || EpspotAgg == eplsphoptype || EpspotMaterialize == eplsphoptype)
+	ULONG var_no = var->varno;
+	if (EpspotWindow == plstmt_physical_op_type || EpspotAgg == plstmt_physical_op_type || EpspotMaterialize == plstmt_physical_op_type)
 	{
 		// Agg and Materialize need to employ OUTER, since they have other
 		// values in GPDB world
-		ulVarNo = OUTER;
+		var_no = OUTER;
 	}
 
-	CGPDBAttInfo *pgpdbattinfo = GPOS_NEW(m_pmp) CGPDBAttInfo(ulAbsQueryLevel, ulVarNo, pvar->varattno);
-	CGPDBAttOptCol *pgpdbattoptcol = m_pmvcmap->PtLookup(pgpdbattinfo);
+	CGPDBAttInfo *gpdb_att_info = GPOS_NEW(m_mp) CGPDBAttInfo(abs_query_level, var_no, var->varattno);
+	CGPDBAttOptCol *gpdb_att_opt_col_info = m_gpdb_att_opt_col_mapping->Find(gpdb_att_info);
 	
-	if (NULL == pgpdbattoptcol)
+	if (NULL == gpdb_att_opt_col_info)
 	{
 		// TODO: Sept 09 2013, remove temporary fix (revert exception to assert) to avoid crash during algebrization
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("No variable"));
 	}
 
-	pgpdbattinfo->Release();
-	return pgpdbattoptcol;
+	gpdb_att_info->Release();
+	return gpdb_att_opt_col_info;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::PstrColName
+//		CMappingVarColId::GetOptColName
 //
 //	@doc:
 //		Given a gpdb attribute, return a column name in optimizer world
 //
 //---------------------------------------------------------------------------
 const CWStringBase *
-CMappingVarColId::PstrColName
+CMappingVarColId::GetOptColName
 	(
-	ULONG ulCurrentQueryLevel,
-	const Var *pvar,
-	EPlStmtPhysicalOpType eplsphoptype
+	ULONG current_query_level,
+	const Var *var,
+	EPlStmtPhysicalOpType plstmt_physical_op_type
 	)
 	const
 {
-	return Pgpdbattoptcol(ulCurrentQueryLevel, pvar, eplsphoptype)->Poptcolinfo()->PstrColName();
+	return GetGPDBAttOptColMapping(current_query_level, var, plstmt_physical_op_type)->GetOptColInfo()->GetOptColName();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::UlColId
+//		CMappingVarColId::GetColId
 //
 //	@doc:
 //		given a gpdb attribute, return a column id in optimizer world
 //
 //---------------------------------------------------------------------------
 ULONG
-CMappingVarColId::UlColId
+CMappingVarColId::GetColId
 	(
-	ULONG ulCurrentQueryLevel,
-	const Var *pvar,
-	EPlStmtPhysicalOpType eplsphoptype
+	ULONG current_query_level,
+	const Var *var,
+	EPlStmtPhysicalOpType plstmt_physical_op_type
 	)
 	const
 {
-	return Pgpdbattoptcol(ulCurrentQueryLevel, pvar, eplsphoptype)->Poptcolinfo()->UlColId();
+	return GetGPDBAttOptColMapping(current_query_level, var, plstmt_physical_op_type)->GetOptColInfo()->GetColId();
 }
 
 //---------------------------------------------------------------------------
@@ -144,33 +144,33 @@ CMappingVarColId::UlColId
 void
 CMappingVarColId::Insert
 	(
-	ULONG ulQueryLevel,
-	ULONG ulVarNo,
-	INT iAttNo,
-	ULONG ulColId,
-	CWStringBase *pstrColName
+	ULONG query_level,
+	ULONG var_no,
+	INT attrnum,
+	ULONG colid,
+	CWStringBase *column_name
 	)
 {
 	// GPDB agg node uses 0 in Var, but that should've been taken care of
 	// by translator
-	GPOS_ASSERT(ulVarNo > 0);
+	GPOS_ASSERT(var_no > 0);
 
 	// create key
-	CGPDBAttInfo *pgpdbattinfo = GPOS_NEW(m_pmp) CGPDBAttInfo(ulQueryLevel, ulVarNo, iAttNo);
+	CGPDBAttInfo *gpdb_att_info = GPOS_NEW(m_mp) CGPDBAttInfo(query_level, var_no, attrnum);
 
 	// create value
-	COptColInfo *poptcolinfo = GPOS_NEW(m_pmp) COptColInfo(ulColId, pstrColName);
+	COptColInfo *opt_col_info = GPOS_NEW(m_mp) COptColInfo(colid, column_name);
 
 	// key is part of value, bump up refcount
-	pgpdbattinfo->AddRef();
-	CGPDBAttOptCol *pgpdbattoptcol = GPOS_NEW(m_pmp) CGPDBAttOptCol(pgpdbattinfo, poptcolinfo);
+	gpdb_att_info->AddRef();
+	CGPDBAttOptCol *gpdb_att_opt_col_info = GPOS_NEW(m_mp) CGPDBAttOptCol(gpdb_att_info, opt_col_info);
 
 #ifdef GPOS_DEBUG
-	BOOL fResult =
+	BOOL result =
 #endif // GPOS_DEBUG
-			m_pmvcmap->FInsert(pgpdbattinfo, pgpdbattoptcol);
+			m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info, gpdb_att_opt_col_info);
 
-	GPOS_ASSERT(fResult);
+	GPOS_ASSERT(result);
 }
 
 //---------------------------------------------------------------------------
@@ -185,25 +185,25 @@ CMappingVarColId::Insert
 void
 CMappingVarColId::LoadTblColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const CDXLTableDescr *pdxltabdesc
+	ULONG query_level,
+	ULONG RTE_index,
+	const CDXLTableDescr *table_descr
 	)
 {
-	GPOS_ASSERT(NULL != pdxltabdesc);
-	const ULONG ulSize = pdxltabdesc->UlArity();
+	GPOS_ASSERT(NULL != table_descr);
+	const ULONG size = table_descr->Arity();
 
 	// add mapping information for columns
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG i = 0; i < size; i++)
 	{
-		const CDXLColDescr *pdxlcd = pdxltabdesc->Pdxlcd(ul);
+		const CDXLColDescr *dxl_col_descr = table_descr->GetColumnDescrAt(i);
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				pdxlcd->IAttno(),
-				pdxlcd->UlID(),
-				pdxlcd->Pmdname()->Pstr()->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				dxl_col_descr->AttrNum(),
+				dxl_col_descr->Id(),
+				dxl_col_descr->MdName()->GetMDName()->Copy(m_mp)
 				);
 	}
 
@@ -221,28 +221,28 @@ CMappingVarColId::LoadTblColumns
 void
 CMappingVarColId::LoadIndexColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const IMDIndex *pmdindex,
-	const CDXLTableDescr *pdxltabdesc
+	ULONG query_level,
+	ULONG RTE_index,
+	const IMDIndex *index,
+	const CDXLTableDescr *table_descr
 	)
 {
-	GPOS_ASSERT(NULL != pdxltabdesc);
+	GPOS_ASSERT(NULL != table_descr);
 
-	const ULONG ulSize = pmdindex->UlKeys();
+	const ULONG size = index->Keys();
 
 	// add mapping information for columns
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG i = 0; i < size; i++)
 	{
-		ULONG ulPos = pmdindex->UlKey(ul);
-		const CDXLColDescr *pdxlcd = pdxltabdesc->Pdxlcd(ulPos);
+		ULONG pos = index->KeyAt(i);
+		const CDXLColDescr *dxl_col_descr = table_descr->GetColumnDescrAt(pos);
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				INT(ul + 1),
-				pdxlcd->UlID(),
-				pdxlcd->Pmdname()->Pstr()->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				INT(i + 1),
+				dxl_col_descr->Id(),
+				dxl_col_descr->MdName()->GetMDName()->Copy(m_mp)
 				);
 	}
 
@@ -259,34 +259,34 @@ CMappingVarColId::LoadIndexColumns
 void
 CMappingVarColId::Load
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	CIdGenerator *pidgtor,
-	List *plColNames
+	ULONG query_level,
+	ULONG RTE_index,
+	CIdGenerator *id_generator,
+	List *col_names
 	)
 {
-	ListCell *plcCol = NULL;
-	ULONG ul = 0;
+	ListCell *col_name = NULL;
+	ULONG i = 0;
 
 	// add mapping information for columns
-	ForEach(plcCol, plColNames)
+	ForEach(col_name, col_names)
 	{
-		Value *pvalue = (Value *) lfirst(plcCol);
-		CHAR *szColName = strVal(pvalue);
+		Value *value = (Value *) lfirst(col_name);
+		CHAR *col_name_char_array = strVal(value);
 
-		CWStringDynamic *pstrColName = CDXLUtils::PstrFromSz(m_pmp, szColName);
+		CWStringDynamic *column_name = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, col_name_char_array);
 
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				INT(ul + 1),
-				pidgtor->UlNextId(),
-				pstrColName->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				INT(i + 1),
+				id_generator->next_id(),
+				column_name->Copy(m_mp)
 				);
 
-		ul ++;
-		GPOS_DELETE(pstrColName);
+		i ++;
+		GPOS_DELETE(column_name);
 	}
 }
 
@@ -301,25 +301,25 @@ CMappingVarColId::Load
 void
 CMappingVarColId::LoadColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const DrgPdxlcd *pdrgdxlcd
+	ULONG query_level,
+	ULONG RTE_index,
+	const CDXLColDescrArray *column_descrs
 	)
 {
-	GPOS_ASSERT(NULL != pdrgdxlcd);
-	const ULONG ulSize = pdrgdxlcd->UlLength();
+	GPOS_ASSERT(NULL != column_descrs);
+	const ULONG size = column_descrs->Size();
 
 	// add mapping information for columns
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG i = 0; i < size; i++)
 	{
-		const CDXLColDescr *pdxlcd = (*pdrgdxlcd)[ul];
+		const CDXLColDescr *dxl_col_descr = (*column_descrs)[i];
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				pdxlcd->IAttno(),
-				pdxlcd->UlID(),
-				pdxlcd->Pmdname()->Pstr()->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				dxl_col_descr->AttrNum(),
+				dxl_col_descr->Id(),
+				dxl_col_descr->MdName()->GetMDName()->Copy(m_mp)
 				);
 	}
 
@@ -336,36 +336,36 @@ CMappingVarColId::LoadColumns
 void
 CMappingVarColId::LoadDerivedTblColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const DrgPdxln *pdrgpdxlnDerivedColumns,
-	List *plTargetList
+	ULONG query_level,
+	ULONG RTE_index,
+	const CDXLNodeArray *derived_columns_dxl,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpdxlnDerivedColumns);
-	GPOS_ASSERT( (ULONG) gpdb::UlListLength(plTargetList) >= pdrgpdxlnDerivedColumns->UlLength());
+	GPOS_ASSERT(NULL != derived_columns_dxl);
+	GPOS_ASSERT( (ULONG) gpdb::ListLength(target_list) >= derived_columns_dxl->Size());
 
-	ULONG ulDrvdTblColCounter = 0; // counter for the dynamic array of DXL nodes
-	ListCell *plc = NULL;
-	ForEach (plc, plTargetList)
+	ULONG drvd_tbl_col_counter = 0; // counter for the dynamic array of DXL nodes
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		if (!pte->resjunk)
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		if (!target_entry->resjunk)
 		{
-			GPOS_ASSERT(0 < pte->resno);
-			CDXLNode *pdxln = (*pdrgpdxlnDerivedColumns)[ulDrvdTblColCounter];
-			GPOS_ASSERT(NULL != pdxln);
-			CDXLScalarIdent *pdxlnIdent = CDXLScalarIdent::PdxlopConvert(pdxln->Pdxlop());
-			const CDXLColRef *pdxlcr = pdxlnIdent->Pdxlcr();
+			GPOS_ASSERT(0 < target_entry->resno);
+			CDXLNode *dxlnode = (*derived_columns_dxl)[drvd_tbl_col_counter];
+			GPOS_ASSERT(NULL != dxlnode);
+			CDXLScalarIdent *dxl_sc_ident = CDXLScalarIdent::Cast(dxlnode->GetOperator());
+			const CDXLColRef *dxl_colref = dxl_sc_ident->GetDXLColRef();
 			this->Insert
 					(
-					ulQueryLevel,
-					ulRTEIndex,
-					INT(pte->resno),
-					pdxlcr->UlID(),
-					pdxlcr->Pmdname()->Pstr()->PStrCopy(m_pmp)
+					query_level,
+					RTE_index,
+					INT(target_entry->resno),
+					dxl_colref->Id(),
+					dxl_colref->MdName()->GetMDName()->Copy(m_mp)
 					);
-			ulDrvdTblColCounter++;
+			drvd_tbl_col_counter++;
 		}
 	}
 }
@@ -381,35 +381,35 @@ CMappingVarColId::LoadDerivedTblColumns
 void
 CMappingVarColId::LoadCTEColumns
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const DrgPul *pdrgpulCTEColumns,
-	List *plTargetList
+	ULONG query_level,
+	ULONG RTE_index,
+	const ULongPtrArray *CTE_columns,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpulCTEColumns);
-	GPOS_ASSERT( (ULONG) gpdb::UlListLength(plTargetList) >= pdrgpulCTEColumns->UlLength());
+	GPOS_ASSERT(NULL != CTE_columns);
+	GPOS_ASSERT( (ULONG) gpdb::ListLength(target_list) >= CTE_columns->Size());
 
-	ULONG ulCTE = 0;
-	ListCell *plc = NULL;
-	ForEach (plc, plTargetList)
+	ULONG idx = 0;
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		if (!pte->resjunk)
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		if (!target_entry->resjunk)
 		{
-			GPOS_ASSERT(0 < pte->resno);
-			ULONG ulCTEColId = *((*pdrgpulCTEColumns)[ulCTE]);
+			GPOS_ASSERT(0 < target_entry->resno);
+			ULONG CTE_colid = *((*CTE_columns)[idx]);
 			
-			CWStringDynamic *pstrColName = CDXLUtils::PstrFromSz(m_pmp, pte->resname);
+			CWStringDynamic *column_name = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, target_entry->resname);
 			this->Insert
 					(
-					ulQueryLevel,
-					ulRTEIndex,
-					INT(pte->resno),
-					ulCTEColId,
-					pstrColName
+					query_level,
+					RTE_index,
+					INT(target_entry->resno),
+					CTE_colid,
+					column_name
 					);
-			ulCTE++;
+			idx++;
 		}
 	}
 }
@@ -425,170 +425,170 @@ CMappingVarColId::LoadCTEColumns
 void
 CMappingVarColId::LoadProjectElements
 	(
-	ULONG ulQueryLevel,
-	ULONG ulRTEIndex,
-	const CDXLNode *pdxlnPrL
+	ULONG query_level,
+	ULONG RTE_index,
+	const CDXLNode *project_list_dxlnode
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnPrL);
-	const ULONG ulSize = pdxlnPrL->UlArity();
+	GPOS_ASSERT(NULL != project_list_dxlnode);
+	const ULONG size = project_list_dxlnode->Arity();
 	// add mapping information for columns
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG i = 0; i < size; i++)
 	{
-		CDXLNode *pdxln = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrEl = CDXLScalarProjElem::PdxlopConvert(pdxln->Pdxlop());
+		CDXLNode *dxlnode = (*project_list_dxlnode)[i];
+		CDXLScalarProjElem *dxl_proj_elem = CDXLScalarProjElem::Cast(dxlnode->GetOperator());
 		this->Insert
 				(
-				ulQueryLevel,
-				ulRTEIndex,
-				INT(ul + 1),
-				pdxlopPrEl->UlId(),
-				pdxlopPrEl->PmdnameAlias()->Pstr()->PStrCopy(m_pmp)
+				query_level,
+				RTE_index,
+				INT(i + 1),
+				dxl_proj_elem->Id(),
+				dxl_proj_elem->GetMdNameAlias()->GetMDName()->Copy(m_mp)
 				);
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::PmapvarcolidCopy
+//		CMappingVarColId::CopyMapColId
 //
 //	@doc:
 //		Create a deep copy
 //
 //---------------------------------------------------------------------------
 CMappingVarColId *
-CMappingVarColId::PmapvarcolidCopy
+CMappingVarColId::CopyMapColId
 	(
-	ULONG ulQueryLevel
+	ULONG query_level
 	)
 	const
 {
-	CMappingVarColId *pmapvarcolid = GPOS_NEW(m_pmp) CMappingVarColId(m_pmp);
+	CMappingVarColId *var_colid_mapping = GPOS_NEW(m_mp) CMappingVarColId(m_mp);
 
 	// iterate over full map
-	CMVCMapIter mvcmi(this->m_pmvcmap);
-	while (mvcmi.FAdvance())
+	GPDBAttOptColHashMapIter col_map_iterator(this->m_gpdb_att_opt_col_mapping);
+	while (col_map_iterator.Advance())
 	{
-		const CGPDBAttOptCol *pgpdbattoptcol = mvcmi.Pt();
-		const CGPDBAttInfo *pgpdbattinfo = pgpdbattoptcol->Pgpdbattinfo();
-		const COptColInfo *poptcolinfo = pgpdbattoptcol->Poptcolinfo();
+		const CGPDBAttOptCol *gpdb_att_opt_col_info = col_map_iterator.Value();
+		const CGPDBAttInfo *gpdb_att_info = gpdb_att_opt_col_info->GetGPDBAttInfo();
+		const COptColInfo *opt_col_info = gpdb_att_opt_col_info->GetOptColInfo();
 
-		if (pgpdbattinfo->UlQueryLevel() <= ulQueryLevel)
+		if (gpdb_att_info->GetQueryLevel() <= query_level)
 		{
 			// include all variables defined at same query level or before
-			CGPDBAttInfo *pgpdbattinfoNew = GPOS_NEW(m_pmp) CGPDBAttInfo(pgpdbattinfo->UlQueryLevel(), pgpdbattinfo->UlVarNo(), pgpdbattinfo->IAttNo());
-			COptColInfo *poptcolinfoNew = GPOS_NEW(m_pmp) COptColInfo(poptcolinfo->UlColId(), GPOS_NEW(m_pmp) CWStringConst(m_pmp, poptcolinfo->PstrColName()->Wsz()));
-			pgpdbattinfoNew->AddRef();
-			CGPDBAttOptCol *pgpdbattoptcolNew = GPOS_NEW(m_pmp) CGPDBAttOptCol(pgpdbattinfoNew, poptcolinfoNew);
+			CGPDBAttInfo *gpdb_att_info_new = GPOS_NEW(m_mp) CGPDBAttInfo(gpdb_att_info->GetQueryLevel(), gpdb_att_info->GetVarNo(), gpdb_att_info->GetAttNo());
+			COptColInfo *opt_col_info_new = GPOS_NEW(m_mp) COptColInfo(opt_col_info->GetColId(), GPOS_NEW(m_mp) CWStringConst(m_mp, opt_col_info->GetOptColName()->GetBuffer()));
+			gpdb_att_info_new->AddRef();
+			CGPDBAttOptCol *gpdb_att_opt_col_new = GPOS_NEW(m_mp) CGPDBAttOptCol(gpdb_att_info_new, opt_col_info_new);
 
 			// insert into hashmap
 #ifdef GPOS_DEBUG
-			BOOL fResult =
+			BOOL result =
 #endif // GPOS_DEBUG
-					pmapvarcolid->m_pmvcmap->FInsert(pgpdbattinfoNew, pgpdbattoptcolNew);
-			GPOS_ASSERT(fResult);
+					var_colid_mapping->m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info_new, gpdb_att_opt_col_new);
+			GPOS_ASSERT(result);
 		}
 	}
 
-	return pmapvarcolid;
+	return var_colid_mapping;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::PmapvarcolidCopy
+//		CMappingVarColId::CopyMapColId
 //
 //	@doc:
 //		Create a deep copy
 //
 //---------------------------------------------------------------------------
 CMappingVarColId *
-CMappingVarColId::PmapvarcolidCopy
+CMappingVarColId::CopyMapColId
 	(
-	IMemoryPool *pmp
+	IMemoryPool *mp
 	)
 	const
 {
-	CMappingVarColId *pmapvarcolid = GPOS_NEW(pmp) CMappingVarColId(pmp);
+	CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
 
 	// iterate over full map
-	CMVCMapIter mvcmi(this->m_pmvcmap);
-	while (mvcmi.FAdvance())
+	GPDBAttOptColHashMapIter col_map_iterator(this->m_gpdb_att_opt_col_mapping);
+	while (col_map_iterator.Advance())
 	{
-		const CGPDBAttOptCol *pgpdbattoptcol = mvcmi.Pt();
-		const CGPDBAttInfo *pgpdbattinfo = pgpdbattoptcol->Pgpdbattinfo();
-		const COptColInfo *poptcolinfo = pgpdbattoptcol->Poptcolinfo();
+		const CGPDBAttOptCol *gpdb_att_opt_col_info = col_map_iterator.Value();
+		const CGPDBAttInfo *gpdb_att_info = gpdb_att_opt_col_info->GetGPDBAttInfo();
+		const COptColInfo *opt_col_info = gpdb_att_opt_col_info->GetOptColInfo();
 
-		CGPDBAttInfo *pgpdbattinfoNew = GPOS_NEW(pmp) CGPDBAttInfo(pgpdbattinfo->UlQueryLevel(), pgpdbattinfo->UlVarNo(), pgpdbattinfo->IAttNo());
-		COptColInfo *poptcolinfoNew = GPOS_NEW(pmp) COptColInfo(poptcolinfo->UlColId(), GPOS_NEW(pmp) CWStringConst(pmp, poptcolinfo->PstrColName()->Wsz()));
-		pgpdbattinfoNew->AddRef();
-		CGPDBAttOptCol *pgpdbattoptcolNew = GPOS_NEW(pmp) CGPDBAttOptCol(pgpdbattinfoNew, poptcolinfoNew);
+		CGPDBAttInfo *gpdb_att_info_new = GPOS_NEW(mp) CGPDBAttInfo(gpdb_att_info->GetQueryLevel(), gpdb_att_info->GetVarNo(), gpdb_att_info->GetAttNo());
+		COptColInfo *opt_col_info_new = GPOS_NEW(mp) COptColInfo(opt_col_info->GetColId(), GPOS_NEW(mp) CWStringConst(mp, opt_col_info->GetOptColName()->GetBuffer()));
+		gpdb_att_info_new->AddRef();
+		CGPDBAttOptCol *gpdb_att_opt_col_new = GPOS_NEW(mp) CGPDBAttOptCol(gpdb_att_info_new, opt_col_info_new);
 
 		// insert into hashmap
 #ifdef GPOS_DEBUG
-	BOOL fResult =
+	BOOL result =
 #endif // GPOS_DEBUG
-		pmapvarcolid->m_pmvcmap->FInsert(pgpdbattinfoNew, pgpdbattoptcolNew);
-		GPOS_ASSERT(fResult);
+		var_colid_mapping->m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info_new, gpdb_att_opt_col_new);
+		GPOS_ASSERT(result);
 	}
 
-	return pmapvarcolid;
+	return var_colid_mapping;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMappingVarColId::PmapvarcolidRemap
+//		CMappingVarColId::CopyRemapColId
 //
 //	@doc:
 //		Create a copy of the mapping replacing the old column ids by new ones
 //
 //---------------------------------------------------------------------------
 CMappingVarColId *
-CMappingVarColId::PmapvarcolidRemap
+CMappingVarColId::CopyRemapColId
 	(
-	IMemoryPool *pmp,
-	DrgPul *pdrgpulOld,
-	DrgPul *pdrgpulNew
+	IMemoryPool *mp,
+	ULongPtrArray *old_colids,
+	ULongPtrArray *new_colids
 	)
 	const
 {
-	GPOS_ASSERT(NULL != pdrgpulOld);
-	GPOS_ASSERT(NULL != pdrgpulNew);
-	GPOS_ASSERT(pdrgpulNew->UlLength() == pdrgpulOld->UlLength());
+	GPOS_ASSERT(NULL != old_colids);
+	GPOS_ASSERT(NULL != new_colids);
+	GPOS_ASSERT(new_colids->Size() == old_colids->Size());
 	
 	// construct a mapping old cols -> new cols
-	HMUlUl *phmulul = CTranslatorUtils::PhmululMap(pmp, pdrgpulOld, pdrgpulNew);
+	UlongToUlongMap *old_new_col_mapping = CTranslatorUtils::MakeNewToOldColMapping(mp, old_colids, new_colids);
 		
-	CMappingVarColId *pmapvarcolid = GPOS_NEW(pmp) CMappingVarColId(pmp);
+	CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
 
-	CMVCMapIter mvcmi(this->m_pmvcmap);
-	while (mvcmi.FAdvance())
+	GPDBAttOptColHashMapIter col_map_iterator(this->m_gpdb_att_opt_col_mapping);
+	while (col_map_iterator.Advance())
 	{
-		const CGPDBAttOptCol *pgpdbattoptcol = mvcmi.Pt();
-		const CGPDBAttInfo *pgpdbattinfo = pgpdbattoptcol->Pgpdbattinfo();
-		const COptColInfo *poptcolinfo = pgpdbattoptcol->Poptcolinfo();
+		const CGPDBAttOptCol *gpdb_att_opt_col_info = col_map_iterator.Value();
+		const CGPDBAttInfo *gpdb_att_info = gpdb_att_opt_col_info->GetGPDBAttInfo();
+		const COptColInfo *opt_col_info = gpdb_att_opt_col_info->GetOptColInfo();
 
-		CGPDBAttInfo *pgpdbattinfoNew = GPOS_NEW(pmp) CGPDBAttInfo(pgpdbattinfo->UlQueryLevel(), pgpdbattinfo->UlVarNo(), pgpdbattinfo->IAttNo());
-		ULONG ulColId = poptcolinfo->UlColId();
-		ULONG *pulColIdNew = phmulul->PtLookup(&ulColId);
-		if (NULL != pulColIdNew)
+		CGPDBAttInfo *gpdb_att_info_new = GPOS_NEW(mp) CGPDBAttInfo(gpdb_att_info->GetQueryLevel(), gpdb_att_info->GetVarNo(), gpdb_att_info->GetAttNo());
+		ULONG colid = opt_col_info->GetColId();
+		ULONG *new_colid = old_new_col_mapping->Find(&colid);
+		if (NULL != new_colid)
 		{
-			ulColId = *pulColIdNew;
+			colid = *new_colid;
 		}
 		
-		COptColInfo *poptcolinfoNew = GPOS_NEW(pmp) COptColInfo(ulColId, GPOS_NEW(pmp) CWStringConst(pmp, poptcolinfo->PstrColName()->Wsz()));
-		pgpdbattinfoNew->AddRef();
-		CGPDBAttOptCol *pgpdbattoptcolNew = GPOS_NEW(pmp) CGPDBAttOptCol(pgpdbattinfoNew, poptcolinfoNew);
+		COptColInfo *opt_col_info_new = GPOS_NEW(mp) COptColInfo(colid, GPOS_NEW(mp) CWStringConst(mp, opt_col_info->GetOptColName()->GetBuffer()));
+		gpdb_att_info_new->AddRef();
+		CGPDBAttOptCol *gpdb_att_opt_col_new = GPOS_NEW(mp) CGPDBAttOptCol(gpdb_att_info_new, opt_col_info_new);
 
 #ifdef GPOS_DEBUG
-		BOOL fResult =
+		BOOL result =
 #endif // GPOS_DEBUG
-		pmapvarcolid->m_pmvcmap->FInsert(pgpdbattinfoNew, pgpdbattoptcolNew);
-		GPOS_ASSERT(fResult);
+		var_colid_mapping->m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info_new, gpdb_att_opt_col_new);
+		GPOS_ASSERT(result);
 	}
 	
-	phmulul->Release();
+	old_new_col_mapping->Release();
 
-	return pmapvarcolid;
+	return var_colid_mapping;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -37,31 +37,31 @@ using namespace gpmd;
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::FNeedsPrLNormalization
+//		CQueryMutators::NeedsProjListNormalization
 //
 //	@doc:
 //		Is the group by project list flat (contains only aggregates
 //		and grouping columns)
 //---------------------------------------------------------------------------
 BOOL
-CQueryMutators::FNeedsPrLNormalization
+CQueryMutators::NeedsProjListNormalization
 	(
-	const Query *pquery
+	const Query *query
 	)
 {
-	if (!pquery->hasAggs && NULL == pquery->groupClause)
+	if (!query->hasAggs && NULL == query->groupClause)
 	{
 		return false;
 	}
 
-	SContextTLWalker ctxTLWalker(pquery->targetList, pquery->groupClause);
+	SContextTLWalker context(query->targetList, query->groupClause);
 
-	ListCell *plc = NULL;
-	ForEach (plc, pquery->targetList)
+	ListCell *lc = NULL;
+	ForEach (lc, query->targetList)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
 
-		if (FNeedsToFallback((Node *) pte->expr, &ctxTLWalker))
+		if (ShouldFallback((Node *) target_entry->expr, &context))
 		{
 			// TODO: remove temporary fix (revert exception to assert) to avoid crash during algebrization
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("No attribute"));
@@ -69,7 +69,7 @@ CQueryMutators::FNeedsPrLNormalization
 
 		// Normalize when there is an expression that is neither used for grouping
 		// nor is an aggregate function
-		if (!IsA(pte->expr, PercentileExpr) && !IsA(pte->expr, Aggref) && !IsA(pte->expr, GroupingFunc) && !CTranslatorUtils::FGroupingColumn( (Node*) pte->expr, pquery->groupClause, pquery->targetList))
+		if (!IsA(target_entry->expr, PercentileExpr) && !IsA(target_entry->expr, Aggref) && !IsA(target_entry->expr, GroupingFunc) && !CTranslatorUtils::IsGroupingColumn( (Node*) target_entry->expr, query->groupClause, query->targetList))
 		{
 			return true;
 		}
@@ -81,46 +81,44 @@ CQueryMutators::FNeedsPrLNormalization
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::FNeedsToFallback
+//		CQueryMutators::ShouldFallback
 //
 //	@doc:
 //		Fall back when the target list refers to a attribute which algebrizer
 //		at this point cannot resolve
 //---------------------------------------------------------------------------
 BOOL
-CQueryMutators::FNeedsToFallback
+CQueryMutators::ShouldFallback
 	(
-	Node *pnode,
-	void *pvCtx
+	Node *node,
+	SContextTLWalker *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return false;
 	}
 
-	if (IsA(pnode, Const) || IsA(pnode, Aggref) || IsA(pnode, PercentileExpr) || IsA(pnode, GroupingFunc) || IsA(pnode, SubLink))
+	if (IsA(node, Const) || IsA(node, Aggref) || IsA(node, PercentileExpr) || IsA(node, GroupingFunc) || IsA(node, SubLink))
 	{
 		return false;
 	}
 
-	SContextTLWalker *pctx = (SContextTLWalker *) pvCtx;
-
-	TargetEntry *pteFound = gpdb::PteMember(pnode, pctx->m_plTE);
-	if (NULL != pteFound && CTranslatorUtils::FGroupingColumn( (Node *) pteFound->expr, pctx->m_groupClause, pctx->m_plTE))
+	TargetEntry *entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_target_entries);
+	if (NULL != entry && CTranslatorUtils::IsGroupingColumn( (Node *) entry->expr, context->m_group_clause, context->m_target_entries))
 	{
 		return false;
 	}
 
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
 		return false;
 	}
 
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvar = (Var *) pnode;
-		if (0 == pvar->varlevelsup)
+		Var *var = (Var *) node;
+		if (0 == var->varlevelsup)
 		{
 			// if we reach a Var that was not a grouping column then there is an equivalent column
 			// which the algebrizer at this point cannot resolve
@@ -136,13 +134,13 @@ CQueryMutators::FNeedsToFallback
 		return false;
 	}
 
-	return gpdb::FWalkExpressionTree(pnode, (PfFallback) CQueryMutators::FNeedsToFallback, pvCtx);
+	return gpdb::WalkExpressionTree(node, (FallbackWalkerFn) CQueryMutators::ShouldFallback, context);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryNormalizeGrpByPrL
+//		CQueryMutators::NormalizeGroupByProjList
 //
 //	@doc:
 // 		Flatten expressions in project list to contain only aggregates and
@@ -155,92 +153,90 @@ CQueryMutators::FNeedsToFallback
 //											   FROM t where r.b = t.e) t2)
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryNormalizeGrpByPrL
+CQueryMutators::NormalizeGroupByProjList
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const Query *pquery
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const Query *query
 	)
 {
-	Query *pqueryCopy = (Query *) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+	Query *query_copy = (Query *) gpdb::CopyObject(const_cast<Query*>(query));
 
-	if (!FNeedsPrLNormalization(pqueryCopy))
+	if (!NeedsProjListNormalization(query_copy))
 	{
-		return pqueryCopy;
+		return query_copy;
 	}
 
-	Query *pqueryNew = PqueryConvertToDerivedTable(pqueryCopy, false /*fFixTargetList*/, true /*fFixHavingQual*/);
-	gpdb::GPDBFree(pqueryCopy);
+	Query *new_query = ConvertToDerivedTable(query_copy, false /*should_fix_target_list*/, true /*should_fix_having_qual*/);
+	gpdb::GPDBFree(query_copy);
 
-	GPOS_ASSERT(1 == gpdb::UlListLength(pqueryNew->rtable));
-	Query *pqueryDrdTbl = (Query *) ((RangeTblEntry *) gpdb::PvListNth(pqueryNew->rtable, 0))->subquery;
-	SContextGrpbyPlMutator ctxGbPrLMutator(pmp, pmda, pqueryDrdTbl, NULL);
-	List *plTEcopy = (List*) gpdb::PvCopyObject(pqueryDrdTbl->targetList);
-	ListCell *plc = NULL;
+	GPOS_ASSERT(1 == gpdb::ListLength(new_query->rtable));
+	Query *derived_table_query = (Query *) ((RangeTblEntry *) gpdb::ListNth(new_query->rtable, 0))->subquery;
+	SContextGrpbyPlMutator context(mp, md_accessor, derived_table_query, NULL);
+	List *target_list_copy = (List*) gpdb::CopyObject(derived_table_query->targetList);
+	ListCell *lc = NULL;
 
 	// first normalize grouping columns
-	ForEach (plc, plTEcopy)
+	ForEach (lc, target_list_copy)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		GPOS_ASSERT(NULL != pte);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		GPOS_ASSERT(NULL != target_entry);
 
-		if (CTranslatorUtils::FGroupingColumn(pte, pqueryDrdTbl->groupClause))
+		if (CTranslatorUtils::IsGroupingColumn(target_entry, derived_table_query->groupClause))
 		{
-			pte->expr = (Expr*) PnodeFixGrpCol( (Node*) pte->expr, pte, &ctxGbPrLMutator);
+			target_entry->expr = (Expr*) FixGroupingCols( (Node*) target_entry->expr, target_entry, &context);
 		}
 	}
 
-	plc = NULL;
+	lc = NULL;
 	// normalize remaining project elements
-	ForEach (plc, plTEcopy)
+	ForEach (lc, target_list_copy)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		GPOS_ASSERT(NULL != pte);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		GPOS_ASSERT(NULL != target_entry);
 
-		BOOL fGroupingCol = CTranslatorUtils::FGroupingColumn(pte, pqueryDrdTbl->groupClause);
-		if (!fGroupingCol)
+		BOOL is_grouping_col = CTranslatorUtils::IsGroupingColumn(target_entry, derived_table_query->groupClause);
+		if (!is_grouping_col)
 		{
-			pte->expr = (Expr*) PnodeGrpbyPrLMutator( (Node*) pte->expr, &ctxGbPrLMutator);
+			target_entry->expr = (Expr*) RunGroupByProjListMutator( (Node*) target_entry->expr, &context);
 			GPOS_ASSERT
 				(
-				(!IsA(pte->expr, Aggref) && !IsA(pte->expr, PercentileExpr)) && !IsA(pte->expr, GroupingFunc) &&
+				(!IsA(target_entry->expr, Aggref) && !IsA(target_entry->expr, PercentileExpr)) && !IsA(target_entry->expr, GroupingFunc) &&
 				"New target list entry should not contain any Aggrefs or PercentileExpr"
 				);
 		}
 	}
 
-	pqueryDrdTbl->targetList = ctxGbPrLMutator.m_plTENewGroupByQuery;
-	pqueryNew->targetList = plTEcopy;
+	derived_table_query->targetList = context.m_groupby_target_list;
+	new_query->targetList = target_list_copy;
 
-	ReassignSortClause(pqueryNew, pqueryDrdTbl);
+	ReassignSortClause(new_query, derived_table_query);
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeIncrementLevelsupMutator
+//		CQueryMutators::RunIncrLevelsUpMutator
 //
 //	@doc:
 //		Increment any the query levels up of any outer reference by one
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeIncrementLevelsupMutator
+CQueryMutators::RunIncrLevelsUpMutator
 	(
-	Node *pnode,
-	void *pvCtx
+	Node *node,
+	SContextIncLevelsupMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	SContextIncLevelsupMutator *pctxIncLvlMutator = (SContextIncLevelsupMutator *) pvCtx;
-
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvar = (Var *) gpdb::PvCopyObject(pnode);
+		Var *var = (Var *) gpdb::CopyObject(node);
 
 		// Consider the following use case:
 		//	ORGINAL QUERY:
@@ -254,180 +250,178 @@ CQueryMutators::PnodeIncrementLevelsupMutator
 		// In such a scenario, we need increment the levels up for the
 		// correlation variable r.b in the subquery by 1.
 
-		if (pvar->varlevelsup > pctxIncLvlMutator->m_ulCurrLevelsUp)
+		if (var->varlevelsup > context->m_current_query_level)
 		{
-			pvar->varlevelsup++;
-			return (Node *) pvar;
+			var->varlevelsup++;
+			return (Node *) var;
 		}
-		return (Node *) pvar;
+		return (Node *) var;
 	}
 
-	if (IsA(pnode, CommonTableExpr))
+	if (IsA(node, CommonTableExpr))
 	{
-		CommonTableExpr *pcte = (CommonTableExpr *) gpdb::PvCopyObject(pnode);
-		GPOS_ASSERT(IsA(pcte->ctequery, Query));
+		CommonTableExpr *cte = (CommonTableExpr *) gpdb::CopyObject(node);
+		GPOS_ASSERT(IsA(cte->ctequery, Query));
 
-		Query *pqueryCte = (Query *) pcte->ctequery;
+		Query *cte_query = (Query *) cte->ctequery;
 
-		pctxIncLvlMutator->m_ulCurrLevelsUp++;
-		pcte->ctequery = PnodeIncrementLevelsupMutator((Node *) pqueryCte, pctxIncLvlMutator);
-		pctxIncLvlMutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level++;
+		cte->ctequery = RunIncrLevelsUpMutator((Node *) cte_query, context);
+		context->m_current_query_level--;
 
-		gpdb::GPDBFree(pqueryCte);
+		gpdb::GPDBFree(cte_query);
 
-		return (Node *) pcte;
+		return (Node *) cte;
 	}
 
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		SubLink *psublink = (SubLink *) gpdb::PvCopyObject(pnode);
-		GPOS_ASSERT(IsA(psublink->subselect, Query));
+		SubLink *sublink = (SubLink *) gpdb::CopyObject(node);
+		GPOS_ASSERT(IsA(sublink->subselect, Query));
 
-		Query *pquerySublink = (Query *) psublink->subselect;
+		Query *sublink_query = (Query *) sublink->subselect;
 
-		pctxIncLvlMutator->m_ulCurrLevelsUp++;
-		psublink->subselect = PnodeIncrementLevelsupMutator( (Node *) pquerySublink, pctxIncLvlMutator);
-		pctxIncLvlMutator->m_ulCurrLevelsUp--;
-		gpdb::GPDBFree(pquerySublink);
+		context->m_current_query_level++;
+		sublink->subselect = RunIncrLevelsUpMutator( (Node *) sublink_query, context);
+		context->m_current_query_level--;
+		gpdb::GPDBFree(sublink_query);
 
-		return (Node *) psublink;
+		return (Node *) sublink;
 	}
 
-	if (IsA(pnode, TargetEntry) && 0 == pctxIncLvlMutator->m_ulCurrLevelsUp && !pctxIncLvlMutator->m_fFixTargetListTopLevel)
+	if (IsA(node, TargetEntry) && 0 == context->m_current_query_level && !context->m_should_fix_top_level_target_list)
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
 	// recurse into query structure
-	if (IsA(pnode, Query))
+	if (IsA(node, Query))
 	{
-		Query *pquery = gpdb::PqueryMutateQueryTree
+		Query *query = gpdb::MutateQueryTree
 								(
-								(Query *) pnode,
-								(Pfnode) CQueryMutators::PnodeIncrementLevelsupMutator,
-								pctxIncLvlMutator,
+								(Query *) node,
+								(MutatorWalkerFn) CQueryMutators::RunIncrLevelsUpMutator,
+								context,
 								1 // flag -- do not mutate range table entries
 								);
 
 		// fix the outer reference in derived table entries
-		List *plRtable = pquery->rtable;
-		ListCell *plc = NULL;
-		ForEach (plc, plRtable)
+		List *rtable = query->rtable;
+		ListCell *lc = NULL;
+		ForEach (lc, rtable)
 		{
-			RangeTblEntry *prte = (RangeTblEntry *) lfirst(plc);
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 
-			if (RTE_SUBQUERY == prte->rtekind)
+			if (RTE_SUBQUERY == rte->rtekind)
 			{
-				Query *pquerySubquery = prte->subquery;
+				Query *subquery = rte->subquery;
 				// since we did not walk inside derived tables
-				pctxIncLvlMutator->m_ulCurrLevelsUp++;
-				prte->subquery = (Query *) PnodeIncrementLevelsupMutator( (Node *) pquerySubquery, pctxIncLvlMutator);
-				pctxIncLvlMutator->m_ulCurrLevelsUp--;
-				gpdb::GPDBFree(pquerySubquery);
+				context->m_current_query_level++;
+				rte->subquery = (Query *) RunIncrLevelsUpMutator( (Node *) subquery, context);
+				context->m_current_query_level--;
+				gpdb::GPDBFree(subquery);
 			}
 		}
 
-		return (Node *) pquery;
+		return (Node *) query;
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeIncrementLevelsupMutator, pvCtx);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunIncrLevelsUpMutator, context);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeFixCTELevelsupMutator
+//		CQueryMutators::RunFixCTELevelsUpMutator
 //
 //	@doc:
 //		Increment any the query levels up of any CTE range table reference by one
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeFixCTELevelsupMutator
+CQueryMutators::RunFixCTELevelsUpMutator
 	(
-	Node *pnode,
-	void *pvCtx
+	Node *node,
+	SContextIncLevelsupMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	SContextIncLevelsupMutator *pctxinclvlmutator = (SContextIncLevelsupMutator *) pvCtx;
-
 	// recurse into query structure
-	if (IsA(pnode, Query))
+	if (IsA(node, Query))
 	{
-		Query *pquery = gpdb::PqueryMutateQueryTree
+		Query *query = gpdb::MutateQueryTree
 								(
-								(Query *) pnode,
-								(Pfnode) CQueryMutators::PnodeFixCTELevelsupMutator,
-								pvCtx,
+								(Query *) node,
+								(MutatorWalkerFn) CQueryMutators::RunFixCTELevelsUpMutator,
+								context,
 								1 // flag -- do not mutate range table entries
 								);
 
-		List *plRtable = pquery->rtable;
-		ListCell *plc = NULL;
-		ForEach (plc, plRtable)
+		List *rtable = query->rtable;
+		ListCell *lc = NULL;
+		ForEach (lc, rtable)
 		{
-			RangeTblEntry *prte = (RangeTblEntry *) lfirst(plc);
-			if (RTE_CTE == prte->rtekind  && FNeedsLevelsUpCorrection(pctxinclvlmutator, prte->ctelevelsup))
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+			if (RTE_CTE == rte->rtekind  && NeedsLevelsUpCorrection(context, rte->ctelevelsup))
 			{
 				// fix the levels up for CTE range table entry when needed
 				// the walker in GPDB does not walk range table entries of type CTE
-				prte->ctelevelsup++;
+				rte->ctelevelsup++;
 			}
 
-			if (RTE_SUBQUERY == prte->rtekind)
+			if (RTE_SUBQUERY == rte->rtekind)
 			{
-				Query *pquerySubquery = prte->subquery;
+				Query *subquery = rte->subquery;
 				// since we did not walk inside derived tables
-				pctxinclvlmutator->m_ulCurrLevelsUp++;
-				prte->subquery = (Query *) PnodeFixCTELevelsupMutator( (Node *) pquerySubquery, pctxinclvlmutator);
-				pctxinclvlmutator->m_ulCurrLevelsUp--;
-				gpdb::GPDBFree(pquerySubquery);
+				context->m_current_query_level++;
+				rte->subquery = (Query *) RunFixCTELevelsUpMutator( (Node *) subquery, context);
+				context->m_current_query_level--;
+				gpdb::GPDBFree(subquery);
 			}
 		}
 
-		return (Node *) pquery;
+		return (Node *) query;
 	}
 
-	if (IsA(pnode, CommonTableExpr))
+	if (IsA(node, CommonTableExpr))
 	{
-		CommonTableExpr *pcte = (CommonTableExpr *) gpdb::PvCopyObject(pnode);
-		GPOS_ASSERT(IsA(pcte->ctequery, Query));
+		CommonTableExpr *cte = (CommonTableExpr *) gpdb::CopyObject(node);
+		GPOS_ASSERT(IsA(cte->ctequery, Query));
 
-		Query *pqueryCte = (Query *) pcte->ctequery;
-		pcte->ctequery = NULL;
+		Query *cte_query = (Query *) cte->ctequery;
+		cte->ctequery = NULL;
 
-		pctxinclvlmutator->m_ulCurrLevelsUp++;
-		pcte->ctequery = PnodeFixCTELevelsupMutator((Node *) pqueryCte, pctxinclvlmutator);
-		pctxinclvlmutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level++;
+		cte->ctequery = RunFixCTELevelsUpMutator((Node *) cte_query, context);
+		context->m_current_query_level--;
 
-		gpdb::GPDBFree(pqueryCte);
+		gpdb::GPDBFree(cte_query);
 
-		return (Node *) pcte;
+		return (Node *) cte;
 	}
 
 	// recurse into a query attached to sublink
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		SubLink *psublink = (SubLink *) gpdb::PvCopyObject(pnode);
-		GPOS_ASSERT(IsA(psublink->subselect, Query));
+		SubLink *sublink = (SubLink *) gpdb::CopyObject(node);
+		GPOS_ASSERT(IsA(sublink->subselect, Query));
 
-		Query *pquerySublink = (Query *) psublink->subselect;
-		psublink->subselect = NULL;
+		Query *sublink_query = (Query *) sublink->subselect;
+		sublink->subselect = NULL;
 
-		pctxinclvlmutator->m_ulCurrLevelsUp++;
-		psublink->subselect = PnodeFixCTELevelsupMutator((Node *) pquerySublink, pctxinclvlmutator);
-		pctxinclvlmutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level++;
+		sublink->subselect = RunFixCTELevelsUpMutator((Node *) sublink_query, context);
+		context->m_current_query_level--;
 
-		gpdb::GPDBFree(pquerySublink);
+		gpdb::GPDBFree(sublink_query);
 
-		return (Node *) psublink;
+		return (Node *) sublink;
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeFixCTELevelsupMutator, pctxinclvlmutator);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunFixCTELevelsUpMutator, context);
 }
 
 //---------------------------------------------------------------------------
@@ -438,382 +432,379 @@ CQueryMutators::PnodeFixCTELevelsupMutator
 //		Check if the cte levels up is the expected query level
 //---------------------------------------------------------------------------
 BOOL
-CQueryMutators::FNeedsLevelsUpCorrection
+CQueryMutators::NeedsLevelsUpCorrection
 	(
-	SContextIncLevelsupMutator *pctxinclvlmutator,
-	Index idxCtelevelsup
+	SContextIncLevelsupMutator *context,
+	Index cte_levels_up
 	)
 {
 	// when converting the query to derived table, all references to cte defined at the current level
 	// or above needs to be incremented
-	return idxCtelevelsup >= pctxinclvlmutator->m_ulCurrLevelsUp;
+	return cte_levels_up >= context->m_current_query_level;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeGrpbyPrLMutator
+//		CQueryMutators::RunGroupByProjListMutator
 //
 //	@doc:
 // 		Traverse the project list of a groupby operator and extract all aggregate
 //		functions in an arbitrarily complex project element
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeGrpbyPrLMutator
+CQueryMutators::RunGroupByProjListMutator
 	(
-	Node *pnode,
-	void *pctx
+	Node *node,
+	SContextGrpbyPlMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	if (IsA(pnode, Const))
+	if (IsA(node, Const))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	SContextGrpbyPlMutator *pctxGrpByMutator = (SContextGrpbyPlMutator *) pctx;
 
-	if (IsA(pnode, Var) && pctxGrpByMutator->m_fAggregateArg)
+	if (IsA(node, Var) && context->m_is_mutating_agg_arg)
 	{
 		// if we are mutating an aggregate argument do nothing since the aggregate will be place in the derived table's target list
 		// fix any outer references in the grouping column expression or arguments of an aggregate
-		return (Node *) PvarOuterReferenceIncrLevelsUp((Var*) pnode);
+		return (Node *) IncrLevelsUpInVar((Var*) node);
 	}
 	
 	// if we find an aggregate or precentile expression then insert into the new derived table
 	// and refer to it in the top-level query
 
-	if (IsA(pnode, Aggref))
+	if (IsA(node, Aggref))
 	{
-		Aggref *paggrefOld = (Aggref*) pnode;
-		Aggref *paggref = PaggrefFlatCopy(paggrefOld);
-		paggref->agglevelsup = paggrefOld->agglevelsup;
+		Aggref *old_aggref = (Aggref*) node;
+		Aggref *aggref = FlatCopyAggref(old_aggref);
+		aggref->agglevelsup = old_aggref->agglevelsup;
 
-		List *plArgsNew = NIL;
-		ListCell *plc = NULL;
+		List *new_args = NIL;
+		ListCell *lc = NULL;
 
-		BOOL fAggregate = pctxGrpByMutator->m_fAggregateArg;
-		pctxGrpByMutator->m_fAggregateArg = true;
+		BOOL fAggregate = context->m_is_mutating_agg_arg;
+		context->m_is_mutating_agg_arg = true;
 
-		ForEach (plc, paggrefOld->args)
+		ForEach (lc, old_aggref->args)
 		{
-			Node *pnodeArg = (Node *) gpdb::PvCopyObject((Node*) lfirst(plc));
-			GPOS_ASSERT(NULL != pnodeArg);
+			Node *arg = (Node *) gpdb::CopyObject((Node*) lfirst(lc));
+			GPOS_ASSERT(NULL != arg);
 			// traverse each argument and fix levels up when needed
-			plArgsNew = gpdb::PlAppendElement
+			new_args = gpdb::LAppend
 						(
-						plArgsNew,
-						gpdb::PnodeMutateQueryOrExpressionTree
+						new_args,
+						gpdb::MutateQueryOrExpressionTree
 							(
-							pnodeArg,
-							(Pfnode) CQueryMutators::PnodeGrpbyPrLMutator,
-							(void *) pctx,
+							arg,
+							(MutatorWalkerFn) CQueryMutators::RunGroupByProjListMutator,
+							(void *) context,
 							0 // flags -- mutate into cte-lists
 							)
 						);
 		}
-		pctxGrpByMutator->m_fAggregateArg = fAggregate;
-		paggref->args = plArgsNew;
+		context->m_is_mutating_agg_arg = fAggregate;
+		aggref->args = new_args;
 
-		const ULONG ulAttno = gpdb::UlListLength(pctxGrpByMutator->m_plTENewGroupByQuery) + 1;
-		TargetEntry *pte = PteAggregateOrPercentileExpr(pctxGrpByMutator->m_pmp, pctxGrpByMutator->m_pmda, (Node *) paggref, ulAttno);
+		const ULONG attno = gpdb::ListLength(context->m_groupby_target_list) + 1;
+		TargetEntry *target_entry = PteAggregateOrPercentileExpr(context->m_mp, context->m_md_accessor, (Node *) aggref, attno);
 
 		// Add a new target entry to the query
-		pctxGrpByMutator->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctxGrpByMutator->m_plTENewGroupByQuery, pte);
+		context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
-		Var *pvarNew = gpdb::PvarMakeVar
+		Var *new_var = gpdb::MakeVar
 						(
 						1, // varno
-						(AttrNumber) ulAttno,
-						gpdb::OidExprType(pnode),
-						gpdb::IExprTypeMod(pnode),
+						(AttrNumber) attno,
+						gpdb::ExprType(node),
+						gpdb::ExprTypeMod(node),
 						0 // query levelsup
 						);
 
-		return (Node*) pvarNew;
+		return (Node*) new_var;
 	}
 
-	if (IsA(pnode, PercentileExpr) || IsA(pnode, GroupingFunc))
+	if (IsA(node, PercentileExpr) || IsA(node, GroupingFunc))
 	{
-		Node *pnodeCopy = (Node *) gpdb::PvCopyObject(pnode);
+		Node *pnodeCopy = (Node *) gpdb::CopyObject(node);
 
-		const ULONG ulAttno = gpdb::UlListLength(pctxGrpByMutator->m_plTENewGroupByQuery) + 1;
-		TargetEntry *pte = PteAggregateOrPercentileExpr(pctxGrpByMutator->m_pmp, pctxGrpByMutator->m_pmda, pnodeCopy, ulAttno);
+		const ULONG attno = gpdb::ListLength(context->m_groupby_target_list) + 1;
+		TargetEntry *target_entry = PteAggregateOrPercentileExpr(context->m_mp, context->m_md_accessor, pnodeCopy, attno);
 
 		// Add a new target entry to the query
-		pctxGrpByMutator->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctxGrpByMutator->m_plTENewGroupByQuery, pte);
+		context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
-		Var *pvarNew = gpdb::PvarMakeVar
+		Var *new_var = gpdb::MakeVar
 								(
 								1, // varno
-								(AttrNumber) ulAttno,
-								gpdb::OidExprType(pnode),
-								gpdb::IExprTypeMod(pnode),
+								(AttrNumber) attno,
+								gpdb::ExprType(node),
+								gpdb::ExprTypeMod(node),
 								0 // query levelsup
 								);
 
-		return (Node*) pvarNew;
+		return (Node*) new_var;
 	}
 
-	if (!pctxGrpByMutator->m_fAggregateArg)
+	if (!context->m_is_mutating_agg_arg)
 	{
 		// if we find a target entry in the new derived table then return the appropriate var
 		// else investigate it to see if it needs to be added to the new derived table
 
-		TargetEntry *pteFound = gpdb::PteMember(pnode, pctxGrpByMutator->m_plTENewGroupByQuery);
+		TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
 
-		if (NULL != pteFound)
+		if (NULL != found_target_entry)
 		{
-			pteFound->resjunk = false;
-			Var *pvarNew = gpdb::PvarMakeVar
+			found_target_entry->resjunk = false;
+			Var *new_var = gpdb::MakeVar
 					(
 							1, // varno
-							pteFound->resno,
-							gpdb::OidExprType((Node*) pteFound->expr),
-							gpdb::IExprTypeMod( (Node*) pteFound->expr),
+							found_target_entry->resno,
+							gpdb::ExprType((Node*) found_target_entry->expr),
+							gpdb::ExprTypeMod( (Node*) found_target_entry->expr),
 							0 // query levelsup
 					);
 
-			return (Node*) pvarNew;
+			return (Node*) new_var;
 		}
 
 		// if it is grouping column then we have already added it to the derived table
 		// so merely refer to it in the top-level query
-		TargetEntry *pteFoundNewDrvdTable = gpdb::PteMember(pnode, pctxGrpByMutator->m_plTENewGroupByQuery);
-		if (NULL != pteFoundNewDrvdTable)
+		TargetEntry *new_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
+		if (NULL != new_target_entry)
 		{
-			return (Node *) gpdb::PvarMakeVar
+			return (Node *) gpdb::MakeVar
 							(
 							1, // varno
-							(AttrNumber) pteFoundNewDrvdTable->resno,
-							gpdb::OidExprType( (Node*) pteFoundNewDrvdTable->expr),
-							gpdb::IExprTypeMod( (Node*) pteFoundNewDrvdTable->expr),
+							(AttrNumber) new_target_entry->resno,
+							gpdb::ExprType( (Node*) new_target_entry->expr),
+							gpdb::ExprTypeMod( (Node*) new_target_entry->expr),
 							0 // query levelsup
 							);
 		}
 	}
 
 	// do not traverse into sub queries as they will be inserted into top-level query as is
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeGrpbyPrLMutator, pctx);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunGroupByProjListMutator, context);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeGrpColMutator
+//		CQueryMutators::RunGroupingColMutator
 //
 //	@doc:
 // 		Mutate the grouping columns, fix levels up when necessary
 //
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeGrpColMutator
+CQueryMutators::RunGroupingColMutator
 	(
-	Node *pnode,
-	void *pctx
+	Node *node,
+	SContextGrpbyPlMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	if (IsA(pnode, Const))
+	if (IsA(node, Const))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	SContextGrpbyPlMutator *pctxGrpByMutator = (SContextGrpbyPlMutator *) pctx;
-
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvarCopy = (Var *) gpdb::PvCopyObject(pnode);
+		Var *var_copy = (Var *) gpdb::CopyObject(node);
 
-		if (pvarCopy->varlevelsup > pctxGrpByMutator->m_ulCurrLevelsUp)
+		if (var_copy->varlevelsup > context->m_current_query_level)
 		{
-			pvarCopy->varlevelsup++;
+			var_copy->varlevelsup++;
 		}
 
-		return (Node *) pvarCopy;
+		return (Node *) var_copy;
 	}
 
-	if (IsA(pnode, Aggref))
+	if (IsA(node, Aggref))
 	{
 		// merely fix the arguments of an aggregate
-		Aggref *paggrefOld = (Aggref*) pnode;
-		Aggref *paggref = PaggrefFlatCopy(paggrefOld);
-		paggref->agglevelsup = paggrefOld->agglevelsup;
+		Aggref *old_aggref = (Aggref*) node;
+		Aggref *aggref = FlatCopyAggref(old_aggref);
+		aggref->agglevelsup = old_aggref->agglevelsup;
 
-		List *plArgsNew = NIL;
-		ListCell *plc = NULL;
+		List *new_args = NIL;
+		ListCell *lc = NULL;
 
-		BOOL fAggregate = pctxGrpByMutator->m_fAggregateArg;
-		pctxGrpByMutator->m_fAggregateArg = true;
+		BOOL is_agg = context->m_is_mutating_agg_arg;
+		context->m_is_mutating_agg_arg = true;
 
-		ForEach (plc, paggrefOld->args)
+		ForEach (lc, old_aggref->args)
 		{
-			Node *pnodeArg = (Node *) gpdb::PvCopyObject((Node*) lfirst(plc));
-			GPOS_ASSERT(NULL != pnodeArg);
+			Node *arg = (Node *) gpdb::CopyObject((Node*) lfirst(lc));
+			GPOS_ASSERT(NULL != arg);
 			// traverse each argument and fix levels up when needed
-			plArgsNew = gpdb::PlAppendElement
+			new_args = gpdb::LAppend
 						(
-						plArgsNew,
-						gpdb::PnodeMutateQueryOrExpressionTree
+						new_args,
+						gpdb::MutateQueryOrExpressionTree
 							(
-							pnodeArg,
-							(Pfnode) CQueryMutators::PnodeGrpColMutator,
-							(void *) pctxGrpByMutator,
+							arg,
+							(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+							(void *) context,
 							0 // flags -- mutate into cte-lists
 							)
 						);
 		}
-		pctxGrpByMutator->m_fAggregateArg = fAggregate;
-		paggref->args = plArgsNew;
+		context->m_is_mutating_agg_arg = is_agg;
+		aggref->args = new_args;
 
-		return (Node*) paggref;
+		return (Node*) aggref;
 	}
 
-	if (IsA(pnode, PercentileExpr) || IsA(pnode, GroupingFunc))
+	if (IsA(node, PercentileExpr) || IsA(node, GroupingFunc))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		SubLink *psublinkOld = (SubLink *) pnode;
+		SubLink *old_sublink = (SubLink *) node;
 
-		SubLink *psublinkNew = MakeNode(SubLink);
-		psublinkNew->subLinkType = psublinkOld->subLinkType;
-		psublinkNew->location = psublinkOld->location;
-		psublinkNew->operName = (List *) gpdb::PvCopyObject(psublinkOld->operName);
+		SubLink *new_sublink = MakeNode(SubLink);
+		new_sublink->subLinkType = old_sublink->subLinkType;
+		new_sublink->location = old_sublink->location;
+		new_sublink->operName = (List *) gpdb::CopyObject(old_sublink->operName);
 
-		psublinkNew->testexpr =	gpdb::PnodeMutateQueryOrExpressionTree
+		new_sublink->testexpr =	gpdb::MutateQueryOrExpressionTree
 										(
-										psublinkOld->testexpr,
-										(Pfnode) CQueryMutators::PnodeGrpColMutator,
-										(void *) pctxGrpByMutator,
+										old_sublink->testexpr,
+										(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+										(void *) context,
 										0 // flags -- mutate into cte-lists
 										);
-		pctxGrpByMutator->m_ulCurrLevelsUp++;
+		context->m_current_query_level++;
 
-		GPOS_ASSERT(IsA(psublinkOld->subselect, Query));
+		GPOS_ASSERT(IsA(old_sublink->subselect, Query));
 
-		psublinkNew->subselect = gpdb::PnodeMutateQueryOrExpressionTree
+		new_sublink->subselect = gpdb::MutateQueryOrExpressionTree
 										(
-										psublinkOld->subselect,
-										(Pfnode) CQueryMutators::PnodeGrpColMutator,
-										(void *) pctxGrpByMutator,
+										old_sublink->subselect,
+										(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+										context,
 										0 // flags -- mutate into cte-lists
 										);
 
-		pctxGrpByMutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level--;
 
-		return (Node *) psublinkNew;
+		return (Node *) new_sublink;
 	}
 
-	if (IsA(pnode, CommonTableExpr))
+	if (IsA(node, CommonTableExpr))
 	{
-		CommonTableExpr *pcte = (CommonTableExpr *) gpdb::PvCopyObject(pnode);
-		pctxGrpByMutator->m_ulCurrLevelsUp++;
+		CommonTableExpr *cte = (CommonTableExpr *) gpdb::CopyObject(node);
+		context->m_current_query_level++;
 
-		GPOS_ASSERT(IsA(pcte->ctequery, Query));
+		GPOS_ASSERT(IsA(cte->ctequery, Query));
 
-		pcte->ctequery = gpdb::PnodeMutateQueryOrExpressionTree
+		cte->ctequery = gpdb::MutateQueryOrExpressionTree
 									(
-									pcte->ctequery,
-									(Pfnode) CQueryMutators::PnodeGrpColMutator,
-									(void *) pctxGrpByMutator,
+									cte->ctequery,
+									(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+									(void *) context,
 									0 // flags --- mutate into cte-lists
 									);
 
-		pctxGrpByMutator->m_ulCurrLevelsUp--;
-		return (Node *) pcte;
+		context->m_current_query_level--;
+		return (Node *) cte;
 	}
 
 	// recurse into query structure
-	if (IsA(pnode, Query))
+	if (IsA(node, Query))
 	{
-		Query *pquery = gpdb::PqueryMutateQueryTree
+		Query *query = gpdb::MutateQueryTree
 								(
-								(Query *) pnode,
-								(Pfnode) CQueryMutators::PnodeGrpColMutator,
-								pctxGrpByMutator,
+								(Query *) node,
+								(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator,
+								context,
 								1 // flag -- do not mutate range table entries
 								);
 
 		// fix the outer reference in derived table entries
-		List *plRtable = pquery->rtable;
-		ListCell *plc = NULL;
-		ForEach (plc, plRtable)
+		List *rtable = query->rtable;
+		ListCell *lc = NULL;
+		ForEach (lc, rtable)
 		{
-			RangeTblEntry *prte = (RangeTblEntry *) lfirst(plc);
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 
-			if (RTE_SUBQUERY == prte->rtekind)
+			if (RTE_SUBQUERY == rte->rtekind)
 			{
-				Query *pquerySubquery = prte->subquery;
+				Query *subquery = rte->subquery;
 				// since we did not walk inside derived tables
-				pctxGrpByMutator->m_ulCurrLevelsUp++;
-				prte->subquery = (Query *) PnodeGrpColMutator( (Node *) pquerySubquery, pctxGrpByMutator);
-				pctxGrpByMutator->m_ulCurrLevelsUp--;
-				gpdb::GPDBFree(pquerySubquery);
+				context->m_current_query_level++;
+				rte->subquery = (Query *) RunGroupingColMutator( (Node *) subquery, context);
+				context->m_current_query_level--;
+				gpdb::GPDBFree(subquery);
 			}
 		}
 
-		return (Node *) pquery;
+		return (Node *) query;
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeGrpColMutator, pctx);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunGroupingColMutator, context);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeFixGrpCol
+//		CQueryMutators::FixGroupingCols
 //
 //	@doc:
 // 		Mutate the grouping columns, fix levels up when necessary
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeFixGrpCol
+CQueryMutators::FixGroupingCols
 	(
-	Node *pnode,
-	TargetEntry *pteOriginal,
-	SContextGrpbyPlMutator *pctx
+	Node *node,
+	TargetEntry *orginal_target_entry,
+	SContextGrpbyPlMutator *context
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 
-	ULONG ulArity = gpdb::UlListLength(pctx->m_plTENewGroupByQuery) + 1;
+	ULONG arity = gpdb::ListLength(context->m_groupby_target_list) + 1;
 
 	// fix any outer references in the grouping column expression
-	Node *pnodeExpr = (Node *) PnodeGrpColMutator( pnode, pctx);
+	Node *expr = (Node *) RunGroupingColMutator(node, context);
 
-	CHAR* szName = CQueryMutators::SzTEName(pteOriginal,pctx->m_pquery);
-	TargetEntry *pteNew = gpdb::PteMakeTargetEntry((Expr*) pnodeExpr, (AttrNumber) ulArity, szName, false /*resjunk */);
+	CHAR* name = CQueryMutators::GetTargetEntryColName(orginal_target_entry,context->m_query);
+	TargetEntry *new_target_entry = gpdb::MakeTargetEntry((Expr*) expr, (AttrNumber) arity, name, false /*resjunk */);
 
-	pteNew->ressortgroupref = pteOriginal->ressortgroupref;
-	pteNew->resjunk = false;
+	new_target_entry->ressortgroupref = orginal_target_entry->ressortgroupref;
+	new_target_entry->resjunk = false;
 
-	pctx->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctx->m_plTENewGroupByQuery, pteNew);
+	context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, new_target_entry);
 
-	Var *pvarNew = gpdb::PvarMakeVar
+	Var *new_var = gpdb::MakeVar
 			(
 					1, // varno
-					(AttrNumber) ulArity,
-					gpdb::OidExprType( (Node*) pteOriginal->expr),
-					gpdb::IExprTypeMod( (Node*) pteOriginal->expr),
+					(AttrNumber) arity,
+					gpdb::ExprType( (Node*) orginal_target_entry->expr),
+					gpdb::ExprTypeMod( (Node*) orginal_target_entry->expr),
 					0 // query levelsup
 			);
 
-	return (Node*) pvarNew;
+	return (Node*) new_var;
 }
 
 
@@ -827,57 +818,57 @@ CQueryMutators::PnodeFixGrpCol
 TargetEntry *
 CQueryMutators::PteAggregateOrPercentileExpr
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	Node *pnode,
-	ULONG ulAttno
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	Node *node,
+	ULONG attno
 	)
 {
-	GPOS_ASSERT(IsA(pnode, PercentileExpr) || IsA(pnode, Aggref) || IsA(pnode, GroupingFunc));
+	GPOS_ASSERT(IsA(node, PercentileExpr) || IsA(node, Aggref) || IsA(node, GroupingFunc));
 
 	// get the function/aggregate name
-	CHAR *szName = NULL;
-	if (IsA(pnode, PercentileExpr))
+	CHAR *name = NULL;
+	if (IsA(node, PercentileExpr))
 	{
-		PercentileExpr *ppercentile = (PercentileExpr*) pnode;
+		PercentileExpr *percentile = (PercentileExpr*) node;
 
-		if (PERC_MEDIAN == ppercentile->perckind)
+		if (PERC_MEDIAN == percentile->perckind)
 		{
-			szName = CTranslatorUtils::SzFromWsz(GPOS_WSZ_LIT("Median"));
+            name = CTranslatorUtils::CreateMultiByteCharStringFromWCString(GPOS_WSZ_LIT("Median"));
 		}
-		else if (PERC_CONT == ppercentile->perckind)
+		else if (PERC_CONT == percentile->perckind)
 		{
-			szName = CTranslatorUtils::SzFromWsz(GPOS_WSZ_LIT("Cont"));
+            name = CTranslatorUtils::CreateMultiByteCharStringFromWCString(GPOS_WSZ_LIT("Cont"));
 		}
 		else
 		{
-			GPOS_ASSERT(PERC_DISC == ppercentile->perckind);
-			szName = CTranslatorUtils::SzFromWsz(GPOS_WSZ_LIT("Disc"));
+			GPOS_ASSERT(PERC_DISC == percentile->perckind);
+            name = CTranslatorUtils::CreateMultiByteCharStringFromWCString(GPOS_WSZ_LIT("Disc"));
 		}
 	}
-	else if (IsA(pnode, GroupingFunc))
+	else if (IsA(node, GroupingFunc))
 	{
-		szName = CTranslatorUtils::SzFromWsz(GPOS_WSZ_LIT("grouping"));
+		name = CTranslatorUtils::CreateMultiByteCharStringFromWCString(GPOS_WSZ_LIT("grouping"));
 	}
 	else
 	{
-		Aggref *paggref = (Aggref*) pnode;
+		Aggref *aggref = (Aggref*) node;
 
-		CMDIdGPDB *pmdidAgg = GPOS_NEW(pmp) CMDIdGPDB(paggref->aggfnoid);
-		const IMDAggregate *pmdagg = pmda->Pmdagg(pmdidAgg);
-		pmdidAgg->Release();
+		CMDIdGPDB *agg_mdid = GPOS_NEW(mp) CMDIdGPDB(aggref->aggfnoid);
+		const IMDAggregate *md_agg = md_accessor->RetrieveAgg(agg_mdid);
+		agg_mdid->Release();
 
-		const CWStringConst *pstr = pmdagg->Mdname().Pstr();
-		szName = CTranslatorUtils::SzFromWsz(pstr->Wsz());
+		const CWStringConst *str = md_agg->Mdname().GetMDName();
+		name = CTranslatorUtils::CreateMultiByteCharStringFromWCString(str->GetBuffer());
 	}
-	GPOS_ASSERT(NULL != szName);
+	GPOS_ASSERT(NULL != name);
 
-	return gpdb::PteMakeTargetEntry((Expr*) pnode, (AttrNumber) ulAttno, szName, false);
+	return gpdb::MakeTargetEntry((Expr*) node, (AttrNumber) attno, name, false);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeHavingQualMutator
+//		CQueryMutators::RunHavingQualMutator
 //
 //	@doc:
 // 		This mutator function checks to see if the current node is an AggRef
@@ -888,260 +879,258 @@ CQueryMutators::PteAggregateOrPercentileExpr
 //			Then replaces it with a attribute from the top-level query.
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeHavingQualMutator
+CQueryMutators::RunHavingQualMutator
 	(
-	Node *pnode,
-	void *pctx
+	Node *node,
+	SContextHavingQualMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
-	if (IsA(pnode, Const))
+	if (IsA(node, Const))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	SContextHavingQualMutator *pctxHavingQualMutator = (SContextHavingQualMutator *) pctx;
-
 	// check to see if the node is in the target list of the derived table.
-	// check if we have the corresponding pte entry in derived tables target list
-	if (0 == pctxHavingQualMutator->m_ulCurrLevelsUp)
+	// check if we have the corresponding target_entry entry in derived tables target list
+	if (0 == context->m_current_query_level)
 	{
-		if (IsA(pnode, Var) && pctxHavingQualMutator->m_fAggregateArg)
+		if (IsA(node, Var) && context->m_is_mutating_agg_arg)
 		{
 			// fix outer references used in the aggregates
-			return (Node *) PvarOuterReferenceIncrLevelsUp((Var*) pnode);
+			return (Node *) IncrLevelsUpInVar((Var*) node);
 		}
 
 		// check if an entry already exists, if so no need for duplicate
-		Node *pnodeFound = PnodeFind(pnode, pctxHavingQualMutator);
-		if (NULL != pnodeFound)
+		Node *found_node = FindNodeInTargetEntries(node, context);
+		if (NULL != found_node)
 		{
-			return pnodeFound;
+			return found_node;
 		}
 
-		if (IsA(pnode, PercentileExpr) || IsA(pnode, GroupingFunc))
+		if (IsA(node, PercentileExpr) || IsA(node, GroupingFunc))
 		{
 			// create a new entry in the derived table and return its corresponding var
-			Node *pnodeCopy = (Node*) gpdb::PvCopyObject(pnode);
-			return (Node *) PvarInsertIntoDerivedTable(pnodeCopy, pctxHavingQualMutator);
+			Node *node_copy = (Node*) gpdb::CopyObject(node);
+			return (Node *) MakeVarInDerivedTable(node_copy, context);
 		}
 	}
 
-	if (IsA(pnode, Aggref))
+	if (IsA(node, Aggref))
 	{
-		Aggref *paggrefOld = (Aggref *) pnode;
-		if (paggrefOld->agglevelsup == pctxHavingQualMutator->m_ulCurrLevelsUp)
+		Aggref *old_aggref = (Aggref *) node;
+		if (old_aggref->agglevelsup == context->m_current_query_level)
 		{
-			Aggref *paggrefNew = PaggrefFlatCopy(paggrefOld);
+			Aggref *new_aggref = FlatCopyAggref(old_aggref);
 			
-			BOOL fAggregateOld = pctxHavingQualMutator->m_fAggregateArg;
-			ULONG ulAggregateLevelUp = pctxHavingQualMutator->m_ulAggregateLevelUp;
+			BOOL is_agg_old = context->m_is_mutating_agg_arg;
+			ULONG agg_levels_up = context->m_agg_levels_up;
 
-			pctxHavingQualMutator->m_fAggregateArg = true;
-			pctxHavingQualMutator->m_ulAggregateLevelUp = paggrefOld->agglevelsup;
+			context->m_is_mutating_agg_arg = true;
+			context->m_agg_levels_up = old_aggref->agglevelsup;
 
-			List *plargsNew = NIL;
-			ListCell *plc = NULL;
+			List *new_args = NIL;
+			ListCell *lc = NULL;
 
-			ForEach (plc, paggrefOld->args)
+			ForEach (lc, old_aggref->args)
 			{
-				Node *pnodeArg = (Node*) lfirst(plc);
-				GPOS_ASSERT(NULL != pnodeArg);
+				Node *arg = (Node*) lfirst(lc);
+				GPOS_ASSERT(NULL != arg);
 				// traverse each argument and fix levels up when needed
-				plargsNew = gpdb::PlAppendElement
+				new_args = gpdb::LAppend
 									(
-									plargsNew,
-									gpdb::PnodeMutateQueryOrExpressionTree
+									new_args,
+									gpdb::MutateQueryOrExpressionTree
 											(
-											pnodeArg,
-											(Pfnode) CQueryMutators::PnodeHavingQualMutator,
-											(void *) pctxHavingQualMutator,
+											arg,
+											(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+											(void *) context,
 											0 // mutate into cte-lists
 											)
 									);
 			}
-			paggrefNew->args = plargsNew;
-			pctxHavingQualMutator->m_fAggregateArg = fAggregateOld;
-			pctxHavingQualMutator->m_ulAggregateLevelUp = ulAggregateLevelUp;
+			new_aggref->args = new_args;
+			context->m_is_mutating_agg_arg = is_agg_old;
+			context->m_agg_levels_up = agg_levels_up;
 
 			// check if an entry already exists, if so no need for duplicate
-			Node *pnodeFound = PnodeFind((Node*) paggrefNew, pctxHavingQualMutator);
-			if (NULL != pnodeFound)
+			Node *found_node = FindNodeInTargetEntries((Node*) new_aggref, context);
+			if (NULL != found_node)
 			{
-				return pnodeFound;
+				return found_node;
 			}
 
 			// create a new entry in the derived table and return its corresponding var
-			return (Node *) PvarInsertIntoDerivedTable((Node *) paggrefNew, pctxHavingQualMutator);
+			return (Node *) MakeVarInDerivedTable((Node *) new_aggref, context);
 		}
 	}
 
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvar = (Var *) gpdb::PvCopyObject(pnode);
-		if (pvar->varlevelsup == pctxHavingQualMutator->m_ulCurrLevelsUp)
+		Var *var = (Var *) gpdb::CopyObject(node);
+		if (var->varlevelsup == context->m_current_query_level)
 		{
 			// process outer references
-			if (pvar->varlevelsup == pctxHavingQualMutator->m_ulAggregateLevelUp)
+			if (var->varlevelsup == context->m_agg_levels_up)
 			{
 				// an argument of an outer aggregate
-				pvar->varlevelsup = 0;
+				var->varlevelsup = 0;
 
-				return (Node *) pvar;
+				return (Node *) var;
 			}
 
-			pvar->varlevelsup = 0;
-			TargetEntry *pteFound = gpdb::PteMember( (Node*) pvar, pctxHavingQualMutator->m_plTENewGroupByQuery);
+			var->varlevelsup = 0;
+			TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList( (Node*) var, context->m_groupby_target_list);
 
-			if (NULL == pteFound)
+			if (NULL == found_target_entry)
 			{
 				// Consider two table r(a,b) and s(c,d) and the following query
 				// SELECT 1 from r LEFT JOIN s on (r.a = s.c) group by r.a having count(*) > a
 				// The having clause refers to the output of the left outer join while the
 				// grouping column refers to the base table column.
 				// While r.a and a are equivalent, the algebrizer at this point cannot detect this.
-				// Therefore, pteFound will be NULL and we fall back.
+				// Therefore, found_target_entry will be NULL and we fall back.
 
-				pctxHavingQualMutator->m_fFallbackToPlanner = true;
+				context->m_should_fallback = true;
 				return NULL;
 			}
 
-			pvar->varlevelsup = pctxHavingQualMutator->m_ulCurrLevelsUp;
-			pvar->varno = 1;
-			pvar->varattno = pteFound->resno;
-			pteFound->resjunk = false;
+			var->varlevelsup = context->m_current_query_level;
+			var->varno = 1;
+			var->varattno = found_target_entry->resno;
+			found_target_entry->resjunk = false;
 
-			return (Node*) pvar;
+			return (Node*) var;
 		}
-		return (Node *) pvar;
+		return (Node *) var;
 	}
 
-	if (IsA(pnode, CommonTableExpr))
+	if (IsA(node, CommonTableExpr))
 	{
-		CommonTableExpr *pcte = (CommonTableExpr *) gpdb::PvCopyObject(pnode);
-		pctxHavingQualMutator->m_ulCurrLevelsUp++;
+		CommonTableExpr *cte = (CommonTableExpr *) gpdb::CopyObject(node);
+		context->m_current_query_level++;
 
-		GPOS_ASSERT(IsA(pcte->ctequery, Query));
+		GPOS_ASSERT(IsA(cte->ctequery, Query));
 
-		pcte->ctequery = gpdb::PnodeMutateQueryOrExpressionTree
+		cte->ctequery = gpdb::MutateQueryOrExpressionTree
 									(
-									pcte->ctequery,
-									(Pfnode) CQueryMutators::PnodeHavingQualMutator,
-									(void *) pctxHavingQualMutator,
+									cte->ctequery,
+									(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+									(void *) context,
 									0 // flags --- mutate into cte-lists
 									);
 
-		pctxHavingQualMutator->m_ulCurrLevelsUp--;
-		return (Node *) pcte;
+		context->m_current_query_level--;
+		return (Node *) cte;
 	}
 
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		SubLink *psublinkOld = (SubLink *) pnode;
+		SubLink *old_sublink = (SubLink *) node;
 
-		SubLink *psublinkNew = MakeNode(SubLink);
-		psublinkNew->subLinkType = psublinkOld->subLinkType;
-		psublinkNew->location = psublinkOld->location;
-		psublinkNew->operName = (List *) gpdb::PvCopyObject(psublinkOld->operName);
+		SubLink *new_sublink = MakeNode(SubLink);
+		new_sublink->subLinkType = old_sublink->subLinkType;
+		new_sublink->location = old_sublink->location;
+		new_sublink->operName = (List *) gpdb::CopyObject(old_sublink->operName);
 
-		psublinkNew->testexpr =	gpdb::PnodeMutateQueryOrExpressionTree
+		new_sublink->testexpr =	gpdb::MutateQueryOrExpressionTree
 										(
-										psublinkOld->testexpr,
-										(Pfnode) CQueryMutators::PnodeHavingQualMutator,
-										(void *) pctxHavingQualMutator,
+										old_sublink->testexpr,
+										(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+										(void *) context,
 										0 // flags -- mutate into cte-lists
 										);
-		pctxHavingQualMutator->m_ulCurrLevelsUp++;
+		context->m_current_query_level++;
 
-		GPOS_ASSERT(IsA(psublinkOld->subselect, Query));
+		GPOS_ASSERT(IsA(old_sublink->subselect, Query));
 
-		psublinkNew->subselect = gpdb::PnodeMutateQueryOrExpressionTree
+		new_sublink->subselect = gpdb::MutateQueryOrExpressionTree
 										(
-										psublinkOld->subselect,
-										(Pfnode) CQueryMutators::PnodeHavingQualMutator,
-										(void *) pctxHavingQualMutator,
+										old_sublink->subselect,
+										(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+										(void *) context,
 										0 // flags -- mutate into cte-lists
 										);
 
-		pctxHavingQualMutator->m_ulCurrLevelsUp--;
+		context->m_current_query_level--;
 
-		return (Node *) psublinkNew;
+		return (Node *) new_sublink;
 	}
 	
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeHavingQualMutator, pctxHavingQualMutator);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunHavingQualMutator, context);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PvarInsertIntoDerivedTable
+//		CQueryMutators::MakeVarInDerivedTable
 //
 //	@doc:
 //		Create a new entry in the derived table and return its corresponding var
 //---------------------------------------------------------------------------
 Var *
-CQueryMutators::PvarInsertIntoDerivedTable
+CQueryMutators::MakeVarInDerivedTable
 	(
-	Node *pnode,
+	Node *node,
 	SContextHavingQualMutator *context
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 	GPOS_ASSERT(NULL != context);
-	GPOS_ASSERT(IsA(pnode, PercentileExpr) || IsA(pnode, Aggref) || IsA(pnode, GroupingFunc));
+	GPOS_ASSERT(IsA(node, PercentileExpr) || IsA(node, Aggref) || IsA(node, GroupingFunc));
 
-	const ULONG ulAttno = gpdb::UlListLength(context->m_plTENewGroupByQuery) + 1;
-	TargetEntry *pte = PteAggregateOrPercentileExpr(context->m_pmp, context->m_pmda, (Node *) pnode, ulAttno);
-	context->m_plTENewGroupByQuery = gpdb::PlAppendElement(context->m_plTENewGroupByQuery, pte);
+	const ULONG attno = gpdb::ListLength(context->m_groupby_target_list) + 1;
+	TargetEntry *target_entry = PteAggregateOrPercentileExpr(context->m_mp, context->m_md_accessor, (Node *) node, attno);
+	context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
-	Var *pvarNew = gpdb::PvarMakeVar
+	Var *new_var = gpdb::MakeVar
 					(
 					1, // varno
-					ulAttno,
-					gpdb::OidExprType((Node*) pnode),
-					gpdb::IExprTypeMod((Node*) pnode),
-					context->m_ulCurrLevelsUp
+					attno,
+					gpdb::ExprType((Node*) node),
+					gpdb::ExprTypeMod((Node*) node),
+					context->m_current_query_level
 					);
 
-	return pvarNew;
+	return new_var;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeFind
+//		CQueryMutators::FindNodeInTargetEntries
 //
 //	@doc:
 //		Check if a matching entry already exists in the list of target
 //		entries, if yes return its corresponding var, otherwise return NULL
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeFind
+CQueryMutators::FindNodeInTargetEntries
 	(
-	Node *pnode,
+	Node *node,
 	SContextHavingQualMutator *context
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 	GPOS_ASSERT(NULL != context);
 	
-	TargetEntry *pteFound = gpdb::PteMember(pnode, context->m_plTENewGroupByQuery);
-	if (NULL != pteFound)
+	TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
+	if (NULL != found_target_entry)
 	{
-		gpdb::GPDBFree(pnode);
-		Var *pvarNew = gpdb::PvarMakeVar
+		gpdb::GPDBFree(node);
+		Var *new_var = gpdb::MakeVar
 						(
 						1, // varno
-						pteFound->resno,
-						gpdb::OidExprType( (Node*) pteFound->expr),
-						gpdb::IExprTypeMod( (Node*) pteFound->expr),
-						context->m_ulCurrLevelsUp
+						found_target_entry->resno,
+						gpdb::ExprType( (Node*) found_target_entry->expr),
+						gpdb::ExprTypeMod( (Node*) found_target_entry->expr),
+						context->m_current_query_level
 						);
 
-		pteFound->resjunk = false;
-		return (Node*) pvarNew;
+		found_target_entry->resjunk = false;
+		return (Node*) new_var;
 	}
 
 	return NULL;
@@ -1149,188 +1138,188 @@ CQueryMutators::PnodeFind
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PaggrefFlatCopy
+//		CQueryMutators::FlatCopyAggref
 //
 //	@doc:
 //		Make a copy of the aggref (minus the arguments)
 //---------------------------------------------------------------------------
 Aggref *
-CQueryMutators::PaggrefFlatCopy
+CQueryMutators::FlatCopyAggref
 	(
-	Aggref *paggrefOld
+	Aggref *old_aggref
 	)
 {
-	Aggref *paggrefNew = MakeNode(Aggref);
+	Aggref *new_aggref = MakeNode(Aggref);
 
-	paggrefNew->aggfnoid = paggrefOld->aggfnoid;
-	paggrefNew->aggdistinct = paggrefOld->aggdistinct;
-	paggrefNew->agglevelsup = 0;
-	paggrefNew->location = paggrefOld->location;
-	paggrefNew->aggtype = paggrefOld->aggtype;
-	paggrefNew->aggstage = paggrefOld->aggstage;
-	paggrefNew->aggstar = paggrefOld->aggstar;
+    new_aggref->aggfnoid = old_aggref->aggfnoid;
+    new_aggref->aggdistinct = old_aggref->aggdistinct;
+    new_aggref->agglevelsup = 0;
+    new_aggref->location = old_aggref->location;
+    new_aggref->aggtype = old_aggref->aggtype;
+    new_aggref->aggstage = old_aggref->aggstage;
+    new_aggref->aggstar = old_aggref->aggstar;
 
-	return paggrefNew;
+	return new_aggref;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PvarOuterReferenceIncrLevelsUp
+//		CQueryMutators::IncrLevelsUpInVar
 //
 //	@doc:
 //		Increment the levels up of outer references
 //---------------------------------------------------------------------------
 Var *
-CQueryMutators::PvarOuterReferenceIncrLevelsUp
+CQueryMutators::IncrLevelsUpInVar
 	(
-	Var *pvar
+	Var *var
 	)
 {
-	GPOS_ASSERT(NULL != pvar);
+	GPOS_ASSERT(NULL != var);
 
-	Var *pvarCopy = (Var *) gpdb::PvCopyObject(pvar);
-	if (0 != pvarCopy->varlevelsup)
+	Var *var_copy = (Var *) gpdb::CopyObject(var);
+	if (0 != var_copy->varlevelsup)
 	{
-		pvarCopy->varlevelsup++;
+		var_copy->varlevelsup++;
 	}
 
-	return pvarCopy;
+	return var_copy;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryNormalizeHaving
+//		CQueryMutators::NormalizeHaving
 //
 //	@doc:
 //		Pull up having qual into a select and fix correlated references
 //		to the top-level query
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryNormalizeHaving
+CQueryMutators::NormalizeHaving
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const Query *pquery
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const Query *query
 	)
 {
-	Query *pqueryCopy = (Query *) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+	Query *query_copy = (Query *) gpdb::CopyObject(const_cast<Query*>(query));
 
-	if (NULL == pquery->havingQual)
+	if (NULL == query->havingQual)
 	{
-		return pqueryCopy;
+		return query_copy;
 	}
 
-	Query *pqueryNew = PqueryConvertToDerivedTable(pqueryCopy, true /*fFixTargetList*/, false /*fFixHavingQual*/);
-	gpdb::GPDBFree(pqueryCopy);
+	Query *new_query = ConvertToDerivedTable(query_copy, true /*should_fix_target_list*/, false /*should_fix_having_qual*/);
+	gpdb::GPDBFree(query_copy);
 
-	RangeTblEntry *prte = ((RangeTblEntry *) gpdb::PvListNth(pqueryNew->rtable, 0));
-	Query *pqueryDrdTbl = (Query *) prte->subquery;
+	RangeTblEntry *rte = ((RangeTblEntry *) gpdb::ListNth(new_query->rtable, 0));
+	Query *derived_table_query = (Query *) rte->subquery;
 
 	// Add all necessary target list entries of subquery
 	// into the target list of the RTE as well as the new top most query
-	ListCell *plc = NULL;
-	ULONG ulTECount = 1;
-	ForEach (plc, pqueryDrdTbl->targetList)
+	ListCell *lc = NULL;
+	ULONG num_target_entries = 1;
+	ForEach (lc, derived_table_query->targetList)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		GPOS_ASSERT(NULL != pte);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		GPOS_ASSERT(NULL != target_entry);
 
 		// Add to the target lists:
 		// 	(1) All grouping / sorting columns even if they do not appear in the subquery output (resjunked)
 		//	(2) All non-resjunked target list entries
-		if (CTranslatorUtils::FGroupingColumn(pte, pqueryDrdTbl->groupClause) ||
-			CTranslatorUtils::FSortingColumn(pte, pqueryDrdTbl->sortClause) || !pte->resjunk)
+		if (CTranslatorUtils::IsGroupingColumn(target_entry, derived_table_query->groupClause) ||
+			CTranslatorUtils::IsSortingColumn(target_entry, derived_table_query->sortClause) || !target_entry->resjunk)
 		{
-			TargetEntry *pteNew = Pte(pte, ulTECount);
-			pqueryNew->targetList = gpdb::PlAppendElement(pqueryNew->targetList, pteNew);
+			TargetEntry *new_target_entry = MakeTopLevelTargetEntry(target_entry, num_target_entries);
+			new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry);
 			// Ensure that such target entries is not suppressed in the target list of the RTE
 			// and has a name
-			pte->resname = SzTEName(pte, pqueryDrdTbl);
-			pte->resjunk = false;
-			pteNew->ressortgroupref = pte->ressortgroupref;
+			target_entry->resname = GetTargetEntryColName(target_entry, derived_table_query);
+			target_entry->resjunk = false;
+			new_target_entry->ressortgroupref = target_entry->ressortgroupref;
 
-			ulTECount++;
+			num_target_entries++;
 		}
 	}
 
-	SContextHavingQualMutator ctxHavingQualMutator(pmp, pmda, ulTECount, pqueryDrdTbl->targetList);
+	SContextHavingQualMutator context(mp, md_accessor, num_target_entries, derived_table_query->targetList);
 
 	// fix outer references in the qual
-	pqueryNew->jointree->quals = PnodeHavingQualMutator(pqueryDrdTbl->havingQual, &ctxHavingQualMutator);
+	new_query->jointree->quals = RunHavingQualMutator(derived_table_query->havingQual, &context);
 
-	if (ctxHavingQualMutator.m_fFallbackToPlanner)
+	if (context.m_should_fallback)
 	{
 		// TODO: Oct 14 2013, remove temporary fix (revert exception to assert) to avoid crash during algebrization
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("No attribute"));
 	}
 
-	pqueryDrdTbl->havingQual = NULL;
+	derived_table_query->havingQual = NULL;
 
-	ReassignSortClause(pqueryNew, prte->subquery);
+	ReassignSortClause(new_query, rte->subquery);
 
-	if (!prte->subquery->hasAggs && NIL == prte->subquery->groupClause)
+	if (!rte->subquery->hasAggs && NIL == rte->subquery->groupClause)
 	{
 		// if the derived table has no grouping columns or aggregates then the
 		// subquery is equivalent to select XXXX FROM CONST-TABLE 
 		// (where XXXX is the original subquery's target list)
 
-		Query *pqueryNewSubquery = MakeNode(Query);
+		Query *new_subquery = MakeNode(Query);
 
-		pqueryNewSubquery->commandType = CMD_SELECT;
-		pqueryNewSubquery->targetList = NIL;
+		new_subquery->commandType = CMD_SELECT;
+		new_subquery->targetList = NIL;
 
-		pqueryNewSubquery->hasAggs = false;
-		pqueryNewSubquery->hasWindFuncs = false;
-		pqueryNewSubquery->hasSubLinks = false;
+		new_subquery->hasAggs = false;
+		new_subquery->hasWindFuncs = false;
+		new_subquery->hasSubLinks = false;
 
-		ListCell *plc = NULL;
-		ForEach (plc, prte->subquery->targetList)
+		ListCell *lc = NULL;
+		ForEach (lc, rte->subquery->targetList)
 		{
-			TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-			GPOS_ASSERT(NULL != pte);
+			TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+			GPOS_ASSERT(NULL != target_entry);
 
-			GPOS_ASSERT(!pte->resjunk);
+			GPOS_ASSERT(!target_entry->resjunk);
 			
-			pqueryNewSubquery->targetList =  gpdb::PlAppendElement
+			new_subquery->targetList =  gpdb::LAppend
 													(
-													pqueryNewSubquery->targetList,
-													(TargetEntry *) gpdb::PvCopyObject(const_cast<TargetEntry*>(pte))
+													new_subquery->targetList,
+													(TargetEntry *) gpdb::CopyObject(const_cast<TargetEntry*>(target_entry))
 													);
 		}
 
-		gpdb::GPDBFree(prte->subquery);
+		gpdb::GPDBFree(rte->subquery);
 
-		prte->subquery = pqueryNewSubquery;
-		prte->subquery->jointree = MakeNode(FromExpr);
-		prte->subquery->groupClause = NIL;
-		prte->subquery->sortClause = NIL;
-		prte->subquery->windowClause = NIL;
+		rte->subquery = new_subquery;
+		rte->subquery->jointree = MakeNode(FromExpr);
+		rte->subquery->groupClause = NIL;
+		rte->subquery->sortClause = NIL;
+		rte->subquery->windowClause = NIL;
 	}
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryNormalize
+//		CQueryMutators::NormalizeQuery
 //
 //	@doc:
 //		Normalize queries with having and group by clauses
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryNormalize
+CQueryMutators::NormalizeQuery
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const Query *pquery,
-	ULONG ulQueryLevel
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const Query *query,
+	ULONG query_level
 	)
 {
 	// flatten join alias vars defined at the current level of the query
-	Query *pqueryResolveJoinVarReferences = gpdb::PqueryFlattenJoinAliasVar(const_cast<Query*>(pquery), ulQueryLevel);
+	Query *pqueryResolveJoinVarReferences = gpdb::FlattenJoinAliasVar(const_cast<Query*>(query), query_level);
 
 	// eliminate distinct clause
-	Query *pqueryEliminateDistinct = CQueryMutators::PqueryEliminateDistinctClause(pqueryResolveJoinVarReferences);
+	Query *pqueryEliminateDistinct = CQueryMutators::EliminateDistinctClause(pqueryResolveJoinVarReferences);
 	GPOS_ASSERT(NULL == pqueryEliminateDistinct->distinctClause);
 	gpdb::GPDBFree(pqueryResolveJoinVarReferences);
 
@@ -1339,24 +1328,24 @@ CQueryMutators::PqueryNormalize
 	gpdb::GPDBFree(pqueryEliminateDistinct);
 
 	// normalize window operator's project list
-	Query *pqueryWindowPlNormalized = CQueryMutators::PqueryNormalizeWindowPrL(pmp, pmda, pqueryFixedWindowFrameEdge);
+	Query *pqueryWindowPlNormalized = CQueryMutators::NormalizeWindowProjList(mp, md_accessor, pqueryFixedWindowFrameEdge);
 	gpdb::GPDBFree(pqueryFixedWindowFrameEdge);
 
 	// pull-up having quals into a select
-	Query *pqueryHavingNormalized = CQueryMutators::PqueryNormalizeHaving(pmp, pmda, pqueryWindowPlNormalized);
+	Query *pqueryHavingNormalized = CQueryMutators::NormalizeHaving(mp, md_accessor, pqueryWindowPlNormalized);
 	GPOS_ASSERT(NULL == pqueryHavingNormalized->havingQual);
 	gpdb::GPDBFree(pqueryWindowPlNormalized);
 
 	// normalize the group by project list
-	Query *pqueryNew = CQueryMutators::PqueryNormalizeGrpByPrL(pmp, pmda, pqueryHavingNormalized);
+	Query *new_query = CQueryMutators::NormalizeGroupByProjList(mp, md_accessor, pqueryHavingNormalized);
 	gpdb::GPDBFree(pqueryHavingNormalized);
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::Pte
+//		CQueryMutators::GetTargetEntry
 //
 //	@doc:
 //		Given an Target list entry in the derived table, create a new
@@ -1364,248 +1353,252 @@ CQueryMutators::PqueryNormalize
 //		memory
 //---------------------------------------------------------------------------
 TargetEntry *
-CQueryMutators::Pte
+CQueryMutators::MakeTopLevelTargetEntry
 	(
-	TargetEntry *pteOld,
-	ULONG ulVarAttno
+	TargetEntry *old_target_entry,
+	ULONG attno
 	)
 {
-	Var *pvarNew = gpdb::PvarMakeVar
+	Var *new_var = gpdb::MakeVar
 							(
 							1,
-							(AttrNumber) ulVarAttno,
-							gpdb::OidExprType( (Node*) pteOld->expr),
-							gpdb::IExprTypeMod( (Node*) pteOld->expr),
+							(AttrNumber) attno,
+							gpdb::ExprType( (Node*) old_target_entry->expr),
+							gpdb::ExprTypeMod( (Node*) old_target_entry->expr),
 							0 // query levelsup
 							);
 
-	TargetEntry *pteNew = gpdb::PteMakeTargetEntry((Expr*) pvarNew, (AttrNumber) ulVarAttno, pteOld->resname, pteOld->resjunk);
+	TargetEntry *new_target_entry = gpdb::MakeTargetEntry((Expr*) new_var, (AttrNumber) attno, old_target_entry->resname, old_target_entry->resjunk);
 
-	return pteNew;
+	return new_target_entry;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::SzTEName
+//		CQueryMutators::GetTargetEntryColName
 //
 //	@doc:
 //		Return the column name of the target list entry
 //---------------------------------------------------------------------------
 CHAR *
-CQueryMutators::SzTEName
+CQueryMutators::GetTargetEntryColName
 	(
-	TargetEntry *pte,
-	Query *pquery
+	TargetEntry *target_entry,
+	Query *query
 	)
 {
-	if (NULL != pte->resname)
+	if (NULL != target_entry->resname)
 	{
-		return pte->resname;
+		return target_entry->resname;
 	}
 
 	// Since a resjunked target list entry will not have a column name create a dummy column name
-	CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
+	CWStringConst dummy_colname(GPOS_WSZ_LIT("?column?"));
 
-	return CTranslatorUtils::SzFromWsz(strUnnamedCol.Wsz());
+	return CTranslatorUtils::CreateMultiByteCharStringFromWCString(dummy_colname.GetBuffer());
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryConvertToDerivedTable
+//		CQueryMutators::ConvertToDerivedTable
 //
 //	@doc:
 //		Converts query into a derived table and return the new top-level query
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryConvertToDerivedTable
+CQueryMutators::ConvertToDerivedTable
 	(
-	const Query *pquery,
-	BOOL fFixTargetList,
-	BOOL fFixHavingQual
+	const Query *query,
+	BOOL should_fix_target_list,
+	BOOL should_fix_having_qual
 	)
 {
-	Query *pqueryCopy = (Query *) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+	Query *query_copy = (Query *) gpdb::CopyObject(const_cast<Query*>(query));
 
-	// fix any outer references
-	SContextIncLevelsupMutator ctxIncLvlMutator(0, fFixTargetList);
-
-	Node *pnodeHavingQual = NULL;
-	if (!fFixHavingQual)
+	Node *having_qual = NULL;
+	if (!should_fix_having_qual)
 	{
-		pnodeHavingQual = pqueryCopy->havingQual;
-		pqueryCopy->havingQual = NULL;
+		having_qual = query_copy->havingQual;
+		query_copy->havingQual = NULL;
 	}
 
 	// fix outer references
-	Query *pqueryDrvd = (Query *) PnodeIncrementLevelsupMutator((Node*) pqueryCopy, &ctxIncLvlMutator);
-	gpdb::GPDBFree(pqueryCopy);
+	Query *derived_table_query;
+	{
+		SContextIncLevelsupMutator context(0, should_fix_target_list);
+		derived_table_query = (Query *) RunIncrLevelsUpMutator((Node*) query_copy, &context);
+	}
+	gpdb::GPDBFree(query_copy);
 
 	// fix the CTE levels up -- while the old query is converted into a derived table, its cte list
 	// is re-assigned to the new top-level query. The references to the ctes listed in the old query
 	// as well as those listed before the current query level are accordingly adjusted in the new
 	// derived table.
-	List *plCteOriginal = pqueryDrvd->cteList;
-	pqueryDrvd->cteList = NIL;
+	List *original_cte_list = derived_table_query->cteList;
+	derived_table_query->cteList = NIL;
 
-	SContextIncLevelsupMutator ctxinclvlmutator(0 /*starting level */, fFixTargetList);
-
-	Query *pqueryDrvdNew  = (Query *) PnodeFixCTELevelsupMutator( (Node *) pqueryDrvd, &ctxinclvlmutator);
-	gpdb::GPDBFree(pqueryDrvd);
-	pqueryDrvd = pqueryDrvdNew;
+	Query *new_derived_table_query;
+	{
+		SContextIncLevelsupMutator context(0 /*starting level */, should_fix_target_list);
+		new_derived_table_query  = (Query *) RunFixCTELevelsUpMutator( (Node *) derived_table_query, &context);
+	}
+	gpdb::GPDBFree(derived_table_query);
+	derived_table_query = new_derived_table_query;
 
 	// create a range table entry for the query node
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
-	prte->rtekind = RTE_SUBQUERY;
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
+	rte->rtekind = RTE_SUBQUERY;
 
-	prte->subquery = pqueryDrvd;
-	prte->inFromCl = true;
-	prte->subquery->cteList = NIL;
+	rte->subquery = derived_table_query;
+	rte->inFromCl = true;
+	rte->subquery->cteList = NIL;
 
-	if (NULL != pnodeHavingQual)
+	if (NULL != having_qual)
 	{
-		pqueryDrvd->havingQual = pnodeHavingQual;
+		derived_table_query->havingQual = having_qual;
 	}
 
 	// create a new range table reference for the new RTE
-	RangeTblRef *prtref = MakeNode(RangeTblRef);
-	prtref->rtindex = 1;
+	RangeTblRef *rtref = MakeNode(RangeTblRef);
+	rtref->rtindex = 1;
 
 	// intoClause, if not null, must be set on the top query, not on the derived table
-	IntoClause *origIntoClause = pqueryDrvd->intoClause;
-	pqueryDrvd->intoClause = NULL;
-	struct GpPolicy* origIntoPolicy = pqueryDrvd->intoPolicy;
-	pqueryDrvd->intoPolicy = NULL;
+	IntoClause *origIntoClause = derived_table_query->intoClause;
+	derived_table_query->intoClause = NULL;
+	// intoClause, if not null, must be set on the top query, not on the derived table
+	struct GpPolicy* into_policy = derived_table_query->intoPolicy;
+	derived_table_query->intoPolicy = NULL;
 
 	// create a new top-level query with the new RTE in its from clause
-	Query *pqueryNew = MakeNode(Query);
-	pqueryNew->cteList = plCteOriginal;
-	pqueryNew->hasAggs = false;
-	pqueryNew->rtable = gpdb::PlAppendElement(pqueryNew->rtable, prte);
-	pqueryNew->intoClause = origIntoClause;
-	pqueryNew->intoPolicy = origIntoPolicy;
+	Query *new_query = MakeNode(Query);
+    new_query->cteList = original_cte_list;
+    new_query->hasAggs = false;
+    new_query->rtable = gpdb::LAppend(new_query->rtable, rte);
+    new_query->intoClause = origIntoClause;
+    new_query->intoPolicy = into_policy;
 
-	FromExpr *pfromexpr = MakeNode(FromExpr);
-	pfromexpr->quals = NULL;
-	pfromexpr->fromlist = gpdb::PlAppendElement(pfromexpr->fromlist, prtref);
+	FromExpr *fromexpr = MakeNode(FromExpr);
+	fromexpr->quals = NULL;
+	fromexpr->fromlist = gpdb::LAppend(fromexpr->fromlist, rtref);
 
-	pqueryNew->jointree = pfromexpr;
-	pqueryNew->commandType = CMD_SELECT;
+	new_query->jointree = fromexpr;
+	new_query->commandType = CMD_SELECT;
 
-	GPOS_ASSERT(1 == gpdb::UlListLength(pqueryNew->rtable));
-	return pqueryNew;
+	GPOS_ASSERT(1 == gpdb::ListLength(new_query->rtable));
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryEliminateDistinctClause
+//		CQueryMutators::EliminateDistinctClause
 //
 //	@doc:
 //		Eliminate distinct columns by translating it into a grouping columns
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryEliminateDistinctClause
+CQueryMutators::EliminateDistinctClause
 	(
-	const Query *pquery
+	const Query *query
 	)
 {
-	if (0 == gpdb::UlListLength(pquery->distinctClause))
+	if (0 == gpdb::ListLength(query->distinctClause))
 	{
-		return (Query*) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+		return (Query*) gpdb::CopyObject(const_cast<Query*>(query));
 	}
 
 	// create a derived table out of the previous query
-	Query *pqueryNew = PqueryConvertToDerivedTable(pquery, true /*fFixTargetList*/, true /*fFixHavingQual*/);
+	Query *new_query = ConvertToDerivedTable(query, true /*should_fix_target_list*/, true /*should_fix_having_qual*/);
 
-	GPOS_ASSERT(1 == gpdb::UlListLength(pqueryNew->rtable));
-	Query *pqueryDrdTbl = (Query *) ((RangeTblEntry *) gpdb::PvListNth(pqueryNew->rtable, 0))->subquery;
+	GPOS_ASSERT(1 == gpdb::ListLength(new_query->rtable));
+	Query *derived_table_query = (Query *) ((RangeTblEntry *) gpdb::ListNth(new_query->rtable, 0))->subquery;
 
-	ReassignSortClause(pqueryNew, pqueryDrdTbl);
+	ReassignSortClause(new_query, derived_table_query);
 
-	pqueryNew->targetList = NIL;
-	List *plTE = pqueryDrdTbl->targetList;
-	ListCell *plc = NULL;
+	new_query->targetList = NIL;
+	List *target_entries = derived_table_query->targetList;
+	ListCell *lc = NULL;
 
 	// build the project list of the new top-level query
-	ForEach (plc, plTE)
+	ForEach (lc, target_entries)
 	{
-		ULONG ulResNo = gpdb::UlListLength(pqueryNew->targetList) + 1;
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		GPOS_ASSERT(NULL != pte);
+		ULONG resno = gpdb::ListLength(new_query->targetList) + 1;
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		GPOS_ASSERT(NULL != target_entry);
 
-		if (!pte->resjunk)
+		if (!target_entry->resjunk)
 		{
 			// create a new target entry that points to the corresponding entry in the derived table
-			Var *pvarNew = gpdb::PvarMakeVar
+			Var *new_var = gpdb::MakeVar
 									(
 									1,
-									pte->resno,
-									gpdb::OidExprType((Node*) pte->expr),
-									gpdb::IExprTypeMod((Node*) pte->expr),
+									target_entry->resno,
+									gpdb::ExprType((Node*) target_entry->expr),
+									gpdb::ExprTypeMod((Node*) target_entry->expr),
 									0 // query levels up
 									);
-			TargetEntry *pteNew= gpdb::PteMakeTargetEntry((Expr*) pvarNew, (AttrNumber) ulResNo, pte->resname, false);
+			TargetEntry *new_target_entry= gpdb::MakeTargetEntry((Expr*) new_var, (AttrNumber) resno, target_entry->resname, false);
 
-			pteNew->ressortgroupref =  pte->ressortgroupref;
-			pqueryNew->targetList = gpdb::PlAppendElement(pqueryNew->targetList, pteNew);
+			new_target_entry->ressortgroupref =  target_entry->ressortgroupref;
+			new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry);
 		}
 
-		if (0 < pte->ressortgroupref &&
-			!CTranslatorUtils::FGroupingColumn(pte, pqueryDrdTbl->groupClause) &&
-			!CTranslatorUtils::FWindowSpec(pte, pqueryDrdTbl->windowClause))
+		if (0 < target_entry->ressortgroupref &&
+			!CTranslatorUtils::IsGroupingColumn(target_entry, derived_table_query->groupClause) &&
+			!CTranslatorUtils::IsWindowSpec(target_entry, derived_table_query->windowClause))
 		{
 			// initialize the ressortgroupref of target entries not used in the grouping clause
-			 pte->ressortgroupref = 0;
+			 target_entry->ressortgroupref = 0;
 		}
 	}
 
-	if (gpdb::UlListLength(pqueryNew->targetList) != gpdb::UlListLength(pquery->distinctClause))
+	if (gpdb::ListLength(new_query->targetList) != gpdb::ListLength(query->distinctClause))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("DISTINCT operation on a subset of target list columns"));
 	}
 
-	ListCell *plcDistinctCl = NULL;
-	ForEach (plcDistinctCl, pquery->distinctClause)
+	ListCell *pl = NULL;
+	ForEach (pl, query->distinctClause)
 	{
-		SortClause *psortcl  = (SortClause*) lfirst(plcDistinctCl);
-		GPOS_ASSERT(NULL != psortcl);
+		SortClause *sort_group_clause  = (SortClause*) lfirst(pl);
+		GPOS_ASSERT(NULL != sort_group_clause);
 
-		GroupClause *pgrpcl = MakeNode(GroupClause);
-		pgrpcl->tleSortGroupRef = psortcl->tleSortGroupRef;
-		pgrpcl->sortop = psortcl->sortop;
-		pgrpcl->nulls_first = psortcl->nulls_first;
-		pqueryNew->groupClause = gpdb::PlAppendElement(pqueryNew->groupClause, pgrpcl);
+		GroupClause *new_group_clause = MakeNode(GroupClause);
+        new_group_clause->tleSortGroupRef = sort_group_clause->tleSortGroupRef;
+        new_group_clause->sortop = sort_group_clause->sortop;
+        new_group_clause->nulls_first = sort_group_clause->nulls_first;
+        new_query->groupClause = gpdb::LAppend(new_query->groupClause, new_group_clause);
 	}
-	pqueryNew->distinctClause = NIL;
-	pqueryDrdTbl->distinctClause = NIL;
+	new_query->distinctClause = NIL;
+	derived_table_query->distinctClause = NIL;
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::FNeedsWindowPrLNormalization
+//		CQueryMutators::NeedsProjListWindowNormalization
 //
 //	@doc:
 //		Check whether the window operator's project list only contains
 //		window functions and columns used in the window specification
 //---------------------------------------------------------------------------
 BOOL
-CQueryMutators::FNeedsWindowPrLNormalization
+CQueryMutators::NeedsProjListWindowNormalization
 	(
-	const Query *pquery
+	const Query *query
 	)
 {
-	if (!pquery->hasWindFuncs)
+	if (!query->hasWindFuncs)
 	{
 		return false;
 	}
 
-	ListCell *plc = NULL;
-	ForEach (plc, pquery->targetList)
+	ListCell *lc = NULL;
+	ForEach (lc, query->targetList)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
 
-		if (!CTranslatorUtils::FWindowSpec( (Node *) pte->expr, pquery->windowClause, pquery->targetList) && !IsA(pte->expr, WindowRef) && !IsA(pte->expr, Var))
+		if (!CTranslatorUtils::IsWindowSpec( (Node *) target_entry->expr, query->windowClause, query->targetList) && !IsA(target_entry->expr, WindowRef) && !IsA(target_entry->expr, Var))
 		{
 			// computed columns in the target list that is not
 			// used in the order by or partition by of the window specification(s)
@@ -1629,7 +1622,7 @@ CQueryMutators::PqueryFixWindowFrameEdgeBoundary
 	const Query *pquery
 	)
 {
-	Query *pqueryNew = (Query *) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+	Query *pqueryNew = (Query *) gpdb::CopyObject(const_cast<Query*>(pquery));
 
 	List *plWindowClause = pqueryNew->windowClause;
 	ListCell *plcWindowCl = NULL;
@@ -1672,7 +1665,7 @@ CQueryMutators::PqueryFixWindowFrameEdgeBoundary
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PqueryNormalizeWindowPrL
+//		CQueryMutators::NormalizeWindowProjList
 //
 //	@doc:
 // 		Flatten expressions in project list to contain only window functions and
@@ -1685,193 +1678,192 @@ CQueryMutators::PqueryFixWindowFrameEdgeBoundary
 //			SELECT rn+rk from (SELECT row_number() over() as rn rank() over(partition by a+b order by a-b) as rk FROM foo) foo_new
 //---------------------------------------------------------------------------
 Query *
-CQueryMutators::PqueryNormalizeWindowPrL
+CQueryMutators::NormalizeWindowProjList
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const Query *pquery
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const Query *query
 	)
 {
-	Query *pqueryCopy = (Query *) gpdb::PvCopyObject(const_cast<Query*>(pquery));
+	Query *query_copy = (Query *) gpdb::CopyObject(const_cast<Query*>(query));
 
-	if (!FNeedsWindowPrLNormalization(pquery))
+	if (!NeedsProjListWindowNormalization(query))
 	{
-		return pqueryCopy;
+		return query_copy;
 	}
 
 	// we do not fix target list of the derived table since we will be mutating it below
 	// to ensure that it does not have operations with window function
-	Query *pqueryNew = PqueryConvertToDerivedTable(pqueryCopy, false /*fFixTargetList*/, true /*fFixHavingQual*/);
-	gpdb::GPDBFree(pqueryCopy);
+	Query *new_query = ConvertToDerivedTable(query_copy, false /*should_fix_target_list*/, true /*should_fix_having_qual*/);
+	gpdb::GPDBFree(query_copy);
 
-	GPOS_ASSERT(1 == gpdb::UlListLength(pqueryNew->rtable));
-	Query *pqueryDrdTbl = (Query *) ((RangeTblEntry *) gpdb::PvListNth(pqueryNew->rtable, 0))->subquery;
+	GPOS_ASSERT(1 == gpdb::ListLength(new_query->rtable));
+	Query *derived_table_query = (Query *) ((RangeTblEntry *) gpdb::ListNth(new_query->rtable, 0))->subquery;
 
-	SContextGrpbyPlMutator ctxWindowPrLMutator(pmp, pmda, pqueryDrdTbl, NULL);
-	ListCell *plc = NULL;
-	List *plTE = pqueryDrdTbl->targetList;
-	ForEach (plc, plTE)
+	SContextGrpbyPlMutator context(mp, md_accessor, derived_table_query, NULL);
+	ListCell *lc = NULL;
+	List *target_entries = derived_table_query->targetList;
+	ForEach (lc, target_entries)
 	{
-		TargetEntry *pte  = (TargetEntry*) lfirst(plc);
-		const ULONG ulResNoNew = gpdb::UlListLength(pqueryNew->targetList) + 1;
+		TargetEntry *target_entry  = (TargetEntry*) lfirst(lc);
+		const ULONG ulResNoNew = gpdb::ListLength(new_query->targetList) + 1;
 
-		if (CTranslatorUtils::FWindowSpec(pte, pquery->windowClause))
+		if (CTranslatorUtils::IsWindowSpec(target_entry, query->windowClause))
 		{
 			// insert the target list entry used in the window specification as is
-			TargetEntry *pteNew = (TargetEntry *) gpdb::PvCopyObject(pte);
-			pteNew->resno = gpdb::UlListLength(ctxWindowPrLMutator.m_plTENewGroupByQuery) + 1;
-			ctxWindowPrLMutator.m_plTENewGroupByQuery = gpdb::PlAppendElement(ctxWindowPrLMutator.m_plTENewGroupByQuery, pteNew);
+			TargetEntry *new_target_entry = (TargetEntry *) gpdb::CopyObject(target_entry);
+			new_target_entry->resno = gpdb::ListLength(context.m_groupby_target_list) + 1;
+			context.m_groupby_target_list = gpdb::LAppend(context.m_groupby_target_list, new_target_entry);
 
-			if (!pte->resjunk || CTranslatorUtils::FSortingColumn(pte, pquery->sortClause))
+			if (!target_entry->resjunk || CTranslatorUtils::IsSortingColumn(target_entry, query->sortClause))
 			{
 				// if the target list entry used in the window specification is present
 				// in the query output then add it to the target list of the new top level query
-				Var *pvarNew = gpdb::PvarMakeVar
+				Var *new_var = gpdb::MakeVar
 										(
 										1,
-										pteNew->resno,
-										gpdb::OidExprType((Node*) pte->expr),
-										gpdb::IExprTypeMod((Node*) pte->expr),
+										new_target_entry->resno,
+										gpdb::ExprType((Node*) target_entry->expr),
+										gpdb::ExprTypeMod((Node*) target_entry->expr),
 										0 // query levels up
 										);
-				TargetEntry *pteNewCopy = gpdb::PteMakeTargetEntry((Expr*) pvarNew, ulResNoNew, pte->resname, pte->resjunk);
+				TargetEntry *new_target_entry_copy = gpdb::MakeTargetEntry((Expr*) new_var, ulResNoNew, target_entry->resname, target_entry->resjunk);
 
 				// Copy the resortgroupref and resjunk information for the top-level target list entry
 				// Set target list entry of the derived table to be non-resjunked
-				pteNewCopy->resjunk = pteNew->resjunk;
-				pteNewCopy->ressortgroupref = pteNew->ressortgroupref;
-				pteNew->resjunk = false;
+				new_target_entry_copy->resjunk = new_target_entry->resjunk;
+				new_target_entry_copy->ressortgroupref = new_target_entry->ressortgroupref;
+				new_target_entry->resjunk = false;
 
-				pqueryNew->targetList = gpdb::PlAppendElement(pqueryNew->targetList, pteNewCopy);
+				new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry_copy);
 			}
 		}
 		else
 		{
 			// normalize target list entry
-			ctxWindowPrLMutator.m_ulRessortgroupref = pte->ressortgroupref;
-			Expr *pexprNew = (Expr*) PnodeWindowPrLMutator( (Node*) pte->expr, &ctxWindowPrLMutator);
-			TargetEntry *pteNew = gpdb::PteMakeTargetEntry(pexprNew, ulResNoNew, pte->resname, pte->resjunk);
-			pteNew->ressortgroupref = pte->ressortgroupref;
-			pqueryNew->targetList = gpdb::PlAppendElement(pqueryNew->targetList, pteNew);
+			context.m_sort_group_ref = target_entry->ressortgroupref;
+			Expr *pexprNew = (Expr*) RunWindowProjListMutator( (Node*) target_entry->expr, &context);
+			TargetEntry *new_target_entry = gpdb::MakeTargetEntry(pexprNew, ulResNoNew, target_entry->resname, target_entry->resjunk);
+			new_target_entry->ressortgroupref = target_entry->ressortgroupref;
+			new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry);
 		}
 	}
-	pqueryDrdTbl->targetList = ctxWindowPrLMutator.m_plTENewGroupByQuery;
+	derived_table_query->targetList = context.m_groupby_target_list;
 
-	GPOS_ASSERT(gpdb::UlListLength(pqueryNew->targetList) <= gpdb::UlListLength(pquery->targetList));
+	GPOS_ASSERT(gpdb::ListLength(new_query->targetList) <= gpdb::ListLength(query->targetList));
 
-	pqueryNew->hasWindFuncs = false;
-	ReassignSortClause(pqueryNew, pqueryDrdTbl);
+	new_query->hasWindFuncs = false;
+	ReassignSortClause(new_query, derived_table_query);
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::PnodeWindowPrLMutator
+//		CQueryMutators::RunWindowProjListMutator
 //
 //	@doc:
 // 		Traverse the project list of extract all window functions in an
 //		arbitrarily complex project element
 //---------------------------------------------------------------------------
 Node *
-CQueryMutators::PnodeWindowPrLMutator
+CQueryMutators::RunWindowProjListMutator
 	(
-	Node *pnode,
-	void *pctx
+	Node *node,
+	SContextGrpbyPlMutator *context
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
 	// do not traverse into sub queries as they will be inserted are inserted into
 	// top-level query as is
-	if (IsA(pnode, SubLink))
+	if (IsA(node, SubLink))
 	{
-		return (Node *) gpdb::PvCopyObject(pnode);
+		return (Node *) gpdb::CopyObject(node);
 	}
 
-	SContextGrpbyPlMutator *pctxWindowPrLMutator = (SContextGrpbyPlMutator *) pctx;
-	const ULONG ulResNo = gpdb::UlListLength(pctxWindowPrLMutator->m_plTENewGroupByQuery) + 1;
+	const ULONG resno = gpdb::ListLength(context->m_groupby_target_list) + 1;
 
-	if (IsA(pnode, WindowRef))
+	if (IsA(node, WindowRef))
 	{
 		// insert window operator into the derived table
         // and refer to it in the top-level query's target list
-		WindowRef *pwindowref = (WindowRef*) gpdb::PvCopyObject(pnode);
+		WindowRef *window_ref = (WindowRef*) gpdb::CopyObject(node);
 
 		// get the function name and add it to the target list
-		CMDIdGPDB *pmdidFunc = GPOS_NEW(pctxWindowPrLMutator->m_pmp) CMDIdGPDB(pwindowref->winfnoid);
-		const CWStringConst *pstr = CMDAccessorUtils::PstrWindowFuncName(pctxWindowPrLMutator->m_pmda, pmdidFunc);
-		pmdidFunc->Release();
+		CMDIdGPDB *mdid_func = GPOS_NEW(context->m_mp) CMDIdGPDB(window_ref->winfnoid);
+		const CWStringConst *str = CMDAccessorUtils::PstrWindowFuncName(context->m_md_accessor, mdid_func);
+        mdid_func->Release();
 
-		TargetEntry *pte = gpdb::PteMakeTargetEntry
+		TargetEntry *target_entry = gpdb::MakeTargetEntry
 								(
-								(Expr*) gpdb::PvCopyObject(pnode),
-								(AttrNumber) ulResNo,
-								CTranslatorUtils::SzFromWsz(pstr->Wsz()),
+								(Expr*) gpdb::CopyObject(node),
+								(AttrNumber) resno,
+								CTranslatorUtils::CreateMultiByteCharStringFromWCString(str->GetBuffer()),
 								false /* resjunk */
 								);
-		pctxWindowPrLMutator->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctxWindowPrLMutator->m_plTENewGroupByQuery, pte);
+		context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
 		// return a variable referring to the new derived table's corresponding target list entry
-		Var *pvarNew = gpdb::PvarMakeVar
+		Var *new_var = gpdb::MakeVar
 								(
 								1,
-								(AttrNumber) ulResNo,
-								gpdb::OidExprType(pnode),
-								gpdb::IExprTypeMod(pnode),
+								(AttrNumber) resno,
+								gpdb::ExprType(node),
+								gpdb::ExprTypeMod(node),
 								0 // query levelsup
 								);
 
-		return (Node*) pvarNew;
+		return (Node*) new_var;
 	}
 
-	if (IsA(pnode, Var))
+	if (IsA(node, Var))
 	{
-		Var *pvarNew = NULL;
+		Var *new_var = NULL;
 
-		TargetEntry *pteFound = gpdb::PteMember(pnode, pctxWindowPrLMutator->m_plTENewGroupByQuery);
-		if (NULL == pteFound)
+		TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
+		if (NULL == found_target_entry)
 		{
 			// insert target entry into the target list of the derived table
-			CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
-			TargetEntry *pte = gpdb::PteMakeTargetEntry
+			CWStringConst str_unnamed_col(GPOS_WSZ_LIT("?column?"));
+			TargetEntry *target_entry = gpdb::MakeTargetEntry
 									(
-									(Expr*) gpdb::PvCopyObject(pnode),
-									(AttrNumber) ulResNo,
-									CTranslatorUtils::SzFromWsz(strUnnamedCol.Wsz()),
+									(Expr*) gpdb::CopyObject(node),
+									(AttrNumber) resno,
+									CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_unnamed_col.GetBuffer()),
 									false /* resjunk */
 									);
-			pctxWindowPrLMutator->m_plTENewGroupByQuery = gpdb::PlAppendElement(pctxWindowPrLMutator->m_plTENewGroupByQuery, pte);
+			context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
 
-			pvarNew = gpdb::PvarMakeVar
+			new_var = gpdb::MakeVar
 								(
 								1,
-								(AttrNumber) ulResNo,
-								gpdb::OidExprType(pnode),
-								gpdb::IExprTypeMod(pnode),
+								(AttrNumber) resno,
+								gpdb::ExprType(node),
+								gpdb::ExprTypeMod(node),
 								0 // query levelsup
 								);
 		}
 		else
 		{
-			pteFound->resjunk = false; // ensure that the derived target list is not resjunked
-			pvarNew = gpdb::PvarMakeVar
+			found_target_entry->resjunk = false; // ensure that the derived target list is not resjunked
+			new_var = gpdb::MakeVar
 								(
 								1,
-								pteFound->resno,
-								gpdb::OidExprType(pnode),
-								gpdb::IExprTypeMod(pnode),
+								found_target_entry->resno,
+								gpdb::ExprType(node),
+								gpdb::ExprTypeMod(node),
 								0 // query levelsup
 								);
 		}
 
-		return (Node*) pvarNew;
+		return (Node*) new_var;
 	}
 
-	return gpdb::PnodeMutateExpressionTree(pnode, (Pfnode) CQueryMutators::PnodeWindowPrLMutator, pctx);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunWindowProjListMutator, context);
 }
 
 //---------------------------------------------------------------------------
@@ -1884,16 +1876,16 @@ CQueryMutators::PnodeWindowPrLMutator
 void
 CQueryMutators::ReassignSortClause
 	(
-	Query *pqueryNew,
-	Query *pqueryDrdTbl
+	Query *top_level_query,
+	Query *derived_table_query
 	)
 {
-	pqueryNew->sortClause = pqueryDrdTbl->sortClause;
-	pqueryNew->limitOffset = pqueryDrdTbl->limitOffset;
-	pqueryNew->limitCount = pqueryDrdTbl->limitCount;
-	pqueryDrdTbl->sortClause = NULL;
-	pqueryDrdTbl->limitOffset = NULL;
-	pqueryDrdTbl->limitCount = NULL;
+	top_level_query->sortClause = derived_table_query->sortClause;
+	top_level_query->limitOffset = derived_table_query->limitOffset;
+	top_level_query->limitCount = derived_table_query->limitCount;
+	derived_table_query->sortClause = NULL;
+	derived_table_query->limitOffset = NULL;
+	derived_table_query->limitCount = NULL;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -66,23 +66,23 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	CContextDXLToPlStmt* pctxdxltoplstmt,
-	ULONG ulSegments
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	CContextDXLToPlStmt* dxl_to_plstmt_context,
+	ULONG num_of_segments
 	)
 	:
-	m_pmp(pmp),
-	m_pmda(pmda),
-	m_pctxdxltoplstmt(pctxdxltoplstmt),
-	m_cmdtype(CMD_SELECT),
-	m_fTargetTableDistributed(false),
-	m_plResultRelations(NULL),
-	m_ulExternalScanCounter(0),
-	m_ulSegments(ulSegments),
-	m_ulPartitionSelectorCounter(0)
+	m_mp(mp),
+	m_md_accessor(md_accessor),
+	m_dxl_to_plstmt_context(dxl_to_plstmt_context),
+	m_cmd_type(CMD_SELECT),
+	m_is_tgt_tbl_distributed(false),
+	m_result_rel_list(NULL),
+	m_external_scan_counter(0),
+	m_num_of_segments(num_of_segments),
+	m_partition_selector_counter(0)
 {
-	m_pdxlsctranslator = GPOS_NEW(m_pmp) CTranslatorDXLToScalar(m_pmp, m_pmda, m_ulSegments);
+	m_translator_dxl_to_scalar = GPOS_NEW(m_mp) CTranslatorDXLToScalar(m_mp, m_md_accessor, m_num_of_segments);
 	InitTranslators();
 }
 
@@ -96,7 +96,7 @@ CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt
 //---------------------------------------------------------------------------
 CTranslatorDXLToPlStmt::~CTranslatorDXLToPlStmt()
 {
-	GPOS_DELETE(m_pdxlsctranslator);
+	GPOS_DELETE(m_translator_dxl_to_scalar);
 }
 
 //---------------------------------------------------------------------------
@@ -110,189 +110,189 @@ CTranslatorDXLToPlStmt::~CTranslatorDXLToPlStmt()
 void
 CTranslatorDXLToPlStmt::InitTranslators()
 {
-	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(m_rgpfTranslators); ul++)
+	for (ULONG idx = 0; idx < GPOS_ARRAY_SIZE(m_dxlop_translator_func_mapping_array); idx++)
 	{
-		m_rgpfTranslators[ul] = NULL;
+		m_dxlop_translator_func_mapping_array[idx] = NULL;
 	}
 
 	// array mapping operator type to translator function
-	static const STranslatorMapping rgTranslators[] =
+	static const STranslatorMapping dxlop_translator_func_mapping_array[] =
 	{
-			{EdxlopPhysicalTableScan,				&gpopt::CTranslatorDXLToPlStmt::PtsFromDXLTblScan},
-			{EdxlopPhysicalExternalScan,			&gpopt::CTranslatorDXLToPlStmt::PtsFromDXLTblScan},
-			{EdxlopPhysicalIndexScan,				&gpopt::CTranslatorDXLToPlStmt::PisFromDXLIndexScan},
-			{EdxlopPhysicalHashJoin, 				&gpopt::CTranslatorDXLToPlStmt::PhjFromDXLHJ},
-			{EdxlopPhysicalNLJoin, 					&gpopt::CTranslatorDXLToPlStmt::PnljFromDXLNLJ},
-			{EdxlopPhysicalMergeJoin,				&gpopt::CTranslatorDXLToPlStmt::PmjFromDXLMJ},
-			{EdxlopPhysicalMotionGather,			&gpopt::CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion},
-			{EdxlopPhysicalMotionBroadcast,			&gpopt::CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion},
-			{EdxlopPhysicalMotionRedistribute,		&gpopt::CTranslatorDXLToPlStmt::PplanTranslateDXLMotion},
-			{EdxlopPhysicalMotionRandom,			&gpopt::CTranslatorDXLToPlStmt::PplanTranslateDXLMotion},
-			{EdxlopPhysicalMotionRoutedDistribute,	&gpopt::CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion},
-			{EdxlopPhysicalLimit, 					&gpopt::CTranslatorDXLToPlStmt::PlimitFromDXLLimit},
-			{EdxlopPhysicalAgg, 					&gpopt::CTranslatorDXLToPlStmt::PaggFromDXLAgg},
-			{EdxlopPhysicalWindow, 					&gpopt::CTranslatorDXLToPlStmt::PwindowFromDXLWindow},
-			{EdxlopPhysicalSort,					&gpopt::CTranslatorDXLToPlStmt::PsortFromDXLSort},
-			{EdxlopPhysicalSubqueryScan,			&gpopt::CTranslatorDXLToPlStmt::PsubqscanFromDXLSubqScan},
-			{EdxlopPhysicalResult, 					&gpopt::CTranslatorDXLToPlStmt::PresultFromDXLResult},
-			{EdxlopPhysicalAppend, 					&gpopt::CTranslatorDXLToPlStmt::PappendFromDXLAppend},
-			{EdxlopPhysicalMaterialize, 			&gpopt::CTranslatorDXLToPlStmt::PmatFromDXLMaterialize},
-			{EdxlopPhysicalSequence, 				&gpopt::CTranslatorDXLToPlStmt::PplanSequence},
-			{EdxlopPhysicalDynamicTableScan,		&gpopt::CTranslatorDXLToPlStmt::PplanDTS},
-			{EdxlopPhysicalDynamicIndexScan,		&gpopt::CTranslatorDXLToPlStmt::PplanDIS},
-			{EdxlopPhysicalTVF,						&gpopt::CTranslatorDXLToPlStmt::PplanFunctionScanFromDXLTVF},
-			{EdxlopPhysicalDML,						&gpopt::CTranslatorDXLToPlStmt::PplanDML},
-			{EdxlopPhysicalSplit,					&gpopt::CTranslatorDXLToPlStmt::PplanSplit},
-			{EdxlopPhysicalRowTrigger,				&gpopt::CTranslatorDXLToPlStmt::PplanRowTrigger},
-			{EdxlopPhysicalAssert,					&gpopt::CTranslatorDXLToPlStmt::PplanAssert},
-			{EdxlopPhysicalCTEProducer, 			&gpopt::CTranslatorDXLToPlStmt::PshscanFromDXLCTEProducer},
-			{EdxlopPhysicalCTEConsumer, 			&gpopt::CTranslatorDXLToPlStmt::PshscanFromDXLCTEConsumer},
-			{EdxlopPhysicalBitmapTableScan,			&gpopt::CTranslatorDXLToPlStmt::PplanBitmapTableScan},
-			{EdxlopPhysicalDynamicBitmapTableScan,	&gpopt::CTranslatorDXLToPlStmt::PplanBitmapTableScan},
-			{EdxlopPhysicalCTAS, 					&gpopt::CTranslatorDXLToPlStmt::PplanCTAS},
-			{EdxlopPhysicalPartitionSelector,		&gpopt::CTranslatorDXLToPlStmt::PplanPartitionSelector},
-			{EdxlopPhysicalValuesScan,				&gpopt::CTranslatorDXLToPlStmt::PplanValueScan},
+			{EdxlopPhysicalTableScan,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
+			{EdxlopPhysicalExternalScan,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
+			{EdxlopPhysicalIndexScan,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLIndexScan},
+			{EdxlopPhysicalHashJoin, 				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLHashJoin},
+			{EdxlopPhysicalNLJoin, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLNLJoin},
+			{EdxlopPhysicalMergeJoin,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMergeJoin},
+			{EdxlopPhysicalMotionGather,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMotion},
+			{EdxlopPhysicalMotionBroadcast,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMotion},
+			{EdxlopPhysicalMotionRedistribute,		&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion},
+			{EdxlopPhysicalMotionRandom,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion},
+			{EdxlopPhysicalMotionRoutedDistribute,	&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMotion},
+			{EdxlopPhysicalLimit, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLLimit},
+			{EdxlopPhysicalAgg, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLAgg},
+			{EdxlopPhysicalWindow, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLWindow},
+			{EdxlopPhysicalSort,					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLSort},
+			{EdxlopPhysicalSubqueryScan,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLSubQueryScan},
+			{EdxlopPhysicalResult, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLResult},
+			{EdxlopPhysicalAppend, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLAppend},
+			{EdxlopPhysicalMaterialize, 			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMaterialize},
+			{EdxlopPhysicalSequence, 				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLSequence},
+			{EdxlopPhysicalDynamicTableScan,		&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDynTblScan},
+			{EdxlopPhysicalDynamicIndexScan,		&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan},
+			{EdxlopPhysicalTVF,						&gpopt::CTranslatorDXLToPlStmt::TranslateDXLTvf},
+			{EdxlopPhysicalDML,						&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDml},
+			{EdxlopPhysicalSplit,					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLSplit},
+			{EdxlopPhysicalRowTrigger,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLRowTrigger},
+			{EdxlopPhysicalAssert,					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLAssert},
+			{EdxlopPhysicalCTEProducer, 			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan},
+			{EdxlopPhysicalCTEConsumer, 			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan},
+			{EdxlopPhysicalBitmapTableScan,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan},
+			{EdxlopPhysicalDynamicBitmapTableScan,	&gpopt::CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan},
+			{EdxlopPhysicalCTAS, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLCtas},
+			{EdxlopPhysicalPartitionSelector,		&gpopt::CTranslatorDXLToPlStmt::TranslateDXLPartSelector},
+			{EdxlopPhysicalValuesScan,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLValueScan},
 	};
 
-	const ULONG ulTranslators = GPOS_ARRAY_SIZE(rgTranslators);
+	const ULONG num_of_translators = GPOS_ARRAY_SIZE(dxlop_translator_func_mapping_array);
 
-	for (ULONG ul = 0; ul < ulTranslators; ul++)
+	for (ULONG idx = 0; idx < num_of_translators; idx++)
 	{
-		STranslatorMapping elem = rgTranslators[ul];
-		m_rgpfTranslators[elem.edxlopid] = elem.pf;
+		STranslatorMapping elem = dxlop_translator_func_mapping_array[idx];
+		m_dxlop_translator_func_mapping_array[elem.dxl_op_id] = elem.dxlnode_to_logical_funct;
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplstmtFromDXL
+//		CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL
 //
 //	@doc:
 //		Translate DXL node into a PlannedStmt
 //
 //---------------------------------------------------------------------------
 PlannedStmt *
-CTranslatorDXLToPlStmt::PplstmtFromDXL
+CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL
 	(
-	const CDXLNode *pdxln,
-	bool canSetTag
+	const CDXLNode *dxlnode,
+	bool can_set_tag
 	)
 {
-	GPOS_ASSERT(NULL != pdxln);
+	GPOS_ASSERT(NULL != dxlnode);
 
-	CDXLTranslateContext dxltrctx(m_pmp, false);
+	CDXLTranslateContext dxl_translate_ctxt(m_mp, false);
 
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	Plan *pplan = PplFromDXL(pdxln, &dxltrctx, pdrgpdxltrctxPrevSiblings);
-	pdrgpdxltrctxPrevSiblings->Release();
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	Plan *plan = TranslateDXLOperatorToPlan(dxlnode, &dxl_translate_ctxt, ctxt_translation_prev_siblings);
+	ctxt_translation_prev_siblings->Release();
 
-	GPOS_ASSERT(NULL != pplan);
+	GPOS_ASSERT(NULL != plan);
 
 	// collect oids from rtable
-	List *plOids = NIL;
+	List *oids_list = NIL;
 
-	ListCell *plcRTE = NULL;
-	ForEach (plcRTE, m_pctxdxltoplstmt->PlPrte())
+	ListCell *lc_rte = NULL;
+	ForEach (lc_rte, m_dxl_to_plstmt_context->GetRTableEntriesList())
 	{
-		RangeTblEntry *pRTE = (RangeTblEntry *) lfirst(plcRTE);
+		RangeTblEntry *pRTE = (RangeTblEntry *) lfirst(lc_rte);
 
 		if (pRTE->rtekind == RTE_RELATION)
 		{
-			plOids = gpdb::PlAppendOid(plOids, pRTE->relid);
+			oids_list = gpdb::LAppendOid(oids_list, pRTE->relid);
 		}
 	}
 
 	// assemble planned stmt
-	PlannedStmt *pplstmt = MakeNode(PlannedStmt);
-	pplstmt->planGen = PLANGEN_OPTIMIZER;
+	PlannedStmt *planned_stmt = MakeNode(PlannedStmt);
+	planned_stmt->planGen = PLANGEN_OPTIMIZER;
 	
-	pplstmt->rtable = m_pctxdxltoplstmt->PlPrte();
-	pplstmt->subplans = m_pctxdxltoplstmt->PlPplanSubplan();
-	pplstmt->planTree = pplan;
+	planned_stmt->rtable = m_dxl_to_plstmt_context->GetRTableEntriesList();
+	planned_stmt->subplans = m_dxl_to_plstmt_context->GetSubplanEntriesList();
+	planned_stmt->planTree = plan;
 
 	// store partitioned table indexes in planned stmt
-	pplstmt->queryPartOids = m_pctxdxltoplstmt->PlPartitionedTables();
-	pplstmt->canSetTag = canSetTag;
-	pplstmt->relationOids = plOids;
-	pplstmt->numSelectorsPerScanId = m_pctxdxltoplstmt->PlNumPartitionSelectors();
+	planned_stmt->queryPartOids = m_dxl_to_plstmt_context->GetPartitionedTablesList();
+	planned_stmt->canSetTag = can_set_tag;
+	planned_stmt->relationOids = oids_list;
+	planned_stmt->numSelectorsPerScanId = m_dxl_to_plstmt_context->GetNumPartitionSelectorsList();
 
-	pplan->nMotionNodes  = m_pctxdxltoplstmt->UlCurrentMotionId()-1;
-	pplstmt->nMotionNodes =  m_pctxdxltoplstmt->UlCurrentMotionId()-1;
+	plan->nMotionNodes  = m_dxl_to_plstmt_context->GetCurrentMotionId()-1;
+	planned_stmt->nMotionNodes =  m_dxl_to_plstmt_context->GetCurrentMotionId()-1;
 
-	pplstmt->commandType = m_cmdtype;
+	planned_stmt->commandType = m_cmd_type;
 	
-	GPOS_ASSERT(pplan->nMotionNodes >= 0);
-	if (0 == pplan->nMotionNodes && !m_fTargetTableDistributed)
+	GPOS_ASSERT(plan->nMotionNodes >= 0);
+	if (0 == plan->nMotionNodes && !m_is_tgt_tbl_distributed)
 	{
 		// no motion nodes and not a DML on a distributed table
-		pplan->dispatch = DISPATCH_SEQUENTIAL;
+		plan->dispatch = DISPATCH_SEQUENTIAL;
 	}
 	else
 	{
-		pplan->dispatch = DISPATCH_PARALLEL;
+		plan->dispatch = DISPATCH_PARALLEL;
 	}
 	
-	pplstmt->resultRelations = m_plResultRelations;
-	pplstmt->intoClause = m_pctxdxltoplstmt->Pintocl();
-	pplstmt->intoPolicy = m_pctxdxltoplstmt->Pdistrpolicy();
+	planned_stmt->resultRelations = m_result_rel_list;
+	planned_stmt->intoClause = m_dxl_to_plstmt_context->GetIntoClause();
+	planned_stmt->intoPolicy = m_dxl_to_plstmt_context->GetDistributionPolicy();
 	
-	SetInitPlanVariables(pplstmt);
+	SetInitPlanVariables(planned_stmt);
 	
-	if (CMD_SELECT == m_cmdtype && NULL != pdxln->Pdxlddinfo())
+	if (CMD_SELECT == m_cmd_type && NULL != dxlnode->GetDXLDirectDispatchInfo())
 	{
-		List *plDirectDispatchSegIds = PlDirectDispatchSegIds(pdxln->Pdxlddinfo());
-		pplan->directDispatch.contentIds = plDirectDispatchSegIds;
-		pplan->directDispatch.isDirectDispatch = (NIL != plDirectDispatchSegIds);
+		List *direct_dispatch_segids = TranslateDXLDirectDispatchInfo(dxlnode->GetDXLDirectDispatchInfo());
+		plan->directDispatch.contentIds = direct_dispatch_segids;
+		plan->directDispatch.isDirectDispatch = (NIL != direct_dispatch_segids);
 		
-		if (pplan->directDispatch.isDirectDispatch)
+		if (plan->directDispatch.isDirectDispatch)
 		{
-			List *plMotions = gpdb::PlExtractNodesPlan(pplstmt->planTree, T_Motion, true /*descendIntoSubqueries*/);
-			ListCell *plc = NULL;
-			ForEach(plc, plMotions)
+			List *motion_node_list = gpdb::ExtractNodesPlan(planned_stmt->planTree, T_Motion, true /*descendIntoSubqueries*/);
+			ListCell *lc = NULL;
+			ForEach(lc, motion_node_list)
 			{
-				Motion *pmotion = (Motion *) lfirst(plc);
-				GPOS_ASSERT(IsA(pmotion, Motion));
-				GPOS_ASSERT(gpdb::FMotionGather(pmotion));
+				Motion *motion = (Motion *) lfirst(lc);
+				GPOS_ASSERT(IsA(motion, Motion));
+				GPOS_ASSERT(gpdb::IsMotionGather(motion));
 				
-				pmotion->plan.directDispatch.isDirectDispatch = true;
-				pmotion->plan.directDispatch.contentIds = pplan->directDispatch.contentIds;
+				motion->plan.directDispatch.isDirectDispatch = true;
+				motion->plan.directDispatch.contentIds = plan->directDispatch.contentIds;
 			}
 		}
 	}
 	
-	return pplstmt;
+	return planned_stmt;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplFromDXL
+//		CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan
 //
 //	@doc:
 //		Translates a DXL tree into a Plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplFromDXL
+CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan
 	(
-	const CDXLNode *pdxln,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	GPOS_ASSERT(NULL != pdxln);
-	GPOS_ASSERT(NULL != pdrgpdxltrctxPrevSiblings);
+	GPOS_ASSERT(NULL != dxlnode);
+	GPOS_ASSERT(NULL != ctxt_translation_prev_siblings);
 
-	CDXLOperator *pdxlop = pdxln->Pdxlop();
-	ULONG ulOpId =  (ULONG) pdxlop->Edxlop();
+	CDXLOperator *dxlop = dxlnode->GetOperator();
+	ULONG ulOpId =  (ULONG) dxlop->GetDXLOperator();
 
-	PfPplan pf = m_rgpfTranslators[ulOpId];
+	PfPplan dxlnode_to_logical_funct = m_dxlop_translator_func_mapping_array[ulOpId];
 
-	if (NULL == pf)
+	if (NULL == dxlnode_to_logical_funct)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, pdxln->Pdxlop()->PstrOpName()->Wsz());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, dxlnode->GetOperator()->GetOpNameStr()->GetBuffer());
 	}
 
-	return (this->* pf)(pdxln, pdxltrctxOut, pdrgpdxltrctxPrevSiblings);
+	return (this->* dxlnode_to_logical_funct)(dxlnode, output_context, ctxt_translation_prev_siblings);
 }
 
 //---------------------------------------------------------------------------
@@ -304,46 +304,46 @@ CTranslatorDXLToPlStmt::PplFromDXL
 //		as well as its subplans. Set the number of parameters used in the plan.
 //---------------------------------------------------------------------------
 void
-CTranslatorDXLToPlStmt::SetInitPlanVariables(PlannedStmt* pplstmt)
+CTranslatorDXLToPlStmt::SetInitPlanVariables(PlannedStmt* planned_stmt)
 {
-	if(1 != m_pctxdxltoplstmt->UlCurrentMotionId()) // For Distributed Tables m_ulMotionId > 1
+	if(1 != m_dxl_to_plstmt_context->GetCurrentMotionId()) // For Distributed Tables m_ulMotionId > 1
 	{
-		pplstmt->nInitPlans = m_pctxdxltoplstmt->UlCurrentParamId();
-		pplstmt->planTree->nInitPlans = m_pctxdxltoplstmt->UlCurrentParamId();
+		planned_stmt->nInitPlans = m_dxl_to_plstmt_context->GetCurrentParamId();
+		planned_stmt->planTree->nInitPlans = m_dxl_to_plstmt_context->GetCurrentParamId();
 	}
 
-	pplstmt->nParamExec = m_pctxdxltoplstmt->UlCurrentParamId();
+	planned_stmt->nParamExec = m_dxl_to_plstmt_context->GetCurrentParamId();
 
 	// Extract all subplans defined in the planTree
-	List *plSubPlans = gpdb::PlExtractNodesPlan(pplstmt->planTree, T_SubPlan, true);
+	List *subplan_list = gpdb::ExtractNodesPlan(planned_stmt->planTree, T_SubPlan, true);
 
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 
-	ForEach (plc, plSubPlans)
+	ForEach (lc, subplan_list)
 	{
-		SubPlan *psubplan = (SubPlan*) lfirst(plc);
-		if (psubplan->is_initplan)
+		SubPlan *subplan = (SubPlan*) lfirst(lc);
+		if (subplan->is_initplan)
 		{
-			SetInitPlanSliceInformation(psubplan);
+			SetInitPlanSliceInformation(subplan);
 		}
 	}
 
 	// InitPlans can also be defined in subplans. We therefore have to iterate
 	// over all the subplans referred to in the planned statement.
 
-	List *plInitPlans = pplstmt->subplans;
+	List *initplan_list = planned_stmt->subplans;
 
-	ForEach (plc,plInitPlans)
+	ForEach (lc,initplan_list)
 	{
-		plSubPlans = gpdb::PlExtractNodesPlan((Plan*) lfirst(plc), T_SubPlan, true);
-		ListCell *plc2;
+		subplan_list = gpdb::ExtractNodesPlan((Plan*) lfirst(lc), T_SubPlan, true);
+		ListCell *lc2;
 
-		ForEach (plc2, plSubPlans)
+		ForEach (lc2, subplan_list)
 		{
-			SubPlan *psubplan = (SubPlan*) lfirst(plc2);
-			if (psubplan->is_initplan)
+			SubPlan *subplan = (SubPlan*) lfirst(lc2);
+			if (subplan->is_initplan)
 			{
-				SetInitPlanSliceInformation(psubplan);
+				SetInitPlanSliceInformation(subplan);
 			}
 		}
 	}
@@ -362,21 +362,21 @@ CTranslatorDXLToPlStmt::SetInitPlanVariables(PlannedStmt* pplstmt)
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorDXLToPlStmt::SetInitPlanSliceInformation(SubPlan * psubplan)
+CTranslatorDXLToPlStmt::SetInitPlanSliceInformation(SubPlan * subplan)
 {
-	GPOS_ASSERT(psubplan->is_initplan && "This is processed for initplans only");
+	GPOS_ASSERT(subplan->is_initplan && "This is processed for initplans only");
 
-	if (psubplan->is_initplan)
+	if (subplan->is_initplan)
 	{
-		GPOS_ASSERT(0 < m_pctxdxltoplstmt->UlCurrentMotionId());
+		GPOS_ASSERT(0 < m_dxl_to_plstmt_context->GetCurrentMotionId());
 
-		if(1 < m_pctxdxltoplstmt->UlCurrentMotionId())
+		if(1 < m_dxl_to_plstmt_context->GetCurrentMotionId())
 		{
-			psubplan->qDispSliceId =  m_pctxdxltoplstmt->UlCurrentMotionId() + psubplan->plan_id-1;
+			subplan->qDispSliceId =  m_dxl_to_plstmt_context->GetCurrentMotionId() + subplan->plan_id-1;
 		}
 		else
 		{
-			psubplan->qDispSliceId = 0;
+			subplan->qDispSliceId = 0;
 		}
 	}
 }
@@ -390,22 +390,22 @@ CTranslatorDXLToPlStmt::SetInitPlanSliceInformation(SubPlan * psubplan)
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorDXLToPlStmt::SetParamIds(Plan* pplan)
+CTranslatorDXLToPlStmt::SetParamIds(Plan* plan)
 {
-	List *plParams = gpdb::PlExtractNodesPlan(pplan, T_Param, true);
+	List *params_node_list = gpdb::ExtractNodesPlan(plan, T_Param, true);
 
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 
-	Bitmapset  *pbitmapset = NULL;
+	Bitmapset  *bitmapset = NULL;
 
-	ForEach (plc, plParams)
+	ForEach (lc, params_node_list)
 	{
-		Param *pparam = (Param*) lfirst(plc);
-		pbitmapset = gpdb::PbmsAddMember(pbitmapset, pparam->paramid);
+		Param *param = (Param*) lfirst(lc);
+		bitmapset = gpdb::BmsAddMember(bitmapset, param->paramid);
 	}
 
-	pplan->extParam = pbitmapset;
-	pplan->allParam = pbitmapset;
+	plan->extParam = bitmapset;
+	plan->allParam = bitmapset;
 }
 
 
@@ -429,16 +429,16 @@ CTranslatorDXLToPlStmt::MapLocationsFile
 	)
 {
 	// extract file path and name from URI strings and assign them a primary segdb
-	
-	ExtTableEntry *extentry = gpdb::Pexttable(oidRel);
+
+	ExtTableEntry *extentry = gpdb::GetExternalTableEntry(oidRel);
 
 	ListCell *plcLocation = NULL;
 	ForEach (plcLocation, extentry->urilocations)
 	{
 		Value* pvLocation = (Value *)lfirst(plcLocation);
 		CHAR *szUri = pvLocation->val.str;
-		
-		Uri *pUri = gpdb::PuriParseExternalTable(szUri);
+
+		Uri *pUri = gpdb::ParseExternTableUri(szUri);
 
 		BOOL fCandidateFound = false;
 		BOOL fMatchFound = false;
@@ -451,8 +451,8 @@ CTranslatorDXLToPlStmt::MapLocationsFile
 			if (SEGMENT_IS_ACTIVE_PRIMARY(pcdbCompDBInfo))
 			{
 				if (URI_FILE == pUri->protocol &&
-					0 != gpdb::IStrCmpIgnoreCase(pUri->hostname, pcdbCompDBInfo->hostname) &&
-					0 != gpdb::IStrCmpIgnoreCase(pUri->hostname, pcdbCompDBInfo->address))
+					0 != gpdb::StrCmpIgnoreCase(pUri->hostname, pcdbCompDBInfo->hostname) &&
+					0 != gpdb::StrCmpIgnoreCase(pUri->hostname, pcdbCompDBInfo->address))
 				{
 					continue;
 				}
@@ -471,7 +471,7 @@ CTranslatorDXLToPlStmt::MapLocationsFile
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtExternalScanError,
 					GPOS_WSZ_LIT("Could not assign a segment database for external file"));
 		}
-	}	
+	}
 }
 
 //---------------------------------------------------------------------------
@@ -498,10 +498,10 @@ CTranslatorDXLToPlStmt::MapLocationsFdist
 {
 	ULONG ulParticipatingSegments = ulTotalPrimaries;
 	ULONG ulMaxParticipants = ulParticipatingSegments;
-	
-	ExtTableEntry *extentry = gpdb::Pexttable(oidRel);
 
-	const ULONG ulLocations = gpdb::UlListLength(extentry->urilocations);
+	ExtTableEntry *extentry = gpdb::GetExternalTableEntry(oidRel);
+
+	const ULONG ulLocations = gpdb::ListLength(extentry->urilocations);
 	if (URI_GPFDIST == pUri->protocol || URI_GPFDISTS == pUri->protocol)
 	{
 		ulMaxParticipants = ulLocations * gp_external_max_segs;
@@ -541,7 +541,7 @@ CTranslatorDXLToPlStmt::MapLocationsFdist
 		{
 			Value* pvLocation = (Value *)lfirst(plcLocation);
 			CHAR *szUri = pvLocation->val.str;
-			plModifiedLocations = gpdb::PlAppendElement(plModifiedLocations, gpdb::PvalMakeString(szUri));
+			plModifiedLocations = gpdb::LAppend(plModifiedLocations, gpdb::MakeStringValue(szUri));
 			ulModifiedLocations ++;
 
 			if (ulModifiedLocations == ulParticipatingSegments)
@@ -561,7 +561,7 @@ CTranslatorDXLToPlStmt::MapLocationsFdist
 	BOOL *rgfSkipMap = NULL;
 	if (fSkipRandomly)
 	{
-		rgfSkipMap = gpdb::RgfRandomSegMap(ulTotalPrimaries, ulSkip);
+		rgfSkipMap = gpdb::ConstructRandomSegMap(ulTotalPrimaries, ulSkip);
 	}
 
 	// assign each URI from the new location list a primary segdb
@@ -628,11 +628,11 @@ CTranslatorDXLToPlStmt::MapLocationsExecute
 	const ULONG ulTotalPrimaries
 	)
 {
-	ExtTableEntry *extentry = gpdb::Pexttable(oidRel);
+	ExtTableEntry *extentry = gpdb::GetExternalTableEntry(oidRel);
 	CHAR *szCommand = extentry->command;
 	const CHAR *szPrefix = "execute:";
-	
-	StringInfo si = gpdb::SiMakeStringInfo();
+
+	StringInfo si = gpdb::MakeStringInfo();
 	gpdb::AppendStringInfo(si, szPrefix, szCommand);
 	CHAR *szPrefixedCommand = PStrDup(si->data);
 
@@ -641,37 +641,37 @@ CTranslatorDXLToPlStmt::MapLocationsExecute
 	si = NULL;
 
 	// get the ON clause (execute location) information
-	Value *pvOnClause = (Value *) gpdb::PvListNth(extentry->execlocations, 0);
+	Value *pvOnClause = (Value *) gpdb::ListNth(extentry->execlocations, 0);
 	CHAR *szOnClause = pvOnClause->val.str;
-	
-	if (0 == gpos::clib::IStrCmp(szOnClause, "ALL_SEGMENTS"))
+
+	if (0 == gpos::clib::Strcmp(szOnClause, "ALL_SEGMENTS"))
 	{
 		MapLocationsExecuteAllSegments(szPrefixedCommand, rgszSegFileMap, pcdbCompDB);
 	}
-	else if (0 == gpos::clib::IStrCmp(szOnClause, "PER_HOST"))
+	else if (0 == gpos::clib::Strcmp(szOnClause, "PER_HOST"))
 	{
 		MapLocationsExecutePerHost(szPrefixedCommand, rgszSegFileMap, pcdbCompDB);
 	}
-	else if (0 == gpos::clib::IStrNCmp(szOnClause, "HOST:", gpos::clib::UlStrLen("HOST:")))
+	else if (0 == gpos::clib::Strncmp(szOnClause, "HOST:", gpos::clib::Strlen("HOST:")))
 	{
-		CHAR *szHostName = szOnClause + gpos::clib::UlStrLen("HOST:");
+		CHAR *szHostName = szOnClause + gpos::clib::Strlen("HOST:");
 		MapLocationsExecuteOneHost(szHostName, szPrefixedCommand, rgszSegFileMap, pcdbCompDB);
 	}
-	else if (0 == gpos::clib::IStrNCmp(szOnClause, "SEGMENT_ID:", gpos::clib::UlStrLen("SEGMENT_ID:")))
+	else if (0 == gpos::clib::Strncmp(szOnClause, "SEGMENT_ID:", gpos::clib::Strlen("SEGMENT_ID:")))
 	{
 		CHAR *pcEnd = NULL;
-		INT iTargetSegInd = (INT) gpos::clib::LStrToL(szOnClause + gpos::clib::UlStrLen("SEGMENT_ID:"), &pcEnd, 10);
+		INT iTargetSegInd = (INT) gpos::clib::Strtol(szOnClause + gpos::clib::Strlen("SEGMENT_ID:"), &pcEnd, 10);
 		MapLocationsExecuteOneSegment(iTargetSegInd, szPrefixedCommand, rgszSegFileMap, pcdbCompDB);
 	}
-	else if (0 == gpos::clib::IStrNCmp(szOnClause, "TOTAL_SEGS:", gpos::clib::UlStrLen("TOTAL_SEGS:")))
+	else if (0 == gpos::clib::Strncmp(szOnClause, "TOTAL_SEGS:", gpos::clib::Strlen("TOTAL_SEGS:")))
 	{
 		// total n segments selected randomly
 		CHAR *pcEnd = NULL;
-		ULONG ulSegsToUse = gpos::clib::LStrToL(szOnClause + gpos::clib::UlStrLen("TOTAL_SEGS:"), &pcEnd, 10);
+		ULONG ulSegsToUse = gpos::clib::Strtol(szOnClause + gpos::clib::Strlen("TOTAL_SEGS:"), &pcEnd, 10);
 
 		MapLocationsExecuteRandomSegments(ulSegsToUse, ulTotalPrimaries, szPrefixedCommand, rgszSegFileMap, pcdbCompDB);
 	}
-	else if (0 == gpos::clib::IStrCmp(szOnClause, "MASTER_ONLY"))
+	else if (0 == gpos::clib::Strcmp(szOnClause, "MASTER_ONLY"))
 	{
 		rgszSegFileMap[0] = PStrDup(szPrefixedCommand);
 	}
@@ -739,7 +739,7 @@ CTranslatorDXLToPlStmt::MapLocationsExecutePerHost
 			ForEach (plc, plVisitedHosts)
 			{
 				const CHAR *szHostName = (CHAR *) strVal(lfirst(plc));
-				if (0 == gpdb::IStrCmpIgnoreCase(szHostName, pcdbCompDBInfo->hostname))
+				if (0 == gpdb::StrCmpIgnoreCase(szHostName, pcdbCompDBInfo->hostname))
 				{
 					fHostTaken = true;
 					break;
@@ -749,10 +749,10 @@ CTranslatorDXLToPlStmt::MapLocationsExecutePerHost
 			if (!fHostTaken)
 			{
 				rgszSegFileMap[iSegInd] = PStrDup(szPrefixedCommand);
-				plVisitedHosts = gpdb::PlAppendElement
+				plVisitedHosts = gpdb::LAppend
 										(
 										plVisitedHosts,
-										gpdb::PvalMakeString(PStrDup(pcdbCompDBInfo->hostname))
+										gpdb::MakeStringValue(PStrDup(pcdbCompDBInfo->hostname))
 										);
 			}
 		}
@@ -783,7 +783,7 @@ CTranslatorDXLToPlStmt::MapLocationsExecuteOneHost
 		INT iSegInd = pcdbCompDBInfo->segindex;
 
 		if (SEGMENT_IS_ACTIVE_PRIMARY(pcdbCompDBInfo) &&
-			0 == gpdb::IStrCmpIgnoreCase(szHostName, pcdbCompDBInfo->hostname))
+			0 == gpdb::StrCmpIgnoreCase(szHostName, pcdbCompDBInfo->hostname))
 		{
 			rgszSegFileMap[iSegInd] = PStrDup(szPrefixedCommand);
 			fMatchFound = true;
@@ -858,7 +858,7 @@ CTranslatorDXLToPlStmt::MapLocationsExecuteRandomSegments
 	}
 
 	ULONG ulSkip = ulTotalPrimaries - ulSegments;
-	BOOL *rgfSkipMap = gpdb::RgfRandomSegMap(ulTotalPrimaries, ulSkip);
+	BOOL *rgfSkipMap = gpdb::ConstructRandomSegMap(ulTotalPrimaries, ulSkip);
 
 	for (int i = 0; i < pcdbCompDB->total_segment_dbs; i++)
 	{
@@ -915,8 +915,8 @@ CTranslatorDXLToPlStmt::PlExternalScanUriList
 	OID oidRel
 	)
 {
-	ExtTableEntry *extentry = gpdb::Pexttable(oidRel);
-	
+	ExtTableEntry *extentry = gpdb::GetExternalTableEntry(oidRel);
+
 	if (extentry->iswritable)
 	{
 		// This should match the same error in createplan.c
@@ -927,7 +927,7 @@ CTranslatorDXLToPlStmt::PlExternalScanUriList
 	}
 
 	//get the total valid primary segdb count
-	CdbComponentDatabases *pcdbCompDB = gpdb::PcdbComponentDatabases();
+	CdbComponentDatabases *pcdbCompDB = gpdb::GetComponentDatabases();
 	ULONG ulTotalPrimaries = 0;
 	for (int i = 0; i < pcdbCompDB->total_segment_dbs; i++)
 	{
@@ -940,7 +940,7 @@ CTranslatorDXLToPlStmt::PlExternalScanUriList
 
 	char **rgszSegFileMap = NULL;
     rgszSegFileMap = (char **) gpdb::GPDBAlloc(ulTotalPrimaries * sizeof(char *));
-    gpos::clib::PvMemSet(rgszSegFileMap, 0, ulTotalPrimaries * sizeof(char *));
+    gpos::clib::Memset(rgszSegFileMap, 0, ulTotalPrimaries * sizeof(char *));
 
 	// is this an EXECUTE table or a LOCATION (URI) table
 	BOOL fUsingExecute = false;
@@ -963,14 +963,14 @@ CTranslatorDXLToPlStmt::PlExternalScanUriList
 		fUsingLocation = true;
 	}
 
-	GPOS_ASSERT(0 < gpdb::UlListLength(extentry->urilocations));
-	
+	GPOS_ASSERT(0 < gpdb::ListLength(extentry->urilocations));
+
 	CHAR *szFirstUri = NULL;
 	Uri *pUri = NULL;
 	if (!fUsingExecute)
 	{
-		szFirstUri = ((Value *) gpdb::PvListNth(extentry->urilocations, 0))->val.str;
-		pUri = gpdb::PuriParseExternalTable(szFirstUri);
+		szFirstUri = ((Value *) gpdb::ListNth(extentry->urilocations, 0))->val.str;
+		pUri = gpdb::ParseExternTableUri(szFirstUri);
 	}
 
 	if (fUsingLocation && (URI_FILE == pUri->protocol || URI_HTTP == pUri->protocol))
@@ -1001,7 +1001,7 @@ CTranslatorDXLToPlStmt::PlExternalScanUriList
 		Value *pval = NULL;
 	    if (NULL != rgszSegFileMap[ul])
 	    {
-	    	pval = gpdb::PvalMakeString(rgszSegFileMap[ul]);
+	    	pval = gpdb::MakeStringValue(rgszSegFileMap[ul]);
 	    }
 	    else
 		{
@@ -1009,7 +1009,7 @@ CTranslatorDXLToPlStmt::PlExternalScanUriList
 			pval = MakeNode(Value);
 			pval->type = T_Null;
 		}
-		plFileNames = gpdb::PlAppendElement(plFileNames, pval);
+		plFileNames = gpdb::LAppend(plFileNames, pval);
 	}
 
 	return plFileNames;
@@ -1018,120 +1018,120 @@ CTranslatorDXLToPlStmt::PlExternalScanUriList
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PtsFromDXLTblScan
+//		CTranslatorDXLToPlStmt::TranslateDXLTblScan
 //
 //	@doc:
 //		Translates a DXL table scan node into a TableScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PtsFromDXLTblScan
+CTranslatorDXLToPlStmt::TranslateDXLTblScan
 	(
-	const CDXLNode *pdxlnTblScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *tbl_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translate table descriptor into a range table entry
-	CDXLPhysicalTableScan *pdxlopTS = CDXLPhysicalTableScan::PdxlopConvert(pdxlnTblScan->Pdxlop());
+	CDXLPhysicalTableScan *phy_tbl_scan_dxlop = CDXLPhysicalTableScan::Cast(tbl_scan_dxlnode->GetOperator());
 
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// we will add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	const CDXLTableDescr *pdxltabdesc = pdxlopTS->Pdxltabdesc();
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
-	m_pctxdxltoplstmt->AddRTE(prte);
+	const CDXLTableDescr *dxl_table_descr = phy_tbl_scan_dxlop->GetDXLTableDescr();
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(dxl_table_descr->MDId());
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dxl_table_descr, NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	Plan *pplan = NULL;
-	Plan *pplanReturn = NULL;
-	if (IMDRelation::ErelstorageExternal == pmdrel->Erelstorage())
+	Plan *plan = NULL;
+	Plan *plan_return = NULL;
+	if (IMDRelation::ErelstorageExternal == md_rel->RetrieveRelStorageType())
 	{
-		const IMDRelationExternal *pmdrelext = dynamic_cast<const IMDRelationExternal*>(pmdrel);
-		OID oidRel = CMDIdGPDB::PmdidConvert(pmdrel->Pmdid())->OidObjectId();
-		ExtTableEntry *pextentry = gpdb::Pexttable(oidRel);
+		const IMDRelationExternal *md_rel_ext = dynamic_cast<const IMDRelationExternal*>(md_rel);
+		OID oidRel = CMDIdGPDB::CastMdid(md_rel->MDId())->Oid();
+		ExtTableEntry *ext_table_entry = gpdb::GetExternalTableEntry(oidRel);
 		
 		// create external scan node
-		ExternalScan *pes = MakeNode(ExternalScan);
-		pes->scan.scanrelid = iRel;
-		pes->uriList = PlExternalScanUriList(oidRel);
-		Value *pval = gpdb::PvalMakeString(pextentry->fmtopts);
-		pes->fmtOpts = ListMake1(pval);
-		pes->fmtType = pextentry->fmtcode;
-		pes->isMasterOnly = (IMDRelation::EreldistrMasterOnly == pmdrelext->Ereldistribution());
-		pes->rejLimit = pmdrelext->IRejectLimit();
-		pes->rejLimitInRows = pmdrelext->FRejLimitInRows();
+		ExternalScan *ext_scan = MakeNode(ExternalScan);
+		ext_scan->scan.scanrelid = index;
+		ext_scan->uriList = PlExternalScanUriList(oidRel);
+		Value *val = gpdb::MakeStringValue(ext_table_entry->fmtopts);
+		ext_scan->fmtOpts = ListMake1(val);
+		ext_scan->fmtType = ext_table_entry->fmtcode;
+		ext_scan->isMasterOnly = (IMDRelation::EreldistrMasterOnly == md_rel_ext->GetRelDistribution());
+		ext_scan->rejLimit = md_rel_ext->RejectLimit();
+		ext_scan->rejLimitInRows = md_rel_ext->IsRejectLimitInRows();
 
-		IMDId *pmdidFmtErrTbl = pmdrelext->PmdidFmtErrRel();
+		IMDId *pmdidFmtErrTbl = md_rel_ext->GetFormatErrTableMdid();
 		if (NULL == pmdidFmtErrTbl)
 		{
-			pes->fmterrtbl = InvalidOid;
+			ext_scan->fmterrtbl = InvalidOid;
 		}
 		else
 		{
-			pes->fmterrtbl = CMDIdGPDB::PmdidConvert(pmdidFmtErrTbl)->OidObjectId();
+			ext_scan->fmterrtbl = CMDIdGPDB::CastMdid(pmdidFmtErrTbl)->Oid();
 		}
 
-		pes->encoding = pextentry->encoding;
-		pes->scancounter = m_ulExternalScanCounter++;
+		ext_scan->encoding = ext_table_entry->encoding;
+		ext_scan->scancounter = m_external_scan_counter++;
 
-		pplan = &(pes->scan.plan);
-		pplanReturn = (Plan *) pes;
+		plan = &(ext_scan->scan.plan);
+		plan_return = (Plan *) ext_scan;
 	}
 	else
 	{
 		// create table scan node
-		TableScan *pts = MakeNode(TableScan);
-		pts->scanrelid = iRel;
-		pplan = &(pts->plan);
-		pplanReturn = (Plan *) pts;
+		TableScan *table_scan = MakeNode(TableScan);
+		table_scan->scanrelid = index;
+		plan = &(table_scan->plan);
+		plan_return = (Plan *) table_scan;
 	}
 
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnTblScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(tbl_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// a table scan node must have 2 children: projection list and filter
-	GPOS_ASSERT(2 == pdxlnTblScan->UlArity());
+	GPOS_ASSERT(2 == tbl_scan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnTblScan)[EdxltsIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnTblScan)[EdxltsIndexFilter];
+	CDXLNode *project_list_dxlnode = (*tbl_scan_dxlnode)[EdxltsIndexProjList];
+	CDXLNode *filter_dxlnode = (*tbl_scan_dxlnode)[EdxltsIndexFilter];
 
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
-		&dxltrctxbt,	// translate context for the base table
-		NULL,			// pdxltrctxLeft and pdxltrctxRight,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		project_list_dxlnode,
+		filter_dxlnode,
+		&base_table_context,	// translate context for the base table
+		NULL,			// translate_ctxt_left and pdxltrctxRight,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return pplanReturn;
+	return plan_return;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::FSetIndexVarAttno
+//		CTranslatorDXLToPlStmt::SetIndexVarAttnoWalker
 //
 //	@doc:
 //		Walker to set index var attno's,
@@ -1140,187 +1140,187 @@ CTranslatorDXLToPlStmt::PtsFromDXLTblScan
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorDXLToPlStmt::FSetIndexVarAttno
+CTranslatorDXLToPlStmt::SetIndexVarAttnoWalker
 	(
-	Node *pnode,
-	SContextIndexVarAttno *pctxtidxvarattno
+	Node *node,
+	SContextIndexVarAttno *ctxt_index_var_attno_walker
 	)
 {
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return false;
 	}
 
-	if (IsA(pnode, Var) && ((Var *)pnode)->varno != OUTER)
+	if (IsA(node, Var) && ((Var *)node)->varno != OUTER)
 	{
-		INT iAttno = ((Var *)pnode)->varattno;
-		const IMDRelation *pmdrel = pctxtidxvarattno->m_pmdrel;
-		const IMDIndex *pmdindex = pctxtidxvarattno->m_pmdindex;
+		INT attno = ((Var *)node)->varattno;
+		const IMDRelation *md_rel = ctxt_index_var_attno_walker->m_md_rel;
+		const IMDIndex *index = ctxt_index_var_attno_walker->m_md_index;
 
-		ULONG ulIndexColPos = gpos::ulong_max;
-		const ULONG ulArity = pmdrel->UlColumns();
-		for (ULONG ulColPos = 0; ulColPos < ulArity; ulColPos++)
+		ULONG index_col_pos_idx_max = gpos::ulong_max;
+		const ULONG arity = md_rel->ColumnCount();
+		for (ULONG col_pos_idx = 0; col_pos_idx < arity; col_pos_idx++)
 		{
-			const IMDColumn *pmdcol = pmdrel->Pmdcol(ulColPos);
-			if (iAttno == pmdcol->IAttno())
+			const IMDColumn *md_col = md_rel->GetMdCol(col_pos_idx);
+			if (attno == md_col->AttrNum())
 			{
-				ulIndexColPos = ulColPos;
+				index_col_pos_idx_max = col_pos_idx;
 				break;
 			}
 		}
 
-		if (gpos::ulong_max > ulIndexColPos)
+		if (gpos::ulong_max > index_col_pos_idx_max)
 		{
-			((Var *)pnode)->varattno =  1 + pmdindex->UlPosInKey(ulIndexColPos);
+			((Var *)node)->varattno =  1 + index->GetKeyPos(index_col_pos_idx_max);
 		}
 
 		return false;
 	}
 
-	return gpdb::FWalkExpressionTree
+	return gpdb::WalkExpressionTree
 			(
-			pnode,
-			(BOOL (*)()) CTranslatorDXLToPlStmt::FSetIndexVarAttno,
-			pctxtidxvarattno
+			node,
+			(BOOL (*)()) CTranslatorDXLToPlStmt::SetIndexVarAttnoWalker,
+			ctxt_index_var_attno_walker
 			);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PisFromDXLIndexScan
+//		CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 //
 //	@doc:
 //		Translates a DXL index scan node into a IndexScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PisFromDXLIndexScan
+CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 	(
-	const CDXLNode *pdxlnIndexScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *index_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translate table descriptor into a range table entry
-	CDXLPhysicalIndexScan *pdxlopIndexScan = CDXLPhysicalIndexScan::PdxlopConvert(pdxlnIndexScan->Pdxlop());
+	CDXLPhysicalIndexScan *physical_idx_scan_dxlop = CDXLPhysicalIndexScan::Cast(index_scan_dxlnode->GetOperator());
 
-	return PisFromDXLIndexScan(pdxlnIndexScan, pdxlopIndexScan, pdxltrctxOut, false /*fIndexOnlyScan*/, pdrgpdxltrctxPrevSiblings);
+	return TranslateDXLIndexScan(index_scan_dxlnode, physical_idx_scan_dxlop, output_context, false /*is_index_only_scan*/, ctxt_translation_prev_siblings);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PisFromDXLIndexScan
+//		CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 //
 //	@doc:
 //		Translates a DXL index scan node into a IndexScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PisFromDXLIndexScan
+CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 	(
-	const CDXLNode *pdxlnIndexScan,
-	CDXLPhysicalIndexScan *pdxlopIndexScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	BOOL fIndexOnlyScan,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *index_scan_dxlnode,
+	CDXLPhysicalIndexScan *physical_idx_scan_dxlop,
+	CDXLTranslateContext *output_context,
+	BOOL is_index_only_scan,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	const CDXLIndexDescr *pdxlid = NULL;
-	if (fIndexOnlyScan)
+	const CDXLIndexDescr *index_descr_dxl = NULL;
+	if (is_index_only_scan)
 	{
-		pdxlid = pdxlopIndexScan->Pdxlid();
+		index_descr_dxl = physical_idx_scan_dxlop->GetDXLIndexDescr();
 	}
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlopIndexScan->Pdxltabdesc()->Pmdid());
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(physical_idx_scan_dxlop->GetDXLTableDescr()->MDId());
 
-	RangeTblEntry *prte = PrteFromTblDescr(pdxlopIndexScan->Pdxltabdesc(), pdxlid, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
-	m_pctxdxltoplstmt->AddRTE(prte);
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(physical_idx_scan_dxlop->GetDXLTableDescr(), index_descr_dxl, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	IndexScan *pis = NULL;
-	GPOS_ASSERT(!fIndexOnlyScan);
-	pis = MakeNode(IndexScan);
-	pis->scan.scanrelid = iRel;
+	IndexScan *index_scan = NULL;
+	GPOS_ASSERT(!is_index_only_scan);
+	index_scan = MakeNode(IndexScan);
+	index_scan->scan.scanrelid = index;
 
-	CMDIdGPDB *pmdidIndex = CMDIdGPDB::PmdidConvert(pdxlopIndexScan->Pdxlid()->Pmdid());
-	const IMDIndex *pmdindex = m_pmda->Pmdindex(pmdidIndex);
-	Oid oidIndex = pmdidIndex->OidObjectId();
+	CMDIdGPDB *mdid_index = CMDIdGPDB::CastMdid(physical_idx_scan_dxlop->GetDXLIndexDescr()->MDId());
+	const IMDIndex *md_index = m_md_accessor->RetrieveIndex(mdid_index);
+	Oid index_oid = mdid_index->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidIndex);
-	pis->indexid = oidIndex;
+	GPOS_ASSERT(InvalidOid != index_oid);
+	index_scan->indexid = index_oid;
 
-	Plan *pplan = &(pis->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	Plan *plan = &(index_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnIndexScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(index_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// an index scan node must have 3 children: projection list, filter and index condition list
-	GPOS_ASSERT(3 == pdxlnIndexScan->UlArity());
+	GPOS_ASSERT(3 == index_scan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnIndexScan)[EdxlisIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnIndexScan)[EdxlisIndexFilter];
-	CDXLNode *pdxlnIndexCondList = (*pdxlnIndexScan)[EdxlisIndexCondition];
+	CDXLNode *project_list_dxlnode = (*index_scan_dxlnode)[EdxlisIndexProjList];
+	CDXLNode *filter_dxlnode = (*index_scan_dxlnode)[EdxlisIndexFilter];
+	CDXLNode *index_cond_list_dxlnode = (*index_scan_dxlnode)[EdxlisIndexCondition];
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList(pdxlnPrL, &dxltrctxbt, NULL /*pdrgpdxltrctx*/, pdxltrctxOut);
+	plan->targetlist = TranslateDXLProjList(project_list_dxlnode, &base_table_context, NULL /*child_contexts*/, output_context);
 
 	// translate index filter
-	pplan->qual = PlTranslateIndexFilter
+	plan->qual = TranslateDXLIndexFilter
 					(
-					pdxlnFilter,
-					pdxltrctxOut,
-					&dxltrctxbt,
-					pdrgpdxltrctxPrevSiblings
+					filter_dxlnode,
+					output_context,
+					&base_table_context,
+					ctxt_translation_prev_siblings
 					);
 
-	pis->indexorderdir = CTranslatorUtils::Scandirection(pdxlopIndexScan->EdxlScanDirection());
+	index_scan->indexorderdir = CTranslatorUtils::GetScanDirection(physical_idx_scan_dxlop->GetIndexScanDir());
 
 	// translate index condition list
-	List *plIndexConditions = NIL;
-	List *plIndexOrigConditions = NIL;
-	List *plIndexStratgey = NIL;
-	List *plIndexSubtype = NIL;
+	List *index_cond = NIL;
+	List *index_orig_cond = NIL;
+	List *index_strategy_list = NIL;
+	List *index_subtype_list = NIL;
 
 	TranslateIndexConditions
 		(
-		pdxlnIndexCondList, 
-		pdxlopIndexScan->Pdxltabdesc(), 
-		fIndexOnlyScan, 
-		pmdindex, 
-		pmdrel,
-		pdxltrctxOut,
-		&dxltrctxbt, 
-		pdrgpdxltrctxPrevSiblings,
-		&plIndexConditions, 
-		&plIndexOrigConditions, 
-		&plIndexStratgey, 
-		&plIndexSubtype
+		index_cond_list_dxlnode,
+		physical_idx_scan_dxlop->GetDXLTableDescr(),
+		is_index_only_scan,
+		md_index,
+		md_rel,
+		output_context,
+		&base_table_context,
+		ctxt_translation_prev_siblings,
+		&index_cond,
+		&index_orig_cond,
+		&index_strategy_list,
+		&index_subtype_list
 		);
 
-	pis->indexqual = plIndexConditions;
-	pis->indexqualorig = plIndexOrigConditions;
-	pis->indexstrategy = plIndexStratgey;
-	pis->indexsubtype = plIndexSubtype;
-	SetParamIds(pplan);
+	index_scan->indexqual = index_cond;
+	index_scan->indexqualorig = index_orig_cond;
+	index_scan->indexstrategy = index_strategy_list;
+	index_scan->indexsubtype = index_subtype_list;
+	SetParamIds(plan);
 
-	return (Plan *) pis;
+	return (Plan *) index_scan;
 }
 
 //---------------------------------------------------------------------------
@@ -1332,28 +1332,28 @@ CTranslatorDXLToPlStmt::PisFromDXLIndexScan
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTranslateIndexFilter
+CTranslatorDXLToPlStmt::TranslateDXLIndexFilter
 	(
-	CDXLNode *pdxlnFilter,
-	CDXLTranslateContext *pdxltrctxOut,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	CDXLNode *filter_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	List *plQuals = NIL;
+	List *quals_list = NIL;
 
 	// build colid->var mapping
-	CMappingColIdVarPlStmt mapcidvarplstmt(m_pmp, pdxltrctxbt, pdrgpdxltrctxPrevSiblings, pdxltrctxOut, m_pctxdxltoplstmt);
+	CMappingColIdVarPlStmt colid_var_mapping(m_mp, base_table_context, ctxt_translation_prev_siblings, output_context, m_dxl_to_plstmt_context);
 
-	const ULONG ulArity = pdxlnFilter->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = filter_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnIndexFilter = (*pdxlnFilter)[ul];
-		Expr *pexprIndexFilter = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnIndexFilter, &mapcidvarplstmt);
-		plQuals = gpdb::PlAppendElement(plQuals, pexprIndexFilter);
+		CDXLNode *index_filter_dxlnode = (*filter_dxlnode)[ul];
+		Expr *index_filter_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(index_filter_dxlnode, &colid_var_mapping);
+		quals_list = gpdb::LAppend(quals_list, index_filter_expr);
 	}
 
-	return plQuals;
+	return quals_list;
 }
 
 
@@ -1368,1188 +1368,1188 @@ CTranslatorDXLToPlStmt::PlTranslateIndexFilter
 void 
 CTranslatorDXLToPlStmt::TranslateIndexConditions
 	(
-	CDXLNode *pdxlnIndexCondList,
-	const CDXLTableDescr *pdxltd,
-	BOOL fIndexOnlyScan,
-	const IMDIndex *pmdindex,
-	const IMDRelation *pmdrel,
-	CDXLTranslateContext *pdxltrctxOut,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-	List **pplIndexConditions,
-	List **pplIndexOrigConditions,
-	List **pplIndexStratgey,
-	List **pplIndexSubtype
+	CDXLNode *index_cond_list_dxlnode,
+	const CDXLTableDescr *dxl_tbl_descr,
+	BOOL is_index_only_scan,
+	const IMDIndex *index,
+	const IMDRelation *md_rel,
+	CDXLTranslateContext *output_context,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+	List **index_cond,
+	List **index_orig_cond,
+	List **index_strategy_list,
+	List **index_subtype_list
 	)
 {
 	// array of index qual info
-	DrgPindexqualinfo *pdrgpindexqualinfo = GPOS_NEW(m_pmp) DrgPindexqualinfo(m_pmp);
+	CIndexQualInfoArray *index_qual_info_array = GPOS_NEW(m_mp) CIndexQualInfoArray(m_mp);
 
 	// build colid->var mapping
-	CMappingColIdVarPlStmt mapcidvarplstmt(m_pmp, pdxltrctxbt, pdrgpdxltrctxPrevSiblings, pdxltrctxOut, m_pctxdxltoplstmt);
+	CMappingColIdVarPlStmt colid_var_mapping(m_mp, base_table_context, ctxt_translation_prev_siblings, output_context, m_dxl_to_plstmt_context);
 
-	const ULONG ulArity = pdxlnIndexCondList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = index_cond_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnIndexCond = (*pdxlnIndexCondList)[ul];
+		CDXLNode *index_cond_dxlnode = (*index_cond_list_dxlnode)[ul];
 
-		Expr *pexprOrigIndexCond = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnIndexCond, &mapcidvarplstmt);
-		Expr *pexprIndexCond = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnIndexCond, &mapcidvarplstmt);
-		GPOS_ASSERT((IsA(pexprIndexCond, OpExpr) || IsA(pexprIndexCond, ScalarArrayOpExpr))
+		Expr *original_index_cond_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(index_cond_dxlnode, &colid_var_mapping);
+		Expr *index_cond_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(index_cond_dxlnode, &colid_var_mapping);
+		GPOS_ASSERT((IsA(index_cond_expr, OpExpr) || IsA(index_cond_expr, ScalarArrayOpExpr))
 				&& "expected OpExpr or ScalarArrayOpExpr in index qual");
 
-		if (IsA(pexprIndexCond, ScalarArrayOpExpr) && IMDIndex::EmdindBitmap != pmdindex->Emdindt())
+		if (IsA(index_cond_expr, ScalarArrayOpExpr) && IMDIndex::EmdindBitmap != index->IndexType())
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, GPOS_WSZ_LIT("ScalarArrayOpExpr condition on index scan"));
 		}
 
 		// for indexonlyscan, we already have the attno referring to the index
-		if (!fIndexOnlyScan)
+		if (!is_index_only_scan)
 		{
 			// Otherwise, we need to perform mapping of Varattnos relative to column positions in index keys
-			SContextIndexVarAttno ctxtidxvarattno(pmdrel, pmdindex);
-			FSetIndexVarAttno((Node *) pexprIndexCond, &ctxtidxvarattno);
+			SContextIndexVarAttno index_varattno_ctxt(md_rel, index);
+			SetIndexVarAttnoWalker((Node *) index_cond_expr, &index_varattno_ctxt);
 		}
 		
 		// find index key's attno
-		List *plistArgs = NULL;
-		if (IsA(pexprIndexCond, OpExpr))
+		List *args_list = NULL;
+		if (IsA(index_cond_expr, OpExpr))
 		{
-			plistArgs = ((OpExpr *) pexprIndexCond)->args;
+			args_list = ((OpExpr *) index_cond_expr)->args;
 		}
 		else
 		{
-			plistArgs = ((ScalarArrayOpExpr *) pexprIndexCond)->args;
+			args_list = ((ScalarArrayOpExpr *) index_cond_expr)->args;
 		}
 
-		Node *pnodeFst = (Node *) lfirst(gpdb::PlcListHead(plistArgs));
-		Node *pnodeSnd = (Node *) lfirst(gpdb::PlcListTail(plistArgs));
+		Node *left_arg = (Node *) lfirst(gpdb::ListHead(args_list));
+		Node *right_arg = (Node *) lfirst(gpdb::ListTail(args_list));
 				
-		BOOL fRelabel = false;
-		if (IsA(pnodeFst, RelabelType) && IsA(((RelabelType *) pnodeFst)->arg, Var))
+		BOOL is_relabel_type = false;
+		if (IsA(left_arg, RelabelType) && IsA(((RelabelType *) left_arg)->arg, Var))
 		{
-			pnodeFst = (Node *) ((RelabelType *) pnodeFst)->arg;
-			fRelabel = true;
+			left_arg = (Node *) ((RelabelType *) left_arg)->arg;
+			is_relabel_type = true;
 		}
-		else if (IsA(pnodeSnd, RelabelType) && IsA(((RelabelType *) pnodeSnd)->arg, Var))
+		else if (IsA(right_arg, RelabelType) && IsA(((RelabelType *) right_arg)->arg, Var))
 		{
-			pnodeSnd = (Node *) ((RelabelType *) pnodeSnd)->arg;
-			fRelabel = true;
+			right_arg = (Node *) ((RelabelType *) right_arg)->arg;
+			is_relabel_type = true;
 		}
 		
-		if (fRelabel)
+		if (is_relabel_type)
 		{
-			List *plNewArgs = ListMake2(pnodeFst, pnodeSnd);
-			gpdb::GPDBFree(plistArgs);
-			if (IsA(pexprIndexCond, OpExpr))
+			List *new_args_list = ListMake2(left_arg, right_arg);
+			gpdb::GPDBFree(args_list);
+			if (IsA(index_cond_expr, OpExpr))
 			{
-				((OpExpr *) pexprIndexCond)->args = plNewArgs;
+				((OpExpr *) index_cond_expr)->args = new_args_list;
 			}
 			else
 			{
-				((ScalarArrayOpExpr *) pexprIndexCond)->args = plNewArgs;
+				((ScalarArrayOpExpr *) index_cond_expr)->args = new_args_list;
 			}
 		}
 		
-		GPOS_ASSERT((IsA(pnodeFst, Var) || IsA(pnodeSnd, Var)) && "expected index key in index qual");
+		GPOS_ASSERT((IsA(left_arg, Var) || IsA(right_arg, Var)) && "expected index key in index qual");
 
-		INT iAttno = 0;
-		if (IsA(pnodeFst, Var) && ((Var *) pnodeFst)->varno != OUTER)
+		INT attno = 0;
+		if (IsA(left_arg, Var) && ((Var *) left_arg)->varno != OUTER)
 		{
 			// index key is on the left side
-			iAttno =  ((Var *) pnodeFst)->varattno;
+			attno =  ((Var *) left_arg)->varattno;
 		}
 		else
 		{
 			// index key is on the right side
-			GPOS_ASSERT(((Var *) pnodeSnd)->varno != OUTER && "unexpected outer reference in index qual");
-			iAttno = ((Var *) pnodeSnd)->varattno;
+			GPOS_ASSERT(((Var *) right_arg)->varno != OUTER && "unexpected outer reference in index qual");
+			attno = ((Var *) right_arg)->varattno;
 		}
 		
 		// retrieve index strategy and subtype
-		INT iSN = 0;
-		OID oidIndexSubtype = InvalidOid;
-		BOOL fRecheck = false;
+		INT strategy_num = 0;
+		OID index_subtype_oid = InvalidOid;
+		BOOL recheck = false;
 		
-		OID oidCmpOperator = CTranslatorUtils::OidCmpOperator(pexprIndexCond);
-		GPOS_ASSERT(InvalidOid != oidCmpOperator);
-		OID oidOpFamily = CTranslatorUtils::OidIndexQualOpFamily(iAttno, CMDIdGPDB::PmdidConvert(pmdindex->Pmdid())->OidObjectId());
-		GPOS_ASSERT(InvalidOid != oidOpFamily);
-		gpdb::IndexOpProperties(oidCmpOperator, oidOpFamily, &iSN, &oidIndexSubtype, &fRecheck);
+		OID cmp_operator_oid = CTranslatorUtils::OidCmpOperator(index_cond_expr);
+		GPOS_ASSERT(InvalidOid != cmp_operator_oid);
+		OID op_family_oid = CTranslatorUtils::GetOpFamilyForIndexQual(attno, CMDIdGPDB::CastMdid(index->MDId())->Oid());
+		GPOS_ASSERT(InvalidOid != op_family_oid);
+		gpdb::IndexOpProperties(cmp_operator_oid, op_family_oid, &strategy_num, &index_subtype_oid, &recheck);
 		
 		// create index qual
-		pdrgpindexqualinfo->Append(GPOS_NEW(m_pmp) CIndexQualInfo(iAttno, pexprIndexCond, pexprOrigIndexCond, (StrategyNumber) iSN, oidIndexSubtype));
+		index_qual_info_array->Append(GPOS_NEW(m_mp) CIndexQualInfo(attno, index_cond_expr, original_index_cond_expr, (StrategyNumber) strategy_num, index_subtype_oid));
 	}
 
 	// the index quals much be ordered by attribute number
-	pdrgpindexqualinfo->Sort(CIndexQualInfo::IIndexQualInfoCmp);
+	index_qual_info_array->Sort(CIndexQualInfo::IndexQualInfoCmp);
 
-	ULONG ulLen = pdrgpindexqualinfo->UlLength();
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	ULONG length = index_qual_info_array->Size();
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		CIndexQualInfo *pindexqualinfo = (*pdrgpindexqualinfo)[ul];
-		*pplIndexConditions = gpdb::PlAppendElement(*pplIndexConditions, pindexqualinfo->m_pexpr);
-		*pplIndexOrigConditions = gpdb::PlAppendElement(*pplIndexOrigConditions, pindexqualinfo->m_pexprOriginal);
-		*pplIndexStratgey = gpdb::PlAppendInt(*pplIndexStratgey, pindexqualinfo->m_sn);
-		*pplIndexSubtype = gpdb::PlAppendOid(*pplIndexSubtype, pindexqualinfo->m_oidIndexSubtype);
+		CIndexQualInfo *index_qual_info = (*index_qual_info_array)[ul];
+		*index_cond = gpdb::LAppend(*index_cond, index_qual_info->m_expr);
+		*index_orig_cond = gpdb::LAppend(*index_orig_cond, index_qual_info->m_original_expr);
+		*index_strategy_list = gpdb::LAppendInt(*index_strategy_list, index_qual_info->m_strategy_num);
+		*index_subtype_list = gpdb::LAppendOid(*index_subtype_list, index_qual_info->m_index_subtype_oid);
 	}
 
 	// clean up
-	pdrgpindexqualinfo->Release();
+	index_qual_info_array->Release();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlTranslateAssertConstraints
+//		CTranslatorDXLToPlStmt::TranslateDXLAssertConstraints
 //
 //	@doc:
 //		Translate the constraints from an Assert node into a list of quals
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTranslateAssertConstraints
+CTranslatorDXLToPlStmt::TranslateDXLAssertConstraints
 	(
-	CDXLNode *pdxlnAssertConstraintList,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctx
+	CDXLNode *assert_contraint_list_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *child_contexts
 	)
 {
-	List *plQuals = NIL;
+	List *quals_list = NIL;
 
 	// build colid->var mapping
-	CMappingColIdVarPlStmt mapcidvarplstmt(m_pmp, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
+	CMappingColIdVarPlStmt colid_var_mapping(m_mp, NULL /*base_table_context*/, child_contexts, output_context, m_dxl_to_plstmt_context);
 
-	const ULONG ulArity = pdxlnAssertConstraintList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = assert_contraint_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnpdxlnAssertConstraint = (*pdxlnAssertConstraintList)[ul];
-		Expr *pexprAssertConstraint = m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnpdxlnAssertConstraint)[0], &mapcidvarplstmt);
-		plQuals = gpdb::PlAppendElement(plQuals, pexprAssertConstraint);
+		CDXLNode *assert_contraint_dxlnode = (*assert_contraint_list_dxlnode)[ul];
+		Expr *assert_contraint_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar((*assert_contraint_dxlnode)[0], &colid_var_mapping);
+		quals_list = gpdb::LAppend(quals_list, assert_contraint_expr);
 	}
 
-	return plQuals;
+	return quals_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlimitFromDXLLimit
+//		CTranslatorDXLToPlStmt::TranslateDXLLimit
 //
 //	@doc:
 //		Translates a DXL Limit node into a Limit node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PlimitFromDXLLimit
+CTranslatorDXLToPlStmt::TranslateDXLLimit
 	(
-	const CDXLNode *pdxlnLimit,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *limit_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create limit node
-	Limit *plimit = MakeNode(Limit);
+	Limit *limit = MakeNode(Limit);
 
-	Plan *pplan = &(plimit->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(limit->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnLimit->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(limit_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	GPOS_ASSERT(4 == pdxlnLimit->UlArity());
+	GPOS_ASSERT(4 == limit_dxlnode->Arity());
 
-	CDXLTranslateContext dxltrctxLeft(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext left_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
 	// translate proj list
-	CDXLNode *pdxlnPrL = (*pdxlnLimit)[EdxllimitIndexProjList];
-	CDXLNode *pdxlnChildPlan = (*pdxlnLimit)[EdxllimitIndexChildPlan];
-	CDXLNode *pdxlnLimitCount = (*pdxlnLimit)[EdxllimitIndexLimitCount];
-	CDXLNode *pdxlnLimitOffset = (*pdxlnLimit)[EdxllimitIndexLimitOffset];
+	CDXLNode *project_list_dxlnode = (*limit_dxlnode)[EdxllimitIndexProjList];
+	CDXLNode *child_plan_dxlnode = (*limit_dxlnode)[EdxllimitIndexChildPlan];
+	CDXLNode *limit_count_dxlnode = (*limit_dxlnode)[EdxllimitIndexLimitCount];
+	CDXLNode *limit_offset_dxlnode = (*limit_dxlnode)[EdxllimitIndexLimitOffset];
 
 	// NOTE: Limit node has only the left plan while the right plan is left empty
-	Plan *pplanLeft = PplFromDXL(pdxlnChildPlan, &dxltrctxLeft, pdrgpdxltrctxPrevSiblings);
+	Plan *left_plan = TranslateDXLOperatorToPlan(child_plan_dxlnode, &left_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxLeft);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&left_dxl_translate_ctxt);
 
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 								(
-								pdxlnPrL,
+								project_list_dxlnode,
 								NULL,		// base table translation context
-								pdrgpdxltrctx,
-								pdxltrctxOut
+								child_contexts,
+								output_context
 								);
 
-	pplan->lefttree = pplanLeft;
+	plan->lefttree = left_plan;
 
-	if(NULL != pdxlnLimitCount && pdxlnLimitCount->UlArity() >0)
+	if(NULL != limit_count_dxlnode && limit_count_dxlnode->Arity() >0)
 	{
-		CMappingColIdVarPlStmt mapcidvarplstmt(m_pmp, NULL, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
-		Node *pnodeLimitCount = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnLimitCount)[0], &mapcidvarplstmt);
-		plimit->limitCount = pnodeLimitCount;
+		CMappingColIdVarPlStmt colid_var_mapping(m_mp, NULL, child_contexts, output_context, m_dxl_to_plstmt_context);
+		Node *limit_count = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar((*limit_count_dxlnode)[0], &colid_var_mapping);
+		limit->limitCount = limit_count;
 	}
 
-	if(NULL != pdxlnLimitOffset && pdxlnLimitOffset->UlArity() >0)
+	if(NULL != limit_offset_dxlnode && limit_offset_dxlnode->Arity() >0)
 	{
-		CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt(m_pmp, NULL, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
-		Node *pexprLimitOffset = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnLimitOffset)[0], &mapcidvarplstmt);
-		plimit->limitOffset = pexprLimitOffset;
+		CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt(m_mp, NULL, child_contexts, output_context, m_dxl_to_plstmt_context);
+		Node *limit_offset = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar((*limit_offset_dxlnode)[0], &colid_var_mapping);
+		limit->limitOffset = limit_offset;
 	}
 
-	pplan->nMotionNodes = pplanLeft->nMotionNodes;
-	SetParamIds(pplan);
+	plan->nMotionNodes = left_plan->nMotionNodes;
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return  (Plan *) plimit;
+	return  (Plan *) limit;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PhjFromDXLHJ
+//		CTranslatorDXLToPlStmt::TranslateDXLHashJoin
 //
 //	@doc:
 //		Translates a DXL hash join node into a HashJoin node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PhjFromDXLHJ
+CTranslatorDXLToPlStmt::TranslateDXLHashJoin
 	(
-	const CDXLNode *pdxlnHJ,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *hj_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	GPOS_ASSERT(pdxlnHJ->Pdxlop()->Edxlop() == EdxlopPhysicalHashJoin);
-	GPOS_ASSERT(pdxlnHJ->UlArity() == EdxlhjIndexSentinel);
+	GPOS_ASSERT(hj_dxlnode->GetOperator()->GetDXLOperator() == EdxlopPhysicalHashJoin);
+	GPOS_ASSERT(hj_dxlnode->Arity() == EdxlhjIndexSentinel);
 
 	// create hash join node
-	HashJoin *phj = MakeNode(HashJoin);
+	HashJoin *hashjoin = MakeNode(HashJoin);
 
-	Join *pj = &(phj->join);
-	Plan *pplan = &(pj->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Join *join = &(hashjoin->join);
+	Plan *plan = &(join->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalHashJoin *pdxlopHashJoin = CDXLPhysicalHashJoin::PdxlopConvert(pdxlnHJ->Pdxlop());
+	CDXLPhysicalHashJoin *hashjoin_dxlop = CDXLPhysicalHashJoin::Cast(hj_dxlnode->GetOperator());
 
 	// set join type
-	pj->jointype = JtFromEdxljt(pdxlopHashJoin->Edxltype());
-	pj->prefetch_inner = true;
+	join->jointype = GetGPDBJoinTypeFromDXLJoinType(hashjoin_dxlop->GetJoinType());
+	join->prefetch_inner = true;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnHJ->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(hj_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate join children
-	CDXLNode *pdxlnLeft = (*pdxlnHJ)[EdxlhjIndexHashLeft];
-	CDXLNode *pdxlnRight = (*pdxlnHJ)[EdxlhjIndexHashRight];
-	CDXLNode *pdxlnPrL = (*pdxlnHJ)[EdxlhjIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnHJ)[EdxlhjIndexFilter];
-	CDXLNode *pdxlnJoinFilter = (*pdxlnHJ)[EdxlhjIndexJoinFilter];
-	CDXLNode *pdxlnHashCondList = (*pdxlnHJ)[EdxlhjIndexHashCondList];
+	CDXLNode *left_tree_dxlnode = (*hj_dxlnode)[EdxlhjIndexHashLeft];
+	CDXLNode *right_tree_dxlnode = (*hj_dxlnode)[EdxlhjIndexHashRight];
+	CDXLNode *project_list_dxlnode = (*hj_dxlnode)[EdxlhjIndexProjList];
+	CDXLNode *filter_dxlnode = (*hj_dxlnode)[EdxlhjIndexFilter];
+	CDXLNode *join_filter_dxlnode = (*hj_dxlnode)[EdxlhjIndexJoinFilter];
+	CDXLNode *hash_cond_list_dxlnode = (*hj_dxlnode)[EdxlhjIndexHashCondList];
 
-	CDXLTranslateContext dxltrctxLeft(m_pmp, false, pdxltrctxOut->PhmColParam());
-	CDXLTranslateContext dxltrctxRight(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext left_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
+	CDXLTranslateContext right_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanLeft = PplFromDXL(pdxlnLeft, &dxltrctxLeft, pdrgpdxltrctxPrevSiblings);
+	Plan *left_plan = TranslateDXLOperatorToPlan(left_tree_dxlnode, &left_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
 	// the right side of the join is the one where the hash phase is done
-	DrgPdxltrctx *pdrgpdxltrctxWithSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctxWithSiblings->Append(&dxltrctxLeft);
-	pdrgpdxltrctxWithSiblings->AppendArray(pdrgpdxltrctxPrevSiblings);
-	Plan *pplanRight = (Plan*) PhhashFromDXL(pdxlnRight, &dxltrctxRight, pdrgpdxltrctxWithSiblings);
+	CDXLTranslationContextArray *translation_context_arr_with_siblings = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	translation_context_arr_with_siblings->Append(&left_dxl_translate_ctxt);
+	translation_context_arr_with_siblings->AppendArray(ctxt_translation_prev_siblings);
+	Plan *right_plan = (Plan*) TranslateDXLHash(right_tree_dxlnode, &right_dxl_translate_ctxt, translation_context_arr_with_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxLeft));
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxRight));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&left_dxl_translate_ctxt));
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&right_dxl_translate_ctxt));
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate join filter
-	pj->joinqual = PlQualFromFilter
+	join->joinqual = TranslateDXLFilterToQual
 					(
-					pdxlnJoinFilter,
+					join_filter_dxlnode,
 					NULL,			// translate context for the base table
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					child_contexts,
+					output_context
 					);
 
 	// translate hash cond
-	List *plHashConditions = NIL;
+	List *hash_conditions_list = NIL;
 
-	BOOL fHasINDFCond = false;
+	BOOL has_is_not_distinct_from_cond = false;
 
-	const ULONG ulArity = pdxlnHashCondList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = hash_cond_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnHashCond = (*pdxlnHashCondList)[ul];
+		CDXLNode *hash_cond_dxlnode = (*hash_cond_list_dxlnode)[ul];
 
-		List *plHashCond = PlQualFromScalarCondNode
+		List *hash_cond_list = TranslateDXLScCondToQual
 				(
-				pdxlnHashCond,
+				hash_cond_dxlnode,
 				NULL,			// base table translation context
-				pdrgpdxltrctx,
-				pdxltrctxOut
+				child_contexts,
+				output_context
 				);
 
-		GPOS_ASSERT(1 == gpdb::UlListLength(plHashCond));
+		GPOS_ASSERT(1 == gpdb::ListLength(hash_cond_list));
 
-		Expr *pexpr = (Expr *) LInitial(plHashCond);
-		if (IsA(pexpr, BoolExpr) && ((BoolExpr *) pexpr)->boolop == NOT_EXPR)
+		Expr *expr = (Expr *) LInitial(hash_cond_list);
+		if (IsA(expr, BoolExpr) && ((BoolExpr *) expr)->boolop == NOT_EXPR)
 		{
 			// INDF test
-			GPOS_ASSERT(gpdb::UlListLength(((BoolExpr *) pexpr)->args) == 1 &&
-						(IsA((Expr *) LInitial(((BoolExpr *) pexpr)->args), DistinctExpr)));
-			fHasINDFCond = true;
+			GPOS_ASSERT(gpdb::ListLength(((BoolExpr *) expr)->args) == 1 &&
+						(IsA((Expr *) LInitial(((BoolExpr *) expr)->args), DistinctExpr)));
+			has_is_not_distinct_from_cond = true;
 		}
-		plHashConditions = gpdb::PlConcat(plHashConditions, plHashCond);
+		hash_conditions_list = gpdb::ListConcat(hash_conditions_list, hash_cond_list);
 	}
 
-	if (!fHasINDFCond)
+	if (!has_is_not_distinct_from_cond)
 	{
 		// no INDF conditions in the hash condition list
-		phj->hashclauses = plHashConditions;
+		hashjoin->hashclauses = hash_conditions_list;
 	}
 	else
 	{
 		// hash conditions contain INDF clauses -> extract equality conditions to
 		// construct the hash clauses list
-		List *plHashClauses = NIL;
+		List *hash_clauses_list = NIL;
 
-		for (ULONG ul = 0; ul < ulArity; ul++)
+		for (ULONG ul = 0; ul < arity; ul++)
 		{
-			CDXLNode *pdxlnHashCond = (*pdxlnHashCondList)[ul];
+			CDXLNode *hash_cond_dxlnode = (*hash_cond_list_dxlnode)[ul];
 
 			// condition can be either a scalar comparison or a NOT DISTINCT FROM expression
-			GPOS_ASSERT(EdxlopScalarCmp == pdxlnHashCond->Pdxlop()->Edxlop() ||
-						EdxlopScalarBoolExpr == pdxlnHashCond->Pdxlop()->Edxlop());
+			GPOS_ASSERT(EdxlopScalarCmp == hash_cond_dxlnode->GetOperator()->GetDXLOperator() ||
+						EdxlopScalarBoolExpr == hash_cond_dxlnode->GetOperator()->GetDXLOperator());
 
-			if (EdxlopScalarBoolExpr == pdxlnHashCond->Pdxlop()->Edxlop())
+			if (EdxlopScalarBoolExpr == hash_cond_dxlnode->GetOperator()->GetDXLOperator())
 			{
 				// clause is a NOT DISTINCT FROM check -> extract the distinct comparison node
-				GPOS_ASSERT(Edxlnot == CDXLScalarBoolExpr::PdxlopConvert(pdxlnHashCond->Pdxlop())->EdxlBoolType());
-				pdxlnHashCond = (*pdxlnHashCond)[0];
-				GPOS_ASSERT(EdxlopScalarDistinct == pdxlnHashCond->Pdxlop()->Edxlop());
+				GPOS_ASSERT(Edxlnot == CDXLScalarBoolExpr::Cast(hash_cond_dxlnode->GetOperator())->GetDxlBoolTypeStr());
+				hash_cond_dxlnode = (*hash_cond_dxlnode)[0];
+				GPOS_ASSERT(EdxlopScalarDistinct == hash_cond_dxlnode->GetOperator()->GetDXLOperator());
 			}
 
-			CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+			CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 														(
-														m_pmp,
+														m_mp,
 														NULL,
-														pdrgpdxltrctx,
-														pdxltrctxOut,
-														m_pctxdxltoplstmt
+														child_contexts,
+														output_context,
+														m_dxl_to_plstmt_context
 														);
 
 			// translate the DXL scalar or scalar distinct comparison into an equality comparison
 			// to store in the hash clauses
-			Expr *pexpr2 = (Expr *) m_pdxlsctranslator->PopexprFromDXLNodeScCmp
+			Expr *hash_clause_expr = (Expr *) m_translator_dxl_to_scalar->TranslateDXLScalarCmpToScalar
 									(
-									pdxlnHashCond,
-									&mapcidvarplstmt
+									hash_cond_dxlnode,
+									&colid_var_mapping
 									);
 
-			plHashClauses = gpdb::PlAppendElement(plHashClauses, pexpr2);
+			hash_clauses_list = gpdb::LAppend(hash_clauses_list, hash_clause_expr);
 		}
 
-		phj->hashclauses = plHashClauses;
-		phj->hashqualclauses = plHashConditions;
+		hashjoin->hashclauses = hash_clauses_list;
+		hashjoin->hashqualclauses = hash_conditions_list;
 	}
 
-	GPOS_ASSERT(NIL != phj->hashclauses);
+	GPOS_ASSERT(NIL != hashjoin->hashclauses);
 
-	pplan->lefttree = pplanLeft;
-	pplan->righttree = pplanRight;
-	pplan->nMotionNodes = pplanLeft->nMotionNodes + pplanRight->nMotionNodes;
-	SetParamIds(pplan);
+	plan->lefttree = left_plan;
+	plan->righttree = right_plan;
+	plan->nMotionNodes = left_plan->nMotionNodes + right_plan->nMotionNodes;
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctxWithSiblings->Release();
-	pdrgpdxltrctx->Release();
+	translation_context_arr_with_siblings->Release();
+	child_contexts->Release();
 
-	return  (Plan *) phj;
+	return  (Plan *) hashjoin;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanFunctionScanFromDXLTVF
+//		CTranslatorDXLToPlStmt::TranslateDXLTvf
 //
 //	@doc:
 //		Translates a DXL TVF node into a GPDB Function scan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanFunctionScanFromDXLTVF
+CTranslatorDXLToPlStmt::TranslateDXLTvf
 	(
-	const CDXLNode *pdxlnTVF,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *tvf_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translation context for column mappings
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// create function scan node
-	FunctionScan *pfuncscan = MakeNode(FunctionScan);
-	Plan *pplan = &(pfuncscan->scan.plan);
+	FunctionScan *func_scan = MakeNode(FunctionScan);
+	Plan *plan = &(func_scan->scan.plan);
 
-	RangeTblEntry *prte = PrteFromDXLTVF(pdxlnTVF, pdxltrctxOut, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
+	RangeTblEntry *rte = TranslateDXLTvfToRangeTblEntry(tvf_dxlnode, output_context, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
 
-	pfuncscan->funcexpr = prte->funcexpr;
-	pfuncscan->funccolnames = prte->eref->colnames;
+	func_scan->funcexpr = rte->funcexpr;
+	func_scan->funccolnames = rte->eref->colnames;
 
 	// we will add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
-	dxltrctxbt.SetIdx(iRel);
-	pfuncscan->scan.scanrelid = iRel;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
+	base_table_context.SetRelIndex(index);
+	func_scan->scan.scanrelid = index;
 
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnTVF->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(tvf_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// a table scan node must have at least 1 child: projection list
-	GPOS_ASSERT(1 <= pdxlnTVF->UlArity());
+	GPOS_ASSERT(1 <= tvf_dxlnode->Arity());
 
-	CDXLNode *pdxlnPrL = (*pdxlnTVF)[EdxltsIndexProjList];
+	CDXLNode *project_list_dxlnode = (*tvf_dxlnode)[EdxltsIndexProjList];
 
 	// translate proj list
-	List *plTargetList = PlTargetListFromProjList
+	List *target_list = TranslateDXLProjList
 						(
-						pdxlnPrL,
-						&dxltrctxbt,
+						project_list_dxlnode,
+						&base_table_context,
 						NULL,
-						pdxltrctxOut
+						output_context
 						);
 
-	pplan->targetlist = plTargetList;
+	plan->targetlist = target_list;
 
-	ListCell *plcTe = NULL;
+	ListCell *lc_target_entry = NULL;
 
-	ForEach (plcTe, plTargetList)
+	ForEach (lc_target_entry, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTe);
-		OID oidType = gpdb::OidExprType((Node*) pte->expr);
-		GPOS_ASSERT(InvalidOid != oidType);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc_target_entry);
+		OID oid_type = gpdb::ExprType((Node*) target_entry->expr);
+		GPOS_ASSERT(InvalidOid != oid_type);
 
-		INT typMod = gpdb::IExprTypeMod((Node*) pte->expr);
+		INT typ_mod = gpdb::ExprTypeMod((Node*) target_entry->expr);
 
-		pfuncscan->funccoltypes = gpdb::PlAppendOid(pfuncscan->funccoltypes, oidType);
-		pfuncscan->funccoltypmods = gpdb::PlAppendInt(pfuncscan->funccoltypmods, typMod);
+		func_scan->funccoltypes = gpdb::LAppendOid(func_scan->funccoltypes, oid_type);
+		func_scan->funccoltypmods = gpdb::LAppendInt(func_scan->funccoltypmods, typ_mod);
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pfuncscan;
+	return (Plan *) func_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PrteFromDXLTVF
+//		CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry
 //
 //	@doc:
 //		Create a range table entry from a CDXLPhysicalTVF node
 //
 //---------------------------------------------------------------------------
 RangeTblEntry *
-CTranslatorDXLToPlStmt::PrteFromDXLTVF
+CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry
 	(
-	const CDXLNode *pdxlnTVF,
-	CDXLTranslateContext *pdxltrctxOut,
-	CDXLTranslateContextBaseTable *pdxltrctxbt
+	const CDXLNode *tvf_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslateContextBaseTable *base_table_context
 	)
 {
-	CDXLPhysicalTVF *pdxlop = CDXLPhysicalTVF::PdxlopConvert(pdxlnTVF->Pdxlop());
+	CDXLPhysicalTVF *dxlop = CDXLPhysicalTVF::Cast(tvf_dxlnode->GetOperator());
 
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
-	prte->rtekind = RTE_FUNCTION;
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
+	rte->rtekind = RTE_FUNCTION;
 
-	FuncExpr *pfuncexpr = MakeNode(FuncExpr);
+	FuncExpr *func_expr = MakeNode(FuncExpr);
 
-	pfuncexpr->funcid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidFunc())->OidObjectId();
-	pfuncexpr->funcretset = true;
+	func_expr->funcid = CMDIdGPDB::CastMdid(dxlop->FuncMdId())->Oid();
+	func_expr->funcretset = true;
 	// this is a function call, as opposed to a cast
-	pfuncexpr->funcformat = COERCE_EXPLICIT_CALL;
-	pfuncexpr->funcresulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidRetType())->OidObjectId();
+	func_expr->funcformat = COERCE_EXPLICIT_CALL;
+	func_expr->funcresulttype = CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
 
-	Alias *palias = MakeNode(Alias);
-	palias->colnames = NIL;
+	Alias *alias = MakeNode(Alias);
+	alias->colnames = NIL;
 
 	// get function alias
-	palias->aliasname = CTranslatorUtils::SzFromWsz(pdxlop->Pstr()->Wsz());
+	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxlop->Pstr()->GetBuffer());
 
 	// project list
-	CDXLNode *pdxlnPrL = (*pdxlnTVF)[EdxltsIndexProjList];
+	CDXLNode *project_list_dxlnode = (*tvf_dxlnode)[EdxltsIndexProjList];
 
 	// get column names
-	const ULONG ulCols = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulCols; ul++)
+	const ULONG num_of_cols = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < num_of_cols; ul++)
 	{
-		CDXLNode *pdxlnPrElem = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrEl = CDXLScalarProjElem::PdxlopConvert(pdxlnPrElem->Pdxlop());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		CDXLScalarProjElem *dxl_proj_elem = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
 
-		CHAR *szColName = CTranslatorUtils::SzFromWsz(pdxlopPrEl->PmdnameAlias()->Pstr()->Wsz());
+		CHAR *col_name_char_array = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxl_proj_elem->GetMdNameAlias()->GetMDName()->GetBuffer());
 
-		Value *pvalColName = gpdb::PvalMakeString(szColName);
-		palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalColName);
+		Value *val_colname = gpdb::MakeStringValue(col_name_char_array);
+		alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
 
 		// save mapping col id -> index in translate context
-		(void) pdxltrctxbt->FInsertMapping(pdxlopPrEl->UlId(), ul+1 /*iAttno*/);
+		(void) base_table_context->InsertMapping(dxl_proj_elem->Id(), ul+1 /*attno*/);
 	}
 
 	// function arguments
-	const ULONG ulChildren = pdxlnTVF->UlArity();
-	for (ULONG ul = 1; ul < ulChildren; ++ul)
+	const ULONG num_of_child = tvf_dxlnode->Arity();
+	for (ULONG ul = 1; ul < num_of_child; ++ul)
 	{
-		CDXLNode *pdxlnFuncArg = (*pdxlnTVF)[ul];
+		CDXLNode *func_arg_dxlnode = (*tvf_dxlnode)[ul];
 
-		CMappingColIdVarPlStmt mapcidvarplstmt
+		CMappingColIdVarPlStmt colid_var_mapping
 									(
-									m_pmp,
-									pdxltrctxbt,
+									m_mp,
+									base_table_context,
 									NULL,
-									pdxltrctxOut,
-									m_pctxdxltoplstmt
+									output_context,
+									m_dxl_to_plstmt_context
 									);
 
-		Expr *pexprFuncArg = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnFuncArg, &mapcidvarplstmt);
-		pfuncexpr->args = gpdb::PlAppendElement(pfuncexpr->args, pexprFuncArg);
+		Expr *pexprFuncArg = m_translator_dxl_to_scalar->TranslateDXLToScalar(func_arg_dxlnode, &colid_var_mapping);
+		func_expr->args = gpdb::LAppend(func_expr->args, pexprFuncArg);
 	}
 
-	prte->funcexpr = (Node *)pfuncexpr;
-	prte->inFromCl = true;
-	prte->eref = palias;
+	rte->funcexpr = (Node *)func_expr;
+	rte->inFromCl = true;
+	rte->eref = alias;
 
-	return prte;
+	return rte;
 }
 
 
 // create a range table entry from a CDXLPhysicalValuesScan node
 RangeTblEntry *
-CTranslatorDXLToPlStmt::PrteFromDXLValueScan
+CTranslatorDXLToPlStmt::TranslateDXLValueScanToRangeTblEntry
 	(
-	const CDXLNode *pdxlnValueScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	CDXLTranslateContextBaseTable *pdxltrctxbt
+	const CDXLNode *value_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslateContextBaseTable *base_table_context
 	)
 {
-	CDXLPhysicalValuesScan *pdxlop = CDXLPhysicalValuesScan::PdxlopConvert(pdxlnValueScan->Pdxlop());
+	CDXLPhysicalValuesScan *phy_values_scan_dxlop = CDXLPhysicalValuesScan::Cast(value_scan_dxlnode->GetOperator());
 
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
 
-	prte->relid = InvalidOid;
-	prte->subquery = NULL;
-	prte->rtekind = RTE_VALUES;
-	prte->inh = false;			/* never true for values RTEs */
-	prte->inFromCl = true;
-	prte->requiredPerms = 0;
-	prte->checkAsUser = InvalidOid;
+	rte->relid = InvalidOid;
+	rte->subquery = NULL;
+	rte->rtekind = RTE_VALUES;
+	rte->inh = false;			/* never true for values RTEs */
+	rte->inFromCl = true;
+	rte->requiredPerms = 0;
+	rte->checkAsUser = InvalidOid;
 
-	Alias *palias = MakeNode(Alias);
-	palias->colnames = NIL;
+	Alias *alias = MakeNode(Alias);
+	alias->colnames = NIL;
 
 	// get value alias
-	palias->aliasname = CTranslatorUtils::SzFromWsz(pdxlop->PstrOpName()->Wsz());
+	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(phy_values_scan_dxlop->GetOpNameStr()->GetBuffer());
 
 	// project list
-	CDXLNode *pdxlnPrL = (*pdxlnValueScan)[EdxltsIndexProjList];
+	CDXLNode *project_list_dxlnode = (*value_scan_dxlnode)[EdxltsIndexProjList];
 
 	// get column names
-	const ULONG ulCols = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulCols; ul++)
+	const ULONG num_of_cols = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < num_of_cols; ul++)
 	{
-		CDXLNode *pdxlnPrElem = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrEl = CDXLScalarProjElem::PdxlopConvert(pdxlnPrElem->Pdxlop());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		CDXLScalarProjElem *dxl_proj_elem = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
 
-		CHAR *szColName = CTranslatorUtils::SzFromWsz(pdxlopPrEl->PmdnameAlias()->Pstr()->Wsz());
+		CHAR *col_name_char_array = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxl_proj_elem->GetMdNameAlias()->GetMDName()->GetBuffer());
 
-		Value *pvalColName = gpdb::PvalMakeString(szColName);
-		palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalColName);
+		Value *val_colname = gpdb::MakeStringValue(col_name_char_array);
+		alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
 
 		// save mapping col id -> index in translate context
-		(void) pdxltrctxbt->FInsertMapping(pdxlopPrEl->UlId(), ul+1 /*iAttno*/);
+		(void) base_table_context->InsertMapping(dxl_proj_elem->Id(), ul+1 /*attno*/);
 	}
 
-	CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt(m_pmp, pdxltrctxbt, NULL, pdxltrctxOut, m_pctxdxltoplstmt);
-	const ULONG ulChildren = pdxlnValueScan->UlArity();
+	CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt(m_mp, base_table_context, NULL, output_context, m_dxl_to_plstmt_context);
+	const ULONG num_of_child = value_scan_dxlnode->Arity();
 	List *values_lists = NIL;
-	for (ULONG ulValue = EdxlValIndexConstStart; ulValue < ulChildren; ulValue++)
+	for (ULONG ulValue = EdxlValIndexConstStart; ulValue < num_of_child; ulValue++)
 	{
-		CDXLNode *pdxlnValueList = (*pdxlnValueScan)[ulValue];
-		const ULONG ulCols = pdxlnValueList->UlArity();
+		CDXLNode *value_list_dxlnode = (*value_scan_dxlnode)[ulValue];
+		const ULONG num_of_cols = value_list_dxlnode->Arity();
 		List *value = NIL;
-		for (ULONG ulCol = 0; ulCol < ulCols ; ulCol++)
+		for (ULONG ulCol = 0; ulCol < num_of_cols ; ulCol++)
 		{
-			Expr *pconst = m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnValueList)[ulCol], &mapcidvarplstmt);
-			value = gpdb::PlAppendElement(value, pconst);
+			Expr *const_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar((*value_list_dxlnode)[ulCol], &colid_var_mapping);
+			value = gpdb::LAppend(value, const_expr);
 		}
-		values_lists = gpdb::PlAppendElement(values_lists, value);
+		values_lists = gpdb::LAppend(values_lists, value);
 	}
 
-	prte->values_lists = (List *) values_lists;
-	prte->eref = palias;
+	rte->values_lists = (List *) values_lists;
+	rte->eref = alias;
 
-	return prte;
+	return rte;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PnljFromDXLNLJ
+//		CTranslatorDXLToPlStmt::TranslateDXLNLJoin
 //
 //	@doc:
 //		Translates a DXL nested loop join node into a NestLoop plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PnljFromDXLNLJ
+CTranslatorDXLToPlStmt::TranslateDXLNLJoin
 	(
-	const CDXLNode *pdxlnNLJ,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *nl_join_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	GPOS_ASSERT(pdxlnNLJ->Pdxlop()->Edxlop() == EdxlopPhysicalNLJoin);
-	GPOS_ASSERT(pdxlnNLJ->UlArity() == EdxlnljIndexSentinel);
+	GPOS_ASSERT(nl_join_dxlnode->GetOperator()->GetDXLOperator() == EdxlopPhysicalNLJoin);
+	GPOS_ASSERT(nl_join_dxlnode->Arity() == EdxlnljIndexSentinel);
 
 	// create hash join node
-	NestLoop *pnlj = MakeNode(NestLoop);
+	NestLoop *nested_loop = MakeNode(NestLoop);
 
-	Join *pj = &(pnlj->join);
-	Plan *pplan = &(pj->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Join *join = &(nested_loop->join);
+	Plan *plan = &(join->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalNLJoin *pdxlnlj = CDXLPhysicalNLJoin::PdxlConvert(pdxlnNLJ->Pdxlop());
+	CDXLPhysicalNLJoin *dxl_nlj = CDXLPhysicalNLJoin::PdxlConvert(nl_join_dxlnode->GetOperator());
 
 	// set join type
-	pj->jointype = JtFromEdxljt(pdxlnlj->Edxltype());
+	join->jointype = GetGPDBJoinTypeFromDXLJoinType(dxl_nlj->GetJoinType());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnNLJ->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(nl_join_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate join children
-	CDXLNode *pdxlnLeft = (*pdxlnNLJ)[EdxlnljIndexLeftChild];
-	CDXLNode *pdxlnRight = (*pdxlnNLJ)[EdxlnljIndexRightChild];
+	CDXLNode *left_tree_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexLeftChild];
+	CDXLNode *right_tree_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexRightChild];
 
-	CDXLNode *pdxlnPrL = (*pdxlnNLJ)[EdxlnljIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnNLJ)[EdxlnljIndexFilter];
-	CDXLNode *pdxlnJoinFilter = (*pdxlnNLJ)[EdxlnljIndexJoinFilter];
+	CDXLNode *project_list_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexProjList];
+	CDXLNode *filter_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexFilter];
+	CDXLNode *join_filter_dxlnode = (*nl_join_dxlnode)[EdxlnljIndexJoinFilter];
 
-	CDXLTranslateContext dxltrctxLeft(m_pmp, false, pdxltrctxOut->PhmColParam());
-	CDXLTranslateContext dxltrctxRight(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext left_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
+	CDXLTranslateContext right_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
 	// setting of prefetch_inner to true except for the case of index NLJ where we cannot prefetch inner
 	// because inner child depends on variables coming from outer child
-	pj->prefetch_inner = !pdxlnlj->FIndexNLJ();
+	join->prefetch_inner = !dxl_nlj->IsIndexNLJ();
 
-	DrgPdxltrctx *pdrgpdxltrctxWithSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	Plan *pplanLeft = NULL;
-	Plan *pplanRight = NULL;
-	if (pdxlnlj->FIndexNLJ())
+	CDXLTranslationContextArray *translation_context_arr_with_siblings = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	Plan *left_plan = NULL;
+	Plan *right_plan = NULL;
+	if (dxl_nlj->IsIndexNLJ())
 	{
 		// right child (the index scan side) has references to left child's columns,
 		// we need to translate left child first to load its columns into translation context
-		pplanLeft = PplFromDXL(pdxlnLeft, &dxltrctxLeft, pdrgpdxltrctxPrevSiblings);
+		left_plan = TranslateDXLOperatorToPlan(left_tree_dxlnode, &left_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-		pdrgpdxltrctxWithSiblings->Append(&dxltrctxLeft);
-		 pdrgpdxltrctxWithSiblings->AppendArray(pdrgpdxltrctxPrevSiblings);
+		translation_context_arr_with_siblings->Append(&left_dxl_translate_ctxt);
+		 translation_context_arr_with_siblings->AppendArray(ctxt_translation_prev_siblings);
 
 		 // translate right child after left child translation is complete
-		pplanRight = PplFromDXL(pdxlnRight, &dxltrctxRight, pdrgpdxltrctxWithSiblings);
+		right_plan = TranslateDXLOperatorToPlan(right_tree_dxlnode, &right_dxl_translate_ctxt, translation_context_arr_with_siblings);
 	}
 	else
 	{
 		// left child may include a PartitionSelector with references to right child's columns,
 		// we need to translate right child first to load its columns into translation context
-		pplanRight = PplFromDXL(pdxlnRight, &dxltrctxRight, pdrgpdxltrctxPrevSiblings);
+		right_plan = TranslateDXLOperatorToPlan(right_tree_dxlnode, &right_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-		pdrgpdxltrctxWithSiblings->Append(&dxltrctxRight);
-		pdrgpdxltrctxWithSiblings->AppendArray(pdrgpdxltrctxPrevSiblings);
+		translation_context_arr_with_siblings->Append(&right_dxl_translate_ctxt);
+		translation_context_arr_with_siblings->AppendArray(ctxt_translation_prev_siblings);
 
 		// translate left child after right child translation is complete
-		pplanLeft = PplFromDXL(pdxlnLeft, &dxltrctxLeft, pdrgpdxltrctxWithSiblings);
+		left_plan = TranslateDXLOperatorToPlan(left_tree_dxlnode, &left_dxl_translate_ctxt, translation_context_arr_with_siblings);
 	}
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxLeft);
-	pdrgpdxltrctx->Append(&dxltrctxRight);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&left_dxl_translate_ctxt);
+	child_contexts->Append(&right_dxl_translate_ctxt);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate join condition
-	pj->joinqual = PlQualFromFilter
+	join->joinqual = TranslateDXLFilterToQual
 					(
-					pdxlnJoinFilter,
+					join_filter_dxlnode,
 					NULL,			// translate context for the base table
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					child_contexts,
+					output_context
 					);
 
-	pplan->lefttree = pplanLeft;
-	pplan->righttree = pplanRight;
-	pplan->nMotionNodes = pplanLeft->nMotionNodes + pplanRight->nMotionNodes;
-	SetParamIds(pplan);
+	plan->lefttree = left_plan;
+	plan->righttree = right_plan;
+	plan->nMotionNodes = left_plan->nMotionNodes + right_plan->nMotionNodes;
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctxWithSiblings->Release();
-	pdrgpdxltrctx->Release();
+	translation_context_arr_with_siblings->Release();
+	child_contexts->Release();
 
-	return  (Plan *) pnlj;
+	return  (Plan *) nested_loop;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PmjFromDXLMJ
+//		CTranslatorDXLToPlStmt::TranslateDXLMergeJoin
 //
 //	@doc:
 //		Translates a DXL merge join node into a MergeJoin node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PmjFromDXLMJ
+CTranslatorDXLToPlStmt::TranslateDXLMergeJoin
 	(
-	const CDXLNode *pdxlnMJ,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *merge_join_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	GPOS_ASSERT(pdxlnMJ->Pdxlop()->Edxlop() == EdxlopPhysicalMergeJoin);
-	GPOS_ASSERT(pdxlnMJ->UlArity() == EdxlmjIndexSentinel);
+	GPOS_ASSERT(merge_join_dxlnode->GetOperator()->GetDXLOperator() == EdxlopPhysicalMergeJoin);
+	GPOS_ASSERT(merge_join_dxlnode->Arity() == EdxlmjIndexSentinel);
 
 	// create merge join node
-	MergeJoin *pmj = MakeNode(MergeJoin);
+	MergeJoin *merge_join = MakeNode(MergeJoin);
 
-	Join *pj = &(pmj->join);
-	Plan *pplan = &(pj->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Join *join = &(merge_join->join);
+	Plan *plan = &(join->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalMergeJoin *pdxlopMergeJoin = CDXLPhysicalMergeJoin::PdxlopConvert(pdxlnMJ->Pdxlop());
+	CDXLPhysicalMergeJoin *merge_join_dxlop = CDXLPhysicalMergeJoin::Cast(merge_join_dxlnode->GetOperator());
 
 	// set join type
-	pj->jointype = JtFromEdxljt(pdxlopMergeJoin->Edxltype());
+	join->jointype = GetGPDBJoinTypeFromDXLJoinType(merge_join_dxlop->GetJoinType());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnMJ->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(merge_join_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate join children
-	CDXLNode *pdxlnLeft = (*pdxlnMJ)[EdxlmjIndexLeftChild];
-	CDXLNode *pdxlnRight = (*pdxlnMJ)[EdxlmjIndexRightChild];
+	CDXLNode *left_tree_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexLeftChild];
+	CDXLNode *right_tree_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexRightChild];
 
-	CDXLNode *pdxlnPrL = (*pdxlnMJ)[EdxlmjIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnMJ)[EdxlmjIndexFilter];
-	CDXLNode *pdxlnJoinFilter = (*pdxlnMJ)[EdxlmjIndexJoinFilter];
-	CDXLNode *pdxlnMergeCondList = (*pdxlnMJ)[EdxlmjIndexMergeCondList];
+	CDXLNode *project_list_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexProjList];
+	CDXLNode *filter_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexFilter];
+	CDXLNode *join_filter_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexJoinFilter];
+	CDXLNode *merge_cond_list_dxlnode = (*merge_join_dxlnode)[EdxlmjIndexMergeCondList];
 
-	CDXLTranslateContext dxltrctxLeft(m_pmp, false, pdxltrctxOut->PhmColParam());
-	CDXLTranslateContext dxltrctxRight(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext left_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
+	CDXLTranslateContext right_dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanLeft = PplFromDXL(pdxlnLeft, &dxltrctxLeft, pdrgpdxltrctxPrevSiblings);
+	Plan *left_plan = TranslateDXLOperatorToPlan(left_tree_dxlnode, &left_dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctxWithSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctxWithSiblings->Append(&dxltrctxLeft);
-	pdrgpdxltrctxWithSiblings->AppendArray(pdrgpdxltrctxPrevSiblings);
+	CDXLTranslationContextArray *translation_context_arr_with_siblings = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	translation_context_arr_with_siblings->Append(&left_dxl_translate_ctxt);
+	translation_context_arr_with_siblings->AppendArray(ctxt_translation_prev_siblings);
 
-	Plan *pplanRight = PplFromDXL(pdxlnRight, &dxltrctxRight, pdrgpdxltrctxWithSiblings);
+	Plan *right_plan = TranslateDXLOperatorToPlan(right_tree_dxlnode, &right_dxl_translate_ctxt, translation_context_arr_with_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxLeft));
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxRight));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&left_dxl_translate_ctxt));
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&right_dxl_translate_ctxt));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate join filter
-	pj->joinqual = PlQualFromFilter
+	join->joinqual = TranslateDXLFilterToQual
 					(
-					pdxlnJoinFilter,
+					join_filter_dxlnode,
 					NULL,			// translate context for the base table
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					child_contexts,
+					output_context
 					);
 
 	// translate merge cond
-	List *plMergeConditions = NIL;
+	List *merge_conditions_list = NIL;
 
-	const ULONG ulArity = pdxlnMergeCondList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = merge_cond_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnMergeCond = (*pdxlnMergeCondList)[ul];
-		List *plMergeCond = PlQualFromScalarCondNode
+		CDXLNode *merge_condition_dxlnode = (*merge_cond_list_dxlnode)[ul];
+		List *merge_condition_list = TranslateDXLScCondToQual
 				(
-				pdxlnMergeCond,
+				merge_condition_dxlnode,
 				NULL,			// base table translation context
-				pdrgpdxltrctx,
-				pdxltrctxOut
+				child_contexts,
+				output_context
 				);
 
-		GPOS_ASSERT(1 == gpdb::UlListLength(plMergeCond));
-		plMergeConditions = gpdb::PlConcat(plMergeConditions, plMergeCond);
+		GPOS_ASSERT(1 == gpdb::ListLength(merge_condition_list));
+		merge_conditions_list = gpdb::ListConcat(merge_conditions_list, merge_condition_list);
 	}
 
-	GPOS_ASSERT(NIL != plMergeConditions);
+	GPOS_ASSERT(NIL != merge_conditions_list);
 
-	pmj->mergeclauses = plMergeConditions;
+	merge_join->mergeclauses = merge_conditions_list;
 
-	pplan->lefttree = pplanLeft;
-	pplan->righttree = pplanRight;
-	pplan->nMotionNodes = pplanLeft->nMotionNodes + pplanRight->nMotionNodes;
-	SetParamIds(pplan);
+	plan->lefttree = left_plan;
+	plan->righttree = right_plan;
+	plan->nMotionNodes = left_plan->nMotionNodes + right_plan->nMotionNodes;
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctxWithSiblings->Release();
-	pdrgpdxltrctx->Release();
+	translation_context_arr_with_siblings->Release();
+	child_contexts->Release();
 
-	return  (Plan *) pmj;
+	return  (Plan *) merge_join;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PhhashFromDXL
+//		CTranslatorDXLToPlStmt::TranslateDXLHash
 //
 //	@doc:
 //		Translates a DXL physical operator node into a Hash node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PhhashFromDXL
+CTranslatorDXLToPlStmt::TranslateDXLHash
 	(
-	const CDXLNode *pdxln,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	Hash *ph = MakeNode(Hash);
+	Hash *hash = MakeNode(Hash);
 
-	Plan *pplan = &(ph->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(hash->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate dxl node
-	CDXLTranslateContext dxltrctx(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanLeft = PplFromDXL(pdxln, &dxltrctx, pdrgpdxltrctxPrevSiblings);
+	Plan *left_plan = TranslateDXLOperatorToPlan(dxlnode, &dxl_translate_ctxt, ctxt_translation_prev_siblings);
 
-	GPOS_ASSERT(0 < pdxln->UlArity());
+	GPOS_ASSERT(0 < dxlnode->Arity());
 
 	// create a reference to each entry in the child project list to create the target list of
 	// the hash node
-	CDXLNode *pdxlnPrL = (*pdxln)[0];
-	List *plTargetList = PlTargetListForHashNode(pdxlnPrL, &dxltrctx, pdxltrctxOut);
+	CDXLNode *project_list_dxlnode = (*dxlnode)[0];
+	List *target_list = TranslateDXLProjectListToHashTargetList(project_list_dxlnode, &dxl_translate_ctxt, output_context);
 
 	// copy costs from child node; the startup cost for the hash node is the total cost
 	// of the child plan, see make_hash in createplan.c
-	pplan->startup_cost = pplanLeft->total_cost;
-	pplan->total_cost = pplanLeft->total_cost;
-	pplan->plan_rows = pplanLeft->plan_rows;
-	pplan->plan_width = pplanLeft->plan_width;
+	plan->startup_cost = left_plan->total_cost;
+	plan->total_cost = left_plan->total_cost;
+	plan->plan_rows = left_plan->plan_rows;
+	plan->plan_width = left_plan->plan_width;
 
-	pplan->targetlist = plTargetList;
-	pplan->lefttree = pplanLeft;
-	pplan->righttree = NULL;
-	pplan->nMotionNodes = pplanLeft->nMotionNodes;
-	pplan->qual = NIL;
-	ph->rescannable = false;
+	plan->targetlist = target_list;
+	plan->lefttree = left_plan;
+	plan->righttree = NULL;
+	plan->nMotionNodes = left_plan->nMotionNodes;
+	plan->qual = NIL;
+	hash->rescannable = false;
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) ph;
+	return (Plan *) hash;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanTranslateDXLMotion
+//		CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion
 //
 //	@doc:
 //		Translate DXL motion node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanTranslateDXLMotion
+CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion
 	(
-	const CDXLNode *pdxlnMotion,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *motion_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalMotion *pdxlopMotion = CDXLPhysicalMotion::PdxlopConvert(pdxlnMotion->Pdxlop());
-	if (CTranslatorUtils::FDuplicateSensitiveMotion(pdxlopMotion))
+	CDXLPhysicalMotion *motion_dxlop = CDXLPhysicalMotion::Cast(motion_dxlnode->GetOperator());
+	if (CTranslatorUtils::IsDuplicateSensitiveMotion(motion_dxlop))
 	{
-		return PplanResultHashFilters(pdxlnMotion, pdxltrctxOut, pdrgpdxltrctxPrevSiblings);
+		return TranslateDXLRedistributeMotionToResultHashFilters(motion_dxlnode, output_context, ctxt_translation_prev_siblings);
 	}
 	
-	return PplanMotionFromDXLMotion(pdxlnMotion, pdxltrctxOut, pdrgpdxltrctxPrevSiblings);
+	return TranslateDXLMotion(motion_dxlnode, output_context, ctxt_translation_prev_siblings);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion
+//		CTranslatorDXLToPlStmt::TranslateDXLMotion
 //
 //	@doc:
 //		Translate DXL motion node into GPDB Motion plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion
+CTranslatorDXLToPlStmt::TranslateDXLMotion
 	(
-	const CDXLNode *pdxlnMotion,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *motion_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalMotion *pdxlopMotion = CDXLPhysicalMotion::PdxlopConvert(pdxlnMotion->Pdxlop());
+	CDXLPhysicalMotion *motion_dxlop = CDXLPhysicalMotion::Cast(motion_dxlnode->GetOperator());
 
 	// create motion node
-	Motion *pmotion = MakeNode(Motion);
+	Motion *motion = MakeNode(Motion);
 
-	Plan *pplan = &(pmotion->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(motion->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnMotion->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(motion_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	CDXLNode *pdxlnPrL = (*pdxlnMotion)[EdxlgmIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnMotion)[EdxlgmIndexFilter];
-	CDXLNode *pdxlnSortColList = (*pdxlnMotion)[EdxlgmIndexSortColList];
+	CDXLNode *project_list_dxlnode = (*motion_dxlnode)[EdxlgmIndexProjList];
+	CDXLNode *filter_dxlnode = (*motion_dxlnode)[EdxlgmIndexFilter];
+	CDXLNode *sort_col_list_dxl = (*motion_dxlnode)[EdxlgmIndexSortColList];
 
 	// translate motion child
 	// child node is in the same position in broadcast and gather motion nodes
 	// but different in redistribute motion nodes
 
-	ULONG ulChildIndex = pdxlopMotion->UlChildIndex();
+	ULONG child_index = motion_dxlop->GetRelationChildIdx();
 
-	CDXLNode *pdxlnChild = (*pdxlnMotion)[ulChildIndex];
+	CDXLNode *child_dxlnode = (*motion_dxlnode)[child_index];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate sorting info
-	ULONG ulNumSortCols = pdxlnSortColList->UlArity();
-	if (0 < ulNumSortCols)
+	ULONG num_sort_cols = sort_col_list_dxl->Arity();
+	if (0 < num_sort_cols)
 	{
-		pmotion->sendSorted = true;
-		pmotion->numSortCols = ulNumSortCols;
-		pmotion->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(ulNumSortCols * sizeof(AttrNumber));
-		pmotion->sortOperators = (Oid *) gpdb::GPDBAlloc(ulNumSortCols * sizeof(Oid));
-		pmotion->nullsFirst = (bool *) gpdb::GPDBAlloc(ulNumSortCols * sizeof(bool));
+		motion->sendSorted = true;
+		motion->numSortCols = num_sort_cols;
+		motion->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(num_sort_cols * sizeof(AttrNumber));
+		motion->sortOperators = (Oid *) gpdb::GPDBAlloc(num_sort_cols * sizeof(Oid));
+		motion->nullsFirst = (bool *) gpdb::GPDBAlloc(num_sort_cols * sizeof(bool));
 
-		TranslateSortCols(pdxlnSortColList, pdxltrctxOut, pmotion->sortColIdx, pmotion->sortOperators, pmotion->nullsFirst);
+		TranslateSortCols(sort_col_list_dxl, output_context, motion->sortColIdx, motion->sortOperators, motion->nullsFirst);
 	}
 	else
 	{
 		// not a sorting motion
-		pmotion->sendSorted = false;
-		pmotion->numSortCols = 0;
-		pmotion->sortColIdx = NULL;
-		pmotion->sortOperators = NULL;
-		pmotion->nullsFirst = NULL;
+		motion->sendSorted = false;
+		motion->numSortCols = 0;
+		motion->sortColIdx = NULL;
+		motion->sortOperators = NULL;
+		motion->nullsFirst = NULL;
 	}
 
-	if (pdxlopMotion->Edxlop() == EdxlopPhysicalMotionRedistribute ||
-		pdxlopMotion->Edxlop() == EdxlopPhysicalMotionRoutedDistribute ||
-		pdxlopMotion->Edxlop() == EdxlopPhysicalMotionRandom)
+	if (motion_dxlop->GetDXLOperator() == EdxlopPhysicalMotionRedistribute ||
+		motion_dxlop->GetDXLOperator() == EdxlopPhysicalMotionRoutedDistribute ||
+		motion_dxlop->GetDXLOperator() == EdxlopPhysicalMotionRandom)
 	{
 		// translate hash expr list
-		List *plHashExpr = NIL;
-		List *plHashExprTypes = NIL;
+		List *hash_expr_list = NIL;
+		List *hash_expr_types_list = NIL;
 
-		if (EdxlopPhysicalMotionRedistribute == pdxlopMotion->Edxlop())
+		if (EdxlopPhysicalMotionRedistribute == motion_dxlop->GetDXLOperator())
 		{
-			CDXLNode *pdxlnHashExprList = (*pdxlnMotion)[EdxlrmIndexHashExprList];
+			CDXLNode *hash_expr_list_dxlnode = (*motion_dxlnode)[EdxlrmIndexHashExprList];
 
 			TranslateHashExprList
 				(
-				pdxlnHashExprList,
-				&dxltrctxChild,
-				&plHashExpr,
-				&plHashExprTypes,
-				pdxltrctxOut
+				hash_expr_list_dxlnode,
+				&child_context,
+				&hash_expr_list,
+				&hash_expr_types_list,
+				output_context
 				);
 		}
-		GPOS_ASSERT(gpdb::UlListLength(plHashExpr) == gpdb::UlListLength(plHashExprTypes));
+		GPOS_ASSERT(gpdb::ListLength(hash_expr_list) == gpdb::ListLength(hash_expr_types_list));
 
-		pmotion->hashExpr = plHashExpr;
-		pmotion->hashDataTypes = plHashExprTypes;
+		motion->hashExpr = hash_expr_list;
+		motion->hashDataTypes = hash_expr_types_list;
 	}
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 	// create flow for child node to distinguish between singleton flows and all-segment flows
-	Flow *pflow = MakeNode(Flow);
+	Flow *flow = MakeNode(Flow);
 
-	const DrgPi *pdrgpiInputSegmentIds = pdxlopMotion->PdrgpiInputSegIds();
+	const IntPtrArray *input_segids_array = motion_dxlop->GetInputSegIdsArray();
 
 
 	// only one sender
-	if (1 == pdrgpiInputSegmentIds->UlLength())
+	if (1 == input_segids_array->Size())
 	{
-		pflow->segindex = *((*pdrgpiInputSegmentIds)[0]);
+		flow->segindex = *((*input_segids_array)[0]);
 
 		// only one segment in total
-		if (1 == gpdb::UlSegmentCountGP())
+		if (1 == gpdb::GetGPSegmentCount())
 		{
-			if (pflow->segindex == MASTER_CONTENT_ID)
+			if (flow->segindex == MASTER_CONTENT_ID)
 				// sender is on master, must be singleton flow
-				pflow->flotype = FLOW_SINGLETON;
+				flow->flotype = FLOW_SINGLETON;
 			else
 				// sender is on segment, can not tell it's singleton or
 				// all-segment flow, just treat it as all-segment flow so
 				// it can be promoted to writer gang later if needed.
-				pflow->flotype = FLOW_UNDEFINED;
+				flow->flotype = FLOW_UNDEFINED;
 		}
 		else
 		{
 			// multiple segments, must be singleton flow
-			pflow->flotype = FLOW_SINGLETON;
+			flow->flotype = FLOW_SINGLETON;
 		}
 	}
 	else
 	{
-		pflow->flotype = FLOW_UNDEFINED;
+		flow->flotype = FLOW_UNDEFINED;
 	}
 
-	pplanChild->flow = pflow;
+	child_plan->flow = flow;
 
-	pmotion->motionID = m_pctxdxltoplstmt->UlNextMotionId();
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes + 1;
+	motion->motionID = m_dxl_to_plstmt_context->GetNextMotionId();
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes + 1;
 
 	// translate properties of the specific type of motion operator
 
-	switch (pdxlopMotion->Edxlop())
+	switch (motion_dxlop->GetDXLOperator())
 	{
 		case EdxlopPhysicalMotionGather:
 		{
-			pmotion->motionType = MOTIONTYPE_FIXED;
+			motion->motionType = MOTIONTYPE_FIXED;
 			// get segment id
-			INT iSegId = CDXLPhysicalGatherMotion::PdxlopConvert(pdxlopMotion)->IOutputSegIdx();
-			pmotion->numOutputSegs = 1;
-			pmotion->outputSegIdx = (INT *) gpdb::GPDBAlloc(sizeof(INT));
-			*(pmotion->outputSegIdx) = iSegId;
+			INT segid = CDXLPhysicalGatherMotion::Cast(motion_dxlop)->IOutputSegIdx();
+			motion->numOutputSegs = 1;
+			motion->outputSegIdx = (INT *) gpdb::GPDBAlloc(sizeof(INT));
+			*(motion->outputSegIdx) = segid;
 			break;
 		}
 		case EdxlopPhysicalMotionRedistribute:
 		case EdxlopPhysicalMotionRandom:
 		{
-			pmotion->motionType = MOTIONTYPE_HASH;
+			motion->motionType = MOTIONTYPE_HASH;
 			// translate output segment ids
-			const DrgPi *pdrgpiSegIds = CDXLPhysicalMotion::PdxlopConvert(pdxlopMotion)->PdrgpiOutputSegIds();
+			const IntPtrArray *output_segids_array = CDXLPhysicalMotion::Cast(motion_dxlop)->GetOutputSegIdsArray();
 
-			GPOS_ASSERT(NULL != pdrgpiSegIds && 0 < pdrgpiSegIds->UlLength());
-			ULONG ulSegIdCount = pdrgpiSegIds->UlLength();
-			pmotion->outputSegIdx = (INT *) gpdb::GPDBAlloc (ulSegIdCount * sizeof(INT));
-			pmotion->numOutputSegs = ulSegIdCount;
+			GPOS_ASSERT(NULL != output_segids_array && 0 < output_segids_array->Size());
+			ULONG segid_count = output_segids_array->Size();
+			motion->outputSegIdx = (INT *) gpdb::GPDBAlloc (segid_count * sizeof(INT));
+			motion->numOutputSegs = segid_count;
 
-			for(ULONG ul = 0; ul < ulSegIdCount; ul++)
+			for(ULONG ul = 0; ul < segid_count; ul++)
 			{
-				INT iSegId = *((*pdrgpiSegIds)[ul]);
-				pmotion->outputSegIdx[ul] = iSegId;
+				INT segid = *((*output_segids_array)[ul]);
+				motion->outputSegIdx[ul] = segid;
 			}
 
 			break;
 		}
 		case EdxlopPhysicalMotionBroadcast:
 		{
-			pmotion->motionType = MOTIONTYPE_FIXED;
-			pmotion->numOutputSegs = 0;
-			pmotion->outputSegIdx = NULL;
+			motion->motionType = MOTIONTYPE_FIXED;
+			motion->numOutputSegs = 0;
+			motion->outputSegIdx = NULL;
 			break;
 		}
 		case EdxlopPhysicalMotionRoutedDistribute:
 		{
-			pmotion->motionType = MOTIONTYPE_EXPLICIT;
-			pmotion->numOutputSegs = 0;
-			pmotion->outputSegIdx = NULL;
-			ULONG ulSegIdCol = CDXLPhysicalRoutedDistributeMotion::PdxlopConvert(pdxlopMotion)->UlSegmentIdCol();
-			const TargetEntry *pteSortCol = dxltrctxChild.Pte(ulSegIdCol);
-			pmotion->segidColIdx = pteSortCol->resno;
+			motion->motionType = MOTIONTYPE_EXPLICIT;
+			motion->numOutputSegs = 0;
+			motion->outputSegIdx = NULL;
+			ULONG segid_col = CDXLPhysicalRoutedDistributeMotion::Cast(motion_dxlop)->SegmentIdCol();
+			const TargetEntry *te_sort_col = child_context.GetTargetEntry(segid_col);
+			motion->segidColIdx = te_sort_col->resno;
 
 			break;
 			
@@ -2559,14 +2559,14 @@ CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion
 			return NULL;
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pmotion;
+	return (Plan *) motion;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanResultHashFilters
+//		CTranslatorDXLToPlStmt::TranslateDXLRedistributeMotionToResultHashFilters
 //
 //	@doc:
 //		Translate DXL duplicate sensitive redistribute motion node into 
@@ -2574,73 +2574,73 @@ CTranslatorDXLToPlStmt::PplanMotionFromDXLMotion
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanResultHashFilters
+CTranslatorDXLToPlStmt::TranslateDXLRedistributeMotionToResultHashFilters
 	(
-	const CDXLNode *pdxlnMotion,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *motion_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create motion node
-	Result *presult = MakeNode(Result);
+	Result *result = MakeNode(Result);
 
-	Plan *pplan = &(presult->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(result->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalMotion *pdxlopMotion = CDXLPhysicalMotion::PdxlopConvert(pdxlnMotion->Pdxlop());
+	CDXLPhysicalMotion *motion_dxlop = CDXLPhysicalMotion::Cast(motion_dxlnode->GetOperator());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnMotion->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(motion_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	CDXLNode *pdxlnPrL = (*pdxlnMotion)[EdxlrmIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnMotion)[EdxlrmIndexFilter];
-	CDXLNode *pdxlnChild = (*pdxlnMotion)[pdxlopMotion->UlChildIndex()];
+	CDXLNode *project_list_dxlnode = (*motion_dxlnode)[EdxlrmIndexProjList];
+	CDXLNode *filter_dxlnode = (*motion_dxlnode)[EdxlrmIndexFilter];
+	CDXLNode *child_dxlnode = (*motion_dxlnode)[motion_dxlop->GetRelationChildIdx()];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
 	// translate hash expr list
-	presult->hashFilter = true;
+	result->hashFilter = true;
 
-	if (EdxlopPhysicalMotionRedistribute == pdxlopMotion->Edxlop())
+	if (EdxlopPhysicalMotionRedistribute == motion_dxlop->GetDXLOperator())
 	{
-		CDXLNode *pdxlnHashExprList = (*pdxlnMotion)[EdxlrmIndexHashExprList];
-		const ULONG ulLength = pdxlnHashExprList->UlArity();
-		GPOS_ASSERT(0 < ulLength);
+		CDXLNode *hash_expr_list_dxlnode = (*motion_dxlnode)[EdxlrmIndexHashExprList];
+		const ULONG length = hash_expr_list_dxlnode->Arity();
+		GPOS_ASSERT(0 < length);
 		
-		for (ULONG ul = 0; ul < ulLength; ul++)
+		for (ULONG ul = 0; ul < length; ul++)
 		{
-			CDXLNode *pdxlnHashExpr = (*pdxlnHashExprList)[ul];
-			CDXLNode *pdxlnExpr = (*pdxlnHashExpr)[0];
+			CDXLNode *hash_expr_dxlnode = (*hash_expr_list_dxlnode)[ul];
+			CDXLNode *expr_dxlnode = (*hash_expr_dxlnode)[0];
 			
-			INT iResno = gpos::int_max;
-			if (EdxlopScalarIdent == pdxlnExpr->Pdxlop()->Edxlop())
+			INT resno = gpos::int_max;
+			if (EdxlopScalarIdent == expr_dxlnode->GetOperator()->GetDXLOperator())
 			{
-				ULONG ulColId = CDXLScalarIdent::PdxlopConvert(pdxlnExpr->Pdxlop())->Pdxlcr()->UlID();
-				iResno = pdxltrctxOut->Pte(ulColId)->resno;
+				ULONG colid = CDXLScalarIdent::Cast(expr_dxlnode->GetOperator())->GetDXLColRef()->Id();
+				resno = output_context->GetTargetEntry(colid)->resno;
 			}
 			else
 			{
@@ -2648,289 +2648,289 @@ CTranslatorDXLToPlStmt::PplanResultHashFilters
 				// Rather, it is an expresssion that is evaluated by the hash filter such as CAST(a) or a+b.
 				// We therefore, create a corresponding GPDB scalar expression and add it to the project list
 				// of the hash filter
-				CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+				CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 															(
-															m_pmp,
+															m_mp,
 															NULL, // translate context for the base table
-															pdrgpdxltrctx,
-															pdxltrctxOut,
-															m_pctxdxltoplstmt
+															child_contexts,
+															output_context,
+															m_dxl_to_plstmt_context
 															);
 				
-				Expr *pexpr = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnExpr, &mapcidvarplstmt);
-				GPOS_ASSERT(NULL != pexpr);
+				Expr *expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(expr_dxlnode, &colid_var_mapping);
+				GPOS_ASSERT(NULL != expr);
 
 				// create a target entry for the hash filter
-				CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
-				TargetEntry *pte = gpdb::PteMakeTargetEntry
+				CWStringConst str_unnamed_col(GPOS_WSZ_LIT("?column?"));
+				TargetEntry *target_entry = gpdb::MakeTargetEntry
 											(
-											pexpr, 
-											gpdb::UlListLength(pplan->targetlist) + 1, 
-											CTranslatorUtils::SzFromWsz(strUnnamedCol.Wsz()), 
+											expr,
+											gpdb::ListLength(plan->targetlist) + 1,
+											CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_unnamed_col.GetBuffer()),
 											false /* resjunk */
 											);
-				pplan->targetlist = gpdb::PlAppendElement(pplan->targetlist, pte);
+				plan->targetlist = gpdb::LAppend(plan->targetlist, target_entry);
 
-				iResno = pte->resno;
+				resno = target_entry->resno;
 			}
-			GPOS_ASSERT(gpos::int_max != iResno);
+			GPOS_ASSERT(gpos::int_max != resno);
 			
-			presult->hashList = gpdb::PlAppendInt(presult->hashList, iResno);
+			result->hashList = gpdb::LAppendInt(result->hashList, resno);
 		}
 	}
 	
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) presult;
+	return (Plan *) result;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PaggFromDXLAgg
+//		CTranslatorDXLToPlStmt::TranslateDXLAgg
 //
 //	@doc:
 //		Translate DXL aggregate node into GPDB Agg plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PaggFromDXLAgg
+CTranslatorDXLToPlStmt::TranslateDXLAgg
 	(
-	const CDXLNode *pdxlnAgg,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *agg_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create aggregate plan node
-	Agg *pagg = MakeNode(Agg);
+	Agg *agg = MakeNode(Agg);
 
-	Plan *pplan = &(pagg->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(agg->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalAgg *pdxlopAgg = CDXLPhysicalAgg::PdxlopConvert(pdxlnAgg->Pdxlop());
+	CDXLPhysicalAgg *dxl_phy_agg_dxlop = CDXLPhysicalAgg::Cast(agg_dxlnode->GetOperator());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnAgg->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(agg_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate agg child
-	CDXLNode *pdxlnChild = (*pdxlnAgg)[EdxlaggIndexChild];
+	CDXLNode *child_dxlnode = (*agg_dxlnode)[EdxlaggIndexChild];
 
-	CDXLNode *pdxlnPrL = (*pdxlnAgg)[EdxlaggIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnAgg)[EdxlaggIndexFilter];
+	CDXLNode *project_list_dxlnode = (*agg_dxlnode)[EdxlaggIndexProjList];
+	CDXLNode *filter_dxlnode = (*agg_dxlnode)[EdxlaggIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, true, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, true, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,			// pdxltrctxRight,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,			// pdxltrctxRight,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
 	// translate aggregation strategy
-	switch (pdxlopAgg->Edxlaggstr())
+	switch (dxl_phy_agg_dxlop->GetAggStrategy())
 	{
 		case EdxlaggstrategyPlain:
-			pagg->aggstrategy = AGG_PLAIN;
+			agg->aggstrategy = AGG_PLAIN;
 			break;
 		case EdxlaggstrategySorted:
-			pagg->aggstrategy = AGG_SORTED;
+			agg->aggstrategy = AGG_SORTED;
 			break;
 		case EdxlaggstrategyHashed:
-			pagg->aggstrategy = AGG_HASHED;
+			agg->aggstrategy = AGG_HASHED;
 			break;
 		default:
 			GPOS_ASSERT(!"Invalid aggregation strategy");
 	}
 
-	pagg->streaming = pdxlopAgg->FStreamSafe();
+	agg->streaming = dxl_phy_agg_dxlop->IsStreamSafe();
 
 	// translate grouping cols
-	const DrgPul *pdrpulGroupingCols = pdxlopAgg->PdrgpulGroupingCols();
-	pagg->numCols = pdrpulGroupingCols->UlLength();
-	if (pagg->numCols > 0)
+	const ULongPtrArray *grouping_colid_array = dxl_phy_agg_dxlop->GetGroupingColidArray();
+	agg->numCols = grouping_colid_array->Size();
+	if (agg->numCols > 0)
 	{
-		pagg->grpColIdx = (AttrNumber *) gpdb::GPDBAlloc(pagg->numCols * sizeof(AttrNumber));
-		pagg->grpOperators = (Oid *) gpdb::GPDBAlloc(pagg->numCols * sizeof(Oid));
+		agg->grpColIdx = (AttrNumber *) gpdb::GPDBAlloc(agg->numCols * sizeof(AttrNumber));
+		agg->grpOperators = (Oid *) gpdb::GPDBAlloc(agg->numCols * sizeof(Oid));
 	}
 	else
 	{
-		pagg->grpColIdx = NULL;
-		pagg->grpOperators = NULL;
+		agg->grpColIdx = NULL;
+		agg->grpOperators = NULL;
 	}
 
-	const ULONG ulLen = pdrpulGroupingCols->UlLength();
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	const ULONG length = grouping_colid_array->Size();
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		ULONG ulGroupingColId = *((*pdrpulGroupingCols)[ul]);
-		const TargetEntry *pteGroupingCol = dxltrctxChild.Pte(ulGroupingColId);
-		if (NULL  == pteGroupingCol)
+		ULONG grouping_colid = *((*grouping_colid_array)[ul]);
+		const TargetEntry *target_entry_grouping_col = child_context.GetTargetEntry(grouping_colid);
+		if (NULL  == target_entry_grouping_col)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, ulGroupingColId);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, grouping_colid);
 		}
-		pagg->grpColIdx[ul] = pteGroupingCol->resno;
+		agg->grpColIdx[ul] = target_entry_grouping_col->resno;
 
 		// Also find the equality operators to use for each grouping col.
-		Oid typeId = gpdb::OidExprType((Node *) pteGroupingCol->expr);
-		pagg->grpOperators[ul] = gpdb::OidEqualityOp(typeId);
-		Assert(pagg->grpOperators[ul] != 0);
+		Oid typeId = gpdb::ExprType((Node *) target_entry_grouping_col->expr);
+		agg->grpOperators[ul] = gpdb::GetEqualityOp(typeId);
+		Assert(agg->grpOperators[ul] != 0);
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pagg;
+	return (Plan *) agg;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PwindowFromDXLWindow
+//		CTranslatorDXLToPlStmt::TranslateDXLWindow
 //
 //	@doc:
 //		Translate DXL window node into GPDB window plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PwindowFromDXLWindow
+CTranslatorDXLToPlStmt::TranslateDXLWindow
 	(
-	const CDXLNode *pdxlnWindow,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *window_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create a window plan node
-	Window *pwindow = MakeNode(Window);
+	Window *window = MakeNode(Window);
 
-	Plan *pplan = &(pwindow->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(window->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalWindow *pdxlopWindow = CDXLPhysicalWindow::PdxlopConvert(pdxlnWindow->Pdxlop());
+	CDXLPhysicalWindow *window_dxlop = CDXLPhysicalWindow::Cast(window_dxlnode->GetOperator());
 
 	// translate the operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnWindow->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(window_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate children
-	CDXLNode *pdxlnChild = (*pdxlnWindow)[EdxlwindowIndexChild];
-	CDXLNode *pdxlnPrL = (*pdxlnWindow)[EdxlwindowIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnWindow)[EdxlwindowIndexFilter];
+	CDXLNode *child_dxlnode = (*window_dxlnode)[EdxlwindowIndexChild];
+	CDXLNode *project_list_dxlnode = (*window_dxlnode)[EdxlwindowIndexProjList];
+	CDXLNode *filter_dxlnode = (*window_dxlnode)[EdxlwindowIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, true, pdxltrctxOut->PhmColParam());
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	CDXLTranslateContext child_context(m_mp, true, output_context->GetColIdToParamIdMap());
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,			// pdxltrctxRight,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,			// pdxltrctxRight,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
 	// translate partition columns
-	const DrgPul *pdrpulPartCols = pdxlopWindow->PrgpulPartCols();
-	pwindow->numPartCols = pdrpulPartCols->UlLength();
-	pwindow->partColIdx = NULL;
-	pwindow->partOperators = NULL;
+	const ULongPtrArray *part_by_cols_array = window_dxlop->GetPartByColsArray();
+	window->numPartCols = part_by_cols_array->Size();
+	window->partColIdx = NULL;
+	window->partOperators = NULL;
 
-	if (pwindow->numPartCols > 0)
+	if (window->numPartCols > 0)
 	{
-		pwindow->partColIdx = (AttrNumber *) gpdb::GPDBAlloc(pwindow->numPartCols * sizeof(AttrNumber));
-		pwindow->partOperators = (Oid *) gpdb::GPDBAlloc(pwindow->numPartCols * sizeof(Oid));
+		window->partColIdx = (AttrNumber *) gpdb::GPDBAlloc(window->numPartCols * sizeof(AttrNumber));
+		window->partOperators = (Oid *) gpdb::GPDBAlloc(window->numPartCols * sizeof(Oid));
 	}
 
-	const ULONG ulPartCols = pdrpulPartCols->UlLength();
-	for (ULONG ul = 0; ul < ulPartCols; ul++)
+	const ULONG num_of_part_cols = part_by_cols_array->Size();
+	for (ULONG ul = 0; ul < num_of_part_cols; ul++)
 	{
-		ULONG ulPartColId = *((*pdrpulPartCols)[ul]);
-		const TargetEntry *ptePartCol = dxltrctxChild.Pte(ulPartColId);
-		if (NULL  == ptePartCol)
+		ULONG part_colid = *((*part_by_cols_array)[ul]);
+		const TargetEntry *te_part_colid = child_context.GetTargetEntry(part_colid);
+		if (NULL  == te_part_colid)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, ulPartColId);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, part_colid);
 		}
-		pwindow->partColIdx[ul] = ptePartCol->resno;
+		window->partColIdx[ul] = te_part_colid->resno;
 
 		// Also find the equality operators to use for each partitioning key col.
-		Oid typeId = gpdb::OidExprType((Node *) ptePartCol->expr);
-		pwindow->partOperators[ul] = gpdb::OidEqualityOp(typeId);
-		Assert(pwindow->partOperators[ul] != 0);
+		Oid type_id = gpdb::ExprType((Node *) te_part_colid->expr);
+		window->partOperators[ul] = gpdb::GetEqualityOp(type_id);
+		Assert(window->partOperators[ul] != 0);
 	}
 
 	// translate window keys
-	pwindow->windowKeys = NIL;
-	const ULONG ulSize = pdxlopWindow->UlWindowKeys();
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	window->windowKeys = NIL;
+	const ULONG size = window_dxlop->WindowKeysCount();
+	for (ULONG ul = 0; ul < size; ul++)
 	{
-		WindowKey *pwindowkey = MakeNode(WindowKey);
+		WindowKey *windowkey = MakeNode(WindowKey);
 
 		// translate the sorting columns used in the window key
-		const CDXLWindowKey *pdxlwindowkey = pdxlopWindow->PdxlWindowKey(ul);
-		const CDXLNode *pdxlnSortColList = pdxlwindowkey->PdxlnSortColList();
+		const CDXLWindowKey *window_key_dxl_op = window_dxlop->GetDXLWindowKeyAt(ul);
+		const CDXLNode *sort_col_list_dxlnode = window_key_dxl_op->GetSortColListDXL();
 
-		const ULONG ulNumCols = pdxlnSortColList->UlArity();
-		pwindowkey->numSortCols = ulNumCols;
-		pwindowkey->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(ulNumCols * sizeof(AttrNumber));
-		pwindowkey->sortOperators = (Oid *) gpdb::GPDBAlloc(ulNumCols * sizeof(Oid));
-		pwindowkey->nullsFirst = (bool *) gpdb::GPDBAlloc(ulNumCols * sizeof(bool));
-		TranslateSortCols(pdxlnSortColList, &dxltrctxChild, pwindowkey->sortColIdx, pwindowkey->sortOperators, pwindowkey->nullsFirst);
+		const ULONG num_of_cols = sort_col_list_dxlnode->Arity();
+		windowkey->numSortCols = num_of_cols;
+		windowkey->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(num_of_cols * sizeof(AttrNumber));
+		windowkey->sortOperators = (Oid *) gpdb::GPDBAlloc(num_of_cols * sizeof(Oid));
+		windowkey->nullsFirst = (bool *) gpdb::GPDBAlloc(num_of_cols * sizeof(bool));
+		TranslateSortCols(sort_col_list_dxlnode, &child_context, windowkey->sortColIdx, windowkey->sortOperators, windowkey->nullsFirst);
 
 		// translate the window frame specified in the window key
-		pwindowkey->frame = NULL;
-		if (NULL != pdxlwindowkey->Pdxlwf())
+		windowkey->frame = NULL;
+		if (NULL != window_key_dxl_op->GetWindowFrame())
 		{
-			pwindowkey->frame = Pwindowframe(pdxlwindowkey->Pdxlwf(), &dxltrctxChild, pdxltrctxOut, pplan);
+			windowkey->frame = Pwindowframe(window_key_dxl_op->GetWindowFrame(), &child_context, output_context, plan);
 		}
-		pwindow->windowKeys = gpdb::PlAppendElement(pwindow->windowKeys, pwindowkey);
+		window->windowKeys = gpdb::LAppend(window->windowKeys, windowkey);
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pwindow;
+	return (Plan *) window;
 }
 
 //---------------------------------------------------------------------------
@@ -2946,818 +2946,818 @@ CTranslatorDXLToPlStmt::Pwindowframe
 	(
 	const CDXLWindowFrame *pdxlwf,
 	const CDXLTranslateContext *pdxltrctxChild,
-	CDXLTranslateContext *pdxltrctxOut,
+	CDXLTranslateContext *output_context,
 	Plan *pplan
 	)
 {
-	WindowFrame *pwindowframe = MakeNode(WindowFrame);
+	WindowFrame *window_frame = MakeNode(WindowFrame);
 
-	if (EdxlfsRow == pdxlwf->Edxlfs())
+	if (EdxlfsRow == pdxlwf->ParseDXLFrameSpec())
 	{
-		pwindowframe->is_rows = true;
+		window_frame->is_rows = true;
 	}
 	else
 	{
-		pwindowframe->is_rows = false;
+		window_frame->is_rows = false;
 	}
-	pwindowframe->is_between = true;
+	window_frame->is_between = true;
 
-	pwindowframe->exclude = CTranslatorUtils::Windowexclusion(pdxlwf->Edxlfes());
+	window_frame->exclude = CTranslatorUtils::Windowexclusion(pdxlwf->ParseFrameExclusionStrategy());
 
 	// translate the CDXLNodes representing the leading and trailing edge
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(pdxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(pdxltrctxChild);
 
-	CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
-												(
-												m_pmp,
-												NULL,
-												pdrgpdxltrctx,
-												pdxltrctxOut,
-												m_pctxdxltoplstmt
-												);
+			CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
+			(
+			 m_mp,
+			 NULL,
+			 child_contexts,
+			 output_context,
+			 m_dxl_to_plstmt_context
+			);
 
-	CDXLNode *pdxlnLead = pdxlwf->PdxlnLeading();
-	pwindowframe->lead = MakeNode(WindowFrameEdge);
-	pwindowframe->lead->kind = CTranslatorUtils::Windowboundkind(CDXLScalarWindowFrameEdge::PdxlopConvert(pdxlnLead->Pdxlop())->Edxlfb());
-	pwindowframe->lead->val = NULL;
-	if (0 != pdxlnLead->UlArity())
+	CDXLNode *win_frame_leading_dxlnode = pdxlwf->PdxlnLeading();
+	window_frame->lead = MakeNode(WindowFrameEdge);
+	window_frame->lead->kind = CTranslatorUtils::Windowboundkind(CDXLScalarWindowFrameEdge::Cast(win_frame_leading_dxlnode->GetOperator())->ParseDXLFrameBoundary());
+	window_frame->lead->val = NULL;
+	if (0 != win_frame_leading_dxlnode->Arity())
 	{
-		pwindowframe->lead->val = (Node*) m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnLead)[0], &mapcidvarplstmt);
+		window_frame->lead->val = (Node*) m_translator_dxl_to_scalar->TranslateDXLToScalar((*win_frame_leading_dxlnode)[0], &colid_var_mapping);
 	}
 
 
-	CDXLNode *pdxlnTrail = pdxlwf->PdxlnTrailing();
-	pwindowframe->trail = MakeNode(WindowFrameEdge);
-	pwindowframe->trail->kind = CTranslatorUtils::Windowboundkind(CDXLScalarWindowFrameEdge::PdxlopConvert(pdxlnTrail->Pdxlop())->Edxlfb());
-	pwindowframe->trail->val = NULL;
-	if (0 != pdxlnTrail->UlArity())
+	CDXLNode *win_frame_trailing_dxlnode = pdxlwf->PdxlnTrailing();
+	window_frame->trail = MakeNode(WindowFrameEdge);
+	window_frame->trail->kind = CTranslatorUtils::Windowboundkind(CDXLScalarWindowFrameEdge::Cast(win_frame_trailing_dxlnode->GetOperator())->ParseDXLFrameBoundary());
+	window_frame->trail->val = NULL;
+	if (0 != win_frame_trailing_dxlnode->Arity())
 	{
-		pwindowframe->trail->val = (Node*) m_pdxlsctranslator->PexprFromDXLNodeScalar((*pdxlnTrail)[0], &mapcidvarplstmt);
+		window_frame->trail->val = (Node*) m_translator_dxl_to_scalar->TranslateDXLToScalar((*win_frame_trailing_dxlnode)[0], &colid_var_mapping);
 	}
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return pwindowframe;
+	return window_frame;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PsortFromDXLSort
+//		CTranslatorDXLToPlStmt::TranslateDXLSort
 //
 //	@doc:
 //		Translate DXL sort node into GPDB Sort plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PsortFromDXLSort
+CTranslatorDXLToPlStmt::TranslateDXLSort
 	(
-	const CDXLNode *pdxlnSort,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *sort_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create sort plan node
-	Sort *psort = MakeNode(Sort);
+	Sort *sort = MakeNode(Sort);
 
-	Plan *pplan = &(psort->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(sort->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalSort *pdxlopSort = CDXLPhysicalSort::PdxlopConvert(pdxlnSort->Pdxlop());
+	CDXLPhysicalSort *sort_dxlop = CDXLPhysicalSort::Cast(sort_dxlnode->GetOperator());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnSort->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(sort_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate sort child
-	CDXLNode *pdxlnChild = (*pdxlnSort)[EdxlsortIndexChild];
-	CDXLNode *pdxlnPrL = (*pdxlnSort)[EdxlsortIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnSort)[EdxlsortIndexFilter];
+	CDXLNode *child_dxlnode = (*sort_dxlnode)[EdxlsortIndexChild];
+	CDXLNode *project_list_dxlnode = (*sort_dxlnode)[EdxlsortIndexProjList];
+	CDXLNode *filter_dxlnode = (*sort_dxlnode)[EdxlsortIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
 	// set sorting info
-	psort->noduplicates = pdxlopSort->FDiscardDuplicates();
+	sort->noduplicates = sort_dxlop->FDiscardDuplicates();
 
 	// translate sorting columns
 
-	const CDXLNode *pdxlnSortColList = (*pdxlnSort)[EdxlsortIndexSortColList];
+	const CDXLNode *sort_col_list_dxl = (*sort_dxlnode)[EdxlsortIndexSortColList];
 
-	const ULONG ulNumCols = pdxlnSortColList->UlArity();
-	psort->numCols = ulNumCols;
-	psort->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(ulNumCols * sizeof(AttrNumber));
-	psort->sortOperators = (Oid *) gpdb::GPDBAlloc(ulNumCols * sizeof(Oid));
-	psort->nullsFirst = (bool *) gpdb::GPDBAlloc(ulNumCols * sizeof(bool));
+	const ULONG num_of_cols = sort_col_list_dxl->Arity();
+	sort->numCols = num_of_cols;
+	sort->sortColIdx = (AttrNumber *) gpdb::GPDBAlloc(num_of_cols * sizeof(AttrNumber));
+	sort->sortOperators = (Oid *) gpdb::GPDBAlloc(num_of_cols * sizeof(Oid));
+	sort->nullsFirst = (bool *) gpdb::GPDBAlloc(num_of_cols * sizeof(bool));
 
-	TranslateSortCols(pdxlnSortColList, &dxltrctxChild, psort->sortColIdx, psort->sortOperators, psort->nullsFirst);
+	TranslateSortCols(sort_col_list_dxl, &child_context, sort->sortColIdx, sort->sortOperators, sort->nullsFirst);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) psort;
+	return (Plan *) sort;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PsubqscanFromDXLSubqScan
+//		CTranslatorDXLToPlStmt::TranslateDXLSubQueryScan
 //
 //	@doc:
 //		Translate DXL subquery scan node into GPDB SubqueryScan plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PsubqscanFromDXLSubqScan
+CTranslatorDXLToPlStmt::TranslateDXLSubQueryScan
 	(
-	const CDXLNode *pdxlnSubqScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *subquery_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create sort plan node
-	SubqueryScan *psubqscan = MakeNode(SubqueryScan);
+	SubqueryScan *subquery_scan = MakeNode(SubqueryScan);
 
-	Plan *pplan = &(psubqscan->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(subquery_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalSubqueryScan *pdxlopSubqscan = CDXLPhysicalSubqueryScan::PdxlopConvert(pdxlnSubqScan->Pdxlop());
+	CDXLPhysicalSubqueryScan *subquery_scan_dxlop = CDXLPhysicalSubqueryScan::Cast(subquery_scan_dxlnode->GetOperator());
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnSubqScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(subquery_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate subplan
-	CDXLNode *pdxlnChild = (*pdxlnSubqScan)[EdxlsubqscanIndexChild];
-	CDXLNode *pdxlnPrL = (*pdxlnSubqScan)[EdxlsubqscanIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnSubqScan)[EdxlsubqscanIndexFilter];
+	CDXLNode *child_dxlnode = (*subquery_scan_dxlnode)[EdxlsubqscanIndexChild];
+	CDXLNode *project_list_dxlnode = (*subquery_scan_dxlnode)[EdxlsubqscanIndexProjList];
+	CDXLNode *filter_dxlnode = (*subquery_scan_dxlnode)[EdxlsubqscanIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
 	// create an rtable entry for the subquery scan
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
-	prte->rtekind = RTE_SUBQUERY;
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
+	rte->rtekind = RTE_SUBQUERY;
 
-	Alias *palias = MakeNode(Alias);
-	palias->colnames = NIL;
+	Alias *alias = MakeNode(Alias);
+	alias->colnames = NIL;
 
 	// get table alias
-	palias->aliasname = CTranslatorUtils::SzFromWsz(pdxlopSubqscan->Pmdname()->Pstr()->Wsz());
+	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(subquery_scan_dxlop->MdName()->GetMDName()->GetBuffer());
 
 	// get column names from child project list
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
-	(psubqscan->scan).scanrelid = iRel;
-	dxltrctxbt.SetIdx(iRel);
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
+	(subquery_scan->scan).scanrelid = index;
+	base_table_context.SetRelIndex(index);
 
-	ListCell *plcTE = NULL;
+	ListCell *lc_tgtentry = NULL;
 
-	CDXLNode *pdxlnChildProjList = (*pdxlnChild)[0];
+	CDXLNode *child_proj_list_dxlnode = (*child_dxlnode)[0];
 
 	ULONG ul = 0;
 
-	ForEach (plcTE, pplanChild->targetlist)
+	ForEach (lc_tgtentry, child_plan->targetlist)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc_tgtentry);
 
 		// non-system attribute
-		CHAR *szColName = PStrDup(pte->resname);
-		Value *pvalColName = gpdb::PvalMakeString(szColName);
-		palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalColName);
+		CHAR *col_name_char_array = PStrDup(target_entry->resname);
+		Value *val_colname = gpdb::MakeStringValue(col_name_char_array);
+		alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
 
 		// get corresponding child project element
-		CDXLScalarProjElem *pdxlopPrel = CDXLScalarProjElem::PdxlopConvert((*pdxlnChildProjList)[ul]->Pdxlop());
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast((*child_proj_list_dxlnode)[ul]->GetOperator());
 
 		// save mapping col id -> index in translate context
-		(void) dxltrctxbt.FInsertMapping(pdxlopPrel->UlId(), pte->resno);
+		(void) base_table_context.InsertMapping(sc_proj_elem_dxlop->Id(), target_entry->resno);
 		ul++;
 	}
 
-	prte->eref = palias;
+	rte->eref = alias;
 
 	// add range table entry for the subquery to the list
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
-		&dxltrctxbt,		// translate context for the base table
+		project_list_dxlnode,
+		filter_dxlnode,
+		&base_table_context,		// translate context for the base table
 		NULL,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	psubqscan->subplan = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	subquery_scan->subplan = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
-	SetParamIds(pplan);
-	return (Plan *) psubqscan;
+	SetParamIds(plan);
+	return (Plan *) subquery_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PresultFromDXLResult
+//		CTranslatorDXLToPlStmt::TranslateDXLResult
 //
 //	@doc:
 //		Translate DXL result node into GPDB result plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PresultFromDXLResult
+CTranslatorDXLToPlStmt::TranslateDXLResult
 	(
-	const CDXLNode *pdxlnResult,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *result_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create result plan node
-	Result *presult = MakeNode(Result);
+	Result *result = MakeNode(Result);
 
-	Plan *pplan = &(presult->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(result->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnResult->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(result_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	pplan->nMotionNodes = 0;
+	plan->nMotionNodes = 0;
 
-	CDXLNode *pdxlnChild = NULL;
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLNode *child_dxlnode = NULL;
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	if (pdxlnResult->UlArity() - 1 == EdxlresultIndexChild)
+	if (result_dxlnode->Arity() - 1 == EdxlresultIndexChild)
 	{
 		// translate child plan
-		pdxlnChild = (*pdxlnResult)[EdxlresultIndexChild];
+		child_dxlnode = (*result_dxlnode)[EdxlresultIndexChild];
 
-		Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+		Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-		GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+		GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-		presult->plan.lefttree = pplanChild;
+		result->plan.lefttree = child_plan;
 
-		pplan->nMotionNodes = pplanChild->nMotionNodes;
+		plan->nMotionNodes = child_plan->nMotionNodes;
 	}
 
-	CDXLNode *pdxlnPrL = (*pdxlnResult)[EdxlresultIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnResult)[EdxlresultIndexFilter];
-	CDXLNode *pdxlnOneTimeFilter = (*pdxlnResult)[EdxlresultIndexOneTimeFilter];
+	CDXLNode *project_list_dxlnode = (*result_dxlnode)[EdxlresultIndexProjList];
+	CDXLNode *filter_dxlnode = (*result_dxlnode)[EdxlresultIndexFilter];
+	CDXLNode *one_time_filter_dxlnode = (*result_dxlnode)[EdxlresultIndexOneTimeFilter];
 
-	List *plQuals = NULL;
+	List *quals_list = NULL;
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,		// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&plQuals,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&quals_list,
+		output_context
 		);
 
 	// translate one time filter
-	List *plOneTimeQuals = PlQualFromFilter
+	List *one_time_quals_list = TranslateDXLFilterToQual
 							(
-							pdxlnOneTimeFilter,
+							one_time_filter_dxlnode,
 							NULL,			// base table translation context
-							pdrgpdxltrctx,
-							pdxltrctxOut
+							child_contexts,
+							output_context
 							);
 
-	pplan->qual = plQuals;
+	plan->qual = quals_list;
 
-	presult->resconstantqual = (Node *) plOneTimeQuals;
+	result->resconstantqual = (Node *) one_time_quals_list;
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) presult;
+	return (Plan *) result;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanPartitionSelector
+//		CTranslatorDXLToPlStmt::TranslateDXLPartSelector
 //
 //	@doc:
 //		Translate DXL PartitionSelector into a GPDB PartitionSelector node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanPartitionSelector
+CTranslatorDXLToPlStmt::TranslateDXLPartSelector
 	(
-	const CDXLNode *pdxlnPartitionSelector,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *partition_selector_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	PartitionSelector *ppartsel = MakeNode(PartitionSelector);
+	PartitionSelector *partition_selector = MakeNode(PartitionSelector);
 
-	Plan *pplan = &(ppartsel->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(partition_selector->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalPartitionSelector *pdxlopPartSel = CDXLPhysicalPartitionSelector::PdxlopConvert(pdxlnPartitionSelector->Pdxlop());
-	const ULONG ulLevels = pdxlopPartSel->UlLevels();
-	ppartsel->nLevels = ulLevels;
-	ppartsel->scanId = pdxlopPartSel->UlScanId();
-	ppartsel->relid = CMDIdGPDB::PmdidConvert(pdxlopPartSel->PmdidRel())->OidObjectId();
-	ppartsel->selectorId = m_ulPartitionSelectorCounter++;
+	CDXLPhysicalPartitionSelector *partition_selector_dxlop = CDXLPhysicalPartitionSelector::Cast(partition_selector_dxlnode->GetOperator());
+	const ULONG num_of_levels = partition_selector_dxlop->GetPartitioningLevel();
+	partition_selector->nLevels = num_of_levels;
+	partition_selector->scanId = partition_selector_dxlop->ScanId();
+	partition_selector->relid = CMDIdGPDB::CastMdid(partition_selector_dxlop->GetRelMdId())->Oid();
+	partition_selector->selectorId = m_partition_selector_counter++;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnPartitionSelector->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(partition_selector_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	pplan->nMotionNodes = 0;
+	plan->nMotionNodes = 0;
 
-	CDXLNode *pdxlnChild = NULL;
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
+	CDXLNode *child_dxlnode = NULL;
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	BOOL fHasChild = (EdxlpsIndexChild == pdxlnPartitionSelector->UlArity() - 1);
-	if (fHasChild)
+	BOOL has_childs = (EdxlpsIndexChild == partition_selector_dxlnode->Arity() - 1);
+	if (has_childs)
 	{
 		// translate child plan
-		pdxlnChild = (*pdxlnPartitionSelector)[EdxlpsIndexChild];
+		child_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexChild];
 
-		Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
-		GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+		Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
+		GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-		ppartsel->plan.lefttree = pplanChild;
-		pplan->nMotionNodes = pplanChild->nMotionNodes;
+		partition_selector->plan.lefttree = child_plan;
+		plan->nMotionNodes = child_plan->nMotionNodes;
 	}
 
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	child_contexts->Append(&child_context);
 
-	CDXLNode *pdxlnPrL = (*pdxlnPartitionSelector)[EdxlpsIndexProjList];
-	CDXLNode *pdxlnEqFilters = (*pdxlnPartitionSelector)[EdxlpsIndexEqFilters];
-	CDXLNode *pdxlnFilters = (*pdxlnPartitionSelector)[EdxlpsIndexFilters];
-	CDXLNode *pdxlnResidualFilter = (*pdxlnPartitionSelector)[EdxlpsIndexResidualFilter];
-	CDXLNode *pdxlnPropExpr = (*pdxlnPartitionSelector)[EdxlpsIndexPropExpr];
+	CDXLNode *project_list_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexProjList];
+	CDXLNode *eq_filters_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexEqFilters];
+	CDXLNode *filters_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexFilters];
+	CDXLNode *residual_filter_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexResidualFilter];
+	CDXLNode *proj_expr_dxlnode = (*partition_selector_dxlnode)[EdxlpsIndexPropExpr];
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList(pdxlnPrL, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut);
+	plan->targetlist = TranslateDXLProjList(project_list_dxlnode, NULL /*base_table_context*/, child_contexts, output_context);
 
 	// translate filter lists
-	GPOS_ASSERT(pdxlnEqFilters->UlArity() == ulLevels);
-	ppartsel->levelEqExpressions = PlFilterList(pdxlnEqFilters, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut);
+	GPOS_ASSERT(eq_filters_dxlnode->Arity() == num_of_levels);
+	partition_selector->levelEqExpressions = TranslateDXLFilterList(eq_filters_dxlnode, NULL /*base_table_context*/, child_contexts, output_context);
 
-	GPOS_ASSERT(pdxlnFilters->UlArity() == ulLevels);
-	ppartsel->levelExpressions = PlFilterList(pdxlnFilters, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut);
+	GPOS_ASSERT(filters_dxlnode->Arity() == num_of_levels);
+	partition_selector->levelExpressions = TranslateDXLFilterList(filters_dxlnode, NULL /*base_table_context*/, child_contexts, output_context);
 
 	//translate residual filter
-	CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt(m_pmp, NULL /*pdxltrctxbt*/, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
-	if (!m_pdxlsctranslator->FConstTrue(pdxlnResidualFilter, m_pmda))
+	CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt(m_mp, NULL /*base_table_context*/, child_contexts, output_context, m_dxl_to_plstmt_context);
+	if (!m_translator_dxl_to_scalar->HasConstTrue(residual_filter_dxlnode, m_md_accessor))
 	{
-		ppartsel->residualPredicate = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnResidualFilter, &mapcidvarplstmt);
+		partition_selector->residualPredicate = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar(residual_filter_dxlnode, &colid_var_mapping);
 	}
 
 	//translate propagation expression
-	if (!m_pdxlsctranslator->FConstNull(pdxlnPropExpr))
+	if (!m_translator_dxl_to_scalar->HasConstNull(proj_expr_dxlnode))
 	{
-		ppartsel->propagationExpression = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnPropExpr, &mapcidvarplstmt);
+		partition_selector->propagationExpression = (Node *) m_translator_dxl_to_scalar->TranslateDXLToScalar(proj_expr_dxlnode, &colid_var_mapping);
 	}
 
 	// no need to translate printable filter - since it is not needed by the executor
 
-	ppartsel->staticPartOids = NIL;
-	ppartsel->staticScanIds = NIL;
-	ppartsel->staticSelection = !fHasChild;
+	partition_selector->staticPartOids = NIL;
+	partition_selector->staticScanIds = NIL;
+	partition_selector->staticSelection = !has_childs;
 
-	if (ppartsel->staticSelection)
+	if (partition_selector->staticSelection)
 	{
-		SelectedParts *sp = gpdb::SpStaticPartitionSelection(ppartsel);
-		ppartsel->staticPartOids = sp->partOids;
-		ppartsel->staticScanIds = sp->scanIds;
+		SelectedParts *sp = gpdb::RunStaticPartitionSelection(partition_selector);
+		partition_selector->staticPartOids = sp->partOids;
+		partition_selector->staticScanIds = sp->scanIds;
 		gpdb::GPDBFree(sp);
 	}
 	else
 	{
 		// if we cannot do static elimination then add this partitioned table oid
 		// to the planned stmt so we can ship the constraints with the plan
-		m_pctxdxltoplstmt->AddPartitionedTable(ppartsel->relid);
+		m_dxl_to_plstmt_context->AddPartitionedTable(partition_selector->relid);
 	}
 
 	// increment the number of partition selectors for the given scan id
-	m_pctxdxltoplstmt->IncrementPartitionSelectors(ppartsel->scanId);
+	m_dxl_to_plstmt_context->IncrementPartitionSelectors(partition_selector->scanId);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) ppartsel;
+	return (Plan *) partition_selector;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlFilterList
+//		CTranslatorDXLToPlStmt::TranslateDXLFilterList
 //
 //	@doc:
 //		Translate DXL filter list into GPDB filter list
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlFilterList
+CTranslatorDXLToPlStmt::TranslateDXLFilterList
 	(
-	const CDXLNode *pdxlnFilterList,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *filter_list_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	CDXLTranslateContext *output_context
 	)
 {
-	GPOS_ASSERT(EdxlopScalarOpList == pdxlnFilterList->Pdxlop()->Edxlop());
+	GPOS_ASSERT(EdxlopScalarOpList == filter_list_dxlnode->GetOperator()->GetDXLOperator());
 
-	List *plFilters = NIL;
+	List *filters_list = NIL;
 
-	CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt(m_pmp, pdxltrctxbt, pdrgpdxltrctx, pdxltrctxOut, m_pctxdxltoplstmt);
-	const ULONG ulArity = pdxlnFilterList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt(m_mp, base_table_context, child_contexts, output_context, m_dxl_to_plstmt_context);
+	const ULONG arity = filter_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnChildFilter = (*pdxlnFilterList)[ul];
+		CDXLNode *child_filter_dxlnode = (*filter_list_dxlnode)[ul];
 
-		if (m_pdxlsctranslator->FConstTrue(pdxlnChildFilter, m_pmda))
+		if (m_translator_dxl_to_scalar->HasConstTrue(child_filter_dxlnode, m_md_accessor))
 		{
-			plFilters = gpdb::PlAppendElement(plFilters, NULL /*datum*/);
+			filters_list = gpdb::LAppend(filters_list, NULL /*datum*/);
 			continue;
 		}
 
-		Expr *pexprFilter = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnChildFilter, &mapcidvarplstmt);
-		plFilters = gpdb::PlAppendElement(plFilters, pexprFilter);
+		Expr *filter_expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(child_filter_dxlnode, &colid_var_mapping);
+		filters_list = gpdb::LAppend(filters_list, filter_expr);
 	}
 
-	return plFilters;
+	return filters_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PappendFromDXLAppend
+//		CTranslatorDXLToPlStmt::TranslateDXLAppend
 //
 //	@doc:
 //		Translate DXL append node into GPDB Append plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PappendFromDXLAppend
+CTranslatorDXLToPlStmt::TranslateDXLAppend
 	(
-	const CDXLNode *pdxlnAppend,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *append_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create append plan node
-	Append *pappend = MakeNode(Append);
+	Append *append = MakeNode(Append);
 
-	Plan *pplan = &(pappend->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(append->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalAppend *pdxlopAppend = CDXLPhysicalAppend::PdxlopConvert(pdxlnAppend->Pdxlop());
+	CDXLPhysicalAppend *pdxlopAppend = CDXLPhysicalAppend::Cast(append_dxlnode->GetOperator());
 
-	pappend->isTarget = pdxlopAppend->FIsTarget();
-	pappend->isZapped = pdxlopAppend->FIsZapped();
+	append->isTarget = pdxlopAppend->IsUsedInUpdDel();
+	append->isZapped = pdxlopAppend->IsZapped();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnAppend->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(append_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	const ULONG ulArity = pdxlnAppend->UlArity();
-	GPOS_ASSERT(EdxlappendIndexFirstChild < ulArity);
-	pplan->nMotionNodes = 0;
-	pappend->appendplans = NIL;
+	const ULONG arity = append_dxlnode->Arity();
+	GPOS_ASSERT(EdxlappendIndexFirstChild < arity);
+	plan->nMotionNodes = 0;
+	append->appendplans = NIL;
 	
 	// translate children
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
-	for (ULONG ul = EdxlappendIndexFirstChild; ul < ulArity; ul++)
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
+	for (ULONG ul = EdxlappendIndexFirstChild; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnChild = (*pdxlnAppend)[ul];
+		CDXLNode *child_dxlnode = (*append_dxlnode)[ul];
 
-		Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+		Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-		GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+		GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-		pappend->appendplans = gpdb::PlAppendElement(pappend->appendplans, pplanChild);
-		pplan->nMotionNodes += pplanChild->nMotionNodes;
+		append->appendplans = gpdb::LAppend(append->appendplans, child_plan);
+		plan->nMotionNodes += child_plan->nMotionNodes;
 	}
 
-	CDXLNode *pdxlnPrL = (*pdxlnAppend)[EdxlappendIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnAppend)[EdxlappendIndexFilter];
+	CDXLNode *project_list_dxlnode = (*append_dxlnode)[EdxlappendIndexProjList];
+	CDXLNode *filter_dxlnode = (*append_dxlnode)[EdxlappendIndexFilter];
 
-	pplan->targetlist = NIL;
-	const ULONG ulLen = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulLen; ++ul)
+	plan->targetlist = NIL;
+	const ULONG length = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < length; ++ul)
 	{
-		CDXLNode *pdxlnPrEl = (*pdxlnPrL)[ul];
-		GPOS_ASSERT(EdxlopScalarProjectElem == pdxlnPrEl->Pdxlop()->Edxlop());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		GPOS_ASSERT(EdxlopScalarProjectElem == proj_elem_dxlnode->GetOperator()->GetDXLOperator());
 
-		CDXLScalarProjElem *pdxlopPrel = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop());
-		GPOS_ASSERT(1 == pdxlnPrEl->UlArity());
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
+		GPOS_ASSERT(1 == proj_elem_dxlnode->Arity());
 
 		// translate proj element expression
-		CDXLNode *pdxlnExpr = (*pdxlnPrEl)[0];
-		CDXLScalarIdent *pdxlopScIdent = CDXLScalarIdent::PdxlopConvert(pdxlnExpr->Pdxlop());
+		CDXLNode *expr_dxlnode = (*proj_elem_dxlnode)[0];
+		CDXLScalarIdent *sc_ident_dxlop = CDXLScalarIdent::Cast(expr_dxlnode->GetOperator());
 
 		Index idxVarno = OUTER;
 		AttrNumber attno = (AttrNumber) (ul + 1);
 
-		Var *pvar = gpdb::PvarMakeVar
+		Var *var = gpdb::MakeVar
 							(
 							idxVarno,
 							attno,
-							CMDIdGPDB::PmdidConvert(pdxlopScIdent->PmdidType())->OidObjectId(),
-							pdxlopScIdent->ITypeModifier(),
+							CMDIdGPDB::CastMdid(sc_ident_dxlop->MdidType())->Oid(),
+							sc_ident_dxlop->TypeModifier(),
 							0	// varlevelsup
 							);
 
-		TargetEntry *pte = MakeNode(TargetEntry);
-		pte->expr = (Expr *) pvar;
-		pte->resname = CTranslatorUtils::SzFromWsz(pdxlopPrel->PmdnameAlias()->Pstr()->Wsz());
-		pte->resno = attno;
+		TargetEntry *target_entry = MakeNode(TargetEntry);
+		target_entry->expr = (Expr *) var;
+		target_entry->resname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
+		target_entry->resno = attno;
 
 		// add column mapping to output translation context
-		pdxltrctxOut->InsertMapping(pdxlopPrel->UlId(), pte);
+		output_context->InsertMapping(sc_proj_elem_dxlop->Id(), target_entry);
 
-		pplan->targetlist = gpdb::PlAppendElement(pplan->targetlist, pte);
+		plan->targetlist = gpdb::LAppend(plan->targetlist, target_entry);
 	}
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(pdxltrctxOut));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(output_context));
 
 	// translate filter
-	pplan->qual = PlQualFromFilter
+	plan->qual = TranslateDXLFilterToQual
 					(
-					pdxlnFilter,
+					filter_dxlnode,
 					NULL, // translate context for the base table
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					child_contexts,
+					output_context
 					);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pappend;
+	return (Plan *) append;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PmatFromDXLMaterialize
+//		CTranslatorDXLToPlStmt::TranslateDXLMaterialize
 //
 //	@doc:
 //		Translate DXL materialize node into GPDB Material plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PmatFromDXLMaterialize
+CTranslatorDXLToPlStmt::TranslateDXLMaterialize
 	(
-	const CDXLNode *pdxlnMaterialize,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *materialize_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create materialize plan node
-	Material *pmat = MakeNode(Material);
+	Material *materialize = MakeNode(Material);
 
-	Plan *pplan = &(pmat->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(materialize->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalMaterialize *pdxlopMat = CDXLPhysicalMaterialize::PdxlopConvert(pdxlnMaterialize->Pdxlop());
+	CDXLPhysicalMaterialize *materialize_dxlop = CDXLPhysicalMaterialize::Cast(materialize_dxlnode->GetOperator());
 
-	pmat->cdb_strict = pdxlopMat->FEager();
+	materialize->cdb_strict = materialize_dxlop->IsEager();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnMaterialize->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(materialize_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate materialize child
-	CDXLNode *pdxlnChild = (*pdxlnMaterialize)[EdxlmatIndexChild];
+	CDXLNode *child_dxlnode = (*materialize_dxlnode)[EdxlmatIndexChild];
 
-	CDXLNode *pdxlnPrL = (*pdxlnMaterialize)[EdxlmatIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnMaterialize)[EdxlmatIndexFilter];
+	CDXLNode *project_list_dxlnode = (*materialize_dxlnode)[EdxlmatIndexProjList];
+	CDXLNode *filter_dxlnode = (*materialize_dxlnode)[EdxlmatIndexFilter];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list and filter
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
+		project_list_dxlnode,
+		filter_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		child_contexts,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
 	// set spooling info
-	if (pdxlopMat->FSpooling())
+	if (materialize_dxlop->IsSpooling())
 	{
-		pmat->share_id = pdxlopMat->UlSpoolId();
-		pmat->driver_slice = pdxlopMat->IExecutorSlice();
-		pmat->nsharer_xslice = pdxlopMat->UlConsumerSlices();
-		pmat->share_type = (0 < pdxlopMat->UlConsumerSlices()) ?
+		materialize->share_id = materialize_dxlop->GetSpoolingOpId();
+		materialize->driver_slice = materialize_dxlop->GetExecutorSlice();
+		materialize->nsharer_xslice = materialize_dxlop->GetNumConsumerSlices();
+		materialize->share_type = (0 < materialize_dxlop->GetNumConsumerSlices()) ?
 							SHARE_MATERIAL_XSLICE : SHARE_MATERIAL;
 	}
 	else
 	{
-		pmat->share_type = SHARE_NOTSHARED;
+		materialize->share_type = SHARE_NOTSHARED;
 	}
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pmat;
+	return (Plan *) materialize;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PshscanFromDXLCTEProducer
+//		CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan
 //
 //	@doc:
 //		Translate DXL CTE Producer node into GPDB share input scan plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PshscanFromDXLCTEProducer
+CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan
 	(
-	const CDXLNode *pdxlnCTEProducer,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *cte_producer_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalCTEProducer *pdxlopCTEProducer = CDXLPhysicalCTEProducer::PdxlopConvert(pdxlnCTEProducer->Pdxlop());
-	ULONG ulCTEId = pdxlopCTEProducer->UlId();
+	CDXLPhysicalCTEProducer *cte_prod_dxlop = CDXLPhysicalCTEProducer::Cast(cte_producer_dxlnode->GetOperator());
+	ULONG cte_id = cte_prod_dxlop->Id();
 
 	// create the shared input scan representing the CTE Producer
-	ShareInputScan *pshscanCTEProducer = MakeNode(ShareInputScan);
-	pshscanCTEProducer->share_id = ulCTEId;
-	Plan *pplan = &(pshscanCTEProducer->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	ShareInputScan *shared_input_scan = MakeNode(ShareInputScan);
+	shared_input_scan->share_id = cte_id;
+	Plan *plan = &(shared_input_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// store share scan node for the translation of CTE Consumers
-	m_pctxdxltoplstmt->AddCTEConsumerInfo(ulCTEId, pshscanCTEProducer);
+	m_dxl_to_plstmt_context->AddCTEConsumerInfo(cte_id, shared_input_scan);
 
 	// translate cost of the producer
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnCTEProducer->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(cte_producer_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// translate child plan
-	CDXLNode *pdxlnPrL = (*pdxlnCTEProducer)[0];
-	CDXLNode *pdxlnChild = (*pdxlnCTEProducer)[1];
+	CDXLNode *project_list_dxlnode = (*cte_producer_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*cte_producer_dxlnode)[1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
-	GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
+	GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 							(
-							pdxlnPrL,
+							project_list_dxlnode,
 							NULL,		// base table translation context
-							pdrgpdxltrctx,
-							pdxltrctxOut
+							child_contexts,
+							output_context
 							);
 
 	// if the child node is neither a sort or materialize node then add a materialize node
-	if (!IsA(pplanChild, Material) && !IsA(pplanChild, Sort))
+	if (!IsA(child_plan, Material) && !IsA(child_plan, Sort))
 	{
-		Material *pmat = MakeNode(Material);
-		pmat->cdb_strict = false; // eager-free
+		Material *materialize = MakeNode(Material);
+		materialize->cdb_strict = false; // eager-free
 
-		Plan *pplanMat = &(pmat->plan);
-		pplanMat->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+		Plan *materialize_plan = &(materialize->plan);
+		materialize_plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 		TranslatePlanCosts
 			(
-			CDXLPhysicalProperties::PdxlpropConvert(pdxlnCTEProducer->Pdxlprop())->Pdxlopcost(),
-			&(pplanMat->startup_cost),
-			&(pplanMat->total_cost),
-			&(pplanMat->plan_rows),
-			&(pplanMat->plan_width)
+			CDXLPhysicalProperties::PdxlpropConvert(cte_producer_dxlnode->GetProperties())->GetDXLOperatorCost(),
+			&(materialize_plan->startup_cost),
+			&(materialize_plan->total_cost),
+			&(materialize_plan->plan_rows),
+			&(materialize_plan->plan_width)
 			);
 
 		// create a target list for the newly added materialize
-		ListCell *plcTe = NULL;
-		pplanMat->targetlist = NIL;
-		ForEach (plcTe, pplan->targetlist)
+		ListCell *lc_target_entry = NULL;
+		materialize_plan->targetlist = NIL;
+		ForEach (lc_target_entry, plan->targetlist)
 		{
-			TargetEntry *pte = (TargetEntry *) lfirst(plcTe);
-			Expr *pexpr = pte->expr;
-			GPOS_ASSERT(IsA(pexpr, Var));
+			TargetEntry *target_entry = (TargetEntry *) lfirst(lc_target_entry);
+			Expr *expr = target_entry->expr;
+			GPOS_ASSERT(IsA(expr, Var));
 
-			Var *pvar = (Var *) pexpr;
-			Var *pvarNew = gpdb::PvarMakeVar(OUTER, pvar->varattno, pvar->vartype, pvar->vartypmod,	0 /* varlevelsup */);
-			pvarNew->varnoold = pvar->varnoold;
-			pvarNew->varoattno = pvar->varoattno;
+			Var *var = (Var *) expr;
+			Var *var_new = gpdb::MakeVar(OUTER, var->varattno, var->vartype, var->vartypmod,	0 /* varlevelsup */);
+			var_new->varnoold = var->varnoold;
+			var_new->varoattno = var->varoattno;
 
-			TargetEntry *pteNew = gpdb::PteMakeTargetEntry((Expr *) pvarNew, pvar->varattno, PStrDup(pte->resname), pte->resjunk);
-			pplanMat->targetlist = gpdb::PlAppendElement(pplanMat->targetlist, pteNew);
+			TargetEntry *te_new = gpdb::MakeTargetEntry((Expr *) var_new, var->varattno, PStrDup(target_entry->resname), target_entry->resjunk);
+			materialize_plan->targetlist = gpdb::LAppend(materialize_plan->targetlist, te_new);
 		}
 
-		pplanMat->lefttree = pplanChild;
-		pplanMat->nMotionNodes = pplanChild->nMotionNodes;
+		materialize_plan->lefttree = child_plan;
+		materialize_plan->nMotionNodes = child_plan->nMotionNodes;
 
-		pplanChild = pplanMat;
+		child_plan = materialize_plan;
 	}
 
-	InitializeSpoolingInfo(pplanChild, ulCTEId);
+	InitializeSpoolingInfo(child_plan, cte_id);
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
-	pplan->qual = NIL;
-	SetParamIds(pplan);
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
+	plan->qual = NIL;
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) pshscanCTEProducer;
+	return (Plan *) shared_input_scan;
 }
 
 //---------------------------------------------------------------------------
@@ -3772,62 +3772,62 @@ CTranslatorDXLToPlStmt::PshscanFromDXLCTEProducer
 void
 CTranslatorDXLToPlStmt::InitializeSpoolingInfo
 	(
-	Plan *pplan,
-	ULONG ulShareId
+	Plan *plan,
+	ULONG share_id
 	)
 {
-	List *plshscanCTEConsumer = m_pctxdxltoplstmt->PshscanCTEConsumer(ulShareId);
-	GPOS_ASSERT(NULL != plshscanCTEConsumer);
+	List *shared_scan_cte_consumer_list = m_dxl_to_plstmt_context->GetCTEConsumerList(share_id);
+	GPOS_ASSERT(NULL != shared_scan_cte_consumer_list);
 
-	Flow *pflow = PflowCTEConsumer(plshscanCTEConsumer);
+	Flow *flow = GetFlowCTEConsumer(shared_scan_cte_consumer_list);
 
-	const ULONG ulLenSis = gpdb::UlListLength(plshscanCTEConsumer);
+	const ULONG num_of_shared_scan = gpdb::ListLength(shared_scan_cte_consumer_list);
 
 	ShareType share_type = SHARE_NOTSHARED;
 
-	if (IsA(pplan, Material))
+	if (IsA(plan, Material))
 	{
-		Material *pmat = (Material *) pplan;
-		pmat->share_id = ulShareId;
-		pmat->nsharer = ulLenSis;
+		Material *materialize = (Material *) plan;
+		materialize->share_id = share_id;
+		materialize->nsharer = num_of_shared_scan;
 		share_type = SHARE_MATERIAL;
 		// the share_type is later reset to SHARE_MATERIAL_XSLICE (if needed) by the apply_shareinput_xslice
-		pmat->share_type = share_type;
-		GPOS_ASSERT(NULL == (pmat->plan).flow);
-		(pmat->plan).flow = pflow;
+		materialize->share_type = share_type;
+		GPOS_ASSERT(NULL == (materialize->plan).flow);
+		(materialize->plan).flow = flow;
 	}
 	else
 	{
-		GPOS_ASSERT(IsA(pplan, Sort));
-		Sort *psort = (Sort *) pplan;
-		psort->share_id = ulShareId;
-		psort->nsharer = ulLenSis;
+		GPOS_ASSERT(IsA(plan, Sort));
+		Sort *sort = (Sort *) plan;
+		sort->share_id = share_id;
+		sort->nsharer = num_of_shared_scan;
 		share_type = SHARE_SORT;
 		// the share_type is later reset to SHARE_SORT_XSLICE (if needed) the apply_shareinput_xslice
-		psort->share_type = share_type;
-		GPOS_ASSERT(NULL == (psort->plan).flow);
-		(psort->plan).flow = pflow;
+		sort->share_type = share_type;
+		GPOS_ASSERT(NULL == (sort->plan).flow);
+		(sort->plan).flow = flow;
 	}
 
 	GPOS_ASSERT(SHARE_NOTSHARED != share_type);
 
 	// set the share type of the consumer nodes based on the producer
-	ListCell *plcShscanCTEConsumer = NULL;
-	ForEach (plcShscanCTEConsumer, plshscanCTEConsumer)
+	ListCell *lc_sh_scan_cte_consumer = NULL;
+	ForEach (lc_sh_scan_cte_consumer, shared_scan_cte_consumer_list)
 	{
-		ShareInputScan *pshscanConsumer = (ShareInputScan *) lfirst(plcShscanCTEConsumer);
-		pshscanConsumer->share_type = share_type;
-		pshscanConsumer->driver_slice = -1; // default
-		if (NULL == (pshscanConsumer->scan.plan).flow)
+		ShareInputScan *share_input_scan_consumer = (ShareInputScan *) lfirst(lc_sh_scan_cte_consumer);
+		share_input_scan_consumer->share_type = share_type;
+		share_input_scan_consumer->driver_slice = -1; // default
+		if (NULL == (share_input_scan_consumer->scan.plan).flow)
 		{
-			(pshscanConsumer->scan.plan).flow = (Flow *) gpdb::PvCopyObject(pflow);
+			(share_input_scan_consumer->scan.plan).flow = (Flow *) gpdb::CopyObject(flow);
 		}
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PflowCTEConsumer
+//		CTranslatorDXLToPlStmt::GetFlowCTEConsumer
 //
 //	@doc:
 //		Retrieve the flow of the shared input scan of the cte consumers. If
@@ -3835,421 +3835,421 @@ CTranslatorDXLToPlStmt::InitializeSpoolingInfo
 //		same type
 //---------------------------------------------------------------------------
 Flow *
-CTranslatorDXLToPlStmt::PflowCTEConsumer
+CTranslatorDXLToPlStmt::GetFlowCTEConsumer
 	(
-	List *plshscanCTEConsumer
+	List *shared_scan_cte_consumer_list
 	)
 {
-	Flow *pflow = NULL;
+	Flow *flow = NULL;
 
-	ListCell *plcShscanCTEConsumer = NULL;
-	ForEach (plcShscanCTEConsumer, plshscanCTEConsumer)
+	ListCell *lc_sh_scan_cte_consumer = NULL;
+	ForEach (lc_sh_scan_cte_consumer, shared_scan_cte_consumer_list)
 	{
-		ShareInputScan *pshscanConsumer = (ShareInputScan *) lfirst(plcShscanCTEConsumer);
-		Flow *pflowCte = (pshscanConsumer->scan.plan).flow;
-		if (NULL != pflowCte)
+		ShareInputScan *share_input_scan_consumer = (ShareInputScan *) lfirst(lc_sh_scan_cte_consumer);
+		Flow *flow_cte = (share_input_scan_consumer->scan.plan).flow;
+		if (NULL != flow_cte)
 		{
-			if (NULL == pflow)
+			if (NULL == flow)
 			{
-				pflow = (Flow *) gpdb::PvCopyObject(pflowCte);
+				flow = (Flow *) gpdb::CopyObject(flow_cte);
 			}
 			else
 			{
-				GPOS_ASSERT(pflow->flotype == pflowCte->flotype);
+				GPOS_ASSERT(flow->flotype == flow_cte->flotype);
 			}
 		}
 	}
 
-	if (NULL == pflow)
+	if (NULL == flow)
 	{
-		pflow = MakeNode(Flow);
-		pflow->flotype = FLOW_UNDEFINED; // default flow
+		flow = MakeNode(Flow);
+		flow->flotype = FLOW_UNDEFINED; // default flow
 	}
 
-	return pflow;
+	return flow;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PshscanFromDXLCTEConsumer
+//		CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan
 //
 //	@doc:
 //		Translate DXL CTE Consumer node into GPDB share input scan plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PshscanFromDXLCTEConsumer
+CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan
 	(
-	const CDXLNode *pdxlnCTEConsumer,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *cte_consumer_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalCTEConsumer *pdxlopCTEConsumer = CDXLPhysicalCTEConsumer::PdxlopConvert(pdxlnCTEConsumer->Pdxlop());
-	ULONG ulCTEId = pdxlopCTEConsumer->UlId();
+	CDXLPhysicalCTEConsumer *cte_consumer_dxlop = CDXLPhysicalCTEConsumer::Cast(cte_consumer_dxlnode->GetOperator());
+	ULONG cte_id = cte_consumer_dxlop->Id();
 
-	ShareInputScan *pshscanCTEConsumer = MakeNode(ShareInputScan);
-	pshscanCTEConsumer->share_id = ulCTEId;
+	ShareInputScan *share_input_scan_cte_consumer = MakeNode(ShareInputScan);
+	share_input_scan_cte_consumer->share_id = cte_id;
 
-	Plan *pplan = &(pshscanCTEConsumer->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(share_input_scan_cte_consumer->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnCTEConsumer->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(cte_consumer_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 #ifdef GPOS_DEBUG
-	DrgPul *pdrgpulCTEColId = pdxlopCTEConsumer->PdrgpulColIds();
+	ULongPtrArray *output_colids_array = cte_consumer_dxlop->GetOutputColIdsArray();
 #endif
 
 	// generate the target list of the CTE Consumer
-	pplan->targetlist = NIL;
-	CDXLNode *pdxlnPrL = (*pdxlnCTEConsumer)[0];
-	const ULONG ulLenPrL = pdxlnPrL->UlArity();
-	GPOS_ASSERT(ulLenPrL == pdrgpulCTEColId->UlLength());
-	for (ULONG ul = 0; ul < ulLenPrL; ul++)
+	plan->targetlist = NIL;
+	CDXLNode *project_list_dxlnode = (*cte_consumer_dxlnode)[0];
+	const ULONG num_of_proj_list_elem = project_list_dxlnode->Arity();
+	GPOS_ASSERT(num_of_proj_list_elem == output_colids_array->Size());
+	for (ULONG ul = 0; ul < num_of_proj_list_elem; ul++)
 	{
-		CDXLNode *pdxlnPrE = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrE = CDXLScalarProjElem::PdxlopConvert(pdxlnPrE->Pdxlop());
-		ULONG ulColId = pdxlopPrE->UlId();
-		GPOS_ASSERT(ulColId == *(*pdrgpulCTEColId)[ul]);
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
+		ULONG colid = sc_proj_elem_dxlop->Id();
+		GPOS_ASSERT(colid == *(*output_colids_array)[ul]);
 
-		CDXLNode *pdxlnScIdent = (*pdxlnPrE)[0];
-		CDXLScalarIdent *pdxlopScIdent = CDXLScalarIdent::PdxlopConvert(pdxlnScIdent->Pdxlop());
-		OID oidType = CMDIdGPDB::PmdidConvert(pdxlopScIdent->PmdidType())->OidObjectId();
+		CDXLNode *sc_ident_dxlnode = (*proj_elem_dxlnode)[0];
+		CDXLScalarIdent *sc_ident_dxlop = CDXLScalarIdent::Cast(sc_ident_dxlnode->GetOperator());
+		OID oid_type = CMDIdGPDB::CastMdid(sc_ident_dxlop->MdidType())->Oid();
 
-		Var *pvar = gpdb::PvarMakeVar(OUTER, (AttrNumber) (ul + 1), oidType, pdxlopScIdent->ITypeModifier(),  0	/* varlevelsup */);
+		Var *var = gpdb::MakeVar(OUTER, (AttrNumber) (ul + 1), oid_type, sc_ident_dxlop->TypeModifier(),  0	/* varlevelsup */);
 
-		CHAR *szResname = CTranslatorUtils::SzFromWsz(pdxlopPrE->PmdnameAlias()->Pstr()->Wsz());
-		TargetEntry *pte = gpdb::PteMakeTargetEntry((Expr *) pvar, (AttrNumber) (ul + 1), szResname, false /* resjunk */);
-		pplan->targetlist = gpdb::PlAppendElement(pplan->targetlist, pte);
+		CHAR *resname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
+		TargetEntry *target_entry = gpdb::MakeTargetEntry((Expr *) var, (AttrNumber) (ul + 1), resname, false /* resjunk */);
+		plan->targetlist = gpdb::LAppend(plan->targetlist, target_entry);
 
-		pdxltrctxOut->InsertMapping(ulColId, pte);
+		output_context->InsertMapping(colid, target_entry);
 	}
 
-	pplan->qual = NULL;
+	plan->qual = NULL;
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// store share scan node for the translation of CTE Consumers
-	m_pctxdxltoplstmt->AddCTEConsumerInfo(ulCTEId, pshscanCTEConsumer);
+	m_dxl_to_plstmt_context->AddCTEConsumerInfo(cte_id, share_input_scan_cte_consumer);
 
-	return (Plan *) pshscanCTEConsumer;
+	return (Plan *) share_input_scan_cte_consumer;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanSequence
+//		CTranslatorDXLToPlStmt::TranslateDXLSequence
 //
 //	@doc:
 //		Translate DXL sequence node into GPDB Sequence plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanSequence
+CTranslatorDXLToPlStmt::TranslateDXLSequence
 	(
-	const CDXLNode *pdxlnSequence,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *sequence_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create append plan node
 	Sequence *psequence = MakeNode(Sequence);
 
-	Plan *pplan = &(psequence->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(psequence->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnSequence->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(sequence_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	ULONG ulArity = pdxlnSequence->UlArity();
+	ULONG arity = sequence_dxlnode->Arity();
 	
 	// translate last child
 	// since last child may be a DynamicIndexScan with outer references,
 	// we pass the context received from parent to translate outer refs here
 
-	CDXLNode *pdxlnLastChild = (*pdxlnSequence)[ulArity - 1];
+	CDXLNode *last_child_dxlnode = (*sequence_dxlnode)[arity - 1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanLastChild = PplFromDXL(pdxlnLastChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
-	pplan->nMotionNodes = pplanLastChild->nMotionNodes;
+	Plan *last_child_plan = TranslateDXLOperatorToPlan(last_child_dxlnode, &child_context, ctxt_translation_prev_siblings);
+	plan->nMotionNodes = last_child_plan->nMotionNodes;
 
-	CDXLNode *pdxlnPrL = (*pdxlnSequence)[0];
+	CDXLNode *project_list_dxlnode = (*sequence_dxlnode)[0];
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 						(
-						pdxlnPrL,
+						project_list_dxlnode,
 						NULL,		// base table translation context
-						pdrgpdxltrctx,
-						pdxltrctxOut
+						child_contexts,
+						output_context
 						);
 
 	// translate the rest of the children
-	for (ULONG ul = 1; ul < ulArity - 1; ul++)
+	for (ULONG ul = 1; ul < arity - 1; ul++)
 	{
-		CDXLNode *pdxlnChild = (*pdxlnSequence)[ul];
+		CDXLNode *child_dxlnode = (*sequence_dxlnode)[ul];
 
-		Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+		Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-		psequence->subplans = gpdb::PlAppendElement(psequence->subplans, pplanChild);
-		pplan->nMotionNodes += pplanChild->nMotionNodes;
+		psequence->subplans = gpdb::LAppend(psequence->subplans, child_plan);
+		plan->nMotionNodes += child_plan->nMotionNodes;
 	}
 
-	psequence->subplans = gpdb::PlAppendElement(psequence->subplans, pplanLastChild);
+	psequence->subplans = gpdb::LAppend(psequence->subplans, last_child_plan);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 	return (Plan *) psequence;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanDTS
+//		CTranslatorDXLToPlStmt::TranslateDXLDynTblScan
 //
 //	@doc:
 //		Translates a DXL dynamic table scan node into a DynamicTableScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanDTS
+CTranslatorDXLToPlStmt::TranslateDXLDynTblScan
 	(
-	const CDXLNode *pdxlnDTS,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dyn_tbl_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translate table descriptor into a range table entry
-	CDXLPhysicalDynamicTableScan *pdxlop = CDXLPhysicalDynamicTableScan::PdxlopConvert(pdxlnDTS->Pdxlop());
+	CDXLPhysicalDynamicTableScan *dyn_tbl_scan_dxlop = CDXLPhysicalDynamicTableScan::Cast(dyn_tbl_scan_dxlnode->GetOperator());
 
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dyn_tbl_scan_dxlop->GetDXLTableDescr(), NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
 
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
 	// create dynamic scan node
-	DynamicTableScan *pdts = MakeNode(DynamicTableScan);
+	DynamicTableScan *dyn_tbl_scan = MakeNode(DynamicTableScan);
 
-	pdts->scanrelid = iRel;
-	pdts->partIndex = pdxlop->UlPartIndexId();
-	pdts->partIndexPrintable = pdxlop->UlPartIndexIdPrintable();
+	dyn_tbl_scan->scanrelid = index;
+	dyn_tbl_scan->partIndex = dyn_tbl_scan_dxlop->GetPartIndexId();
+	dyn_tbl_scan->partIndexPrintable = dyn_tbl_scan_dxlop->GetPartIndexIdPrintable();
 
-	Plan *pplan = &(pdts->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	Plan *plan = &(dyn_tbl_scan->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnDTS->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(dyn_tbl_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	GPOS_ASSERT(2 == pdxlnDTS->UlArity());
+	GPOS_ASSERT(2 == dyn_tbl_scan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnDTS)[EdxltsIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnDTS)[EdxltsIndexFilter];
+	CDXLNode *project_list_dxlnode = (*dyn_tbl_scan_dxlnode)[EdxltsIndexProjList];
+	CDXLNode *filter_dxlnode = (*dyn_tbl_scan_dxlnode)[EdxltsIndexFilter];
 
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
-		&dxltrctxbt,	// translate context for the base table
-		NULL,			// pdxltrctxLeft and pdxltrctxRight,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut
+		project_list_dxlnode,
+		filter_dxlnode,
+		&base_table_context,	// translate context for the base table
+		NULL,			// translate_ctxt_left and pdxltrctxRight,
+		&plan->targetlist,
+		&plan->qual,
+		output_context
 		);
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pdts;
+	return (Plan *) dyn_tbl_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanDIS
+//		CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan
 //
 //	@doc:
 //		Translates a DXL dynamic index scan node into a DynamicIndexScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanDIS
+CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan
 	(
-	const CDXLNode *pdxlnDIS,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dyn_idx_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalDynamicIndexScan *pdxlop = CDXLPhysicalDynamicIndexScan::PdxlopConvert(pdxlnDIS->Pdxlop());
+	CDXLPhysicalDynamicIndexScan *dyn_index_scan_dxlop = CDXLPhysicalDynamicIndexScan::Cast(dyn_idx_scan_dxlnode->GetOperator());
 	
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
-	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
-	m_pctxdxltoplstmt->AddRTE(prte);
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(dyn_index_scan_dxlop->GetDXLTableDescr()->MDId());
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dyn_index_scan_dxlop->GetDXLTableDescr(), NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	DynamicIndexScan *pdis = MakeNode(DynamicIndexScan);
+	DynamicIndexScan *dyn_idx_scan = MakeNode(DynamicIndexScan);
 
-	pdis->scan.scanrelid = iRel;
-	pdis->scan.partIndex = pdxlop->UlPartIndexId();
-	pdis->scan.partIndexPrintable = pdxlop->UlPartIndexIdPrintable();
+	dyn_idx_scan->scan.scanrelid = index;
+	dyn_idx_scan->scan.partIndex = dyn_index_scan_dxlop->GetPartIndexId();
+	dyn_idx_scan->scan.partIndexPrintable = dyn_index_scan_dxlop->GetPartIndexIdPrintable();
 
-	CMDIdGPDB *pmdidIndex = CMDIdGPDB::PmdidConvert(pdxlop->Pdxlid()->Pmdid());
-	const IMDIndex *pmdindex = m_pmda->Pmdindex(pmdidIndex);
-	Oid oidIndex = pmdidIndex->OidObjectId();
+	CMDIdGPDB *mdid_index = CMDIdGPDB::CastMdid(dyn_index_scan_dxlop->GetDXLIndexDescr()->MDId());
+	const IMDIndex *md_index = m_md_accessor->RetrieveIndex(mdid_index);
+	Oid index_oid = mdid_index->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidIndex);
-	pdis->indexid = oidIndex;
-	pdis->logicalIndexInfo = gpdb::Plgidxinfo(prte->relid, oidIndex);
+	GPOS_ASSERT(InvalidOid != index_oid);
+	dyn_idx_scan->indexid = index_oid;
+	dyn_idx_scan->logicalIndexInfo = gpdb::GetLogicalIndexInfo(rte->relid, index_oid);
 
-	Plan *pplan = &(pdis->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	Plan *plan = &(dyn_idx_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnDIS->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(dyn_idx_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
 	// an index scan node must have 3 children: projection list, filter and index condition list
-	GPOS_ASSERT(3 == pdxlnDIS->UlArity());
+	GPOS_ASSERT(3 == dyn_idx_scan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnDIS)[CDXLPhysicalDynamicIndexScan::EdxldisIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnDIS)[CDXLPhysicalDynamicIndexScan::EdxldisIndexFilter];
-	CDXLNode *pdxlnIndexCondList = (*pdxlnDIS)[CDXLPhysicalDynamicIndexScan::EdxldisIndexCondition];
+	CDXLNode *project_list_dxlnode = (*dyn_idx_scan_dxlnode)[CDXLPhysicalDynamicIndexScan::EdxldisIndexProjList];
+	CDXLNode *filter_dxlnode = (*dyn_idx_scan_dxlnode)[CDXLPhysicalDynamicIndexScan::EdxldisIndexFilter];
+	CDXLNode *index_cond_list_dxlnode = (*dyn_idx_scan_dxlnode)[CDXLPhysicalDynamicIndexScan::EdxldisIndexCondition];
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList(pdxlnPrL, &dxltrctxbt, NULL /*pdrgpdxltrctx*/, pdxltrctxOut);
+	plan->targetlist = TranslateDXLProjList(project_list_dxlnode, &base_table_context, NULL /*child_contexts*/, output_context);
 
 	// translate index filter
-	pplan->qual = PlTranslateIndexFilter
+	plan->qual = TranslateDXLIndexFilter
 					(
-					pdxlnFilter,
-					pdxltrctxOut,
-					&dxltrctxbt,
-					pdrgpdxltrctxPrevSiblings
+					filter_dxlnode,
+					output_context,
+					&base_table_context,
+					ctxt_translation_prev_siblings
 					);
 
-	pdis->indexorderdir = CTranslatorUtils::Scandirection(pdxlop->EdxlScanDirection());
+	dyn_idx_scan->indexorderdir = CTranslatorUtils::GetScanDirection(dyn_index_scan_dxlop->GetIndexScanDir());
 
 	// translate index condition list
-	List *plIndexConditions = NIL;
-	List *plIndexOrigConditions = NIL;
-	List *plIndexStratgey = NIL;
-	List *plIndexSubtype = NIL;
+	List *index_cond = NIL;
+	List *index_orig_cond = NIL;
+	List *index_strategy_list = NIL;
+	List *index_subtype_list = NIL;
 
 	TranslateIndexConditions
 		(
-		pdxlnIndexCondList, 
-		pdxlop->Pdxltabdesc(), 
-		false, // fIndexOnlyScan 
-		pmdindex, 
-		pmdrel,
-		pdxltrctxOut,
-		&dxltrctxbt,
-		pdrgpdxltrctxPrevSiblings,
-		&plIndexConditions, 
-		&plIndexOrigConditions, 
-		&plIndexStratgey, 
-		&plIndexSubtype
+		index_cond_list_dxlnode,
+		dyn_index_scan_dxlop->GetDXLTableDescr(),
+		false, // is_index_only_scan
+		md_index,
+		md_rel,
+		output_context,
+		&base_table_context,
+		ctxt_translation_prev_siblings,
+		&index_cond,
+		&index_orig_cond,
+		&index_strategy_list,
+		&index_subtype_list
 		);
 
 
-	pdis->indexqual = plIndexConditions;
-	pdis->indexqualorig = plIndexOrigConditions;
-	pdis->indexstrategy = plIndexStratgey;
-	pdis->indexsubtype = plIndexSubtype;
-	SetParamIds(pplan);
+	dyn_idx_scan->indexqual = index_cond;
+	dyn_idx_scan->indexqualorig = index_orig_cond;
+	dyn_idx_scan->indexstrategy = index_strategy_list;
+	dyn_idx_scan->indexsubtype = index_subtype_list;
+	SetParamIds(plan);
 
-	return (Plan *) pdis;
+	return (Plan *) dyn_idx_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanDML
+//		CTranslatorDXLToPlStmt::TranslateDXLDml
 //
 //	@doc:
 //		Translates a DXL DML node 
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanDML
+CTranslatorDXLToPlStmt::TranslateDXLDml
 	(
-	const CDXLNode *pdxlnDML,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *dml_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translate table descriptor into a range table entry
-	CDXLPhysicalDML *pdxlop = CDXLPhysicalDML::PdxlopConvert(pdxlnDML->Pdxlop());
+	CDXLPhysicalDML *phy_dml_dxlop = CDXLPhysicalDML::Cast(dml_dxlnode->GetOperator());
 
 	// create DML node
-	DML *pdml = MakeNode(DML);
-	Plan *pplan = &(pdml->plan);
-	AclMode aclmode = ACL_NO_RIGHTS;
+	DML *dml = MakeNode(DML);
+	Plan *plan = &(dml->plan);
+	AclMode acl_mode = ACL_NO_RIGHTS;
 	
-	switch (pdxlop->EdxlDmlOpType())
+	switch (phy_dml_dxlop->GetDmlOpType())
 	{
 		case gpdxl::Edxldmldelete:
 		{
-			m_cmdtype = CMD_DELETE;
-			aclmode = ACL_DELETE;
+			m_cmd_type = CMD_DELETE;
+			acl_mode = ACL_DELETE;
 			break;
 		}
 		case gpdxl::Edxldmlupdate:
 		{
-			m_cmdtype = CMD_UPDATE;
-			aclmode = ACL_UPDATE;
+			m_cmd_type = CMD_UPDATE;
+			acl_mode = ACL_UPDATE;
 			break;
 		}
 		case gpdxl::Edxldmlinsert:
 		{
-			m_cmdtype = CMD_INSERT;
-			aclmode = ACL_INSERT;
+			m_cmd_type = CMD_INSERT;
+			acl_mode = ACL_INSERT;
 			break;
 		}
 		case gpdxl::EdxldmlSentinel:
@@ -4261,461 +4261,461 @@ CTranslatorDXLToPlStmt::PplanDML
 		}
 	}
 	
-	IMDId *pmdidTargetTable = pdxlop->Pdxltabdesc()->Pmdid();
-	if (IMDRelation::EreldistrMasterOnly != m_pmda->Pmdrel(pmdidTargetTable)->Ereldistribution())
+	IMDId *mdid_target_table = phy_dml_dxlop->GetDXLTableDescr()->MDId();
+	if (IMDRelation::EreldistrMasterOnly != m_md_accessor->RetrieveRel(mdid_target_table)->GetRelDistribution())
 	{
-		m_fTargetTableDistributed = true;
+		m_is_tgt_tbl_distributed = true;
 	}
 	
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
-	pdml->scanrelid = iRel;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
+	dml->scanrelid = index;
 	
-	m_plResultRelations = gpdb::PlAppendInt(m_plResultRelations, iRel);
+	m_result_rel_list = gpdb::LAppendInt(m_result_rel_list, index);
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(phy_dml_dxlop->GetDXLTableDescr()->MDId());
 
-	CDXLTableDescr *pdxltabdesc = pdxlop->Pdxltabdesc();
-	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= aclmode;
-	m_pctxdxltoplstmt->AddRTE(prte);
+	CDXLTableDescr *table_descr = phy_dml_dxlop->GetDXLTableDescr();
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(table_descr, NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= acl_mode;
+	m_dxl_to_plstmt_context->AddRTE(rte);
 	
-	CDXLNode *pdxlnPrL = (*pdxlnDML)[0];
-	CDXLNode *pdxlnChild = (*pdxlnDML)[1];
+	CDXLNode *project_list_dxlnode = (*dml_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*dml_dxlnode)[1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 
 	// translate proj list
-	List *plTargetListDML = PlTargetListFromProjList
+	List *dml_target_list = TranslateDXLProjList
 		(
-		pdxlnPrL,
+		project_list_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		pdxltrctxOut
+		child_contexts,
+		output_context
 		);
 	
-	if (pmdrel->FHasDroppedColumns())
+	if (md_rel->HasDroppedColumns())
 	{
 		// pad DML target list with NULLs for dropped columns for all DML operator types
-		List *plTargetListWithDroppedCols = PlTargetListWithDroppedCols(plTargetListDML, pmdrel);
-		gpdb::GPDBFree(plTargetListDML);
-		plTargetListDML = plTargetListWithDroppedCols;
+		List *target_list_with_dropped_cols = CreateTargetListWithNullsForDroppedCols(dml_target_list, md_rel);
+		gpdb::GPDBFree(dml_target_list);
+		dml_target_list = target_list_with_dropped_cols;
 	}
 
 	// Extract column numbers of the action and ctid columns from the
 	// target list. ORCA also includes a third similar column for
 	// partition Oid to the target list, but we don't use it for anything
 	// in GPDB.
-	pdml->actionColIdx = UlAddTargetEntryForColId(&plTargetListDML, &dxltrctxChild, pdxlop->UlAction(), true /*fResjunk*/);
-	pdml->ctidColIdx = UlAddTargetEntryForColId(&plTargetListDML, &dxltrctxChild, pdxlop->UlCtid(), true /*fResjunk*/);
-	if (pdxlop->FPreserveOids())
+	dml->actionColIdx = AddTargetEntryForColId(&dml_target_list, &child_context, phy_dml_dxlop->ActionColId(), true /*is_resjunk*/);
+	dml->ctidColIdx = AddTargetEntryForColId(&dml_target_list, &child_context, phy_dml_dxlop->GetCtIdColId(), true /*is_resjunk*/);
+	if (phy_dml_dxlop->IsOidsPreserved())
 	{
-		pdml->tupleoidColIdx = UlAddTargetEntryForColId(&plTargetListDML, &dxltrctxChild, pdxlop->UlTupleOid(), true /*fResjunk*/);
+		dml->tupleoidColIdx = AddTargetEntryForColId(&dml_target_list, &child_context, phy_dml_dxlop->GetTupleOid(), true /*is_resjunk*/);
 	}
 	else
 	{
-		pdml->tupleoidColIdx = 0;
+		dml->tupleoidColIdx = 0;
 	}
 
-	GPOS_ASSERT(0 != pdml->actionColIdx);
+	GPOS_ASSERT(0 != dml->actionColIdx);
 
-	pplan->targetlist = plTargetListDML;
+	plan->targetlist = dml_target_list;
 	
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	if (CMD_INSERT == m_cmdtype && 0 == pplan->nMotionNodes)
+	if (CMD_INSERT == m_cmd_type && 0 == plan->nMotionNodes)
 	{
-		List *plDirectDispatchSegIds = PlDirectDispatchSegIds(pdxlop->Pdxlddinfo());
-		pplan->directDispatch.contentIds = plDirectDispatchSegIds;
-		pplan->directDispatch.isDirectDispatch = (NIL != plDirectDispatchSegIds);
+		List *direct_dispatch_segids = TranslateDXLDirectDispatchInfo(phy_dml_dxlop->GetDXLDirectDispatchInfo());
+		plan->directDispatch.contentIds = direct_dispatch_segids;
+		plan->directDispatch.isDirectDispatch = (NIL != direct_dispatch_segids);
 	}
 	
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnDML->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(dml_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	return (Plan *) pdml;
+	return (Plan *) dml;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlDirectDispatchSegIds
+//		CTranslatorDXLToPlStmt::TranslateDXLDirectDispatchInfo
 //
 //	@doc:
 //		Translate the direct dispatch info
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlDirectDispatchSegIds
+CTranslatorDXLToPlStmt::TranslateDXLDirectDispatchInfo
 	(
-	CDXLDirectDispatchInfo *pdxlddinfo
+	CDXLDirectDispatchInfo *dxl_direct_dispatch_info
 	)
 {
-	if (!optimizer_enable_direct_dispatch || NULL == pdxlddinfo)
+	if (!optimizer_enable_direct_dispatch || NULL == dxl_direct_dispatch_info)
 	{
 		return NIL;
 	}
 	
-	DrgPdrgPdxldatum *pdrgpdrgpdxldatum = pdxlddinfo->Pdrgpdrgpdxldatum();
+	CDXLDatum2dArray *dispatch_identifier_datum_arrays = dxl_direct_dispatch_info->GetDispatchIdentifierDatumArray();
 	
-	if (pdrgpdrgpdxldatum == NULL || 0 == pdrgpdrgpdxldatum->UlLength())
+	if (dispatch_identifier_datum_arrays == NULL || 0 == dispatch_identifier_datum_arrays->Size())
 	{
 		return NIL;
 	}
 	
-	DrgPdxldatum *pdrgpdxldatum = (*pdrgpdrgpdxldatum)[0];
-	GPOS_ASSERT(0 < pdrgpdxldatum->UlLength());
+	CDXLDatumArray *dxl_datum_array = (*dispatch_identifier_datum_arrays)[0];
+	GPOS_ASSERT(0 < dxl_datum_array->Size());
 		
-	ULONG ulHashCode = UlCdbHash(pdrgpdxldatum);
-	const ULONG ulLength = pdrgpdrgpdxldatum->UlLength();
-	for (ULONG ul = 0; ul < ulLength; ul++)
+	ULONG hash_code = GetDXLDatumGPDBHash(dxl_datum_array);
+	const ULONG length = dispatch_identifier_datum_arrays->Size();
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		DrgPdxldatum *pdrgpdxldatumDisj = (*pdrgpdrgpdxldatum)[ul];
-		GPOS_ASSERT(0 < pdrgpdxldatumDisj->UlLength());
-		ULONG ulHashCodeNew = UlCdbHash(pdrgpdxldatumDisj);
+		CDXLDatumArray *dispatch_identifier_datum_array = (*dispatch_identifier_datum_arrays)[ul];
+		GPOS_ASSERT(0 < dispatch_identifier_datum_array->Size());
+		ULONG hash_code_new = GetDXLDatumGPDBHash(dispatch_identifier_datum_array);
 		
-		if (ulHashCode != ulHashCodeNew)
+		if (hash_code != hash_code_new)
 		{
 			// values don't hash to the same segment
 			return NIL;
 		}
 	}
 	
-	List *plSegIds = gpdb::PlAppendInt(NIL, ulHashCode);
-	return plSegIds;
+	List *segids_list = gpdb::LAppendInt(NIL, hash_code);
+	return segids_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::UlCdbHash
+//		CTranslatorDXLToPlStmt::GetDXLDatumGPDBHash
 //
 //	@doc:
 //		Hash a DXL datum
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorDXLToPlStmt::UlCdbHash
+CTranslatorDXLToPlStmt::GetDXLDatumGPDBHash
 	(
-	DrgPdxldatum *pdrgpdxldatum
+	CDXLDatumArray *dxl_datum_array
 	)
 {
-	List *plConsts = NIL;
+	List *consts_list = NIL;
 	
-	const ULONG ulLength = pdrgpdxldatum->UlLength();
+	const ULONG length = dxl_datum_array->Size();
 	
-	for (ULONG ul = 0; ul < ulLength; ul++)
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		CDXLDatum *pdxldatum = (*pdrgpdxldatum)[ul];
+		CDXLDatum *datum_dxl = (*dxl_datum_array)[ul];
 		
-		Const *pconst = (Const *) m_pdxlsctranslator->PconstFromDXLDatum(pdxldatum);
-		plConsts = gpdb::PlAppendElement(plConsts, pconst);
+		Const *const_expr = (Const *) m_translator_dxl_to_scalar->TranslateDXLDatumToScalar(datum_dxl);
+		consts_list = gpdb::LAppend(consts_list, const_expr);
 	}
 
-	ULONG ulHash = gpdb::ICdbHashList(plConsts, m_ulSegments);
+	ULONG hash = gpdb::CdbHashConstList(consts_list, m_num_of_segments);
 
-	gpdb::FreeListDeep(plConsts);
+	gpdb::ListFreeDeep(consts_list);
 	
-	return ulHash;
+	return hash;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanSplit
+//		CTranslatorDXLToPlStmt::TranslateDXLSplit
 //
 //	@doc:
 //		Translates a DXL Split node 
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanSplit
+CTranslatorDXLToPlStmt::TranslateDXLSplit
 	(
-	const CDXLNode *pdxlnSplit,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *split_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalSplit *pdxlop = CDXLPhysicalSplit::PdxlopConvert(pdxlnSplit->Pdxlop());
+	CDXLPhysicalSplit *phy_split_dxlop = CDXLPhysicalSplit::Cast(split_dxlnode->GetOperator());
 
 	// create SplitUpdate node
-	SplitUpdate *psplit = MakeNode(SplitUpdate);
-	Plan *pplan = &(psplit->plan);
+	SplitUpdate *split = MakeNode(SplitUpdate);
+	Plan *plan = &(split->plan);
 	
-	CDXLNode *pdxlnPrL = (*pdxlnSplit)[0];
-	CDXLNode *pdxlnChild = (*pdxlnSplit)[1];
+	CDXLNode *project_list_dxlnode = (*split_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*split_dxlnode)[1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 		(
-		pdxlnPrL,
+		project_list_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		pdxltrctxOut
+		child_contexts,
+		output_context
 		);
 
 	// translate delete and insert columns
-	DrgPul *pdrgpulDeleteCols = pdxlop->PdrgpulDelete();
-	DrgPul *pdrgpulInsertCols = pdxlop->PdrgpulInsert();
+	ULongPtrArray *deletion_colid_array = phy_split_dxlop->GetDeletionColIdArray();
+	ULongPtrArray *insertion_colid_array = phy_split_dxlop->GetInsertionColIdArray();
 		
-	GPOS_ASSERT(pdrgpulInsertCols->UlLength() == pdrgpulDeleteCols->UlLength());
+	GPOS_ASSERT(insertion_colid_array->Size() == deletion_colid_array->Size());
 	
-	psplit->deleteColIdx = CTranslatorUtils::PlAttnosFromColids(pdrgpulDeleteCols, &dxltrctxChild);
-	psplit->insertColIdx = CTranslatorUtils::PlAttnosFromColids(pdrgpulInsertCols, &dxltrctxChild);
+	split->deleteColIdx = CTranslatorUtils::ConvertColidToAttnos(deletion_colid_array, &child_context);
+	split->insertColIdx = CTranslatorUtils::ConvertColidToAttnos(insertion_colid_array, &child_context);
 	
-	const TargetEntry *pteActionCol = pdxltrctxOut->Pte(pdxlop->UlAction());
-	const TargetEntry *pteCtidCol = pdxltrctxOut->Pte(pdxlop->UlCtid());
-	const TargetEntry *pteTupleOidCol = pdxltrctxOut->Pte(pdxlop->UlTupleOid());
+	const TargetEntry *te_action_col = output_context->GetTargetEntry(phy_split_dxlop->ActionColId());
+	const TargetEntry *te_ctid_col = output_context->GetTargetEntry(phy_split_dxlop->GetCtIdColId());
+	const TargetEntry *te_tuple_oid_col = output_context->GetTargetEntry(phy_split_dxlop->GetTupleOid());
 
-	if (NULL  == pteActionCol)
+	if (NULL  == te_action_col)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, pdxlop->UlAction());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, phy_split_dxlop->ActionColId());
 	}
-	if (NULL  == pteCtidCol)
+	if (NULL  == te_ctid_col)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, pdxlop->UlCtid());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, phy_split_dxlop->GetCtIdColId());
 	}	 
 	
-	psplit->actionColIdx = pteActionCol->resno;
-	psplit->ctidColIdx = pteCtidCol->resno;
+	split->actionColIdx = te_action_col->resno;
+	split->ctidColIdx = te_ctid_col->resno;
 	
-	psplit->tupleoidColIdx = FirstLowInvalidHeapAttributeNumber;
-	if (NULL != pteTupleOidCol)
+	split->tupleoidColIdx = FirstLowInvalidHeapAttributeNumber;
+	if (NULL != te_tuple_oid_col)
 	{
-		psplit->tupleoidColIdx = pteTupleOidCol->resno;
+		split->tupleoidColIdx = te_tuple_oid_col->resno;
 	}
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnSplit->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(split_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	return (Plan *) psplit;
+	return (Plan *) split;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanAssert
+//		CTranslatorDXLToPlStmt::TranslateDXLAssert
 //
 //	@doc:
 //		Translate DXL assert node into GPDB assert plan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanAssert
+CTranslatorDXLToPlStmt::TranslateDXLAssert
 	(
-	const CDXLNode *pdxlnAssert,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *assert_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// create assert plan node
-	AssertOp *passert = MakeNode(AssertOp);
+	AssertOp *assert_node = MakeNode(AssertOp);
 
-	Plan *pplan = &(passert->plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	Plan *plan = &(assert_node->plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalAssert *pdxlopAssert = CDXLPhysicalAssert::PdxlopConvert(pdxlnAssert->Pdxlop());
+	CDXLPhysicalAssert *assert_dxlop = CDXLPhysicalAssert::Cast(assert_dxlnode->GetOperator());
 
 	// translate error code into the its internal GPDB representation
-	const CHAR *szErrorCode = pdxlopAssert->SzSQLState();
-	GPOS_ASSERT(GPOS_SQLSTATE_LENGTH == clib::UlStrLen(szErrorCode));
+	const CHAR *error_code = assert_dxlop->GetSQLState();
+	GPOS_ASSERT(GPOS_SQLSTATE_LENGTH == clib::Strlen(error_code));
 	
-	passert->errcode = MAKE_SQLSTATE(szErrorCode[0], szErrorCode[1], szErrorCode[2], szErrorCode[3], szErrorCode[4]);
-	CDXLNode *pdxlnFilter = (*pdxlnAssert)[CDXLPhysicalAssert::EdxlassertIndexFilter];
+	assert_node->errcode = MAKE_SQLSTATE(error_code[0], error_code[1], error_code[2], error_code[3], error_code[4]);
+	CDXLNode *filter_dxlnode = (*assert_dxlnode)[CDXLPhysicalAssert::EdxlassertIndexFilter];
 
-	passert->errmessage = CTranslatorUtils::PlAssertErrorMsgs(pdxlnFilter);
+	assert_node->errmessage = CTranslatorUtils::GetAssertErrorMsgs(filter_dxlnode);
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnAssert->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(assert_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
 	// translate child plan
-	CDXLNode *pdxlnChild = (*pdxlnAssert)[CDXLPhysicalAssert::EdxlassertIndexChild];
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	CDXLNode *child_dxlnode = (*assert_dxlnode)[CDXLPhysicalAssert::EdxlassertIndexChild];
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	GPOS_ASSERT(NULL != pplanChild && "child plan cannot be NULL");
+	GPOS_ASSERT(NULL != child_plan && "child plan cannot be NULL");
 
-	passert->plan.lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
+	assert_node->plan.lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
 
-	CDXLNode *pdxlnPrL = (*pdxlnAssert)[CDXLPhysicalAssert::EdxlassertIndexProjList];
+	CDXLNode *project_list_dxlnode = (*assert_dxlnode)[CDXLPhysicalAssert::EdxlassertIndexProjList];
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(const_cast<CDXLTranslateContext*>(&dxltrctxChild));
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(const_cast<CDXLTranslateContext*>(&child_context));
 
 	// translate proj list
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 				(
-				pdxlnPrL,
+				project_list_dxlnode,
 				NULL,			// translate context for the base table
-				pdrgpdxltrctx,
-				pdxltrctxOut
+				child_contexts,
+				output_context
 				);
 
 	// translate assert constraints
-	pplan->qual = PlTranslateAssertConstraints
+	plan->qual = TranslateDXLAssertConstraints
 					(
-					pdxlnFilter,
-					pdxltrctxOut,
-					pdrgpdxltrctx
+					filter_dxlnode,
+					output_context,
+					child_contexts
 					);
 	
-	GPOS_ASSERT(gpdb::UlListLength(pplan->qual) == gpdb::UlListLength(passert->errmessage));
-	SetParamIds(pplan);
+	GPOS_ASSERT(gpdb::ListLength(plan->qual) == gpdb::ListLength(assert_node->errmessage));
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
-	return (Plan *) passert;
+	return (Plan *) assert_node;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanRowTrigger
+//		CTranslatorDXLToPlStmt::TranslateDXLRowTrigger
 //
 //	@doc:
 //		Translates a DXL Row Trigger node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanRowTrigger
+CTranslatorDXLToPlStmt::TranslateDXLRowTrigger
 	(
-	const CDXLNode *pdxlnRowTrigger,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *row_trigger_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalRowTrigger *pdxlop = CDXLPhysicalRowTrigger::PdxlopConvert(pdxlnRowTrigger->Pdxlop());
+	CDXLPhysicalRowTrigger *phy_row_trigger_dxlop = CDXLPhysicalRowTrigger::Cast(row_trigger_dxlnode->GetOperator());
 
 	// create RowTrigger node
-	RowTrigger *prowtrigger = MakeNode(RowTrigger);
-	Plan *pplan = &(prowtrigger->plan);
+	RowTrigger *row_trigger = MakeNode(RowTrigger);
+	Plan *plan = &(row_trigger->plan);
 
-	CDXLNode *pdxlnPrL = (*pdxlnRowTrigger)[0];
-	CDXLNode *pdxlnChild = (*pdxlnRowTrigger)[1];
+	CDXLNode *project_list_dxlnode = (*row_trigger_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*row_trigger_dxlnode)[1];
 
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *child_plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
-	pplan->targetlist = PlTargetListFromProjList
+	plan->targetlist = TranslateDXLProjList
 		(
-		pdxlnPrL,
+		project_list_dxlnode,
 		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		pdxltrctxOut
+		child_contexts,
+		output_context
 		);
 
-	Oid oidRelid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidRel())->OidObjectId();
-	GPOS_ASSERT(InvalidOid != oidRelid);
-	prowtrigger->relid = oidRelid;
-	prowtrigger->eventFlags = pdxlop->IType();
+	Oid relid_oid = CMDIdGPDB::CastMdid(phy_row_trigger_dxlop->GetRelMdId())->Oid();
+	GPOS_ASSERT(InvalidOid != relid_oid);
+	row_trigger->relid = relid_oid;
+	row_trigger->eventFlags = phy_row_trigger_dxlop->GetType();
 
 	// translate old and new columns
-	DrgPul *pdrgpulOldCols = pdxlop->PdrgpulOld();
-	DrgPul *pdrgpulNewCols = pdxlop->PdrgpulNew();
+	ULongPtrArray *colids_old_array = phy_row_trigger_dxlop->GetColIdsOld();
+	ULongPtrArray *colids_new_array = phy_row_trigger_dxlop->GetColIdsNew();
 
-	GPOS_ASSERT_IMP(NULL != pdrgpulOldCols && NULL != pdrgpulNewCols,
-					pdrgpulNewCols->UlLength() == pdrgpulOldCols->UlLength());
+	GPOS_ASSERT_IMP(NULL != colids_old_array && NULL != colids_new_array,
+					colids_new_array->Size() == colids_old_array->Size());
 
-	if (NULL == pdrgpulOldCols)
+	if (NULL == colids_old_array)
 	{
-		prowtrigger->oldValuesColIdx = NIL;
+		row_trigger->oldValuesColIdx = NIL;
 	}
 	else
 	{
-		prowtrigger->oldValuesColIdx = CTranslatorUtils::PlAttnosFromColids(pdrgpulOldCols, &dxltrctxChild);
+		row_trigger->oldValuesColIdx = CTranslatorUtils::ConvertColidToAttnos(colids_old_array, &child_context);
 	}
 
-	if (NULL == pdrgpulNewCols)
+	if (NULL == colids_new_array)
 	{
-		prowtrigger->newValuesColIdx = NIL;
+		row_trigger->newValuesColIdx = NIL;
 	}
 	else
 	{
-		prowtrigger->newValuesColIdx = CTranslatorUtils::PlAttnosFromColids(pdrgpulNewCols, &dxltrctxChild);
+		row_trigger->newValuesColIdx = CTranslatorUtils::ConvertColidToAttnos(colids_new_array, &child_context);
 	}
 
-	pplan->lefttree = pplanChild;
-	pplan->nMotionNodes = pplanChild->nMotionNodes;
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
+	plan->lefttree = child_plan;
+	plan->nMotionNodes = child_plan->nMotionNodes;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnRowTrigger->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(row_trigger_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	return (Plan *) prowtrigger;
+	return (Plan *) row_trigger;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PrteFromTblDescr
+//		CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry
 //
 //	@doc:
 //		Translates a DXL table descriptor into a range table entry. If an index
@@ -4724,216 +4724,216 @@ CTranslatorDXLToPlStmt::PplanRowTrigger
 //
 //---------------------------------------------------------------------------
 RangeTblEntry *
-CTranslatorDXLToPlStmt::PrteFromTblDescr
+CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry
 	(
-	const CDXLTableDescr *pdxltabdesc,
-	const CDXLIndexDescr *pdxlid, // should be NULL unless we have an index-only scan
-	Index iRel,
-	CDXLTranslateContextBaseTable *pdxltrctxbtOut
+	const CDXLTableDescr *table_descr,
+	const CDXLIndexDescr *index_descr_dxl, // should be NULL unless we have an index-only scan
+	Index index,
+	CDXLTranslateContextBaseTable *base_table_context
 	)
 {
-	GPOS_ASSERT(NULL != pdxltabdesc);
+	GPOS_ASSERT(NULL != table_descr);
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	const ULONG ulRelColumns = CTranslatorUtils::UlNonSystemColumns(pmdrel);
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
+	const ULONG num_of_non_sys_cols = CTranslatorUtils::GetNumNonSystemColumns(md_rel);
 
-	RangeTblEntry *prte = MakeNode(RangeTblEntry);
-	prte->rtekind = RTE_RELATION;
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
+	rte->rtekind = RTE_RELATION;
 
 	// get the index if given
-	const IMDIndex *pmdindex = NULL;
-	if (NULL != pdxlid)
+	const IMDIndex *md_index = NULL;
+	if (NULL != index_descr_dxl)
 	{
-		pmdindex = m_pmda->Pmdindex(pdxlid->Pmdid());
+		md_index = m_md_accessor->RetrieveIndex(index_descr_dxl->MDId());
 	}
 
 	// get oid for table
-	Oid oid = CMDIdGPDB::PmdidConvert(pdxltabdesc->Pmdid())->OidObjectId();
+	Oid oid = CMDIdGPDB::CastMdid(table_descr->MDId())->Oid();
 	GPOS_ASSERT(InvalidOid != oid);
 
-	prte->relid = oid;
-	prte->checkAsUser = pdxltabdesc->UlExecuteAsUser();
-	prte->requiredPerms |= ACL_NO_RIGHTS;
+	rte->relid = oid;
+	rte->checkAsUser = table_descr->GetExecuteAsUserId();
+	rte->requiredPerms |= ACL_NO_RIGHTS;
 
 	// save oid and range index in translation context
-	pdxltrctxbtOut->SetOID(oid);
-	pdxltrctxbtOut->SetIdx(iRel);
+	base_table_context->SetOID(oid);
+	base_table_context->SetRelIndex(index);
 
-	Alias *palias = MakeNode(Alias);
-	palias->colnames = NIL;
+	Alias *alias = MakeNode(Alias);
+	alias->colnames = NIL;
 
 	// get table alias
-	palias->aliasname = CTranslatorUtils::SzFromWsz(pdxltabdesc->Pmdname()->Pstr()->Wsz());
+	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(table_descr->MdName()->GetMDName()->GetBuffer());
 
 	// get column names
-	const ULONG ulArity = pdxltabdesc->UlArity();
+	const ULONG arity = table_descr->Arity();
 	
-	INT iLastAttno = 0;
+	INT last_attno = 0;
 	
-	for (ULONG ul = 0; ul < ulArity; ++ul)
+	for (ULONG ul = 0; ul < arity; ++ul)
 	{
-		const CDXLColDescr *pdxlcd = pdxltabdesc->Pdxlcd(ul);
-		GPOS_ASSERT(NULL != pdxlcd);
+		const CDXLColDescr *dxl_col_descr = table_descr->GetColumnDescrAt(ul);
+		GPOS_ASSERT(NULL != dxl_col_descr);
 
-		INT iAttno = pdxlcd->IAttno();
+		INT attno = dxl_col_descr->AttrNum();
 
-		GPOS_ASSERT(0 != iAttno);
+		GPOS_ASSERT(0 != attno);
 
-		if (0 < iAttno)
+		if (0 < attno)
 		{
-			// if iAttno > iLastAttno + 1, there were dropped attributes
+			// if attno > last_attno + 1, there were dropped attributes
 			// add those to the RTE as they are required by GPDB
-			for (INT iDroppedColAttno = iLastAttno + 1; iDroppedColAttno < iAttno; iDroppedColAttno++)
+			for (INT dropped_col_attno = last_attno + 1; dropped_col_attno < attno; dropped_col_attno++)
 			{
-				Value *pvalDroppedColName = gpdb::PvalMakeString(PStrDup(""));
-				palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalDroppedColName);
+				Value *val_dropped_colname = gpdb::MakeStringValue(PStrDup(""));
+				alias->colnames = gpdb::LAppend(alias->colnames, val_dropped_colname);
 			}
 			
 			// non-system attribute
-			CHAR *szColName = CTranslatorUtils::SzFromWsz(pdxlcd->Pmdname()->Pstr()->Wsz());
-			Value *pvalColName = gpdb::PvalMakeString(szColName);
+			CHAR *col_name_char_array = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxl_col_descr->MdName()->GetMDName()->GetBuffer());
+			Value *val_colname = gpdb::MakeStringValue(col_name_char_array);
 
-			palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalColName);
-			iLastAttno = iAttno;
+			alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
+			last_attno = attno;
 		}
 
 		// get the attno from the index, in case of indexonlyscan
-		if (NULL != pmdindex)
+		if (NULL != md_index)
 		{
-			iAttno = 1 + pmdindex->UlPosInKey((ULONG) iAttno - 1);
+			attno = 1 + md_index->GetKeyPos((ULONG) attno - 1);
 		}
 
 		// save mapping col id -> index in translate context
-		(void) pdxltrctxbtOut->FInsertMapping(pdxlcd->UlID(), iAttno);
+		(void) base_table_context->InsertMapping(dxl_col_descr->Id(), attno);
 	}
 
 	// if there are any dropped columns at the end, add those too to the RangeTblEntry
-	for (ULONG ul = iLastAttno + 1; ul <= ulRelColumns; ul++)
+	for (ULONG ul = last_attno + 1; ul <= num_of_non_sys_cols; ul++)
 	{
-		Value *pvalDroppedColName = gpdb::PvalMakeString(PStrDup(""));
-		palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalDroppedColName);
+		Value *val_dropped_colname = gpdb::MakeStringValue(PStrDup(""));
+		alias->colnames = gpdb::LAppend(alias->colnames, val_dropped_colname);
 	}
 	
-	prte->eref = palias;
+	rte->eref = alias;
 
-	return prte;
+	return rte;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlTargetListFromProjList
+//		CTranslatorDXLToPlStmt::TranslateDXLProjList
 //
 //	@doc:
 //		Translates a DXL projection list node into a target list.
 //		For base table projection lists, the caller should provide a base table
 //		translation context with table oid, rtable index and mappings for the columns.
-//		For other nodes pdxltrctxLeft and pdxltrctxRight give
+//		For other nodes translate_ctxt_left and pdxltrctxRight give
 //		the mappings of column ids to target entries in the corresponding child nodes
 //		for resolving the origin of the target entries
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTargetListFromProjList
+CTranslatorDXLToPlStmt::TranslateDXLProjList
 	(
-	const CDXLNode *pdxlnPrL,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *project_list_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	CDXLTranslateContext *output_context
 	)
 {
-	if (NULL == pdxlnPrL)
+	if (NULL == project_list_dxlnode)
 	{
 		return NULL;
 	}
 
-	List *plTargetList = NIL;
+	List *target_list = NIL;
 
 	// translate each DXL project element into a target entry
-	const ULONG ulArity = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ++ul)
+	const ULONG arity = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ++ul)
 	{
-		CDXLNode *pdxlnPrEl = (*pdxlnPrL)[ul];
-		GPOS_ASSERT(EdxlopScalarProjectElem == pdxlnPrEl->Pdxlop()->Edxlop());
-		CDXLScalarProjElem *pdxlopPrel = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop());
-		GPOS_ASSERT(1 == pdxlnPrEl->UlArity());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		GPOS_ASSERT(EdxlopScalarProjectElem == proj_elem_dxlnode->GetOperator()->GetDXLOperator());
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
+		GPOS_ASSERT(1 == proj_elem_dxlnode->Arity());
 
 		// translate proj element expression
-		CDXLNode *pdxlnExpr = (*pdxlnPrEl)[0];
+		CDXLNode *expr_dxlnode = (*proj_elem_dxlnode)[0];
 
-		CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+		CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 																(
-																m_pmp,
-																pdxltrctxbt,
-																pdrgpdxltrctx,
-																pdxltrctxOut,
-																m_pctxdxltoplstmt
+																m_mp,
+																base_table_context,
+																child_contexts,
+																output_context,
+																m_dxl_to_plstmt_context
 																);
 
-		Expr *pexpr = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnExpr, &mapcidvarplstmt);
+		Expr *expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(expr_dxlnode, &colid_var_mapping);
 
-		GPOS_ASSERT(NULL != pexpr);
+		GPOS_ASSERT(NULL != expr);
 
-		TargetEntry *pte = MakeNode(TargetEntry);
-		pte->expr = pexpr;
-		pte->resname = CTranslatorUtils::SzFromWsz(pdxlopPrel->PmdnameAlias()->Pstr()->Wsz());
-		pte->resno = (AttrNumber) (ul + 1);
+		TargetEntry *target_entry = MakeNode(TargetEntry);
+		target_entry->expr = expr;
+		target_entry->resname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
+		target_entry->resno = (AttrNumber) (ul + 1);
 
-		if (IsA(pexpr, Var))
+		if (IsA(expr, Var))
 		{
 			// check the origin of the left or the right side
 			// of the current operator and if it is derived from a base relation,
 			// set resorigtbl and resorigcol appropriately
 
-			if (NULL != pdxltrctxbt)
+			if (NULL != base_table_context)
 			{
 				// translating project list of a base table
-				pte->resorigtbl = pdxltrctxbt->OidRel();
-				pte->resorigcol = ((Var *) pexpr)->varattno;
+				target_entry->resorigtbl = base_table_context->GetOid();
+				target_entry->resorigcol = ((Var *) expr)->varattno;
 			}
 			else
 			{
 				// not translating a base table proj list: variable must come from
 				// the left or right child of the operator
 
-				GPOS_ASSERT(NULL != pdrgpdxltrctx);
-				GPOS_ASSERT(0 != pdrgpdxltrctx->UlLength());
-				ULONG ulColId = CDXLScalarIdent::PdxlopConvert(pdxlnExpr->Pdxlop())->Pdxlcr()->UlID();
+				GPOS_ASSERT(NULL != child_contexts);
+				GPOS_ASSERT(0 != child_contexts->Size());
+				ULONG colid = CDXLScalarIdent::Cast(expr_dxlnode->GetOperator())->GetDXLColRef()->Id();
 
-				const CDXLTranslateContext *pdxltrctxLeft = (*pdrgpdxltrctx)[0];
-				GPOS_ASSERT(NULL != pdxltrctxLeft);
-				const TargetEntry *pteOriginal = pdxltrctxLeft->Pte(ulColId);
+				const CDXLTranslateContext *translate_ctxt_left = (*child_contexts)[0];
+				GPOS_ASSERT(NULL != translate_ctxt_left);
+				const TargetEntry *pteOriginal = translate_ctxt_left->GetTargetEntry(colid);
 
 				if (NULL == pteOriginal)
 				{
 					// variable not found on the left side
-					GPOS_ASSERT(2 == pdrgpdxltrctx->UlLength());
-					const CDXLTranslateContext *pdxltrctxRight = (*pdrgpdxltrctx)[1];
+					GPOS_ASSERT(2 == child_contexts->Size());
+					const CDXLTranslateContext *pdxltrctxRight = (*child_contexts)[1];
 
 					GPOS_ASSERT(NULL != pdxltrctxRight);
-					pteOriginal = pdxltrctxRight->Pte(ulColId);
+					pteOriginal = pdxltrctxRight->GetTargetEntry(colid);
 				}
 
 				if (NULL  == pteOriginal)
 				{
-					GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, ulColId);
+					GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, colid);
 				}	
-				pte->resorigtbl = pteOriginal->resorigtbl;
-				pte->resorigcol = pteOriginal->resorigcol;
+				target_entry->resorigtbl = pteOriginal->resorigtbl;
+				target_entry->resorigcol = pteOriginal->resorigcol;
 			}
 		}
 
 		// add column mapping to output translation context
-		pdxltrctxOut->InsertMapping(pdxlopPrel->UlId(), pte);
+		output_context->InsertMapping(sc_proj_elem_dxlop->Id(), target_entry);
 
-		plTargetList = gpdb::PlAppendElement(plTargetList, pte);
+		target_list = gpdb::LAppend(target_list, target_entry);
 	}
 
-	return plTargetList;
+	return target_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlTargetListWithDroppedCols
+//		CTranslatorDXLToPlStmt::CreateTargetListWithNullsForDroppedCols
 //
 //	@doc:
 //		Construct the target list for a DML statement by adding NULL elements
@@ -4941,57 +4941,57 @@ CTranslatorDXLToPlStmt::PlTargetListFromProjList
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTargetListWithDroppedCols
+CTranslatorDXLToPlStmt::CreateTargetListWithNullsForDroppedCols
 	(
-	List *plTargetList,
-	const IMDRelation *pmdrel
+	List *target_list,
+	const IMDRelation *md_rel
 	)
 {
-	GPOS_ASSERT(NULL != plTargetList);
-	GPOS_ASSERT(gpdb::UlListLength(plTargetList) <= pmdrel->UlColumns());
+	GPOS_ASSERT(NULL != target_list);
+	GPOS_ASSERT(gpdb::ListLength(target_list) <= md_rel->ColumnCount());
 
-	List *plResult = NIL;
-	ULONG ulLastTLElem = 0;
-	ULONG ulResno = 1;
+	List *result_list = NIL;
+	ULONG last_tgt_elem = 0;
+	ULONG resno = 1;
 	
-	const ULONG ulRelCols = pmdrel->UlColumns();
+	const ULONG num_of_rel_cols = md_rel->ColumnCount();
 	
-	for (ULONG ul = 0; ul < ulRelCols; ul++)
+	for (ULONG ul = 0; ul < num_of_rel_cols; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
+		const IMDColumn *md_col = md_rel->GetMdCol(ul);
 		
-		if (pmdcol->FSystemColumn())
+		if (md_col->IsSystemColumn())
 		{
 			continue;
 		}
 		
-		Expr *pexpr = NULL;	
-		if (pmdcol->FDropped())
+		Expr *expr = NULL;
+		if (md_col->IsDropped())
 		{
 			// add a NULL element
-			OID oidType = CMDIdGPDB::PmdidConvert(m_pmda->PtMDType<IMDTypeInt4>()->Pmdid())->OidObjectId();
+			OID oid_type = CMDIdGPDB::CastMdid(m_md_accessor->PtMDType<IMDTypeInt4>()->MDId())->Oid();
 
-			pexpr = (Expr *) gpdb::PnodeMakeNULLConst(oidType);
+			expr = (Expr *) gpdb::MakeNULLConst(oid_type);
 		}
 		else
 		{
-			TargetEntry *pte = (TargetEntry *) gpdb::PvListNth(plTargetList, ulLastTLElem);
-			pexpr = (Expr *) gpdb::PvCopyObject(pte->expr);
-			ulLastTLElem++;
+			TargetEntry *target_entry = (TargetEntry *) gpdb::ListNth(target_list, last_tgt_elem);
+			expr = (Expr *) gpdb::CopyObject(target_entry->expr);
+			last_tgt_elem++;
 		}
 		
-		CHAR *szName = CTranslatorUtils::SzFromWsz(pmdcol->Mdname().Pstr()->Wsz());
-		TargetEntry *pteNew = gpdb::PteMakeTargetEntry(pexpr, ulResno, szName, false /*resjunk*/);
-		plResult = gpdb::PlAppendElement(plResult, pteNew);
-		ulResno++;
+		CHAR *name_str = CTranslatorUtils::CreateMultiByteCharStringFromWCString(md_col->Mdname().GetMDName()->GetBuffer());
+		TargetEntry *te_new = gpdb::MakeTargetEntry(expr, resno, name_str, false /*resjunk*/);
+		result_list = gpdb::LAppend(result_list, te_new);
+		resno++;
 	}
 	
-	return plResult;
+	return result_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlTargetListForHashNode
+//		CTranslatorDXLToPlStmt::TranslateDXLProjectListToHashTargetList
 //
 //	@doc:
 //		Create a target list for the hash node of a hash join plan node by creating a list
@@ -4999,150 +4999,150 @@ CTranslatorDXLToPlStmt::PlTargetListWithDroppedCols
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlTargetListForHashNode
+CTranslatorDXLToPlStmt::TranslateDXLProjectListToHashTargetList
 	(
-	const CDXLNode *pdxlnPrL,
-	CDXLTranslateContext *pdxltrctxChild,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *project_list_dxlnode,
+	CDXLTranslateContext *child_context,
+	CDXLTranslateContext *output_context
 	)
 {
-	List *plTargetList = NIL;
-	const ULONG ulArity = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	List *target_list = NIL;
+	const ULONG arity = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnPrEl = (*pdxlnPrL)[ul];
-		CDXLScalarProjElem *pdxlopPrel = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop());
+		CDXLNode *proj_elem_dxlnode = (*project_list_dxlnode)[ul];
+		CDXLScalarProjElem *sc_proj_elem_dxlop = CDXLScalarProjElem::Cast(proj_elem_dxlnode->GetOperator());
 
-		const TargetEntry *pteChild = pdxltrctxChild->Pte(pdxlopPrel->UlId());
-		if (NULL  == pteChild)
+		const TargetEntry *te_child = child_context->GetTargetEntry(sc_proj_elem_dxlop->Id());
+		if (NULL  == te_child)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, pdxlopPrel->UlId());
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, sc_proj_elem_dxlop->Id());
 		}	
 
 		// get type oid for project element's expression
-		GPOS_ASSERT(1 == pdxlnPrEl->UlArity());
+		GPOS_ASSERT(1 == proj_elem_dxlnode->Arity());
 
 		// find column type
-		OID oidType = gpdb::OidExprType((Node*) pteChild->expr);
-		INT iTypeModifier = gpdb::IExprTypeMod((Node *) pteChild->expr);
+		OID oid_type = gpdb::ExprType((Node*) te_child->expr);
+		INT type_modifier = gpdb::ExprTypeMod((Node *) te_child->expr);
 
 		// find the original varno and attno for this column
-		Index idxVarnoold = 0;
-		AttrNumber attnoOld = 0;
+		Index idx_varnoold = 0;
+		AttrNumber attno_old = 0;
 
-		if (IsA(pteChild->expr, Var))
+		if (IsA(te_child->expr, Var))
 		{
-			Var *pv = (Var*) pteChild->expr;
-			idxVarnoold = pv->varnoold;
-			attnoOld = pv->varoattno;
+			Var *pv = (Var*) te_child->expr;
+			idx_varnoold = pv->varnoold;
+			attno_old = pv->varoattno;
 		}
 		else
 		{
-			idxVarnoold = OUTER;
-			attnoOld = pteChild->resno;
+			idx_varnoold = OUTER;
+			attno_old = te_child->resno;
 		}
 
 		// create a Var expression for this target list entry expression
-		Var *pvar = gpdb::PvarMakeVar
+		Var *var = gpdb::MakeVar
 					(
 					OUTER,
-					pteChild->resno,
-					oidType,
-					iTypeModifier,
+					te_child->resno,
+					oid_type,
+					type_modifier,
 					0	// varlevelsup
 					);
 
 		// set old varno and varattno since makeVar does not set them
-		pvar->varnoold = idxVarnoold;
-		pvar->varoattno = attnoOld;
+		var->varnoold = idx_varnoold;
+		var->varoattno = attno_old;
 
-		CHAR *szResname = CTranslatorUtils::SzFromWsz(pdxlopPrel->PmdnameAlias()->Pstr()->Wsz());
+		CHAR *resname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
 
-		TargetEntry *pte = gpdb::PteMakeTargetEntry
+		TargetEntry *target_entry = gpdb::MakeTargetEntry
 							(
-							(Expr *) pvar,
+							(Expr *) var,
 							(AttrNumber) (ul + 1),
-							szResname,
+							resname,
 							false		// resjunk
 							);
 
-		plTargetList = gpdb::PlAppendElement(plTargetList, pte);
-		pdxltrctxOut->InsertMapping(pdxlopPrel->UlId(), pte);
+		target_list = gpdb::LAppend(target_list, target_entry);
+		output_context->InsertMapping(sc_proj_elem_dxlop->Id(), target_entry);
 	}
 
-	return plTargetList;
+	return target_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlQualFromFilter
+//		CTranslatorDXLToPlStmt::TranslateDXLFilterToQual
 //
 //	@doc:
 //		Translates a DXL filter node into a Qual list.
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlQualFromFilter
+CTranslatorDXLToPlStmt::TranslateDXLFilterToQual
 	(
-	const CDXLNode * pdxlnFilter,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode * filter_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	CDXLTranslateContext *output_context
 	)
 {
-	const ULONG ulArity = pdxlnFilter->UlArity();
-	if (0 == ulArity)
+	const ULONG arity = filter_dxlnode->Arity();
+	if (0 == arity)
 	{
 		return NIL;
 	}
 
-	GPOS_ASSERT(1 == ulArity);
+	GPOS_ASSERT(1 == arity);
 
-	CDXLNode *pdxlnFilterCond = (*pdxlnFilter)[0];
-	GPOS_ASSERT(CTranslatorDXLToScalar::FBoolean(pdxlnFilterCond, m_pmda));
+	CDXLNode *filter_cond_dxlnode = (*filter_dxlnode)[0];
+	GPOS_ASSERT(CTranslatorDXLToScalar::HasBoolResult(filter_cond_dxlnode, m_md_accessor));
 
-	return PlQualFromScalarCondNode(pdxlnFilterCond, pdxltrctxbt, pdrgpdxltrctx, pdxltrctxOut);
+	return TranslateDXLScCondToQual(filter_cond_dxlnode, base_table_context, child_contexts, output_context);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlQualFromScalarCondNode
+//		CTranslatorDXLToPlStmt::TranslateDXLScCondToQual
 //
 //	@doc:
 //		Translates a DXL scalar condition node node into a Qual list.
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlQualFromScalarCondNode
+CTranslatorDXLToPlStmt::TranslateDXLScCondToQual
 	(
-	const CDXLNode *pdxlnCond,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *condition_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	CDXLTranslateContext *output_context
 	)
 {
-	List *plQuals = NIL;
+	List *quals_list = NIL;
 
-	GPOS_ASSERT(CTranslatorDXLToScalar::FBoolean(const_cast<CDXLNode*>(pdxlnCond), m_pmda));
+	GPOS_ASSERT(CTranslatorDXLToScalar::HasBoolResult(const_cast<CDXLNode*>(condition_dxlnode), m_md_accessor));
 
-	CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+	CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 															(
-															m_pmp,
-															pdxltrctxbt,
-															pdrgpdxltrctx,
-															pdxltrctxOut,
-															m_pctxdxltoplstmt
+															m_mp,
+															base_table_context,
+															child_contexts,
+															output_context,
+															m_dxl_to_plstmt_context
 															);
 
-	Expr *pexpr = m_pdxlsctranslator->PexprFromDXLNodeScalar
+	Expr *expr = m_translator_dxl_to_scalar->TranslateDXLToScalar
 					(
-					pdxlnCond,
-					&mapcidvarplstmt
+					condition_dxlnode,
+					&colid_var_mapping
 					);
 
-	plQuals = gpdb::PlAppendElement(plQuals, pexpr);
+	quals_list = gpdb::LAppend(quals_list, expr);
 
-	return plQuals;
+	return quals_list;
 }
 
 //---------------------------------------------------------------------------
@@ -5156,17 +5156,17 @@ CTranslatorDXLToPlStmt::PlQualFromScalarCondNode
 void
 CTranslatorDXLToPlStmt::TranslatePlanCosts
 	(
-	const CDXLOperatorCost *pdxlopcost,
-	Cost *pcostStartupOut,
-	Cost *pcostTotalOut,
-	Cost *pcostRowsOut,
-	INT * piWidthOut
+	const CDXLOperatorCost *dxl_operator_cost,
+	Cost *startup_cost_out,
+	Cost *total_cost_out,
+	Cost *cost_rows_out,
+	INT * width_out
 	)
 {
-	*pcostStartupOut = CostFromStr(pdxlopcost->PstrStartupCost());
-	*pcostTotalOut = CostFromStr(pdxlopcost->PstrTotalCost());
-	*pcostRowsOut = CostFromStr(pdxlopcost->PstrRows());
-	*piWidthOut = CTranslatorUtils::IFromStr(pdxlopcost->PstrWidth());
+	*startup_cost_out = CostFromStr(dxl_operator_cost->GetStartUpCostStr());
+	*total_cost_out = CostFromStr(dxl_operator_cost->GetTotalCostStr());
+	*cost_rows_out = CostFromStr(dxl_operator_cost->GetRowsOutStr());
+	*width_out = CTranslatorUtils::GetIntFromStr(dxl_operator_cost->GetWidthStr());
 }
 
 //---------------------------------------------------------------------------
@@ -5181,31 +5181,31 @@ CTranslatorDXLToPlStmt::TranslatePlanCosts
 void
 CTranslatorDXLToPlStmt::TranslateProjListAndFilter
 	(
-	const CDXLNode *pdxlnPrL,
-	const CDXLNode *pdxlnFilter,
-	const CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctx,
-	List **pplTargetListOut,
-	List **pplQualOut,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *project_list_dxlnode,
+	const CDXLNode *filter_dxlnode,
+	const CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *child_contexts,
+	List **targetlist_out,
+	List **qual_out,
+	CDXLTranslateContext *output_context
 	)
 {
 	// translate proj list
-	*pplTargetListOut = PlTargetListFromProjList
+	*targetlist_out = TranslateDXLProjList
 						(
-						pdxlnPrL,
-						pdxltrctxbt,		// base table translation context
-						pdrgpdxltrctx,
-						pdxltrctxOut
+						project_list_dxlnode,
+						base_table_context,		// base table translation context
+						child_contexts,
+						output_context
 						);
 
 	// translate filter
-	*pplQualOut = PlQualFromFilter
+	*qual_out = TranslateDXLFilterToQual
 					(
-					pdxlnFilter,
-					pdxltrctxbt,			// base table translation context
-					pdrgpdxltrctx,
-					pdxltrctxOut
+					filter_dxlnode,
+					base_table_context,			// base table translation context
+					child_contexts,
+					output_context
 					);
 }
 
@@ -5222,62 +5222,62 @@ CTranslatorDXLToPlStmt::TranslateProjListAndFilter
 void
 CTranslatorDXLToPlStmt::TranslateHashExprList
 	(
-	const CDXLNode *pdxlnHashExprList,
-	const CDXLTranslateContext *pdxltrctxChild,
-	List **pplHashExprOut,
-	List **pplHashExprTypesOut,
-	CDXLTranslateContext *pdxltrctxOut
+	const CDXLNode *hash_expr_list_dxlnode,
+	const CDXLTranslateContext *child_context,
+	List **hash_expr_out_list,
+	List **hash_expr_types_out_list,
+	CDXLTranslateContext *output_context
 	)
 {
-	GPOS_ASSERT(NIL == *pplHashExprOut);
-	GPOS_ASSERT(NIL == *pplHashExprTypesOut);
+	GPOS_ASSERT(NIL == *hash_expr_out_list);
+	GPOS_ASSERT(NIL == *hash_expr_types_out_list);
 
-	List *plHashExpr = NIL;
-	List *plHashExprTypes = NIL;
+	List *hash_expr_list = NIL;
+	List *hash_expr_types_list = NIL;
 
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(pdxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(child_context);
 
-	const ULONG ulArity = pdxlnHashExprList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = hash_expr_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnHashExpr = (*pdxlnHashExprList)[ul];
-		CDXLScalarHashExpr *pdxlopHashExpr = CDXLScalarHashExpr::PdxlopConvert(pdxlnHashExpr->Pdxlop());
+		CDXLNode *hash_expr_dxlnode = (*hash_expr_list_dxlnode)[ul];
+		CDXLScalarHashExpr *hash_expr_dxlop = CDXLScalarHashExpr::Cast(hash_expr_dxlnode->GetOperator());
 
 		// the type of the hash expression in GPDB is computed as the left operand 
 		// of the equality operator of the actual hash expression type
-		const IMDType *pmdtype = m_pmda->Pmdtype(pdxlopHashExpr->PmdidType());
-		const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pmdtype->PmdidCmp(IMDType::EcmptEq));
+		const IMDType *md_type = m_md_accessor->RetrieveType(hash_expr_dxlop->MdidType());
+		const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(md_type->GetMdidForCmpType(IMDType::EcmptEq));
 		
-		const IMDId *pmdidHashType = pmdscop->PmdidTypeLeft();
+		const IMDId *mdid_hash_type = md_scalar_op->GetLeftMdid();
 		
-		plHashExprTypes = gpdb::PlAppendOid(plHashExprTypes, CMDIdGPDB::PmdidConvert(pmdidHashType)->OidObjectId());
+		hash_expr_types_list = gpdb::LAppendOid(hash_expr_types_list, CMDIdGPDB::CastMdid(mdid_hash_type)->Oid());
 
-		GPOS_ASSERT(1 == pdxlnHashExpr->UlArity());
-		CDXLNode *pdxlnExpr = (*pdxlnHashExpr)[0];
+		GPOS_ASSERT(1 == hash_expr_dxlnode->Arity());
+		CDXLNode *expr_dxlnode = (*hash_expr_dxlnode)[0];
 
-		CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
+		CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt
 																(
-																m_pmp,
+																m_mp,
 																NULL,
-																pdrgpdxltrctx,
-																pdxltrctxOut,
-																m_pctxdxltoplstmt
+																child_contexts,
+																output_context,
+																m_dxl_to_plstmt_context
 																);
 
-		Expr *pexpr = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnExpr, &mapcidvarplstmt);
+		Expr *expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(expr_dxlnode, &colid_var_mapping);
 
-		plHashExpr = gpdb::PlAppendElement(plHashExpr, pexpr);
+		hash_expr_list = gpdb::LAppend(hash_expr_list, expr);
 
-		GPOS_ASSERT((ULONG) gpdb::UlListLength(plHashExpr) == ul + 1);
+		GPOS_ASSERT((ULONG) gpdb::ListLength(hash_expr_list) == ul + 1);
 	}
 
 
-	*pplHashExprOut = plHashExpr;
-	*pplHashExprTypesOut = plHashExprTypes;
+	*hash_expr_out_list = hash_expr_list;
+	*hash_expr_types_out_list = hash_expr_types_list;
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 }
 
 //---------------------------------------------------------------------------
@@ -5293,29 +5293,29 @@ CTranslatorDXLToPlStmt::TranslateHashExprList
 void
 CTranslatorDXLToPlStmt::TranslateSortCols
 	(
-	const CDXLNode *pdxlnSortColList,
-	const CDXLTranslateContext *pdxltrctxChild,
-	AttrNumber *pattnoSortColIds,
-	Oid *poidSortOpIds,
-	bool *pboolNullsFirst
+	const CDXLNode *sort_col_list_dxl,
+	const CDXLTranslateContext *child_context,
+	AttrNumber *att_no_sort_colids,
+	Oid *sort_op_oids,
+	bool *is_nulls_first
 	)
 {
-	const ULONG ulArity = pdxlnSortColList->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = sort_col_list_dxl->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnSortCol = (*pdxlnSortColList)[ul];
-		CDXLScalarSortCol *pdxlopSortCol = CDXLScalarSortCol::PdxlopConvert(pdxlnSortCol->Pdxlop());
+		CDXLNode *sort_col_dxlnode = (*sort_col_list_dxl)[ul];
+		CDXLScalarSortCol *sc_sort_col_dxlop = CDXLScalarSortCol::Cast(sort_col_dxlnode->GetOperator());
 
-		ULONG ulSortColId = pdxlopSortCol->UlColId();
-		const TargetEntry *pteSortCol = pdxltrctxChild->Pte(ulSortColId);
-		if (NULL  == pteSortCol)
+		ULONG sort_colid = sc_sort_col_dxlop->GetColId();
+		const TargetEntry *te_sort_col = child_context->GetTargetEntry(sort_colid);
+		if (NULL  == te_sort_col)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, ulSortColId);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, sort_colid);
 		}	
 
-		pattnoSortColIds[ul] = pteSortCol->resno;
-		poidSortOpIds[ul] = CMDIdGPDB::PmdidConvert(pdxlopSortCol->PmdidSortOp())->OidObjectId();
-		pboolNullsFirst[ul] = pdxlopSortCol->FSortNullsFirst();
+		att_no_sort_colids[ul] = te_sort_col->resno;
+		sort_op_oids[ul] = CMDIdGPDB::CastMdid(sc_sort_col_dxlop->GetMdIdSortOp())->Oid();
+		is_nulls_first[ul] = sc_sort_col_dxlop->IsSortedNullsFirst();
 	}
 }
 
@@ -5330,37 +5330,37 @@ CTranslatorDXLToPlStmt::TranslateSortCols
 Cost
 CTranslatorDXLToPlStmt::CostFromStr
 	(
-	const CWStringBase *pstr
+	const CWStringBase *str
 	)
 {
-	CHAR *sz = CTranslatorUtils::SzFromWsz(pstr->Wsz());
-	return gpos::clib::DStrToD(sz);
+	CHAR *sz = CTranslatorUtils::CreateMultiByteCharStringFromWCString(str->GetBuffer());
+	return gpos::clib::Strtod(sz);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::FTargetTableDistributed
+//		CTranslatorDXLToPlStmt::IsTgtTblDistributed
 //
 //	@doc:
 //		Check if given operator is a DML on a distributed table
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorDXLToPlStmt::FTargetTableDistributed
+CTranslatorDXLToPlStmt::IsTgtTblDistributed
 	(
-	CDXLOperator *pdxlop
+	CDXLOperator *dxlop
 	)
 {
-	if (EdxlopPhysicalDML != pdxlop->Edxlop())
+	if (EdxlopPhysicalDML != dxlop->GetDXLOperator())
 	{
 		return false;
 	}
 
-	CDXLPhysicalDML *pdxlopDML = CDXLPhysicalDML::PdxlopConvert(pdxlop);
-	IMDId *pmdid = pdxlopDML->Pdxltabdesc()->Pmdid();
+	CDXLPhysicalDML *phy_dml_dxlop = CDXLPhysicalDML::Cast(dxlop);
+	IMDId *mdid = phy_dml_dxlop->GetDXLTableDescr()->MDId();
 
-	return IMDRelation::EreldistrMasterOnly != m_pmda->Pmdrel(pmdid)->Ereldistribution();
+	return IMDRelation::EreldistrMasterOnly != m_md_accessor->RetrieveRel(mdid)->GetRelDistribution();
 }
 
 //---------------------------------------------------------------------------
@@ -5373,19 +5373,19 @@ CTranslatorDXLToPlStmt::FTargetTableDistributed
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorDXLToPlStmt::UlAddTargetEntryForColId
+CTranslatorDXLToPlStmt::AddTargetEntryForColId
 	(
-	List **pplTargetList,
-	CDXLTranslateContext *pdxltrctx,
-	ULONG ulColId,
-	BOOL fResjunk
+	List **target_list,
+	CDXLTranslateContext *dxl_translate_ctxt,
+	ULONG colid,
+	BOOL is_resjunk
 	)
 {
-	GPOS_ASSERT(NULL != pplTargetList);
+	GPOS_ASSERT(NULL != target_list);
 	
-	const TargetEntry *pte = pdxltrctx->Pte(ulColId);
+	const TargetEntry *target_entry = dxl_translate_ctxt->GetTargetEntry(colid);
 	
-	if (NULL == pte)
+	if (NULL == target_entry)
 	{
 		// colid not found in translate context
 		return 0;
@@ -5393,43 +5393,43 @@ CTranslatorDXLToPlStmt::UlAddTargetEntryForColId
 	
 	// TODO: Oct 29, 2012; see if entry already exists in the target list
 	
-	OID oidExpr = gpdb::OidExprType((Node*) pte->expr);
-	INT iTypeModifier = gpdb::IExprTypeMod((Node *) pte->expr);
-	Var *pvar = gpdb::PvarMakeVar
+	OID expr_oid = gpdb::ExprType((Node*) target_entry->expr);
+	INT type_modifier = gpdb::ExprTypeMod((Node *) target_entry->expr);
+	Var *var = gpdb::MakeVar
 						(
 						OUTER,
-						pte->resno,
-						oidExpr,
-						iTypeModifier,
+						target_entry->resno,
+						expr_oid,
+						type_modifier,
 						0	// varlevelsup
 						);
-	ULONG ulResNo = gpdb::UlListLength(*pplTargetList) + 1;
-	CHAR *szResName = PStrDup(pte->resname);
-	TargetEntry *pteNew = gpdb::PteMakeTargetEntry((Expr*) pvar, ulResNo, szResName, fResjunk);
-	*pplTargetList = gpdb::PlAppendElement(*pplTargetList, pteNew);
+	ULONG resno = gpdb::ListLength(*target_list) + 1;
+	CHAR *resname_str = PStrDup(target_entry->resname);
+	TargetEntry *te_new = gpdb::MakeTargetEntry((Expr*) var, resno, resname_str, is_resjunk);
+	*target_list = gpdb::LAppend(*target_list, te_new);
 	
-	return pte->resno;
+	return target_entry->resno;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::JtFromEdxljt
+//		CTranslatorDXLToPlStmt::GetGPDBJoinTypeFromDXLJoinType
 //
 //	@doc:
 //		Translates the join type from its DXL representation into the GPDB one
 //
 //---------------------------------------------------------------------------
 JoinType
-CTranslatorDXLToPlStmt::JtFromEdxljt
+CTranslatorDXLToPlStmt::GetGPDBJoinTypeFromDXLJoinType
 	(
-	EdxlJoinType edxljt
+	EdxlJoinType join_type
 	)
 {
-	GPOS_ASSERT(EdxljtSentinel > edxljt);
+	GPOS_ASSERT(EdxljtSentinel > join_type);
 
 	JoinType jt = JOIN_INNER;
 
-	switch (edxljt)
+	switch (join_type)
 	{
 		case EdxljtInner:
 			jt = JOIN_INNER;
@@ -5461,7 +5461,7 @@ CTranslatorDXLToPlStmt::JtFromEdxljt
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanCTAS
+//		CTranslatorDXLToPlStmt::TranslateDXLCtas
 //
 //	@doc:
 //		Sets the vartypmod fields in the target entries of the given target list
@@ -5470,26 +5470,26 @@ CTranslatorDXLToPlStmt::JtFromEdxljt
 void
 CTranslatorDXLToPlStmt::SetVarTypMod
 	(
-	const CDXLPhysicalCTAS *pdxlop,
-	List *plTargetList
+	const CDXLPhysicalCTAS *phy_ctas_dxlop,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != plTargetList);
+	GPOS_ASSERT(NULL != target_list);
 
-	DrgPi *pdrgpi = pdxlop->PdrgpiVarTypeMod();
-	GPOS_ASSERT(pdrgpi->UlLength() == gpdb::UlListLength(plTargetList));
+	IntPtrArray *var_type_mod_array = phy_ctas_dxlop->GetVarTypeModArray();
+	GPOS_ASSERT(var_type_mod_array->Size() == gpdb::ListLength(target_list));
 
 	ULONG ul = 0;
-	ListCell *plc = NULL;
-	ForEach (plc, plTargetList)
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plc);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
 
-		if (IsA(pte->expr, Var))
+		if (IsA(target_entry->expr, Var))
 		{
-			Var *var = (Var*) pte->expr;
-			var->vartypmod = *(*pdrgpi)[ul];
+			Var *var = (Var*) target_entry->expr;
+			var->vartypmod = *(*var_type_mod_array)[ul];
 		}
 		++ul;
 	}
@@ -5497,351 +5497,351 @@ CTranslatorDXLToPlStmt::SetVarTypMod
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanCTAS
+//		CTranslatorDXLToPlStmt::TranslateDXLCtas
 //
 //	@doc:
 //		Translates a DXL CTAS node 
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanCTAS
+CTranslatorDXLToPlStmt::TranslateDXLCtas
 	(
-	const CDXLNode *pdxlnCTAS,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *ctas_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	CDXLPhysicalCTAS *pdxlop = CDXLPhysicalCTAS::PdxlopConvert(pdxlnCTAS->Pdxlop());
-	CDXLNode *pdxlnPrL = (*pdxlnCTAS)[0];
-	CDXLNode *pdxlnChild = (*pdxlnCTAS)[1];
+	CDXLPhysicalCTAS *phy_ctas_dxlop = CDXLPhysicalCTAS::Cast(ctas_dxlnode->GetOperator());
+	CDXLNode *project_list_dxlnode = (*ctas_dxlnode)[0];
+	CDXLNode *child_dxlnode = (*ctas_dxlnode)[1];
 
-	GPOS_ASSERT(NULL == pdxlop->Pdxlctasopt()->Pdrgpctasopt());
+	GPOS_ASSERT(NULL == phy_ctas_dxlop->GetDxlCtasStorageOption()->GetDXLCtasOptionArray());
 	
-	CDXLTranslateContext dxltrctxChild(m_pmp, false, pdxltrctxOut->PhmColParam());
+	CDXLTranslateContext child_context(m_mp, false, output_context->GetColIdToParamIdMap());
 
-	Plan *pplan = PplFromDXL(pdxlnChild, &dxltrctxChild, pdrgpdxltrctxPrevSiblings);
+	Plan *plan = TranslateDXLOperatorToPlan(child_dxlnode, &child_context, ctxt_translation_prev_siblings);
 	
 	// fix target list to match the required column names
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(&dxltrctxChild);
+	CDXLTranslationContextArray *child_contexts = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	child_contexts->Append(&child_context);
 	
-	List *plTargetList = PlTargetListFromProjList
+	List *target_list = TranslateDXLProjList
 						(
-						pdxlnPrL,
-						NULL,		// pdxltrctxbt
-						pdrgpdxltrctx,
-						pdxltrctxOut
+						project_list_dxlnode,
+						NULL,		// base_table_context
+						child_contexts,
+						output_context
 						);
-	SetVarTypMod(pdxlop, plTargetList);
+	SetVarTypMod(phy_ctas_dxlop, target_list);
 	
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
 	// cleanup
-	pdrgpdxltrctx->Release();
+	child_contexts->Release();
 
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnCTAS->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(ctas_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	IntoClause *pintocl = PintoclFromCtas(pdxlop);
-	GpPolicy *pdistrpolicy = PdistrpolicyFromCtas(pdxlop);
-	m_pctxdxltoplstmt->AddCtasInfo(pintocl, pdistrpolicy);
+	IntoClause *into_clause = TranslateDXLPhyCtasToIntoClause(phy_ctas_dxlop);
+	GpPolicy *distr_policy = TranslateDXLPhyCtasToDistrPolicy(phy_ctas_dxlop);
+	m_dxl_to_plstmt_context->AddCtasInfo(into_clause, distr_policy);
 	
-	GPOS_ASSERT(IMDRelation::EreldistrMasterOnly != pdxlop->Ereldistrpolicy());
+	GPOS_ASSERT(IMDRelation::EreldistrMasterOnly != phy_ctas_dxlop->Ereldistrpolicy());
 	
-	m_fTargetTableDistributed = true;
+	m_is_tgt_tbl_distributed = true;
 	
 	// Add a result node on top with the correct projection list
-	Result *presult = MakeNode(Result);
-	Plan *pplanResult = &(presult->plan);
-	pplanResult->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplanResult->nMotionNodes = pplan->nMotionNodes;
-	pplanResult->lefttree = pplan;
+	Result *result = MakeNode(Result);
+	Plan *result_plan = &(result->plan);
+	result_plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	result_plan->nMotionNodes = plan->nMotionNodes;
+	result_plan->lefttree = plan;
 
-	pplanResult->targetlist = plTargetList;
-	SetParamIds(pplanResult);
+	result_plan->targetlist = target_list;
+	SetParamIds(result_plan);
 
-	pplan = (Plan *) presult;
+	plan = (Plan *) result;
 
-	return (Plan *) pplan;
+	return (Plan *) plan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PintoclFromCtas
+//		CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToIntoClause
 //
 //	@doc:
 //		Translates a DXL CTAS into clause 
 //
 //---------------------------------------------------------------------------
 IntoClause *
-CTranslatorDXLToPlStmt::PintoclFromCtas
+CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToIntoClause
 	(
-	const CDXLPhysicalCTAS *pdxlop
+	const CDXLPhysicalCTAS *phy_ctas_dxlop
 	)
 {
-	IntoClause *pintocl = MakeNode(IntoClause);
-	pintocl->rel = MakeNode(RangeVar);
-	pintocl->rel->istemp = pdxlop->FTemporary();
-	pintocl->rel->relname = CTranslatorUtils::SzFromWsz(pdxlop->Pmdname()->Pstr()->Wsz());
-	pintocl->rel->schemaname = NULL;
-	if (NULL != pdxlop->PmdnameSchema())
+	IntoClause *into_clause = MakeNode(IntoClause);
+	into_clause->rel = MakeNode(RangeVar);
+	into_clause->rel->istemp = phy_ctas_dxlop->IsTemporary();
+	into_clause->rel->relname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(phy_ctas_dxlop->MdName()->GetMDName()->GetBuffer());
+	into_clause->rel->schemaname = NULL;
+	if (NULL != phy_ctas_dxlop->GetMdNameSchema())
 	{
-		pintocl->rel->schemaname = CTranslatorUtils::SzFromWsz(pdxlop->PmdnameSchema()->Pstr()->Wsz());
+		into_clause->rel->schemaname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(phy_ctas_dxlop->GetMdNameSchema()->GetMDName()->GetBuffer());
 	}
 	
-	CDXLCtasStorageOptions *pdxlctasopt = pdxlop->Pdxlctasopt();
-	if (NULL != pdxlctasopt->PmdnameTablespace())
+	CDXLCtasStorageOptions *dxl_ctas_storage_option = phy_ctas_dxlop->GetDxlCtasStorageOption();
+	if (NULL != dxl_ctas_storage_option->GetMdNameTableSpace())
 	{
-		pintocl->tableSpaceName = CTranslatorUtils::SzFromWsz(pdxlop->Pdxlctasopt()->PmdnameTablespace()->Pstr()->Wsz());
+		into_clause->tableSpaceName = CTranslatorUtils::CreateMultiByteCharStringFromWCString(phy_ctas_dxlop->GetDxlCtasStorageOption()->GetMdNameTableSpace()->GetMDName()->GetBuffer());
 	}
 	
-	pintocl->onCommit = (OnCommitAction) pdxlctasopt->Ectascommit(); 
-	pintocl->options = PlCtasOptions(pdxlctasopt->Pdrgpctasopt());
+	into_clause->onCommit = (OnCommitAction) dxl_ctas_storage_option->GetOnCommitAction();
+	into_clause->options = TranslateDXLCtasStorageOptions(dxl_ctas_storage_option->GetDXLCtasOptionArray());
 	
 	// get column names
-	DrgPdxlcd *pdrgpdxlcd = pdxlop->Pdrgpdxlcd();
-	const ULONG ulCols = pdrgpdxlcd->UlLength();
-	pintocl->colNames = NIL;
-	for (ULONG ul = 0; ul < ulCols; ++ul)
+	CDXLColDescrArray *dxl_col_descr_array = phy_ctas_dxlop->GetDXLColumnDescrArray();
+	const ULONG num_of_cols = dxl_col_descr_array->Size();
+	into_clause->colNames = NIL;
+	for (ULONG ul = 0; ul < num_of_cols; ++ul)
 	{
-		const CDXLColDescr *pdxlcd = (*pdrgpdxlcd)[ul];
+		const CDXLColDescr *dxl_col_descr = (*dxl_col_descr_array)[ul];
 
-		CHAR *szColName = CTranslatorUtils::SzFromWsz(pdxlcd->Pmdname()->Pstr()->Wsz());
+		CHAR *col_name_char_array = CTranslatorUtils::CreateMultiByteCharStringFromWCString(dxl_col_descr->MdName()->GetMDName()->GetBuffer());
 		
-		ColumnDef *pcoldef = MakeNode(ColumnDef);
-		pcoldef->colname = szColName;
-		pcoldef->is_local = true;
+		ColumnDef *col_def = MakeNode(ColumnDef);
+		col_def->colname = col_name_char_array;
+		col_def->is_local = true;
 
-		pintocl->colNames = gpdb::PlAppendElement(pintocl->colNames, pcoldef);
+		into_clause->colNames = gpdb::LAppend(into_clause->colNames, col_def);
 
 	}
 
-	return pintocl;
+	return into_clause;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PdistrpolicyFromCtas
+//		CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy
 //
 //	@doc:
 //		Translates distribution policy given by a physical CTAS operator 
 //
 //---------------------------------------------------------------------------
 GpPolicy *
-CTranslatorDXLToPlStmt::PdistrpolicyFromCtas
+CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy
 	(
-	const CDXLPhysicalCTAS *pdxlop
+	const CDXLPhysicalCTAS *dxlop
 	)
 {
-	DrgPul *pdrgpulDistrCols = pdxlop->PdrgpulDistr();
+	ULongPtrArray *distr_col_pos_array = dxlop->GetDistrColPosArray();
 
-	const ULONG ulDistrCols = (pdrgpulDistrCols == NULL) ? 0 : pdrgpulDistrCols->UlLength();
+	const ULONG num_of_distr_cols = (distr_col_pos_array == NULL) ? 0 : distr_col_pos_array->Size();
 
-	ULONG ulDistrColsAlloc = 1;
-	if (0 < ulDistrCols)
+	ULONG num_of_distr_cols_alloc = 1;
+	if (0 < num_of_distr_cols)
 	{
-		ulDistrColsAlloc = ulDistrCols;
+		num_of_distr_cols_alloc = num_of_distr_cols;
 	}
 	
-	GpPolicy *pdistrpolicy = (GpPolicy *) gpdb::GPDBAlloc(sizeof(GpPolicy) + 
-															ulDistrColsAlloc * sizeof(AttrNumber));
-	GPOS_ASSERT(IMDRelation::EreldistrHash == pdxlop->Ereldistrpolicy() ||
-				IMDRelation::EreldistrRandom == pdxlop->Ereldistrpolicy());
+	GpPolicy *distr_policy = (GpPolicy *) gpdb::GPDBAlloc(sizeof(GpPolicy) +
+															num_of_distr_cols * sizeof(AttrNumber));
+	GPOS_ASSERT(IMDRelation::EreldistrHash == dxlop->Ereldistrpolicy() ||
+				IMDRelation::EreldistrRandom == dxlop->Ereldistrpolicy());
 	
-	pdistrpolicy->ptype = POLICYTYPE_PARTITIONED;
-	pdistrpolicy->nattrs = 0;
-	if (IMDRelation::EreldistrHash == pdxlop->Ereldistrpolicy())
+	distr_policy->ptype = POLICYTYPE_PARTITIONED;
+	distr_policy->nattrs = 0;
+	if (IMDRelation::EreldistrHash == dxlop->Ereldistrpolicy())
 	{
 		
-		GPOS_ASSERT(0 < ulDistrCols);
-		pdistrpolicy->nattrs = ulDistrCols;
+		GPOS_ASSERT(0 < num_of_distr_cols);
+		distr_policy->nattrs = num_of_distr_cols;
 		
-		for (ULONG ul = 0; ul < ulDistrCols; ul++)
+		for (ULONG ul = 0; ul < num_of_distr_cols; ul++)
 		{
-			ULONG ulColPos = *((*pdrgpulDistrCols)[ul]);
-			pdistrpolicy->attrs[ul] = ulColPos + 1;
+			ULONG col_pos_idx = *((*distr_col_pos_array)[ul]);
+			distr_policy->attrs[ul] = col_pos_idx + 1;
 		}
 	}
-	return pdistrpolicy;
+	return distr_policy;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PlCtasOptions
+//		CTranslatorDXLToPlStmt::TranslateDXLCtasStorageOptions
 //
 //	@doc:
 //		Translates CTAS options
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToPlStmt::PlCtasOptions
+CTranslatorDXLToPlStmt::TranslateDXLCtasStorageOptions
 	(
-	CDXLCtasStorageOptions::DrgPctasOpt *pdrgpctasopt
+	CDXLCtasStorageOptions::CDXLCtasOptionArray *ctas_storage_options
 	)
 {
-	if (NULL == pdrgpctasopt)
+	if (NULL == ctas_storage_options)
 	{
 		return NIL;
 	}
 	
-	const ULONG ulOptions = pdrgpctasopt->UlLength();
-	List *plOptions = NIL;
-	for (ULONG ul = 0; ul < ulOptions; ul++)
+	const ULONG num_of_options = ctas_storage_options->Size();
+	List *options = NIL;
+	for (ULONG ul = 0; ul < num_of_options; ul++)
 	{
-		CDXLCtasStorageOptions::CDXLCtasOption *pdxlopt = (*pdrgpctasopt)[ul];
-		CWStringBase *pstrName = pdxlopt->m_pstrName;
-		CWStringBase *pstrValue = pdxlopt->m_pstrValue;
-		DefElem *pdefelem = MakeNode(DefElem);
-		pdefelem->defname = CTranslatorUtils::SzFromWsz(pstrName->Wsz());
+		CDXLCtasStorageOptions::CDXLCtasOption *pdxlopt = (*ctas_storage_options)[ul];
+		CWStringBase *str_name = pdxlopt->m_str_name;
+		CWStringBase *str_value = pdxlopt->m_str_value;
+		DefElem *def_elem = MakeNode(DefElem);
+		def_elem->defname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_name->GetBuffer());
 
-		if (!pdxlopt->m_fNull)
+		if (!pdxlopt->m_is_null)
 		{
-			NodeTag argType = (NodeTag) pdxlopt->m_ulType;
+			NodeTag arg_type = (NodeTag) pdxlopt->m_type;
 
-			GPOS_ASSERT(T_Integer == argType || T_String == argType);
-			if (T_Integer == argType)
+			GPOS_ASSERT(T_Integer == arg_type || T_String == arg_type);
+			if (T_Integer == arg_type)
 			{
-				pdefelem->arg = (Node *) gpdb::PvalMakeInteger(CTranslatorUtils::LFromStr(pstrValue));
+				def_elem->arg = (Node *) gpdb::MakeIntegerValue(CTranslatorUtils::GetLongFromStr(str_value));
 			}
 			else
 			{
-				pdefelem->arg = (Node *) gpdb::PvalMakeString(CTranslatorUtils::SzFromWsz(pstrValue->Wsz()));
+				def_elem->arg = (Node *) gpdb::MakeStringValue(CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_value->GetBuffer()));
 			}
 		}
 
-		plOptions = gpdb::PlAppendElement(plOptions, pdefelem);
+		options = gpdb::LAppend(options, def_elem);
 	}
 	
-	return plOptions;
+	return options;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanBitmapTableScan
+//		CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan
 //
 //	@doc:
 //		Translates a DXL bitmap table scan node into a BitmapTableScan node
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanBitmapTableScan
+CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan
 	(
-	const CDXLNode *pdxlnBitmapScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *bitmapscan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
-	ULONG ulPartIndex = INVALID_PART_INDEX;
-	ULONG ulPartIndexPrintable = INVALID_PART_INDEX;
-	const CDXLTableDescr *pdxltabdesc = NULL;
-	BOOL fDynamic = false;
+	ULONG part_index_id = INVALID_PART_INDEX;
+	ULONG part_idx_printable_id = INVALID_PART_INDEX;
+	const CDXLTableDescr *table_descr = NULL;
+	BOOL is_dynamic = false;
 
-	CDXLOperator *pdxlop = pdxlnBitmapScan->Pdxlop();
-	if (EdxlopPhysicalBitmapTableScan == pdxlop->Edxlop())
+	CDXLOperator *dxl_operator = bitmapscan_dxlnode->GetOperator();
+	if (EdxlopPhysicalBitmapTableScan == dxl_operator->GetDXLOperator())
 	{
-		pdxltabdesc = CDXLPhysicalBitmapTableScan::PdxlopConvert(pdxlop)->Pdxltabdesc();
+		table_descr = CDXLPhysicalBitmapTableScan::Cast(dxl_operator)->GetDXLTableDescr();
 	}
 	else
 	{
-		GPOS_ASSERT(EdxlopPhysicalDynamicBitmapTableScan == pdxlop->Edxlop());
-		CDXLPhysicalDynamicBitmapTableScan *pdxlopDynamic =
-				CDXLPhysicalDynamicBitmapTableScan::PdxlopConvert(pdxlop);
-		pdxltabdesc = pdxlopDynamic->Pdxltabdesc();
+		GPOS_ASSERT(EdxlopPhysicalDynamicBitmapTableScan == dxl_operator->GetDXLOperator());
+		CDXLPhysicalDynamicBitmapTableScan *phy_dyn_bitmap_tblscan_dxlop =
+				CDXLPhysicalDynamicBitmapTableScan::Cast(dxl_operator);
+		table_descr = phy_dyn_bitmap_tblscan_dxlop->GetDXLTableDescr();
 
-		ulPartIndex = pdxlopDynamic->UlPartIndexId();
-		ulPartIndexPrintable = pdxlopDynamic->UlPartIndexIdPrintable();
-		fDynamic = true;
+		part_index_id = phy_dyn_bitmap_tblscan_dxlop->GetPartIndexId();
+		part_idx_printable_id = phy_dyn_bitmap_tblscan_dxlop->GetPartIndexIdPrintable();
+		is_dynamic = true;
 	}
 
 	// translation context for column mappings in the base relation
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 
-	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, iRel, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
-	prte->requiredPerms |= ACL_SELECT;
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(table_descr, NULL /*index_descr_dxl*/, index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
 
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	BitmapTableScan *pdbts = MakeNode(BitmapTableScan);
-	pdbts->scan.scanrelid = iRel;
-	pdbts->scan.partIndex = ulPartIndex;
-	pdbts->scan.partIndexPrintable = ulPartIndexPrintable;
+	BitmapTableScan *bitmap_tbl_scan = MakeNode(BitmapTableScan);
+	bitmap_tbl_scan->scan.scanrelid = index;
+	bitmap_tbl_scan->scan.partIndex = part_index_id;
+	bitmap_tbl_scan->scan.partIndexPrintable = part_idx_printable_id;
 
-	Plan *pplan = &(pdbts->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	Plan *plan = &(bitmap_tbl_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnBitmapScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(bitmapscan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 		);
 
-	GPOS_ASSERT(4 == pdxlnBitmapScan->UlArity());
+	GPOS_ASSERT(4 == bitmapscan_dxlnode->Arity());
 
 	// translate proj list and filter
-	CDXLNode *pdxlnPrL = (*pdxlnBitmapScan)[0];
-	CDXLNode *pdxlnFilter = (*pdxlnBitmapScan)[1];
-	CDXLNode *pdxlnRecheckCond = (*pdxlnBitmapScan)[2];
-	CDXLNode *pdxlnBitmapAccessPath = (*pdxlnBitmapScan)[3];
+	CDXLNode *project_list_dxlnode = (*bitmapscan_dxlnode)[0];
+	CDXLNode *filter_dxlnode = (*bitmapscan_dxlnode)[1];
+	CDXLNode *recheck_cond_dxlnode = (*bitmapscan_dxlnode)[2];
+	CDXLNode *bitmap_access_path_dxlnode = (*bitmapscan_dxlnode)[3];
 
-	List *plQuals = NULL;
+	List *quals_list = NULL;
 	TranslateProjListAndFilter
 		(
-		pdxlnPrL,
-		pdxlnFilter,
-		&dxltrctxbt,	// translate context for the base table
-		pdrgpdxltrctxPrevSiblings,
-		&pplan->targetlist,
-		&plQuals,
-		pdxltrctxOut
+		project_list_dxlnode,
+		filter_dxlnode,
+		&base_table_context,	// translate context for the base table
+		ctxt_translation_prev_siblings,
+		&plan->targetlist,
+		&quals_list,
+		output_context
 		);
-	pplan->qual = plQuals;
+	plan->qual = quals_list;
 
-	pdbts->bitmapqualorig = PlQualFromFilter
+	bitmap_tbl_scan->bitmapqualorig = TranslateDXLFilterToQual
 							(
-							pdxlnRecheckCond,
-							&dxltrctxbt,
-							pdrgpdxltrctxPrevSiblings,
-							pdxltrctxOut
+							recheck_cond_dxlnode,
+							&base_table_context,
+							ctxt_translation_prev_siblings,
+							output_context
 							);
 
-	pdbts->scan.plan.lefttree = PplanBitmapAccessPath
+	bitmap_tbl_scan->scan.plan.lefttree = TranslateDXLBitmapAccessPath
 								(
-								pdxlnBitmapAccessPath,
-								pdxltrctxOut,
-								pmdrel,
-								pdxltabdesc,
-								&dxltrctxbt,
-								pdrgpdxltrctxPrevSiblings,
-								pdbts
+								bitmap_access_path_dxlnode,
+								output_context,
+								md_rel,
+								table_descr,
+								&base_table_context,
+								ctxt_translation_prev_siblings,
+								bitmap_tbl_scan
 								);
-	SetParamIds(pplan);
+	SetParamIds(plan);
 
-	return (Plan *) pdbts;
+	return (Plan *) bitmap_tbl_scan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanBitmapAccessPath
+//		CTranslatorDXLToPlStmt::TranslateDXLBitmapAccessPath
 //
 //	@doc:
 //		Translate the tree of bitmap index operators that are under the given
@@ -5849,248 +5849,248 @@ CTranslatorDXLToPlStmt::PplanBitmapTableScan
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanBitmapAccessPath
+CTranslatorDXLToPlStmt::TranslateDXLBitmapAccessPath
 	(
-	const CDXLNode *pdxlnBitmapAccessPath,
-	CDXLTranslateContext *pdxltrctxOut,
-	const IMDRelation *pmdrel,
-	const CDXLTableDescr *pdxltabdesc,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-	BitmapTableScan *pdbts
+	const CDXLNode *bitmap_access_path_dxlnode,
+	CDXLTranslateContext *output_context,
+	const IMDRelation *md_rel,
+	const CDXLTableDescr *table_descr,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+	BitmapTableScan *bitmap_tbl_scan
 	)
 {
-	Edxlopid edxlopid = pdxlnBitmapAccessPath->Pdxlop()->Edxlop();
-	if (EdxlopScalarBitmapIndexProbe == edxlopid)
+	Edxlopid dxl_op_id = bitmap_access_path_dxlnode->GetOperator()->GetDXLOperator();
+	if (EdxlopScalarBitmapIndexProbe == dxl_op_id)
 	{
-		return PplanBitmapIndexProbe
+		return TranslateDXLBitmapIndexProbe
 				(
-				pdxlnBitmapAccessPath,
-				pdxltrctxOut,
-				pmdrel,
-				pdxltabdesc,
-				pdxltrctxbt,
-				pdrgpdxltrctxPrevSiblings,
-				pdbts
+				bitmap_access_path_dxlnode,
+				output_context,
+				md_rel,
+				table_descr,
+				base_table_context,
+				ctxt_translation_prev_siblings,
+				bitmap_tbl_scan
 				);
 	}
-	GPOS_ASSERT(EdxlopScalarBitmapBoolOp == edxlopid);
+	GPOS_ASSERT(EdxlopScalarBitmapBoolOp == dxl_op_id);
 
-	return PplanBitmapBoolOp
+	return TranslateDXLBitmapBoolOp
 			(
-			pdxlnBitmapAccessPath, 
-			pdxltrctxOut, 
-			pmdrel, 
-			pdxltabdesc, 
-			pdxltrctxbt,
-			pdrgpdxltrctxPrevSiblings,
-			pdbts
+			bitmap_access_path_dxlnode,
+			output_context,
+			md_rel,
+			table_descr,
+			base_table_context,
+			ctxt_translation_prev_siblings,
+			bitmap_tbl_scan
 			);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PplanBitmapBoolOp
+//		CTranslatorDXLToScalar::TranslateDXLBitmapBoolOp
 //
 //	@doc:
 //		Translates a DML bitmap bool op expression 
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanBitmapBoolOp
+CTranslatorDXLToPlStmt::TranslateDXLBitmapBoolOp
 	(
-	const CDXLNode *pdxlnBitmapBoolOp,
-	CDXLTranslateContext *pdxltrctxOut,
-	const IMDRelation *pmdrel,
-	const CDXLTableDescr *pdxltabdesc,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-	BitmapTableScan *pdbts
+	const CDXLNode *bitmap_boolop_dxlnode,
+	CDXLTranslateContext *output_context,
+	const IMDRelation *md_rel,
+	const CDXLTableDescr *table_descr,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+	BitmapTableScan *bitmap_tbl_scan
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnBitmapBoolOp);
-	GPOS_ASSERT(EdxlopScalarBitmapBoolOp == pdxlnBitmapBoolOp->Pdxlop()->Edxlop());
+	GPOS_ASSERT(NULL != bitmap_boolop_dxlnode);
+	GPOS_ASSERT(EdxlopScalarBitmapBoolOp == bitmap_boolop_dxlnode->GetOperator()->GetDXLOperator());
 
-	CDXLScalarBitmapBoolOp *pdxlop = CDXLScalarBitmapBoolOp::PdxlopConvert(pdxlnBitmapBoolOp->Pdxlop());
+	CDXLScalarBitmapBoolOp *sc_bitmap_boolop_dxlop = CDXLScalarBitmapBoolOp::Cast(bitmap_boolop_dxlnode->GetOperator());
 	
-	CDXLNode *pdxlnLeft = (*pdxlnBitmapBoolOp)[0];
-	CDXLNode *pdxlnRight = (*pdxlnBitmapBoolOp)[1];
+	CDXLNode *left_tree_dxlnode = (*bitmap_boolop_dxlnode)[0];
+	CDXLNode *right_tree_dxlnode = (*bitmap_boolop_dxlnode)[1];
 	
-	Plan *pplanLeft = PplanBitmapAccessPath
+	Plan *left_plan = TranslateDXLBitmapAccessPath
 						(
-						pdxlnLeft,
-						pdxltrctxOut,
-						pmdrel,
-						pdxltabdesc,
-						pdxltrctxbt,
-						pdrgpdxltrctxPrevSiblings,
-						pdbts
+						left_tree_dxlnode,
+						output_context,
+						md_rel,
+						table_descr,
+						base_table_context,
+						ctxt_translation_prev_siblings,
+						bitmap_tbl_scan
 						);
-	Plan *pplanRight = PplanBitmapAccessPath
+	Plan *right_plan = TranslateDXLBitmapAccessPath
 						(
-						pdxlnRight,
-						pdxltrctxOut,
-						pmdrel,
-						pdxltabdesc,
-						pdxltrctxbt,
-						pdrgpdxltrctxPrevSiblings,
-						pdbts
+						right_tree_dxlnode,
+						output_context,
+						md_rel,
+						table_descr,
+						base_table_context,
+						ctxt_translation_prev_siblings,
+						bitmap_tbl_scan
 						);
-	List *plChildPlans = ListMake2(pplanLeft, pplanRight);
+	List *child_plan_list = ListMake2(left_plan, right_plan);
 
-	Plan *pplan = NULL;
+	Plan *plan = NULL;
 	
-	if (CDXLScalarBitmapBoolOp::EdxlbitmapAnd == pdxlop->Edxlbitmapboolop())
+	if (CDXLScalarBitmapBoolOp::EdxlbitmapAnd == sc_bitmap_boolop_dxlop->GetDXLBitmapOpType())
 	{
 		BitmapAnd *bitmapand = MakeNode(BitmapAnd);
-		bitmapand->bitmapplans = plChildPlans;
+		bitmapand->bitmapplans = child_plan_list;
 		bitmapand->plan.targetlist = NULL;
 		bitmapand->plan.qual = NULL;
-		pplan = (Plan *) bitmapand;
+		plan = (Plan *) bitmapand;
 	}
 	else
 	{
 		BitmapOr *bitmapor = MakeNode(BitmapOr);
-		bitmapor->bitmapplans = plChildPlans;
+		bitmapor->bitmapplans = child_plan_list;
 		bitmapor->plan.targetlist = NULL;
 		bitmapor->plan.qual = NULL;
-		pplan = (Plan *) bitmapor;
+		plan = (Plan *) bitmapor;
 	}
 	
 	
-	return pplan;
+	return plan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::PplanBitmapIndexProbe
+//		CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe
 //
 //	@doc:
 //		Translate CDXLScalarBitmapIndexProbe into BitmapIndexScan
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::PplanBitmapIndexProbe
+CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe
 	(
-	const CDXLNode *pdxlnBitmapIndexProbe,
-	CDXLTranslateContext *pdxltrctxOut,
-	const IMDRelation *pmdrel,
-	const CDXLTableDescr *pdxltabdesc,
-	CDXLTranslateContextBaseTable *pdxltrctxbt,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-	BitmapTableScan *pdbts
+	const CDXLNode *bitmap_index_probe_dxlnode,
+	CDXLTranslateContext *output_context,
+	const IMDRelation *md_rel,
+	const CDXLTableDescr *table_descr,
+	CDXLTranslateContextBaseTable *base_table_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+	BitmapTableScan *bitmap_tbl_scan
 	)
 {
-	CDXLScalarBitmapIndexProbe *pdxlopScalar =
-			CDXLScalarBitmapIndexProbe::PdxlopConvert(pdxlnBitmapIndexProbe->Pdxlop());
+	CDXLScalarBitmapIndexProbe *sc_bitmap_idx_probe_dxlop =
+			CDXLScalarBitmapIndexProbe::Cast(bitmap_index_probe_dxlnode->GetOperator());
 
-	BitmapIndexScan *pbis = MakeNode(BitmapIndexScan);
-	pbis->scan.scanrelid = pdbts->scan.scanrelid;
-	pbis->scan.partIndex = pdbts->scan.partIndex;
+	BitmapIndexScan *bitmap_idx_scan = MakeNode(BitmapIndexScan);
+	bitmap_idx_scan->scan.scanrelid = bitmap_tbl_scan->scan.scanrelid;
+	bitmap_idx_scan->scan.partIndex = bitmap_tbl_scan->scan.partIndex;
 
-	CMDIdGPDB *pmdidIndex = CMDIdGPDB::PmdidConvert(pdxlopScalar->Pdxlid()->Pmdid());
-	const IMDIndex *pmdindex = m_pmda->Pmdindex(pmdidIndex);
-	Oid oidIndex = pmdidIndex->OidObjectId();
+	CMDIdGPDB *mdid_index = CMDIdGPDB::CastMdid(sc_bitmap_idx_probe_dxlop->GetDXLIndexDescr()->MDId());
+	const IMDIndex *index = m_md_accessor->RetrieveIndex(mdid_index);
+	Oid index_oid = mdid_index->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidIndex);
-	pbis->indexid = oidIndex;
-	OID oidRel = CMDIdGPDB::PmdidConvert(pdxltabdesc->Pmdid())->OidObjectId();
-	pbis->logicalIndexInfo = gpdb::Plgidxinfo(oidRel, oidIndex);
-	Plan *pplan = &(pbis->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	GPOS_ASSERT(InvalidOid != index_oid);
+	bitmap_idx_scan->indexid = index_oid;
+	OID rel_oid = CMDIdGPDB::CastMdid(table_descr->MDId())->Oid();
+	bitmap_idx_scan->logicalIndexInfo = gpdb::GetLogicalIndexInfo(rel_oid, index_oid);
+	Plan *plan = &(bitmap_idx_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
-	GPOS_ASSERT(1 == pdxlnBitmapIndexProbe->UlArity());
-	CDXLNode *pdxlnIndexCondList = (*pdxlnBitmapIndexProbe)[0];
-	List *plIndexConditions = NIL;
-	List *plIndexOrigConditions = NIL;
-	List *plIndexStratgey = NIL;
-	List *plIndexSubtype = NIL;
+	GPOS_ASSERT(1 == bitmap_index_probe_dxlnode->Arity());
+	CDXLNode *index_cond_list_dxlnode = (*bitmap_index_probe_dxlnode)[0];
+	List *index_cond = NIL;
+	List *index_orig_cond = NIL;
+	List *index_strategy_list = NIL;
+	List *index_subtype_list = NIL;
 
 	TranslateIndexConditions
 		(
-		pdxlnIndexCondList,
-		pdxltabdesc,
-		false /*fIndexOnlyScan*/,
-		pmdindex,
-		pmdrel,
-		pdxltrctxOut,
-		pdxltrctxbt,
-		pdrgpdxltrctxPrevSiblings,
-		&plIndexConditions,
-		&plIndexOrigConditions,
-		&plIndexStratgey,
-		&plIndexSubtype
+		index_cond_list_dxlnode,
+		table_descr,
+		false /*is_index_only_scan*/,
+		index,
+		md_rel,
+		output_context,
+		base_table_context,
+		ctxt_translation_prev_siblings,
+		&index_cond,
+		&index_orig_cond,
+		&index_strategy_list,
+		&index_subtype_list
 		);
 
-	pbis->indexqual = plIndexConditions;
-	pbis->indexqualorig = plIndexOrigConditions;
-	pbis->indexstrategy = plIndexStratgey;
-	pbis->indexsubtype = plIndexSubtype;
-	SetParamIds(pplan);
+	bitmap_idx_scan->indexqual = index_cond;
+	bitmap_idx_scan->indexqualorig = index_orig_cond;
+	bitmap_idx_scan->indexstrategy = index_strategy_list;
+	bitmap_idx_scan->indexsubtype = index_subtype_list;
+	SetParamIds(plan);
 
-	return pplan;
+	return plan;
 }
 
 // translates a DXL Value Scan node into a GPDB Value scan node
 Plan *
-CTranslatorDXLToPlStmt::PplanValueScan
+CTranslatorDXLToPlStmt::TranslateDXLValueScan
 	(
-	const CDXLNode *pdxlnValueScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+	const CDXLNode *value_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
 	// translation context for column mappings
-	CDXLTranslateContextBaseTable dxltrctxbt(m_pmp);
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	// we will add the new range table entry as the last element of the range table
-	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	dxltrctxbt.SetIdx(iRel);
+	base_table_context.SetRelIndex(index);
 
 	// create value scan node
-	ValuesScan *pvaluescan = MakeNode(ValuesScan);
-	pvaluescan->scan.scanrelid = iRel;
-	Plan *pplan = &(pvaluescan->scan.plan);
+	ValuesScan *value_scan = MakeNode(ValuesScan);
+	value_scan->scan.scanrelid = index;
+	Plan *plan = &(value_scan->scan.plan);
 
-	RangeTblEntry *prte = PrteFromDXLValueScan(pdxlnValueScan, pdxltrctxOut, &dxltrctxbt);
-	GPOS_ASSERT(NULL != prte);
+	RangeTblEntry *rte = TranslateDXLValueScanToRangeTblEntry(value_scan_dxlnode, output_context, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
 
-	pvaluescan->values_lists = (List *)gpdb::PvCopyObject(prte->values_lists);
+	value_scan->values_lists = (List *)gpdb::CopyObject(rte->values_lists);
 
-	m_pctxdxltoplstmt->AddRTE(prte);
+	m_dxl_to_plstmt_context->AddRTE(rte);
 
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->nMotionNodes = 0;
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->nMotionNodes = 0;
 
 	// translate operator costs
 	TranslatePlanCosts
 	(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnValueScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
+		CDXLPhysicalProperties::PdxlpropConvert(value_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		&(plan->startup_cost),
+		&(plan->total_cost),
+		&(plan->plan_rows),
+		&(plan->plan_width)
 	);
 
 	// a table scan node must have at least 2 children: projection list and at least 1 value list
-	GPOS_ASSERT(2 <= pdxlnValueScan->UlArity());
+	GPOS_ASSERT(2 <= value_scan_dxlnode->Arity());
 
-	CDXLNode *pdxlnPrL = (*pdxlnValueScan)[EdxltsIndexProjList];
+	CDXLNode *project_list_dxlnode = (*value_scan_dxlnode)[EdxltsIndexProjList];
 
 	// translate proj list
-	List *plTargetList = PlTargetListFromProjList
+	List *target_list = TranslateDXLProjList
 							(
-							pdxlnPrL,
-							&dxltrctxbt,
+							project_list_dxlnode,
+							&base_table_context,
 							NULL,
-							pdxltrctxOut
+							output_context
 							);
 
-	pplan->targetlist = plTargetList;
+	plan->targetlist = target_list;
 
-	return (Plan *) pvaluescan;
+	return (Plan *) value_scan;
 }
 
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -59,124 +59,124 @@ using namespace gpopt;
 //---------------------------------------------------------------------------
 CTranslatorDXLToScalar::CTranslatorDXLToScalar
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	ULONG ulSegments
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	ULONG num_segments
 	)
 	:
-	m_pmp(pmp),
-	m_pmda(pmda),
-	m_fHasSubqueries(false),
-	m_ulSegments(ulSegments)
+	m_mp(mp),
+	m_md_accessor(md_accessor),
+	m_has_subqueries(false),
+	m_num_of_segments(num_segments)
 {
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprFromDXLNodeScalar
+//		CTranslatorDXLToScalar::TranslateDXLToScalar
 //
 //	@doc:
 //		Translates a DXL scalar expression into a GPDB Expression node
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprFromDXLNodeScalar
+CTranslatorDXLToScalar::TranslateDXLToScalar
 	(
-	const CDXLNode *pdxln,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *dxlnode,
+	CMappingColIdVar *colid_var
 	)
 {
-	static const STranslatorElem rgTranslators[] =
+	static const STranslatorElem translators[] =
 	{
-		{EdxlopScalarIdent, &CTranslatorDXLToScalar::PexprFromDXLNodeScId},
-		{EdxlopScalarCmp, &CTranslatorDXLToScalar::PopexprFromDXLNodeScCmp},
-		{EdxlopScalarDistinct, &CTranslatorDXLToScalar::PdistexprFromDXLNodeScDistinctComp},
-		{EdxlopScalarOpExpr, &CTranslatorDXLToScalar::PopexprFromDXLNodeScOpExpr},
-		{EdxlopScalarArrayComp, &CTranslatorDXLToScalar::PstrarrayopexprFromDXLNodeScArrayComp},
-		{EdxlopScalarCoalesce, &CTranslatorDXLToScalar::PcoalesceFromDXLNodeScCoalesce},
-		{EdxlopScalarMinMax, &CTranslatorDXLToScalar::PminmaxFromDXLNodeScMinMax},
-		{EdxlopScalarConstValue, &CTranslatorDXLToScalar::PconstFromDXLNodeScConst},
-		{EdxlopScalarBoolExpr, &CTranslatorDXLToScalar::PboolexprFromDXLNodeScBoolExpr},
-		{EdxlopScalarBooleanTest, &CTranslatorDXLToScalar::PbooleantestFromDXLNodeScBooleanTest},
-		{EdxlopScalarNullTest, &CTranslatorDXLToScalar::PnulltestFromDXLNodeScNullTest},
-		{EdxlopScalarNullIf, &CTranslatorDXLToScalar::PnullifFromDXLNodeScNullIf},
-		{EdxlopScalarIfStmt, &CTranslatorDXLToScalar::PcaseexprFromDXLNodeScIfStmt},
-		{EdxlopScalarSwitch, &CTranslatorDXLToScalar::PcaseexprFromDXLNodeScSwitch},
-		{EdxlopScalarCaseTest, &CTranslatorDXLToScalar::PcasetestexprFromDXLNodeScCaseTest},
-		{EdxlopScalarFuncExpr, &CTranslatorDXLToScalar::PfuncexprFromDXLNodeScFuncExpr},
-		{EdxlopScalarAggref, &CTranslatorDXLToScalar::PaggrefFromDXLNodeScAggref},
-		{EdxlopScalarWindowRef, &CTranslatorDXLToScalar::PwindowrefFromDXLNodeScWindowRef},
-		{EdxlopScalarCast, &CTranslatorDXLToScalar::PrelabeltypeFromDXLNodeScCast},
-		{EdxlopScalarCoerceToDomain, &CTranslatorDXLToScalar::PcoerceFromDXLNodeScCoerceToDomain},
-		{EdxlopScalarCoerceViaIO, &CTranslatorDXLToScalar::PcoerceFromDXLNodeScCoerceViaIO},
-		{EdxlopScalarArrayCoerceExpr, &CTranslatorDXLToScalar::PcoerceFromDXLNodeScArrayCoerceExpr},
-		{EdxlopScalarSubPlan, &CTranslatorDXLToScalar::PsubplanFromDXLNodeScSubPlan},
-		{EdxlopScalarArray, &CTranslatorDXLToScalar::PexprArray},
-		{EdxlopScalarArrayRef, &CTranslatorDXLToScalar::PexprArrayRef},
-		{EdxlopScalarDMLAction, &CTranslatorDXLToScalar::PexprDMLAction},
-		{EdxlopScalarPartDefault, &CTranslatorDXLToScalar::PexprPartDefault},
-		{EdxlopScalarPartBound, &CTranslatorDXLToScalar::PexprPartBound},
-		{EdxlopScalarPartBoundInclusion, &CTranslatorDXLToScalar::PexprPartBoundInclusion},
-		{EdxlopScalarPartBoundOpen, &CTranslatorDXLToScalar::PexprPartBoundOpen},
-		{EdxlopScalarPartListValues, &CTranslatorDXLToScalar::PexprPartListValues},
-		{EdxlopScalarPartListNullTest, &CTranslatorDXLToScalar::PexprPartListNullTest},
+		{EdxlopScalarIdent, &CTranslatorDXLToScalar::TranslateDXLScalarIdentToScalar},
+		{EdxlopScalarCmp, &CTranslatorDXLToScalar::TranslateDXLScalarCmpToScalar},
+		{EdxlopScalarDistinct, &CTranslatorDXLToScalar::TranslateDXLScalarDistinctToScalar},
+		{EdxlopScalarOpExpr, &CTranslatorDXLToScalar::TranslateDXLScalarOpExprToScalar},
+		{EdxlopScalarArrayComp, &CTranslatorDXLToScalar::TranslateDXLScalarArrayCompToScalar},
+		{EdxlopScalarCoalesce, &CTranslatorDXLToScalar::TranslateDXLScalarCoalesceToScalar},
+		{EdxlopScalarMinMax, &CTranslatorDXLToScalar::TranslateDXLScalarMinMaxToScalar},
+		{EdxlopScalarConstValue, &CTranslatorDXLToScalar::TranslateDXLScalarConstToScalar},
+		{EdxlopScalarBoolExpr, &CTranslatorDXLToScalar::TranslateDXLScalarBoolExprToScalar},
+		{EdxlopScalarBooleanTest, &CTranslatorDXLToScalar::TranslateDXLScalarBooleanTestToScalar},
+		{EdxlopScalarNullTest, &CTranslatorDXLToScalar::TranslateDXLScalarNullTestToScalar},
+		{EdxlopScalarNullIf, &CTranslatorDXLToScalar::TranslateDXLScalarNullIfToScalar},
+		{EdxlopScalarIfStmt, &CTranslatorDXLToScalar::TranslateDXLScalarIfStmtToScalar},
+		{EdxlopScalarSwitch, &CTranslatorDXLToScalar::TranslateDXLScalarSwitchToScalar},
+		{EdxlopScalarCaseTest, &CTranslatorDXLToScalar::TranslateDXLScalarCaseTestToScalar},
+		{EdxlopScalarFuncExpr, &CTranslatorDXLToScalar::TranslateDXLScalarFuncExprToScalar},
+		{EdxlopScalarAggref, &CTranslatorDXLToScalar::TranslateDXLScalarAggrefToScalar},
+		{EdxlopScalarWindowRef, &CTranslatorDXLToScalar::TranslateDXLScalarWindowRefToScalar},
+		{EdxlopScalarCast, &CTranslatorDXLToScalar::TranslateDXLScalarCastToScalar},
+		{EdxlopScalarCoerceToDomain, &CTranslatorDXLToScalar::TranslateDXLScalarCoerceToDomainToScalar},
+		{EdxlopScalarCoerceViaIO, &CTranslatorDXLToScalar::TranslateDXLScalarCoerceViaIOToScalar},
+		{EdxlopScalarArrayCoerceExpr, &CTranslatorDXLToScalar::TranslateDXLScalarArrayCoerceExprToScalar},
+		{EdxlopScalarSubPlan, &CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar},
+		{EdxlopScalarArray, &CTranslatorDXLToScalar::TranslateDXLScalarArrayToScalar},
+		{EdxlopScalarArrayRef, &CTranslatorDXLToScalar::TranslateDXLScalarArrayRefToScalar},
+		{EdxlopScalarDMLAction, &CTranslatorDXLToScalar::TranslateDXLScalarDMLActionToScalar},
+		{EdxlopScalarPartDefault, &CTranslatorDXLToScalar::TranslateDXLScalarPartDefaultToScalar},
+		{EdxlopScalarPartBound, &CTranslatorDXLToScalar::TranslateDXLScalarPartBoundToScalar},
+		{EdxlopScalarPartBoundInclusion, &CTranslatorDXLToScalar::TranslateDXLScalarPartBoundInclusionToScalar},
+		{EdxlopScalarPartBoundOpen, &CTranslatorDXLToScalar::TranslateDXLScalarPartBoundOpenToScalar},
+		{EdxlopScalarPartListValues, &CTranslatorDXLToScalar::TranslateDXLScalarPartListValuesToScalar},
+		{EdxlopScalarPartListNullTest, &CTranslatorDXLToScalar::TranslateDXLScalarPartListNullTestToScalar},
 	};
 
-	const ULONG ulTranslators = GPOS_ARRAY_SIZE(rgTranslators);
+	const ULONG num_translators = GPOS_ARRAY_SIZE(translators);
 
-	GPOS_ASSERT(NULL != pdxln);
-	Edxlopid eopid = pdxln->Pdxlop()->Edxlop();
+	GPOS_ASSERT(NULL != dxlnode);
+	Edxlopid eopid = dxlnode->GetOperator()->GetDXLOperator();
 
 	// find translator for the node type
-	PfPexpr pf = NULL;
-	for (ULONG ul = 0; ul < ulTranslators; ul++)
+	expr_func_ptr translate_func = NULL;
+	for (ULONG ul = 0; ul < num_translators; ul++)
 	{
-		STranslatorElem elem = rgTranslators[ul];
+		STranslatorElem elem = translators[ul];
 		if (eopid == elem.eopid)
 		{
-			pf = elem.pf;
+			translate_func = elem.translate_func;
 			break;
 		}
 	}
 
-	if (NULL == pf)
+	if (NULL == translate_func)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, pdxln->Pdxlop()->PstrOpName()->Wsz());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, dxlnode->GetOperator()->GetOpNameStr()->GetBuffer());
 	}
 
-	return (this->*pf)(pdxln, pmapcidvar);
+	return (this->*translate_func)(dxlnode, colid_var);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PcaseexprFromDXLNodeScIfStmt
+//		CTranslatorDXLToScalar::TranslateDXLScalarIfStmtToScalar
 //
 //	@doc:
 //		Translates a DXL scalar if stmt into a GPDB CaseExpr node
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PcaseexprFromDXLNodeScIfStmt
+CTranslatorDXLToScalar::TranslateDXLScalarIfStmtToScalar
 	(
-	const CDXLNode *pdxlnIfStmt,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_if_stmt_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnIfStmt);
-	CDXLScalarIfStmt *pdxlopIfStmt = CDXLScalarIfStmt::PdxlopConvert(pdxlnIfStmt->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_if_stmt_node);
+	CDXLScalarIfStmt *scalar_if_stmt_dxl = CDXLScalarIfStmt::Cast(scalar_if_stmt_node->GetOperator());
 
-	CaseExpr *pcaseexpr = MakeNode(CaseExpr);
-	pcaseexpr->casetype = CMDIdGPDB::PmdidConvert(pdxlopIfStmt->PmdidResultType())->OidObjectId();
+	CaseExpr *case_expr = MakeNode(CaseExpr);
+	case_expr->casetype = CMDIdGPDB::CastMdid(scalar_if_stmt_dxl->GetResultTypeMdId())->Oid();
 
-	CDXLNode *pdxlnCurr = const_cast<CDXLNode*>(pdxlnIfStmt);
-	Expr *pexprElse = NULL;
+	CDXLNode *curr_node = const_cast<CDXLNode*>(scalar_if_stmt_node);
+	Expr *else_expr = NULL;
 
 	// An If statement is of the format: IF <condition> <then> <else>
 	// The leaf else statement is the def result of the case statement
-	BOOL fLeafElseStatement = false;
+	BOOL is_leaf_else_stmt = false;
 
-	while (!fLeafElseStatement)
+	while (!is_leaf_else_stmt)
 	{
 
-		if (3 != pdxlnCurr->UlArity())
+		if (3 != curr_node->Arity())
 		{
 			GPOS_RAISE
 				(
@@ -186,177 +186,177 @@ CTranslatorDXLToScalar::PcaseexprFromDXLNodeScIfStmt
 			return NULL;
 		}
 
-		Expr *pexprWhen = PexprFromDXLNodeScalar((*pdxlnCurr)[0], pmapcidvar);
-		Expr *pexprThen = PexprFromDXLNodeScalar((*pdxlnCurr)[1], pmapcidvar);
+		Expr *when_expr = TranslateDXLToScalar((*curr_node)[0], colid_var);
+		Expr *then_expr = TranslateDXLToScalar((*curr_node)[1], colid_var);
 
-		CaseWhen *pwhen = MakeNode(CaseWhen);
-		pwhen->expr = pexprWhen;
-		pwhen->result = pexprThen;
-		pcaseexpr->args = gpdb::PlAppendElement(pcaseexpr->args,pwhen);
+		CaseWhen *case_when = MakeNode(CaseWhen);
+		case_when->expr = when_expr;
+		case_when->result = then_expr;
+		case_expr->args = gpdb::LAppend(case_expr->args,case_when);
 
-		if (EdxlopScalarIfStmt == (*pdxlnCurr)[2]->Pdxlop()->Edxlop())
+		if (EdxlopScalarIfStmt == (*curr_node)[2]->GetOperator()->GetDXLOperator())
 		{
-			pdxlnCurr = (*pdxlnCurr)[2];
+			curr_node = (*curr_node)[2];
 		}
 		else
 		{
-			fLeafElseStatement = true;
-			pexprElse = PexprFromDXLNodeScalar((*pdxlnCurr)[2], pmapcidvar);
+			is_leaf_else_stmt = true;
+			else_expr = TranslateDXLToScalar((*curr_node)[2], colid_var);
 		}
 	}
 
-	pcaseexpr->defresult = pexprElse;
+	case_expr->defresult = else_expr;
 
-	return (Expr *)pcaseexpr;
+	return (Expr *)case_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PcaseexprFromDXLNodeScSwitch
+//		CTranslatorDXLToScalar::TranslateDXLScalarSwitchToScalar
 //
 //	@doc:
 //		Translates a DXL scalar switch into a GPDB CaseExpr node
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PcaseexprFromDXLNodeScSwitch
+CTranslatorDXLToScalar::TranslateDXLScalarSwitchToScalar
 	(
-	const CDXLNode *pdxlnSwitch,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_switch_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnSwitch);
-	CDXLScalarSwitch *pdxlop = CDXLScalarSwitch::PdxlopConvert(pdxlnSwitch->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_switch_node);
+	CDXLScalarSwitch *dxlop = CDXLScalarSwitch::Cast(scalar_switch_node->GetOperator());
 
-	CaseExpr *pcaseexpr = MakeNode(CaseExpr);
-	pcaseexpr->casetype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidType())->OidObjectId();
+	CaseExpr *case_expr = MakeNode(CaseExpr);
+	case_expr->casetype = CMDIdGPDB::CastMdid(dxlop->MdidType())->Oid();
 
 	// translate arg child
-	pcaseexpr->arg = PexprFromDXLNodeScalar((*pdxlnSwitch)[0], pmapcidvar);
-	GPOS_ASSERT(NULL != pcaseexpr->arg);
+	case_expr->arg = TranslateDXLToScalar((*scalar_switch_node)[0], colid_var);
+	GPOS_ASSERT(NULL != case_expr->arg);
 
-	const ULONG ulArity = pdxlnSwitch->UlArity();
-	GPOS_ASSERT(1 < ulArity);
-	for (ULONG ul = 1; ul < ulArity; ul++)
+	const ULONG arity = scalar_switch_node->Arity();
+	GPOS_ASSERT(1 < arity);
+	for (ULONG ul = 1; ul < arity; ul++)
 	{
-		const CDXLNode *pdxlnChild = (*pdxlnSwitch)[ul];
+		const CDXLNode *child_dxl = (*scalar_switch_node)[ul];
 
-		if (EdxlopScalarSwitchCase == pdxlnChild->Pdxlop()->Edxlop())
+		if (EdxlopScalarSwitchCase == child_dxl->GetOperator()->GetDXLOperator())
 		{
-			CaseWhen *pwhen = MakeNode(CaseWhen);
-			pwhen->expr = PexprFromDXLNodeScalar((*pdxlnChild)[0], pmapcidvar);
-			pwhen->result = PexprFromDXLNodeScalar((*pdxlnChild)[1], pmapcidvar);
-			pcaseexpr->args = gpdb::PlAppendElement(pcaseexpr->args, pwhen);
+			CaseWhen *case_when = MakeNode(CaseWhen);
+			case_when->expr = TranslateDXLToScalar((*child_dxl)[0], colid_var);
+			case_when->result = TranslateDXLToScalar((*child_dxl)[1], colid_var);
+			case_expr->args = gpdb::LAppend(case_expr->args, case_when);
 		}
 		else
 		{
 			// default return value
-			GPOS_ASSERT(ul == ulArity - 1);
-			pcaseexpr->defresult = PexprFromDXLNodeScalar((*pdxlnSwitch)[ul], pmapcidvar);
+			GPOS_ASSERT(ul == arity - 1);
+			case_expr->defresult = TranslateDXLToScalar((*scalar_switch_node)[ul], colid_var);
 		}
 	}
 
-	return (Expr *)pcaseexpr;
+	return (Expr *)case_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PcasetestexprFromDXLNodeScCaseTest
+//		CTranslatorDXLToScalar::TranslateDXLScalarCaseTestToScalar
 //
 //	@doc:
 //		Translates a DXL scalar case test into a GPDB CaseTestExpr node
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PcasetestexprFromDXLNodeScCaseTest
+CTranslatorDXLToScalar::TranslateDXLScalarCaseTestToScalar
 	(
-	const CDXLNode *pdxlnCaseTest,
-	CMappingColIdVar * //pmapcidvar
+	const CDXLNode *scalar_case_test_node,
+	CMappingColIdVar * //colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnCaseTest);
-	CDXLScalarCaseTest *pdxlop = CDXLScalarCaseTest::PdxlopConvert(pdxlnCaseTest->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_case_test_node);
+	CDXLScalarCaseTest *dxlop = CDXLScalarCaseTest::Cast(scalar_case_test_node->GetOperator());
 
-	CaseTestExpr *pcasetestexpr = MakeNode(CaseTestExpr);
-	pcasetestexpr->typeId = CMDIdGPDB::PmdidConvert(pdxlop->PmdidType())->OidObjectId();
-	pcasetestexpr->typeMod = -1;
+	CaseTestExpr *case_test_expr = MakeNode(CaseTestExpr);
+	case_test_expr->typeId = CMDIdGPDB::CastMdid(dxlop->MdidType())->Oid();
+	case_test_expr->typeMod = -1;
 
-	return (Expr *)pcasetestexpr;
+	return (Expr *)case_test_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PopexprFromDXLNodeScOpExpr
+//		CTranslatorDXLToScalar::TranslateDXLScalarOpExprToScalar
 //
 //	@doc:
 //		Translates a DXL scalar opexpr into a GPDB OpExpr node
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PopexprFromDXLNodeScOpExpr
+CTranslatorDXLToScalar::TranslateDXLScalarOpExprToScalar
 	(
-	const CDXLNode *pdxlnOpExpr,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_op_expr_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnOpExpr);
-	CDXLScalarOpExpr *pdxlopOpExpr = CDXLScalarOpExpr::PdxlopConvert(pdxlnOpExpr->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_op_expr_node);
+	CDXLScalarOpExpr *scalar_op_expr_dxl = CDXLScalarOpExpr::Cast(scalar_op_expr_node->GetOperator());
 
-	OpExpr *popexpr = MakeNode(OpExpr);
-	popexpr->opno = CMDIdGPDB::PmdidConvert(pdxlopOpExpr->Pmdid())->OidObjectId();
+	OpExpr *op_expr = MakeNode(OpExpr);
+	op_expr->opno = CMDIdGPDB::CastMdid(scalar_op_expr_dxl->MDId())->Oid();
 
-	const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pdxlopOpExpr->Pmdid());
-	popexpr->opfuncid = CMDIdGPDB::PmdidConvert(pmdscop->PmdidFunc())->OidObjectId();
-	
-	IMDId *pmdidReturnType = pdxlopOpExpr->PmdidReturnType();
-	if (NULL != pmdidReturnType)
+	const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(scalar_op_expr_dxl->MDId());
+	op_expr->opfuncid = CMDIdGPDB::CastMdid(md_scalar_op->FuncMdId())->Oid();
+
+	IMDId *return_type_mdid = scalar_op_expr_dxl->GetReturnTypeMdId();
+	if (NULL != return_type_mdid)
 	{
-		popexpr->opresulttype = CMDIdGPDB::PmdidConvert(pmdidReturnType)->OidObjectId();
+		op_expr->opresulttype = CMDIdGPDB::CastMdid(return_type_mdid)->Oid();
 	}
 	else 
 	{
-		popexpr->opresulttype = OidFunctionReturnType(pmdscop->PmdidFunc());
+		op_expr->opresulttype = GetFunctionReturnTypeOid(md_scalar_op->FuncMdId());
 	}
 
-	const IMDFunction *pmdfunc = m_pmda->Pmdfunc(pmdscop->PmdidFunc());
-	popexpr->opretset = pmdfunc->FReturnsSet();
+	const IMDFunction *md_func = m_md_accessor->RetrieveFunc(md_scalar_op->FuncMdId());
+	op_expr->opretset = md_func->ReturnsSet();
 
-	GPOS_ASSERT(1 == pdxlnOpExpr->UlArity() || 2 == pdxlnOpExpr->UlArity());
+	GPOS_ASSERT(1 == scalar_op_expr_node->Arity() || 2 == scalar_op_expr_node->Arity());
 
 	// translate children
-	popexpr->args = PlistTranslateScalarChildren(popexpr->args, pdxlnOpExpr, pmapcidvar);
+	op_expr->args = TranslateScalarChildren(op_expr->args, scalar_op_expr_node, colid_var);
 
-	return (Expr *)popexpr;
+	return (Expr *)op_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PstrarrayopexprFromDXLNodeScArrayComp
+//		CTranslatorDXLToScalar::TranslateDXLScalarArrayCompToScalar
 //
 //	@doc:
 //		Translates a CDXLScalarArrayComp into a GPDB ScalarArrayOpExpr
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PstrarrayopexprFromDXLNodeScArrayComp
+CTranslatorDXLToScalar::TranslateDXLScalarArrayCompToScalar
 	(
-	const CDXLNode *pdxlnArrayComp,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_array_comp_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnArrayComp);
-	CDXLScalarArrayComp *pdxlopArrayComp = CDXLScalarArrayComp::PdxlopConvert(pdxlnArrayComp->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_array_comp_node);
+	CDXLScalarArrayComp *array_comp_dxl = CDXLScalarArrayComp::Cast(scalar_array_comp_node->GetOperator());
 
-	ScalarArrayOpExpr *parrayopexpr = MakeNode(ScalarArrayOpExpr);
-	parrayopexpr->opno = CMDIdGPDB::PmdidConvert(pdxlopArrayComp->Pmdid())->OidObjectId();
-	const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pdxlopArrayComp->Pmdid());
-	parrayopexpr->opfuncid = CMDIdGPDB::PmdidConvert(pmdscop->PmdidFunc())->OidObjectId();
+	ScalarArrayOpExpr *array_op_expr = MakeNode(ScalarArrayOpExpr);
+	array_op_expr->opno = CMDIdGPDB::CastMdid(array_comp_dxl->MDId())->Oid();
+	const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(array_comp_dxl->MDId());
+	array_op_expr->opfuncid = CMDIdGPDB::CastMdid(md_scalar_op->FuncMdId())->Oid();
 
-	switch(pdxlopArrayComp->Edxlarraycomptype())
+	switch(array_comp_dxl->GetDXLArrayCmpType())
 	{
 		case Edxlarraycomptypeany:
-				parrayopexpr->useOr = true;
+				array_op_expr->useOr = true;
 				break;
 
 		case Edxlarraycomptypeall:
-				parrayopexpr->useOr = false;
+				array_op_expr->useOr = false;
 				break;
 
 		default:
@@ -370,114 +370,114 @@ CTranslatorDXLToScalar::PstrarrayopexprFromDXLNodeScArrayComp
 
 	// translate left and right child
 
-	GPOS_ASSERT(2 == pdxlnArrayComp->UlArity());
+	GPOS_ASSERT(2 == scalar_array_comp_node->Arity());
 
-	CDXLNode *pdxlnLeft = (*pdxlnArrayComp)[EdxlsccmpIndexLeft];
-	CDXLNode *pdxlnRight = (*pdxlnArrayComp)[EdxlsccmpIndexRight];
+	CDXLNode *left_node = (*scalar_array_comp_node)[EdxlsccmpIndexLeft];
+	CDXLNode *right_node = (*scalar_array_comp_node)[EdxlsccmpIndexRight];
 
-	Expr *pexprLeft = PexprFromDXLNodeScalar(pdxlnLeft, pmapcidvar);
-	Expr *pexprRight = PexprFromDXLNodeScalar(pdxlnRight, pmapcidvar);
+	Expr *left_expr = TranslateDXLToScalar(left_node, colid_var);
+	Expr *right_expr = TranslateDXLToScalar(right_node, colid_var);
 
-	parrayopexpr->args = ListMake2(pexprLeft, pexprRight);
+	array_op_expr->args = ListMake2(left_expr, right_expr);
 
-	return (Expr *)parrayopexpr;
+	return (Expr *)array_op_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PdistexprFromDXLNodeScDistinctComp
+//		CTranslatorDXLToScalar::TranslateDXLScalarDistinctToScalar
 //
 //	@doc:
 //		Translates a DXL scalar distinct comparison into a GPDB DistinctExpr node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PdistexprFromDXLNodeScDistinctComp
+CTranslatorDXLToScalar::TranslateDXLScalarDistinctToScalar
 	(
-	const CDXLNode *pdxlnDistComp,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_distinct_cmp_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnDistComp);
-	CDXLScalarDistinctComp *pdxlop = CDXLScalarDistinctComp::PdxlopConvert(pdxlnDistComp->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_distinct_cmp_node);
+	CDXLScalarDistinctComp *dxlop = CDXLScalarDistinctComp::Cast(scalar_distinct_cmp_node->GetOperator());
 
-	DistinctExpr *pdistexpr = MakeNode(DistinctExpr);
-	pdistexpr->opno = CMDIdGPDB::PmdidConvert(pdxlop->Pmdid())->OidObjectId();
+	DistinctExpr *dist_expr = MakeNode(DistinctExpr);
+	dist_expr->opno = CMDIdGPDB::CastMdid(dxlop->MDId())->Oid();
 
-	const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pdxlop->Pmdid());
+	const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(dxlop->MDId());
 
-	pdistexpr->opfuncid = CMDIdGPDB::PmdidConvert(pmdscop->PmdidFunc())->OidObjectId();
-	pdistexpr->opresulttype = OidFunctionReturnType(pmdscop->PmdidFunc());
+	dist_expr->opfuncid = CMDIdGPDB::CastMdid(md_scalar_op->FuncMdId())->Oid();
+	dist_expr->opresulttype = GetFunctionReturnTypeOid(md_scalar_op->FuncMdId());
 
 	// translate left and right child
-	GPOS_ASSERT(2 == pdxlnDistComp->UlArity());
-	CDXLNode *pdxlnLeft = (*pdxlnDistComp)[EdxlscdistcmpIndexLeft];
-	CDXLNode *pdxlnRight = (*pdxlnDistComp)[EdxlscdistcmpIndexRight];
+	GPOS_ASSERT(2 == scalar_distinct_cmp_node->Arity());
+	CDXLNode *left_node = (*scalar_distinct_cmp_node)[EdxlscdistcmpIndexLeft];
+	CDXLNode *right_node = (*scalar_distinct_cmp_node)[EdxlscdistcmpIndexRight];
 
-	Expr *pexprLeft = PexprFromDXLNodeScalar(pdxlnLeft, pmapcidvar);
-	Expr *pexprRight = PexprFromDXLNodeScalar(pdxlnRight, pmapcidvar);
+	Expr *left_expr = TranslateDXLToScalar(left_node, colid_var);
+	Expr *right_expr = TranslateDXLToScalar(right_node, colid_var);
 
-	pdistexpr->args = ListMake2(pexprLeft, pexprRight);
+	dist_expr->args = ListMake2(left_expr, right_expr);
 
-	return (Expr *)pdistexpr;
+	return (Expr *)dist_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PaggrefFromDXLNodeScAggref
+//		CTranslatorDXLToScalar::TranslateDXLScalarAggrefToScalar
 //
 //	@doc:
-//		Translates a DXL scalar aggref into a GPDB Aggref node
+//		Translates a DXL scalar aggref_node into a GPDB Aggref node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PaggrefFromDXLNodeScAggref
+CTranslatorDXLToScalar::TranslateDXLScalarAggrefToScalar
 	(
-	const CDXLNode *pdxlnAggref,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *aggref_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnAggref);
-	CDXLScalarAggref *pdxlop = CDXLScalarAggref::PdxlopConvert(pdxlnAggref->Pdxlop());
+	GPOS_ASSERT(NULL != aggref_node);
+	CDXLScalarAggref *dxlop = CDXLScalarAggref::Cast(aggref_node->GetOperator());
 
-	Aggref *paggref = MakeNode(Aggref);
-	paggref->aggfnoid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidAgg())->OidObjectId();
-	paggref->aggdistinct = pdxlop->FDistinct();
-	paggref->agglevelsup = 0;
-	paggref->location = -1;
+	Aggref *aggref = MakeNode(Aggref);
+	aggref->aggfnoid = CMDIdGPDB::CastMdid(dxlop->GetDXLAggFuncMDid())->Oid();
+	aggref->aggdistinct = dxlop->IsDistinct();
+	aggref->agglevelsup = 0;
+	aggref->location = -1;
 
-	CMDIdGPDB *pmdidAgg = GPOS_NEW(m_pmp) CMDIdGPDB(paggref->aggfnoid);
-	const IMDAggregate *pmdagg = m_pmda->Pmdagg(pmdidAgg);
-	pmdidAgg->Release();
+	CMDIdGPDB *agg_mdid = GPOS_NEW(m_mp) CMDIdGPDB(aggref->aggfnoid);
+	const IMDAggregate *pmdagg = m_md_accessor->RetrieveAgg(agg_mdid);
+	agg_mdid->Release();
 
-	EdxlAggrefStage edxlaggstage = pdxlop->Edxlaggstage();
-	if (NULL != pdxlop->PmdidResolvedRetType())
+	EdxlAggrefStage edxlaggstage = dxlop->GetDXLAggStage();
+	if (NULL != dxlop->GetDXLResolvedRetTypeMDid())
 	{
 		// use resolved type
-		paggref->aggtype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidResolvedRetType())->OidObjectId();
+		aggref->aggtype = CMDIdGPDB::CastMdid(dxlop->GetDXLResolvedRetTypeMDid())->Oid();
 	}
 	else if (EdxlaggstageIntermediate == edxlaggstage || EdxlaggstagePartial == edxlaggstage)
 	{
-		paggref->aggtype = CMDIdGPDB::PmdidConvert(pmdagg->PmdidTypeIntermediate())->OidObjectId();
+		aggref->aggtype = CMDIdGPDB::CastMdid(pmdagg->GetIntermediateResultTypeMdid())->Oid();
 	}
 	else
 	{
-		paggref->aggtype = CMDIdGPDB::PmdidConvert(pmdagg->PmdidTypeResult())->OidObjectId();
+		aggref->aggtype = CMDIdGPDB::CastMdid(pmdagg->GetResultTypeMdid())->Oid();
 	}
 
-	switch(pdxlop->Edxlaggstage())
+	switch(dxlop->GetDXLAggStage())
 	{
 		case EdxlaggstageNormal:
-					paggref->aggstage = AGGSTAGE_NORMAL;
+					aggref->aggstage = AGGSTAGE_NORMAL;
 					break;
 		case EdxlaggstagePartial:
-					paggref->aggstage = AGGSTAGE_PARTIAL;
+					aggref->aggstage = AGGSTAGE_PARTIAL;
 					break;
 		case EdxlaggstageIntermediate:
-					paggref->aggstage = AGGSTAGE_INTERMEDIATE;
+					aggref->aggstage = AGGSTAGE_INTERMEDIATE;
 					break;
 		case EdxlaggstageFinal:
-					paggref->aggstage = AGGSTAGE_FINAL;
+					aggref->aggstage = AGGSTAGE_FINAL;
 					break;
 		default:
 				GPOS_RAISE
@@ -489,219 +489,219 @@ CTranslatorDXLToScalar::PaggrefFromDXLNodeScAggref
 	}
 
 	// translate each DXL argument
-	paggref->args = PlistTranslateScalarChildren(paggref->args, pdxlnAggref, pmapcidvar);
+	aggref->args = TranslateScalarChildren(aggref->args, aggref_node, colid_var);
 
-	return (Expr *)paggref;
+	return (Expr *)aggref;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PwindowrefFromDXLNodeScWindowRef
+//		CTranslatorDXLToScalar::TranslateDXLScalarWindowRefToScalar
 //
 //	@doc:
 //		Translate a DXL scalar window ref into a GPDB WindowRef node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PwindowrefFromDXLNodeScWindowRef
+CTranslatorDXLToScalar::TranslateDXLScalarWindowRefToScalar
 	(
-	const CDXLNode *pdxlnWinref,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_winref_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnWinref);
-	CDXLScalarWindowRef *pdxlop = CDXLScalarWindowRef::PdxlopConvert(pdxlnWinref->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_winref_node);
+	CDXLScalarWindowRef *dxlop = CDXLScalarWindowRef::Cast(scalar_winref_node->GetOperator());
 
 	WindowRef *pwindowref = MakeNode(WindowRef);
-	pwindowref->winfnoid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidFunc())->OidObjectId();
-	pwindowref->windistinct = pdxlop->FDistinct();
+	pwindowref->winfnoid = CMDIdGPDB::CastMdid(dxlop->FuncMdId())->Oid();
+	pwindowref->windistinct = dxlop->IsDistinct();
 	pwindowref->location = -1;
 	pwindowref->winlevel = 0;
-	pwindowref->winspec = pdxlop->UlWinSpecPos();
-	pwindowref->restype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidRetType())->OidObjectId();
+	pwindowref->winspec = dxlop->GetWindSpecPos();
+	pwindowref->restype = CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
 
-	EdxlWinStage edxlwinstage = pdxlop->Edxlwinstage();
-	GPOS_ASSERT(edxlwinstage != EdxlwinstageSentinel);
+	EdxlWinStage dxl_win_stage = dxlop->GetDxlWinStage();
+	GPOS_ASSERT(dxl_win_stage != EdxlwinstageSentinel);
 
-	ULONG rgrgulMapping[][2] =
+	ULONG mapping[][2] =
 			{
 			{WINSTAGE_IMMEDIATE, EdxlwinstageImmediate},
 			{WINSTAGE_PRELIMINARY, EdxlwinstagePreliminary},
 			{WINSTAGE_ROWKEY, EdxlwinstageRowKey},
 			};
 
-	const ULONG ulArity = GPOS_ARRAY_SIZE(rgrgulMapping);
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = GPOS_ARRAY_SIZE(mapping);
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		ULONG *pulElem = rgrgulMapping[ul];
-		if ((ULONG) edxlwinstage == pulElem[1])
+		ULONG *elem = mapping[ul];
+		if ((ULONG) dxl_win_stage == elem[1])
 		{
-			pwindowref->winstage = (WinStage) pulElem[0];
+			pwindowref->winstage = (WinStage) elem[0];
 			break;
 		}
 	}
 
 	// translate the arguments of the window function
-	pwindowref->args = PlistTranslateScalarChildren(pwindowref->args, pdxlnWinref, pmapcidvar);
+	pwindowref->args = TranslateScalarChildren(pwindowref->args, scalar_winref_node, colid_var);
 
 	return (Expr *) pwindowref;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PfuncexprFromDXLNodeScFuncExpr
+//		CTranslatorDXLToScalar::TranslateDXLScalarFuncExprToScalar
 //
 //	@doc:
 //		Translates a DXL scalar opexpr into a GPDB FuncExpr node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PfuncexprFromDXLNodeScFuncExpr
+CTranslatorDXLToScalar::TranslateDXLScalarFuncExprToScalar
 	(
-	const CDXLNode *pdxlnFuncExpr,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_func_expr_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnFuncExpr);
-	CDXLScalarFuncExpr *pdxlop = CDXLScalarFuncExpr::PdxlopConvert(pdxlnFuncExpr->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_func_expr_node);
+	CDXLScalarFuncExpr *dxlop = CDXLScalarFuncExpr::Cast(scalar_func_expr_node->GetOperator());
 
-	FuncExpr *pfuncexpr = MakeNode(FuncExpr);
-	pfuncexpr->funcid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidFunc())->OidObjectId();
-	pfuncexpr->funcretset = pdxlop->FReturnSet();
-	pfuncexpr->funcformat = COERCE_DONTCARE;
-	pfuncexpr->funcresulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidRetType())->OidObjectId();
-	pfuncexpr->args = PlistTranslateScalarChildren(pfuncexpr->args, pdxlnFuncExpr, pmapcidvar);
+	FuncExpr *func_expr = MakeNode(FuncExpr);
+	func_expr->funcid = CMDIdGPDB::CastMdid(dxlop->FuncMdId())->Oid();
+	func_expr->funcretset = dxlop->ReturnsSet();
+	func_expr->funcformat = COERCE_DONTCARE;
+	func_expr->funcresulttype = CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
+	func_expr->args = TranslateScalarChildren(func_expr->args, scalar_func_expr_node, colid_var);
 
-	return (Expr *)pfuncexpr;
+	return (Expr *) func_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PsubplanFromDXLNodeScSubPlan
+//		CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar
 //
 //	@doc:
 //		Translates a DXL scalar SubPlan into a GPDB SubPlan node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PsubplanFromDXLNodeScSubPlan
+CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar
 	(
-	const CDXLNode *pdxlnSubPlan,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_subplan_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	CDXLTranslateContext *pdxltrctxOut = (dynamic_cast<CMappingColIdVarPlStmt*>(pmapcidvar))->PpdxltrctxOut();
+	CDXLTranslateContext *output_context = (dynamic_cast<CMappingColIdVarPlStmt*>(colid_var))->GetOutputContext();
 
-	CContextDXLToPlStmt *pctxdxltoplstmt = (dynamic_cast<CMappingColIdVarPlStmt*>(pmapcidvar))->Pctxdxltoplstmt();
+	CContextDXLToPlStmt *dxl_to_plstmt_ctxt = (dynamic_cast<CMappingColIdVarPlStmt*>(colid_var))->GetDXLToPlStmtContext();
 
-	CDXLScalarSubPlan *pdxlop = CDXLScalarSubPlan::PdxlopConvert(pdxlnSubPlan->Pdxlop());
+	CDXLScalarSubPlan *dxlop = CDXLScalarSubPlan::Cast(scalar_subplan_node->GetOperator());
 
 	// translate subplan test expression
-	List *plparamIds = NIL;
+	List *param_ids = NIL;
 
-	SubLinkType slink = CTranslatorUtils::Slink(pdxlop->Edxlsptype());
-	Expr *pexprTestExpr = PexprSubplanTestExpr(pdxlop->PdxlnTestExpr(), slink, pmapcidvar, &plparamIds);
+	SubLinkType slink = CTranslatorUtils::MapDXLSubplanToSublinkType(dxlop->GetDxlSubplanType());
+	Expr *test_expr = TranslateDXLSubplanTestExprToScalar(dxlop->GetDxlTestExpr(), slink, colid_var, &param_ids);
 
-	const DrgPdxlcr *pdrgdxlcrOuterRefs = pdxlop->DrgdxlcrOuterRefs();
+	const CDXLColRefArray *outer_refs= dxlop->GetDxlOuterColRefsArray();
 
-	const ULONG ulLen = pdrgdxlcrOuterRefs->UlLength();
+	const ULONG len = outer_refs->Size();
 
-	// create a copy of the translate context: the param mappings from the outer scope get copied in the constructor
-	CDXLTranslateContext dxltrctxSubplan(m_pmp, pdxltrctxOut->FParentAggNode(), pdxltrctxOut->PhmColParam());
+	// Translate a copy of the translate context: the param mappings from the outer scope get copied in the constructor
+	CDXLTranslateContext subplan_translate_ctxt(m_mp, output_context->IsParentAggNode(), output_context->GetColIdToParamIdMap());
 
 	// insert new outer ref mappings in the subplan translate context
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	for (ULONG ul = 0; ul < len; ul++)
 	{
-		CDXLColRef *pdxlcr = (*pdrgdxlcrOuterRefs)[ul];
-		IMDId *pmdid = pdxlcr->PmdidType();
-		ULONG ulColid = pdxlcr->UlID();
-		INT iTypeModifier = pdxlcr->ITypeModifier();
+		CDXLColRef *dxl_colref = (*outer_refs)[ul];
+		IMDId *mdid = dxl_colref->MdidType();
+		ULONG colid = dxl_colref->Id();
+		INT type_modifier = dxl_colref->TypeModifier();
 
-		if (NULL == dxltrctxSubplan.Pmecolidparamid(ulColid))
+		if (NULL == subplan_translate_ctxt.GetParamIdMappingElement(colid))
 		{
 			// keep outer reference mapping to the original column for subsequent subplans
-			CMappingElementColIdParamId *pmecolidparamid = GPOS_NEW(m_pmp) CMappingElementColIdParamId(ulColid, pctxdxltoplstmt->UlNextParamId(), pmdid, iTypeModifier);
+			CMappingElementColIdParamId *colid_to_param_id_map = GPOS_NEW(m_mp) CMappingElementColIdParamId(colid, dxl_to_plstmt_ctxt->GetNextParamId(), mdid, type_modifier);
 
 #ifdef GPOS_DEBUG
-			BOOL fInserted =
+			BOOL is_inserted =
 #endif
-			dxltrctxSubplan.FInsertParamMapping(ulColid, pmecolidparamid);
-			GPOS_ASSERT(fInserted);
+			subplan_translate_ctxt.FInsertParamMapping(colid, colid_to_param_id_map);
+			GPOS_ASSERT(is_inserted);
 		}
 	}
 
-	CDXLNode *pdxlnChild = (*pdxlnSubPlan)[0];
-        GPOS_ASSERT(EdxloptypePhysical == pdxlnChild->Pdxlop()->Edxloperatortype());
+	CDXLNode *child_dxl = (*scalar_subplan_node)[0];
+        GPOS_ASSERT(EdxloptypePhysical == child_dxl->GetOperator()->GetDXLOperatorType());
 
-	GPOS_ASSERT(NULL != pdxlnSubPlan);
-	GPOS_ASSERT(EdxlopScalarSubPlan == pdxlnSubPlan->Pdxlop()->Edxlop());
-	GPOS_ASSERT(1 == pdxlnSubPlan->UlArity());
+	GPOS_ASSERT(NULL != scalar_subplan_node);
+	GPOS_ASSERT(EdxlopScalarSubPlan == scalar_subplan_node->GetOperator()->GetDXLOperator());
+	GPOS_ASSERT(1 == scalar_subplan_node->Arity());
 
 	// generate the child plan,
-	// create DXL->PlStmt translator to handle subplan's relational children
-	CTranslatorDXLToPlStmt trdxltoplstmt
+	// Translate DXL->PlStmt translator to handle subplan's relational children
+	CTranslatorDXLToPlStmt dxl_to_plstmt_translator
 							(
-							m_pmp,
-							m_pmda,
-							(dynamic_cast<CMappingColIdVarPlStmt*>(pmapcidvar))->Pctxdxltoplstmt(),
-							m_ulSegments
+							m_mp,
+							m_md_accessor,
+							(dynamic_cast<CMappingColIdVarPlStmt*>(colid_var))->GetDXLToPlStmtContext(),
+							m_num_of_segments
 							);
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	Plan *pplanChild = trdxltoplstmt.PplFromDXL(pdxlnChild, &dxltrctxSubplan, pdrgpdxltrctxPrevSiblings);
-	pdrgpdxltrctxPrevSiblings->Release();
+	CDXLTranslationContextArray *prev_siblings_ctxt_arr = GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
+	Plan *plan_child = dxl_to_plstmt_translator.TranslateDXLOperatorToPlan(child_dxl, &subplan_translate_ctxt, prev_siblings_ctxt_arr);
+	prev_siblings_ctxt_arr->Release();
 
-	GPOS_ASSERT(NULL != pplanChild->targetlist && 1 <= gpdb::UlListLength(pplanChild->targetlist));
+	GPOS_ASSERT(NULL != plan_child->targetlist && 1 <= gpdb::ListLength(plan_child->targetlist));
 
 	// translate subplan and set test expression
-	SubPlan *psubplan = PsubplanFromChildPlan(pplanChild, slink, pctxdxltoplstmt);
-	psubplan->testexpr = (Node *) pexprTestExpr;
-	psubplan->paramIds = plparamIds;
+	SubPlan *subplan = TranslateSubplanFromChildPlan(plan_child, slink, dxl_to_plstmt_ctxt);
+	subplan->testexpr = (Node *) test_expr;
+	subplan->paramIds = param_ids;
 
 	// translate other subplan params
-	TranslateSubplanParams(psubplan, &dxltrctxSubplan, pdrgdxlcrOuterRefs, pmapcidvar);
+	TranslateSubplanParams(subplan, &subplan_translate_ctxt, outer_refs, colid_var);
 
-	return (Expr *)psubplan;
+	return (Expr *)subplan;
 }
 
-inline BOOL FDXLCastedId(CDXLNode *pdxln)
+inline BOOL FDXLCastedId(CDXLNode *dxl_node)
 {
-	return EdxlopScalarCast == pdxln->Pdxlop()->Edxlop() &&
-		   pdxln->UlArity() > 0 && EdxlopScalarIdent == (*pdxln)[0]->Pdxlop()->Edxlop();
+	return EdxlopScalarCast == dxl_node->GetOperator()->GetDXLOperator() &&
+		   dxl_node->Arity() > 0 && EdxlopScalarIdent == (*dxl_node)[0]->GetOperator()->GetDXLOperator();
 }
 
-inline CTranslatorDXLToScalar::STypeOidAndTypeModifier OidParamOidFromDXLIdentOrDXLCastIdent(CDXLNode *pdxlnIdentOrCastIdent)
+inline CTranslatorDXLToScalar::STypeOidAndTypeModifier OidParamOidFromDXLIdentOrDXLCastIdent(CDXLNode *ident_or_cast_ident_node)
 {
-	GPOS_ASSERT(EdxlopScalarIdent == pdxlnIdentOrCastIdent->Pdxlop()->Edxlop() || FDXLCastedId(pdxlnIdentOrCastIdent));
+	GPOS_ASSERT(EdxlopScalarIdent == ident_or_cast_ident_node->GetOperator()->GetDXLOperator() || FDXLCastedId(ident_or_cast_ident_node));
 
-	CDXLScalarIdent *pdxlopInnerIdent;
-	if (EdxlopScalarIdent == pdxlnIdentOrCastIdent->Pdxlop()->Edxlop())
+	CDXLScalarIdent *inner_ident;
+	if (EdxlopScalarIdent == ident_or_cast_ident_node->GetOperator()->GetDXLOperator())
 	{
-		pdxlopInnerIdent = CDXLScalarIdent::PdxlopConvert(pdxlnIdentOrCastIdent->Pdxlop());
+		inner_ident = CDXLScalarIdent::Cast(ident_or_cast_ident_node->GetOperator());
 	}
 	else
 	{
-		pdxlopInnerIdent = CDXLScalarIdent::PdxlopConvert((*pdxlnIdentOrCastIdent)[0]->Pdxlop());
+		inner_ident = CDXLScalarIdent::Cast((*ident_or_cast_ident_node)[0]->GetOperator());
 	}
-	Oid oidInnerType = CMDIdGPDB::PmdidConvert(pdxlopInnerIdent->PmdidType())->OidObjectId();
-	INT iTypeModifier = pdxlopInnerIdent->ITypeModifier();
-	return {oidInnerType, iTypeModifier};
+	Oid inner_type_oid = CMDIdGPDB::CastMdid(inner_ident->MdidType())->Oid();
+	INT type_modifier = inner_ident->TypeModifier();
+	return {inner_type_oid, type_modifier};
 }
 
 //---------------------------------------------------------------------------
 //      @function:
-//              CTranslatorDXLToScalar::PexprSubplanTestExpr
+//              CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar
 //
 //      @doc:
 //              Translate subplan test expression
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprSubplanTestExpr
+CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar
 	(
-	CDXLNode *pdxlnTestExpr,
+	CDXLNode *test_expr_node,
 	SubLinkType slink,
-	CMappingColIdVar *pmapcidvar,
-	List **plparamIds
+	CMappingColIdVar *colid_var,
+	List **param_ids
 	)
 {
 	if (EXPR_SUBLINK == slink || EXISTS_SUBLINK == slink || NOT_EXISTS_SUBLINK == slink)
@@ -709,27 +709,27 @@ CTranslatorDXLToScalar::PexprSubplanTestExpr
 		// expr/exists/not-exists sublinks have no test expression
 		return NULL;
 	}
-	GPOS_ASSERT(NULL != pdxlnTestExpr);
+	GPOS_ASSERT(NULL != test_expr_node);
 
-	if (FConstTrue(pdxlnTestExpr, m_pmda))
+	if (HasConstTrue(test_expr_node, m_md_accessor))
 	{
 		// dummy test expression
-		return (Expr *) PconstFromDXLNodeScConst(pdxlnTestExpr, NULL);
+		return (Expr *) TranslateDXLScalarConstToScalar(test_expr_node, NULL);
 	}
 
-	if (EdxlopScalarCmp != pdxlnTestExpr->Pdxlop()->Edxlop())
+	if (EdxlopScalarCmp != test_expr_node->GetOperator()->GetDXLOperator())
 	{
 		// test expression is expected to be a comparison
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,  GPOS_WSZ_LIT("Unexpected subplan test expression"));
 	}
 
-	GPOS_ASSERT(2 == pdxlnTestExpr->UlArity());
+	GPOS_ASSERT(2 == test_expr_node->Arity());
 	GPOS_ASSERT(ANY_SUBLINK == slink || ALL_SUBLINK == slink);
 
-	CDXLNode *pdxlnOuterChild = (*pdxlnTestExpr)[0];
-	CDXLNode *pdxlnInnerChild = (*pdxlnTestExpr)[1];
+	CDXLNode *outer_child_node = (*test_expr_node)[0];
+	CDXLNode *inner_child_node = (*test_expr_node)[1];
 
-	if (EdxlopScalarIdent != pdxlnInnerChild->Pdxlop()->Edxlop() && !FDXLCastedId(pdxlnInnerChild))
+	if (EdxlopScalarIdent != inner_child_node->GetOperator()->GetDXLOperator() && !FDXLCastedId(inner_child_node))
 	{
 		// test expression is expected to be a comparison between an outer expression 
 		// and a scalar identifier from subplan child
@@ -737,51 +737,51 @@ CTranslatorDXLToScalar::PexprSubplanTestExpr
 	}
 
 	// extract type of inner column
-        CDXLScalarComp *pdxlopCmp = CDXLScalarComp::PdxlopConvert(pdxlnTestExpr->Pdxlop());
+        CDXLScalarComp *scalar_cmp_dxl = CDXLScalarComp::Cast(test_expr_node->GetOperator());
 
 		// create an OpExpr for subplan test expression
-        OpExpr *popexpr = MakeNode(OpExpr);
-        popexpr->opno = CMDIdGPDB::PmdidConvert(pdxlopCmp->Pmdid())->OidObjectId();
-        const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pdxlopCmp->Pmdid());
-        popexpr->opfuncid = CMDIdGPDB::PmdidConvert(pmdscop->PmdidFunc())->OidObjectId();
-        popexpr->opresulttype = CMDIdGPDB::PmdidConvert(m_pmda->PtMDType<IMDTypeBool>()->Pmdid())->OidObjectId();
-        popexpr->opretset = false;
+        OpExpr *op_expr = MakeNode(OpExpr);
+        op_expr->opno = CMDIdGPDB::CastMdid(scalar_cmp_dxl->MDId())->Oid();
+        const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(scalar_cmp_dxl->MDId());
+        op_expr->opfuncid = CMDIdGPDB::CastMdid(md_scalar_op->FuncMdId())->Oid();
+        op_expr->opresulttype = CMDIdGPDB::CastMdid(m_md_accessor->PtMDType<IMDTypeBool>()->MDId())->Oid();
+        op_expr->opretset = false;
 
         // translate outer expression (can be a deep scalar tree)
-        Expr *pexprTestExprOuterArg = PexprFromDXLNodeScalar(pdxlnOuterChild, pmapcidvar);
+        Expr *outer_arg_expr = TranslateDXLToScalar(outer_child_node, colid_var);
 
         // add translated outer expression as first arg of OpExpr
-        List *plistArgs = NIL;
-        plistArgs = gpdb::PlAppendElement(plistArgs, pexprTestExprOuterArg);
+        List *args = NIL;
+        args = gpdb::LAppend(args, outer_arg_expr);
 
 	// second arg must be an EXEC param which is replaced during query execution with subplan output
-	Param *pparam = MakeNode(Param);
-	pparam->paramkind = PARAM_EXEC;
-	CContextDXLToPlStmt *pctxdxltoplstmt = (dynamic_cast<CMappingColIdVarPlStmt *>(pmapcidvar))->Pctxdxltoplstmt();
-	pparam->paramid = pctxdxltoplstmt->UlNextParamId();
-	CTranslatorDXLToScalar::STypeOidAndTypeModifier oidAndTypeModifier = OidParamOidFromDXLIdentOrDXLCastIdent(pdxlnInnerChild);
-	pparam->paramtype = oidAndTypeModifier.OidType;
-	pparam->paramtypmod = oidAndTypeModifier.ITypeModifier;
+	Param *param = MakeNode(Param);
+	param->paramkind = PARAM_EXEC;
+	CContextDXLToPlStmt *dxl_to_plstmt_ctxt = (dynamic_cast<CMappingColIdVarPlStmt *>(colid_var))->GetDXLToPlStmtContext();
+	param->paramid = dxl_to_plstmt_ctxt->GetNextParamId();
+	CTranslatorDXLToScalar::STypeOidAndTypeModifier oidAndTypeModifier = OidParamOidFromDXLIdentOrDXLCastIdent(inner_child_node);
+	param->paramtype = oidAndTypeModifier.oid_type;
+	param->paramtypmod = oidAndTypeModifier.type_modifier;
 
 	// test expression is used for non-scalar subplan,
 	// second arg of test expression must be an EXEC param referring to subplan output,
 	// we add this param to subplan param ids before translating other params
 
-	*plparamIds = gpdb::PlAppendInt(*plparamIds, pparam->paramid);
+	*param_ids = gpdb::LAppendInt(*param_ids, param->paramid);
 
-	if (EdxlopScalarIdent == pdxlnInnerChild->Pdxlop()->Edxlop())
+	if (EdxlopScalarIdent == inner_child_node->GetOperator()->GetDXLOperator())
 	{
-		plistArgs = gpdb::PlAppendElement(plistArgs, pparam);
+		args = gpdb::LAppend(args, param);
 	}
 	else // we have a cast
 	{
-		CDXLScalarCast *pdxlScalaCast = CDXLScalarCast::PdxlopConvert(pdxlnInnerChild->Pdxlop());
-		Expr *pexprCastParam = PrelabeltypeOrFuncexprFromDXLNodeScalarCast(pdxlScalaCast, (Expr *) pparam);
-		plistArgs = gpdb::PlAppendElement(plistArgs, pexprCastParam);
+		CDXLScalarCast *scalar_cast = CDXLScalarCast::Cast(inner_child_node->GetOperator());
+		Expr *pexprCastParam = TranslateRelabelTypeOrFuncExprFromDXL(scalar_cast, (Expr *) param);
+		args = gpdb::LAppend(args, pexprCastParam);
 	}
-	popexpr->args = plistArgs;
+	op_expr->args = args;
 
-	return (Expr *) popexpr;
+	return (Expr *) op_expr;
 }
 
 
@@ -796,167 +796,167 @@ CTranslatorDXLToScalar::PexprSubplanTestExpr
 void
 CTranslatorDXLToScalar::TranslateSubplanParams
 	(
-	SubPlan *psubplan,
-	CDXLTranslateContext *pdxltrctx,
-	const DrgPdxlcr *pdrgdxlcrOuterRefs,
-	CMappingColIdVar *pmapcidvar
+	SubPlan *subplan,
+	CDXLTranslateContext *dxl_translator_ctxt,
+	const CDXLColRefArray *outer_refs,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != psubplan);
-	GPOS_ASSERT(NULL != pdxltrctx);
-	GPOS_ASSERT(NULL != pdrgdxlcrOuterRefs);
-	GPOS_ASSERT(NULL != pmapcidvar);
+	GPOS_ASSERT(NULL != subplan);
+	GPOS_ASSERT(NULL != dxl_translator_ctxt);
+	GPOS_ASSERT(NULL != outer_refs);
+	GPOS_ASSERT(NULL != colid_var);
 
 	// Create the PARAM and ARG nodes
-	const ULONG ulSize = pdrgdxlcrOuterRefs->UlLength();
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	const ULONG size = outer_refs->Size();
+	for (ULONG ul = 0; ul < size; ul++)
 	{
-		CDXLColRef *pdxlcr = (*pdrgdxlcrOuterRefs)[ul];
-		pdxlcr->AddRef();
-		const CMappingElementColIdParamId *pmecolidparamid = pdxltrctx->Pmecolidparamid(pdxlcr->UlID());
+		CDXLColRef *dxl_colref = (*outer_refs)[ul];
+		dxl_colref->AddRef();
+		const CMappingElementColIdParamId *colid_to_param_id_map = dxl_translator_ctxt->GetParamIdMappingElement(dxl_colref->Id());
 
-		// TODO: eliminate pparam, it's not *really* used, and it's (short-term) leaked
-		Param *pparam = PparamFromMapping(pmecolidparamid);
-		psubplan->parParam = gpdb::PlAppendInt(psubplan->parParam, pparam->paramid);
+		// TODO: eliminate param, it's not *really* used, and it's (short-term) leaked
+		Param *param = TranslateParamFromMapping(colid_to_param_id_map);
+		subplan->parParam = gpdb::LAppendInt(subplan->parParam, param->paramid);
 
-		GPOS_ASSERT(pmecolidparamid->PmdidType()->FEquals(pdxlcr->PmdidType()));
+		GPOS_ASSERT(colid_to_param_id_map->MdidType()->Equals(dxl_colref->MdidType()));
 
-		CDXLScalarIdent *pdxlopIdent = GPOS_NEW(m_pmp) CDXLScalarIdent(m_pmp, pdxlcr);
-		Expr *parg = (Expr *) pmapcidvar->PvarFromDXLNodeScId(pdxlopIdent);
+		CDXLScalarIdent *scalar_ident_dxl = GPOS_NEW(m_mp) CDXLScalarIdent(m_mp, dxl_colref);
+		Expr *arg = (Expr *) colid_var->VarFromDXLNodeScId(scalar_ident_dxl);
 
 		// not found in mapping, it must be an external parameter
-		if (NULL == parg)
+		if (NULL == arg)
 		{
-			parg = (Expr*) PparamFromMapping(pmecolidparamid);
-			GPOS_ASSERT(NULL != parg);
+			arg = (Expr*) TranslateParamFromMapping(colid_to_param_id_map);
+			GPOS_ASSERT(NULL != arg);
 		}
 
-		pdxlopIdent->Release();
-		psubplan->args = gpdb::PlAppendElement(psubplan->args, parg);
+		scalar_ident_dxl->Release();
+		subplan->args = gpdb::LAppend(subplan->args, arg);
 	}
 
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PsubplanFromChildPlan
+//		CTranslatorDXLToScalar::TranslateSubplanFromChildPlan
 //
 //	@doc:
 //		add child plan to translation context, and build a subplan from it
 //
 //---------------------------------------------------------------------------
 SubPlan *
-CTranslatorDXLToScalar::PsubplanFromChildPlan
+CTranslatorDXLToScalar::TranslateSubplanFromChildPlan
 	(
-	Plan *pplan,
+	Plan *plan,
 	SubLinkType slink,
-	CContextDXLToPlStmt *pctxdxltoplstmt
+	CContextDXLToPlStmt *dxl_to_plstmt_ctxt
 	)
 {
-	pctxdxltoplstmt->AddSubplan(pplan);
+	dxl_to_plstmt_ctxt->AddSubplan(plan);
 
-	SubPlan *psubplan = MakeNode(SubPlan);
-	psubplan->plan_id = gpdb::UlListLength(pctxdxltoplstmt->PlPplanSubplan());
-	psubplan->plan_name = SzSubplanAlias(psubplan->plan_id);
-	psubplan->is_initplan = false;
-	psubplan->firstColType = gpdb::OidExprType( (Node*) ((TargetEntry*) gpdb::PvListNth(pplan->targetlist, 0))->expr);
-	psubplan->firstColTypmod = -1;
-	psubplan->subLinkType = slink;
-	psubplan->is_multirow = false;
-	psubplan->unknownEqFalse = false;
+	SubPlan *subplan = MakeNode(SubPlan);
+	subplan->plan_id = gpdb::ListLength(dxl_to_plstmt_ctxt->GetSubplanEntriesList());
+	subplan->plan_name = GetSubplanAlias(subplan->plan_id);
+	subplan->is_initplan = false;
+	subplan->firstColType = gpdb::ExprType( (Node*) ((TargetEntry*) gpdb::ListNth(plan->targetlist, 0))->expr);
+	subplan->firstColTypmod = -1;
+	subplan->subLinkType = slink;
+	subplan->is_multirow = false;
+	subplan->unknownEqFalse = false;
 
-	return psubplan;
+	return subplan;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::SzSubplanAlias
+//		CTranslatorDXLToScalar::GetSubplanAlias
 //
 //	@doc:
 //		build plan name, for explain purposes
 //
 //---------------------------------------------------------------------------
 CHAR *
-CTranslatorDXLToScalar::SzSubplanAlias
+CTranslatorDXLToScalar::GetSubplanAlias
 	(
-	ULONG ulPlanId
+	ULONG plan_id
 	)
 {
-	CWStringDynamic *pstr = GPOS_NEW(m_pmp) CWStringDynamic(m_pmp);
-	pstr->AppendFormat(GPOS_WSZ_LIT("SubPlan %d"), ulPlanId);
-	const WCHAR *wsz = pstr->Wsz();
+	CWStringDynamic *plan_name = GPOS_NEW(m_mp) CWStringDynamic(m_mp);
+	plan_name->AppendFormat(GPOS_WSZ_LIT("SubPlan %d"), plan_id);
+	const WCHAR *buf = plan_name->GetBuffer();
 
-	ULONG ulMaxLength = (GPOS_WSZ_LENGTH(wsz) + 1) * GPOS_SIZEOF(WCHAR);
-	CHAR *sz = (CHAR *) gpdb::GPDBAlloc(ulMaxLength);
-	gpos::clib::LWcsToMbs(sz, const_cast<WCHAR *>(wsz), ulMaxLength);
-	sz[ulMaxLength - 1] = '\0';
-	GPOS_DELETE(pstr);
+	ULONG max_length = (GPOS_WSZ_LENGTH(buf) + 1) * GPOS_SIZEOF(WCHAR);
+	CHAR *result_plan_name = (CHAR *) gpdb::GPDBAlloc(max_length);
+	gpos::clib::Wcstombs(result_plan_name, const_cast<WCHAR *>(buf), max_length);
+	result_plan_name[max_length - 1] = '\0';
+	GPOS_DELETE(plan_name);
 
-	return sz;
+	return result_plan_name;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PparamFromMapping
+//		CTranslatorDXLToScalar::TranslateParamFromMapping
 //
 //	@doc:
-//		Creates a GPDB param from the given mapping
+//		Translates a GPDB param from the given mapping
 //
 //---------------------------------------------------------------------------
 Param *
-CTranslatorDXLToScalar::PparamFromMapping
+CTranslatorDXLToScalar::TranslateParamFromMapping
 	(
-	const CMappingElementColIdParamId *pmecolidparamid
+	const CMappingElementColIdParamId *colid_to_param_id_map
 	)
 {
-	Param *pparam = MakeNode(Param);
-	pparam->paramid = pmecolidparamid->UlParamId();
-	pparam->paramkind = PARAM_EXEC;
-	pparam->paramtype = CMDIdGPDB::PmdidConvert(pmecolidparamid->PmdidType())->OidObjectId();
-	pparam->paramtypmod = pmecolidparamid->ITypeModifier();
+	Param *param = MakeNode(Param);
+	param->paramid = colid_to_param_id_map->ParamId();
+	param->paramkind = PARAM_EXEC;
+	param->paramtype = CMDIdGPDB::CastMdid(colid_to_param_id_map->MdidType())->Oid();
+	param->paramtypmod = colid_to_param_id_map->TypeModifier();
 
-	return pparam;
+	return param;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PboolexprFromDXLNodeScBoolExpr
+//		CTranslatorDXLToScalar::TranslateDXLScalarBoolExprToScalar
 //
 //	@doc:
 //		Translates a DXL scalar BoolExpr into a GPDB OpExpr node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PboolexprFromDXLNodeScBoolExpr
+CTranslatorDXLToScalar::TranslateDXLScalarBoolExprToScalar
 	(
-	const CDXLNode *pdxlnBoolExpr,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_bool_expr_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnBoolExpr);
-	CDXLScalarBoolExpr *pdxlop = CDXLScalarBoolExpr::PdxlopConvert(pdxlnBoolExpr->Pdxlop());
-	BoolExpr *pboolexpr = MakeNode(BoolExpr);
+	GPOS_ASSERT(NULL != scalar_bool_expr_node);
+	CDXLScalarBoolExpr *dxlop = CDXLScalarBoolExpr::Cast(scalar_bool_expr_node->GetOperator());
+	BoolExpr *scalar_bool_expr = MakeNode(BoolExpr);
 
-	GPOS_ASSERT(1 <= pdxlnBoolExpr->UlArity());
-	switch (pdxlop->EdxlBoolType())
+	GPOS_ASSERT(1 <= scalar_bool_expr_node->Arity());
+	switch (dxlop->GetDxlBoolTypeStr())
 	{
 		case Edxlnot:
 		{
-			GPOS_ASSERT(1 == pdxlnBoolExpr->UlArity());
-			pboolexpr->boolop = NOT_EXPR;
+			GPOS_ASSERT(1 == scalar_bool_expr_node->Arity());
+			scalar_bool_expr->boolop = NOT_EXPR;
 			break;
 		}
 		case Edxland:
 		{
-			GPOS_ASSERT(2 <= pdxlnBoolExpr->UlArity());
-			pboolexpr->boolop = AND_EXPR;
+			GPOS_ASSERT(2 <= scalar_bool_expr_node->Arity());
+			scalar_bool_expr->boolop = AND_EXPR;
 			break;
 		}
 		case Edxlor:
 		{
-			GPOS_ASSERT(2 <= pdxlnBoolExpr->UlArity());
-			pboolexpr->boolop = OR_EXPR;
+			GPOS_ASSERT(2 <= scalar_bool_expr_node->Arity());
+			scalar_bool_expr->boolop = OR_EXPR;
 			break;
 		}
 		default:
@@ -966,50 +966,50 @@ CTranslatorDXLToScalar::PboolexprFromDXLNodeScBoolExpr
 		}
 	}
 
-	pboolexpr->args = PlistTranslateScalarChildren(pboolexpr->args, pdxlnBoolExpr, pmapcidvar);
-	pboolexpr->location = -1;
+	scalar_bool_expr->args = TranslateScalarChildren(scalar_bool_expr->args, scalar_bool_expr_node, colid_var);
+	scalar_bool_expr->location = -1;
 
-	return (Expr *)pboolexpr;
+	return (Expr *)scalar_bool_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PbooleantestFromDXLNodeScBooleanTest
+//		CTranslatorDXLToScalar::TranslateDXLScalarBooleanTestToScalar
 //
 //	@doc:
 //		Translates a DXL scalar BooleanTest into a GPDB OpExpr node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PbooleantestFromDXLNodeScBooleanTest
+CTranslatorDXLToScalar::TranslateDXLScalarBooleanTestToScalar
 	(
-	const CDXLNode *pdxlnBooleanTest,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_boolean_test_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnBooleanTest);
-	CDXLScalarBooleanTest *pdxlop = CDXLScalarBooleanTest::PdxlopConvert(pdxlnBooleanTest->Pdxlop());
-	BooleanTest *pbooleantest = MakeNode(BooleanTest);
+	GPOS_ASSERT(NULL != scalar_boolean_test_node);
+	CDXLScalarBooleanTest *dxlop = CDXLScalarBooleanTest::Cast(scalar_boolean_test_node->GetOperator());
+	BooleanTest *scalar_boolean_test = MakeNode(BooleanTest);
 
-	switch (pdxlop->EdxlBoolType())
+	switch (dxlop->GetDxlBoolTypeStr())
 	{
 		case EdxlbooleantestIsTrue:
-				pbooleantest->booltesttype = IS_TRUE;
+				scalar_boolean_test->booltesttype = IS_TRUE;
 				break;
 		case EdxlbooleantestIsNotTrue:
-				pbooleantest->booltesttype = IS_NOT_TRUE;
+				scalar_boolean_test->booltesttype = IS_NOT_TRUE;
 				break;
 		case EdxlbooleantestIsFalse:
-				pbooleantest->booltesttype = IS_FALSE;
+				scalar_boolean_test->booltesttype = IS_FALSE;
 				break;
 		case EdxlbooleantestIsNotFalse:
-				pbooleantest->booltesttype = IS_NOT_FALSE;
+				scalar_boolean_test->booltesttype = IS_NOT_FALSE;
 				break;
 		case EdxlbooleantestIsUnknown:
-				pbooleantest->booltesttype = IS_UNKNOWN;
+				scalar_boolean_test->booltesttype = IS_UNKNOWN;
 				break;
 		case EdxlbooleantestIsNotUnknown:
-				pbooleantest->booltesttype = IS_NOT_UNKNOWN;
+				scalar_boolean_test->booltesttype = IS_NOT_UNKNOWN;
 				break;
 		default:
 				{
@@ -1018,878 +1018,878 @@ CTranslatorDXLToScalar::PbooleantestFromDXLNodeScBooleanTest
 				}
 	}
 
-	GPOS_ASSERT(1 == pdxlnBooleanTest->UlArity());
-	CDXLNode *pdxlnArg = (*pdxlnBooleanTest)[0];
+	GPOS_ASSERT(1 == scalar_boolean_test_node->Arity());
+	CDXLNode *dxlnode_arg = (*scalar_boolean_test_node)[0];
 
-	Expr *pexprArg = PexprFromDXLNodeScalar(pdxlnArg, pmapcidvar);
-	pbooleantest->arg = pexprArg;
+	Expr *arg_expr = TranslateDXLToScalar(dxlnode_arg, colid_var);
+	scalar_boolean_test->arg = arg_expr;
 
-	return (Expr *)pbooleantest;
+	return (Expr *)scalar_boolean_test;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PnulltestFromDXLNodeScNullTest
+//		CTranslatorDXLToScalar::TranslateDXLScalarNullTestToScalar
 //
 //	@doc:
 //		Translates a DXL scalar NullTest into a GPDB NullTest node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PnulltestFromDXLNodeScNullTest
+CTranslatorDXLToScalar::TranslateDXLScalarNullTestToScalar
 	(
-	const CDXLNode *pdxlnNullTest,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_null_test_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnNullTest);
-	CDXLScalarNullTest *pdxlop = CDXLScalarNullTest::PdxlopConvert(pdxlnNullTest->Pdxlop());
-	NullTest *pnulltest = MakeNode(NullTest);
+	GPOS_ASSERT(NULL != scalar_null_test_node);
+	CDXLScalarNullTest *dxlop = CDXLScalarNullTest::Cast(scalar_null_test_node->GetOperator());
+	NullTest *null_test = MakeNode(NullTest);
 
-	GPOS_ASSERT(1 == pdxlnNullTest->UlArity());
-	CDXLNode *pdxlnChild = (*pdxlnNullTest)[0];
-	Expr *pexprChild = PexprFromDXLNodeScalar(pdxlnChild, pmapcidvar);
+	GPOS_ASSERT(1 == scalar_null_test_node->Arity());
+	CDXLNode *child_dxl = (*scalar_null_test_node)[0];
+	Expr *child_expr = TranslateDXLToScalar(child_dxl, colid_var);
 
-	if (pdxlop->FIsNullTest())
+	if (dxlop->IsNullTest())
 	{
-		pnulltest->nulltesttype = IS_NULL;
+		null_test->nulltesttype = IS_NULL;
 	}
 	else
 	{
-		pnulltest->nulltesttype = IS_NOT_NULL;
+		null_test->nulltesttype = IS_NOT_NULL;
 	}
 
-	pnulltest->arg = pexprChild;
-	return (Expr *)pnulltest;
+	null_test->arg = child_expr;
+	return (Expr *)null_test;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PnullifFromDXLNodeScNullIf
+//		CTranslatorDXLToScalar::TranslateDXLScalarNullIfToScalar
 //
 //	@doc:
 //		Translates a DXL scalar nullif into a GPDB NullIfExpr node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PnullifFromDXLNodeScNullIf
+CTranslatorDXLToScalar::TranslateDXLScalarNullIfToScalar
 	(
-	const CDXLNode *pdxlnNullIf,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_null_if_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnNullIf);
-	CDXLScalarNullIf *pdxlop = CDXLScalarNullIf::PdxlopConvert(pdxlnNullIf->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_null_if_node);
+	CDXLScalarNullIf *dxlop = CDXLScalarNullIf::Cast(scalar_null_if_node->GetOperator());
 
-	NullIfExpr *pnullifexpr = MakeNode(NullIfExpr);
-	pnullifexpr->opno = CMDIdGPDB::PmdidConvert(pdxlop->PmdidOp())->OidObjectId();
+	NullIfExpr *scalar_null_if_expr = MakeNode(NullIfExpr);
+	scalar_null_if_expr->opno = CMDIdGPDB::CastMdid(dxlop->MdIdOp())->Oid();
 
-	const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pdxlop->PmdidOp());
+	const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(dxlop->MdIdOp());
 
-	pnullifexpr->opfuncid = CMDIdGPDB::PmdidConvert(pmdscop->PmdidFunc())->OidObjectId();
-	pnullifexpr->opresulttype = OidFunctionReturnType(pmdscop->PmdidFunc());
-	pnullifexpr->opretset = false;
+	scalar_null_if_expr->opfuncid = CMDIdGPDB::CastMdid(md_scalar_op->FuncMdId())->Oid();
+	scalar_null_if_expr->opresulttype = GetFunctionReturnTypeOid(md_scalar_op->FuncMdId());
+	scalar_null_if_expr->opretset = false;
 
 	// translate children
-	GPOS_ASSERT(2 == pdxlnNullIf->UlArity());
-	pnullifexpr->args = PlistTranslateScalarChildren(pnullifexpr->args, pdxlnNullIf, pmapcidvar);
+	GPOS_ASSERT(2 == scalar_null_if_node->Arity());
+	scalar_null_if_expr->args = TranslateScalarChildren(scalar_null_if_expr->args, scalar_null_if_node, colid_var);
 
-	return (Expr *) pnullifexpr;
+	return (Expr *) scalar_null_if_expr;
 }
 
 Expr *
-CTranslatorDXLToScalar::PrelabeltypeOrFuncexprFromDXLNodeScalarCast(const CDXLScalarCast *pdxlscalarcast, Expr *pexprChild)
+CTranslatorDXLToScalar::TranslateRelabelTypeOrFuncExprFromDXL(const CDXLScalarCast *scalar_cast, Expr *child_expr)
 {
-	if (IMDId::FValid(pdxlscalarcast->PmdidFunc()))
+	if (IMDId::IsValid(scalar_cast->FuncMdId()))
 	{
-		FuncExpr *pfuncexpr = MakeNode(FuncExpr);
-		pfuncexpr->funcid = CMDIdGPDB::PmdidConvert(pdxlscalarcast->PmdidFunc())->OidObjectId();
+		FuncExpr *func_expr = MakeNode(FuncExpr);
+		func_expr->funcid = CMDIdGPDB::CastMdid(scalar_cast->FuncMdId())->Oid();
 
-		const IMDFunction *pmdfunc = m_pmda->Pmdfunc(pdxlscalarcast->PmdidFunc());
-		pfuncexpr->funcretset = pmdfunc->FReturnsSet();;
+		const IMDFunction *pmdfunc = m_md_accessor->RetrieveFunc(scalar_cast->FuncMdId());
+		func_expr->funcretset = pmdfunc->ReturnsSet();;
 
-		pfuncexpr->funcformat = COERCE_IMPLICIT_CAST;
-		pfuncexpr->funcresulttype = CMDIdGPDB::PmdidConvert(pdxlscalarcast->PmdidType())->OidObjectId();
+		func_expr->funcformat = COERCE_IMPLICIT_CAST;
+		func_expr->funcresulttype = CMDIdGPDB::CastMdid(scalar_cast->MdidType())->Oid();
 
-		pfuncexpr->args = NIL;
-		pfuncexpr->args = gpdb::PlAppendElement(pfuncexpr->args, pexprChild);
+		func_expr->args = NIL;
+		func_expr->args = gpdb::LAppend(func_expr->args, child_expr);
 
-		return (Expr *) pfuncexpr;
+		return (Expr *) func_expr;
 	}
 
-	RelabelType *prelabeltype = MakeNode(RelabelType);
+	RelabelType *relabel_type = MakeNode(RelabelType);
 
-	prelabeltype->resulttype = CMDIdGPDB::PmdidConvert(pdxlscalarcast->PmdidType())->OidObjectId();
-	prelabeltype->arg = pexprChild;
-	prelabeltype->resulttypmod = -1;
-	prelabeltype->location = -1;
-	prelabeltype->relabelformat = COERCE_DONTCARE;
+	relabel_type->resulttype = CMDIdGPDB::CastMdid(scalar_cast->MdidType())->Oid();
+	relabel_type->arg = child_expr;
+	relabel_type->resulttypmod = -1;
+	relabel_type->location = -1;
+	relabel_type->relabelformat = COERCE_DONTCARE;
 
-	return (Expr *) prelabeltype;
+	return (Expr *) relabel_type;
 }
 
 // Translates a DXL scalar cast into a GPDB RelabelType / FuncExpr node
 Expr *
-CTranslatorDXLToScalar::PrelabeltypeFromDXLNodeScCast
+CTranslatorDXLToScalar::TranslateDXLScalarCastToScalar
 	(
-	const CDXLNode *pdxlnCast,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_cast_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnCast);
-	const CDXLScalarCast *pdxlop = CDXLScalarCast::PdxlopConvert(pdxlnCast->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_cast_node);
+	const CDXLScalarCast *dxlop = CDXLScalarCast::Cast(scalar_cast_node->GetOperator());
 
-	GPOS_ASSERT(1 == pdxlnCast->UlArity());
-	CDXLNode *pdxlnChild = (*pdxlnCast)[0];
+	GPOS_ASSERT(1 == scalar_cast_node->Arity());
+	CDXLNode *child_dxl = (*scalar_cast_node)[0];
 
-	Expr *pexprChild = PexprFromDXLNodeScalar(pdxlnChild, pmapcidvar);
+	Expr *child_expr = TranslateDXLToScalar(child_dxl, colid_var);
 
-	return PrelabeltypeOrFuncexprFromDXLNodeScalarCast(pdxlop, pexprChild);
+	return TranslateRelabelTypeOrFuncExprFromDXL(dxlop, child_expr);
 }
 
 
 //---------------------------------------------------------------------------
 //      @function:
-//              CTranslatorDXLToScalar::PcoerceFromDXLNodeScCoerceToDomain
+//              CTranslatorDXLToScalar::TranslateDXLScalarCoerceToDomainToScalar
 //
 //      @doc:
 //              Translates a DXL scalar coerce into a GPDB coercetodomain node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PcoerceFromDXLNodeScCoerceToDomain
+CTranslatorDXLToScalar::TranslateDXLScalarCoerceToDomainToScalar
         (
-        const CDXLNode *pdxlnCoerce,
-        CMappingColIdVar *pmapcidvar
+        const CDXLNode *scalar_coerce_node,
+        CMappingColIdVar *colid_var
         )
 {
-        GPOS_ASSERT(NULL != pdxlnCoerce);
-        CDXLScalarCoerceToDomain *pdxlop = CDXLScalarCoerceToDomain::PdxlopConvert(pdxlnCoerce->Pdxlop());
+        GPOS_ASSERT(NULL != scalar_coerce_node);
+        CDXLScalarCoerceToDomain *dxlop = CDXLScalarCoerceToDomain::Cast(scalar_coerce_node->GetOperator());
 
-        GPOS_ASSERT(1 == pdxlnCoerce->UlArity());
-        CDXLNode *pdxlnChild = (*pdxlnCoerce)[0];
+        GPOS_ASSERT(1 == scalar_coerce_node->Arity());
+        CDXLNode *child_dxl = (*scalar_coerce_node)[0];
 
-        Expr *pexprChild = PexprFromDXLNodeScalar(pdxlnChild, pmapcidvar);
+        Expr *child_expr = TranslateDXLToScalar(child_dxl, colid_var);
 
 
-        CoerceToDomain *pcoerce = MakeNode(CoerceToDomain);
+        CoerceToDomain *coerce = MakeNode(CoerceToDomain);
 
-        pcoerce->resulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidResultType())->OidObjectId();
-        pcoerce->arg = pexprChild;
-        pcoerce->resulttypmod = pdxlop->ITypeModifier();
-        pcoerce->location = pdxlop->ILoc();
-        pcoerce->coercionformat = (CoercionForm)  pdxlop->Edxlcf();
+	coerce->resulttype = CMDIdGPDB::CastMdid(dxlop->GetResultTypeMdId())->Oid();
+	coerce->arg = child_expr;
+	coerce->resulttypmod = dxlop->TypeModifier();
+	coerce->location = dxlop->GetLocation();
+	coerce->coercionformat = (CoercionForm)  dxlop->GetDXLCoercionForm();
 
-        return (Expr *) pcoerce;
+        return (Expr *) coerce;
 }
 
 //---------------------------------------------------------------------------
 //      @function:
-//              CTranslatorDXLToScalar::PcoerceFromDXLNodeScCoerceViaIO
+//              CTranslatorDXLToScalar::TranslateDXLScalarCoerceViaIOToScalar
 //
 //      @doc:
 //              Translates a DXL scalar coerce into a GPDB coerceviaio node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PcoerceFromDXLNodeScCoerceViaIO
+CTranslatorDXLToScalar::TranslateDXLScalarCoerceViaIOToScalar
         (
-        const CDXLNode *pdxlnCoerce,
-        CMappingColIdVar *pmapcidvar
+        const CDXLNode *scalar_coerce_node,
+        CMappingColIdVar *colid_var
         )
 {
-        GPOS_ASSERT(NULL != pdxlnCoerce);
-        CDXLScalarCoerceViaIO *pdxlop = CDXLScalarCoerceViaIO::PdxlopConvert(pdxlnCoerce->Pdxlop());
+        GPOS_ASSERT(NULL != scalar_coerce_node);
+        CDXLScalarCoerceViaIO *dxlop = CDXLScalarCoerceViaIO::Cast(scalar_coerce_node->GetOperator());
 
-        GPOS_ASSERT(1 == pdxlnCoerce->UlArity());
-        CDXLNode *pdxlnChild = (*pdxlnCoerce)[0];
+        GPOS_ASSERT(1 == scalar_coerce_node->Arity());
+        CDXLNode *child_dxl = (*scalar_coerce_node)[0];
 
-        Expr *pexprChild = PexprFromDXLNodeScalar(pdxlnChild, pmapcidvar);
+        Expr *child_expr = TranslateDXLToScalar(child_dxl, colid_var);
 
-        CoerceViaIO *pcoerce = MakeNode(CoerceViaIO);
+        CoerceViaIO *coerce = MakeNode(CoerceViaIO);
 
-        pcoerce->resulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidResultType())->OidObjectId();
-        pcoerce->arg = pexprChild;
-        pcoerce->location = pdxlop->ILoc();
-        pcoerce->coerceformat = (CoercionForm)  pdxlop->Edxlcf();
+	coerce->resulttype = CMDIdGPDB::CastMdid(dxlop->GetResultTypeMdId())->Oid();
+	coerce->arg = child_expr;
+	coerce->location = dxlop->GetLocation();
+	coerce->coerceformat = (CoercionForm)  dxlop->GetDXLCoercionForm();
 
-        return (Expr *) pcoerce;
+        return (Expr *) coerce;
 }
 
 //---------------------------------------------------------------------------
 //      @function:
-//              CTranslatorDXLToScalar::PcoerceFromDXLNodeScArrayCoerceExpr
+//              CTranslatorDXLToScalar::TranslateDXLScalarArrayCoerceExprToScalar
 //
 //      @doc:
 //              Translates a DXL scalar array coerce expr into a GPDB T_ArrayCoerceExpr node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PcoerceFromDXLNodeScArrayCoerceExpr
+CTranslatorDXLToScalar::TranslateDXLScalarArrayCoerceExprToScalar
         (
-        const CDXLNode *pdxlnCoerce,
-        CMappingColIdVar *pmapcidvar
+        const CDXLNode *scalar_coerce_node,
+        CMappingColIdVar *colid_var
         )
 {
-        GPOS_ASSERT(NULL != pdxlnCoerce);
-        CDXLScalarArrayCoerceExpr *pdxlop = CDXLScalarArrayCoerceExpr::PdxlopConvert(pdxlnCoerce->Pdxlop());
+        GPOS_ASSERT(NULL != scalar_coerce_node);
+        CDXLScalarArrayCoerceExpr *dxlop = CDXLScalarArrayCoerceExpr::Cast(scalar_coerce_node->GetOperator());
 
-        GPOS_ASSERT(1 == pdxlnCoerce->UlArity());
-        CDXLNode *pdxlnChild = (*pdxlnCoerce)[0];
+        GPOS_ASSERT(1 == scalar_coerce_node->Arity());
+        CDXLNode *child_dxl = (*scalar_coerce_node)[0];
 
-        Expr *pexprChild = PexprFromDXLNodeScalar(pdxlnChild, pmapcidvar);
+        Expr *child_expr = TranslateDXLToScalar(child_dxl, colid_var);
 
-        ArrayCoerceExpr *pcoerce = MakeNode(ArrayCoerceExpr);
+        ArrayCoerceExpr *coerce = MakeNode(ArrayCoerceExpr);
 
-        pcoerce->arg = pexprChild;
-        pcoerce->elemfuncid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidElementFunc())->OidObjectId();
-        pcoerce->resulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidResultType())->OidObjectId();
-        pcoerce->resulttypmod = pdxlop->ITypeModifier();
-        pcoerce->isExplicit = pdxlop->FIsExplicit();
-        pcoerce->coerceformat = (CoercionForm)  pdxlop->Edxlcf();
-        pcoerce->location = pdxlop->ILoc();
+	coerce->arg = child_expr;
+	coerce->elemfuncid = CMDIdGPDB::CastMdid(dxlop->GetCoerceFuncMDid())->Oid();
+	coerce->resulttype = CMDIdGPDB::CastMdid(dxlop->GetResultTypeMdId())->Oid();
+	coerce->resulttypmod = dxlop->TypeModifier();
+	coerce->isExplicit = dxlop->IsExplicit();
+	coerce->coerceformat = (CoercionForm)  dxlop->GetDXLCoercionForm();
+	coerce->location = dxlop->GetLocation();
 
-        return (Expr *) pcoerce;
+        return (Expr *) coerce;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PcoalesceFromDXLNodeScCoalesce
+//		CTranslatorDXLToScalar::TranslateDXLScalarCoalesceToScalar
 //
 //	@doc:
 //		Translates a DXL scalar coalesce operator into a GPDB coalesce node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PcoalesceFromDXLNodeScCoalesce
+CTranslatorDXLToScalar::TranslateDXLScalarCoalesceToScalar
 	(
-	const CDXLNode *pdxlnCoalesce,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_coalesce_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnCoalesce);
-	CDXLScalarCoalesce *pdxlop = CDXLScalarCoalesce::PdxlopConvert(pdxlnCoalesce->Pdxlop());
-	CoalesceExpr *pcoalesce = MakeNode(CoalesceExpr);
+	GPOS_ASSERT(NULL != scalar_coalesce_node);
+	CDXLScalarCoalesce *dxlop = CDXLScalarCoalesce::Cast(scalar_coalesce_node->GetOperator());
+	CoalesceExpr *coalesce = MakeNode(CoalesceExpr);
 
-	pcoalesce->coalescetype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidType())->OidObjectId();
-	pcoalesce->args = PlistTranslateScalarChildren(pcoalesce->args, pdxlnCoalesce, pmapcidvar);
-	pcoalesce->location = -1;
+	coalesce->coalescetype = CMDIdGPDB::CastMdid(dxlop->MdidType())->Oid();
+	coalesce->args = TranslateScalarChildren(coalesce->args, scalar_coalesce_node, colid_var);
+	coalesce->location = -1;
 
-	return (Expr *) pcoalesce;
+	return (Expr *) coalesce;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PminmaxFromDXLNodeScMinMax
+//		CTranslatorDXLToScalar::TranslateDXLScalarMinMaxToScalar
 //
 //	@doc:
 //		Translates a DXL scalar minmax operator into a GPDB minmax node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PminmaxFromDXLNodeScMinMax
+CTranslatorDXLToScalar::TranslateDXLScalarMinMaxToScalar
 	(
-	const CDXLNode *pdxlnMinMax,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_min_max_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnMinMax);
-	CDXLScalarMinMax *pdxlop = CDXLScalarMinMax::PdxlopConvert(pdxlnMinMax->Pdxlop());
-	MinMaxExpr *pminmax = MakeNode(MinMaxExpr);
+	GPOS_ASSERT(NULL != scalar_min_max_node);
+	CDXLScalarMinMax *dxlop = CDXLScalarMinMax::Cast(scalar_min_max_node->GetOperator());
+	MinMaxExpr *min_max_expr = MakeNode(MinMaxExpr);
 
-	pminmax->minmaxtype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidType())->OidObjectId();
-	pminmax->args = PlistTranslateScalarChildren(pminmax->args, pdxlnMinMax, pmapcidvar);
-	pminmax->location = -1;
+	min_max_expr->minmaxtype = CMDIdGPDB::CastMdid(dxlop->MdidType())->Oid();
+	min_max_expr->args = TranslateScalarChildren(min_max_expr->args, scalar_min_max_node, colid_var);
+	min_max_expr->location = -1;
 
-	CDXLScalarMinMax::EdxlMinMaxType emmt = pdxlop->Emmt();
-	if (CDXLScalarMinMax::EmmtMax == emmt)
+	CDXLScalarMinMax::EdxlMinMaxType min_max_type = dxlop->GetMinMaxType();
+	if (CDXLScalarMinMax::EmmtMax == min_max_type)
 	{
-		pminmax->op = IS_GREATEST;
+		min_max_expr->op = IS_GREATEST;
 	}
 	else
 	{
-		GPOS_ASSERT(CDXLScalarMinMax::EmmtMin == emmt);
-		pminmax->op = IS_LEAST;
+		GPOS_ASSERT(CDXLScalarMinMax::EmmtMin == min_max_type);
+		min_max_expr->op = IS_LEAST;
 	}
 
-	return (Expr *) pminmax;
+	return (Expr *) min_max_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PlistTranslateScalarChildren
+//		CTranslatorDXLToScalar::TranslateScalarChildren
 //
 //	@doc:
 //		Translate children of DXL node, and add them to list
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToScalar::PlistTranslateScalarChildren
+CTranslatorDXLToScalar::TranslateScalarChildren
 	(
-	List *plist,
-	const CDXLNode *pdxln,
-	CMappingColIdVar *pmapcidvar
+	List *list,
+	const CDXLNode *dxlnode,
+	CMappingColIdVar *colid_var
 	)
 {
-	List *plistNew = plist;
+	List *new_list = list;
 
-	const ULONG ulArity = pdxln->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnChild = (*pdxln)[ul];
-		Expr *pexprChild = PexprFromDXLNodeScalar(pdxlnChild, pmapcidvar);
-		plistNew = gpdb::PlAppendElement(plistNew, pexprChild);
+		CDXLNode *child_dxl = (*dxlnode)[ul];
+		Expr *child_expr = TranslateDXLToScalar(child_dxl, colid_var);
+		new_list = gpdb::LAppend(new_list, child_expr);
 	}
 
-	return plistNew;
+	return new_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PconstFromDXLNodeScConst
+//		CTranslatorDXLToScalar::TranslateDXLScalarConstToScalar
 //
 //	@doc:
 //		Translates a DXL scalar constant operator into a GPDB scalar const node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PconstFromDXLNodeScConst
+CTranslatorDXLToScalar::TranslateDXLScalarConstToScalar
 	(
-	const CDXLNode *pdxlnConst,
-	CMappingColIdVar * //pmapcidvar
+	const CDXLNode *const_node,
+	CMappingColIdVar * //colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnConst);
-	CDXLScalarConstValue *pdxlop = CDXLScalarConstValue::PdxlopConvert(pdxlnConst->Pdxlop());
-	CDXLDatum *pdxldatum = const_cast<CDXLDatum*>(pdxlop->Pdxldatum());
+	GPOS_ASSERT(NULL != const_node);
+	CDXLScalarConstValue *dxlop = CDXLScalarConstValue::Cast(const_node->GetOperator());
+	CDXLDatum *datum_dxl = const_cast<CDXLDatum*>(dxlop->GetDatumVal());
 
-	return PconstFromDXLDatum(pdxldatum);
+	return TranslateDXLDatumToScalar(datum_dxl);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PconstFromDXLDatum
+//		CTranslatorDXLToScalar::TranslateDXLDatumToScalar
 //
 //	@doc:
 //		Translates a DXL datum into a GPDB scalar const node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PconstFromDXLDatum
+CTranslatorDXLToScalar::TranslateDXLDatumToScalar
 	(
-	CDXLDatum *pdxldatum
+	CDXLDatum *datum_dxl
 	)
 {
-	GPOS_ASSERT(NULL != pdxldatum);
-	
-	static const SDatumTranslatorElem rgTranslators[] =
+	GPOS_ASSERT(NULL != datum_dxl);
+
+	static const SDatumTranslatorElem translators[] =
 		{
-			{CDXLDatum::EdxldatumInt2 , &CTranslatorDXLToScalar::PconstInt2},
-			{CDXLDatum::EdxldatumInt4 , &CTranslatorDXLToScalar::PconstInt4},
-			{CDXLDatum::EdxldatumInt8 , &CTranslatorDXLToScalar::PconstInt8},
-			{CDXLDatum::EdxldatumBool , &CTranslatorDXLToScalar::PconstBool},
-			{CDXLDatum::EdxldatumOid , &CTranslatorDXLToScalar::PconstOid},
-			{CDXLDatum::EdxldatumGeneric, &CTranslatorDXLToScalar::PconstGeneric},
-			{CDXLDatum::EdxldatumStatsDoubleMappable, &CTranslatorDXLToScalar::PconstGeneric},
-			{CDXLDatum::EdxldatumStatsLintMappable, &CTranslatorDXLToScalar::PconstGeneric}
+			{CDXLDatum::EdxldatumInt2 , &CTranslatorDXLToScalar::ConvertDXLDatumToConstInt2},
+			{CDXLDatum::EdxldatumInt4 , &CTranslatorDXLToScalar::ConvertDXLDatumToConstInt4},
+			{CDXLDatum::EdxldatumInt8 , &CTranslatorDXLToScalar::ConvertDXLDatumToConstInt8},
+			{CDXLDatum::EdxldatumBool , &CTranslatorDXLToScalar::ConvertDXLDatumToConstBool},
+			{CDXLDatum::EdxldatumOid , &CTranslatorDXLToScalar::ConvertDXLDatumToConstOid},
+			{CDXLDatum::EdxldatumGeneric, &CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar},
+			{CDXLDatum::EdxldatumStatsDoubleMappable, &CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar},
+			{CDXLDatum::EdxldatumStatsLintMappable, &CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar}
 		};
 
-	const ULONG ulTranslators = GPOS_ARRAY_SIZE(rgTranslators);
-	CDXLDatum::EdxldatumType edxldatumtype = pdxldatum->Edxldt();
+	const ULONG num_translators = GPOS_ARRAY_SIZE(translators);
+	CDXLDatum::EdxldatumType edxldatumtype = datum_dxl->GetDatumType();
 
 	// find translator for the node type
-	PfPconst pf = NULL;
-	for (ULONG ul = 0; ul < ulTranslators; ul++)
+	const_func_ptr translate_func = NULL;
+	for (ULONG i = 0; i < num_translators; i++)
 	{
-		SDatumTranslatorElem elem = rgTranslators[ul];
+		SDatumTranslatorElem elem = translators[i];
 		if (edxldatumtype == elem.edxldt)
 		{
-			pf = elem.pf;
+			translate_func = elem.translate_func;
 			break;
 		}
 	}
 
-	if (NULL == pf)
+	if (NULL == translate_func)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, CDXLTokens::PstrToken(EdxltokenScalarConstValue)->Wsz());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, CDXLTokens::GetDXLTokenStr(EdxltokenScalarConstValue)->GetBuffer());
 	}
 
-	return (Expr*) (this->*pf)(pdxldatum);
+	return (Expr*) (this->*translate_func)(datum_dxl);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PconstOid
+//		CTranslatorDXLToScalar::ConvertDXLDatumToConstOid
 //
 //	@doc:
 //		Translates an oid datum into a constant
 //
 //---------------------------------------------------------------------------
 Const *
-CTranslatorDXLToScalar::PconstOid
+CTranslatorDXLToScalar::ConvertDXLDatumToConstOid
 	(
-	CDXLDatum *pdxldatum
+	CDXLDatum *datum_dxl
 	)
 {
-	CDXLDatumOid *pdxldatumOid = CDXLDatumOid::PdxldatumConvert(pdxldatum);
+	CDXLDatumOid *oid_datum_dxl = CDXLDatumOid::Cast(datum_dxl);
 
-	Const *pconst = MakeNode(Const);
-	pconst->consttype = CMDIdGPDB::PmdidConvert(pdxldatumOid->Pmdid())->OidObjectId();
-	pconst->consttypmod = -1;
-	pconst->constbyval = pdxldatumOid->FByValue();
-	pconst->constisnull = pdxldatumOid->FNull();
-	pconst->constlen = pdxldatumOid->UlLength();
+	Const *constant = MakeNode(Const);
+	constant->consttype = CMDIdGPDB::CastMdid(oid_datum_dxl->MDId())->Oid();
+	constant->consttypmod = -1;
+	constant->constbyval = oid_datum_dxl->IsPassedByValue();
+	constant->constisnull = oid_datum_dxl->IsNull();
+	constant->constlen = oid_datum_dxl->Length();
 
-	if (pconst->constisnull)
+	if (constant->constisnull)
 	{
-		pconst->constvalue = (Datum) 0;
+		constant->constvalue = (Datum) 0;
 	}
 	else
 	{
-		pconst->constvalue = gpdb::DDatumFromInt32(pdxldatumOid->OidValue());
+		constant->constvalue = gpdb::DatumFromInt32(oid_datum_dxl->OidValue());
 	}
 
-	return pconst;
+	return constant;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PconstInt2
+//		CTranslatorDXLToScalar::ConvertDXLDatumToConstInt2
 //
 //	@doc:
 //		Translates an int2 datum into a constant
 //
 //---------------------------------------------------------------------------
 Const *
-CTranslatorDXLToScalar::PconstInt2
+CTranslatorDXLToScalar::ConvertDXLDatumToConstInt2
 	(
-	CDXLDatum *pdxldatum
+	CDXLDatum *datum_dxl
 	)
 {
-	CDXLDatumInt2 *pdxldatumint2 = CDXLDatumInt2::PdxldatumConvert(pdxldatum);
+	CDXLDatumInt2 *datum_int2_dxl = CDXLDatumInt2::Cast(datum_dxl);
 
-	Const *pconst = MakeNode(Const);
-	pconst->consttype = CMDIdGPDB::PmdidConvert(pdxldatumint2->Pmdid())->OidObjectId();
-	pconst->consttypmod = -1;
-	pconst->constbyval = pdxldatumint2->FByValue();
-	pconst->constisnull = pdxldatumint2->FNull();
-	pconst->constlen = pdxldatumint2->UlLength();
+	Const *constant = MakeNode(Const);
+	constant->consttype = CMDIdGPDB::CastMdid(datum_int2_dxl->MDId())->Oid();
+	constant->consttypmod = -1;
+	constant->constbyval = datum_int2_dxl->IsPassedByValue();
+	constant->constisnull = datum_int2_dxl->IsNull();
+	constant->constlen = datum_int2_dxl->Length();
 
-	if (pconst->constisnull)
+	if (constant->constisnull)
 	{
-		pconst->constvalue = (Datum) 0;
+		constant->constvalue = (Datum) 0;
 	}
 	else
 	{
-		pconst->constvalue = gpdb::DDatumFromInt16(pdxldatumint2->SValue());
+		constant->constvalue = gpdb::DatumFromInt16(datum_int2_dxl->Value());
 	}
 
-	return pconst;
+	return constant;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PconstInt4
+//		CTranslatorDXLToScalar::ConvertDXLDatumToConstInt4
 //
 //	@doc:
 //		Translates an int4 datum into a constant
 //
 //---------------------------------------------------------------------------
 Const *
-CTranslatorDXLToScalar::PconstInt4
+CTranslatorDXLToScalar::ConvertDXLDatumToConstInt4
 	(
-	CDXLDatum *pdxldatum
+	CDXLDatum *datum_dxl
 	)
 {
-	CDXLDatumInt4 *pdxldatumint4 = CDXLDatumInt4::PdxldatumConvert(pdxldatum);
+	CDXLDatumInt4 *datum_int4_dxl = CDXLDatumInt4::Cast(datum_dxl);
 
-	Const *pconst = MakeNode(Const);
-	pconst->consttype = CMDIdGPDB::PmdidConvert(pdxldatumint4->Pmdid())->OidObjectId();
-	pconst->consttypmod = -1;
-	pconst->constbyval = pdxldatumint4->FByValue();
-	pconst->constisnull = pdxldatumint4->FNull();
-	pconst->constlen = pdxldatumint4->UlLength();
+	Const *constant = MakeNode(Const);
+	constant->consttype = CMDIdGPDB::CastMdid(datum_int4_dxl->MDId())->Oid();
+	constant->consttypmod = -1;
+	constant->constbyval = datum_int4_dxl->IsPassedByValue();
+	constant->constisnull = datum_int4_dxl->IsNull();
+	constant->constlen = datum_int4_dxl->Length();
 
-	if (pconst->constisnull)
+	if (constant->constisnull)
 	{
-		pconst->constvalue = (Datum) 0;
+		constant->constvalue = (Datum) 0;
 	}
 	else
 	{
-		pconst->constvalue = gpdb::DDatumFromInt32(pdxldatumint4->IValue());
+		constant->constvalue = gpdb::DatumFromInt32(datum_int4_dxl->Value());
 	}
 
-	return pconst;
+	return constant;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PconstInt8
+//		CTranslatorDXLToScalar::ConvertDXLDatumToConstInt8
 //
 //	@doc:
 //		Translates an int8 datum into a constant
 //
 //---------------------------------------------------------------------------
 Const *
-CTranslatorDXLToScalar::PconstInt8
+CTranslatorDXLToScalar::ConvertDXLDatumToConstInt8
 	(
-	CDXLDatum *pdxldatum
+	CDXLDatum *datum_dxl
 	)
 {
-	CDXLDatumInt8 *pdxldatumint8 = CDXLDatumInt8::PdxldatumConvert(pdxldatum);
+	CDXLDatumInt8 *datum_int8_dxl = CDXLDatumInt8::Cast(datum_dxl);
 
-	Const *pconst = MakeNode(Const);
-	pconst->consttype = CMDIdGPDB::PmdidConvert(pdxldatumint8->Pmdid())->OidObjectId();
-	pconst->consttypmod = -1;
-	pconst->constbyval = pdxldatumint8->FByValue();
-	pconst->constisnull = pdxldatumint8->FNull();
-	pconst->constlen = pdxldatumint8->UlLength();
+	Const *constant = MakeNode(Const);
+	constant->consttype = CMDIdGPDB::CastMdid(datum_int8_dxl->MDId())->Oid();
+	constant->consttypmod = -1;
+	constant->constbyval = datum_int8_dxl->IsPassedByValue();
+	constant->constisnull = datum_int8_dxl->IsNull();
+	constant->constlen = datum_int8_dxl->Length();
 
-	if (pconst->constisnull)
+	if (constant->constisnull)
 	{
-		pconst->constvalue = (Datum) 0;
+		constant->constvalue = (Datum) 0;
 	}
 	else
 	{
-		pconst->constvalue = gpdb::DDatumFromInt64(pdxldatumint8->LValue());
+		constant->constvalue = gpdb::DatumFromInt64(datum_int8_dxl->Value());
 	}
 
-	return pconst;
+	return constant;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PconstBool
+//		CTranslatorDXLToScalar::ConvertDXLDatumToConstBool
 //
 //	@doc:
 //		Translates a boolean datum into a constant
 //
 //---------------------------------------------------------------------------
 Const *
-CTranslatorDXLToScalar::PconstBool
+CTranslatorDXLToScalar::ConvertDXLDatumToConstBool
 	(
-	CDXLDatum *pdxldatum
+	CDXLDatum *datum_dxl
 	)
 {
-	CDXLDatumBool *pdxldatumbool = CDXLDatumBool::PdxldatumConvert(pdxldatum);
+	CDXLDatumBool *datum_bool_dxl = CDXLDatumBool::Cast(datum_dxl);
 
-	Const *pconst = MakeNode(Const);
-	pconst->consttype = CMDIdGPDB::PmdidConvert(pdxldatumbool->Pmdid())->OidObjectId();
-	pconst->consttypmod = -1;
-	pconst->constbyval = pdxldatumbool->FByValue();
-	pconst->constisnull = pdxldatumbool->FNull();
-	pconst->constlen = pdxldatumbool->UlLength();
+	Const *constant = MakeNode(Const);
+	constant->consttype = CMDIdGPDB::CastMdid(datum_bool_dxl->MDId())->Oid();
+	constant->consttypmod = -1;
+	constant->constbyval = datum_bool_dxl->IsPassedByValue();
+	constant->constisnull = datum_bool_dxl->IsNull();
+	constant->constlen = datum_bool_dxl->Length();
 
-	if (pconst->constisnull)
+	if (constant->constisnull)
 	{
-		pconst->constvalue = (Datum) 0;
+		constant->constvalue = (Datum) 0;
 	}
 	else
 	{
-		pconst->constvalue = gpdb::DDatumFromBool(pdxldatumbool->FValue());
+		constant->constvalue = gpdb::DatumFromBool(datum_bool_dxl->GetValue());
 	}
 
 
-	return pconst;
+	return constant;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PconstGeneric
+//		CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar
 //
 //	@doc:
 //		Translates a datum of generic type into a constant
 //
 //---------------------------------------------------------------------------
 Const *
-CTranslatorDXLToScalar::PconstGeneric
+CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar
 	(
-	CDXLDatum *pdxldatum
+	CDXLDatum *datum_dxl
 	)
 {
-	CDXLDatumGeneric *pdxldatumgeneric = CDXLDatumGeneric::PdxldatumConvert(pdxldatum);
+	CDXLDatumGeneric *datum_generic_dxl = CDXLDatumGeneric::Cast(datum_dxl);
 
-	Const *pconst = MakeNode(Const);
-	pconst->consttype = CMDIdGPDB::PmdidConvert(pdxldatumgeneric->Pmdid())->OidObjectId();
-	pconst->consttypmod = pdxldatumgeneric->ITypeModifier();
-	pconst->constbyval = pdxldatumgeneric->FByValue();
-	pconst->constisnull = pdxldatumgeneric->FNull();
-	pconst->constlen = pdxldatumgeneric->UlLength();
+	Const *constant = MakeNode(Const);
+	constant->consttype = CMDIdGPDB::CastMdid(datum_generic_dxl->MDId())->Oid();
+	constant->consttypmod = datum_generic_dxl->TypeModifier();
+	constant->constbyval = datum_generic_dxl->IsPassedByValue();
+	constant->constisnull = datum_generic_dxl->IsNull();
+	constant->constlen = datum_generic_dxl->Length();
 
-	if (pconst->constisnull)
+	if (constant->constisnull)
 	{
-		pconst->constvalue = (Datum) 0;
+		constant->constvalue = (Datum) 0;
 	}
-	else if (pconst->constbyval)
+	else if (constant->constbyval)
 	{
 		// if it is a by-value constant, the value is stored in the datum.
-		GPOS_ASSERT(pconst->constlen >= 0);
-		GPOS_ASSERT((ULONG) pconst->constlen <= sizeof(Datum));
-		memcpy(&pconst->constvalue, pdxldatumgeneric->Pba(), sizeof(Datum));
+		GPOS_ASSERT(constant->constlen >= 0);
+		GPOS_ASSERT((ULONG) constant->constlen <= sizeof(Datum));
+		memcpy(&constant->constvalue, datum_generic_dxl->GetByteArray(), sizeof(Datum));
 	}
 	else
 	{
-		Datum dVal = gpdb::DDatumFromPointer(pdxldatumgeneric->Pba());
-		ULONG ulLength = (ULONG) gpdb::SDatumSize(dVal, false, pconst->constlen);
+		Datum val = gpdb::DatumFromPointer(datum_generic_dxl->GetByteArray());
+		ULONG length = (ULONG) gpdb::DatumSize(val, false, constant->constlen);
 
-		CHAR *pcsz = (CHAR *) gpdb::GPDBAlloc(ulLength + 1);
-		memcpy(pcsz, pdxldatumgeneric->Pba(), ulLength);
-		pcsz[ulLength] = '\0';
-		pconst->constvalue = gpdb::DDatumFromPointer(pcsz);
+		CHAR *str = (CHAR *) gpdb::GPDBAlloc(length + 1);
+		memcpy(str, datum_generic_dxl->GetByteArray(), length);
+		str[length] = '\0';
+		constant->constvalue = gpdb::DatumFromPointer(str);
 	}
 
-	return pconst;
+	return constant;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprPartDefault
+//		CTranslatorDXLToScalar::TranslateDXLScalarPartDefaultToScalar
 //
 //	@doc:
 //		Translates a DXL part default into a GPDB part default
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprPartDefault
+CTranslatorDXLToScalar::TranslateDXLScalarPartDefaultToScalar
 	(
-	const CDXLNode *pdxlnPartDefault,
-	CMappingColIdVar * //pmapcidvar
+	const CDXLNode *part_default_node,
+	CMappingColIdVar * //colid_var
 	)
 {
-	CDXLScalarPartDefault *pdxlop = CDXLScalarPartDefault::PdxlopConvert(pdxlnPartDefault->Pdxlop());
+	CDXLScalarPartDefault *dxlop = CDXLScalarPartDefault::Cast(part_default_node->GetOperator());
 
-	PartDefaultExpr *pexpr = MakeNode(PartDefaultExpr);
-	pexpr->level = pdxlop->UlLevel();
+	PartDefaultExpr *expr = MakeNode(PartDefaultExpr);
+	expr->level = dxlop->GetPartitioningLevel();
 
-	return (Expr *) pexpr;
+	return (Expr *) expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprPartBound
+//		CTranslatorDXLToScalar::TranslateDXLScalarPartBoundToScalar
 //
 //	@doc:
 //		Translates a DXL part bound into a GPDB part bound
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprPartBound
+CTranslatorDXLToScalar::TranslateDXLScalarPartBoundToScalar
 	(
-	const CDXLNode *pdxlnPartBound,
-	CMappingColIdVar * //pmapcidvar
+	const CDXLNode *part_bound_node,
+	CMappingColIdVar * //colid_var
 	)
 {
-	CDXLScalarPartBound *pdxlop = CDXLScalarPartBound::PdxlopConvert(pdxlnPartBound->Pdxlop());
+	CDXLScalarPartBound *dxlop = CDXLScalarPartBound::Cast(part_bound_node->GetOperator());
 
-	PartBoundExpr *pexpr = MakeNode(PartBoundExpr);
-	pexpr->level = pdxlop->UlLevel();
-	pexpr->boundType = CMDIdGPDB::PmdidConvert(pdxlop->PmdidType())->OidObjectId();
-	pexpr->isLowerBound = pdxlop->FLower();
+	PartBoundExpr *expr = MakeNode(PartBoundExpr);
+	expr->level = dxlop->GetPartitioningLevel();
+	expr->boundType = CMDIdGPDB::CastMdid(dxlop->MdidType())->Oid();
+	expr->isLowerBound = dxlop->IsLowerBound();
 
-	return (Expr *) pexpr;
+	return (Expr *) expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprPartBoundInclusion
+//		CTranslatorDXLToScalar::TranslateDXLScalarPartBoundInclusionToScalar
 //
 //	@doc:
 //		Translates a DXL part bound inclusion into a GPDB part bound inclusion
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprPartBoundInclusion
+CTranslatorDXLToScalar::TranslateDXLScalarPartBoundInclusionToScalar
 	(
-	const CDXLNode *pdxlnPartBoundIncl,
-	CMappingColIdVar * //pmapcidvar
+	const CDXLNode *part_bound_incl_node,
+	CMappingColIdVar * //colid_var
 	)
 {
-	CDXLScalarPartBoundInclusion *pdxlop = CDXLScalarPartBoundInclusion::PdxlopConvert(pdxlnPartBoundIncl->Pdxlop());
+	CDXLScalarPartBoundInclusion *dxlop = CDXLScalarPartBoundInclusion::Cast(part_bound_incl_node->GetOperator());
 
-	PartBoundInclusionExpr *pexpr = MakeNode(PartBoundInclusionExpr);
-	pexpr->level = pdxlop->UlLevel();
-	pexpr->isLowerBound = pdxlop->FLower();
+	PartBoundInclusionExpr *expr = MakeNode(PartBoundInclusionExpr);
+	expr->level = dxlop->GetPartitioningLevel();
+	expr->isLowerBound = dxlop->IsLowerBound();
 
-	return (Expr *) pexpr;
+	return (Expr *) expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprPartBoundOpen
+//		CTranslatorDXLToScalar::TranslateDXLScalarPartBoundOpenToScalar
 //
 //	@doc:
 //		Translates a DXL part bound openness into a GPDB part bound openness
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprPartBoundOpen
+CTranslatorDXLToScalar::TranslateDXLScalarPartBoundOpenToScalar
 	(
-	const CDXLNode *pdxlnPartBoundOpen,
-	CMappingColIdVar * //pmapcidvar
+	const CDXLNode *part_bound_open_node,
+	CMappingColIdVar * //colid_var
 	)
 {
-	CDXLScalarPartBoundOpen *pdxlop = CDXLScalarPartBoundOpen::PdxlopConvert(pdxlnPartBoundOpen->Pdxlop());
+	CDXLScalarPartBoundOpen *dxlop = CDXLScalarPartBoundOpen::Cast(part_bound_open_node->GetOperator());
 
-	PartBoundOpenExpr *pexpr = MakeNode(PartBoundOpenExpr);
-	pexpr->level = pdxlop->UlLevel();
-	pexpr->isLowerBound = pdxlop->FLower();
+	PartBoundOpenExpr *expr = MakeNode(PartBoundOpenExpr);
+	expr->level = dxlop->GetPartitioningLevel();
+	expr->isLowerBound = dxlop->IsLowerBound();
 
-	return (Expr *) pexpr;
+	return (Expr *) expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprPartListValues
+//		CTranslatorDXLToScalar::TranslateDXLScalarPartListValuesToScalar
 //
 //	@doc:
 //		Translates a DXL part list values into a GPDB part list values
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprPartListValues
+CTranslatorDXLToScalar::TranslateDXLScalarPartListValuesToScalar
 	(
-	const CDXLNode *pdxlnPartListValues,
-	CMappingColIdVar * //pmapcidvar
+	const CDXLNode *part_list_values_node,
+	CMappingColIdVar * //colid_var
 	)
 {
-	CDXLScalarPartListValues *pdxlop = CDXLScalarPartListValues::PdxlopConvert(pdxlnPartListValues->Pdxlop());
+	CDXLScalarPartListValues *dxlop = CDXLScalarPartListValues::Cast(part_list_values_node->GetOperator());
 
-	PartListRuleExpr *pexpr = MakeNode(PartListRuleExpr);
-	pexpr->level = pdxlop->UlLevel();
-	pexpr->resulttype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidResult())->OidObjectId();
-	pexpr->elementtype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidElement())->OidObjectId();
+	PartListRuleExpr *expr = MakeNode(PartListRuleExpr);
+	expr->level = dxlop->GetPartitioningLevel();
+	expr->resulttype = CMDIdGPDB::CastMdid(dxlop->GetResultTypeMdId())->Oid();
+	expr->elementtype = CMDIdGPDB::CastMdid(dxlop->GetElemTypeMdId())->Oid();
 
-	return (Expr *) pexpr;
+	return (Expr *) expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprPartListNullTest
+//		CTranslatorDXLToScalar::TranslateDXLScalarPartListNullTestToScalar
 //
 //	@doc:
 //		Translates a DXL part list values into a GPDB part list null test
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprPartListNullTest
+CTranslatorDXLToScalar::TranslateDXLScalarPartListNullTestToScalar
 	(
-	const CDXLNode *pdxlnPartListNullTest,
-	CMappingColIdVar * //pmapcidvar
+	const CDXLNode *part_list_null_test_node,
+	CMappingColIdVar * //colid_var
 	)
 {
-	CDXLScalarPartListNullTest *pdxlop = CDXLScalarPartListNullTest::PdxlopConvert(pdxlnPartListNullTest->Pdxlop());
+	CDXLScalarPartListNullTest *dxlop = CDXLScalarPartListNullTest::Cast(part_list_null_test_node->GetOperator());
 
-	PartListNullTestExpr *pexpr = MakeNode(PartListNullTestExpr);
-	pexpr->level = pdxlop->UlLevel();
-	pexpr->nulltesttype = pdxlop->FIsNull() ? IS_NULL : IS_NOT_NULL;
+	PartListNullTestExpr *expr = MakeNode(PartListNullTestExpr);
+	expr->level = dxlop->GetPartitioningLevel();
+	expr->nulltesttype = dxlop->IsNull() ? IS_NULL : IS_NOT_NULL;
 
-	return (Expr *) pexpr;
+	return (Expr *) expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprFromDXLNodeScId
+//		CTranslatorDXLToScalar::TranslateDXLScalarIdentToScalar
 //
 //	@doc:
 //		Translates a DXL scalar ident into a GPDB Expr node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprFromDXLNodeScId
+CTranslatorDXLToScalar::TranslateDXLScalarIdentToScalar
 	(
-	const CDXLNode *pdxlnIdent,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_id_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	CMappingColIdVarPlStmt *pmapcidvarplstmt = dynamic_cast<CMappingColIdVarPlStmt*>(pmapcidvar);
+	CMappingColIdVarPlStmt *colid_var_plstmt_map = dynamic_cast<CMappingColIdVarPlStmt*>(colid_var);
 
 	// scalar identifier
-	CDXLScalarIdent *pdxlop = CDXLScalarIdent::PdxlopConvert(pdxlnIdent->Pdxlop());
-	Expr *pexprResult = NULL;
-	if (NULL == pmapcidvarplstmt || NULL == pmapcidvarplstmt->PpdxltrctxOut()->Pmecolidparamid(pdxlop->Pdxlcr()->UlID()))
+	CDXLScalarIdent *dxlop = CDXLScalarIdent::Cast(scalar_id_node->GetOperator());
+	Expr *result_expr = NULL;
+	if (NULL == colid_var_plstmt_map || NULL == colid_var_plstmt_map->GetOutputContext()->GetParamIdMappingElement(dxlop->GetDXLColRef()->Id()))
 	{
-		// not an outer ref -> create var node
-		pexprResult = (Expr *) pmapcidvar->PvarFromDXLNodeScId(pdxlop);
+		// not an outer ref -> Translate var node
+		result_expr = (Expr *) colid_var->VarFromDXLNodeScId(dxlop);
 	}
 	else
 	{
-		// outer ref -> create param node
-		pexprResult = (Expr *) pmapcidvarplstmt->PparamFromDXLNodeScId(pdxlop);
+		// outer ref -> Translate param node
+		result_expr = (Expr *) colid_var_plstmt_map->ParamFromDXLNodeScId(dxlop);
 	}
 
-	if (NULL  == pexprResult)
+	if (NULL  == result_expr)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, pdxlop->Pdxlcr()->UlID());
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtAttributeNotFound, dxlop->GetDXLColRef()->Id());
 	}
-	return pexprResult;
+	return result_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PopexprFromDXLNodeScCmp
+//		CTranslatorDXLToScalar::TranslateDXLScalarCmpToScalar
 //
 //	@doc:
 //		Translates a DXL scalar comparison operator or a scalar distinct comparison into a GPDB OpExpr node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PopexprFromDXLNodeScCmp
+CTranslatorDXLToScalar::TranslateDXLScalarCmpToScalar
 	(
-	const CDXLNode *pdxlnCmp,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_cmp_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnCmp);
-	CDXLScalarComp *pdxlop = CDXLScalarComp::PdxlopConvert(pdxlnCmp->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_cmp_node);
+	CDXLScalarComp *dxlop = CDXLScalarComp::Cast(scalar_cmp_node->GetOperator());
 
-	OpExpr *popexpr = MakeNode(OpExpr);
-	popexpr->opno = CMDIdGPDB::PmdidConvert(pdxlop->Pmdid())->OidObjectId();
+	OpExpr *op_expr = MakeNode(OpExpr);
+	op_expr->opno = CMDIdGPDB::CastMdid(dxlop->MDId())->Oid();
 
-	const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pdxlop->Pmdid());
+	const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(dxlop->MDId());
 
-	popexpr->opfuncid = CMDIdGPDB::PmdidConvert(pmdscop->PmdidFunc())->OidObjectId();
-	popexpr->opresulttype = CMDIdGPDB::PmdidConvert(m_pmda->PtMDType<IMDTypeBool>()->Pmdid())->OidObjectId();
-	popexpr->opretset = false;
+	op_expr->opfuncid = CMDIdGPDB::CastMdid(md_scalar_op->FuncMdId())->Oid();
+	op_expr->opresulttype = CMDIdGPDB::CastMdid(m_md_accessor->PtMDType<IMDTypeBool>()->MDId())->Oid();
+	op_expr->opretset = false;
 
 	// translate left and right child
-	GPOS_ASSERT(2 == pdxlnCmp->UlArity());
+	GPOS_ASSERT(2 == scalar_cmp_node->Arity());
 
-	CDXLNode *pdxlnLeft = (*pdxlnCmp)[EdxlsccmpIndexLeft];
-	CDXLNode *pdxlnRight = (*pdxlnCmp)[EdxlsccmpIndexRight];
+	CDXLNode *left_node = (*scalar_cmp_node)[EdxlsccmpIndexLeft];
+	CDXLNode *right_node = (*scalar_cmp_node)[EdxlsccmpIndexRight];
 
-	Expr *pexprLeft = PexprFromDXLNodeScalar(pdxlnLeft, pmapcidvar);
-	Expr *pexprRight = PexprFromDXLNodeScalar(pdxlnRight, pmapcidvar);
+	Expr *left_expr = TranslateDXLToScalar(left_node, colid_var);
+	Expr *right_expr = TranslateDXLToScalar(right_node, colid_var);
 
-	popexpr->args = ListMake2(pexprLeft, pexprRight);
+	op_expr->args = ListMake2(left_expr, right_expr);
 
-	return (Expr *) popexpr;
+	return (Expr *) op_expr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprArray
+//		CTranslatorDXLToScalar::TranslateDXLScalarArrayToScalar
 //
 //	@doc:
 //		Translates a DXL scalar array into a GPDB ArrayExpr node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprArray
+CTranslatorDXLToScalar::TranslateDXLScalarArrayToScalar
 	(
-	const CDXLNode *pdxlnArray,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_array_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnArray);
-	CDXLScalarArray *pdxlop = CDXLScalarArray::PdxlopConvert(pdxlnArray->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_array_node);
+	CDXLScalarArray *dxlop = CDXLScalarArray::Cast(scalar_array_node->GetOperator());
 
-	ArrayExpr *pexpr = MakeNode(ArrayExpr);
-	pexpr->element_typeid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidElem())->OidObjectId();
-	pexpr->array_typeid = CMDIdGPDB::PmdidConvert(pdxlop->PmdidArray())->OidObjectId();
-	pexpr->multidims = pdxlop->FMultiDimensional();
-	pexpr->elements = PlistTranslateScalarChildren(pexpr->elements, pdxlnArray, pmapcidvar);
+	ArrayExpr *expr = MakeNode(ArrayExpr);
+	expr->element_typeid = CMDIdGPDB::CastMdid(dxlop->ElementTypeMDid())->Oid();
+	expr->array_typeid = CMDIdGPDB::CastMdid(dxlop->ArrayTypeMDid())->Oid();
+	expr->multidims = dxlop->IsMultiDimensional();
+	expr->elements = TranslateScalarChildren(expr->elements, scalar_array_node, colid_var);
 
 	/*
 	 * ORCA doesn't know how to construct array constants, so it will
@@ -1899,201 +1899,201 @@ CTranslatorDXLToScalar::PexprArray
 	 * expressions were already simplified as much as we could before they
 	 * were passed to ORCA. But there's little harm in trying).
 	 */
-	return (Expr *) gpdb::PnodeEvalConstExpressions((Node *) pexpr);
+	return (Expr *) gpdb::EvalConstExpressions((Node *) expr);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprArrayRef
+//		CTranslatorDXLToScalar::TranslateDXLScalarArrayRefToScalar
 //
 //	@doc:
 //		Translates a DXL scalar arrayref into a GPDB ArrayRef node
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprArrayRef
+CTranslatorDXLToScalar::TranslateDXLScalarArrayRefToScalar
 	(
-	const CDXLNode *pdxlnArrayref,
-	CMappingColIdVar *pmapcidvar
+	const CDXLNode *scalar_array_ref_node,
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnArrayref);
-	CDXLScalarArrayRef *pdxlop = CDXLScalarArrayRef::PdxlopConvert(pdxlnArrayref->Pdxlop());
+	GPOS_ASSERT(NULL != scalar_array_ref_node);
+	CDXLScalarArrayRef *dxlop = CDXLScalarArrayRef::Cast(scalar_array_ref_node->GetOperator());
 
-	ArrayRef *parrayref = MakeNode(ArrayRef);
-	parrayref->refarraytype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidArray())->OidObjectId();
-	parrayref->refelemtype = CMDIdGPDB::PmdidConvert(pdxlop->PmdidElem())->OidObjectId();
-	parrayref->reftypmod = pdxlop->ITypeModifier();
+	ArrayRef *array_ref = MakeNode(ArrayRef);
+	array_ref->refarraytype = CMDIdGPDB::CastMdid(dxlop->ArrayTypeMDid())->Oid();
+	array_ref->refelemtype = CMDIdGPDB::CastMdid(dxlop->ElementTypeMDid())->Oid();
+	array_ref->reftypmod = dxlop->TypeModifier();
 
-	const ULONG ulArity = pdxlnArrayref->UlArity();
-	GPOS_ASSERT(3 == ulArity || 4 == ulArity);
+	const ULONG arity = scalar_array_ref_node->Arity();
+	GPOS_ASSERT(3 == arity || 4 == arity);
 
-	parrayref->reflowerindexpr = PlTranslateArrayRefIndexList((*pdxlnArrayref)[0], CDXLScalarArrayRefIndexList::EilbLower, pmapcidvar);
-	parrayref->refupperindexpr = PlTranslateArrayRefIndexList((*pdxlnArrayref)[1], CDXLScalarArrayRefIndexList::EilbUpper, pmapcidvar);
+	array_ref->reflowerindexpr = TranslateDXLArrayRefIndexListToScalar((*scalar_array_ref_node)[0], CDXLScalarArrayRefIndexList::EilbLower, colid_var);
+	array_ref->refupperindexpr = TranslateDXLArrayRefIndexListToScalar((*scalar_array_ref_node)[1], CDXLScalarArrayRefIndexList::EilbUpper, colid_var);
 
-	parrayref->refexpr = PexprFromDXLNodeScalar((*pdxlnArrayref)[2], pmapcidvar);
-	parrayref->refassgnexpr = NULL;
-	if (4 == ulArity)
+	array_ref->refexpr = TranslateDXLToScalar((*scalar_array_ref_node)[2], colid_var);
+	array_ref->refassgnexpr = NULL;
+	if (4 == arity)
 	{
-		parrayref->refassgnexpr = PexprFromDXLNodeScalar((*pdxlnArrayref)[3], pmapcidvar);
+		array_ref->refassgnexpr = TranslateDXLToScalar((*scalar_array_ref_node)[3], colid_var);
 	}
 
-	return (Expr *) parrayref;
+	return (Expr *) array_ref;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PlTranslateArrayRefIndexList
+//		CTranslatorDXLToScalar::TranslateDXLArrayRefIndexListToScalar
 //
 //	@doc:
 //		Translates a DXL arrayref index list
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorDXLToScalar::PlTranslateArrayRefIndexList
+CTranslatorDXLToScalar::TranslateDXLArrayRefIndexListToScalar
 	(
-	const CDXLNode *pdxlnIndexlist,
+	const CDXLNode *index_list_node,
 	CDXLScalarArrayRefIndexList::EIndexListBound
 #ifdef GPOS_DEBUG
-	eilb
+	index_list_bound
 #endif //GPOS_DEBUG
 	,
-	CMappingColIdVar *pmapcidvar
+	CMappingColIdVar *colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnIndexlist);
-	GPOS_ASSERT(eilb == CDXLScalarArrayRefIndexList::PdxlopConvert(pdxlnIndexlist->Pdxlop())->Eilb());
+	GPOS_ASSERT(NULL != index_list_node);
+	GPOS_ASSERT(index_list_bound == CDXLScalarArrayRefIndexList::Cast(index_list_node->GetOperator())->GetDXLIndexListBound());
 
-	List *plChildren = NIL;
-	plChildren = PlistTranslateScalarChildren(plChildren, pdxlnIndexlist, pmapcidvar);
+	List *children = NIL;
+	children = TranslateScalarChildren(children, index_list_node, colid_var);
 
-	return plChildren;
+	return children;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::PexprDMLAction
+//		CTranslatorDXLToScalar::TranslateDXLScalarDMLActionToScalar
 //
 //	@doc:
 //		Translates a DML action expression 
 //
 //---------------------------------------------------------------------------
 Expr *
-CTranslatorDXLToScalar::PexprDMLAction
+CTranslatorDXLToScalar::TranslateDXLScalarDMLActionToScalar
 	(
 	const CDXLNode *
 #ifdef GPOS_DEBUG
-	pdxlnDMLAction
+	dml_action_node
 #endif
 	,
-	CMappingColIdVar * // pmapcidvar
+	CMappingColIdVar * // colid_var
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnDMLAction);
-	GPOS_ASSERT(EdxlopScalarDMLAction == pdxlnDMLAction->Pdxlop()->Edxlop());
+	GPOS_ASSERT(NULL != dml_action_node);
+	GPOS_ASSERT(EdxlopScalarDMLAction == dml_action_node->GetOperator()->GetDXLOperator());
 
-	DMLActionExpr *pexpr = MakeNode(DMLActionExpr);
+	DMLActionExpr *expr = MakeNode(DMLActionExpr);
 
-	return (Expr *) pexpr;
+	return (Expr *) expr;
 }
 
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::OidFunctionReturnType
+//		CTranslatorDXLToScalar::GetFunctionReturnTypeOid
 //
 //	@doc:
 //		Returns the operator return type oid for the operator funcid from the translation context
 //
 //---------------------------------------------------------------------------
 Oid
-CTranslatorDXLToScalar::OidFunctionReturnType
+CTranslatorDXLToScalar::GetFunctionReturnTypeOid
 	(
-	IMDId *pmdid
+	IMDId *mdid
 	)
 	const
 {
-	return CMDIdGPDB::PmdidConvert(m_pmda->Pmdfunc(pmdid)->PmdidTypeResult())->OidObjectId();
+	return CMDIdGPDB::CastMdid(m_md_accessor->RetrieveFunc(mdid)->GetResultTypeMdid())->Oid();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::FBoolean
+//		CTranslatorDXLToScalar::HasBoolResult
 //
 //	@doc:
 //		Check to see if the operator returns a boolean result
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorDXLToScalar::FBoolean
+CTranslatorDXLToScalar::HasBoolResult
 	(
-	CDXLNode *pdxln,
-	CMDAccessor *pmda
+	CDXLNode *dxlnode,
+	CMDAccessor *md_accessor
 	)
 {
-	GPOS_ASSERT(NULL != pdxln);
+	GPOS_ASSERT(NULL != dxlnode);
 
-	if(EdxloptypeScalar != pdxln->Pdxlop()->Edxloperatortype())
+	if(EdxloptypeScalar != dxlnode->GetOperator()->GetDXLOperatorType())
 	{
 		return false;
 	}
 
-	CDXLScalar *pdxlop = dynamic_cast<CDXLScalar*>(pdxln->Pdxlop());
+	CDXLScalar *dxlop = dynamic_cast<CDXLScalar*>(dxlnode->GetOperator());
 
-	return pdxlop->FBoolean(pmda);
+	return dxlop->HasBoolResult(md_accessor);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::FConstTrue
+//		CTranslatorDXLToScalar::HasConstTrue
 //
 //	@doc:
 //		Check if the operator is a "true" bool constant
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorDXLToScalar::FConstTrue
+CTranslatorDXLToScalar::HasConstTrue
 	(
-	CDXLNode *pdxln,
-	CMDAccessor *pmda
+	CDXLNode *dxlnode,
+	CMDAccessor *md_accessor
 	)
 {
-	GPOS_ASSERT(NULL != pdxln);
-	if (!FBoolean(pdxln, pmda) || EdxlopScalarConstValue != pdxln->Pdxlop()->Edxlop())
+	GPOS_ASSERT(NULL != dxlnode);
+	if (!HasBoolResult(dxlnode, md_accessor) || EdxlopScalarConstValue != dxlnode->GetOperator()->GetDXLOperator())
 	{
 		return false;
 	}
 
-	CDXLScalarConstValue *pdxlop = CDXLScalarConstValue::PdxlopConvert(pdxln->Pdxlop());
-	CDXLDatumBool *pdxldatumbool = CDXLDatumBool::PdxldatumConvert(const_cast<CDXLDatum *>(pdxlop->Pdxldatum()));
+	CDXLScalarConstValue *dxlop = CDXLScalarConstValue::Cast(dxlnode->GetOperator());
+	CDXLDatumBool *datum_bool_dxl = CDXLDatumBool::Cast(const_cast<CDXLDatum *>(dxlop->GetDatumVal()));
 
-	return pdxldatumbool->FValue();
+	return datum_bool_dxl->GetValue();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToScalar::FConstNull
+//		CTranslatorDXLToScalar::HasConstNull
 //
 //	@doc:
 //		Check if the operator is a NULL constant
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorDXLToScalar::FConstNull
+CTranslatorDXLToScalar::HasConstNull
 	(
-	CDXLNode *pdxln
+	CDXLNode *dxlnode
 	)
 {
-	GPOS_ASSERT(NULL != pdxln);
-	if (EdxlopScalarConstValue != pdxln->Pdxlop()->Edxlop())
+	GPOS_ASSERT(NULL != dxlnode);
+	if (EdxlopScalarConstValue != dxlnode->GetOperator()->GetDXLOperator())
 	{
 		return false;
 	}
 
-	CDXLScalarConstValue *pdxlop = CDXLScalarConstValue::PdxlopConvert(pdxln->Pdxlop());
+	CDXLScalarConstValue *dxlop = CDXLScalarConstValue::Cast(dxlnode->GetOperator());
 
-	return pdxlop->Pdxldatum()->FNull();
+	return dxlop->GetDatumVal()->IsNull();
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -64,7 +64,7 @@ extern bool optimizer_enable_dml_constraints;
 extern bool optimizer_enable_multiple_distinct_aggs;
 
 // OIDs of variants of LEAD window function
-static const OID rgOIDLead[] =
+static const OID lead_func_oids[] =
 	{
 	7011, 7074, 7075, 7310, 7312,
 	7314, 7316, 7318,
@@ -91,7 +91,7 @@ static const OID rgOIDLead[] =
 	};
 
 // OIDs of variants of LAG window function
-static const OID rgOIDLag[] =
+static const OID lag_func_oids[] =
 	{
 	7675, 7491, 7493, 7495, 7497, 7499,
 	7501, 7503, 7505, 7507, 7509,
@@ -127,50 +127,50 @@ static const OID rgOIDLag[] =
 //---------------------------------------------------------------------------
 CTranslatorQueryToDXL::CTranslatorQueryToDXL
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	CIdGenerator *pidgtorColId,
-	CIdGenerator *pidgtorCTE,
-	CMappingVarColId *pmapvarcolid,
-	Query *pquery,
-	ULONG ulQueryLevel,
-	BOOL fTopDMLQuery,
-	HMUlCTEListEntry *phmulCTEEntries
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	CIdGenerator *m_colid_counter,
+	CIdGenerator *cte_id_counter,
+	CMappingVarColId *var_colid_mapping,
+	Query *query,
+	ULONG query_level,
+	BOOL is_top_query_dml,
+	HMUlCTEListEntry *query_level_to_cte_map
 	)
 	:
-	m_pmp(pmp),
+	m_mp(mp),
 	m_sysid(IMDId::EmdidGPDB, GPMD_GPDB_SYSID),
-	m_pmda(pmda),
-	m_pidgtorCol(pidgtorColId),
-	m_pidgtorCTE(pidgtorCTE),
-	m_pmapvarcolid(pmapvarcolid),
-	m_ulQueryLevel(ulQueryLevel),
-	m_fHasDistributedTables(false),
-	m_fTopDMLQuery(fTopDMLQuery),
-	m_fCTASQuery(false),
-	m_phmulCTEEntries(NULL),
-	m_pdrgpdxlnQueryOutput(NULL),
-	m_pdrgpdxlnCTE(NULL),
-	m_phmulfCTEProducers(NULL)
+	m_md_accessor(md_accessor),
+	m_colid_counter(m_colid_counter),
+	m_cte_id_counter(cte_id_counter),
+	m_var_to_colid_map(var_colid_mapping),
+	m_query_level(query_level),
+	m_has_distributed_tables(false),
+	m_is_top_query_dml(is_top_query_dml),
+	m_is_ctas_query(false),
+	m_query_level_to_cte_map(NULL),
+	m_dxl_query_output_cols(NULL),
+	m_dxl_cte_producers(NULL),
+	m_cteid_at_current_query_level_map(NULL)
 {
-	GPOS_ASSERT(NULL != pquery);
-	CheckSupportedCmdType(pquery);
+	GPOS_ASSERT(NULL != query);
+	CheckSupportedCmdType(query);
 	
-	m_phmulCTEEntries = GPOS_NEW(m_pmp) HMUlCTEListEntry(m_pmp);
-	m_pdrgpdxlnCTE = GPOS_NEW(m_pmp) DrgPdxln(m_pmp);
-	m_phmulfCTEProducers = GPOS_NEW(m_pmp) HMUlF(m_pmp);
+	m_query_level_to_cte_map = GPOS_NEW(m_mp) HMUlCTEListEntry(m_mp);
+	m_dxl_cte_producers = GPOS_NEW(m_mp) CDXLNodeArray(m_mp);
+	m_cteid_at_current_query_level_map = GPOS_NEW(m_mp) UlongBoolHashMap(m_mp);
 	
-	if (NULL != phmulCTEEntries)
+	if (NULL != query_level_to_cte_map)
 	{
-		HMIterUlCTEListEntry hmiterullist(phmulCTEEntries);
+		HMIterUlCTEListEntry cte_list_hashmap_iter(query_level_to_cte_map);
 
-		while (hmiterullist.FAdvance())
+		while (cte_list_hashmap_iter.Advance())
 		{
-			ULONG ulCTEQueryLevel = *(hmiterullist.Pk());
+			ULONG cte_query_level = *(cte_list_hashmap_iter.Key());
 
-			CCTEListEntry *pctelistentry =  const_cast<CCTEListEntry *>(hmiterullist.Pt());
+			CCTEListEntry *cte_list_entry =  const_cast<CCTEListEntry *>(cte_list_hashmap_iter.Value());
 
-			// CTE's that have been defined before the m_ulQueryLevel
+			// CTE's that have been defined before the m_query_level
 			// should only be inserted into the hash map
 			// For example:
 			// WITH ab as (SELECT a as a, b as b from foo)
@@ -186,78 +186,78 @@ CTranslatorQueryToDXL::CTranslatorQueryToDXL
 			// we have already seen three CTE namely: "ab", "aEq10" and "aEq20". BUT when we expand aEq10
 			// in the dt1, we should only have access of CTE's defined prior to its level namely "ab".
 
-			if (ulCTEQueryLevel < ulQueryLevel && NULL != pctelistentry)
+			if (cte_query_level < query_level && NULL != cte_list_entry)
 			{
-				pctelistentry->AddRef();
+				cte_list_entry->AddRef();
 #ifdef GPOS_DEBUG
-				BOOL fRes =
+				BOOL is_res =
 #endif
-				m_phmulCTEEntries->FInsert(GPOS_NEW(pmp) ULONG(ulCTEQueryLevel), pctelistentry);
-				GPOS_ASSERT(fRes);
+				m_query_level_to_cte_map->Insert(GPOS_NEW(mp) ULONG(cte_query_level), cte_list_entry);
+				GPOS_ASSERT(is_res);
 			}
 		}
 	}
 
 	// check if the query has any unsupported node types
-	CheckUnsupportedNodeTypes(pquery);
+	CheckUnsupportedNodeTypes(query);
 
 	// check if the query has SIRV functions in the targetlist without a FROM clause
-	CheckSirvFuncsWithoutFromClause(pquery);
+	CheckSirvFuncsWithoutFromClause(query);
 
 	// first normalize the query
-	m_pquery = CQueryMutators::PqueryNormalize(m_pmp, m_pmda, pquery, ulQueryLevel);
+	m_query = CQueryMutators::NormalizeQuery(m_mp, m_md_accessor, query, query_level);
 
-	if (NULL != m_pquery->cteList)
+	if (NULL != m_query->cteList)
 	{
-		ConstructCTEProducerList(m_pquery->cteList, ulQueryLevel);
+		ConstructCTEProducerList(m_query->cteList, query_level);
 	}
 
-	m_psctranslator = GPOS_NEW(m_pmp) CTranslatorScalarToDXL
+	m_scalar_translator = GPOS_NEW(m_mp) CTranslatorScalarToDXL
 									(
-									m_pmp,
-									m_pmda,
-									m_pidgtorCol,
-									m_pidgtorCTE,
-									m_ulQueryLevel,
+									m_mp,
+									m_md_accessor,
+									m_colid_counter,
+									m_cte_id_counter,
+									m_query_level,
 									true, /* m_fQuery */
-									m_phmulCTEEntries,
-									m_pdrgpdxlnCTE
+									m_query_level_to_cte_map,
+									m_dxl_cte_producers
 									);
 
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PtrquerytodxlInstance
+//		CTranslatorQueryToDXL::QueryToDXLInstance
 //
 //	@doc:
 //		Factory function
 //
 //---------------------------------------------------------------------------
 CTranslatorQueryToDXL *
-CTranslatorQueryToDXL::PtrquerytodxlInstance
+CTranslatorQueryToDXL::QueryToDXLInstance
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	CIdGenerator *pidgtorColId,
-	CIdGenerator *pidgtorCTE,
-	CMappingVarColId *pmapvarcolid,
-	Query *pquery,
-	ULONG ulQueryLevel,
-	HMUlCTEListEntry *phmulCTEEntries
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	CIdGenerator *m_colid_counter,
+	CIdGenerator *cte_id_counter,
+	CMappingVarColId *var_colid_mapping,
+	Query *query,
+	ULONG query_level,
+	HMUlCTEListEntry *query_level_to_cte_map
 	)
 {
-	return GPOS_NEW(pmp) CTranslatorQueryToDXL
+	return GPOS_NEW(mp) CTranslatorQueryToDXL
 		(
-		pmp,
-		pmda,
-		pidgtorColId,
-		pidgtorCTE,
-		pmapvarcolid,
-		pquery,
-		ulQueryLevel,
-		false,  // fTopDMLQuery
-		phmulCTEEntries
+		mp,
+		md_accessor,
+		m_colid_counter,
+		cte_id_counter,
+		var_colid_mapping,
+		query,
+		query_level,
+		false,  // is_top_query_dml
+		query_level_to_cte_map
 		);
 }
 
@@ -271,13 +271,13 @@ CTranslatorQueryToDXL::PtrquerytodxlInstance
 //---------------------------------------------------------------------------
 CTranslatorQueryToDXL::~CTranslatorQueryToDXL()
 {
-	GPOS_DELETE(m_psctranslator);
-	GPOS_DELETE(m_pmapvarcolid);
-	gpdb::GPDBFree(m_pquery);
-	m_phmulCTEEntries->Release();
-	m_pdrgpdxlnCTE->Release();
-	m_phmulfCTEProducers->Release();
-	CRefCount::SafeRelease(m_pdrgpdxlnQueryOutput);
+	GPOS_DELETE(m_scalar_translator);
+	GPOS_DELETE(m_var_to_colid_map);
+	gpdb::GPDBFree(m_query);
+	m_query_level_to_cte_map->Release();
+	m_dxl_cte_producers->Release();
+	m_cteid_at_current_query_level_map->Release();
+	CRefCount::SafeRelease(m_dxl_query_output_cols);
 }
 
 //---------------------------------------------------------------------------
@@ -291,10 +291,10 @@ CTranslatorQueryToDXL::~CTranslatorQueryToDXL()
 void
 CTranslatorQueryToDXL::CheckUnsupportedNodeTypes
 	(
-	Query *pquery
+	Query *query
 	)
 {
-	static const SUnsupportedFeature rgUnsupported[] =
+	static const SUnsupportedFeature unsupported_features[] =
 	{
 		{T_RowExpr, GPOS_WSZ_LIT("ROW EXPRESSION")},
 		{T_RowCompareExpr, GPOS_WSZ_LIT("ROW COMPARE")},
@@ -306,18 +306,18 @@ CTranslatorQueryToDXL::CheckUnsupportedNodeTypes
 		{T_CurrentOfExpr, GPOS_WSZ_LIT("CURRENT OF")},
 	};
 
-	List *plUnsupported = NIL;
-	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(rgUnsupported); ul++)
+	List *unsupported_list = NIL;
+	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(unsupported_features); ul++)
 	{
-		plUnsupported = gpdb::PlAppendInt(plUnsupported, rgUnsupported[ul].ent);
+		unsupported_list = gpdb::LAppendInt(unsupported_list, unsupported_features[ul].node_tag);
 	}
 
-	INT iUnsupported = gpdb::IFindNodes((Node *) pquery, plUnsupported);
-	gpdb::GPDBFree(plUnsupported);
+	INT unsupported_node = gpdb::FindNodes((Node *) query, unsupported_list);
+	gpdb::GPDBFree(unsupported_list);
 
-	if (0 <= iUnsupported)
+	if (0 <= unsupported_node)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, rgUnsupported[iUnsupported].m_wsz);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, unsupported_features[unsupported_node].m_feature_name);
 	}
 }
 
@@ -333,18 +333,18 @@ CTranslatorQueryToDXL::CheckUnsupportedNodeTypes
 void
 CTranslatorQueryToDXL::CheckSirvFuncsWithoutFromClause
 	(
-	Query *pquery
+	Query *query
 	)
 {
 	// if there is a FROM clause or if target list is empty, look no further
-	if ((NULL != pquery->jointree && 0 < gpdb::UlListLength(pquery->jointree->fromlist))
-		|| NIL == pquery->targetList)
+	if ((NULL != query->jointree && 0 < gpdb::ListLength(query->jointree->fromlist))
+		|| NIL == query->targetList)
 	{
 		return;
 	}
 
 	// see if we have SIRV functions in the target list
-	if (FHasSirvFunctions((Node *) pquery->targetList))
+	if (HasSirvFunctions((Node *) query->targetList))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("SIRV functions"));
 	}
@@ -352,37 +352,37 @@ CTranslatorQueryToDXL::CheckSirvFuncsWithoutFromClause
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::FHasSirvFunctions
+//		CTranslatorQueryToDXL::HasSirvFunctions
 //
 //	@doc:
 //		Check for SIRV functions in the tree rooted at the given node
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorQueryToDXL::FHasSirvFunctions
+CTranslatorQueryToDXL::HasSirvFunctions
 	(
-	Node *pnode
+	Node *node
 	)
 	const
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 
-	List *plFunctions =	gpdb::PlExtractNodesExpression(pnode, T_FuncExpr, true /*descendIntoSubqueries*/);
-	ListCell *plc = NULL;
+	List *function_list =	gpdb::ExtractNodesExpression(node, T_FuncExpr, true /*descendIntoSubqueries*/);
+	ListCell *lc = NULL;
 
-	BOOL fHasSirv = false;
-	ForEach (plc, plFunctions)
+	BOOL has_sirv = false;
+	ForEach (lc, function_list)
 	{
-		FuncExpr *pfuncexpr = (FuncExpr *) lfirst(plc);
-		if (CTranslatorUtils::FSirvFunc(m_pmp, m_pmda, pfuncexpr->funcid))
+		FuncExpr *func_expr = (FuncExpr *) lfirst(lc);
+		if (CTranslatorUtils::IsSirvFunc(m_mp, m_md_accessor, func_expr->funcid))
 		{
-			fHasSirv = true;
+			has_sirv = true;
 			break;
 		}
 	}
-	gpdb::FreeList(plFunctions);
+	gpdb::ListFree(function_list);
 
-	return fHasSirv;
+	return has_sirv;
 }
 
 //---------------------------------------------------------------------------
@@ -396,17 +396,17 @@ CTranslatorQueryToDXL::FHasSirvFunctions
 void
 CTranslatorQueryToDXL::CheckSupportedCmdType
 	(
-	Query *pquery
+	Query *query
 	)
 {
-	if (NULL != pquery->utilityStmt)
+	if (NULL != query->utilityStmt)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("UTILITY command"));
 	}
 
-	if (CMD_SELECT == pquery->commandType)
-	{		
-		if (!optimizer_enable_ctas && NULL != pquery->intoClause)
+	if (CMD_SELECT == query->commandType)
+	{
+		if (!optimizer_enable_ctas && NULL != query->intoClause)
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA"));
 		}
@@ -415,53 +415,53 @@ CTranslatorQueryToDXL::CheckSupportedCmdType
 		return;
 	}
 
-	static const SCmdNameElem rgStrMap[] =
+	static const SCmdNameElem unsupported_commands[] =
 		{
 		{CMD_UTILITY, GPOS_WSZ_LIT("UTILITY command")}
 		};
 
-	const ULONG ulLen = GPOS_ARRAY_SIZE(rgStrMap);
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	const ULONG length = GPOS_ARRAY_SIZE(unsupported_commands);
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		SCmdNameElem mapelem = rgStrMap[ul];
-		if (mapelem.m_cmdtype == pquery->commandType)
+		SCmdNameElem mapelem = unsupported_commands[ul];
+		if (mapelem.m_cmd_type == query->commandType)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, mapelem.m_wsz);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, mapelem.m_cmd_name);
 		}
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdrgpdxlnQueryOutput
+//		CTranslatorQueryToDXL::GetQueryOutputCols
 //
 //	@doc:
 //		Return the list of query output columns
 //
 //---------------------------------------------------------------------------
-DrgPdxln *
-CTranslatorQueryToDXL::PdrgpdxlnQueryOutput() const
+CDXLNodeArray *
+CTranslatorQueryToDXL::GetQueryOutputCols() const
 {
-	return m_pdrgpdxlnQueryOutput;
+	return m_dxl_query_output_cols;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdrgpdxlnCTE
+//		CTranslatorQueryToDXL::GetCTEs
 //
 //	@doc:
 //		Return the list of CTEs
 //
 //---------------------------------------------------------------------------
-DrgPdxln *
-CTranslatorQueryToDXL::PdrgpdxlnCTE() const
+CDXLNodeArray *
+CTranslatorQueryToDXL::GetCTEs() const
 {
-	return m_pdrgpdxlnCTE;
+	return m_dxl_cte_producers;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromQueryInternal
+//		CTranslatorQueryToDXL::TranslateSelectQueryToDXL
 //
 //	@doc:
 //		Translates a Query into a DXL tree. The function allocates memory in
@@ -469,125 +469,125 @@ CTranslatorQueryToDXL::PdrgpdxlnCTE() const
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromQueryInternal()
+CTranslatorQueryToDXL::TranslateSelectQueryToDXL()
 {
 	// The parsed query contains an RTE for the view, which is maintained all the way through planned statement.
 	// This entries is annotated as requiring SELECT permissions for the current user.
 	// In Orca, we only keep range table entries for the base tables in the planned statement, but not for the view itself.
 	// Since permissions are only checked during ExecutorStart, we lose track of the permissions required for the view and the select goes through successfully.
 	// We therefore need to check permissions before we go into optimization for all RTEs, including the ones not explicitly referred in the query, e.g. views.
-	CTranslatorUtils::CheckRTEPermissions(m_pquery->rtable);
-	
-	CDXLNode *pdxlnChild = NULL;
-	HMIUl *phmiulSortGroupColsColId =  GPOS_NEW(m_pmp) HMIUl(m_pmp);
-	HMIUl *phmiulOutputCols = GPOS_NEW(m_pmp) HMIUl(m_pmp);
+	CTranslatorUtils::CheckRTEPermissions(m_query->rtable);
+
+	CDXLNode *child_dxlnode = NULL;
+	IntToUlongMap *sort_group_attno_to_colid_mapping =  GPOS_NEW(m_mp) IntToUlongMap(m_mp);
+	IntToUlongMap *output_attno_to_colid_mapping = GPOS_NEW(m_mp) IntToUlongMap(m_mp);
 
 	// construct CTEAnchor operators for the CTEs defined at the top level
-	CDXLNode *pdxlnCTEAnchorTop = NULL;
-	CDXLNode *pdxlnCTEAnchorBottom = NULL;
-	ConstructCTEAnchors(m_pdrgpdxlnCTE, &pdxlnCTEAnchorTop, &pdxlnCTEAnchorBottom);
-	GPOS_ASSERT_IMP(m_pdrgpdxlnCTE == NULL || 0 < m_pdrgpdxlnCTE->UlLength(),
-					NULL != pdxlnCTEAnchorTop && NULL != pdxlnCTEAnchorBottom);
+	CDXLNode *dxl_cte_anchor_top = NULL;
+	CDXLNode *dxl_cte_anchor_bottom = NULL;
+	ConstructCTEAnchors(m_dxl_cte_producers, &dxl_cte_anchor_top, &dxl_cte_anchor_bottom);
+	GPOS_ASSERT_IMP(m_dxl_cte_producers == NULL || 0 < m_dxl_cte_producers->Size(),
+					NULL != dxl_cte_anchor_top && NULL != dxl_cte_anchor_bottom);
 	
-	GPOS_ASSERT_IMP(NULL != m_pquery->setOperations, 0 == gpdb::UlListLength(m_pquery->windowClause));
-	if (NULL != m_pquery->setOperations)
+	GPOS_ASSERT_IMP(NULL != m_query->setOperations, 0 == gpdb::ListLength(m_query->windowClause));
+	if (NULL != m_query->setOperations)
 	{
-		List *plTargetList = m_pquery->targetList;
+		List *target_list = m_query->targetList;
 		// translate set operations
-		pdxlnChild = PdxlnFromSetOp(m_pquery->setOperations, plTargetList, phmiulOutputCols);
+		child_dxlnode = TranslateSetOpToDXL(m_query->setOperations, target_list, output_attno_to_colid_mapping);
 
-		CDXLLogicalSetOp *pdxlop = CDXLLogicalSetOp::PdxlopConvert(pdxlnChild->Pdxlop());
-		const DrgPdxlcd *pdrgpdxlcd = pdxlop->Pdrgpdxlcd();
-		ListCell *plcTE = NULL;
-		ULONG ulResNo = 1;
-		ForEach (plcTE, plTargetList)
+		CDXLLogicalSetOp *dxlop = CDXLLogicalSetOp::Cast(child_dxlnode->GetOperator());
+		const CDXLColDescrArray *dxl_col_descr_array = dxlop->GetDXLColumnDescrArray();
+		ListCell *lc = NULL;
+		ULONG resno = 1;
+		ForEach (lc, target_list)
 		{
-			TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-			if (0 < pte->ressortgroupref)
+			TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+			if (0 < target_entry->ressortgroupref)
 			{
-				ULONG ulColId = ((*pdrgpdxlcd)[ulResNo - 1])->UlID();
-				AddSortingGroupingColumn(pte, phmiulSortGroupColsColId, ulColId);
+				ULONG colid = ((*dxl_col_descr_array)[resno - 1])->Id();
+				AddSortingGroupingColumn(target_entry, sort_group_attno_to_colid_mapping, colid);
 			}
-			ulResNo++;
+			resno++;
 		}
 	}
-	else if (0 != gpdb::UlListLength(m_pquery->windowClause)) // translate window clauses
+	else if (0 != gpdb::ListLength(m_query->windowClause)) // translate window clauses
 	{
-		CDXLNode *pdxln = PdxlnFromGPDBFromExpr(m_pquery->jointree);
-		GPOS_ASSERT(NULL == m_pquery->groupClause);
-		pdxlnChild = PdxlnWindow
+		CDXLNode *dxlnode = TranslateFromExprToDXL(m_query->jointree);
+		GPOS_ASSERT(NULL == m_query->groupClause);
+		child_dxlnode = TranslateWindowToDXL
 						(
-						pdxln,
-						m_pquery->targetList,
-						m_pquery->windowClause,
-						m_pquery->sortClause,
-						phmiulSortGroupColsColId,
-						phmiulOutputCols
+						dxlnode,
+						m_query->targetList,
+						m_query->windowClause,
+						m_query->sortClause,
+						sort_group_attno_to_colid_mapping,
+						output_attno_to_colid_mapping
 						);
 	}
 	else
 	{
-		pdxlnChild = PdxlnGroupingSets(m_pquery->jointree, m_pquery->targetList, m_pquery->groupClause, m_pquery->hasAggs, phmiulSortGroupColsColId, phmiulOutputCols);
+		child_dxlnode = TranslateGroupingSets(m_query->jointree, m_query->targetList, m_query->groupClause, m_query->hasAggs, sort_group_attno_to_colid_mapping, output_attno_to_colid_mapping);
 	}
 
 	// translate limit clause
-	CDXLNode *pdxlnLimit = PdxlnLgLimit(m_pquery->sortClause, m_pquery->limitCount, m_pquery->limitOffset, pdxlnChild, phmiulSortGroupColsColId);
+	CDXLNode *limit_dxlnode = TranslateLimitToDXLGroupBy(m_query->sortClause, m_query->limitCount, m_query->limitOffset, child_dxlnode, sort_group_attno_to_colid_mapping);
 
 
-	if (NULL == m_pquery->targetList)
+	if (NULL == m_query->targetList)
 	{
-		m_pdrgpdxlnQueryOutput = GPOS_NEW(m_pmp) DrgPdxln(m_pmp);
+		m_dxl_query_output_cols = GPOS_NEW(m_mp) CDXLNodeArray(m_mp);
 	}
 	else
 	{
-		m_pdrgpdxlnQueryOutput = PdrgpdxlnConstructOutputCols(m_pquery->targetList, phmiulOutputCols);
+		m_dxl_query_output_cols = CreateDXLOutputCols(m_query->targetList, output_attno_to_colid_mapping);
 	}
 
 	// cleanup
-	CRefCount::SafeRelease(phmiulSortGroupColsColId);
+	CRefCount::SafeRelease(sort_group_attno_to_colid_mapping);
 
-	phmiulOutputCols->Release();
+	output_attno_to_colid_mapping->Release();
 	
 	// add CTE anchors if needed
-	CDXLNode *pdxlnResult = pdxlnLimit;
+	CDXLNode *result_dxlnode = limit_dxlnode;
 	
-	if (NULL != pdxlnCTEAnchorTop)
+	if (NULL != dxl_cte_anchor_top)
 	{
-		GPOS_ASSERT(NULL != pdxlnCTEAnchorBottom);
-		pdxlnCTEAnchorBottom->AddChild(pdxlnResult);
-		pdxlnResult = pdxlnCTEAnchorTop;
+		GPOS_ASSERT(NULL != dxl_cte_anchor_bottom);
+		dxl_cte_anchor_bottom->AddChild(result_dxlnode);
+		result_dxlnode = dxl_cte_anchor_top;
 	}
 	
-	return pdxlnResult;
+	return result_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnSPJ
+//		CTranslatorQueryToDXL::TranslateSelectProjectJoinToDXL
 //
 //	@doc:
 //		Construct a DXL SPJ tree from the given query parts
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnSPJ
+CTranslatorQueryToDXL::TranslateSelectProjectJoinToDXL
 	(
-	List *plTargetList,
-	FromExpr *pfromexpr,
-	HMIUl *phmiulSortGroupColsColId,
-	HMIUl *phmiulOutputCols,
-	List *plGroupClause
+	List *target_list,
+	FromExpr *from_expr,
+	IntToUlongMap *sort_group_attno_to_colid_mapping,
+	IntToUlongMap *output_attno_to_colid_mapping,
+	List *group_clause
 	)
 {
-	CDXLNode *pdxlnJoinTree = PdxlnFromGPDBFromExpr(pfromexpr);
+	CDXLNode *join_tree_dxlnode = TranslateFromExprToDXL(from_expr);
 
 	// translate target list entries into a logical project
-	return PdxlnLgProjectFromGPDBTL(plTargetList, pdxlnJoinTree, phmiulSortGroupColsColId, phmiulOutputCols, plGroupClause);
+	return TranslateTargetListToDXLProject(target_list, join_tree_dxlnode, sort_group_attno_to_colid_mapping, output_attno_to_colid_mapping, group_clause);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnSPJForGroupingSets
+//		CTranslatorQueryToDXL::TranslateSelectProjectJoinForGrpSetsToDXL
 //
 //	@doc:
 //		Construct a DXL SPJ tree from the given query parts, and keep variables
@@ -595,52 +595,52 @@ CTranslatorQueryToDXL::PdxlnSPJ
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnSPJForGroupingSets
+CTranslatorQueryToDXL::TranslateSelectProjectJoinForGrpSetsToDXL
 	(
-	List *plTargetList,
-	FromExpr *pfromexpr,
-	HMIUl *phmiulSortGroupColsColId,
-	HMIUl *phmiulOutputCols,
-	List *plGroupClause
+	List *target_list,
+	FromExpr *from_expr,
+	IntToUlongMap *sort_group_attno_to_colid_mapping,
+	IntToUlongMap *output_attno_to_colid_mapping,
+	List *group_clause
 	)
 {
-	CDXLNode *pdxlnJoinTree = PdxlnFromGPDBFromExpr(pfromexpr);
+	CDXLNode *join_tree_dxlnode = TranslateFromExprToDXL(from_expr);
 
 	// translate target list entries into a logical project
-	return PdxlnLgProjectFromGPDBTL(plTargetList, pdxlnJoinTree, phmiulSortGroupColsColId, phmiulOutputCols, plGroupClause, true /*fExpandAggrefExpr*/);
+	return TranslateTargetListToDXLProject(target_list, join_tree_dxlnode, sort_group_attno_to_colid_mapping, output_attno_to_colid_mapping, group_clause, true /*is_expand_aggref_expr*/);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromQuery
+//		CTranslatorQueryToDXL::TranslateQueryToDXL
 //
 //	@doc:
 //		Main driver
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromQuery()
+CTranslatorQueryToDXL::TranslateQueryToDXL()
 {
 	CAutoTimer at("\n[OPT]: Query To DXL Translation Time", GPOS_FTRACE(EopttracePrintOptimizationStatistics));
 
-	switch (m_pquery->commandType)
+	switch (m_query->commandType)
 	{
 		case CMD_SELECT:
-			if (NULL == m_pquery->intoClause)
+			if (NULL == m_query->intoClause)
 			{
-				return PdxlnFromQueryInternal();
+				return TranslateSelectQueryToDXL();
 			}
 
-			return PdxlnCTAS();
-			
+			return TranslateCTASToDXL();
+
 		case CMD_INSERT:
-			return PdxlnInsert();
+			return TranslateInsertQueryToDXL();
 
 		case CMD_DELETE:
-			return PdxlnDelete();
+			return TranslateDeleteQueryToDXL();
 
 		case CMD_UPDATE:
-			return PdxlnUpdate();
+			return TranslateUpdateQueryToDXL();
 
 		default:
 			GPOS_ASSERT(!"Statement type not supported");
@@ -650,189 +650,189 @@ CTranslatorQueryToDXL::PdxlnFromQuery()
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnInsert
+//		CTranslatorQueryToDXL::TranslateInsertQueryToDXL
 //
 //	@doc:
 //		Translate an insert stmt
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnInsert()
+CTranslatorQueryToDXL::TranslateInsertQueryToDXL()
 {
-	GPOS_ASSERT(CMD_INSERT == m_pquery->commandType);
-	GPOS_ASSERT(0 < m_pquery->resultRelation);
+	GPOS_ASSERT(CMD_INSERT == m_query->commandType);
+	GPOS_ASSERT(0 < m_query->resultRelation);
 
-	CDXLNode *pdxlnQuery = PdxlnFromQueryInternal();
-	const RangeTblEntry *prte = (RangeTblEntry *) gpdb::PvListNth(m_pquery->rtable, m_pquery->resultRelation - 1);
+	CDXLNode *query_dxlnode = TranslateSelectQueryToDXL();
+	const RangeTblEntry *rte = (RangeTblEntry *) gpdb::ListNth(m_query->rtable, m_query->resultRelation - 1);
 
-	CDXLTableDescr *pdxltabdesc = CTranslatorUtils::Pdxltabdesc(m_pmp, m_pmda, m_pidgtorCol, prte, &m_fHasDistributedTables);
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	if (!optimizer_enable_dml_triggers && CTranslatorUtils::FRelHasTriggers(m_pmp, m_pmda, pmdrel, Edxldmlinsert))
+	CDXLTableDescr *table_descr = CTranslatorUtils::GetTableDescr(m_mp, m_md_accessor, m_colid_counter, rte, &m_has_distributed_tables);
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
+	if (!optimizer_enable_dml_triggers && CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel, Edxldmlinsert))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("INSERT with triggers"));
 	}
 
-	BOOL fRelHasConstraints = CTranslatorUtils::FRelHasConstraints(pmdrel);
-	if (!optimizer_enable_dml_constraints && fRelHasConstraints)
+	BOOL rel_has_constraints = CTranslatorUtils::RelHasConstraints(md_rel);
+	if (!optimizer_enable_dml_constraints && rel_has_constraints)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("INSERT with constraints"));
 	}
 	
-	const ULONG ulLenTblCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
-	const ULONG ulLenTL = gpdb::UlListLength(m_pquery->targetList);
-	GPOS_ASSERT(ulLenTblCols >= ulLenTL);
-	GPOS_ASSERT(ulLenTL == m_pdrgpdxlnQueryOutput->UlLength());
+	const ULONG num_table_columns = CTranslatorUtils::GetNumNonSystemColumns(md_rel);
+	const ULONG target_list_length = gpdb::ListLength(m_query->targetList);
+	GPOS_ASSERT(num_table_columns >= target_list_length);
+	GPOS_ASSERT(target_list_length == m_dxl_query_output_cols->Size());
 
-	CDXLNode *pdxlnPrL = NULL;
+	CDXLNode *project_list_dxlnode = NULL;
 	
-	const ULONG ulSystemCols = pmdrel->UlColumns() - ulLenTblCols;
-	const ULONG ulLenNonDroppedCols = pmdrel->UlNonDroppedCols() - ulSystemCols;
-	if (ulLenNonDroppedCols > ulLenTL)
+	const ULONG num_system_cols = md_rel->ColumnCount() - num_table_columns;
+	const ULONG num_non_dropped_cols = md_rel->NonDroppedColsCount() - num_system_cols;
+	if (num_non_dropped_cols > target_list_length)
 	{
 		// missing target list entries
-		pdxlnPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
+		project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 	}
 
-	DrgPul *pdrgpulSource = GPOS_NEW(m_pmp) DrgPul(m_pmp);
+	ULongPtrArray *source_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 
-	ULONG ulPosTL = 0;
-	for (ULONG ul = 0; ul < ulLenTblCols; ul++)
+	ULONG target_list_pos = 0;
+	for (ULONG ul = 0; ul < num_table_columns; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		GPOS_ASSERT(!pmdcol->FSystemColumn());
+		const IMDColumn *mdcol = md_rel->GetMdCol(ul);
+		GPOS_ASSERT(!mdcol->IsSystemColumn());
 		
-		if (pmdcol->FDropped())
+		if (mdcol->IsDropped())
 		{
 			continue;
 		}
 		
-		if (ulPosTL < ulLenTL)
+		if (target_list_pos < target_list_length)
 		{
-			INT iAttno = pmdcol->IAttno();
+			INT attno = mdcol->AttrNum();
 			
-			TargetEntry *pte = (TargetEntry *) gpdb::PvListNth(m_pquery->targetList, ulPosTL);
-			AttrNumber iResno = pte->resno;
+			TargetEntry *target_entry = (TargetEntry *) gpdb::ListNth(m_query->targetList, target_list_pos);
+			AttrNumber resno = target_entry->resno;
 
-			if (iAttno == iResno)
+			if (attno == resno)
 			{
-				CDXLNode *pdxlnCol = (*m_pdrgpdxlnQueryOutput)[ulPosTL];
-				CDXLScalarIdent *pdxlopIdent = CDXLScalarIdent::PdxlopConvert(pdxlnCol->Pdxlop());
-				pdrgpulSource->Append(GPOS_NEW(m_pmp) ULONG(pdxlopIdent->Pdxlcr()->UlID()));
-				ulPosTL++;
+				CDXLNode *dxl_column = (*m_dxl_query_output_cols)[target_list_pos];
+				CDXLScalarIdent *dxl_ident = CDXLScalarIdent::Cast(dxl_column->GetOperator());
+				source_array->Append(GPOS_NEW(m_mp) ULONG(dxl_ident->GetDXLColRef()->Id()));
+				target_list_pos++;
 				continue;
 			}
 		}
 
 		// target entry corresponding to the tables column not found, therefore
 		// add a project element with null value scalar child
-		CDXLNode *pdxlnPrE = CTranslatorUtils::PdxlnPrElNull(m_pmp, m_pmda, m_pidgtorCol, pmdcol);
-		ULONG ulColId = CDXLScalarProjElem::PdxlopConvert(pdxlnPrE->Pdxlop())->UlId();
- 	 	pdxlnPrL->AddChild(pdxlnPrE);
-	 	pdrgpulSource->Append(GPOS_NEW(m_pmp) ULONG(ulColId));
+		CDXLNode *project_elem_dxlnode = CTranslatorUtils::CreateDXLProjElemConstNULL(m_mp, m_md_accessor, m_colid_counter, mdcol);
+		ULONG colid = CDXLScalarProjElem::Cast(project_elem_dxlnode->GetOperator())->Id();
+		project_list_dxlnode->AddChild(project_elem_dxlnode);
+	 	source_array->Append(GPOS_NEW(m_mp) ULONG(colid));
 	}
 
-	CDXLLogicalInsert *pdxlopInsert = GPOS_NEW(m_pmp) CDXLLogicalInsert(m_pmp, pdxltabdesc, pdrgpulSource);
+	CDXLLogicalInsert *insert_dxlnode = GPOS_NEW(m_mp) CDXLLogicalInsert(m_mp, table_descr, source_array);
 
-	if (NULL != pdxlnPrL)
+	if (NULL != project_list_dxlnode)
 	{
-		GPOS_ASSERT(0 < pdxlnPrL->UlArity());
+		GPOS_ASSERT(0 < project_list_dxlnode->Arity());
 		
-		CDXLNode *pdxlnProject = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalProject(m_pmp));
-		pdxlnProject->AddChild(pdxlnPrL);
-		pdxlnProject->AddChild(pdxlnQuery);
-		pdxlnQuery = pdxlnProject;
+		CDXLNode *project_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalProject(m_mp));
+		project_dxlnode->AddChild(project_list_dxlnode);
+		project_dxlnode->AddChild(query_dxlnode);
+		query_dxlnode = project_dxlnode;
 	}
 
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopInsert, pdxlnQuery);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, insert_dxlnode, query_dxlnode);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnCTAS
+//		CTranslatorQueryToDXL::TranslateCTASToDXL
 //
 //	@doc:
 //		Translate a CTAS
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnCTAS()
+CTranslatorQueryToDXL::TranslateCTASToDXL()
 {
-	GPOS_ASSERT(CMD_SELECT == m_pquery->commandType);
-	GPOS_ASSERT(NULL != m_pquery->intoClause);
+	GPOS_ASSERT(CMD_SELECT == m_query->commandType);
+	GPOS_ASSERT(NULL != m_query->intoClause);
 
-	m_fCTASQuery = true;
-	CDXLNode *pdxlnQuery = PdxlnFromQueryInternal();
-	
-	IntoClause *pintocl = m_pquery->intoClause;
-		
-	CMDName *pmdnameRel = CDXLUtils::PmdnameFromSz(m_pmp, pintocl->rel->relname);
-	
-	DrgPdxlcd *pdrgpdxlcd = GPOS_NEW(m_pmp) DrgPdxlcd(m_pmp);
-	
-	const ULONG ulColumns = gpdb::UlListLength(m_pquery->targetList);
+	m_is_ctas_query = true;
+	CDXLNode *query_dxlnode = TranslateSelectQueryToDXL();
 
-	DrgPul *pdrgpulSource = GPOS_NEW(m_pmp) DrgPul(m_pmp);
-	DrgPi* pdrgpiVarTypMod = GPOS_NEW(m_pmp) DrgPi(m_pmp);
+	IntoClause *into_clause = m_query->intoClause;
+
+	CMDName *md_relname = CDXLUtils::CreateMDNameFromCharArray(m_mp, into_clause->rel->relname);
 	
-	List *plColnames = pintocl->colNames;
-	for (ULONG ul = 0; ul < ulColumns; ul++)
+	CDXLColDescrArray *dxl_col_descr_array = GPOS_NEW(m_mp) CDXLColDescrArray(m_mp);
+	
+	const ULONG num_columns = gpdb::ListLength(m_query->targetList);
+
+	ULongPtrArray *source_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
+	IntPtrArray* var_typmods = GPOS_NEW(m_mp) IntPtrArray(m_mp);
+	
+	List *col_names = into_clause->colNames;
+	for (ULONG ul = 0; ul < num_columns; ul++)
 	{
-		TargetEntry *pte = (TargetEntry *) gpdb::PvListNth(m_pquery->targetList, ul);
-		if (pte->resjunk)
+		TargetEntry *target_entry = (TargetEntry *) gpdb::ListNth(m_query->targetList, ul);
+		if (target_entry->resjunk)
 		{
 			continue;
 		}
-		AttrNumber iResno = pte->resno;
-		int iVarTypMod = gpdb::IExprTypeMod((Node*)pte->expr);
-		pdrgpiVarTypMod->Append(GPOS_NEW(m_pmp) INT(iVarTypMod));
+		AttrNumber resno = target_entry->resno;
+		int var_typmod = gpdb::ExprTypeMod((Node*)target_entry->expr);
+		var_typmods->Append(GPOS_NEW(m_mp) INT(var_typmod));
 
-		CDXLNode *pdxlnCol = (*m_pdrgpdxlnQueryOutput)[ul];
-		CDXLScalarIdent *pdxlopIdent = CDXLScalarIdent::PdxlopConvert(pdxlnCol->Pdxlop());
-		pdrgpulSource->Append(GPOS_NEW(m_pmp) ULONG(pdxlopIdent->Pdxlcr()->UlID()));
+		CDXLNode *dxl_column = (*m_dxl_query_output_cols)[ul];
+		CDXLScalarIdent *dxl_ident = CDXLScalarIdent::Cast(dxl_column->GetOperator());
+		source_array->Append(GPOS_NEW(m_mp) ULONG(dxl_ident->GetDXLColRef()->Id()));
 		
-		CMDName *pmdnameCol = NULL;
-		if (NULL != plColnames && ul < gpdb::UlListLength(plColnames))
+		CMDName *md_colname = NULL;
+		if (NULL != col_names && ul < gpdb::ListLength(col_names))
 		{
-			ColumnDef *pcoldef = (ColumnDef *) gpdb::PvListNth(plColnames, ul);
-			pmdnameCol = CDXLUtils::PmdnameFromSz(m_pmp, pcoldef->colname);
+			ColumnDef *col_def = (ColumnDef *) gpdb::ListNth(col_names, ul);
+			md_colname = CDXLUtils::CreateMDNameFromCharArray(m_mp, col_def->colname);
 		}
 		else
 		{
-			pmdnameCol = GPOS_NEW(m_pmp) CMDName(m_pmp, pdxlopIdent->Pdxlcr()->Pmdname()->Pstr());
+			md_colname = GPOS_NEW(m_mp) CMDName(m_mp, dxl_ident->GetDXLColRef()->MdName()->GetMDName());
 		}
 		
-		GPOS_ASSERT(NULL != pmdnameCol);
-		IMDId *pmdid = pdxlopIdent->PmdidType();
-		pmdid->AddRef();
-		CDXLColDescr *pdxlcd = GPOS_NEW(m_pmp) CDXLColDescr
+		GPOS_ASSERT(NULL != md_colname);
+		IMDId *mdid = dxl_ident->MdidType();
+		mdid->AddRef();
+		CDXLColDescr *dxl_col_descr = GPOS_NEW(m_mp) CDXLColDescr
 											(
-											m_pmp,
-											pmdnameCol,
-											m_pidgtorCol->UlNextId(),
-											iResno /* iAttno */,
-											pmdid,
-											pdxlopIdent->ITypeModifier(),
-											false /* fDropped */
+											m_mp,
+											md_colname,
+											m_colid_counter->next_id(),
+											resno /* attno */,
+											mdid,
+											dxl_ident->TypeModifier(),
+											false /* is_dropped */
 											);
-		pdrgpdxlcd->Append(pdxlcd);
+		dxl_col_descr_array->Append(dxl_col_descr);
 	}
 
-	IMDRelation::Ereldistrpolicy ereldistrpolicy = IMDRelation::EreldistrRandom;
-	DrgPul *pdrgpulDistr = NULL;
+	IMDRelation::Ereldistrpolicy rel_distr_policy = IMDRelation::EreldistrRandom;
+	ULongPtrArray *distribution_colids = NULL;
 	
-	if (NULL != m_pquery->intoPolicy)
+	if (NULL != m_query->intoPolicy)
 	{
-		ereldistrpolicy = CTranslatorRelcacheToDXL::Ereldistribution(m_pquery->intoPolicy);
+		rel_distr_policy = CTranslatorRelcacheToDXL::GetRelDistribution(m_query->intoPolicy);
 		
-		if (IMDRelation::EreldistrHash == ereldistrpolicy)
+		if (IMDRelation::EreldistrHash == rel_distr_policy)
 		{
-			pdrgpulDistr = GPOS_NEW(m_pmp) DrgPul(m_pmp);
+			distribution_colids = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 
-			for (ULONG ul = 0; ul < (ULONG) m_pquery->intoPolicy->nattrs; ul++)
+			for (ULONG ul = 0; ul < (ULONG) m_query->intoPolicy->nattrs; ul++)
 			{
-				AttrNumber attno = m_pquery->intoPolicy->attrs[ul];
+				AttrNumber attno = m_query->intoPolicy->attrs[ul];
 				GPOS_ASSERT(0 < attno);
-				pdrgpulDistr->Append(GPOS_NEW(m_pmp) ULONG(attno - 1));
+				distribution_colids->Append(GPOS_NEW(m_mp) ULONG(attno - 1));
 			}
 		}
 	}
@@ -844,167 +844,167 @@ CTranslatorQueryToDXL::PdxlnCTAS()
 					   NULL);
 	}
 	
-	GPOS_ASSERT(IMDRelation::EreldistrMasterOnly != ereldistrpolicy);
-	m_fHasDistributedTables = true;
+	GPOS_ASSERT(IMDRelation::EreldistrMasterOnly != rel_distr_policy);
+	m_has_distributed_tables = true;
 
 	// TODO: Mar 5, 2014; reserve an OID
 	OID oid = 1;
-	CMDIdGPDB *pmdid = GPOS_NEW(m_pmp) CMDIdGPDBCtas(oid);
+	CMDIdGPDB *mdid = GPOS_NEW(m_mp) CMDIdGPDBCtas(oid);
 	
-	CMDName *pmdnameTableSpace = NULL;
-	if (NULL != pintocl->tableSpaceName)
+	CMDName *md_tablespace_name = NULL;
+	if (NULL != into_clause->tableSpaceName)
 	{
-		pmdnameTableSpace = CDXLUtils::PmdnameFromSz(m_pmp, pintocl->tableSpaceName);
+		md_tablespace_name = CDXLUtils::CreateMDNameFromCharArray(m_mp, into_clause->tableSpaceName);
 	}
 	
-	CMDName *pmdnameSchema = NULL;
-	if (NULL != pintocl->rel->schemaname)
+	CMDName *md_schema_name = NULL;
+	if (NULL != into_clause->rel->schemaname)
 	{
-		pmdnameSchema = CDXLUtils::PmdnameFromSz(m_pmp, pintocl->rel->schemaname);
+		md_schema_name = CDXLUtils::CreateMDNameFromCharArray(m_mp, into_clause->rel->schemaname);
 	}
 	
-	CDXLCtasStorageOptions::ECtasOnCommitAction ectascommit = (CDXLCtasStorageOptions::ECtasOnCommitAction) pintocl->onCommit;
-	
-	IMDRelation::Erelstoragetype erelstorage = IMDRelation::ErelstorageHeap;
-	CDXLCtasStorageOptions::DrgPctasOpt *pdrgpctasopt = Pdrgpctasopt(pintocl->options, &erelstorage);
-	
-	BOOL fHasOids = gpdb::FInterpretOidsOption(pintocl->options);
-	CDXLLogicalCTAS *pdxlopCTAS = GPOS_NEW(m_pmp) CDXLLogicalCTAS
+	CDXLCtasStorageOptions::ECtasOnCommitAction ctas_commit_action = (CDXLCtasStorageOptions::ECtasOnCommitAction) into_clause->onCommit;
+
+	IMDRelation::Erelstoragetype rel_storage_type = IMDRelation::ErelstorageHeap;
+	CDXLCtasStorageOptions::CDXLCtasOptionArray *ctas_storage_options = GetDXLCtasOptionArray(into_clause->options, &rel_storage_type);
+
+	BOOL has_oids = gpdb::InterpretOidsOption(into_clause->options);
+	CDXLLogicalCTAS *ctas_dxlop = GPOS_NEW(m_mp) CDXLLogicalCTAS
 									(
-									m_pmp, 
-									pmdid,
-									pmdnameSchema,
-									pmdnameRel, 
-									pdrgpdxlcd, 
-									GPOS_NEW(m_pmp) CDXLCtasStorageOptions(pmdnameTableSpace, ectascommit, pdrgpctasopt),
-									ereldistrpolicy,
-									pdrgpulDistr,  
-									pintocl->rel->istemp, 
-									fHasOids,
-									erelstorage, 
-									pdrgpulSource,
-									pdrgpiVarTypMod
+									m_mp,
+									mdid,
+									md_schema_name,
+									md_relname,
+									dxl_col_descr_array,
+									GPOS_NEW(m_mp) CDXLCtasStorageOptions(md_tablespace_name, ctas_commit_action, ctas_storage_options),
+									rel_distr_policy,
+									distribution_colids,
+									into_clause->rel->istemp,
+									has_oids,
+									rel_storage_type,
+									source_array,
+									var_typmods
 									);
 
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopCTAS, pdxlnQuery);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, ctas_dxlop, query_dxlnode);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::Pdrgpctasopt
+//		CTranslatorQueryToDXL::GetDXLCtasOptionArray
 //
 //	@doc:
 //		Translate CTAS storage options
 //
 //---------------------------------------------------------------------------
-CDXLCtasStorageOptions::DrgPctasOpt *
-CTranslatorQueryToDXL::Pdrgpctasopt
+CDXLCtasStorageOptions::CDXLCtasOptionArray *
+CTranslatorQueryToDXL::GetDXLCtasOptionArray
 	(
-	List *plOptions,
-	IMDRelation::Erelstoragetype *perelstoragetype // output parameter: storage type
+	List *options,
+	IMDRelation::Erelstoragetype *storage_type // output parameter: storage type
 	)
 {
-	if (NULL == plOptions)
+	if (NULL == options)
 	{
 		return NULL;
 	}
 
-	GPOS_ASSERT(NULL != perelstoragetype);
+	GPOS_ASSERT(NULL != storage_type);
 	
-	CDXLCtasStorageOptions::DrgPctasOpt *pdrgpctasopt = GPOS_NEW(m_pmp) CDXLCtasStorageOptions::DrgPctasOpt(m_pmp);
-	ListCell *plc = NULL;
-	BOOL fAO = false;
-	BOOL fAOCO = false;
-	BOOL fParquet = false;
+	CDXLCtasStorageOptions::CDXLCtasOptionArray *ctas_storage_options = GPOS_NEW(m_mp) CDXLCtasStorageOptions::CDXLCtasOptionArray(m_mp);
+	ListCell *lc = NULL;
+	BOOL is_ao_table = false;
+	BOOL is_AOCO = false;
+	BOOL is_parquet = false;
 	
-	CWStringConst strAppendOnly(GPOS_WSZ_LIT("appendonly"));
-	CWStringConst strOrientation(GPOS_WSZ_LIT("orientation"));
-	CWStringConst strOrientationParquet(GPOS_WSZ_LIT("parquet"));
-	CWStringConst strOrientationColumn(GPOS_WSZ_LIT("column"));
+	CWStringConst str_append_only(GPOS_WSZ_LIT("appendonly"));
+	CWStringConst str_orientation(GPOS_WSZ_LIT("orientation"));
+	CWStringConst str_orientation_parquet(GPOS_WSZ_LIT("parquet"));
+	CWStringConst str_orientation_column(GPOS_WSZ_LIT("column"));
 	
-	ForEach (plc, plOptions)
+	ForEach (lc, options)
 	{
-		DefElem *pdefelem = (DefElem *) lfirst(plc);
-		CWStringDynamic *pstrName = CDXLUtils::PstrFromSz(m_pmp, pdefelem->defname);
-		CWStringDynamic *pstrValue = NULL;
+		DefElem *def_elem = (DefElem *) lfirst(lc);
+		CWStringDynamic *name_str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, def_elem->defname);
+		CWStringDynamic *value_str = NULL;
 		
-		BOOL fNullArg = (NULL == pdefelem->arg);
+		BOOL is_null_arg = (NULL == def_elem->arg);
 
-		// pdefelem->arg is NULL for queries of the form "create table t with (oids) as ... "
-		if (fNullArg)
+		// def_elem->arg is NULL for queries of the form "create table t with (oids) as ... "
+		if (is_null_arg)
 		{
 			// we represent null options as an empty arg string and set the IsNull flag on
-			pstrValue = GPOS_NEW(m_pmp) CWStringDynamic(m_pmp);
+			value_str = GPOS_NEW(m_mp) CWStringDynamic(m_mp);
 		}
 		else
 		{
-			pstrValue = PstrExtractOptionValue(pdefelem);
+			value_str = ExtractStorageOptionStr(def_elem);
 
-			if (pstrName->FEquals(&strAppendOnly) && pstrValue->FEquals(CDXLTokens::PstrToken(EdxltokenTrue)))
+			if (name_str->Equals(&str_append_only) && value_str->Equals(CDXLTokens::GetDXLTokenStr(EdxltokenTrue)))
 			{
-				fAO = true;
+				is_ao_table = true;
 			}
 			
-			if (pstrName->FEquals(&strOrientation) && pstrValue->FEquals(&strOrientationColumn))
+			if (name_str->Equals(&str_orientation) && value_str->Equals(&str_orientation_column))
 			{
-				GPOS_ASSERT(!fParquet);
-				fAOCO = true;
+				GPOS_ASSERT(!is_parquet);
+				is_AOCO = true;
 			}
 
-			if (pstrName->FEquals(&strOrientation) && pstrValue->FEquals(&strOrientationParquet))
+			if (name_str->Equals(&str_orientation) && value_str->Equals(&str_orientation_parquet))
 			{
-				GPOS_ASSERT(!fAOCO);
-				fParquet = true;
+				GPOS_ASSERT(!is_AOCO);
+				is_parquet = true;
 			}
 		}
 
-		NodeTag argType = T_Null;
-		if (!fNullArg)
+		NodeTag arg_type = T_Null;
+		if (!is_null_arg)
 		{
-			argType = pdefelem->arg->type;
+			arg_type = def_elem->arg->type;
 		}
 
-		CDXLCtasStorageOptions::CDXLCtasOption *pdxlctasopt =
-				GPOS_NEW(m_pmp) CDXLCtasStorageOptions::CDXLCtasOption(argType, pstrName, pstrValue, fNullArg);
-		pdrgpctasopt->Append(pdxlctasopt);
+		CDXLCtasStorageOptions::CDXLCtasOption *dxl_ctas_storage_option =
+				GPOS_NEW(m_mp) CDXLCtasStorageOptions::CDXLCtasOption(arg_type, name_str, value_str, is_null_arg);
+		ctas_storage_options->Append(dxl_ctas_storage_option);
 	}
-	if (fAOCO)
+	if (is_AOCO)
 	{
-		*perelstoragetype = IMDRelation::ErelstorageAppendOnlyCols;
+		*storage_type = IMDRelation::ErelstorageAppendOnlyCols;
 	}
-	else if (fAO)
+	else if (is_ao_table)
 	{
-		*perelstoragetype = IMDRelation::ErelstorageAppendOnlyRows;
+		*storage_type = IMDRelation::ErelstorageAppendOnlyRows;
 	}
-	else if (fParquet)
+	else if (is_parquet)
 	{
-		*perelstoragetype = IMDRelation::ErelstorageAppendOnlyParquet;
+		*storage_type = IMDRelation::ErelstorageAppendOnlyParquet;
 	}
 	
-	return pdrgpctasopt;
+	return ctas_storage_options;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PstrExtractOptionValue
+//		CTranslatorQueryToDXL::ExtractStorageOptionStr
 //
 //	@doc:
 //		Extract value for storage option
 //
 //---------------------------------------------------------------------------
 CWStringDynamic *
-CTranslatorQueryToDXL::PstrExtractOptionValue
+CTranslatorQueryToDXL::ExtractStorageOptionStr
 	(
-	DefElem *pdefelem
+	DefElem *def_elem
 	)
 {
-	GPOS_ASSERT(NULL != pdefelem);
+	GPOS_ASSERT(NULL != def_elem);
 
-	CHAR *szValue = gpdb::SzDefGetString(pdefelem);
+	CHAR *value = gpdb::DefGetString(def_elem);
 
-	CWStringDynamic *pstrResult = CDXLUtils::PstrFromSz(m_pmp, szValue);
+	CWStringDynamic *result_str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, value);
 	
-	return pstrResult;
+	return result_str;
 }
 
 //---------------------------------------------------------------------------
@@ -1019,25 +1019,24 @@ CTranslatorQueryToDXL::PstrExtractOptionValue
 void
 CTranslatorQueryToDXL::GetCtidAndSegmentId
 	(
-	ULONG *pulCtid,
-	ULONG *pulSegmentId
+	ULONG *ctid,
+	ULONG *segment_id
 	)
 {
 	// ctid column id
-	IMDId *pmdid = CTranslatorUtils::PmdidSystemColType(m_pmp, SelfItemPointerAttributeNumber);
-	*pulCtid = CTranslatorUtils::UlColId(m_ulQueryLevel, m_pquery->resultRelation, SelfItemPointerAttributeNumber, pmdid, m_pmapvarcolid);
-	pmdid->Release();
+	IMDId *mdid = CTranslatorUtils::GetSystemColType(m_mp, SelfItemPointerAttributeNumber);
+	*ctid = CTranslatorUtils::GetColId(m_query_level, m_query->resultRelation, SelfItemPointerAttributeNumber, mdid, m_var_to_colid_map);
+	mdid->Release();
 
 	// segmentid column id
-	pmdid = CTranslatorUtils::PmdidSystemColType(m_pmp, GpSegmentIdAttributeNumber);
-	*pulSegmentId = CTranslatorUtils::UlColId(m_ulQueryLevel, m_pquery->resultRelation, GpSegmentIdAttributeNumber, pmdid, m_pmapvarcolid);
-	pmdid->Release();
+	mdid = CTranslatorUtils::GetSystemColType(m_mp, GpSegmentIdAttributeNumber);
+	*segment_id = CTranslatorUtils::GetColId(m_query_level, m_query->resultRelation, GpSegmentIdAttributeNumber, mdid, m_var_to_colid_map);
+	mdid->Release();
 }
-
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::UlTupleOidColId
+//		CTranslatorQueryToDXL::GetTupleOidColId
 //
 //	@doc:
 //		Obtains the id of the tuple oid column for the target table of a DML
@@ -1045,65 +1044,65 @@ CTranslatorQueryToDXL::GetCtidAndSegmentId
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorQueryToDXL::UlTupleOidColId()
+CTranslatorQueryToDXL::GetTupleOidColId()
 {
-	IMDId *pmdid = CTranslatorUtils::PmdidSystemColType(m_pmp, ObjectIdAttributeNumber);
-	ULONG ulTupleOidColId = CTranslatorUtils::UlColId(m_ulQueryLevel, m_pquery->resultRelation, ObjectIdAttributeNumber, pmdid, m_pmapvarcolid);
-	pmdid->Release();
-	return ulTupleOidColId;
+	IMDId *mdid = CTranslatorUtils::GetSystemColType(m_mp, ObjectIdAttributeNumber);
+	ULONG tuple_oid_colid = CTranslatorUtils::GetColId(m_query_level, m_query->resultRelation, ObjectIdAttributeNumber, mdid, m_var_to_colid_map);
+	mdid->Release();
+	return tuple_oid_colid;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnDelete
+//		CTranslatorQueryToDXL::TranslateDeleteQueryToDXL
 //
 //	@doc:
 //		Translate a delete stmt
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnDelete()
+CTranslatorQueryToDXL::TranslateDeleteQueryToDXL()
 {
-	GPOS_ASSERT(CMD_DELETE == m_pquery->commandType);
-	GPOS_ASSERT(0 < m_pquery->resultRelation);
+	GPOS_ASSERT(CMD_DELETE == m_query->commandType);
+	GPOS_ASSERT(0 < m_query->resultRelation);
 
-	CDXLNode *pdxlnQuery = PdxlnFromQueryInternal();
-	const RangeTblEntry *prte = (RangeTblEntry *) gpdb::PvListNth(m_pquery->rtable, m_pquery->resultRelation - 1);
+	CDXLNode *query_dxlnode = TranslateSelectQueryToDXL();
+	const RangeTblEntry *rte = (RangeTblEntry *) gpdb::ListNth(m_query->rtable, m_query->resultRelation - 1);
 
-	CDXLTableDescr *pdxltabdesc = CTranslatorUtils::Pdxltabdesc(m_pmp, m_pmda, m_pidgtorCol, prte, &m_fHasDistributedTables);
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	if (!optimizer_enable_dml_triggers && CTranslatorUtils::FRelHasTriggers(m_pmp, m_pmda, pmdrel, Edxldmldelete))
+	CDXLTableDescr *table_descr = CTranslatorUtils::GetTableDescr(m_mp, m_md_accessor, m_colid_counter, rte, &m_has_distributed_tables);
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
+	if (!optimizer_enable_dml_triggers && CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel, Edxldmldelete))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("DELETE with triggers"));
 	}
 
-	ULONG ulCtid = 0;
-	ULONG ulSegmentId = 0;
-	GetCtidAndSegmentId(&ulCtid, &ulSegmentId);
+	ULONG ctid_colid = 0;
+	ULONG segid_colid = 0;
+	GetCtidAndSegmentId(&ctid_colid, &segid_colid);
 
-	DrgPul *pdrgpulDelete = GPOS_NEW(m_pmp) DrgPul(m_pmp);
+	ULongPtrArray *delete_colid_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 
-	const ULONG ulRelColumns = pmdrel->UlColumns();
-	for (ULONG ul = 0; ul < ulRelColumns; ul++)
+	const ULONG num_of_non_sys_cols = md_rel->ColumnCount();
+	for (ULONG ul = 0; ul < num_of_non_sys_cols; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		if (pmdcol->FSystemColumn() || pmdcol->FDropped())
+		const IMDColumn *mdcol = md_rel->GetMdCol(ul);
+		if (mdcol->IsSystemColumn() || mdcol->IsDropped())
 		{
 			continue;
 		}
 
-		ULONG ulColId = CTranslatorUtils::UlColId(m_ulQueryLevel, m_pquery->resultRelation, pmdcol->IAttno(), pmdcol->PmdidType(), m_pmapvarcolid);
-		pdrgpulDelete->Append(GPOS_NEW(m_pmp) ULONG(ulColId));
+		ULONG colid = CTranslatorUtils::GetColId(m_query_level, m_query->resultRelation, mdcol->AttrNum(), mdcol->MdidType(), m_var_to_colid_map);
+		delete_colid_array->Append(GPOS_NEW(m_mp) ULONG(colid));
 	}
 
-	CDXLLogicalDelete *pdxlopdelete = GPOS_NEW(m_pmp) CDXLLogicalDelete(m_pmp, pdxltabdesc, ulCtid, ulSegmentId, pdrgpulDelete);
+	CDXLLogicalDelete *delete_dxlop = GPOS_NEW(m_mp) CDXLLogicalDelete(m_mp, table_descr, ctid_colid, segid_colid, delete_colid_array);
 
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopdelete, pdxlnQuery);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, delete_dxlop, query_dxlnode);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnUpdate
+//		CTranslatorQueryToDXL::TranslateUpdateQueryToDXL
 //
 //	@doc:
 //		Translate an update stmt
@@ -1111,261 +1110,261 @@ CTranslatorQueryToDXL::PdxlnDelete()
 //---------------------------------------------------------------------------
 
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnUpdate()
+CTranslatorQueryToDXL::TranslateUpdateQueryToDXL()
 {
-	GPOS_ASSERT(CMD_UPDATE == m_pquery->commandType);
-	GPOS_ASSERT(0 < m_pquery->resultRelation);
+	GPOS_ASSERT(CMD_UPDATE == m_query->commandType);
+	GPOS_ASSERT(0 < m_query->resultRelation);
 
-	CDXLNode *pdxlnQuery = PdxlnFromQueryInternal();
-	const RangeTblEntry *prte = (RangeTblEntry *) gpdb::PvListNth(m_pquery->rtable, m_pquery->resultRelation - 1);
+	CDXLNode *query_dxlnode = TranslateSelectQueryToDXL();
+	const RangeTblEntry *rte = (RangeTblEntry *) gpdb::ListNth(m_query->rtable, m_query->resultRelation - 1);
 
-	CDXLTableDescr *pdxltabdesc = CTranslatorUtils::Pdxltabdesc(m_pmp, m_pmda, m_pidgtorCol, prte, &m_fHasDistributedTables);
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	if (!optimizer_enable_dml_triggers && CTranslatorUtils::FRelHasTriggers(m_pmp, m_pmda, pmdrel, Edxldmlupdate))
+	CDXLTableDescr *table_descr = CTranslatorUtils::GetTableDescr(m_mp, m_md_accessor, m_colid_counter, rte, &m_has_distributed_tables);
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
+	if (!optimizer_enable_dml_triggers && CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel, Edxldmlupdate))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("UPDATE with triggers"));
 	}
 	
-	if (!optimizer_enable_dml_constraints && CTranslatorUtils::FRelHasConstraints(pmdrel))
+	if (!optimizer_enable_dml_constraints && CTranslatorUtils::RelHasConstraints(md_rel))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("UPDATE with constraints"));
 	}
 	
 
-	ULONG ulCtidColId = 0;
-	ULONG ulSegmentIdColId = 0;
-	GetCtidAndSegmentId(&ulCtidColId, &ulSegmentIdColId);
+	ULONG ctid_colid = 0;
+	ULONG segmentid_colid = 0;
+	GetCtidAndSegmentId(&ctid_colid, &segmentid_colid);
 	
-	ULONG ulTupleOidColId = 0;
+	ULONG tuple_oid_colid = 0;
 	
 
-	BOOL fHasOids = pmdrel->FHasOids();
-	if (fHasOids)
+	BOOL has_oids = md_rel->HasOids();
+	if (has_oids)
 	{
-		ulTupleOidColId = UlTupleOidColId();
+		tuple_oid_colid = GetTupleOidColId();
 	}
 
 	// get (resno -> colId) mapping of columns to be updated
-	HMIUl *phmiulUpdateCols = PhmiulUpdateCols();
+	IntToUlongMap *update_column_map = UpdatedColumnMapping();
 
-	const ULONG ulRelColumns = pmdrel->UlColumns();
-	DrgPul *pdrgpulInsert = GPOS_NEW(m_pmp) DrgPul(m_pmp);
-	DrgPul *pdrgpulDelete = GPOS_NEW(m_pmp) DrgPul(m_pmp);
+	const ULONG num_of_non_sys_cols = md_rel->ColumnCount();
+	ULongPtrArray *insert_colid_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
+	ULongPtrArray *delete_colid_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 
-	for (ULONG ul = 0; ul < ulRelColumns; ul++)
+	for (ULONG ul = 0; ul < num_of_non_sys_cols; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		if (pmdcol->FSystemColumn() || pmdcol->FDropped())
+		const IMDColumn *mdcol = md_rel->GetMdCol(ul);
+		if (mdcol->IsSystemColumn() || mdcol->IsDropped())
 		{
 			continue;
 		}
 
-		INT iAttno = pmdcol->IAttno();
-		ULONG *pulColId = phmiulUpdateCols->PtLookup(&iAttno);
+		INT attno = mdcol->AttrNum();
+		ULONG *updated_colid = update_column_map->Find(&attno);
 
-		ULONG ulColId = CTranslatorUtils::UlColId(m_ulQueryLevel, m_pquery->resultRelation, iAttno, pmdcol->PmdidType(), m_pmapvarcolid);
+		ULONG colid = CTranslatorUtils::GetColId(m_query_level, m_query->resultRelation, attno, mdcol->MdidType(), m_var_to_colid_map);
 
 		// if the column is in the query outputs then use it
 		// otherwise get the column id created by the child query
-		if (NULL != pulColId)
+		if (NULL != updated_colid)
 		{
-			pdrgpulInsert->Append(GPOS_NEW(m_pmp) ULONG(*pulColId));
+			insert_colid_array->Append(GPOS_NEW(m_mp) ULONG(*updated_colid));
 		}
 		else
 		{
-			pdrgpulInsert->Append(GPOS_NEW(m_pmp) ULONG(ulColId));
+			insert_colid_array->Append(GPOS_NEW(m_mp) ULONG(colid));
 		}
 
-		pdrgpulDelete->Append(GPOS_NEW(m_pmp) ULONG(ulColId));
+		delete_colid_array->Append(GPOS_NEW(m_mp) ULONG(colid));
 	}
 
-	phmiulUpdateCols->Release();
-	CDXLLogicalUpdate *pdxlopupdate = GPOS_NEW(m_pmp) CDXLLogicalUpdate(m_pmp, pdxltabdesc, ulCtidColId, ulSegmentIdColId, pdrgpulDelete, pdrgpulInsert, fHasOids, ulTupleOidColId);
+	update_column_map->Release();
+	CDXLLogicalUpdate *pdxlopupdate = GPOS_NEW(m_mp) CDXLLogicalUpdate(m_mp, table_descr, ctid_colid, segmentid_colid, delete_colid_array, insert_colid_array, has_oids, tuple_oid_colid);
 
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopupdate, pdxlnQuery);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, pdxlopupdate, query_dxlnode);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PhmiulUpdateCols
+//		CTranslatorQueryToDXL::UpdatedColumnMapping
 //
 //	@doc:
 // 		Return resno -> colId mapping of columns to be updated
 //
 //---------------------------------------------------------------------------
-HMIUl *
-CTranslatorQueryToDXL::PhmiulUpdateCols()
+IntToUlongMap *
+CTranslatorQueryToDXL::UpdatedColumnMapping()
 {
-	GPOS_ASSERT(gpdb::UlListLength(m_pquery->targetList) == m_pdrgpdxlnQueryOutput->UlLength());
-	HMIUl *phmiulUpdateCols = GPOS_NEW(m_pmp) HMIUl(m_pmp);
+	GPOS_ASSERT(gpdb::ListLength(m_query->targetList) == m_dxl_query_output_cols->Size());
+	IntToUlongMap *update_column_map = GPOS_NEW(m_mp) IntToUlongMap(m_mp);
 
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 	ULONG ul = 0;
-	ForEach (plc, m_pquery->targetList)
+	ForEach (lc, m_query->targetList)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plc);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
-		ULONG ulResno = pte->resno;
-		GPOS_ASSERT(0 < ulResno);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
+		ULONG resno = target_entry->resno;
+		GPOS_ASSERT(0 < resno);
 
-		CDXLNode *pdxlnCol = (*m_pdrgpdxlnQueryOutput)[ul];
-		CDXLScalarIdent *pdxlopIdent = CDXLScalarIdent::PdxlopConvert(pdxlnCol->Pdxlop());
-		ULONG ulColId = pdxlopIdent->Pdxlcr()->UlID();
+		CDXLNode *dxl_column = (*m_dxl_query_output_cols)[ul];
+		CDXLScalarIdent *dxl_ident = CDXLScalarIdent::Cast(dxl_column->GetOperator());
+		ULONG colid = dxl_ident->GetDXLColRef()->Id();
 
-		StoreAttnoColIdMapping(phmiulUpdateCols, ulResno, ulColId);
+		StoreAttnoColIdMapping(update_column_map, resno, colid);
 		ul++;
 	}
 
-	return phmiulUpdateCols;
+	return update_column_map;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::FOIDFound
+//		CTranslatorQueryToDXL::OIDFound
 //
 //	@doc:
 // 		Helper to check if OID is included in given array of OIDs
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorQueryToDXL::FOIDFound
+CTranslatorQueryToDXL::OIDFound
 	(
 	OID oid,
-	const OID rgOID[],
-	ULONG ulSize
+	const OID oids[],
+	ULONG size
 	)
 {
-	BOOL fFound = false;
-	for (ULONG ul = 0; !fFound && ul < ulSize; ul++)
+	BOOL found = false;
+	for (ULONG ul = 0; !found && ul < size; ul++)
 	{
-		fFound = (rgOID[ul] == oid);
+		found = (oids[ul] == oid);
 	}
 
-	return fFound;
+	return found;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::FLeadWindowFunc
+//		CTranslatorQueryToDXL::IsLeadWindowFunc
 //
 //	@doc:
 // 		Check if given operator is LEAD window function
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorQueryToDXL::FLeadWindowFunc
+CTranslatorQueryToDXL::IsLeadWindowFunc
 	(
-	CDXLOperator *pdxlop
+	CDXLOperator *dxlop
 	)
 {
-	BOOL fLead = false;
-	if (EdxlopScalarWindowRef == pdxlop->Edxlop())
+	BOOL is_lead_func = false;
+	if (EdxlopScalarWindowRef == dxlop->GetDXLOperator())
 	{
-		CDXLScalarWindowRef *pdxlopWinref = CDXLScalarWindowRef::PdxlopConvert(pdxlop);
-		const CMDIdGPDB *pmdidgpdb = CMDIdGPDB::PmdidConvert(pdxlopWinref->PmdidFunc());
-		OID oid = pmdidgpdb->OidObjectId();
-		fLead =  FOIDFound(oid, rgOIDLead, GPOS_ARRAY_SIZE(rgOIDLead));
+		CDXLScalarWindowRef *winref_dxlop = CDXLScalarWindowRef::Cast(dxlop);
+		const CMDIdGPDB *mdid_gpdb = CMDIdGPDB::CastMdid(winref_dxlop->FuncMdId());
+		OID oid = mdid_gpdb->Oid();
+		is_lead_func =  OIDFound(oid, lead_func_oids, GPOS_ARRAY_SIZE(lead_func_oids));
 	}
 
-	return fLead;
+	return is_lead_func;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::FLagWindowFunc
+//		CTranslatorQueryToDXL::IsLagWindowFunc
 //
 //	@doc:
 // 		Check if given operator is LAG window function
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorQueryToDXL::FLagWindowFunc
+CTranslatorQueryToDXL::IsLagWindowFunc
 	(
-	CDXLOperator *pdxlop
+	CDXLOperator *dxlop
 	)
 {
-	BOOL fLag = false;
-	if (EdxlopScalarWindowRef == pdxlop->Edxlop())
+	BOOL is_lag = false;
+	if (EdxlopScalarWindowRef == dxlop->GetDXLOperator())
 	{
-		CDXLScalarWindowRef *pdxlopWinref = CDXLScalarWindowRef::PdxlopConvert(pdxlop);
-		const CMDIdGPDB *pmdidgpdb = CMDIdGPDB::PmdidConvert(pdxlopWinref->PmdidFunc());
-		OID oid = pmdidgpdb->OidObjectId();
-		fLag =  FOIDFound(oid, rgOIDLag, GPOS_ARRAY_SIZE(rgOIDLag));
+		CDXLScalarWindowRef *winref_dxlop = CDXLScalarWindowRef::Cast(dxlop);
+		const CMDIdGPDB *mdid_gpdb = CMDIdGPDB::CastMdid(winref_dxlop->FuncMdId());
+		OID oid = mdid_gpdb->Oid();
+		is_lag =  OIDFound(oid, lag_func_oids, GPOS_ARRAY_SIZE(lag_func_oids));
 	}
 
-	return fLag;
+	return is_lag;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlwfLeadLag
+//		CTranslatorQueryToDXL::CreateWindowFramForLeadLag
 //
 //	@doc:
 // 		Manufacture window frame for lead/lag functions
 //
 //---------------------------------------------------------------------------
 CDXLWindowFrame *
-CTranslatorQueryToDXL::PdxlwfLeadLag
+CTranslatorQueryToDXL::CreateWindowFramForLeadLag
 	(
-	BOOL fLead,
-	CDXLNode *pdxlnOffset
+	BOOL is_lead_func,
+	CDXLNode *dxl_offset
 	)
 	const
 {
-	EdxlFrameBoundary edxlfbLead = EdxlfbBoundedFollowing;
-	EdxlFrameBoundary edxlfbTrail = EdxlfbBoundedFollowing;
-	if (!fLead)
+	EdxlFrameBoundary dxl_frame_lead = EdxlfbBoundedFollowing;
+	EdxlFrameBoundary dxl_frame_trail = EdxlfbBoundedFollowing;
+	if (!is_lead_func)
 	{
-		edxlfbLead = EdxlfbBoundedPreceding;
-		edxlfbTrail = EdxlfbBoundedPreceding;
+		dxl_frame_lead = EdxlfbBoundedPreceding;
+		dxl_frame_trail = EdxlfbBoundedPreceding;
 	}
 
-	CDXLNode *pdxlnLeadEdge = NULL;
-	CDXLNode *pdxlnTrailEdge = NULL;
-	if (NULL == pdxlnOffset)
+	CDXLNode *dxl_lead_edge = NULL;
+	CDXLNode *dxl_trail_edge = NULL;
+	if (NULL == dxl_offset)
 	{
-		pdxlnLeadEdge = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarWindowFrameEdge(m_pmp, true /* fLeading */, edxlfbLead));
-		pdxlnTrailEdge = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarWindowFrameEdge(m_pmp, false /* fLeading */, edxlfbTrail));
+		dxl_lead_edge = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarWindowFrameEdge(m_mp, true /* fLeading */, dxl_frame_lead));
+		dxl_trail_edge = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarWindowFrameEdge(m_mp, false /* fLeading */, dxl_frame_trail));
 
-		pdxlnLeadEdge->AddChild(CTranslatorUtils::PdxlnInt8Const(m_pmp, m_pmda, 1 /*iVal*/));
-		pdxlnTrailEdge->AddChild(CTranslatorUtils::PdxlnInt8Const(m_pmp, m_pmda, 1 /*iVal*/));
+		dxl_lead_edge->AddChild(CTranslatorUtils::CreateDXLProjElemFromInt8Const(m_mp, m_md_accessor, 1 /*iVal*/));
+		dxl_trail_edge->AddChild(CTranslatorUtils::CreateDXLProjElemFromInt8Const(m_mp, m_md_accessor, 1 /*iVal*/));
 	}
 	else
 	{
 		// overwrite frame edge types based on specified offset type
-		if (EdxlopScalarConstValue != pdxlnOffset->Pdxlop()->Edxlop())
+		if (EdxlopScalarConstValue != dxl_offset->GetOperator()->GetDXLOperator())
 		{
-			if (fLead)
+			if (is_lead_func)
 			{
-				edxlfbLead = EdxlfbDelayedBoundedFollowing;
-				edxlfbTrail = EdxlfbDelayedBoundedFollowing;
+				dxl_frame_lead = EdxlfbDelayedBoundedFollowing;
+				dxl_frame_trail = EdxlfbDelayedBoundedFollowing;
 			}
 			else
 			{
-				edxlfbLead = EdxlfbDelayedBoundedPreceding;
-				edxlfbTrail = EdxlfbDelayedBoundedPreceding;
+				dxl_frame_lead = EdxlfbDelayedBoundedPreceding;
+				dxl_frame_trail = EdxlfbDelayedBoundedPreceding;
 			}
 		}
-		pdxlnLeadEdge = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarWindowFrameEdge(m_pmp, true /* fLeading */, edxlfbLead));
-		pdxlnTrailEdge = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarWindowFrameEdge(m_pmp, false /* fLeading */, edxlfbTrail));
+		dxl_lead_edge = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarWindowFrameEdge(m_mp, true /* fLeading */, dxl_frame_lead));
+		dxl_trail_edge = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarWindowFrameEdge(m_mp, false /* fLeading */, dxl_frame_trail));
 
-		pdxlnOffset->AddRef();
-		pdxlnLeadEdge->AddChild(pdxlnOffset);
-		pdxlnOffset->AddRef();
-		pdxlnTrailEdge->AddChild(pdxlnOffset);
+		dxl_offset->AddRef();
+		dxl_lead_edge->AddChild(dxl_offset);
+		dxl_offset->AddRef();
+		dxl_trail_edge->AddChild(dxl_offset);
 	}
 
 	// manufacture a frame for LEAD/LAG function
-	return GPOS_NEW(m_pmp) CDXLWindowFrame
+	return GPOS_NEW(m_mp) CDXLWindowFrame
 							(
-							m_pmp,
+							m_mp,
 							EdxlfsRow, // frame specification
 							EdxlfesNulls, // frame exclusion strategy is set to exclude NULLs in GPDB
-							pdxlnLeadEdge,
-							pdxlnTrailEdge
+							dxl_lead_edge,
+							dxl_trail_edge
 							);
 }
 
@@ -1386,57 +1385,57 @@ CTranslatorQueryToDXL::PdxlwfLeadLag
 void
 CTranslatorQueryToDXL::UpdateLeadLagWinSpecPos
 	(
-	CDXLNode *pdxlnPrL, // project list holding WinRef nodes
-	DrgPdxlws *pdrgpdxlws // original list of window spec
+	CDXLNode *project_list_dxlnode, // project list holding WinRef nodes
+	CDXLWindowSpecArray *window_spec_array // original list of window spec
 	)
 	const
 {
-	GPOS_ASSERT(NULL != pdxlnPrL);
-	GPOS_ASSERT(NULL != pdrgpdxlws);
+	GPOS_ASSERT(NULL != project_list_dxlnode);
+	GPOS_ASSERT(NULL != window_spec_array);
 
-	const ULONG ulArity = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnChild = (*(*pdxlnPrL)[ul])[0];
-		CDXLOperator *pdxlop = pdxlnChild->Pdxlop();
-		BOOL fLead = FLeadWindowFunc(pdxlop);
-		BOOL fLag = FLagWindowFunc(pdxlop);
-		if (fLead || fLag)
+		CDXLNode *child_dxlnode = (*(*project_list_dxlnode)[ul])[0];
+		CDXLOperator *dxlop = child_dxlnode->GetOperator();
+		BOOL is_lead_func = IsLeadWindowFunc(dxlop);
+		BOOL is_lag = IsLagWindowFunc(dxlop);
+		if (is_lead_func || is_lag)
 		{
-			CDXLScalarWindowRef *pdxlopWinref = CDXLScalarWindowRef::PdxlopConvert(pdxlop);
-			CDXLWindowSpec *pdxlws = (*pdrgpdxlws)[pdxlopWinref->UlWinSpecPos()];
-			CMDName *pmdname = NULL;
-			if (NULL != pdxlws->Pmdname())
+			CDXLScalarWindowRef *winref_dxlop = CDXLScalarWindowRef::Cast(dxlop);
+			CDXLWindowSpec *window_spec_dxlnode = (*window_spec_array)[winref_dxlop->GetWindSpecPos()];
+			CMDName *mdname = NULL;
+			if (NULL != window_spec_dxlnode->MdName())
 			{
-				pmdname = GPOS_NEW(m_pmp) CMDName(m_pmp, pdxlws->Pmdname()->Pstr());
+				mdname = GPOS_NEW(m_mp) CMDName(m_mp, window_spec_dxlnode->MdName()->GetMDName());
 			}
 
 			// find if an offset is specified
-			CDXLNode *pdxlnOffset = NULL;
-			if (1 < pdxlnChild->UlArity())
+			CDXLNode *dxl_offset = NULL;
+			if (1 < child_dxlnode->Arity())
 			{
-				pdxlnOffset = (*pdxlnChild)[1];
+				dxl_offset = (*child_dxlnode)[1];
 			}
 
 			// create LEAD/LAG frame
-			CDXLWindowFrame *pdxlwf = PdxlwfLeadLag(fLead, pdxlnOffset);
+			CDXLWindowFrame *window_frame = CreateWindowFramForLeadLag(is_lead_func, dxl_offset);
 
 			// create new window spec object
-			pdxlws->PdrgulPartColList()->AddRef();
-			pdxlws->PdxlnSortColList()->AddRef();
+			window_spec_dxlnode->GetPartitionByColIdArray()->AddRef();
+			window_spec_dxlnode->GetSortColListDXL()->AddRef();
 			CDXLWindowSpec *pdxlwsNew =
-				GPOS_NEW(m_pmp) CDXLWindowSpec
+				GPOS_NEW(m_mp) CDXLWindowSpec
 					(
-					m_pmp,
-					pdxlws->PdrgulPartColList(),
-					pmdname,
-					pdxlws->PdxlnSortColList(),
-					pdxlwf
+					m_mp,
+					window_spec_dxlnode->GetPartitionByColIdArray(),
+					mdname,
+					window_spec_dxlnode->GetSortColListDXL(),
+					window_frame
 					);
-			pdrgpdxlws->Append(pdxlwsNew);
+			window_spec_array->Append(pdxlwsNew);
 
 			// update win spec pos of LEAD/LAG function
-			pdxlopWinref->SetWinSpecPos(pdrgpdxlws->UlLength() - 1);
+			winref_dxlop->SetWinSpecPos(window_spec_array->Size() - 1);
 		}
 	}
 }
@@ -1444,363 +1443,363 @@ CTranslatorQueryToDXL::UpdateLeadLagWinSpecPos
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::Pdrgpdxlws
+//		CTranslatorQueryToDXL::TranslateWindowSpecToDXL
 //
 //	@doc:
 //		Translate window specs
 //
 //---------------------------------------------------------------------------
-DrgPdxlws *
-CTranslatorQueryToDXL::Pdrgpdxlws
+CDXLWindowSpecArray *
+CTranslatorQueryToDXL::TranslateWindowSpecToDXL
 	(
-	List *plWindowClause,
-	HMIUl *phmiulSortColsColId,
-	CDXLNode *pdxlnScPrL
+	List *window_clause,
+	IntToUlongMap *sort_col_attno_to_colid_mapping,
+	CDXLNode *project_list_dxlnode_node
 	)
 {
-	GPOS_ASSERT(NULL != plWindowClause);
-	GPOS_ASSERT(NULL != phmiulSortColsColId);
-	GPOS_ASSERT(NULL != pdxlnScPrL);
+	GPOS_ASSERT(NULL != window_clause);
+	GPOS_ASSERT(NULL != sort_col_attno_to_colid_mapping);
+	GPOS_ASSERT(NULL != project_list_dxlnode_node);
 
-	DrgPdxlws *pdrgpdxlws = GPOS_NEW(m_pmp) DrgPdxlws(m_pmp);
+	CDXLWindowSpecArray *window_spec_array = GPOS_NEW(m_mp) CDXLWindowSpecArray(m_mp);
 
 	// translate window specification
-	ListCell *plcWindowSpec = NULL;
-	ForEach (plcWindowSpec, plWindowClause)
+	ListCell *lc = NULL;
+	ForEach (lc, window_clause)
 	{
-		WindowSpec *pwindowspec = (WindowSpec *) lfirst(plcWindowSpec);
-		DrgPul *pdrgppulPartCol = PdrgpulPartCol(pwindowspec->partition, phmiulSortColsColId);
+		WindowSpec *pwindowspec = (WindowSpec *) lfirst(lc);
+		ULongPtrArray *part_columns = TranslatePartColumns(pwindowspec->partition, sort_col_attno_to_colid_mapping);
 
-		CDXLNode *pdxlnSortColList = NULL;
-		CMDName *pmdname = NULL;
-		CDXLWindowFrame *pdxlwf = NULL;
+		CDXLNode *sort_col_list_dxl = NULL;
+		CMDName *mdname = NULL;
+		CDXLWindowFrame *window_frame = NULL;
 
 		if (NULL != pwindowspec->name)
 		{
-			CWStringDynamic *pstrAlias = CDXLUtils::PstrFromSz(m_pmp, pwindowspec->name);
-			pmdname = GPOS_NEW(m_pmp) CMDName(m_pmp, pstrAlias);
-			GPOS_DELETE(pstrAlias);
+			CWStringDynamic *alias_str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, pwindowspec->name);
+			mdname = GPOS_NEW(m_mp) CMDName(m_mp, alias_str);
+			GPOS_DELETE(alias_str);
 		}
 
-		if (0 < gpdb::UlListLength(pwindowspec->order))
+		if (0 < gpdb::ListLength(pwindowspec->order))
 		{
 			// create a sorting col list
-			pdxlnSortColList = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarSortColList(m_pmp));
+			sort_col_list_dxl = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarSortColList(m_mp));
 
-			DrgPdxln *pdrgpdxlnSortCol = PdrgpdxlnSortCol(pwindowspec->order, phmiulSortColsColId);
-			const ULONG ulSize = pdrgpdxlnSortCol->UlLength();
-			for (ULONG ul = 0; ul < ulSize; ul++)
+			CDXLNodeArray *dxl_sort_cols = TranslateSortColumnsToDXL(pwindowspec->order, sort_col_attno_to_colid_mapping);
+			const ULONG size = dxl_sort_cols->Size();
+			for (ULONG ul = 0; ul < size; ul++)
 			{
-				CDXLNode *pdxlnSortClause = (*pdrgpdxlnSortCol)[ul];
-				pdxlnSortClause->AddRef();
-				pdxlnSortColList->AddChild(pdxlnSortClause);
+				CDXLNode *dxl_sort_clause = (*dxl_sort_cols)[ul];
+				dxl_sort_clause->AddRef();
+				sort_col_list_dxl->AddChild(dxl_sort_clause);
 			}
-			pdrgpdxlnSortCol->Release();
+			dxl_sort_cols->Release();
 		}
 
 		if (NULL != pwindowspec->frame)
 		{
-			pdxlwf = m_psctranslator->Pdxlwf((Expr *) pwindowspec->frame, m_pmapvarcolid, pdxlnScPrL, &m_fHasDistributedTables);
+			window_frame = m_scalar_translator->GetWindowFrame((Expr *) pwindowspec->frame, m_var_to_colid_map, project_list_dxlnode_node, &m_has_distributed_tables);
 		}
 
-		CDXLWindowSpec *pdxlws = GPOS_NEW(m_pmp) CDXLWindowSpec(m_pmp, pdrgppulPartCol, pmdname, pdxlnSortColList, pdxlwf);
-		pdrgpdxlws->Append(pdxlws);
+		CDXLWindowSpec *window_spec_dxlnode = GPOS_NEW(m_mp) CDXLWindowSpec(m_mp, part_columns, mdname, sort_col_list_dxl, window_frame);
+		window_spec_array->Append(window_spec_dxlnode);
 	}
 
-	return pdrgpdxlws;
+	return window_spec_array;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnWindow
+//		CTranslatorQueryToDXL::TranslateWindowToDXL
 //
 //	@doc:
 //		Translate a window operator
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnWindow
+CTranslatorQueryToDXL::TranslateWindowToDXL
 	(
-	CDXLNode *pdxlnChild,
-	List *plTargetList,
-	List *plWindowClause,
-	List *plSortClause,
-	HMIUl *phmiulSortColsColId,
-	HMIUl *phmiulOutputCols
+	CDXLNode *child_dxlnode,
+	List *target_list,
+	List *window_clause,
+	List *sort_clause,
+	IntToUlongMap *sort_col_attno_to_colid_mapping,
+	IntToUlongMap *output_attno_to_colid_mapping
 	)
 {
-	if (0 == gpdb::UlListLength(plWindowClause))
+	if (0 == gpdb::ListLength(window_clause))
 	{
-		return pdxlnChild;
+		return child_dxlnode;
 	}
 
 	// translate target list entries
-	CDXLNode *pdxlnPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
+	CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
-	CDXLNode *pdxlnNewChildScPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
-	ListCell *plcTE = NULL;
-	ULONG ulResno = 1;
+	CDXLNode *new_child_project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
+	ListCell *lc = NULL;
+	ULONG resno = 1;
 
 	// target entries that are result of flattening join alias and 
 	// are equivalent to a defined Window specs target entry
-	List *plTEOmitted = NIL; 
-	List *plResno = NIL;
+	List *omitted_target_entries = NIL;
+	List *resno_list = NIL;
 	
-	ForEach (plcTE, plTargetList)
+	ForEach (lc, target_list)
 	{
-		BOOL fInsertSortInfo = true;
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
+		BOOL insert_sort_info = true;
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
 
 		// create the DXL node holding the target list entry
-		CDXLNode *pdxlnPrEl =  PdxlnPrEFromGPDBExpr(pte->expr, pte->resname);
-		ULONG ulColId = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop())->UlId();
+		CDXLNode *project_elem_dxlnode =  TranslateExprToDXLProject(target_entry->expr, target_entry->resname);
+		ULONG colid = CDXLScalarProjElem::Cast(project_elem_dxlnode->GetOperator())->Id();
 
-		if (IsA(pte->expr, WindowRef))
+		if (IsA(target_entry->expr, WindowRef))
 		{
-			CTranslatorUtils::CheckAggregateWindowFn((Node*) pte->expr);
+			CTranslatorUtils::CheckAggregateWindowFn((Node*) target_entry->expr);
 		}
-		if (!pte->resjunk)
+		if (!target_entry->resjunk)
 		{
-			if (IsA(pte->expr, Var) || IsA(pte->expr, WindowRef))
+			if (IsA(target_entry->expr, Var) || IsA(target_entry->expr, WindowRef))
 			{
 				// add window functions and non-computed columns to the project list of the window operator
-				pdxlnPrL->AddChild(pdxlnPrEl);
+				project_list_dxlnode->AddChild(project_elem_dxlnode);
 
-				StoreAttnoColIdMapping(phmiulOutputCols, ulResno, ulColId);
+				StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 			}
-			else if (CTranslatorUtils::FWindowSpec(pte, plWindowClause))
+			else if (CTranslatorUtils::IsWindowSpec(target_entry, window_clause))
 			{
 				// add computed column used in window specification needed in the output columns
 				// to the child's project list
-				pdxlnNewChildScPrL->AddChild(pdxlnPrEl);
+				new_child_project_list_dxlnode->AddChild(project_elem_dxlnode);
 
 				// construct a scalar identifier that points to the computed column and
 				// add it to the project list of the window operator
-				CMDName *pmdnameAlias = GPOS_NEW(m_pmp) CMDName
+				CMDName *mdname_alias = GPOS_NEW(m_mp) CMDName
 													(
-													m_pmp,
-													CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop())->PmdnameAlias()->Pstr()
+													m_mp,
+													CDXLScalarProjElem::Cast(project_elem_dxlnode->GetOperator())->GetMdNameAlias()->GetMDName()
 													);
-				CDXLNode *pdxlnPrElNew = GPOS_NEW(m_pmp) CDXLNode
+				CDXLNode *new_project_elem_dxlnode = GPOS_NEW(m_mp) CDXLNode
 													(
-													m_pmp,
-													GPOS_NEW(m_pmp) CDXLScalarProjElem(m_pmp, ulColId, pmdnameAlias)
+													m_mp,
+													GPOS_NEW(m_mp) CDXLScalarProjElem(m_mp, colid, mdname_alias)
 													);
-				CDXLNode *pdxlnPrElNewChild = GPOS_NEW(m_pmp) CDXLNode
+				CDXLNode *project_elem_new_child_dxlnode = GPOS_NEW(m_mp) CDXLNode
 															(
-															m_pmp,
-															GPOS_NEW(m_pmp) CDXLScalarIdent
+															m_mp,
+															GPOS_NEW(m_mp) CDXLScalarIdent
 																		(
-																		m_pmp,
-																		GPOS_NEW(m_pmp) CDXLColRef
+																		m_mp,
+																		GPOS_NEW(m_mp) CDXLColRef
 																					(
-																					m_pmp,
-																					GPOS_NEW(m_pmp) CMDName(m_pmp, pmdnameAlias->Pstr()),
-																					ulColId,
-																					GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType((Node*) pte->expr)),
-																					gpdb::IExprTypeMod((Node*) pte->expr)
+																					m_mp,
+																					GPOS_NEW(m_mp) CMDName(m_mp, mdname_alias->GetMDName()),
+																					colid,
+																					GPOS_NEW(m_mp) CMDIdGPDB(gpdb::ExprType((Node*) target_entry->expr)),
+																					gpdb::ExprTypeMod((Node*) target_entry->expr)
 																					)
 																		)
 															);
-				pdxlnPrElNew->AddChild(pdxlnPrElNewChild);
-				pdxlnPrL->AddChild(pdxlnPrElNew);
+				new_project_elem_dxlnode->AddChild(project_elem_new_child_dxlnode);
+				project_list_dxlnode->AddChild(new_project_elem_dxlnode);
 
-				StoreAttnoColIdMapping(phmiulOutputCols, ulResno, ulColId);
+				StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 			}
 			else
 			{
-				fInsertSortInfo = false;
-				plTEOmitted = gpdb::PlAppendElement(plTEOmitted, pte);
-				plResno = gpdb::PlAppendInt(plResno, ulResno);
+				insert_sort_info = false;
+				omitted_target_entries = gpdb::LAppend(omitted_target_entries, target_entry);
+				resno_list = gpdb::LAppendInt(resno_list, resno);
 
-				pdxlnPrEl->Release();
+				project_elem_dxlnode->Release();
 			}
 		}
-		else if (IsA(pte->expr, WindowRef))
+		else if (IsA(target_entry->expr, WindowRef))
 		{
 			// computed columns used in the order by clause
-			pdxlnPrL->AddChild(pdxlnPrEl);
+			project_list_dxlnode->AddChild(project_elem_dxlnode);
 		}
-		else if (!IsA(pte->expr, Var))
+		else if (!IsA(target_entry->expr, Var))
 		{
-			GPOS_ASSERT(CTranslatorUtils::FWindowSpec(pte, plWindowClause));
+			GPOS_ASSERT(CTranslatorUtils::IsWindowSpec(target_entry, window_clause));
 			// computed columns used in the window specification
-			pdxlnNewChildScPrL->AddChild(pdxlnPrEl);
+			new_child_project_list_dxlnode->AddChild(project_elem_dxlnode);
 		}
 		else
 		{
-			pdxlnPrEl->Release();
+			project_elem_dxlnode->Release();
 		}
 
-		if (fInsertSortInfo)
+		if (insert_sort_info)
 		{
-			AddSortingGroupingColumn(pte, phmiulSortColsColId, ulColId);
+			AddSortingGroupingColumn(target_entry, sort_col_attno_to_colid_mapping, colid);
 		}
 
-		ulResno++;
+		resno++;
 	}
 
-	plcTE = NULL;
+	lc = NULL;
 
 	// process target entries that are a result of flattening join alias
-	ListCell *plcResno = NULL;
-	ForBoth (plcTE, plTEOmitted,
-			plcResno, plResno)
+	ListCell *lc_resno = NULL;
+	ForBoth (lc, omitted_target_entries,
+			lc_resno, resno_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		INT iResno = (INT) lfirst_int(plcResno);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		INT resno = (INT) lfirst_int(lc_resno);
 
-		TargetEntry *pteWindowSpec = CTranslatorUtils::PteWindowSpec( (Node*) pte->expr, plWindowClause, plTargetList);
-		if (NULL != pteWindowSpec)
+		TargetEntry *te_window_spec = CTranslatorUtils::GetWindowSpecTargetEntry( (Node*) target_entry->expr, window_clause, target_list);
+		if (NULL != te_window_spec)
 		{
-			const ULONG ulColId = CTranslatorUtils::UlColId( (INT) pteWindowSpec->ressortgroupref, phmiulSortColsColId);
-			StoreAttnoColIdMapping(phmiulOutputCols, iResno, ulColId);
-			AddSortingGroupingColumn(pte, phmiulSortColsColId, ulColId);
+			const ULONG colid = CTranslatorUtils::GetColId( (INT) te_window_spec->ressortgroupref, sort_col_attno_to_colid_mapping);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
+			AddSortingGroupingColumn(target_entry, sort_col_attno_to_colid_mapping, colid);
 		}
 	}
-	if (NIL != plTEOmitted)
+	if (NIL != omitted_target_entries)
 	{
-		gpdb::GPDBFree(plTEOmitted);
+		gpdb::GPDBFree(omitted_target_entries);
 	}
 
 	// translate window spec
-	DrgPdxlws *pdrgpdxlws = Pdrgpdxlws(plWindowClause, phmiulSortColsColId, pdxlnNewChildScPrL);
+	CDXLWindowSpecArray *window_spec_array = TranslateWindowSpecToDXL(window_clause, sort_col_attno_to_colid_mapping, new_child_project_list_dxlnode);
 
-	CDXLNode *pdxlnNewChild = NULL;
+	CDXLNode *new_child_dxlnode = NULL;
 
-	if (0 < pdxlnNewChildScPrL->UlArity())
+	if (0 < new_child_project_list_dxlnode->Arity())
 	{
 		// create a project list for the computed columns used in the window specification
-		pdxlnNewChild = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalProject(m_pmp));
-		pdxlnNewChild->AddChild(pdxlnNewChildScPrL);
-		pdxlnNewChild->AddChild(pdxlnChild);
-		pdxlnChild = pdxlnNewChild;
+		new_child_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalProject(m_mp));
+		new_child_dxlnode->AddChild(new_child_project_list_dxlnode);
+		new_child_dxlnode->AddChild(child_dxlnode);
+		child_dxlnode = new_child_dxlnode;
 	}
 	else
 	{
 		// clean up
-		pdxlnNewChildScPrL->Release();
+		new_child_project_list_dxlnode->Release();
 	}
 
-	if (!CTranslatorUtils::FHasProjElem(pdxlnPrL, EdxlopScalarWindowRef))
+	if (!CTranslatorUtils::HasProjElem(project_list_dxlnode, EdxlopScalarWindowRef))
 	{
-		pdxlnPrL->Release();
-		pdrgpdxlws->Release();
+		project_list_dxlnode->Release();
+		window_spec_array->Release();
 
-		return pdxlnChild;
+		return child_dxlnode;
 	}
 
 	// update window spec positions of LEAD/LAG functions
-	UpdateLeadLagWinSpecPos(pdxlnPrL, pdrgpdxlws);
+	UpdateLeadLagWinSpecPos(project_list_dxlnode, window_spec_array);
 
-	CDXLLogicalWindow *pdxlopWindow = GPOS_NEW(m_pmp) CDXLLogicalWindow(m_pmp, pdrgpdxlws);
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopWindow);
+	CDXLLogicalWindow *window_dxlop = GPOS_NEW(m_mp) CDXLLogicalWindow(m_mp, window_spec_array);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, window_dxlop);
 
-	pdxln->AddChild(pdxlnPrL);
-	pdxln->AddChild(pdxlnChild);
+	dxlnode->AddChild(project_list_dxlnode);
+	dxlnode->AddChild(child_dxlnode);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdrgpulPartCol
+//		CTranslatorQueryToDXL::TranslatePartColumns
 //
 //	@doc:
 //		Translate the list of partition-by column identifiers
 //
 //---------------------------------------------------------------------------
-DrgPul *
-CTranslatorQueryToDXL::PdrgpulPartCol
+ULongPtrArray *
+CTranslatorQueryToDXL::TranslatePartColumns
 	(
-	List *plPartCl,
-	HMIUl *phmiulColColId
+	List *partition_by_clause,
+	IntToUlongMap *col_attno_colid_mapping
 	)
 	const
 {
-	DrgPul *pdrgpul = GPOS_NEW(m_pmp) DrgPul(m_pmp);
+	ULongPtrArray *part_cols = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 
-	ListCell *plcPartCl = NULL;
-	ForEach (plcPartCl, plPartCl)
+	ListCell *lc = NULL;
+	ForEach (lc, partition_by_clause)
 	{
-		Node *pnodePartCl = (Node*) lfirst(plcPartCl);
-		GPOS_ASSERT(NULL != pnodePartCl);
+		Node *partition_clause = (Node*) lfirst(lc);
+		GPOS_ASSERT(NULL != partition_clause);
 
-		GPOS_ASSERT(IsA(pnodePartCl, SortClause));
-		SortClause *psortcl = (SortClause*) pnodePartCl;
+		GPOS_ASSERT(IsA(partition_clause, SortClause));
+		SortClause *sort_group_clause = (SortClause*) partition_clause;
 
 		// get the colid of the partition-by column
-		ULONG ulColId = CTranslatorUtils::UlColId((INT) psortcl->tleSortGroupRef, phmiulColColId);
+		ULONG colid = CTranslatorUtils::GetColId((INT) sort_group_clause->tleSortGroupRef, col_attno_colid_mapping);
 
-		pdrgpul->Append(GPOS_NEW(m_pmp) ULONG(ulColId));
+		part_cols->Append(GPOS_NEW(m_mp) ULONG(colid));
 	}
 
-	return pdrgpul;
+	return part_cols;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdrgpdxlnSortCol
+//		CTranslatorQueryToDXL::TranslateSortColumnsToDXL
 //
 //	@doc:
 //		Translate the list of sorting columns
 //
 //---------------------------------------------------------------------------
-DrgPdxln *
-CTranslatorQueryToDXL::PdrgpdxlnSortCol
+CDXLNodeArray *
+CTranslatorQueryToDXL::TranslateSortColumnsToDXL
 	(
-	List *plSortCl,
-	HMIUl *phmiulColColId
+	List *sort_clause,
+	IntToUlongMap *col_attno_colid_mapping
 	)
 	const
 {
-	DrgPdxln *pdrgpdxln = GPOS_NEW(m_pmp) DrgPdxln(m_pmp);
+	CDXLNodeArray *dxlnodes = GPOS_NEW(m_mp) CDXLNodeArray(m_mp);
 
-	ListCell *plcSortCl = NULL;
-	ForEach (plcSortCl, plSortCl)
+	ListCell *lc = NULL;
+	ForEach (lc, sort_clause)
 	{
-		Node *pnodeSortCl = (Node*) lfirst(plcSortCl);
-		GPOS_ASSERT(NULL != pnodeSortCl);
+		Node *node_sort_clause = (Node*) lfirst(lc);
+		GPOS_ASSERT(NULL != node_sort_clause);
 
-		GPOS_ASSERT(IsA(pnodeSortCl, SortClause));
+		GPOS_ASSERT(IsA(node_sort_clause, SortClause));
 
-		SortClause *psortcl = (SortClause*) pnodeSortCl;
+		SortClause *sort_group_clause = (SortClause *) node_sort_clause;
 
 		// get the colid of the sorting column
-		const ULONG ulColId = CTranslatorUtils::UlColId((INT) psortcl->tleSortGroupRef, phmiulColColId);
+		const ULONG colid = CTranslatorUtils::GetColId((INT) sort_group_clause->tleSortGroupRef, col_attno_colid_mapping);
 
-		OID oid = psortcl->sortop;
+		OID oid = sort_group_clause->sortop;
 
 		// get operator name
-		CMDIdGPDB *pmdidScOp = GPOS_NEW(m_pmp) CMDIdGPDB(oid);
-		const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pmdidScOp);
+		CMDIdGPDB *op_mdid = GPOS_NEW(m_mp) CMDIdGPDB(oid);
+		const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(op_mdid);
 
-		const CWStringConst *pstr = pmdscop->Mdname().Pstr();
-		GPOS_ASSERT(NULL != pstr);
+		const CWStringConst *str = md_scalar_op->Mdname().GetMDName();
+		GPOS_ASSERT(NULL != str);
 
-		CDXLScalarSortCol *pdxlop = GPOS_NEW(m_pmp) CDXLScalarSortCol
+		CDXLScalarSortCol *sc_sort_col_dxlop = GPOS_NEW(m_mp) CDXLScalarSortCol
 												(
-												m_pmp,
-												ulColId,
-												pmdidScOp,
-												GPOS_NEW(m_pmp) CWStringConst(pstr->Wsz()),
-												psortcl->nulls_first
+												m_mp,
+												colid,
+												op_mdid,
+												GPOS_NEW(m_mp) CWStringConst(str->GetBuffer()),
+												sort_group_clause->nulls_first
 												);
 
 		// create the DXL node holding the sorting col
-		CDXLNode *pdxlnSortCol = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+		CDXLNode *sort_col_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, sc_sort_col_dxlop);
 
-		pdrgpdxln->Append(pdxlnSortCol);
+		dxlnodes->Append(sort_col_dxlnode);
 	}
 
-	return pdrgpdxln;
+	return dxlnodes;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnLgLimit
+//		CTranslatorQueryToDXL::TranslateLimitToDXLGroupBy
 //
 //	@doc:
 //		Translate the list of sorting columns, limit offset and limit count
@@ -1808,69 +1807,69 @@ CTranslatorQueryToDXL::PdrgpdxlnSortCol
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnLgLimit
+CTranslatorQueryToDXL::TranslateLimitToDXLGroupBy
 	(
-	List *plSortCl,
-	Node *pnodeLimitCount,
-	Node *pnodeLimitOffset,
-	CDXLNode *pdxlnChild,
-	HMIUl *phmiulGrpColsColId
+	List *sort_clause,
+	Node *limit_count,
+	Node *limit_offset_node,
+	CDXLNode *child_dxlnode,
+	IntToUlongMap *grpcols_to_colid_mapping
 	)
 {
-	if (0 == gpdb::UlListLength(plSortCl) && NULL == pnodeLimitCount && NULL == pnodeLimitOffset)
+	if (0 == gpdb::ListLength(sort_clause) && NULL == limit_count && NULL == limit_offset_node)
 	{
-		return pdxlnChild;
+		return child_dxlnode;
 	}
 
 	// do not remove limit if it is immediately under a DML (JIRA: GPSQL-2669)
 	// otherwise we may increase the storage size because there are less opportunities for compression
-	BOOL fTopLevelLimit = (m_fTopDMLQuery && 1 == m_ulQueryLevel) || (m_fCTASQuery && 0 == m_ulQueryLevel);
-	CDXLNode *pdxlnLimit =
-			GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalLimit(m_pmp, fTopLevelLimit));
+	BOOL is_limit_top_level = (m_is_top_query_dml && 1 == m_query_level) || (m_is_ctas_query && 0 == m_query_level);
+	CDXLNode *limit_dxlnode =
+			GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalLimit(m_mp, is_limit_top_level));
 
 	// create a sorting col list
-	CDXLNode *pdxlnSortColList = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarSortColList(m_pmp));
+	CDXLNode *sort_col_list_dxl = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarSortColList(m_mp));
 
-	DrgPdxln *pdrgpdxlnSortCol = PdrgpdxlnSortCol(plSortCl, phmiulGrpColsColId);
-	const ULONG ulSize = pdrgpdxlnSortCol->UlLength();
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	CDXLNodeArray *dxl_sort_cols = TranslateSortColumnsToDXL(sort_clause, grpcols_to_colid_mapping);
+	const ULONG size = dxl_sort_cols->Size();
+	for (ULONG ul = 0; ul < size; ul++)
 	{
-		CDXLNode *pdxlnSortCol = (*pdrgpdxlnSortCol)[ul];
-		pdxlnSortCol->AddRef();
-		pdxlnSortColList->AddChild(pdxlnSortCol);
+		CDXLNode *sort_col_dxlnode = (*dxl_sort_cols)[ul];
+		sort_col_dxlnode->AddRef();
+		sort_col_list_dxl->AddChild(sort_col_dxlnode);
 	}
-	pdrgpdxlnSortCol->Release();
+	dxl_sort_cols->Release();
 
 	// create limit count
-	CDXLNode *pdxlnLimitCount = GPOS_NEW(m_pmp) CDXLNode
+	CDXLNode *limit_count_dxlnode = GPOS_NEW(m_mp) CDXLNode
 										(
-										m_pmp,
-										GPOS_NEW(m_pmp) CDXLScalarLimitCount(m_pmp)
+										m_mp,
+										GPOS_NEW(m_mp) CDXLScalarLimitCount(m_mp)
 										);
 
-	if (NULL != pnodeLimitCount)
+	if (NULL != limit_count)
 	{
-		pdxlnLimitCount->AddChild(PdxlnScFromGPDBExpr((Expr*) pnodeLimitCount));
+		limit_count_dxlnode->AddChild(TranslateExprToDXL((Expr*) limit_count));
 	}
 
 	// create limit offset
-	CDXLNode *pdxlnLimitOffset = GPOS_NEW(m_pmp) CDXLNode
+	CDXLNode *limit_offset_dxlnode = GPOS_NEW(m_mp) CDXLNode
 										(
-										m_pmp,
-										GPOS_NEW(m_pmp) CDXLScalarLimitOffset(m_pmp)
+										m_mp,
+										GPOS_NEW(m_mp) CDXLScalarLimitOffset(m_mp)
 										);
 
-	if (NULL != pnodeLimitOffset)
+	if (NULL != limit_offset_node)
 	{
-		pdxlnLimitOffset->AddChild(PdxlnScFromGPDBExpr((Expr*) pnodeLimitOffset));
+		limit_offset_dxlnode->AddChild(TranslateExprToDXL((Expr*) limit_offset_node));
 	}
 
-	pdxlnLimit->AddChild(pdxlnSortColList);
-	pdxlnLimit->AddChild(pdxlnLimitCount);
-	pdxlnLimit->AddChild(pdxlnLimitOffset);
-	pdxlnLimit->AddChild(pdxlnChild);
+	limit_dxlnode->AddChild(sort_col_list_dxl);
+	limit_dxlnode->AddChild(limit_count_dxlnode);
+	limit_dxlnode->AddChild(limit_offset_dxlnode);
+	limit_dxlnode->AddChild(child_dxlnode);
 
-	return pdxlnLimit;
+	return limit_dxlnode;
 }
 
 //---------------------------------------------------------------------------
@@ -1884,64 +1883,64 @@ CTranslatorQueryToDXL::PdxlnLgLimit
 void
 CTranslatorQueryToDXL::AddSortingGroupingColumn
 	(
-	TargetEntry *pte,
-	HMIUl *phmiulSortgrouprefColId,
-	ULONG ulColId
+	TargetEntry *target_entry,
+	IntToUlongMap *sort_grpref_to_colid_mapping,
+	ULONG colid
 	)
 	const
 {
-	if (0 < pte->ressortgroupref)
+	if (0 < target_entry->ressortgroupref)
 	{
-		INT *piKey = GPOS_NEW(m_pmp) INT(pte->ressortgroupref);
-		ULONG *pulValue = GPOS_NEW(m_pmp) ULONG(ulColId);
+		INT *key = GPOS_NEW(m_mp) INT(target_entry->ressortgroupref);
+		ULONG *value = GPOS_NEW(m_mp) ULONG(colid);
 
 		// insert idx-colid mapping in the hash map
 #ifdef GPOS_DEBUG
-		BOOL fRes =
+		BOOL is_res =
 #endif // GPOS_DEBUG
-				phmiulSortgrouprefColId->FInsert(piKey, pulValue);
+				sort_grpref_to_colid_mapping->Insert(key, value);
 
-		GPOS_ASSERT(fRes);
+		GPOS_ASSERT(is_res);
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnSimpleGroupBy
+//		CTranslatorQueryToDXL::CreateSimpleGroupBy
 //
 //	@doc:
 //		Translate a query with grouping clause into a CDXLLogicalGroupBy node
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnSimpleGroupBy
+CTranslatorQueryToDXL::CreateSimpleGroupBy
 	(
-	List *plTargetList,
-	List *plGroupClause,
-	CBitSet *pbsGroupByCols,
-	BOOL fHasAggs,
-	BOOL fGroupingSets,
-	CDXLNode *pdxlnChild,
-	HMIUl *phmiulSortgrouprefColId,
-	HMIUl *phmiulChild,
-	HMIUl *phmiulOutputCols
+	List *target_list,
+	List *group_clause,
+	CBitSet *grpby_cols_bitset,
+	BOOL has_aggs,
+	BOOL has_grouping_sets,
+	CDXLNode *child_dxlnode,
+	IntToUlongMap *sort_grpref_to_colid_mapping,
+	IntToUlongMap *child_attno_colid_mapping,
+	IntToUlongMap *output_attno_to_colid_mapping
 	)
 {
-	if (NULL == pbsGroupByCols)
+	if (NULL == grpby_cols_bitset)
 	{ 
-		GPOS_ASSERT(!fHasAggs);
-		if (!fGroupingSets)
+		GPOS_ASSERT(!has_aggs);
+		if (!has_grouping_sets)
 		{
 			// no group by needed and not part of a grouping sets query: 
 			// propagate child columns to output columns
-			HMIUlIter mi(phmiulChild);
-			while (mi.FAdvance())
+			IntUlongHashmapIter mi(child_attno_colid_mapping);
+			while (mi.Advance())
 			{
 	#ifdef GPOS_DEBUG
-				BOOL fResult =
+				BOOL result =
 	#endif // GPOS_DEBUG
-				phmiulOutputCols->FInsert(GPOS_NEW(m_pmp) INT(*(mi.Pk())), GPOS_NEW(m_pmp) ULONG(*(mi.Pt())));
-				GPOS_ASSERT(fResult);
+				output_attno_to_colid_mapping->Insert(GPOS_NEW(m_mp) INT(*(mi.Key())), GPOS_NEW(m_mp) ULONG(*(mi.Value())));
+				GPOS_ASSERT(result);
 			}
 		}
 		// else:
@@ -1949,110 +1948,110 @@ CTranslatorQueryToDXL::PdxlnSimpleGroupBy
 		// in that case do not propagate the child columns to the output hash map, as later
 		// processing may introduce NULLs for those
 
-		return pdxlnChild;
+		return child_dxlnode;
 	}
 
-	List *plDQA = NIL;
+	List *dqa_list = NIL;
 	// construct the project list of the group-by operator
-	CDXLNode *pdxlnPrLGrpBy = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
+	CDXLNode *project_list_grpby_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
-	ListCell *plcTE = NULL;
-	ULONG ulDQAs = 0;
-	ForEach (plcTE, plTargetList)
+	ListCell *lc = NULL;
+	ULONG num_dqa = 0;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
-		GPOS_ASSERT(0 < pte->resno);
-		ULONG ulResNo = pte->resno;
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
+		GPOS_ASSERT(0 < target_entry->resno);
+		ULONG resno = target_entry->resno;
 
-		TargetEntry *pteEquivalent = CTranslatorUtils::PteGroupingColumn( (Node *) pte->expr, plGroupClause, plTargetList);
+		TargetEntry *te_equivalent = CTranslatorUtils::GetGroupingColumnTargetEntry( (Node *) target_entry->expr, group_clause, target_list);
 
-		BOOL fGroupingCol = pbsGroupByCols->FBit(pte->ressortgroupref) || (NULL != pteEquivalent && pbsGroupByCols->FBit(pteEquivalent->ressortgroupref));
-		ULONG ulColId = 0;
+		BOOL is_grouping_col = grpby_cols_bitset->Get(target_entry->ressortgroupref) || (NULL != te_equivalent && grpby_cols_bitset->Get(te_equivalent->ressortgroupref));
+		ULONG colid = 0;
 
-		if (fGroupingCol)
+		if (is_grouping_col)
 		{
 			// find colid for grouping column
-			ulColId = CTranslatorUtils::UlColId(ulResNo, phmiulChild);
+			colid = CTranslatorUtils::GetColId(resno, child_attno_colid_mapping);
 		}
-		else if (IsA(pte->expr, Aggref) || IsA(pte->expr, PercentileExpr))
+		else if (IsA(target_entry->expr, Aggref) || IsA(target_entry->expr, PercentileExpr))
 		{
-			if (IsA(pte->expr, Aggref) && ((Aggref *) pte->expr)->aggdistinct && !FDuplicateDqaArg(plDQA, (Aggref *) pte->expr))
+			if (IsA(target_entry->expr, Aggref) && ((Aggref *) target_entry->expr)->aggdistinct && !IsDuplicateDqaArg(dqa_list, (Aggref *) target_entry->expr))
 			{
-				plDQA = gpdb::PlAppendElement(plDQA, gpdb::PvCopyObject(pte->expr));
-				ulDQAs++;
+				dqa_list = gpdb::LAppend(dqa_list, gpdb::CopyObject(target_entry->expr));
+				num_dqa++;
 			}
 
 			// create a project element for aggregate
-			CDXLNode *pdxlnPrEl = PdxlnPrEFromGPDBExpr(pte->expr, pte->resname);
-			pdxlnPrLGrpBy->AddChild(pdxlnPrEl);
-			ulColId = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop())->UlId();
-			AddSortingGroupingColumn(pte, phmiulSortgrouprefColId, ulColId);
+			CDXLNode *project_elem_dxlnode = TranslateExprToDXLProject(target_entry->expr, target_entry->resname);
+			project_list_grpby_dxlnode->AddChild(project_elem_dxlnode);
+			colid = CDXLScalarProjElem::Cast(project_elem_dxlnode->GetOperator())->Id();
+			AddSortingGroupingColumn(target_entry, sort_grpref_to_colid_mapping, colid);
 		}
 
-		if (fGroupingCol || IsA(pte->expr, Aggref) || IsA(pte->expr, PercentileExpr))
+		if (is_grouping_col || IsA(target_entry->expr, Aggref) || IsA(target_entry->expr, PercentileExpr))
 		{
 			// add to the list of output columns
-			StoreAttnoColIdMapping(phmiulOutputCols, ulResNo, ulColId);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 		}
-		else if (0 == pbsGroupByCols->CElements() && !fGroupingSets && !fHasAggs)
+		else if (0 == grpby_cols_bitset->Size() && !has_grouping_sets && !has_aggs)
 		{
-			StoreAttnoColIdMapping(phmiulOutputCols, ulResNo, ulColId);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 		}
 	}
 
-	if (1 < ulDQAs && !optimizer_enable_multiple_distinct_aggs)
+	if (1 < num_dqa && !optimizer_enable_multiple_distinct_aggs)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Multiple Distinct Qualified Aggregates are disabled in the optimizer"));
 	}
 
 	// initialize the array of grouping columns
-	DrgPul *pdrgpul = CTranslatorUtils::PdrgpulGroupingCols(m_pmp, pbsGroupByCols, phmiulSortgrouprefColId);
+	ULongPtrArray *grouping_cols = CTranslatorUtils::GetGroupingColidArray(m_mp, grpby_cols_bitset, sort_grpref_to_colid_mapping);
 
 	// clean up
-	if (NIL != plDQA)
+	if (NIL != dqa_list)
 	{
-		gpdb::FreeList(plDQA);
+		gpdb::ListFree(dqa_list);
 	}
 
-	return GPOS_NEW(m_pmp) CDXLNode
+	return GPOS_NEW(m_mp) CDXLNode
 						(
-						m_pmp,
-						GPOS_NEW(m_pmp) CDXLLogicalGroupBy(m_pmp, pdrgpul),
-						pdxlnPrLGrpBy,
-						pdxlnChild
+						m_mp,
+						GPOS_NEW(m_mp) CDXLLogicalGroupBy(m_mp, grouping_cols),
+						project_list_grpby_dxlnode,
+						child_dxlnode
 						);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::FDuplicateDqaArg
+//		CTranslatorQueryToDXL::IsDuplicateDqaArg
 //
 //	@doc:
 //		Check if the argument of a DQA has already being used by another DQA
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorQueryToDXL::FDuplicateDqaArg
+CTranslatorQueryToDXL::IsDuplicateDqaArg
 	(
-	List *plDQA,
-	Aggref *paggref
+	List *dqa_list,
+	Aggref *aggref
 	)
 {
-	GPOS_ASSERT(NULL != paggref);
+	GPOS_ASSERT(NULL != aggref);
 
-	if (NIL == plDQA || 0 == gpdb::UlListLength(plDQA))
+	if (NIL == dqa_list || 0 == gpdb::ListLength(dqa_list))
 	{
 		return false;
 	}
 
-	ListCell *plc = NULL;
-	ForEach (plc, plDQA)
+	ListCell *lc = NULL;
+	ForEach (lc, dqa_list)
 	{
-		Node *pnode = (Node *) lfirst(plc);
-		GPOS_ASSERT(IsA(pnode, Aggref));
+		Node *node = (Node *) lfirst(lc);
+		GPOS_ASSERT(IsA(node, Aggref));
 
-		if (gpdb::FEqual(paggref->args, ((Aggref *) pnode)->args))
+		if (gpdb::Equals(aggref->args, ((Aggref *) node)->args))
 		{
 			return true;
 		}
@@ -2063,445 +2062,445 @@ CTranslatorQueryToDXL::FDuplicateDqaArg
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnGroupingSets
+//		CTranslatorQueryToDXL::TranslateGroupingSets
 //
 //	@doc:
 //		Translate a query with grouping sets
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnGroupingSets
+CTranslatorQueryToDXL::TranslateGroupingSets
 	(
-	FromExpr *pfromexpr,
-	List *plTargetList,
-	List *plGroupClause,
-	BOOL fHasAggs,
-	HMIUl *phmiulSortgrouprefColId,
-	HMIUl *phmiulOutputCols
+	FromExpr *from_expr,
+	List *target_list,
+	List *group_clause,
+	BOOL has_aggs,
+	IntToUlongMap *sort_grpref_to_colid_mapping,
+	IntToUlongMap *output_attno_to_colid_mapping
 	)
 {
-	const ULONG ulCols = gpdb::UlListLength(plTargetList) + 1;
+	const ULONG num_of_cols = gpdb::ListLength(target_list) + 1;
 
-	if (NULL == plGroupClause)
+	if (NULL == group_clause)
 	{
-		HMIUl *phmiulChild = GPOS_NEW(m_pmp) HMIUl(m_pmp);
+		IntToUlongMap *child_attno_colid_mapping = GPOS_NEW(m_mp) IntToUlongMap(m_mp);
 
-		CDXLNode *pdxlnSPJ = PdxlnSPJ(plTargetList, pfromexpr, phmiulSortgrouprefColId, phmiulChild, plGroupClause);
+		CDXLNode *select_project_join_dxlnode = TranslateSelectProjectJoinToDXL(target_list, from_expr, sort_grpref_to_colid_mapping, child_attno_colid_mapping, group_clause);
 
-		CBitSet *pbs = NULL;
-		if (fHasAggs)
+		CBitSet *bitset = NULL;
+		if (has_aggs)
 		{ 
-			pbs = GPOS_NEW(m_pmp) CBitSet(m_pmp);
+			bitset = GPOS_NEW(m_mp) CBitSet(m_mp);
 		}
 		
 		// in case of aggregates, construct a group by operator
-		CDXLNode *pdxlnResult = PdxlnSimpleGroupBy
+		CDXLNode *result_dxlnode = CreateSimpleGroupBy
 								(
-								plTargetList,
-								plGroupClause,
-								pbs,
-								fHasAggs,
-								false, // fGroupingSets
-								pdxlnSPJ,
-								phmiulSortgrouprefColId,
-								phmiulChild,
-								phmiulOutputCols
+								target_list,
+								group_clause,
+								bitset,
+								has_aggs,
+								false, // has_grouping_sets
+								select_project_join_dxlnode,
+								sort_grpref_to_colid_mapping,
+								child_attno_colid_mapping,
+								output_attno_to_colid_mapping
 								);
 
 		// cleanup
-		phmiulChild->Release();
-		CRefCount::SafeRelease(pbs);
-		return pdxlnResult;
+		child_attno_colid_mapping->Release();
+		CRefCount::SafeRelease(bitset);
+		return result_dxlnode;
 	}
 
 	// grouping functions refer to grouping col positions, so construct a map pos->grouping column
 	// while processing the grouping clause
-	HMUlUl *phmululGrpColPos = GPOS_NEW(m_pmp) HMUlUl(m_pmp);
-	CBitSet *pbsUniqueueGrpCols = GPOS_NEW(m_pmp) CBitSet(m_pmp, ulCols);
-	DrgPbs *pdrgpbs = CTranslatorUtils::PdrgpbsGroupBy(m_pmp, plGroupClause, ulCols, phmululGrpColPos, pbsUniqueueGrpCols);
+	UlongToUlongMap *grpcol_index_to_colid_mapping = GPOS_NEW(m_mp) UlongToUlongMap(m_mp);
+	CBitSet *unique_grp_cols_bitset = GPOS_NEW(m_mp) CBitSet(m_mp, num_of_cols);
+	CBitSetArray *bitset_array = CTranslatorUtils::GetColumnAttnosForGroupBy(m_mp, group_clause, num_of_cols, grpcol_index_to_colid_mapping, unique_grp_cols_bitset);
 
-	const ULONG ulGroupingSets = pdrgpbs->UlLength();
+	const ULONG num_of_grouping_sets = bitset_array->Size();
 
-	if (1 == ulGroupingSets)
+	if (1 == num_of_grouping_sets)
 	{
 		// simple group by
-		HMIUl *phmiulChild = GPOS_NEW(m_pmp) HMIUl(m_pmp);
-		CDXLNode *pdxlnSPJ = PdxlnSPJ(plTargetList, pfromexpr, phmiulSortgrouprefColId, phmiulChild, plGroupClause);
+		IntToUlongMap *child_attno_colid_mapping = GPOS_NEW(m_mp) IntToUlongMap(m_mp);
+		CDXLNode *select_project_join_dxlnode = TranslateSelectProjectJoinToDXL(target_list, from_expr, sort_grpref_to_colid_mapping, child_attno_colid_mapping, group_clause);
 
 		// translate the groupby clauses into a logical group by operator
-		CBitSet *pbs = (*pdrgpbs)[0];
+		CBitSet *bitset = (*bitset_array)[0];
 
 
-		CDXLNode *pdxlnGroupBy = PdxlnSimpleGroupBy
+		CDXLNode *groupby_dxlnode = CreateSimpleGroupBy
 								(
-								plTargetList,
-								plGroupClause,
-								pbs,
-								fHasAggs,
-								false, // fGroupingSets
-								pdxlnSPJ,
-								phmiulSortgrouprefColId,
-								phmiulChild,
-								phmiulOutputCols
+								target_list,
+								group_clause,
+								bitset,
+								has_aggs,
+								false, // has_grouping_sets
+								select_project_join_dxlnode,
+								sort_grpref_to_colid_mapping,
+								child_attno_colid_mapping,
+								output_attno_to_colid_mapping
 								);
 		
-		CDXLNode *pdxlnResult = PdxlnProjectGroupingFuncs
+		CDXLNode *result_dxlnode = CreateDXLProjectGroupingFuncs
 									(
-									plTargetList,
-									pdxlnGroupBy,
-									pbs,
-									phmiulOutputCols,
-									phmululGrpColPos,
-									phmiulSortgrouprefColId
+									target_list,
+									groupby_dxlnode,
+									bitset,
+									output_attno_to_colid_mapping,
+									grpcol_index_to_colid_mapping,
+									sort_grpref_to_colid_mapping
 									);
 
-		phmiulChild->Release();
-		pdrgpbs->Release();
-		pbsUniqueueGrpCols->Release();
-		phmululGrpColPos->Release();
+		child_attno_colid_mapping->Release();
+		bitset_array->Release();
+		unique_grp_cols_bitset->Release();
+		grpcol_index_to_colid_mapping->Release();
 		
-		return pdxlnResult;
+		return result_dxlnode;
 	}
 	
-	CDXLNode *pdxlnResult = PdxlnUnionAllForGroupingSets
+	CDXLNode *result_dxlnode = CreateDXLUnionAllForGroupingSets
 			(
-			pfromexpr,
-			plTargetList,
-			plGroupClause,
-			fHasAggs,
-			pdrgpbs,
-			phmiulSortgrouprefColId,
-			phmiulOutputCols,
-			phmululGrpColPos
+			from_expr,
+			target_list,
+			group_clause,
+			has_aggs,
+			bitset_array,
+			sort_grpref_to_colid_mapping,
+			output_attno_to_colid_mapping,
+			grpcol_index_to_colid_mapping
 			);
 
-	pbsUniqueueGrpCols->Release();
-	phmululGrpColPos->Release();
+	unique_grp_cols_bitset->Release();
+	grpcol_index_to_colid_mapping->Release();
 	
-	return pdxlnResult;
+	return result_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnUnionAllForGroupingSets
+//		CTranslatorQueryToDXL::CreateDXLUnionAllForGroupingSets
 //
 //	@doc:
 //		Construct a union all for the given grouping sets
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnUnionAllForGroupingSets
+CTranslatorQueryToDXL::CreateDXLUnionAllForGroupingSets
 	(
-	FromExpr *pfromexpr,
-	List *plTargetList,
-	List *plGroupClause,
-	BOOL fHasAggs,
-	DrgPbs *pdrgpbs,
-	HMIUl *phmiulSortgrouprefColId,
-	HMIUl *phmiulOutputCols,
-	HMUlUl *phmululGrpColPos		// mapping pos->unique grouping columns for grouping func arguments
+	FromExpr *from_expr,
+	List *target_list,
+	List *group_clause,
+	BOOL has_aggs,
+	CBitSetArray *bitset_array,
+	IntToUlongMap *sort_grpref_to_colid_mapping,
+	IntToUlongMap *output_attno_to_colid_mapping,
+	UlongToUlongMap *grpcol_index_to_colid_mapping		// mapping pos->unique grouping columns for grouping func arguments
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpbs);
-	GPOS_ASSERT(1 < pdrgpbs->UlLength());
+	GPOS_ASSERT(NULL != bitset_array);
+	GPOS_ASSERT(1 < bitset_array->Size());
 
-	const ULONG ulGroupingSets = pdrgpbs->UlLength();
-	CDXLNode *pdxlnUnionAll = NULL;
-	DrgPul *pdrgpulColIdsInner = NULL;
+	const ULONG num_of_grouping_sets = bitset_array->Size();
+	CDXLNode *unionall_dxlnode = NULL;
+	ULongPtrArray *colid_array_inner = NULL;
 
-	const ULONG ulCTEId = m_pidgtorCTE->UlNextId();
+	const ULONG cte_id = m_cte_id_counter->next_id();
 	
 	// construct a CTE producer on top of the SPJ query
-	HMIUl *phmiulSPJ = GPOS_NEW(m_pmp) HMIUl(m_pmp);
-	HMIUl *phmiulSortgrouprefColIdProducer = GPOS_NEW(m_pmp) HMIUl(m_pmp);
-	CDXLNode *pdxlnSPJ = PdxlnSPJForGroupingSets(plTargetList, pfromexpr, phmiulSortgrouprefColIdProducer, phmiulSPJ, plGroupClause);
+	IntToUlongMap *spj_output_attno_to_colid_mapping = GPOS_NEW(m_mp) IntToUlongMap(m_mp);
+	IntToUlongMap *sort_groupref_to_colid_producer_mapping = GPOS_NEW(m_mp) IntToUlongMap(m_mp);
+	CDXLNode *select_project_join_dxlnode = TranslateSelectProjectJoinForGrpSetsToDXL(target_list, from_expr, sort_groupref_to_colid_producer_mapping, spj_output_attno_to_colid_mapping, group_clause);
 
 	// construct output colids
-	DrgPul *pdrgpulCTEProducer = PdrgpulExtractColIds(m_pmp, phmiulSPJ);
+	ULongPtrArray *op_colid_array_cte_producer = ExtractColIds(m_mp, spj_output_attno_to_colid_mapping);
 
-	GPOS_ASSERT (NULL != m_pdrgpdxlnCTE);
+	GPOS_ASSERT (NULL != m_dxl_cte_producers);
 	
-	CDXLLogicalCTEProducer *pdxlopCTEProducer = GPOS_NEW(m_pmp) CDXLLogicalCTEProducer(m_pmp, ulCTEId, pdrgpulCTEProducer);
-	CDXLNode *pdxlnCTEProducer = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopCTEProducer, pdxlnSPJ);
-	m_pdrgpdxlnCTE->Append(pdxlnCTEProducer);
+	CDXLLogicalCTEProducer *cte_prod_dxlop = GPOS_NEW(m_mp) CDXLLogicalCTEProducer(m_mp, cte_id, op_colid_array_cte_producer);
+	CDXLNode *cte_producer_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, cte_prod_dxlop, select_project_join_dxlnode);
+	m_dxl_cte_producers->Append(cte_producer_dxlnode);
 	
-	CMappingVarColId *pmapvarcolidOriginal = m_pmapvarcolid->PmapvarcolidCopy(m_pmp);
+	CMappingVarColId *var_colid_orig_mapping = m_var_to_colid_map->CopyMapColId(m_mp);
 	
-	for (ULONG ul = 0; ul < ulGroupingSets; ul++)
+	for (ULONG ul = 0; ul < num_of_grouping_sets; ul++)
 	{
-		CBitSet *pbsGroupingSet = (*pdrgpbs)[ul];
+		CBitSet *grouping_set_bitset = (*bitset_array)[ul];
 
 		// remap columns
-		DrgPul *pdrgpulCTEConsumer = PdrgpulGenerateColIds(m_pmp, pdrgpulCTEProducer->UlLength());
+		ULongPtrArray *colid_array_cte_consumer = GenerateColIds(m_mp, op_colid_array_cte_producer->Size());
 		
 		// reset col mapping with new consumer columns
-		GPOS_DELETE(m_pmapvarcolid);
-		m_pmapvarcolid = pmapvarcolidOriginal->PmapvarcolidRemap(m_pmp, pdrgpulCTEProducer, pdrgpulCTEConsumer);
+		GPOS_DELETE(m_var_to_colid_map);
+		m_var_to_colid_map = var_colid_orig_mapping->CopyRemapColId(m_mp, op_colid_array_cte_producer, colid_array_cte_consumer);
 		
-		HMIUl *phmiulSPJConsumer = PhmiulRemapColIds(m_pmp, phmiulSPJ, pdrgpulCTEProducer, pdrgpulCTEConsumer);
-		HMIUl *phmiulSortgrouprefColIdConsumer = PhmiulRemapColIds(m_pmp, phmiulSortgrouprefColIdProducer, pdrgpulCTEProducer, pdrgpulCTEConsumer);
+		IntToUlongMap *spj_consumer_output_attno_to_colid_mapping = RemapColIds(m_mp, spj_output_attno_to_colid_mapping, op_colid_array_cte_producer, colid_array_cte_consumer);
+		IntToUlongMap *phmiulSortgrouprefColIdConsumer = RemapColIds(m_mp, sort_groupref_to_colid_producer_mapping, op_colid_array_cte_producer, colid_array_cte_consumer);
 
 		// construct a CTE consumer
-		CDXLNode *pdxlnCTEConsumer = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalCTEConsumer(m_pmp, ulCTEId, pdrgpulCTEConsumer));
+		CDXLNode *cte_consumer_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalCTEConsumer(m_mp, cte_id, colid_array_cte_consumer));
 
-		HMIUl *phmiulGroupBy = GPOS_NEW(m_pmp) HMIUl(m_pmp);
-		CDXLNode *pdxlnGroupBy = PdxlnSimpleGroupBy
+		IntToUlongMap *groupby_attno_to_colid_mapping = GPOS_NEW(m_mp) IntToUlongMap(m_mp);
+		CDXLNode *groupby_dxlnode = CreateSimpleGroupBy
 					(
-					plTargetList,
-					plGroupClause,
-					pbsGroupingSet,
-					fHasAggs,
-					true, // fGroupingSets
-					pdxlnCTEConsumer,
+					target_list,
+					group_clause,
+					grouping_set_bitset,
+					has_aggs,
+					true, // has_grouping_sets
+					cte_consumer_dxlnode,
 					phmiulSortgrouprefColIdConsumer,
-					phmiulSPJConsumer,
-					phmiulGroupBy
+					spj_consumer_output_attno_to_colid_mapping,
+					groupby_attno_to_colid_mapping
 					);
 
 		// add a project list for the NULL values
-		CDXLNode *pdxlnProject = PdxlnProjectNullsForGroupingSets(plTargetList, pdxlnGroupBy, pbsGroupingSet, phmiulSortgrouprefColIdConsumer, phmiulGroupBy, phmululGrpColPos);
+		CDXLNode *project_dxlnode = CreateDXLProjectNullsForGroupingSets(target_list, groupby_dxlnode, grouping_set_bitset, phmiulSortgrouprefColIdConsumer, groupby_attno_to_colid_mapping, grpcol_index_to_colid_mapping);
 
-		DrgPul *pdrgpulColIdsOuter = CTranslatorUtils::PdrgpulColIds(m_pmp, plTargetList, phmiulGroupBy);
-		if (NULL != pdxlnUnionAll)
+		ULongPtrArray *colids_outer_array = CTranslatorUtils::GetOutputColIdsArray(m_mp, target_list, groupby_attno_to_colid_mapping);
+		if (NULL != unionall_dxlnode)
 		{
-			GPOS_ASSERT(NULL != pdrgpulColIdsInner);
-			DrgPdxlcd *pdrgpdxlcd = CTranslatorUtils::Pdrgpdxlcd(m_pmp, plTargetList, pdrgpulColIdsOuter, true /* fKeepResjunked */);
+			GPOS_ASSERT(NULL != colid_array_inner);
+			CDXLColDescrArray *dxl_col_descr_array = CTranslatorUtils::GetDXLColumnDescrArray(m_mp, target_list, colids_outer_array, true /* keep_res_junked */);
 
-			pdrgpulColIdsOuter->AddRef();
+			colids_outer_array->AddRef();
 
-			DrgPdrgPul *pdrgpdrgulInputColIds = GPOS_NEW(m_pmp) DrgPdrgPul(m_pmp);
-			pdrgpdrgulInputColIds->Append(pdrgpulColIdsOuter);
-			pdrgpdrgulInputColIds->Append(pdrgpulColIdsInner);
+			ULongPtr2dArray *input_colids = GPOS_NEW(m_mp) ULongPtr2dArray(m_mp);
+			input_colids->Append(colids_outer_array);
+			input_colids->Append(colid_array_inner);
 
-			CDXLLogicalSetOp *pdxlopSetop = GPOS_NEW(m_pmp) CDXLLogicalSetOp(m_pmp, EdxlsetopUnionAll, pdrgpdxlcd, pdrgpdrgulInputColIds, false);
-			pdxlnUnionAll = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopSetop, pdxlnProject, pdxlnUnionAll);
+			CDXLLogicalSetOp *dxl_setop = GPOS_NEW(m_mp) CDXLLogicalSetOp(m_mp, EdxlsetopUnionAll, dxl_col_descr_array, input_colids, false);
+			unionall_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_setop, project_dxlnode, unionall_dxlnode);
 		}
 		else
 		{
-			pdxlnUnionAll = pdxlnProject;
+			unionall_dxlnode = project_dxlnode;
 		}
 
-		pdrgpulColIdsInner = pdrgpulColIdsOuter;
+		colid_array_inner = colids_outer_array;
 		
-		if (ul == ulGroupingSets - 1)
+		if (ul == num_of_grouping_sets - 1)
 		{
 			// add the sortgroup columns to output map of the last column
-			ULONG ulTargetEntryPos = 0;
-			ListCell *plcTE = NULL;
-			ForEach (plcTE, plTargetList)
+			ULONG te_pos = 0;
+			ListCell *lc = NULL;
+			ForEach (lc, target_list)
 			{
-				TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
+				TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
 
-				INT iSortGrpRef = INT (pte->ressortgroupref);
-				if (0 < iSortGrpRef && NULL != phmiulSortgrouprefColIdConsumer->PtLookup(&iSortGrpRef))
+				INT sortgroupref = INT (target_entry->ressortgroupref);
+				if (0 < sortgroupref && NULL != phmiulSortgrouprefColIdConsumer->Find(&sortgroupref))
 				{
 					// add the mapping information for sorting columns
-					AddSortingGroupingColumn(pte, phmiulSortgrouprefColId, *(*pdrgpulColIdsInner)[ulTargetEntryPos]);
+					AddSortingGroupingColumn(target_entry, sort_grpref_to_colid_mapping, *(*colid_array_inner)[te_pos]);
 				}
 
-				ulTargetEntryPos++;
+				te_pos++;
 			}
 		}
 
 		// cleanup
-		phmiulGroupBy->Release();
-		phmiulSPJConsumer->Release();
+		groupby_attno_to_colid_mapping->Release();
+		spj_consumer_output_attno_to_colid_mapping->Release();
 		phmiulSortgrouprefColIdConsumer->Release();
 	}
 
 	// cleanup
-	phmiulSPJ->Release();
-	phmiulSortgrouprefColIdProducer->Release();
-	GPOS_DELETE(pmapvarcolidOriginal);
-	pdrgpulColIdsInner->Release();
+	spj_output_attno_to_colid_mapping->Release();
+	sort_groupref_to_colid_producer_mapping->Release();
+	GPOS_DELETE(var_colid_orig_mapping);
+	colid_array_inner->Release();
 
 	// compute output columns
-	CDXLLogicalSetOp *pdxlopUnion = CDXLLogicalSetOp::PdxlopConvert(pdxlnUnionAll->Pdxlop());
+	CDXLLogicalSetOp *union_dxlop = CDXLLogicalSetOp::Cast(unionall_dxlnode->GetOperator());
 
-	ListCell *plcTE = NULL;
-	ULONG ulOutputColIndex = 0;
-	ForEach (plcTE, plTargetList)
+	ListCell *lc = NULL;
+	ULONG output_col_idx = 0;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
-		GPOS_ASSERT(0 < pte->resno);
-		ULONG ulResNo = pte->resno;
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
+		GPOS_ASSERT(0 < target_entry->resno);
+		ULONG resno = target_entry->resno;
 
 		// note that all target list entries are kept in union all's output column
-		// this is achieved by the fKeepResjunked flag in CTranslatorUtils::Pdrgpdxlcd
-		const CDXLColDescr *pdxlcd = pdxlopUnion->Pdxlcd(ulOutputColIndex);
-		const ULONG ulColId = pdxlcd->UlID();
-		ulOutputColIndex++;
+		// this is achieved by the keep_res_junked flag in CTranslatorUtils::GetDXLColumnDescrArray
+		const CDXLColDescr *dxl_col_descr = union_dxlop->GetColumnDescrAt(output_col_idx);
+		const ULONG colid = dxl_col_descr->Id();
+		output_col_idx++;
 
-		if (!pte->resjunk)
+		if (!target_entry->resjunk)
 		{
 			// add non-resjunk columns to the hash map that maintains the output columns
-			StoreAttnoColIdMapping(phmiulOutputCols, ulResNo, ulColId);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 		}
 	}
 
 	// cleanup
-	pdrgpbs->Release();
+	bitset_array->Release();
 
 	// construct a CTE anchor operator on top of the union all
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalCTEAnchor(m_pmp, ulCTEId), pdxlnUnionAll);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalCTEAnchor(m_mp, cte_id), unionall_dxlnode);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnConstTableGet
+//		CTranslatorQueryToDXL::DXLDummyConstTableGet
 //
 //	@doc:
 //		Create a dummy constant table get (CTG) with a boolean true value
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnConstTableGet() const
+CTranslatorQueryToDXL::DXLDummyConstTableGet() const
 {
 
 	// construct the schema of the const table
-	DrgPdxlcd *pdrgpdxlcd = GPOS_NEW(m_pmp) DrgPdxlcd(m_pmp);
+	CDXLColDescrArray *dxl_col_descr_array = GPOS_NEW(m_mp) CDXLColDescrArray(m_mp);
 
-	const CMDTypeBoolGPDB *pmdtypeBool = dynamic_cast<const CMDTypeBoolGPDB *>(m_pmda->PtMDType<IMDTypeBool>(m_sysid));
-	const CMDIdGPDB *pmdid = CMDIdGPDB::PmdidConvert(pmdtypeBool->Pmdid());
+	const CMDTypeBoolGPDB *md_type_bool = dynamic_cast<const CMDTypeBoolGPDB *>(m_md_accessor->PtMDType<IMDTypeBool>(m_sysid));
+	const CMDIdGPDB *mdid = CMDIdGPDB::CastMdid(md_type_bool->MDId());
 
 	// empty column name
-	CWStringConst strUnnamedCol(GPOS_WSZ_LIT(""));
-	CMDName *pmdname = GPOS_NEW(m_pmp) CMDName(m_pmp, &strUnnamedCol);
-	CDXLColDescr *pdxlcd = GPOS_NEW(m_pmp) CDXLColDescr
+	CWStringConst str_unnamed_col(GPOS_WSZ_LIT(""));
+	CMDName *mdname = GPOS_NEW(m_mp) CMDName(m_mp, &str_unnamed_col);
+	CDXLColDescr *dxl_col_descr = GPOS_NEW(m_mp) CDXLColDescr
 										(
-										m_pmp,
-										pmdname,
-										m_pidgtorCol->UlNextId(),
-										1 /* iAttno */,
-										GPOS_NEW(m_pmp) CMDIdGPDB(pmdid->OidObjectId()),
-										IDefaultTypeModifier,
-										false /* fDropped */
+										m_mp,
+										mdname,
+										m_colid_counter->next_id(),
+										1 /* attno */,
+										GPOS_NEW(m_mp) CMDIdGPDB(mdid->Oid()),
+										default_type_modifier,
+										false /* is_dropped */
 										);
-	pdrgpdxlcd->Append(pdxlcd);
+	dxl_col_descr_array->Append(dxl_col_descr);
 
 	// create the array of datum arrays
-	DrgPdrgPdxldatum *pdrgpdrgpdxldatum = GPOS_NEW(m_pmp) DrgPdrgPdxldatum(m_pmp);
+	CDXLDatum2dArray *dispatch_identifier_datum_arrays = GPOS_NEW(m_mp) CDXLDatum2dArray(m_mp);
 	
 	// create a datum array
-	DrgPdxldatum *pdrgpdxldatum = GPOS_NEW(m_pmp) DrgPdxldatum(m_pmp);
+	CDXLDatumArray *dxl_datum_array = GPOS_NEW(m_mp) CDXLDatumArray(m_mp);
 
-	Const *pconst = (Const*) gpdb::PnodeMakeBoolConst(true /*value*/, false /*isnull*/);
-	CDXLDatum *pdxldatum = m_psctranslator->Pdxldatum(pconst);
-	gpdb::GPDBFree(pconst);
+	Const *const_expr = (Const*) gpdb::MakeBoolConst(true /*value*/, false /*isnull*/);
+	CDXLDatum *datum_dxl = m_scalar_translator->TranslateConstToDXL(const_expr);
+	gpdb::GPDBFree(const_expr);
 
-	pdrgpdxldatum->Append(pdxldatum);
-	pdrgpdrgpdxldatum->Append(pdrgpdxldatum);
+	dxl_datum_array->Append(datum_dxl);
+	dispatch_identifier_datum_arrays->Append(dxl_datum_array);
 
-	CDXLLogicalConstTable *pdxlop = GPOS_NEW(m_pmp) CDXLLogicalConstTable(m_pmp, pdrgpdxlcd, pdrgpdrgpdxldatum);
+	CDXLLogicalConstTable *dxlop = GPOS_NEW(m_mp) CDXLLogicalConstTable(m_mp, dxl_col_descr_array, dispatch_identifier_datum_arrays);
 
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromSetOp
+//		CTranslatorQueryToDXL::TranslateSetOpToDXL
 //
 //	@doc:
 //		Translate a set operation
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromSetOp
+CTranslatorQueryToDXL::TranslateSetOpToDXL
 	(
-	Node *pnodeSetOp,
-	List *plTargetList,
-	HMIUl *phmiulOutputCols
+	Node *setop_node,
+	List *target_list,
+	IntToUlongMap *output_attno_to_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pnodeSetOp, SetOperationStmt));
-	SetOperationStmt *psetopstmt = (SetOperationStmt*) pnodeSetOp;
+	GPOS_ASSERT(IsA(setop_node, SetOperationStmt));
+	SetOperationStmt *psetopstmt = (SetOperationStmt*) setop_node;
 	GPOS_ASSERT(SETOP_NONE != psetopstmt->op);
 
-	EdxlSetOpType edxlsetop = CTranslatorUtils::Edxlsetop(psetopstmt->op, psetopstmt->all);
+	EdxlSetOpType setop_type = CTranslatorUtils::GetSetOpType(psetopstmt->op, psetopstmt->all);
 
 	// translate the left and right child
-	DrgPul *pdrgpulLeft = GPOS_NEW(m_pmp) DrgPul(m_pmp);
-	DrgPul *pdrgpulRight = GPOS_NEW(m_pmp) DrgPul(m_pmp);
-	DrgPmdid *pdrgpmdidLeft = GPOS_NEW(m_pmp) DrgPmdid(m_pmp);
-	DrgPmdid *pdrgpmdidRight = GPOS_NEW(m_pmp) DrgPmdid(m_pmp);
+	ULongPtrArray *leftchild_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
+	ULongPtrArray *rightchild_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
+	IMdIdArray *mdid_array_leftchild = GPOS_NEW(m_mp) IMdIdArray(m_mp);
+	IMdIdArray *mdid_array_rightchild = GPOS_NEW(m_mp) IMdIdArray(m_mp);
 
-	CDXLNode *pdxlnLeftChild = PdxlnSetOpChild(psetopstmt->larg, pdrgpulLeft, pdrgpmdidLeft, plTargetList);
-	CDXLNode *pdxlnRightChild = PdxlnSetOpChild(psetopstmt->rarg, pdrgpulRight, pdrgpmdidRight, plTargetList);
+	CDXLNode *left_child_dxlnode = TranslateSetOpChild(psetopstmt->larg, leftchild_array, mdid_array_leftchild, target_list);
+	CDXLNode *right_child_dxlnode = TranslateSetOpChild(psetopstmt->rarg, rightchild_array, mdid_array_rightchild, target_list);
 
 	// mark outer references in input columns from left child
-	ULONG *pulColId = GPOS_NEW_ARRAY(m_pmp, ULONG, pdrgpulLeft->UlLength());
-	BOOL *pfOuterRef = GPOS_NEW_ARRAY(m_pmp, BOOL, pdrgpulLeft->UlLength());
-	const ULONG ulSize = pdrgpulLeft->UlLength();
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	ULONG *colid = GPOS_NEW_ARRAY(m_mp, ULONG, leftchild_array->Size());
+	BOOL *outer_ref_array = GPOS_NEW_ARRAY(m_mp, BOOL, leftchild_array->Size());
+	const ULONG size = leftchild_array->Size();
+	for (ULONG ul = 0; ul < size; ul++)
 	{
-		pulColId[ul] =  *(*pdrgpulLeft)[ul];
-		pfOuterRef[ul] = true;
+		colid[ul] =  *(*leftchild_array)[ul];
+		outer_ref_array[ul] = true;
 	}
-	CTranslatorUtils::MarkOuterRefs(pulColId, pfOuterRef, ulSize, pdxlnLeftChild);
+	CTranslatorUtils::MarkOuterRefs(colid, outer_ref_array, size, left_child_dxlnode);
 
-	DrgPdrgPul *pdrgpdrgulInputColIds = GPOS_NEW(m_pmp) DrgPdrgPul(m_pmp);
-	pdrgpdrgulInputColIds->Append(pdrgpulLeft);
-	pdrgpdrgulInputColIds->Append(pdrgpulRight);
+	ULongPtr2dArray *input_colids = GPOS_NEW(m_mp) ULongPtr2dArray(m_mp);
+	input_colids->Append(leftchild_array);
+	input_colids->Append(rightchild_array);
 	
-	DrgPul *pdrgpulOutput =  CTranslatorUtils::PdrgpulGenerateColIds
+	ULongPtrArray *output_colids =  CTranslatorUtils::GenerateColIds
 												(
-												m_pmp,
-												plTargetList,
-												pdrgpmdidLeft,
-												pdrgpulLeft,
-												pfOuterRef,
-												m_pidgtorCol
+												m_mp,
+												target_list,
+												mdid_array_leftchild,
+												leftchild_array,
+												outer_ref_array,
+												m_colid_counter
 												);
- 	GPOS_ASSERT(pdrgpulOutput->UlLength() == pdrgpulLeft->UlLength());
+ 	GPOS_ASSERT(output_colids->Size() == leftchild_array->Size());
 
- 	GPOS_DELETE_ARRAY(pulColId);
- 	GPOS_DELETE_ARRAY(pfOuterRef);
+ 	GPOS_DELETE_ARRAY(colid);
+ 	GPOS_DELETE_ARRAY(outer_ref_array);
 
-	BOOL fCastAcrossInput = FCast(plTargetList, pdrgpmdidLeft) || FCast(plTargetList, pdrgpmdidRight);
+	BOOL is_cast_across_input = SetOpNeedsCast(target_list, mdid_array_leftchild) || SetOpNeedsCast(target_list, mdid_array_rightchild);
 	
-	DrgPdxln *pdrgpdxlnChildren  = GPOS_NEW(m_pmp) DrgPdxln(m_pmp);
-	pdrgpdxlnChildren->Append(pdxlnLeftChild);
-	pdrgpdxlnChildren->Append(pdxlnRightChild);
+	CDXLNodeArray *children_dxlnodes  = GPOS_NEW(m_mp) CDXLNodeArray(m_mp);
+	children_dxlnodes->Append(left_child_dxlnode);
+	children_dxlnodes->Append(right_child_dxlnode);
 
-	CDXLNode *pdxln = PdxlnSetOp
+	CDXLNode *dxlnode = CreateDXLSetOpFromColumns
 						(
-						edxlsetop,
-						plTargetList,
-						pdrgpulOutput,
-						pdrgpdrgulInputColIds,
-						pdrgpdxlnChildren,
-						fCastAcrossInput,
-						false /* fKeepResjunked */
+						setop_type,
+						target_list,
+						output_colids,
+						input_colids,
+						children_dxlnodes,
+						is_cast_across_input,
+						false /* keep_res_junked */
 						);
 
-	CDXLLogicalSetOp *pdxlop = CDXLLogicalSetOp::PdxlopConvert(pdxln->Pdxlop());
-	const DrgPdxlcd *pdrgpdxlcd = pdxlop->Pdrgpdxlcd();
+	CDXLLogicalSetOp *dxlop = CDXLLogicalSetOp::Cast(dxlnode->GetOperator());
+	const CDXLColDescrArray *dxl_col_descr_array = dxlop->GetDXLColumnDescrArray();
 
-	ULONG ulOutputColIndex = 0;
-	ListCell *plcTE = NULL;
-	ForEach (plcTE, plTargetList)
+	ULONG output_col_idx = 0;
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
-		GPOS_ASSERT(0 < pte->resno);
-		ULONG ulResNo = pte->resno;
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
+		GPOS_ASSERT(0 < target_entry->resno);
+		ULONG resno = target_entry->resno;
 
-		if (!pte->resjunk)
+		if (!target_entry->resjunk)
 		{
-			const CDXLColDescr *pdxlcdNew = (*pdrgpdxlcd)[ulOutputColIndex];
-			ULONG ulColId = pdxlcdNew->UlID();
-			StoreAttnoColIdMapping(phmiulOutputCols, ulResNo, ulColId);
-			ulOutputColIndex++;
+			const CDXLColDescr *dxl_col_descr_new = (*dxl_col_descr_array)[output_col_idx];
+			ULONG colid = dxl_col_descr_new->Id();
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
+			output_col_idx++;
 		}
 	}
 
 	// clean up
-	pdrgpulOutput->Release();
-	pdrgpmdidLeft->Release();
-	pdrgpmdidRight->Release();
+	output_colids->Release();
+	mdid_array_leftchild->Release();
+	mdid_array_rightchild->Release();
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
@@ -2512,150 +2511,150 @@ CTranslatorQueryToDXL::PdxlnFromSetOp
 //		Create a set op after adding dummy cast on input columns where needed
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnSetOp
+CTranslatorQueryToDXL::CreateDXLSetOpFromColumns
 	(
-	EdxlSetOpType edxlsetop,
-	List *plTargetListOutput,
-	DrgPul *pdrgpulOutput,
-	DrgPdrgPul *pdrgpdrgulInputColIds,
-	DrgPdxln *pdrgpdxlnChildren,
-	BOOL fCastAcrossInput,
-	BOOL fKeepResjunked
+	EdxlSetOpType setop_type,
+	List *output_target_list,
+	ULongPtrArray *output_colids,
+	ULongPtr2dArray *input_colids,
+	CDXLNodeArray *children_dxlnodes,
+	BOOL is_cast_across_input,
+	BOOL keep_res_junked
 	)
 	const
 {
-	GPOS_ASSERT(NULL != plTargetListOutput);
-	GPOS_ASSERT(NULL != pdrgpulOutput);
-	GPOS_ASSERT(NULL != pdrgpdrgulInputColIds);
-	GPOS_ASSERT(NULL != pdrgpdxlnChildren);
-	GPOS_ASSERT(1 < pdrgpdrgulInputColIds->UlLength());
-	GPOS_ASSERT(1 < pdrgpdxlnChildren->UlLength());
+	GPOS_ASSERT(NULL != output_target_list);
+	GPOS_ASSERT(NULL != output_colids);
+	GPOS_ASSERT(NULL != input_colids);
+	GPOS_ASSERT(NULL != children_dxlnodes);
+	GPOS_ASSERT(1 < input_colids->Size());
+	GPOS_ASSERT(1 < children_dxlnodes->Size());
 
 	// positions of output columns in the target list
-	DrgPul *pdrgpulTLPos = CTranslatorUtils::PdrgpulPosInTargetList(m_pmp, plTargetListOutput, fKeepResjunked);
+	ULongPtrArray *output_col_pos = CTranslatorUtils::GetPosInTargetList(m_mp, output_target_list, keep_res_junked);
 
-	const ULONG ulCols = pdrgpulOutput->UlLength();
-	DrgPul *pdrgpulInputFirstChild = (*pdrgpdrgulInputColIds)[0];
-	GPOS_ASSERT(ulCols == pdrgpulInputFirstChild->UlLength());
-	GPOS_ASSERT(ulCols == pdrgpulOutput->UlLength());
+	const ULONG num_of_cols = output_colids->Size();
+	ULongPtrArray *input_first_child_array = (*input_colids)[0];
+	GPOS_ASSERT(num_of_cols == input_first_child_array->Size());
+	GPOS_ASSERT(num_of_cols == output_colids->Size());
 
-	CBitSet *pbs = GPOS_NEW(m_pmp) CBitSet(m_pmp);
+	CBitSet *bitset = GPOS_NEW(m_mp) CBitSet(m_mp);
 
 	// project list to maintain the casting of the duplicate input columns
-	CDXLNode *pdxlnNewChildScPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
+	CDXLNode *new_child_project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
-	DrgPul *pdrgpulInputFirstChildNew = GPOS_NEW(m_pmp) DrgPul (m_pmp);
-	DrgPdxlcd *pdrgpdxlcdOutput = GPOS_NEW(m_pmp) DrgPdxlcd(m_pmp);
-	for (ULONG ul = 0; ul < ulCols; ul++)
+	ULongPtrArray *input_first_child_new_array = GPOS_NEW(m_mp) ULongPtrArray (m_mp);
+	CDXLColDescrArray *output_col_descrs = GPOS_NEW(m_mp) CDXLColDescrArray(m_mp);
+	for (ULONG ul = 0; ul < num_of_cols; ul++)
 	{
-		ULONG ulColIdOutput = *(*pdrgpulOutput)[ul];
-		ULONG ulColIdInput = *(*pdrgpulInputFirstChild)[ul];
+		ULONG colid_output = *(*output_colids)[ul];
+		ULONG colid_input = *(*input_first_child_array)[ul];
 
-		BOOL fColExists = pbs->FBit(ulColIdInput);
-		BOOL fCastedCol = (ulColIdOutput != ulColIdInput);
+		BOOL is_col_exists = bitset->Get(colid_input);
+		BOOL is_casted_col = (colid_output != colid_input);
 
-		ULONG ulTLPos = *(*pdrgpulTLPos)[ul];
-		TargetEntry *pte = (TargetEntry*) gpdb::PvListNth(plTargetListOutput, ulTLPos);
-		GPOS_ASSERT(NULL != pte);
+		ULONG target_list_pos = *(*output_col_pos)[ul];
+		TargetEntry *target_entry = (TargetEntry*) gpdb::ListNth(output_target_list, target_list_pos);
+		GPOS_ASSERT(NULL != target_entry);
 
-		CDXLColDescr *pdxlcdOutput = NULL;
-		if (!fColExists)
+		CDXLColDescr *output_col_descr = NULL;
+		if (!is_col_exists)
 		{
-			pbs->FExchangeSet(ulColIdInput);
-			pdrgpulInputFirstChildNew->Append(GPOS_NEW(m_pmp) ULONG(ulColIdInput));
+			bitset->ExchangeSet(colid_input);
+			input_first_child_new_array->Append(GPOS_NEW(m_mp) ULONG(colid_input));
 
-			pdxlcdOutput = CTranslatorUtils::Pdxlcd(m_pmp, pte, ulColIdOutput, ul + 1);
+			output_col_descr = CTranslatorUtils::GetColumnDescrAt(m_mp, target_entry, colid_output, ul + 1);
 		}
 		else
 		{
 			// we add a dummy-cast to distinguish between the output columns of the union
-			ULONG ulColIdNew = m_pidgtorCol->UlNextId();
-			pdrgpulInputFirstChildNew->Append(GPOS_NEW(m_pmp) ULONG(ulColIdNew));
+			ULONG colid_new = m_colid_counter->next_id();
+			input_first_child_new_array->Append(GPOS_NEW(m_mp) ULONG(colid_new));
 
-			ULONG ulColIdUnionOutput = ulColIdNew;
-			if (fCastedCol)
+			ULONG colid_union_output = colid_new;
+			if (is_casted_col)
 			{
 				// create new output column id since current colid denotes its duplicate
-				ulColIdUnionOutput = m_pidgtorCol->UlNextId();
+				colid_union_output = m_colid_counter->next_id();
 			}
 
-			pdxlcdOutput = CTranslatorUtils::Pdxlcd(m_pmp, pte, ulColIdUnionOutput, ul + 1);
-			CDXLNode *pdxlnPrEl = CTranslatorUtils::PdxlnDummyPrElem(m_pmp, ulColIdInput, ulColIdNew, pdxlcdOutput);
+			output_col_descr = CTranslatorUtils::GetColumnDescrAt(m_mp, target_entry, colid_union_output, ul + 1);
+			CDXLNode *project_elem_dxlnode = CTranslatorUtils::CreateDummyProjectElem(m_mp, colid_input, colid_new, output_col_descr);
 
-			pdxlnNewChildScPrL->AddChild(pdxlnPrEl);
+			new_child_project_list_dxlnode->AddChild(project_elem_dxlnode);
 		}
 
-		pdrgpdxlcdOutput->Append(pdxlcdOutput);
+		output_col_descrs->Append(output_col_descr);
 	}
 
-	pdrgpdrgulInputColIds->Replace(0, pdrgpulInputFirstChildNew);
+	input_colids->Replace(0, input_first_child_new_array);
 
-	if (0 < pdxlnNewChildScPrL->UlArity())
+	if (0 < new_child_project_list_dxlnode->Arity())
 	{
 		// create a project node for the dummy casted columns
-		CDXLNode *pdxlnFirstChild = (*pdrgpdxlnChildren)[0];
-		pdxlnFirstChild->AddRef();
-		CDXLNode *pdxlnNewChild = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalProject(m_pmp));
-		pdxlnNewChild->AddChild(pdxlnNewChildScPrL);
-		pdxlnNewChild->AddChild(pdxlnFirstChild);
+		CDXLNode *first_child_dxlnode = (*children_dxlnodes)[0];
+		first_child_dxlnode->AddRef();
+		CDXLNode *new_child_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalProject(m_mp));
+		new_child_dxlnode->AddChild(new_child_project_list_dxlnode);
+		new_child_dxlnode->AddChild(first_child_dxlnode);
 
-		pdrgpdxlnChildren->Replace(0, pdxlnNewChild);
+		children_dxlnodes->Replace(0, new_child_dxlnode);
 	}
 	else
 	{
-		pdxlnNewChildScPrL->Release();
+		new_child_project_list_dxlnode->Release();
 	}
 
-	CDXLLogicalSetOp *pdxlop = GPOS_NEW(m_pmp) CDXLLogicalSetOp
+	CDXLLogicalSetOp *dxlop = GPOS_NEW(m_mp) CDXLLogicalSetOp
 											(
-											m_pmp,
-											edxlsetop,
-											pdrgpdxlcdOutput,
-											pdrgpdrgulInputColIds,
-											fCastAcrossInput
+											m_mp,
+											setop_type,
+											output_col_descrs,
+											input_colids,
+											is_cast_across_input
 											);
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop, pdrgpdxlnChildren);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop, children_dxlnodes);
 
-	pbs->Release();
-	pdrgpulTLPos->Release();
+	bitset->Release();
+	output_col_pos->Release();
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::FCast
+//		CTranslatorQueryToDXL::SetOpNeedsCast
 //
 //	@doc:
 //		Check if the set operation need to cast any of its input columns
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorQueryToDXL::FCast
+CTranslatorQueryToDXL::SetOpNeedsCast
 	(
-	List *plTargetList,
-	DrgPmdid *pdrgpmdid
+	List *target_list,
+	IMdIdArray *input_col_mdids
 	)
 	const
 {
-	GPOS_ASSERT(NULL != pdrgpmdid);
-	GPOS_ASSERT(NULL != plTargetList);
-	GPOS_ASSERT(pdrgpmdid->UlLength() <= gpdb::UlListLength(plTargetList)); // there may be resjunked columns
+	GPOS_ASSERT(NULL != input_col_mdids);
+	GPOS_ASSERT(NULL != target_list);
+	GPOS_ASSERT(input_col_mdids->Size() <= gpdb::ListLength(target_list)); // there may be resjunked columns
 
-	ULONG ulColPos = 0;
-	ListCell *plcTE = NULL;
-	ForEach (plcTE, plTargetList)
+	ULONG col_pos_idx = 0;
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		OID oidExprType = gpdb::OidExprType((Node*) pte->expr);
-		if (!pte->resjunk)
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		OID expr_type_oid = gpdb::ExprType((Node*) target_entry->expr);
+		if (!target_entry->resjunk)
 		{
-			IMDId *pmdid = (*pdrgpmdid)[ulColPos];
-			if (CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId() != oidExprType)
+			IMDId *mdid = (*input_col_mdids)[col_pos_idx];
+			if (CMDIdGPDB::CastMdid(mdid)->Oid() != expr_type_oid)
 			{
 				return true;
 			}
-			ulColPos++;
+			col_pos_idx++;
 		}
 	}
 
@@ -2664,113 +2663,113 @@ CTranslatorQueryToDXL::FCast
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnSetOpChild
+//		CTranslatorQueryToDXL::TranslateSetOpChild
 //
 //	@doc:
 //		Translate the child of a set operation
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnSetOpChild
+CTranslatorQueryToDXL::TranslateSetOpChild
 	(
-	Node *pnodeChild,
-	DrgPul *pdrgpul,
-	DrgPmdid *pdrgpmdid,
-	List *plTargetList
+	Node *child_node,
+	ULongPtrArray *colids,
+	IMdIdArray *input_col_mdids,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpul);
-	GPOS_ASSERT(NULL != pdrgpmdid);
+	GPOS_ASSERT(NULL != colids);
+	GPOS_ASSERT(NULL != input_col_mdids);
 
-	if (IsA(pnodeChild, RangeTblRef))
+	if (IsA(child_node, RangeTblRef))
 	{
-		RangeTblRef *prtref = (RangeTblRef*) pnodeChild;
-		const ULONG ulRTIndex = prtref->rtindex;
-		const RangeTblEntry *prte = (RangeTblEntry *) gpdb::PvListNth(m_pquery->rtable, ulRTIndex - 1);
+		RangeTblRef *range_tbl_ref = (RangeTblRef*) child_node;
+		const ULONG rt_index = range_tbl_ref->rtindex;
+		const RangeTblEntry *rte = (RangeTblEntry *) gpdb::ListNth(m_query->rtable, rt_index - 1);
 
-		if (RTE_SUBQUERY == prte->rtekind)
+		if (RTE_SUBQUERY == rte->rtekind)
 		{
-			Query *pqueryDerTbl = CTranslatorUtils::PqueryFixUnknownTypeConstant(prte->subquery, plTargetList);
-			GPOS_ASSERT(NULL != pqueryDerTbl);
+			Query *query_derived_tbl = CTranslatorUtils::FixUnknownTypeConstant(rte->subquery, target_list);
+			GPOS_ASSERT(NULL != query_derived_tbl);
 
-			CMappingVarColId *pmapvarcolid = m_pmapvarcolid->PmapvarcolidCopy(m_pmp);
-			CTranslatorQueryToDXL trquerytodxl
+			CMappingVarColId *var_colid_mapping = m_var_to_colid_map->CopyMapColId(m_mp);
+			CTranslatorQueryToDXL query_to_dxl_translator
 					(
-					m_pmp,
-					m_pmda,
-					m_pidgtorCol,
-					m_pidgtorCTE,
-					pmapvarcolid,
-					pqueryDerTbl,
-					m_ulQueryLevel + 1,
-					FDMLQuery(),
-					m_phmulCTEEntries
+					m_mp,
+					m_md_accessor,
+					m_colid_counter,
+					m_cte_id_counter,
+					var_colid_mapping,
+					query_derived_tbl,
+					m_query_level + 1,
+					IsDMLQuery(),
+					m_query_level_to_cte_map
 					);
 
 			// translate query representing the derived table to its DXL representation
-			CDXLNode *pdxln = trquerytodxl.PdxlnFromQueryInternal();
-			GPOS_ASSERT(NULL != pdxln);
+			CDXLNode *query_dxlnode = query_to_dxl_translator.TranslateSelectQueryToDXL();
+			GPOS_ASSERT(NULL != query_dxlnode);
 
-			DrgPdxln *pdrgpdxlnCTE = trquerytodxl.PdrgpdxlnCTE();
-			CUtils::AddRefAppend(m_pdrgpdxlnCTE, pdrgpdxlnCTE);
-			m_fHasDistributedTables = m_fHasDistributedTables || trquerytodxl.FHasDistributedTables();
+			CDXLNodeArray *cte_dxlnode_array = query_to_dxl_translator.GetCTEs();
+			CUtils::AddRefAppend(m_dxl_cte_producers, cte_dxlnode_array);
+			m_has_distributed_tables = m_has_distributed_tables || query_to_dxl_translator.HasDistributedTables();
 
 			// get the output columns of the derived table
-			DrgPdxln *pdrgpdxln = trquerytodxl.PdrgpdxlnQueryOutput();
-			GPOS_ASSERT(pdrgpdxln != NULL);
-			const ULONG ulLen = pdrgpdxln->UlLength();
-			for (ULONG ul = 0; ul < ulLen; ul++)
+			CDXLNodeArray *dxlnodes = query_to_dxl_translator.GetQueryOutputCols();
+			GPOS_ASSERT(dxlnodes != NULL);
+			const ULONG length = dxlnodes->Size();
+			for (ULONG ul = 0; ul < length; ul++)
 			{
-				CDXLNode *pdxlnCurr = (*pdrgpdxln)[ul];
-				CDXLScalarIdent *pdxlnIdent = CDXLScalarIdent::PdxlopConvert(pdxlnCurr->Pdxlop());
-				ULONG *pulColId = GPOS_NEW(m_pmp) ULONG(pdxlnIdent->Pdxlcr()->UlID());
-				pdrgpul->Append(pulColId);
+				CDXLNode *current_dxlnode = (*dxlnodes)[ul];
+				CDXLScalarIdent *dxl_scalar_ident = CDXLScalarIdent::Cast(current_dxlnode->GetOperator());
+				ULONG *colid = GPOS_NEW(m_mp) ULONG(dxl_scalar_ident->GetDXLColRef()->Id());
+				colids->Append(colid);
 
-				IMDId *pmdidCol = pdxlnIdent->PmdidType();
-				GPOS_ASSERT(NULL != pmdidCol);
-				pmdidCol->AddRef();
-				pdrgpmdid->Append(pmdidCol);
+				IMDId *mdid_col = dxl_scalar_ident->MdidType();
+				GPOS_ASSERT(NULL != mdid_col);
+				mdid_col->AddRef();
+				input_col_mdids->Append(mdid_col);
 			}
 
-			return pdxln;
+			return query_dxlnode;
 		}
 	}
-	else if (IsA(pnodeChild, SetOperationStmt))
+	else if (IsA(child_node, SetOperationStmt))
 	{
-		HMIUl *phmiulOutputCols = GPOS_NEW(m_pmp) HMIUl(m_pmp);
-		CDXLNode *pdxln = PdxlnFromSetOp(pnodeChild, plTargetList, phmiulOutputCols);
+		IntToUlongMap *output_attno_to_colid_mapping = GPOS_NEW(m_mp) IntToUlongMap(m_mp);
+		CDXLNode *dxlnode = TranslateSetOpToDXL(child_node, target_list, output_attno_to_colid_mapping);
 
 		// cleanup
-		phmiulOutputCols->Release();
+		output_attno_to_colid_mapping->Release();
 
-		const DrgPdxlcd *pdrgpdxlcd = CDXLLogicalSetOp::PdxlopConvert(pdxln->Pdxlop())->Pdrgpdxlcd();
-		GPOS_ASSERT(NULL != pdrgpdxlcd);
-		const ULONG ulLen = pdrgpdxlcd->UlLength();
-		for (ULONG ul = 0; ul < ulLen; ul++)
+		const CDXLColDescrArray *dxl_col_descr_array = CDXLLogicalSetOp::Cast(dxlnode->GetOperator())->GetDXLColumnDescrArray();
+		GPOS_ASSERT(NULL != dxl_col_descr_array);
+		const ULONG length = dxl_col_descr_array->Size();
+		for (ULONG ul = 0; ul < length; ul++)
 		{
-			const CDXLColDescr *pdxlcd = (*pdrgpdxlcd)[ul];
-			ULONG *pulColId = GPOS_NEW(m_pmp) ULONG(pdxlcd->UlID());
-			pdrgpul->Append(pulColId);
+			const CDXLColDescr *dxl_col_descr = (*dxl_col_descr_array)[ul];
+			ULONG *colid = GPOS_NEW(m_mp) ULONG(dxl_col_descr->Id());
+			colids->Append(colid);
 
-			IMDId *pmdidCol = pdxlcd->PmdidType();
-			GPOS_ASSERT(NULL != pmdidCol);
-			pmdidCol->AddRef();
-			pdrgpmdid->Append(pmdidCol);
+			IMDId *mdid_col = dxl_col_descr->MdidType();
+			GPOS_ASSERT(NULL != mdid_col);
+			mdid_col->AddRef();
+			input_col_mdids->Append(mdid_col);
 		}
 
-		return pdxln;
+		return dxlnode;
 	}
 
-	CHAR *sz = (CHAR*) gpdb::SzNodeToString(const_cast<Node*>(pnodeChild));
-	CWStringDynamic *pstr = CDXLUtils::PstrFromSz(m_pmp, sz);
+	CHAR *temp_str = (CHAR*) gpdb::NodeToString(const_cast<Node*>(child_node));
+	CWStringDynamic *str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, temp_str);
 
-	GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, pstr->Wsz());
+	GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, str->GetBuffer());
 	return NULL;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromGPDBFromExpr
+//		CTranslatorQueryToDXL::TranslateFromExprToDXL
 //
 //	@doc:
 //		Translate the FromExpr on a GPDB query into either a CDXLLogicalJoin
@@ -2778,24 +2777,24 @@ CTranslatorQueryToDXL::PdxlnSetOpChild
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromGPDBFromExpr
+CTranslatorQueryToDXL::TranslateFromExprToDXL
 	(
-	FromExpr *pfromexpr
+	FromExpr *from_expr
 	)
 {
-	CDXLNode *pdxln = NULL;
+	CDXLNode *dxlnode = NULL;
 
-	if (0 == gpdb::UlListLength(pfromexpr->fromlist))
+	if (0 == gpdb::ListLength(from_expr->fromlist))
 	{
-		pdxln = PdxlnConstTableGet();
+		dxlnode = DXLDummyConstTableGet();
 	}
 	else
 	{
-		if (1 == gpdb::UlListLength(pfromexpr->fromlist))
+		if (1 == gpdb::ListLength(from_expr->fromlist))
 		{
-			Node *pnode = (Node*) gpdb::PvListNth(pfromexpr->fromlist, 0);
-			GPOS_ASSERT(NULL != pnode);
-			pdxln = PdxlnFromGPDBFromClauseEntry(pnode);
+			Node *node = (Node*) gpdb::ListNth(from_expr->fromlist, 0);
+			GPOS_ASSERT(NULL != node);
+			dxlnode = TranslateFromClauseToDXL(node);
 		}
 		else
 		{
@@ -2803,54 +2802,54 @@ CTranslatorQueryToDXL::PdxlnFromGPDBFromExpr
 			// The join conditions represented in the FromExpr->quals is translated
 			// into a CDXLLogicalSelect on top of the CDXLLogicalJoin
 
-			pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalJoin(m_pmp, EdxljtInner));
+			dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalJoin(m_mp, EdxljtInner));
 
-			ListCell *plc = NULL;
-			ForEach (plc, pfromexpr->fromlist)
+			ListCell *lc = NULL;
+			ForEach (lc, from_expr->fromlist)
 			{
-				Node *pnode = (Node*) lfirst(plc);
-				CDXLNode *pdxlnChild = PdxlnFromGPDBFromClauseEntry(pnode);
-				pdxln->AddChild(pdxlnChild);
+				Node *node = (Node*) lfirst(lc);
+				CDXLNode *child_dxlnode = TranslateFromClauseToDXL(node);
+				dxlnode->AddChild(child_dxlnode);
 			}
 		}
 	}
 
 	// translate the quals
-	Node *pnodeQuals = pfromexpr->quals;
-	CDXLNode *pdxlnCond = NULL;
-	if (NULL != pnodeQuals)
+	Node *qual_node = from_expr->quals;
+	CDXLNode *condition_dxlnode = NULL;
+	if (NULL != qual_node)
 	{
-		pdxlnCond = PdxlnScFromGPDBExpr( (Expr*) pnodeQuals);
+		condition_dxlnode = TranslateExprToDXL( (Expr*) qual_node);
 	}
 
-	if (1 >= gpdb::UlListLength(pfromexpr->fromlist))
+	if (1 >= gpdb::ListLength(from_expr->fromlist))
 	{
-		if (NULL != pdxlnCond)
+		if (NULL != condition_dxlnode)
 		{
-			CDXLNode *pdxlnSelect = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalSelect(m_pmp));
-			pdxlnSelect->AddChild(pdxlnCond);
-			pdxlnSelect->AddChild(pdxln);
+			CDXLNode *select_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalSelect(m_mp));
+			select_dxlnode->AddChild(condition_dxlnode);
+			select_dxlnode->AddChild(dxlnode);
 
-			pdxln = pdxlnSelect;
+			dxlnode = select_dxlnode;
 		}
 	}
 	else //n-ary joins
 	{
-		if (NULL == pdxlnCond)
+		if (NULL == condition_dxlnode)
 		{
 			// A cross join (the scalar condition is true)
-			pdxlnCond = PdxlnScConstValueTrue();
+			condition_dxlnode = CreateDXLConstValueTrue();
 		}
 
-		pdxln->AddChild(pdxlnCond);
+		dxlnode->AddChild(condition_dxlnode);
 	}
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromGPDBFromClauseEntry
+//		CTranslatorQueryToDXL::TranslateFromClauseToDXL
 //
 //	@doc:
 //		Returns a CDXLNode representing a from clause entry which can either be
@@ -2858,67 +2857,67 @@ CTranslatorQueryToDXL::PdxlnFromGPDBFromExpr
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromGPDBFromClauseEntry
+CTranslatorQueryToDXL::TranslateFromClauseToDXL
 	(
-	Node *pnode
+	Node *node
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 
-	if (IsA(pnode, RangeTblRef))
+	if (IsA(node, RangeTblRef))
 	{
-		RangeTblRef *prtref = (RangeTblRef *) pnode;
-		ULONG ulRTIndex = prtref->rtindex ;
-		const RangeTblEntry *prte = (RangeTblEntry *) gpdb::PvListNth(m_pquery->rtable, ulRTIndex - 1);
-		GPOS_ASSERT(NULL != prte);
+		RangeTblRef *range_tbl_ref = (RangeTblRef *) node;
+		ULONG rt_index = range_tbl_ref->rtindex ;
+		const RangeTblEntry *rte = (RangeTblEntry *) gpdb::ListNth(m_query->rtable, rt_index - 1);
+		GPOS_ASSERT(NULL != rte);
 
-		if (prte->forceDistRandom)
+		if (rte->forceDistRandom)
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("gp_dist_random"));
 		}
 
-		static const SRTETranslator rgTranslators[] =
+		static const SRTETranslator dxlop_translator_func_mapping_array[] =
 		{
-			{RTE_RELATION, &CTranslatorQueryToDXL::PdxlnFromRelation},
-			{RTE_VALUES, &CTranslatorQueryToDXL::PdxlnFromValues},
-			{RTE_CTE, &CTranslatorQueryToDXL::PdxlnFromCTE},
-			{RTE_SUBQUERY, &CTranslatorQueryToDXL::PdxlnFromDerivedTable},
-			{RTE_FUNCTION, &CTranslatorQueryToDXL::PdxlnFromTVF},
+			{RTE_RELATION, &CTranslatorQueryToDXL::TranslateRTEToDXLLogicalGet},
+			{RTE_VALUES, &CTranslatorQueryToDXL::TranslateValueScanRTEToDXL},
+			{RTE_CTE, &CTranslatorQueryToDXL::TranslateCTEToDXL},
+			{RTE_SUBQUERY, &CTranslatorQueryToDXL::TranslateDerivedTablesToDXL},
+			{RTE_FUNCTION, &CTranslatorQueryToDXL::TranslateTVFToDXL},
 		};
 		
-		const ULONG ulTranslators = GPOS_ARRAY_SIZE(rgTranslators);
+		const ULONG num_of_translators = GPOS_ARRAY_SIZE(dxlop_translator_func_mapping_array);
 		
 		// find translator for the rtekind
-		PfPdxlnLogical pf = NULL;
-		for (ULONG ul = 0; ul < ulTranslators; ul++)
+		DXLNodeToLogicalFunc dxlnode_to_logical_funct = NULL;
+		for (ULONG ul = 0; ul < num_of_translators; ul++)
 		{
-			SRTETranslator elem = rgTranslators[ul];
-			if (prte->rtekind == elem.m_rtekind)
+			SRTETranslator elem = dxlop_translator_func_mapping_array[ul];
+			if (rte->rtekind == elem.m_rtekind)
 			{
-				pf = elem.pf;
+				dxlnode_to_logical_funct = elem.dxlnode_to_logical_funct;
 				break;
 			}
 		}
 		
-		if (NULL == pf)
+		if (NULL == dxlnode_to_logical_funct)
 		{
-			UnsupportedRTEKind(prte->rtekind);
+			UnsupportedRTEKind(rte->rtekind);
 
 			return NULL;
 		}
 		
-		return (this->*pf)(prte, ulRTIndex, m_ulQueryLevel);
+		return (this->*dxlnode_to_logical_funct)(rte, rt_index, m_query_level);
 	}
 
-	if (IsA(pnode, JoinExpr))
+	if (IsA(node, JoinExpr))
 	{
-		return PdxlnLgJoinFromGPDBJoinExpr((JoinExpr*) pnode);
+		return TranslateJoinExprInFromToDXL((JoinExpr*) node);
 	}
 
-	CHAR *sz = (CHAR*) gpdb::SzNodeToString(const_cast<Node*>(pnode));
-	CWStringDynamic *pstr = CDXLUtils::PstrFromSz(m_pmp, sz);
+	CHAR *sz = (CHAR*) gpdb::NodeToString(const_cast<Node*>(node));
+	CWStringDynamic *str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, sz);
 
-	GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, pstr->Wsz());
+	GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, str->GetBuffer());
 
 	return NULL;
 }
@@ -2941,7 +2940,7 @@ CTranslatorQueryToDXL::UnsupportedRTEKind
 				|| RTE_FUNCTION == rtekind || RTE_SUBQUERY == rtekind
 				|| RTE_VALUES == rtekind));
 
-	static const SRTENameElem rgStrMap[] =
+	static const SRTENameElem rte_name_map[] =
 		{
 		{RTE_JOIN, GPOS_WSZ_LIT("RangeTableEntry of type Join")},
 		{RTE_SPECIAL, GPOS_WSZ_LIT("RangeTableEntry of type Special")},
@@ -2949,14 +2948,14 @@ CTranslatorQueryToDXL::UnsupportedRTEKind
 		{RTE_TABLEFUNCTION, GPOS_WSZ_LIT("RangeTableEntry of type Table Function")}
 		};
 
-	const ULONG ulLen = GPOS_ARRAY_SIZE(rgStrMap);
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	const ULONG length = GPOS_ARRAY_SIZE(rte_name_map);
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		SRTENameElem mapelem = rgStrMap[ul];
+		SRTENameElem mapelem = rte_name_map[ul];
 
 		if (mapelem.m_rtekind == rtekind)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, mapelem.m_wsz);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, mapelem.m_rte_name);
 		}
 	}
 
@@ -2965,254 +2964,254 @@ CTranslatorQueryToDXL::UnsupportedRTEKind
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromRelation
+//		CTranslatorQueryToDXL::TranslateRTEToDXLLogicalGet
 //
 //	@doc:
 //		Returns a CDXLNode representing a from relation range table entry
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromRelation
+CTranslatorQueryToDXL::TranslateRTEToDXLLogicalGet
 	(
-	const RangeTblEntry *prte,
-	ULONG ulRTIndex,
-	ULONG //ulCurrQueryLevel 
+	const RangeTblEntry *rte,
+	ULONG rt_index,
+	ULONG //current_query_level
 	)
 {
-	// construct table descriptor for the scan node from the range table entry
-	CDXLTableDescr *pdxltabdesc = CTranslatorUtils::Pdxltabdesc(m_pmp, m_pmda, m_pidgtorCol, prte, &m_fHasDistributedTables);
+	CDXLTableDescr *table_descr = CTranslatorUtils::GetTableDescr(m_mp, m_md_accessor, m_colid_counter, rte, &m_has_distributed_tables);
 
-	CDXLLogicalGet *pdxlop = NULL;
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
+	CDXLLogicalGet *dxlop = NULL;
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 
-	if (false == prte->inh && IMDRelation::ErelstorageExternal != pmdrel->Erelstorage())
+
+	if (false == rte->inh  && IMDRelation::ErelstorageExternal != md_rel->RetrieveRelStorageType())
 	{
-		GPOS_ASSERT(RTE_RELATION == prte->rtekind);
-		// RangeTblEntry::inh is set to false if there is ONLY in the FROM clause.
-		// c.f. transformTableEntry, called from transformFromClauseItem.  Ignore
-		// external tables, however, since inh is always false for external tables.
+		GPOS_ASSERT(RTE_RELATION == rte->rtekind);
+		// RangeTblEntry::inh is set to false iff there is ONLY in the FROM
+		// clause. c.f. transformTableEntry, called from transformFromClauseItem
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("ONLY in the FROM clause"));
 	}
 
-	if (IMDRelation::ErelstorageExternal == pmdrel->Erelstorage())
+	// construct table descriptor for the scan node from the range table entry
+	if (IMDRelation::ErelstorageExternal == md_rel->RetrieveRelStorageType())
 	{
-		pdxlop = GPOS_NEW(m_pmp) CDXLLogicalExternalGet(m_pmp, pdxltabdesc);
+		dxlop = GPOS_NEW(m_mp) CDXLLogicalExternalGet(m_mp, table_descr);
 	}
 	else
 	{
-		pdxlop = GPOS_NEW(m_pmp) CDXLLogicalGet(m_pmp, pdxltabdesc);
+		dxlop = GPOS_NEW(m_mp) CDXLLogicalGet(m_mp, table_descr);
 	}
 
-	CDXLNode *pdxlnGet = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *get_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
 	// make note of new columns from base relation
-	m_pmapvarcolid->LoadTblColumns(m_ulQueryLevel, ulRTIndex, pdxltabdesc);
+	m_var_to_colid_map->LoadTblColumns(m_query_level, rt_index, table_descr);
 
-	return pdxlnGet;
+	return get_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromValues
+//		CTranslatorQueryToDXL::TranslateValueScanRTEToDXL
 //
 //	@doc:
 //		Returns a CDXLNode representing a range table entry of values
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromValues
+CTranslatorQueryToDXL::TranslateValueScanRTEToDXL
 	(
-	const RangeTblEntry *prte,
-	ULONG ulRTIndex,
-	ULONG ulCurrQueryLevel
+	const RangeTblEntry *rte,
+	ULONG rt_index,
+	ULONG current_query_level
 	)
 {
-	List *plTuples = prte->values_lists;
-	GPOS_ASSERT(NULL != plTuples);
+	List *tuples_list = rte->values_lists;
+	GPOS_ASSERT(NULL != tuples_list);
 
-	const ULONG ulValues = gpdb::UlListLength(plTuples);
-	GPOS_ASSERT(0 < ulValues);
+	const ULONG num_of_tuples = gpdb::ListLength(tuples_list);
+	GPOS_ASSERT(0 < num_of_tuples);
 
 	// children of the UNION ALL
-	DrgPdxln *pdrgpdxln = GPOS_NEW(m_pmp) DrgPdxln(m_pmp);
+	CDXLNodeArray *dxlnodes = GPOS_NEW(m_mp) CDXLNodeArray(m_mp);
 
 	// array of datum arrays for Values
-	DrgPdrgPdxldatum *pdrgpdrgpdxldatumValues = GPOS_NEW(m_pmp) DrgPdrgPdxldatum(m_pmp);
+	CDXLDatum2dArray *dxl_values_datum_array = GPOS_NEW(m_mp) CDXLDatum2dArray(m_mp);
 
 	// array of input colid arrays
-	DrgPdrgPul *pdrgpdrgulInputColIds = GPOS_NEW(m_pmp) DrgPdrgPul(m_pmp);
+	ULongPtr2dArray *input_colids = GPOS_NEW(m_mp) ULongPtr2dArray(m_mp);
 
 	// array of column descriptor for the UNION ALL operator
-	DrgPdxlcd *pdrgpdxlcd = GPOS_NEW(m_pmp) DrgPdxlcd(m_pmp);
+	CDXLColDescrArray *dxl_col_descr_array = GPOS_NEW(m_mp) CDXLColDescrArray(m_mp);
 
 	// translate the tuples in the value scan
-	ULONG ulTuplePos = 0;
-	ListCell *plcTuple = NULL;
-	GPOS_ASSERT(NULL != prte->eref);
+	ULONG tuple_pos = 0;
+	ListCell *lc_tuple = NULL;
+	GPOS_ASSERT(NULL != rte->eref);
 
 	// flag for checking value list has only constants. For all constants --> VALUESCAN operator else retain UnionAll
 	BOOL fAllConstant = true;
-	ForEach (plcTuple, plTuples)
+	ForEach (lc_tuple, tuples_list)
 	{
-		List *plTuple = (List *) lfirst(plcTuple);
-		GPOS_ASSERT(IsA(plTuple, List));
+		List *tuple_list = (List *) lfirst(lc_tuple);
+		GPOS_ASSERT(IsA(tuple_list, List));
 
 		// array of column colids  
-		DrgPul *pdrgpulColIds = GPOS_NEW(m_pmp) DrgPul(m_pmp);
+		ULongPtrArray *colid_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 
 		// array of project elements (for expression elements)
-		DrgPdxln *pdrgpdxlnPrEl = GPOS_NEW(m_pmp) DrgPdxln(m_pmp);
+		CDXLNodeArray *project_elem_dxlnode_array = GPOS_NEW(m_mp) CDXLNodeArray(m_mp);
 
 		// array of datum (for datum constant values)
-		DrgPdxldatum *pdrgpdxldatum = GPOS_NEW(m_pmp) DrgPdxldatum(m_pmp);
+		CDXLDatumArray *dxl_datum_array = GPOS_NEW(m_mp) CDXLDatumArray(m_mp);
 
 		// array of column descriptors for the CTG containing the datum array
-		DrgPdxlcd *pdrgpdxlcdCTG = GPOS_NEW(m_pmp) DrgPdxlcd(m_pmp);
+		CDXLColDescrArray *dxl_column_descriptors = GPOS_NEW(m_mp) CDXLColDescrArray(m_mp);
 
-		List *plColnames = prte->eref->colnames;
-		GPOS_ASSERT(NULL != plColnames);
-		GPOS_ASSERT(gpdb::UlListLength(plTuple) == gpdb::UlListLength(plColnames));
+		List *col_names = rte->eref->colnames;
+		GPOS_ASSERT(NULL != col_names);
+		GPOS_ASSERT(gpdb::ListLength(tuple_list) == gpdb::ListLength(col_names));
 
 		// translate the columns
-		ULONG ulColPos = 0;
-		ListCell *plcColumn = NULL;
-		ForEach (plcColumn, plTuple)
+		ULONG col_pos_idx = 0;
+		ListCell *lc_column = NULL;
+		ForEach (lc_column, tuple_list)
 		{
-			Expr *pexpr = (Expr *) lfirst(plcColumn);
+			Expr *expr = (Expr *) lfirst(lc_column);
 
-			CHAR *szColName = (CHAR *) strVal(gpdb::PvListNth(plColnames, ulColPos));
-			ULONG ulColId = gpos::ulong_max;
-			if (IsA(pexpr, Const))
+			CHAR *col_name_char_array = (CHAR *) strVal(gpdb::ListNth(col_names, col_pos_idx));
+			ULONG colid = gpos::ulong_max;
+			if (IsA(expr, Const))
 			{
 				// extract the datum
-				Const *pconst = (Const *) pexpr;
-				CDXLDatum *pdxldatum = m_psctranslator->Pdxldatum(pconst);
-				pdrgpdxldatum->Append(pdxldatum);
+				Const *const_expr = (Const *) expr;
+				CDXLDatum *datum_dxl = m_scalar_translator->TranslateConstToDXL(const_expr);
+				dxl_datum_array->Append(datum_dxl);
 
-				ulColId = m_pidgtorCol->UlNextId();
+				colid = m_colid_counter->next_id();
 
-				CWStringDynamic *pstrAlias = CDXLUtils::PstrFromSz(m_pmp, szColName);
-				CMDName *pmdname = GPOS_NEW(m_pmp) CMDName(m_pmp, pstrAlias);
-				GPOS_DELETE(pstrAlias);
+				CWStringDynamic *alias_str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, col_name_char_array);
+				CMDName *mdname = GPOS_NEW(m_mp) CMDName(m_mp, alias_str);
+				GPOS_DELETE(alias_str);
 
-				CDXLColDescr *pdxlcd = GPOS_NEW(m_pmp) CDXLColDescr
+				CDXLColDescr *dxl_col_descr = GPOS_NEW(m_mp) CDXLColDescr
 													(
-													m_pmp,
-													pmdname,
-													ulColId,
-													ulColPos + 1 /* iAttno */,
-													GPOS_NEW(m_pmp) CMDIdGPDB(pconst->consttype),
-													pconst->consttypmod,
-													false /* fDropped */
+													m_mp,
+													mdname,
+													colid,
+													col_pos_idx + 1 /* attno */,
+													GPOS_NEW(m_mp) CMDIdGPDB(const_expr->consttype),
+													const_expr->consttypmod,
+													false /* is_dropped */
 													);
 
-				if (0 == ulTuplePos)
+				if (0 == tuple_pos)
 				{
-					pdxlcd->AddRef();
-					pdrgpdxlcd->Append(pdxlcd);
+					dxl_col_descr->AddRef();
+					dxl_col_descr_array->Append(dxl_col_descr);
 				}
-				pdrgpdxlcdCTG->Append(pdxlcd);
+				dxl_column_descriptors->Append(dxl_col_descr);
 			}
 			else
 			{
 				fAllConstant = false;
 				// translate the scalar expression into a project element
-				CDXLNode *pdxlnPrE = PdxlnPrEFromGPDBExpr(pexpr, szColName, true /* fInsistNewColIds */ );
-				pdrgpdxlnPrEl->Append(pdxlnPrE);
-				ulColId = CDXLScalarProjElem::PdxlopConvert(pdxlnPrE->Pdxlop())->UlId();
+				CDXLNode *project_elem_dxlnode = TranslateExprToDXLProject(expr, col_name_char_array, true /* insist_new_colids */ );
+				project_elem_dxlnode_array->Append(project_elem_dxlnode);
+				colid = CDXLScalarProjElem::Cast(project_elem_dxlnode->GetOperator())->Id();
 
-				if (0 == ulTuplePos)
+				if (0 == tuple_pos)
 				{
-					CWStringDynamic *pstrAlias = CDXLUtils::PstrFromSz(m_pmp, szColName);
-					CMDName *pmdname = GPOS_NEW(m_pmp) CMDName(m_pmp, pstrAlias);
-					GPOS_DELETE(pstrAlias);
+					CWStringDynamic *alias_str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, col_name_char_array);
+					CMDName *mdname = GPOS_NEW(m_mp) CMDName(m_mp, alias_str);
+					GPOS_DELETE(alias_str);
 
-					CDXLColDescr *pdxlcd = GPOS_NEW(m_pmp) CDXLColDescr
+					CDXLColDescr *dxl_col_descr = GPOS_NEW(m_mp) CDXLColDescr
 														(
-														m_pmp,
-														pmdname,
-														ulColId,
-														ulColPos + 1 /* iAttno */,
-														GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType((Node*) pexpr)),
-														gpdb::IExprTypeMod((Node*) pexpr),
-														false /* fDropped */
+														m_mp,
+														mdname,
+														colid,
+														col_pos_idx + 1 /* attno */,
+														GPOS_NEW(m_mp) CMDIdGPDB(gpdb::ExprType((Node*) expr)),
+														gpdb::ExprTypeMod((Node*) expr),
+														false /* is_dropped */
 														);
-					pdrgpdxlcd->Append(pdxlcd);
+					dxl_col_descr_array->Append(dxl_col_descr);
 				}
 			}
 
-			GPOS_ASSERT(gpos::ulong_max != ulColId);
+			GPOS_ASSERT(gpos::ulong_max != colid);
 
-			pdrgpulColIds->Append(GPOS_NEW(m_pmp) ULONG(ulColId));
-			ulColPos++;
+			colid_array->Append(GPOS_NEW(m_mp) ULONG(colid));
+			col_pos_idx++;
 		}
 
-		pdrgpdxln->Append(PdxlnFromColumnValues(pdrgpdxldatum, pdrgpdxlcdCTG, pdrgpdxlnPrEl));
+		dxlnodes->Append(TranslateColumnValuesToDXL(dxl_datum_array, dxl_column_descriptors, project_elem_dxlnode_array));
 		if (fAllConstant)
 		{
-			pdrgpdxldatum->AddRef();
-			pdrgpdrgpdxldatumValues->Append(pdrgpdxldatum);
+			dxl_datum_array->AddRef();
+			dxl_values_datum_array->Append(dxl_datum_array);
 		}
 
-		pdrgpdrgulInputColIds->Append(pdrgpulColIds);
-		ulTuplePos++;
+		input_colids->Append(colid_array);
+		tuple_pos++;
 
 		// cleanup
-		pdrgpdxldatum->Release();
-		pdrgpdxlnPrEl->Release();
-		pdrgpdxlcdCTG->Release();
+		dxl_datum_array->Release();
+		project_elem_dxlnode_array->Release();
+		dxl_column_descriptors->Release();
 	}
 
-	GPOS_ASSERT(NULL != pdrgpdxlcd);
+	GPOS_ASSERT(NULL != dxl_col_descr_array);
 
 	if (fAllConstant)
 	{
 		// create Const Table DXL Node
-		CDXLLogicalConstTable *pdxlop = GPOS_NEW(m_pmp) CDXLLogicalConstTable(m_pmp, pdrgpdxlcd, pdrgpdrgpdxldatumValues);
-		CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+		CDXLLogicalConstTable *dxlop = GPOS_NEW(m_mp) CDXLLogicalConstTable(m_mp, dxl_col_descr_array, dxl_values_datum_array);
+		CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
 		// make note of new columns from Value Scan
-		m_pmapvarcolid->LoadColumns(m_ulQueryLevel, ulRTIndex, pdxlop->Pdrgpdxlcd());
+		m_var_to_colid_map->LoadColumns(m_query_level, rt_index, dxlop->GetDXLColumnDescrArray());
 
 		// cleanup
-		pdrgpdxln->Release();
-		pdrgpdrgulInputColIds->Release();
+		dxlnodes->Release();
+		input_colids->Release();
 
-		return pdxln;
+		return dxlnode;
 	}
-	else if (1 < ulValues)
+	else if (1 < num_of_tuples)
 	{
 		// create a UNION ALL operator
-		CDXLLogicalSetOp *pdxlop = GPOS_NEW(m_pmp) CDXLLogicalSetOp(m_pmp, EdxlsetopUnionAll, pdrgpdxlcd, pdrgpdrgulInputColIds, false);
-		CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop, pdrgpdxln);
+		CDXLLogicalSetOp *dxlop = GPOS_NEW(m_mp) CDXLLogicalSetOp(m_mp, EdxlsetopUnionAll, dxl_col_descr_array, input_colids, false);
+		CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop, dxlnodes);
 
 		// make note of new columns from UNION ALL
-		m_pmapvarcolid->LoadColumns(m_ulQueryLevel, ulRTIndex, pdxlop->Pdrgpdxlcd());
-		pdrgpdrgpdxldatumValues->Release();
+		m_var_to_colid_map->LoadColumns(m_query_level, rt_index, dxlop->GetDXLColumnDescrArray());
+		dxl_values_datum_array->Release();
 
-		return pdxln;
+		return dxlnode;
 	}
 
-	GPOS_ASSERT(1 == pdrgpdxln->UlLength());
+	GPOS_ASSERT(1 == dxlnodes->Size());
 
-	CDXLNode *pdxln = (*pdrgpdxln)[0];
-	pdxln->AddRef();
+	CDXLNode *dxlnode = (*dxlnodes)[0];
+	dxlnode->AddRef();
 
 	// make note of new columns
-	m_pmapvarcolid->LoadColumns(m_ulQueryLevel, ulRTIndex, pdrgpdxlcd);	
+	m_var_to_colid_map->LoadColumns(m_query_level, rt_index, dxl_col_descr_array);
 
 	//cleanup
-	pdrgpdrgpdxldatumValues->Release();
-	pdrgpdxln->Release();
-	pdrgpdrgulInputColIds->Release();
-	pdrgpdxlcd->Release();
+	dxl_values_datum_array->Release();
+	dxlnodes->Release();
+	input_colids->Release();
+	dxl_col_descr_array->Release();
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromColumnValues
+//		CTranslatorQueryToDXL::TranslateColumnValuesToDXL
 //
 //	@doc:
 //		Generate a DXL node from column values, where each column value is 
@@ -3220,154 +3219,154 @@ CTranslatorQueryToDXL::PdxlnFromValues
 //		Each datum is associated with a column descriptors used by the CTG
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromColumnValues
+CTranslatorQueryToDXL::TranslateColumnValuesToDXL
 	(
-	DrgPdxldatum *pdrgpdxldatumCTG,
-	DrgPdxlcd *pdrgpdxlcdCTG,
-	DrgPdxln *pdrgpdxlnPrEl
+	CDXLDatumArray *dxl_datum_array_const_tbl_get,
+	CDXLColDescrArray *dxl_column_descriptors,
+	CDXLNodeArray *project_elem_dxlnode_array
 	)
 	const
 {
-	GPOS_ASSERT(NULL != pdrgpdxldatumCTG);
-	GPOS_ASSERT(NULL != pdrgpdxlnPrEl);
+	GPOS_ASSERT(NULL != dxl_datum_array_const_tbl_get);
+	GPOS_ASSERT(NULL != project_elem_dxlnode_array);
 	
-	CDXLNode *pdxlnCTG = NULL;
-	if (0 == pdrgpdxldatumCTG->UlLength())
+	CDXLNode *const_tbl_get_dxlnode = NULL;
+	if (0 == dxl_datum_array_const_tbl_get->Size())
 	{
 		// add a dummy CTG
-		pdxlnCTG = PdxlnConstTableGet();
+		const_tbl_get_dxlnode = DXLDummyConstTableGet();
 	}
 	else 
 	{
 		// create the array of datum arrays
-		DrgPdrgPdxldatum *pdrgpdrgpdxldatumCTG = GPOS_NEW(m_pmp) DrgPdrgPdxldatum(m_pmp);
+		CDXLDatum2dArray *dxl_datum_arrays_const_tbl_get = GPOS_NEW(m_mp) CDXLDatum2dArray(m_mp);
 		
-		pdrgpdxldatumCTG->AddRef();
-		pdrgpdrgpdxldatumCTG->Append(pdrgpdxldatumCTG);
+		dxl_datum_array_const_tbl_get->AddRef();
+		dxl_datum_arrays_const_tbl_get->Append(dxl_datum_array_const_tbl_get);
 		
-		pdrgpdxlcdCTG->AddRef();
-		CDXLLogicalConstTable *pdxlop = GPOS_NEW(m_pmp) CDXLLogicalConstTable(m_pmp, pdrgpdxlcdCTG, pdrgpdrgpdxldatumCTG);
+		dxl_column_descriptors->AddRef();
+		CDXLLogicalConstTable *dxlop = GPOS_NEW(m_mp) CDXLLogicalConstTable(m_mp, dxl_column_descriptors, dxl_datum_arrays_const_tbl_get);
 		
-		pdxlnCTG = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+		const_tbl_get_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 	}
 
-	if (0 == pdrgpdxlnPrEl->UlLength())
+	if (0 == project_elem_dxlnode_array->Size())
 	{
-		return pdxlnCTG;
+		return const_tbl_get_dxlnode;
 	}
 
 	// create a project node for the list of project elements
-	pdrgpdxlnPrEl->AddRef();
-	CDXLNode *pdxlnPrL = GPOS_NEW(m_pmp) CDXLNode
+	project_elem_dxlnode_array->AddRef();
+	CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode
 										(
-										m_pmp,
-										GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp),
-										pdrgpdxlnPrEl
+										m_mp,
+										GPOS_NEW(m_mp) CDXLScalarProjList(m_mp),
+										project_elem_dxlnode_array
 										);
 	
-	CDXLNode *pdxlnProject = GPOS_NEW(m_pmp) CDXLNode
+	CDXLNode *project_dxlnode = GPOS_NEW(m_mp) CDXLNode
 											(
-											m_pmp,
-											GPOS_NEW(m_pmp) CDXLLogicalProject(m_pmp),
-											pdxlnPrL,
-											pdxlnCTG
+											m_mp,
+											GPOS_NEW(m_mp) CDXLLogicalProject(m_mp),
+											project_list_dxlnode,
+											const_tbl_get_dxlnode
 											);
 
-	return pdxlnProject;
+	return project_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromTVF
+//		CTranslatorQueryToDXL::TranslateTVFToDXL
 //
 //	@doc:
 //		Returns a CDXLNode representing a from relation range table entry
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromTVF
+CTranslatorQueryToDXL::TranslateTVFToDXL
 	(
-	const RangeTblEntry *prte,
-	ULONG ulRTIndex,
-	ULONG //ulCurrQueryLevel
+	const RangeTblEntry *rte,
+	ULONG rt_index,
+	ULONG //current_query_level
 	)
 {
-	GPOS_ASSERT(NULL != prte->funcexpr);
+	GPOS_ASSERT(NULL != rte->funcexpr);
 
 	// if this is a folded function expression, generate a project over a CTG
-	if (!IsA(prte->funcexpr, FuncExpr))
+	if (!IsA(rte->funcexpr, FuncExpr))
 	{
-		CDXLNode *pdxlnCTG = PdxlnConstTableGet();
+		CDXLNode *const_tbl_get_dxlnode = DXLDummyConstTableGet();
 
-		CDXLNode *pdxlnPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
+		CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
-		CDXLNode *pdxlnPrEl =  PdxlnPrEFromGPDBExpr((Expr *) prte->funcexpr, prte->eref->aliasname, true /* fInsistNewColIds */);
-		pdxlnPrL->AddChild(pdxlnPrEl);
+		CDXLNode *project_elem_dxlnode =  TranslateExprToDXLProject((Expr *) rte->funcexpr, rte->eref->aliasname, true /* insist_new_colids */);
+		project_list_dxlnode->AddChild(project_elem_dxlnode);
 
-		CDXLNode *pdxlnProject = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalProject(m_pmp));
-		pdxlnProject->AddChild(pdxlnPrL);
-		pdxlnProject->AddChild(pdxlnCTG);
+		CDXLNode *project_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalProject(m_mp));
+		project_dxlnode->AddChild(project_list_dxlnode);
+		project_dxlnode->AddChild(const_tbl_get_dxlnode);
 
-		m_pmapvarcolid->LoadProjectElements(m_ulQueryLevel, ulRTIndex, pdxlnPrL);
+		m_var_to_colid_map->LoadProjectElements(m_query_level, rt_index, project_list_dxlnode);
 
-		return pdxlnProject;
+		return project_dxlnode;
 	}
 
-	CDXLLogicalTVF *pdxlopTVF = CTranslatorUtils::Pdxltvf(m_pmp, m_pmda, m_pidgtorCol, prte);
-	CDXLNode *pdxlnTVF = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopTVF);
+	CDXLLogicalTVF *tvf_dxlop = CTranslatorUtils::ConvertToCDXLLogicalTVF(m_mp, m_md_accessor, m_colid_counter, rte);
+	CDXLNode *tvf_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, tvf_dxlop);
 
 	// make note of new columns from function
-	m_pmapvarcolid->LoadColumns(m_ulQueryLevel, ulRTIndex, pdxlopTVF->Pdrgpdxlcd());
+	m_var_to_colid_map->LoadColumns(m_query_level, rt_index, tvf_dxlop->GetDXLColumnDescrArray());
 
-	FuncExpr *pfuncexpr = (FuncExpr *) prte->funcexpr;
-	BOOL fSubqueryInArgs = false;
+	FuncExpr *func_expr = (FuncExpr *) rte->funcexpr;
+	BOOL is_subquery_in_args = false;
 
 	// check if arguments contain SIRV functions
-	if (NIL != pfuncexpr->args && FHasSirvFunctions((Node *) pfuncexpr->args))
+	if (NIL != func_expr->args && HasSirvFunctions((Node *) func_expr->args))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("SIRV functions"));
 	}
 
-	ListCell *plc = NULL;
-	ForEach (plc, pfuncexpr->args)
+	ListCell *lc = NULL;
+	ForEach (lc, func_expr->args)
 	{
-		Node *pnodeArg = (Node *) lfirst(plc);
-		fSubqueryInArgs = fSubqueryInArgs || CTranslatorUtils::FHasSubquery(pnodeArg);
-		CDXLNode *pdxlnFuncExprArg =
-				m_psctranslator->PdxlnScOpFromExpr((Expr *) pnodeArg, m_pmapvarcolid, &m_fHasDistributedTables);
-		GPOS_ASSERT(NULL != pdxlnFuncExprArg);
-		pdxlnTVF->AddChild(pdxlnFuncExprArg);
+		Node *arg_node = (Node *) lfirst(lc);
+		is_subquery_in_args = is_subquery_in_args || CTranslatorUtils::HasSubquery(arg_node);
+		CDXLNode *func_expr_arg_dxlnode =
+				m_scalar_translator->TranslateScalarToDXL((Expr *) arg_node, m_var_to_colid_map, &m_has_distributed_tables);
+		GPOS_ASSERT(NULL != func_expr_arg_dxlnode);
+		tvf_dxlnode->AddChild(func_expr_arg_dxlnode);
 	}
 
-	CMDIdGPDB *pmdidFunc = GPOS_NEW(m_pmp) CMDIdGPDB(pfuncexpr->funcid);
-	const IMDFunction *pmdfunc = m_pmda->Pmdfunc(pmdidFunc);
-	if (fSubqueryInArgs && IMDFunction::EfsVolatile == pmdfunc->EfsStability())
+	CMDIdGPDB *mdid_func = GPOS_NEW(m_mp) CMDIdGPDB(func_expr->funcid);
+	const IMDFunction *pmdfunc = m_md_accessor->RetrieveFunc(mdid_func);
+	if (is_subquery_in_args && IMDFunction::EfsVolatile == pmdfunc->GetFuncStability())
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Volatile functions with subqueries in arguments"));
 	}
-	pmdidFunc->Release();
+	mdid_func->Release();
 
-	return pdxlnTVF;
+	return tvf_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromCTE
+//		CTranslatorQueryToDXL::TranslateCTEToDXL
 //
 //	@doc:
 //		Translate a common table expression into CDXLNode
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromCTE
+CTranslatorQueryToDXL::TranslateCTEToDXL
 	(
-	const RangeTblEntry *prte,
-	ULONG ulRTIndex,
-	ULONG ulCurrQueryLevel
+	const RangeTblEntry *rte,
+	ULONG rt_index,
+	ULONG current_query_level
 	)
 {
-	const ULONG ulCteQueryLevel = ulCurrQueryLevel - prte->ctelevelsup;
-	const CCTEListEntry *pctelistentry = m_phmulCTEEntries->PtLookup(&ulCteQueryLevel);
-	if (NULL == pctelistentry)
+	const ULONG cte_query_level = current_query_level - rte->ctelevelsup;
+	const CCTEListEntry *cte_list_entry = m_query_level_to_cte_map->Find(&cte_query_level);
+	if (NULL == cte_list_entry)
 	{
 		// TODO: Sept 09 2013, remove temporary fix  (revert exception to assert) to avoid crash during algebrization
 		GPOS_RAISE
@@ -3378,195 +3377,194 @@ CTranslatorQueryToDXL::PdxlnFromCTE
 			);
 	}
 
-	const CDXLNode *pdxlnCTEProducer = pctelistentry->PdxlnCTEProducer(prte->ctename);
-	const List *plCTEProducerTargetList = pctelistentry->PlCTEProducerTL(prte->ctename);
+	const CDXLNode *cte_producer_dxlnode = cte_list_entry->GetCTEProducer(rte->ctename);
+	const List *cte_producer_target_list = cte_list_entry->GetCTEProducerTargetList(rte->ctename);
 	
-	GPOS_ASSERT(NULL != pdxlnCTEProducer && NULL != plCTEProducerTargetList);
+	GPOS_ASSERT(NULL != cte_producer_dxlnode && NULL != cte_producer_target_list);
 
-	CDXLLogicalCTEProducer *pdxlopProducer = CDXLLogicalCTEProducer::PdxlopConvert(pdxlnCTEProducer->Pdxlop()); 
-	ULONG ulCTEId = pdxlopProducer->UlId();
-	DrgPul *pdrgpulCTEProducer = pdxlopProducer->PdrgpulColIds();
+	CDXLLogicalCTEProducer *cte_producer_dxlop = CDXLLogicalCTEProducer::Cast(cte_producer_dxlnode->GetOperator());
+	ULONG cte_id = cte_producer_dxlop->Id();
+	ULongPtrArray *op_colid_array_cte_producer = cte_producer_dxlop->GetOutputColIdsArray();
 	
 	// construct output column array
-	DrgPul *pdrgpulCTEConsumer = PdrgpulGenerateColIds(m_pmp, pdrgpulCTEProducer->UlLength());
+	ULongPtrArray *colid_array_cte_consumer = GenerateColIds(m_mp, op_colid_array_cte_producer->Size());
 			
 	// load the new columns from the CTE
-	m_pmapvarcolid->LoadCTEColumns(ulCurrQueryLevel, ulRTIndex, pdrgpulCTEConsumer, const_cast<List *>(plCTEProducerTargetList));
+	m_var_to_colid_map->LoadCTEColumns(current_query_level, rt_index, colid_array_cte_consumer, const_cast<List *>(cte_producer_target_list));
 
-	CDXLLogicalCTEConsumer *pdxlopCTEConsumer = GPOS_NEW(m_pmp) CDXLLogicalCTEConsumer(m_pmp, ulCTEId, pdrgpulCTEConsumer);
-	CDXLNode *pdxlnCTE = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopCTEConsumer);
+	CDXLLogicalCTEConsumer *cte_consumer_dxlop = GPOS_NEW(m_mp) CDXLLogicalCTEConsumer(m_mp, cte_id, colid_array_cte_consumer);
+	CDXLNode *cte_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, cte_consumer_dxlop);
 
-	return pdxlnCTE;
+	return cte_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnFromDerivedTable
+//		CTranslatorQueryToDXL::TranslateDerivedTablesToDXL
 //
 //	@doc:
 //		Translate a derived table into CDXLNode
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnFromDerivedTable
+CTranslatorQueryToDXL::TranslateDerivedTablesToDXL
 	(
-	const RangeTblEntry *prte,
-	ULONG ulRTIndex,
-	ULONG ulCurrQueryLevel
+	const RangeTblEntry *rte,
+	ULONG rt_index,
+	ULONG current_query_level
 	)
 {
-	Query *pqueryDerTbl = prte->subquery;
-	GPOS_ASSERT(NULL != pqueryDerTbl);
+	CMappingVarColId *var_to_colid_map = m_var_to_colid_map->CopyMapColId(m_mp);
+	Query *query_derived_tbl = rte->subquery;
+	GPOS_ASSERT(NULL != query_derived_tbl);
 
-	CMappingVarColId *pmapvarcolid = m_pmapvarcolid->PmapvarcolidCopy(m_pmp);
-
-	CTranslatorQueryToDXL trquerytodxl
+	CTranslatorQueryToDXL query_to_dxl_translator
 		(
-		m_pmp,
-		m_pmda,
-		m_pidgtorCol,
-		m_pidgtorCTE,
-		pmapvarcolid,
-		pqueryDerTbl,
-		m_ulQueryLevel + 1,
-		FDMLQuery(),
-		m_phmulCTEEntries
+		m_mp,
+		m_md_accessor,
+		m_colid_counter,
+		m_cte_id_counter,
+		var_to_colid_map,
+		query_derived_tbl,
+		m_query_level + 1,
+		IsDMLQuery(),
+		m_query_level_to_cte_map
 		);
 
 	// translate query representing the derived table to its DXL representation
-	CDXLNode *pdxlnDerTbl = trquerytodxl.PdxlnFromQueryInternal();
+	CDXLNode *derived_tbl_dxlnode = query_to_dxl_translator.TranslateSelectQueryToDXL();
 
 	// get the output columns of the derived table
-	DrgPdxln *pdrgpdxlnQueryOutputDerTbl = trquerytodxl.PdrgpdxlnQueryOutput();
-	DrgPdxln *pdrgpdxlnCTE = trquerytodxl.PdrgpdxlnCTE();
-	GPOS_ASSERT(NULL != pdxlnDerTbl && pdrgpdxlnQueryOutputDerTbl != NULL);
+	CDXLNodeArray *query_output_cols_dxlnode_array = query_to_dxl_translator.GetQueryOutputCols();
+	CDXLNodeArray *cte_dxlnode_array = query_to_dxl_translator.GetCTEs();
+	GPOS_ASSERT(NULL != derived_tbl_dxlnode && query_output_cols_dxlnode_array != NULL);
 
-	CUtils::AddRefAppend(m_pdrgpdxlnCTE, pdrgpdxlnCTE);
+	CUtils::AddRefAppend(m_dxl_cte_producers, cte_dxlnode_array);
 	
-	m_fHasDistributedTables = m_fHasDistributedTables || trquerytodxl.FHasDistributedTables();
+	m_has_distributed_tables = m_has_distributed_tables || query_to_dxl_translator.HasDistributedTables();
 
 	// make note of new columns from derived table
-	m_pmapvarcolid->LoadDerivedTblColumns(ulCurrQueryLevel, ulRTIndex, pdrgpdxlnQueryOutputDerTbl, trquerytodxl.Pquery()->targetList);
+	m_var_to_colid_map->LoadDerivedTblColumns(current_query_level, rt_index, query_output_cols_dxlnode_array, query_to_dxl_translator.Pquery()->targetList);
 
-	return pdxlnDerTbl;
+	return derived_tbl_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnScFromGPDBExpr
+//		CTranslatorQueryToDXL::TranslateExprToDXL
 //
 //	@doc:
 //		Translate the Expr into a CDXLScalar node
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnScFromGPDBExpr
+CTranslatorQueryToDXL::TranslateExprToDXL
 	(
-	Expr *pexpr
+	Expr *expr
 	)
 {
-	CDXLNode *pdxlnScalar = m_psctranslator->PdxlnScOpFromExpr(pexpr, m_pmapvarcolid, &m_fHasDistributedTables);
-	GPOS_ASSERT(NULL != pdxlnScalar);
+	CDXLNode *scalar_dxlnode = m_scalar_translator->TranslateScalarToDXL(expr, m_var_to_colid_map, &m_has_distributed_tables);
+	GPOS_ASSERT(NULL != scalar_dxlnode);
 
-	return pdxlnScalar;
+	return scalar_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnLgJoinFromGPDBJoinExpr
+//		CTranslatorQueryToDXL::TranslateJoinExprInFromToDXL
 //
 //	@doc:
 //		Translate the JoinExpr on a GPDB query into a CDXLLogicalJoin node
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnLgJoinFromGPDBJoinExpr
+CTranslatorQueryToDXL::TranslateJoinExprInFromToDXL
 	(
-	JoinExpr *pjoinexpr
+	JoinExpr *join_expr
 	)
 {
-	GPOS_ASSERT(NULL != pjoinexpr);
+	GPOS_ASSERT(NULL != join_expr);
 
-	CDXLNode *pdxlnLeftChild = PdxlnFromGPDBFromClauseEntry(pjoinexpr->larg);
-	CDXLNode *pdxlnRightChild = PdxlnFromGPDBFromClauseEntry(pjoinexpr->rarg);
-	EdxlJoinType edxljt = CTranslatorUtils::EdxljtFromJoinType(pjoinexpr->jointype);
-	CDXLNode *pdxlnJoin = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalJoin(m_pmp, edxljt));
+	CDXLNode *left_child_dxlnode = TranslateFromClauseToDXL(join_expr->larg);
+	CDXLNode *right_child_dxlnode = TranslateFromClauseToDXL(join_expr->rarg);
+	EdxlJoinType join_type = CTranslatorUtils::ConvertToDXLJoinType(join_expr->jointype);
+	CDXLNode *join_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalJoin(m_mp, join_type));
 
-	GPOS_ASSERT(NULL != pdxlnLeftChild && NULL != pdxlnRightChild);
+	GPOS_ASSERT(NULL != left_child_dxlnode && NULL != right_child_dxlnode);
 
-	pdxlnJoin->AddChild(pdxlnLeftChild);
-	pdxlnJoin->AddChild(pdxlnRightChild);
+	join_dxlnode->AddChild(left_child_dxlnode);
+	join_dxlnode->AddChild(right_child_dxlnode);
 
-	Node* pnode = pjoinexpr->quals;
+	Node* node = join_expr->quals;
 
 	// translate the join condition
-	if (NULL != pnode)
+	if (NULL != node)
 	{
-		pdxlnJoin->AddChild(PdxlnScFromGPDBExpr( (Expr*) pnode));
+		join_dxlnode->AddChild(TranslateExprToDXL( (Expr*) node));
 	}
 	else
 	{
 		// a cross join therefore add a CDXLScalarConstValue representing the value "true"
-		pdxlnJoin->AddChild(PdxlnScConstValueTrue());
+		join_dxlnode->AddChild(CreateDXLConstValueTrue());
 	}
 
 	// extract the range table entry for the join expr to:
 	// 1. Process the alias names of the columns
 	// 2. Generate a project list for the join expr and maintain it in our hash map
 
-	const ULONG ulRtIndex = pjoinexpr->rtindex;
-	RangeTblEntry *prte = (RangeTblEntry *) gpdb::PvListNth(m_pquery->rtable, ulRtIndex - 1);
-	GPOS_ASSERT(NULL != prte);
+	const ULONG rtindex = join_expr->rtindex;
+	RangeTblEntry *rte = (RangeTblEntry *) gpdb::ListNth(m_query->rtable, rtindex - 1);
+	GPOS_ASSERT(NULL != rte);
 
-	Alias *palias = prte->eref;
-	GPOS_ASSERT(NULL != palias);
-	GPOS_ASSERT(NULL != palias->colnames && 0 < gpdb::UlListLength(palias->colnames));
-	GPOS_ASSERT(gpdb::UlListLength(prte->joinaliasvars) == gpdb::UlListLength(palias->colnames));
+	Alias *alias = rte->eref;
+	GPOS_ASSERT(NULL != alias);
+	GPOS_ASSERT(NULL != alias->colnames && 0 < gpdb::ListLength(alias->colnames));
+	GPOS_ASSERT(gpdb::ListLength(rte->joinaliasvars) == gpdb::ListLength(alias->colnames));
 
-	CDXLNode *pdxlnPrLComputedColumns = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
-	CDXLNode *pdxlnPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
+	CDXLNode *project_list_computed_cols_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
+	CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
 	// construct a proj element node for each entry in the joinaliasvars
-	ListCell *plcNode = NULL;
-	ListCell *plcColName = NULL;
-	ForBoth (plcNode, prte->joinaliasvars,
-			plcColName, palias->colnames)
+	ListCell *lc_node = NULL;
+	ListCell *lc_col_name = NULL;
+	ForBoth (lc_node, rte->joinaliasvars,
+			lc_col_name, alias->colnames)
 	{
-		Node *pnodeJoinAlias = (Node *) lfirst(plcNode);
-		GPOS_ASSERT(IsA(pnodeJoinAlias, Var) || IsA(pnodeJoinAlias, CoalesceExpr));
-		Value *pvalue = (Value *) lfirst(plcColName);
-		CHAR *szColName = strVal(pvalue);
+		Node *join_alias_node = (Node *) lfirst(lc_node);
+		GPOS_ASSERT(IsA(join_alias_node, Var) || IsA(join_alias_node, CoalesceExpr));
+		Value *value = (Value *) lfirst(lc_col_name);
+		CHAR *col_name_char_array = strVal(value);
 
 		// create the DXL node holding the target list entry and add it to proj list
-		CDXLNode *pdxlnPrEl =  PdxlnPrEFromGPDBExpr( (Expr*) pnodeJoinAlias, szColName);
-		pdxlnPrL->AddChild(pdxlnPrEl);
+		CDXLNode *project_elem_dxlnode =  TranslateExprToDXLProject( (Expr*) join_alias_node, col_name_char_array);
+		project_list_dxlnode->AddChild(project_elem_dxlnode);
 
-		if (IsA(pnodeJoinAlias, CoalesceExpr))
+		if (IsA(join_alias_node, CoalesceExpr))
 		{
 			// add coalesce expression to the computed columns
-			pdxlnPrEl->AddRef();
-			pdxlnPrLComputedColumns->AddChild(pdxlnPrEl);
+			project_elem_dxlnode->AddRef();
+			project_list_computed_cols_dxlnode->AddChild(project_elem_dxlnode);
 		}
 	}
-	m_pmapvarcolid->LoadProjectElements(m_ulQueryLevel, ulRtIndex, pdxlnPrL);
-	pdxlnPrL->Release();
+	m_var_to_colid_map->LoadProjectElements(m_query_level, rtindex, project_list_dxlnode);
+	project_list_dxlnode->Release();
 
-	if (0 == pdxlnPrLComputedColumns->UlArity())
+	if (0 == project_list_computed_cols_dxlnode->Arity())
 	{
-		pdxlnPrLComputedColumns->Release();
-		return pdxlnJoin;
+		project_list_computed_cols_dxlnode->Release();
+		return join_dxlnode;
 	}
 
-	CDXLNode *pdxlnProject = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalProject(m_pmp));
-	pdxlnProject->AddChild(pdxlnPrLComputedColumns);
-	pdxlnProject->AddChild(pdxlnJoin);
+	CDXLNode *project_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalProject(m_mp));
+	project_dxlnode->AddChild(project_list_computed_cols_dxlnode);
+	project_dxlnode->AddChild(join_dxlnode);
 
-	return pdxlnProject;
+	return project_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnLgProjectFromGPDBTL
+//		CTranslatorQueryToDXL::TranslateTargetListToDXLProject
 //
 //	@doc:
 //		Create a DXL project list from the target list. The function allocates
@@ -3574,129 +3572,129 @@ CTranslatorQueryToDXL::PdxlnLgJoinFromGPDBJoinExpr
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnLgProjectFromGPDBTL
+CTranslatorQueryToDXL::TranslateTargetListToDXLProject
 	(
-	List *plTargetList,
-	CDXLNode *pdxlnChild,
-	HMIUl *phmiulSortgrouprefColId,
-	HMIUl *phmiulOutputCols,
+	List *target_list,
+	CDXLNode *child_dxlnode,
+	IntToUlongMap *sort_grpref_to_colid_mapping,
+	IntToUlongMap *output_attno_to_colid_mapping,
 	List *plgrpcl,
-	BOOL fExpandAggrefExpr
+	BOOL is_expand_aggref_expr
 	)
 {
-	BOOL fGroupBy = (0 != gpdb::UlListLength(m_pquery->groupClause) || m_pquery->hasAggs);
+	BOOL is_groupby = (0 != gpdb::ListLength(m_query->groupClause) || m_query->hasAggs);
 
-	CDXLNode *pdxlnPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
+	CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
 	// construct a proj element node for each entry in the target list
-	ListCell *plcTE = NULL;
+	ListCell *lc = NULL;
 	
 	// target entries that are result of flattening join alias
 	// and are equivalent to a defined grouping column target entry
-	List *plOmittedTE = NIL; 
+	List *omitted_te_list = NIL;
 
 	// list for all vars used in aggref expressions
-	List *plVars = NULL;
-	ULONG ulResno = 0;
-	ForEach(plcTE, plTargetList)
+	List *vars_list = NULL;
+	ULONG resno = 0;
+	ForEach(lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
-		GPOS_ASSERT(0 < pte->resno);
-		ulResno = pte->resno;
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
+		GPOS_ASSERT(0 < target_entry->resno);
+		resno = target_entry->resno;
 
-		BOOL fGroupingCol = CTranslatorUtils::FGroupingColumn(pte, plgrpcl);
-		if (!fGroupBy || (fGroupBy && fGroupingCol))
+		BOOL is_grouping_col = CTranslatorUtils::IsGroupingColumn(target_entry, plgrpcl);
+		if (!is_groupby || (is_groupby && is_grouping_col))
 		{
-			CDXLNode *pdxlnPrEl =  PdxlnPrEFromGPDBExpr(pte->expr, pte->resname);
-			ULONG ulColId = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop())->UlId();
+			CDXLNode *project_elem_dxlnode =  TranslateExprToDXLProject(target_entry->expr, target_entry->resname);
+			ULONG colid = CDXLScalarProjElem::Cast(project_elem_dxlnode->GetOperator())->Id();
 
-			AddSortingGroupingColumn(pte, phmiulSortgrouprefColId, ulColId);
+			AddSortingGroupingColumn(target_entry, sort_grpref_to_colid_mapping, colid);
 
 			// add column to the list of output columns of the query
-			StoreAttnoColIdMapping(phmiulOutputCols, ulResno, ulColId);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 
-			if (!IsA(pte->expr, Var))
+			if (!IsA(target_entry->expr, Var))
 			{
 				// only add computed columns to the project list
-				pdxlnPrL->AddChild(pdxlnPrEl);
+				project_list_dxlnode->AddChild(project_elem_dxlnode);
 			}
 			else
 			{
-				pdxlnPrEl->Release();
+				project_elem_dxlnode->Release();
 			}
 		}
-		else if (fExpandAggrefExpr && IsA(pte->expr, Aggref))
+		else if (is_expand_aggref_expr && IsA(target_entry->expr, Aggref))
 		{
-			plVars = gpdb::PlConcat(plVars, gpdb::PlExtractNodesExpression((Node *) pte->expr, T_Var, false /*descendIntoSubqueries*/));
+			vars_list = gpdb::ListConcat(vars_list, gpdb::ExtractNodesExpression((Node *) target_entry->expr, T_Var, false /*descendIntoSubqueries*/));
 		}
-		else if (!IsA(pte->expr, Aggref))
+		else if (!IsA(target_entry->expr, Aggref))
 		{
-			plOmittedTE = gpdb::PlAppendElement(plOmittedTE, pte);
+			omitted_te_list = gpdb::LAppend(omitted_te_list, target_entry);
 		}
 	}
 
 	// process target entries that are a result of flattening join alias
-	plcTE = NULL;
-	ForEach(plcTE, plOmittedTE)
+	lc = NULL;
+	ForEach(lc, omitted_te_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		INT iSortGroupRef = (INT) pte->ressortgroupref;
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		INT sort_group_ref = (INT) target_entry->ressortgroupref;
 
-		TargetEntry *pteGroupingColumn = CTranslatorUtils::PteGroupingColumn( (Node*) pte->expr, plgrpcl, plTargetList);
-		if (NULL != pteGroupingColumn)
+		TargetEntry *te_grouping_col = CTranslatorUtils::GetGroupingColumnTargetEntry( (Node*) target_entry->expr, plgrpcl, target_list);
+		if (NULL != te_grouping_col)
 		{
-			const ULONG ulColId = CTranslatorUtils::UlColId((INT) pteGroupingColumn->ressortgroupref, phmiulSortgrouprefColId);
-			StoreAttnoColIdMapping(phmiulOutputCols, pte->resno, ulColId);
-			if (0 < iSortGroupRef && 0 < ulColId && NULL == phmiulSortgrouprefColId->PtLookup(&iSortGroupRef))
+			const ULONG colid = CTranslatorUtils::GetColId((INT) te_grouping_col->ressortgroupref, sort_grpref_to_colid_mapping);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, target_entry->resno, colid);
+			if (0 < sort_group_ref && 0 < colid && NULL == sort_grpref_to_colid_mapping->Find(&sort_group_ref))
 			{
-				AddSortingGroupingColumn(pte, phmiulSortgrouprefColId, ulColId);
+				AddSortingGroupingColumn(target_entry, sort_grpref_to_colid_mapping, colid);
 			}
 		}
 	}
-	if (NIL != plOmittedTE)
+	if (NIL != omitted_te_list)
 	{
-		gpdb::GPDBFree(plOmittedTE);
+		gpdb::GPDBFree(omitted_te_list);
 	}
 
-	GPOS_ASSERT_IMP(!fExpandAggrefExpr, NULL == plVars);
+	GPOS_ASSERT_IMP(!is_expand_aggref_expr, NULL == vars_list);
 	
 	// process all additional vars in aggref expressions
-	ListCell *plcVar = NULL;
-	ForEach (plcVar, plVars)
+	ListCell *lc_var = NULL;
+	ForEach (lc_var, vars_list)
 	{
-		ulResno++;
-		Var *pvar = (Var *) lfirst(plcVar);
+		resno++;
+		Var *var = (Var *) lfirst(lc_var);
 
 		// TODO: Dec 28, 2012; figure out column's name
-		CDXLNode *pdxlnPrEl =  PdxlnPrEFromGPDBExpr((Expr*) pvar, "?col?");
+		CDXLNode *project_elem_dxlnode =  TranslateExprToDXLProject((Expr*) var, "?col?");
 		
-		ULONG ulColId = CDXLScalarProjElem::PdxlopConvert(pdxlnPrEl->Pdxlop())->UlId();
+		ULONG colid = CDXLScalarProjElem::Cast(project_elem_dxlnode->GetOperator())->Id();
 
 		// add column to the list of output columns of the query
-		StoreAttnoColIdMapping(phmiulOutputCols, ulResno, ulColId);
+		StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 		
-		pdxlnPrEl->Release();
+		project_elem_dxlnode->Release();
 	}
 	
-	if (0 < pdxlnPrL->UlArity())
+	if (0 < project_list_dxlnode->Arity())
 	{
 		// create a node with the CDXLLogicalProject operator and add as its children:
 		// the CDXLProjectList node and the node representing the input to the project node
-		CDXLNode *pdxlnProject = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalProject(m_pmp));
-		pdxlnProject->AddChild(pdxlnPrL);
-		pdxlnProject->AddChild(pdxlnChild);
-		GPOS_ASSERT(NULL != pdxlnProject);
-		return pdxlnProject;
+		CDXLNode *project_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalProject(m_mp));
+		project_dxlnode->AddChild(project_list_dxlnode);
+		project_dxlnode->AddChild(child_dxlnode);
+		GPOS_ASSERT(NULL != project_dxlnode);
+		return project_dxlnode;
 	}
 
-	pdxlnPrL->Release();
-	return pdxlnChild;
+	project_list_dxlnode->Release();
+	return child_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnProjectNullsForGroupingSets
+//		CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets
 //
 //	@doc:
 //		Construct a DXL project node projecting NULL values for the columns in the
@@ -3704,90 +3702,90 @@ CTranslatorQueryToDXL::PdxlnLgProjectFromGPDBTL
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnProjectNullsForGroupingSets
+CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets
 	(
-	List *plTargetList,
-	CDXLNode *pdxlnChild,
-	CBitSet *pbs,					// group by columns
-	HMIUl *phmiulSortgrouprefCols,	// mapping of sorting and grouping columns
-	HMIUl *phmiulOutputCols,		// mapping of output columns
-	HMUlUl *phmululGrpColPos		// mapping of unique grouping col positions
+	List *target_list,
+	CDXLNode *child_dxlnode,
+	CBitSet *bitset,					// group by columns
+	IntToUlongMap *sort_grouping_col_mapping,	// mapping of sorting and grouping columns
+	IntToUlongMap *output_attno_to_colid_mapping,		// mapping of output columns
+	UlongToUlongMap *grpcol_index_to_colid_mapping		// mapping of unique grouping col positions
 	)
 	const
 {
-	CDXLNode *pdxlnPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
+	CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
 	// construct a proj element node for those non-aggregate entries in the target list which
 	// are not included in the grouping set
-	ListCell *plcTE = NULL;
-	ForEach (plcTE, plTargetList)
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
 
-		BOOL fGroupingCol = pbs->FBit(pte->ressortgroupref);
-		ULONG ulResno = pte->resno;
+		BOOL is_grouping_col = bitset->Get(target_entry->ressortgroupref);
+		ULONG resno = target_entry->resno;
 
-		ULONG ulColId = 0;
+		ULONG colid = 0;
 		
-		if (IsA(pte->expr, GroupingFunc))
+		if (IsA(target_entry->expr, GroupingFunc))
 		{
-			ulColId = m_pidgtorCol->UlNextId();
-			CDXLNode *pdxlnGroupingFunc = PdxlnGroupingFunc(pte->expr, pbs, phmululGrpColPos);
-			CMDName *pmdnameAlias = NULL;
+			colid = m_colid_counter->next_id();
+			CDXLNode *grouping_func_dxlnode = TranslateGroupingFuncToDXL(target_entry->expr, bitset, grpcol_index_to_colid_mapping);
+			CMDName *mdname_alias = NULL;
 
-			if (NULL == pte->resname)
+			if (NULL == target_entry->resname)
 			{
-				CWStringConst strUnnamedCol(GPOS_WSZ_LIT("grouping"));
-				pmdnameAlias = GPOS_NEW(m_pmp) CMDName(m_pmp, &strUnnamedCol);
+				CWStringConst str_unnamed_col(GPOS_WSZ_LIT("grouping"));
+				mdname_alias = GPOS_NEW(m_mp) CMDName(m_mp, &str_unnamed_col);
 			}
 			else
 			{
-				CWStringDynamic *pstrAlias = CDXLUtils::PstrFromSz(m_pmp, pte->resname);
-				pmdnameAlias = GPOS_NEW(m_pmp) CMDName(m_pmp, pstrAlias);
-				GPOS_DELETE(pstrAlias);
+				CWStringDynamic *alias_str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, target_entry->resname);
+				mdname_alias = GPOS_NEW(m_mp) CMDName(m_mp, alias_str);
+				GPOS_DELETE(alias_str);
 			}
-			CDXLNode *pdxlnPrEl = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjElem(m_pmp, ulColId, pmdnameAlias), pdxlnGroupingFunc);
-			pdxlnPrL->AddChild(pdxlnPrEl);
-			StoreAttnoColIdMapping(phmiulOutputCols, ulResno, ulColId);
+			CDXLNode *project_elem_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjElem(m_mp, colid, mdname_alias), grouping_func_dxlnode);
+			project_list_dxlnode->AddChild(project_elem_dxlnode);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 		}
-		else if (!fGroupingCol && !IsA(pte->expr, Aggref))
+		else if (!is_grouping_col && !IsA(target_entry->expr, Aggref))
 		{
-			OID oidType = gpdb::OidExprType((Node *) pte->expr);
+			OID oid_type = gpdb::ExprType((Node *) target_entry->expr);
 
-			ulColId = m_pidgtorCol->UlNextId();
+			colid = m_colid_counter->next_id();
 
-			CMDIdGPDB *pmdid = GPOS_NEW(m_pmp) CMDIdGPDB(oidType);
-			CDXLNode *pdxlnPrEl = CTranslatorUtils::PdxlnPrElNull(m_pmp, m_pmda, pmdid, ulColId, pte->resname);
-			pmdid->Release();
+			CMDIdGPDB *mdid = GPOS_NEW(m_mp) CMDIdGPDB(oid_type);
+			CDXLNode *project_elem_dxlnode = CTranslatorUtils::CreateDXLProjElemConstNULL(m_mp, m_md_accessor, mdid, colid, target_entry->resname);
+			mdid->Release();
 			
-			pdxlnPrL->AddChild(pdxlnPrEl);
-			StoreAttnoColIdMapping(phmiulOutputCols, ulResno, ulColId);
+			project_list_dxlnode->AddChild(project_elem_dxlnode);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 		}
 		
-		INT iSortGroupRef = INT (pte->ressortgroupref);
+		INT sort_group_ref = INT (target_entry->ressortgroupref);
 		
-		GPOS_ASSERT_IMP(0 == phmiulSortgrouprefCols, NULL != phmiulSortgrouprefCols->PtLookup(&iSortGroupRef) && "Grouping column with no mapping");
+		GPOS_ASSERT_IMP(0 == sort_grouping_col_mapping, NULL != sort_grouping_col_mapping->Find(&sort_group_ref) && "Grouping column with no mapping");
 		
-		if (0 < iSortGroupRef && 0 < ulColId && NULL == phmiulSortgrouprefCols->PtLookup(&iSortGroupRef))
+		if (0 < sort_group_ref && 0 < colid && NULL == sort_grouping_col_mapping->Find(&sort_group_ref))
 		{
-			AddSortingGroupingColumn(pte, phmiulSortgrouprefCols, ulColId);
+			AddSortingGroupingColumn(target_entry, sort_grouping_col_mapping, colid);
 		}
 	}
 
-	if (0 == pdxlnPrL->UlArity())
+	if (0 == project_list_dxlnode->Arity())
 	{
 		// no project necessary
-		pdxlnPrL->Release();
-		return pdxlnChild;
+		project_list_dxlnode->Release();
+		return child_dxlnode;
 	}
 
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalProject(m_pmp), pdxlnPrL, pdxlnChild);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalProject(m_mp), project_list_dxlnode, child_dxlnode);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnProjectGroupingFuncs
+//		CTranslatorQueryToDXL::CreateDXLProjectGroupingFuncs
 //
 //	@doc:
 //		Construct a DXL project node projecting values for the grouping funcs in
@@ -3795,61 +3793,61 @@ CTranslatorQueryToDXL::PdxlnProjectNullsForGroupingSets
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnProjectGroupingFuncs
+CTranslatorQueryToDXL::CreateDXLProjectGroupingFuncs
 	(
-	List *plTargetList,
-	CDXLNode *pdxlnChild,
-	CBitSet *pbs,
-	HMIUl *phmiulOutputCols,
-	HMUlUl *phmululGrpColPos,
-	HMIUl *phmiulSortgrouprefColId
+	List *target_list,
+	CDXLNode *child_dxlnode,
+	CBitSet *bitset,
+	IntToUlongMap *output_attno_to_colid_mapping,
+	UlongToUlongMap *grpcol_index_to_colid_mapping,
+	IntToUlongMap *sort_grpref_to_colid_mapping
 	)
 	const
 {
-	CDXLNode *pdxlnPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp));
+	CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
 	// construct a proj element node for those non-aggregate entries in the target list which
 	// are not included in the grouping set
-	ListCell *plcTE = NULL;
-	ForEach (plcTE, plTargetList)
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(IsA(pte, TargetEntry));
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
 
-		ULONG ulResno = pte->resno;
+		ULONG resno = target_entry->resno;
 
-		if (IsA(pte->expr, GroupingFunc))
+		if (IsA(target_entry->expr, GroupingFunc))
 		{
-			ULONG ulColId = m_pidgtorCol->UlNextId();
-			CDXLNode *pdxlnGroupingFunc = PdxlnGroupingFunc(pte->expr, pbs, phmululGrpColPos);
-			CMDName *pmdnameAlias = NULL;
+			ULONG colid = m_colid_counter->next_id();
+			CDXLNode *grouping_func_dxlnode = TranslateGroupingFuncToDXL(target_entry->expr, bitset, grpcol_index_to_colid_mapping);
+			CMDName *mdname_alias = NULL;
 
-			if (NULL == pte->resname)
+			if (NULL == target_entry->resname)
 			{
-				CWStringConst strUnnamedCol(GPOS_WSZ_LIT("grouping"));
-				pmdnameAlias = GPOS_NEW(m_pmp) CMDName(m_pmp, &strUnnamedCol);
+				CWStringConst str_unnamed_col(GPOS_WSZ_LIT("grouping"));
+				mdname_alias = GPOS_NEW(m_mp) CMDName(m_mp, &str_unnamed_col);
 			}
 			else
 			{
-				CWStringDynamic *pstrAlias = CDXLUtils::PstrFromSz(m_pmp, pte->resname);
-				pmdnameAlias = GPOS_NEW(m_pmp) CMDName(m_pmp, pstrAlias);
-				GPOS_DELETE(pstrAlias);
+				CWStringDynamic *alias_str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, target_entry->resname);
+				mdname_alias = GPOS_NEW(m_mp) CMDName(m_mp, alias_str);
+				GPOS_DELETE(alias_str);
 			}
-			CDXLNode *pdxlnPrEl = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjElem(m_pmp, ulColId, pmdnameAlias), pdxlnGroupingFunc);
-			pdxlnPrL->AddChild(pdxlnPrEl);
-			StoreAttnoColIdMapping(phmiulOutputCols, ulResno, ulColId);
-			AddSortingGroupingColumn(pte, phmiulSortgrouprefColId, ulColId);
+			CDXLNode *project_elem_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjElem(m_mp, colid, mdname_alias), grouping_func_dxlnode);
+			project_list_dxlnode->AddChild(project_elem_dxlnode);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
+			AddSortingGroupingColumn(target_entry, sort_grpref_to_colid_mapping, colid);
 		}
 	}
 
-	if (0 == pdxlnPrL->UlArity())
+	if (0 == project_list_dxlnode->Arity())
 	{
 		// no project necessary
-		pdxlnPrL->Release();
-		return pdxlnChild;
+		project_list_dxlnode->Release();
+		return child_dxlnode;
 	}
 
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalProject(m_pmp), pdxlnPrL, pdxlnChild);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalProject(m_mp), project_list_dxlnode, child_dxlnode);
 }
 
 //---------------------------------------------------------------------------
@@ -3863,94 +3861,94 @@ CTranslatorQueryToDXL::PdxlnProjectGroupingFuncs
 void
 CTranslatorQueryToDXL::StoreAttnoColIdMapping
 	(
-	HMIUl *phmiul,
-	INT iAttno,
-	ULONG ulColId
+	IntToUlongMap *attno_to_colid_mapping,
+	INT attno,
+	ULONG colid
 	)
 	const
 {
-	GPOS_ASSERT(NULL != phmiul);
+	GPOS_ASSERT(NULL != attno_to_colid_mapping);
 
 #ifdef GPOS_DEBUG
-	BOOL fResult =
+	BOOL result =
 #endif // GPOS_DEBUG
-	phmiul->FInsert(GPOS_NEW(m_pmp) INT(iAttno), GPOS_NEW(m_pmp) ULONG(ulColId));
+	attno_to_colid_mapping->Insert(GPOS_NEW(m_mp) INT(attno), GPOS_NEW(m_mp) ULONG(colid));
 
-	GPOS_ASSERT(fResult);
+	GPOS_ASSERT(result);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdrgpdxlnConstructOutputCols
+//		CTranslatorQueryToDXL::CreateDXLOutputCols
 //
 //	@doc:
 //		Construct an array of DXL nodes representing the query output
 //
 //---------------------------------------------------------------------------
-DrgPdxln *
-CTranslatorQueryToDXL::PdrgpdxlnConstructOutputCols
+CDXLNodeArray *
+CTranslatorQueryToDXL::CreateDXLOutputCols
 	(
-	List *plTargetList,
-	HMIUl *phmiulAttnoColId
+	List *target_list,
+	IntToUlongMap *attno_to_colid_mapping
 	)
 	const
 {
-	GPOS_ASSERT(NULL != plTargetList);
-	GPOS_ASSERT(NULL != phmiulAttnoColId);
+	GPOS_ASSERT(NULL != target_list);
+	GPOS_ASSERT(NULL != attno_to_colid_mapping);
 
-	DrgPdxln *pdrgpdxln = GPOS_NEW(m_pmp) DrgPdxln(m_pmp);
+	CDXLNodeArray *dxlnodes = GPOS_NEW(m_mp) CDXLNodeArray(m_mp);
 
-	ListCell *plc = NULL;
-	ForEach (plc, plTargetList)
+	ListCell *lc = NULL;
+	ForEach (lc, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plc);
-		GPOS_ASSERT(0 < pte->resno);
-		ULONG ulResNo = pte->resno;
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(0 < target_entry->resno);
+		ULONG resno = target_entry->resno;
 
-		if (pte->resjunk)
+		if (target_entry->resjunk)
 		{
 			continue;
 		}
 
-		GPOS_ASSERT(NULL != pte);
-		CMDName *pmdname = NULL;
-		if (NULL == pte->resname)
+		GPOS_ASSERT(NULL != target_entry);
+		CMDName *mdname = NULL;
+		if (NULL == target_entry->resname)
 		{
-			CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
-			pmdname = GPOS_NEW(m_pmp) CMDName(m_pmp, &strUnnamedCol);
+			CWStringConst str_unnamed_col(GPOS_WSZ_LIT("?column?"));
+			mdname = GPOS_NEW(m_mp) CMDName(m_mp, &str_unnamed_col);
 		}
 		else
 		{
-			CWStringDynamic *pstrAlias = CDXLUtils::PstrFromSz(m_pmp, pte->resname);
-			pmdname = GPOS_NEW(m_pmp) CMDName(m_pmp, pstrAlias);
+			CWStringDynamic *alias_str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, target_entry->resname);
+			mdname = GPOS_NEW(m_mp) CMDName(m_mp, alias_str);
 			// CName constructor copies string
-			GPOS_DELETE(pstrAlias);
+			GPOS_DELETE(alias_str);
 		}
 
-		const ULONG ulColId = CTranslatorUtils::UlColId(ulResNo, phmiulAttnoColId);
+		const ULONG colid = CTranslatorUtils::GetColId(resno, attno_to_colid_mapping);
 
 		// create a column reference
-		IMDId *pmdidType = GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType( (Node*) pte->expr));
-		INT iTypeModifier = gpdb::IExprTypeMod((Node*) pte->expr);
-		CDXLColRef *pdxlcr = GPOS_NEW(m_pmp) CDXLColRef(m_pmp, pmdname, ulColId, pmdidType, iTypeModifier);
-		CDXLScalarIdent *pdxlopIdent = GPOS_NEW(m_pmp) CDXLScalarIdent
+		IMDId *mdid_type = GPOS_NEW(m_mp) CMDIdGPDB(gpdb::ExprType( (Node*) target_entry->expr));
+		INT type_modifier = gpdb::ExprTypeMod((Node*) target_entry->expr);
+		CDXLColRef *dxl_colref = GPOS_NEW(m_mp) CDXLColRef(m_mp, mdname, colid, mdid_type, type_modifier);
+		CDXLScalarIdent *dxl_ident = GPOS_NEW(m_mp) CDXLScalarIdent
 												(
-												m_pmp,
-												pdxlcr
+												m_mp,
+												dxl_colref
 												);
 
 		// create the DXL node holding the scalar ident operator
-		CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopIdent);
+		CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_ident);
 
-		pdrgpdxln->Append(pdxln);
+		dxlnodes->Append(dxlnode);
 	}
 
-	return pdrgpdxln;
+	return dxlnodes;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnPrEFromGPDBExpr
+//		CTranslatorQueryToDXL::TranslateExprToDXLProject
 //
 //	@doc:
 //		Create a DXL project element node from the target list entry or var.
@@ -3958,121 +3956,121 @@ CTranslatorQueryToDXL::PdrgpdxlnConstructOutputCols
 //		is responsible for freeing it.
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnPrEFromGPDBExpr
+CTranslatorQueryToDXL::TranslateExprToDXLProject
 	(
-	Expr *pexpr,
-	const CHAR *szAliasName,
-	BOOL fInsistNewColIds
+	Expr *expr,
+	const CHAR *alias_name,
+	BOOL insist_new_colids
 	)
 {
-	GPOS_ASSERT(NULL != pexpr);
+	GPOS_ASSERT(NULL != expr);
 
 	// construct a scalar operator
-	CDXLNode *pdxlnChild = PdxlnScFromGPDBExpr(pexpr);
+	CDXLNode *child_dxlnode = TranslateExprToDXL(expr);
 
 	// get the id and alias for the proj elem
-	ULONG ulPrElId;
-	CMDName *pmdnameAlias = NULL;
+	ULONG project_elem_id;
+	CMDName *mdname_alias = NULL;
 
-	if (NULL == szAliasName)
+	if (NULL == alias_name)
 	{
-		CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
-		pmdnameAlias = GPOS_NEW(m_pmp) CMDName(m_pmp, &strUnnamedCol);
+		CWStringConst str_unnamed_col(GPOS_WSZ_LIT("?column?"));
+		mdname_alias = GPOS_NEW(m_mp) CMDName(m_mp, &str_unnamed_col);
 	}
 	else
 	{
-		CWStringDynamic *pstrAlias = CDXLUtils::PstrFromSz(m_pmp, szAliasName);
-		pmdnameAlias = GPOS_NEW(m_pmp) CMDName(m_pmp, pstrAlias);
-		GPOS_DELETE(pstrAlias);
+		CWStringDynamic *alias_str = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, alias_name);
+		mdname_alias = GPOS_NEW(m_mp) CMDName(m_mp, alias_str);
+		GPOS_DELETE(alias_str);
 	}
 
-	if (IsA(pexpr, Var) && !fInsistNewColIds)
+	if (IsA(expr, Var) && !insist_new_colids)
 	{
 		// project elem is a a reference to a column - use the colref id
-		GPOS_ASSERT(EdxlopScalarIdent == pdxlnChild->Pdxlop()->Edxlop());
-		CDXLScalarIdent *pdxlopIdent = (CDXLScalarIdent *) pdxlnChild->Pdxlop();
-		ulPrElId = pdxlopIdent->Pdxlcr()->UlID();
+		GPOS_ASSERT(EdxlopScalarIdent == child_dxlnode->GetOperator()->GetDXLOperator());
+		CDXLScalarIdent *dxl_ident = (CDXLScalarIdent *) child_dxlnode->GetOperator();
+		project_elem_id = dxl_ident->GetDXLColRef()->Id();
 	}
 	else
 	{
 		// project elem is a defined column - get a new id
-		ulPrElId = m_pidgtorCol->UlNextId();
+		project_elem_id = m_colid_counter->next_id();
 	}
 
-	CDXLNode *pdxlnPrEl = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjElem(m_pmp, ulPrElId, pmdnameAlias));
-	pdxlnPrEl->AddChild(pdxlnChild);
+	CDXLNode *project_elem_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjElem(m_mp, project_elem_id, mdname_alias));
+	project_elem_dxlnode->AddChild(child_dxlnode);
 
-	return pdxlnPrEl;
+	return project_elem_dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnScConstValueTrue
+//		CTranslatorQueryToDXL::CreateDXLConstValueTrue
 //
 //	@doc:
 //		Returns a CDXLNode representing scalar condition "true"
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnScConstValueTrue()
+CTranslatorQueryToDXL::CreateDXLConstValueTrue()
 {
-	Const *pconst = (Const*) gpdb::PnodeMakeBoolConst(true /*value*/, false /*isnull*/);
-	CDXLNode *pdxln = PdxlnScFromGPDBExpr((Expr*) pconst);
-	gpdb::GPDBFree(pconst);
+	Const *const_expr = (Const*) gpdb::MakeBoolConst(true /*value*/, false /*isnull*/);
+	CDXLNode *dxlnode = TranslateExprToDXL((Expr*) const_expr);
+	gpdb::GPDBFree(const_expr);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdxlnGroupingFunc
+//		CTranslatorQueryToDXL::TranslateGroupingFuncToDXL
 //
 //	@doc:
 //		Translate grouping func
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::PdxlnGroupingFunc
+CTranslatorQueryToDXL::TranslateGroupingFuncToDXL
 	(
-	const Expr *pexpr,
-	CBitSet *pbs,
-	HMUlUl *phmululGrpColPos
+	const Expr *expr,
+	CBitSet *bitset,
+	UlongToUlongMap *grpcol_index_to_colid_mapping
 	)
 	const
 {
-	GPOS_ASSERT(IsA(pexpr, GroupingFunc));
-	GPOS_ASSERT(NULL != phmululGrpColPos);
+	GPOS_ASSERT(IsA(expr, GroupingFunc));
+	GPOS_ASSERT(NULL != grpcol_index_to_colid_mapping);
 
-	const GroupingFunc *pgroupingfunc = (GroupingFunc *) pexpr;
+	const GroupingFunc *grouping_func = (GroupingFunc *) expr;
 
-	if (1 < gpdb::UlListLength(pgroupingfunc->args))
+	if (1 < gpdb::ListLength(grouping_func->args))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Grouping function with multiple arguments"));
 	}
 	
-	Node *pnode = (Node *) gpdb::PvListNth(pgroupingfunc->args, 0);
-	ULONG ulGroupingIndex = gpdb::IValue(pnode); 
+	Node *node = (Node *) gpdb::ListNth(grouping_func->args, 0);
+	ULONG grouping_idx = gpdb::GetIntFromValue(node);
 		
 	// generate a constant value for the result of the grouping function as follows:
 	// if the grouping function argument is a group-by column, result is 0
 	// otherwise, the result is 1 
-	LINT lValue = 0;
+	LINT l_value = 0;
 	
-	ULONG *pulSortGrpRef = phmululGrpColPos->PtLookup(&ulGroupingIndex);
-	GPOS_ASSERT(NULL != pulSortGrpRef);
-	BOOL fGroupingCol = pbs->FBit(*pulSortGrpRef);	
-	if (!fGroupingCol)
+	ULONG *sort_group_ref = grpcol_index_to_colid_mapping->Find(&grouping_idx);
+	GPOS_ASSERT(NULL != sort_group_ref);
+	BOOL is_grouping_col = bitset->Get(*sort_group_ref);
+	if (!is_grouping_col)
 	{
 		// not a grouping column
-		lValue = 1; 
+		l_value = 1;
 	}
 
-	const IMDType *pmdtype = m_pmda->PtMDType<IMDTypeInt8>(m_sysid);
-	CMDIdGPDB *pmdidMDC = CMDIdGPDB::PmdidConvert(pmdtype->Pmdid());
-	CMDIdGPDB *pmdid = GPOS_NEW(m_pmp) CMDIdGPDB(*pmdidMDC);
+	const IMDType *md_type = m_md_accessor->PtMDType<IMDTypeInt8>(m_sysid);
+	CMDIdGPDB *mdid_cast = CMDIdGPDB::CastMdid(md_type->MDId());
+	CMDIdGPDB *mdid = GPOS_NEW(m_mp) CMDIdGPDB(*mdid_cast);
 	
-	CDXLDatum *pdxldatum = GPOS_NEW(m_pmp) CDXLDatumInt8(m_pmp, pmdid, false /* fNull */, lValue);
-	CDXLScalarConstValue *pdxlop = GPOS_NEW(m_pmp) CDXLScalarConstValue(m_pmp, pdxldatum);
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLDatum *datum_dxl = GPOS_NEW(m_mp) CDXLDatumInt8(m_mp, mdid, false /* is_null */, l_value);
+	CDXLScalarConstValue *dxlop = GPOS_NEW(m_mp) CDXLScalarConstValue(m_mp, datum_dxl);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 }
 
 //---------------------------------------------------------------------------
@@ -4086,95 +4084,95 @@ CTranslatorQueryToDXL::PdxlnGroupingFunc
 void
 CTranslatorQueryToDXL::ConstructCTEProducerList
 	(
-	List *plCTE,
-	ULONG ulCteQueryLevel
+	List *cte_list,
+	ULONG cte_query_level
 	)
 {
-	GPOS_ASSERT(NULL != m_pdrgpdxlnCTE && "CTE Producer list not initialized"); 
+	GPOS_ASSERT(NULL != m_dxl_cte_producers && "CTE Producer list not initialized");
 	
-	if (NULL == plCTE)
+	if (NULL == cte_list)
 	{
 		return;
 	}
 	
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 	
-	ForEach (plc, plCTE)
+	ForEach (lc, cte_list)
 	{
-		CommonTableExpr *pcte = (CommonTableExpr *) lfirst(plc);
-		GPOS_ASSERT(IsA(pcte->ctequery, Query));
+		CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+		GPOS_ASSERT(IsA(cte->ctequery, Query));
 		
-		if (pcte->cterecursive)
+		if (cte->cterecursive)
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("WITH RECURSIVE"));
 		}
 
-		Query *pqueryCte = CQueryMutators::PqueryNormalize(m_pmp, m_pmda, (Query *) pcte->ctequery, ulCteQueryLevel + 1);
+		Query *cte_query = CQueryMutators::NormalizeQuery(m_mp, m_md_accessor, (Query *) cte->ctequery, cte_query_level + 1);
 		
 		// the query representing the cte can only access variables defined in the current level as well as
 		// those defined at prior query levels
-		CMappingVarColId *pmapvarcolid = m_pmapvarcolid->PmapvarcolidCopy(ulCteQueryLevel);
+		CMappingVarColId *var_colid_mapping = m_var_to_colid_map->CopyMapColId(cte_query_level);
 
-		CTranslatorQueryToDXL trquerytodxl
+		CTranslatorQueryToDXL query_to_dxl_translator
 			(
-			m_pmp,
-			m_pmda,
-			m_pidgtorCol,
-			m_pidgtorCTE,
-			pmapvarcolid,
-			pqueryCte,
-			ulCteQueryLevel + 1,
-			FDMLQuery(),
-			m_phmulCTEEntries
+			m_mp,
+			m_md_accessor,
+			m_colid_counter,
+			m_cte_id_counter,
+			var_colid_mapping,
+			cte_query,
+			cte_query_level + 1,
+			IsDMLQuery(),
+			m_query_level_to_cte_map
 			);
 
 		// translate query representing the cte table to its DXL representation
-		CDXLNode *pdxlnCteChild = trquerytodxl.PdxlnFromQueryInternal();
+		CDXLNode *cte_child_dxlnode = query_to_dxl_translator.TranslateSelectQueryToDXL();
 
 		// get the output columns of the cte table
-		DrgPdxln *pdrgpdxlnQueryOutputCte = trquerytodxl.PdrgpdxlnQueryOutput();
-		DrgPdxln *pdrgpdxlnCTE = trquerytodxl.PdrgpdxlnCTE();
-		m_fHasDistributedTables = m_fHasDistributedTables || trquerytodxl.FHasDistributedTables();
+		CDXLNodeArray *cte_query_output_colds_dxlnode_array = query_to_dxl_translator.GetQueryOutputCols();
+		CDXLNodeArray *cte_dxlnode_array = query_to_dxl_translator.GetCTEs();
+		m_has_distributed_tables = m_has_distributed_tables || query_to_dxl_translator.HasDistributedTables();
 
-		GPOS_ASSERT(NULL != pdxlnCteChild && NULL != pdrgpdxlnQueryOutputCte && NULL != pdrgpdxlnCTE);
+		GPOS_ASSERT(NULL != cte_child_dxlnode && NULL != cte_query_output_colds_dxlnode_array && NULL != cte_dxlnode_array);
 		
 		// append any nested CTE
-		CUtils::AddRefAppend(m_pdrgpdxlnCTE, pdrgpdxlnCTE);
+		CUtils::AddRefAppend(m_dxl_cte_producers, cte_dxlnode_array);
 		
-		DrgPul *pdrgpulColIds = GPOS_NEW(m_pmp) DrgPul(m_pmp);
+		ULongPtrArray *colid_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 		
-		const ULONG ulOutputCols = pdrgpdxlnQueryOutputCte->UlLength();
-		for (ULONG ul = 0; ul < ulOutputCols; ul++)
+		const ULONG output_columns = cte_query_output_colds_dxlnode_array->Size();
+		for (ULONG ul = 0; ul < output_columns; ul++)
 		{
-			CDXLNode *pdxlnOutputCol = (*pdrgpdxlnQueryOutputCte)[ul];
-			CDXLScalarIdent *pdxlnIdent = CDXLScalarIdent::PdxlopConvert(pdxlnOutputCol->Pdxlop());
-			pdrgpulColIds->Append(GPOS_NEW(m_pmp) ULONG(pdxlnIdent->Pdxlcr()->UlID()));
+			CDXLNode *output_col_dxlnode = (*cte_query_output_colds_dxlnode_array)[ul];
+			CDXLScalarIdent *dxl_scalar_ident = CDXLScalarIdent::Cast(output_col_dxlnode->GetOperator());
+			colid_array->Append(GPOS_NEW(m_mp) ULONG(dxl_scalar_ident->GetDXLColRef()->Id()));
 		}
 		
-		CDXLLogicalCTEProducer *pdxlop = GPOS_NEW(m_pmp) CDXLLogicalCTEProducer(m_pmp, m_pidgtorCTE->UlNextId(), pdrgpulColIds);
-		CDXLNode *pdxlnCTEProducer = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop, pdxlnCteChild);
+		CDXLLogicalCTEProducer *lg_cte_prod_dxlop = GPOS_NEW(m_mp) CDXLLogicalCTEProducer(m_mp, m_cte_id_counter->next_id(), colid_array);
+		CDXLNode *cte_producer_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, lg_cte_prod_dxlop, cte_child_dxlnode);
 		
-		m_pdrgpdxlnCTE->Append(pdxlnCTEProducer);
+		m_dxl_cte_producers->Append(cte_producer_dxlnode);
 #ifdef GPOS_DEBUG
-		BOOL fResult =
+		BOOL result =
 #endif
-		m_phmulfCTEProducers->FInsert(GPOS_NEW(m_pmp) ULONG(pdxlop->UlId()), GPOS_NEW(m_pmp) BOOL(true));
-		GPOS_ASSERT(fResult);
+		m_cteid_at_current_query_level_map->Insert(GPOS_NEW(m_mp) ULONG(lg_cte_prod_dxlop->Id()), GPOS_NEW(m_mp) BOOL(true));
+		GPOS_ASSERT(result);
 		
 		// update CTE producer mappings
-		CCTEListEntry *pctelistentry = m_phmulCTEEntries->PtLookup(&ulCteQueryLevel);
-		if (NULL == pctelistentry)
+		CCTEListEntry *cte_list_entry = m_query_level_to_cte_map->Find(&cte_query_level);
+		if (NULL == cte_list_entry)
 		{
-			pctelistentry = GPOS_NEW(m_pmp) CCTEListEntry (m_pmp, ulCteQueryLevel, pcte, pdxlnCTEProducer);
+			cte_list_entry = GPOS_NEW(m_mp) CCTEListEntry (m_mp, cte_query_level, cte, cte_producer_dxlnode);
 #ifdef GPOS_DEBUG
-		BOOL fRes =
+		BOOL is_res =
 #endif
-			m_phmulCTEEntries->FInsert(GPOS_NEW(m_pmp) ULONG(ulCteQueryLevel), pctelistentry);
-			GPOS_ASSERT(fRes);
+			m_query_level_to_cte_map->Insert(GPOS_NEW(m_mp) ULONG(cte_query_level), cte_list_entry);
+			GPOS_ASSERT(is_res);
 		}
 		else
 		{
-			pctelistentry->AddCTEProducer(m_pmp, pcte, pdxlnCTEProducer);
+			cte_list_entry->AddCTEProducer(m_mp, cte, cte_producer_dxlnode);
 		}
 	}
 }
@@ -4190,176 +4188,176 @@ CTranslatorQueryToDXL::ConstructCTEProducerList
 void
 CTranslatorQueryToDXL::ConstructCTEAnchors
 	(
-	DrgPdxln *pdrgpdxln,
-	CDXLNode **ppdxlnCTEAnchorTop,
-	CDXLNode **ppdxlnCTEAnchorBottom
+	CDXLNodeArray *dxlnodes,
+	CDXLNode **dxl_cte_anchor_top,
+	CDXLNode **dxl_cte_anchor_bottom
 	)
 {
-	GPOS_ASSERT(NULL == *ppdxlnCTEAnchorTop);
-	GPOS_ASSERT(NULL == *ppdxlnCTEAnchorBottom);
+	GPOS_ASSERT(NULL == *dxl_cte_anchor_top);
+	GPOS_ASSERT(NULL == *dxl_cte_anchor_bottom);
 
-	if (NULL == pdrgpdxln || 0 == pdrgpdxln->UlLength())
+	if (NULL == dxlnodes || 0 == dxlnodes->Size())
 	{
 		return;
 	}
 	
-	const ULONG ulCTEs = pdrgpdxln->UlLength();
+	const ULONG num_of_ctes = dxlnodes->Size();
 	
-	for (ULONG ul = ulCTEs; ul > 0; ul--)
+	for (ULONG ul = num_of_ctes; ul > 0; ul--)
 	{
 		// construct a new CTE anchor on top of the previous one
-		CDXLNode *pdxlnCTEProducer = (*pdrgpdxln)[ul-1];
-		CDXLLogicalCTEProducer *pdxlopCTEProducer = CDXLLogicalCTEProducer::PdxlopConvert(pdxlnCTEProducer->Pdxlop());
-		ULONG ulCTEProducerId = pdxlopCTEProducer->UlId();
+		CDXLNode *cte_producer_dxlnode = (*dxlnodes)[ul-1];
+		CDXLLogicalCTEProducer *cte_prod_dxlop = CDXLLogicalCTEProducer::Cast(cte_producer_dxlnode->GetOperator());
+		ULONG cte_producer_id = cte_prod_dxlop->Id();
 		
-		if (NULL == m_phmulfCTEProducers->PtLookup(&ulCTEProducerId))
+		if (NULL == m_cteid_at_current_query_level_map->Find(&cte_producer_id))
 		{
 			// cte not defined at this level: CTE anchor was already added
 			continue;
 		}
 		
-		CDXLNode *pdxlnCTEAnchorNew = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLLogicalCTEAnchor(m_pmp, ulCTEProducerId));
+		CDXLNode *cte_anchor_new_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalCTEAnchor(m_mp, cte_producer_id));
 		
-		if (NULL == *ppdxlnCTEAnchorBottom)
+		if (NULL == *dxl_cte_anchor_bottom)
 		{
-			*ppdxlnCTEAnchorBottom = pdxlnCTEAnchorNew;
+			*dxl_cte_anchor_bottom = cte_anchor_new_dxlnode;
 		}
 
-		if (NULL != *ppdxlnCTEAnchorTop)
+		if (NULL != *dxl_cte_anchor_top)
 		{
-			pdxlnCTEAnchorNew->AddChild(*ppdxlnCTEAnchorTop);
+			cte_anchor_new_dxlnode->AddChild(*dxl_cte_anchor_top);
 		}
-		*ppdxlnCTEAnchorTop = pdxlnCTEAnchorNew;
+		*dxl_cte_anchor_top = cte_anchor_new_dxlnode;
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdrgpulGenerateColIds
+//		CTranslatorQueryToDXL::GenerateColIds
 //
 //	@doc:
 //		Generate an array of new column ids of the given size
 //
 //---------------------------------------------------------------------------
-DrgPul *
-CTranslatorQueryToDXL::PdrgpulGenerateColIds
+ULongPtrArray *
+CTranslatorQueryToDXL::GenerateColIds
 	(
-	IMemoryPool *pmp,
-	ULONG ulSize
+	IMemoryPool *mp,
+	ULONG size
 	)
 	const
 {
-	DrgPul *pdrgpul = GPOS_NEW(pmp) DrgPul(pmp);
+	ULongPtrArray *colid_array = GPOS_NEW(mp) ULongPtrArray(mp);
 	
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG ul = 0; ul < size; ul++)
 	{
-		pdrgpul->Append(GPOS_NEW(pmp) ULONG(m_pidgtorCol->UlNextId()));
+		colid_array->Append(GPOS_NEW(mp) ULONG(m_colid_counter->next_id()));
 	}
 	
-	return pdrgpul;
+	return colid_array;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PdrgpulExtractColIds
+//		CTranslatorQueryToDXL::ExtractColIds
 //
 //	@doc:
 //		Extract column ids from the given mapping
 //
 //---------------------------------------------------------------------------
-DrgPul *
-CTranslatorQueryToDXL::PdrgpulExtractColIds
+ULongPtrArray *
+CTranslatorQueryToDXL::ExtractColIds
 	(
-	IMemoryPool *pmp,
-	HMIUl *phmiul
+	IMemoryPool *mp,
+	IntToUlongMap *attno_to_colid_mapping
 	)
 	const
 {
-	HMUlUl *phmulul = GPOS_NEW(pmp) HMUlUl(pmp);
+	UlongToUlongMap *old_new_col_mapping = GPOS_NEW(mp) UlongToUlongMap(mp);
 	
-	DrgPul *pdrgpul = GPOS_NEW(pmp) DrgPul(pmp);
+	ULongPtrArray *colid_array = GPOS_NEW(mp) ULongPtrArray(mp);
 	
-	HMIUlIter mi(phmiul);
-	while (mi.FAdvance())
+	IntUlongHashmapIter att_iter(attno_to_colid_mapping);
+	while (att_iter.Advance())
 	{
-		ULONG ulColId = *(mi.Pt());
+		ULONG colid = *(att_iter.Value());
 		
 		// do not insert colid if already inserted
-		if (NULL == phmulul->PtLookup(&ulColId))
+		if (NULL == old_new_col_mapping->Find(&colid))
 		{
-			pdrgpul->Append(GPOS_NEW(m_pmp) ULONG(ulColId));
-			phmulul->FInsert(GPOS_NEW(m_pmp) ULONG(ulColId), GPOS_NEW(m_pmp) ULONG(ulColId));
+			colid_array->Append(GPOS_NEW(m_mp) ULONG(colid));
+			old_new_col_mapping->Insert(GPOS_NEW(m_mp) ULONG(colid), GPOS_NEW(m_mp) ULONG(colid));
 		}
 	}
 		
-	phmulul->Release();
-	return pdrgpul;
+	old_new_col_mapping->Release();
+	return colid_array;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PhmiulRemapColIds
+//		CTranslatorQueryToDXL::RemapColIds
 //
 //	@doc:
 //		Construct a new hashmap which replaces the values in the From array
 //		with the corresponding value in the To array
 //
 //---------------------------------------------------------------------------
-HMIUl *
-CTranslatorQueryToDXL::PhmiulRemapColIds
+IntToUlongMap *
+CTranslatorQueryToDXL::RemapColIds
 	(
-	IMemoryPool *pmp,
-	HMIUl *phmiul,
-	DrgPul *pdrgpulFrom,
-	DrgPul *pdrgpulTo
+	IMemoryPool *mp,
+	IntToUlongMap *attno_to_colid_mapping,
+	ULongPtrArray *from_list_colids,
+	ULongPtrArray *to_list_colids
 	)
 	const
 {
-	GPOS_ASSERT(NULL != phmiul);
-	GPOS_ASSERT(NULL != pdrgpulFrom && NULL != pdrgpulTo);
-	GPOS_ASSERT(pdrgpulFrom->UlLength() == pdrgpulTo->UlLength());
+	GPOS_ASSERT(NULL != attno_to_colid_mapping);
+	GPOS_ASSERT(NULL != from_list_colids && NULL != to_list_colids);
+	GPOS_ASSERT(from_list_colids->Size() == to_list_colids->Size());
 	
 	// compute a map of the positions in the from array
-	HMUlUl *phmulul = GPOS_NEW(pmp) HMUlUl(pmp);
-	const ULONG ulSize = pdrgpulFrom->UlLength();
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	UlongToUlongMap *old_new_col_mapping = GPOS_NEW(mp) UlongToUlongMap(mp);
+	const ULONG size = from_list_colids->Size();
+	for (ULONG ul = 0; ul < size; ul++)
 	{
 #ifdef GPOS_DEBUG
-		BOOL fResult = 
+		BOOL result =
 #endif // GPOS_DEBUG
-		phmulul->FInsert(GPOS_NEW(pmp) ULONG(*((*pdrgpulFrom)[ul])), GPOS_NEW(pmp) ULONG(*((*pdrgpulTo)[ul])));
-		GPOS_ASSERT(fResult);
+		old_new_col_mapping->Insert(GPOS_NEW(mp) ULONG(*((*from_list_colids)[ul])), GPOS_NEW(mp) ULONG(*((*to_list_colids)[ul])));
+		GPOS_ASSERT(result);
 	}
 
-	HMIUl *phmiulResult = GPOS_NEW(pmp) HMIUl(pmp);
-	HMIUlIter mi(phmiul);
-	while (mi.FAdvance())
+	IntToUlongMap *result_attno_to_colid_mapping = GPOS_NEW(mp) IntToUlongMap(mp);
+	IntUlongHashmapIter mi(attno_to_colid_mapping);
+	while (mi.Advance())
 	{
-		INT *piKey = GPOS_NEW(pmp) INT(*(mi.Pk()));
-		const ULONG *pulValue = mi.Pt();
-		GPOS_ASSERT(NULL != pulValue);
+		INT *key = GPOS_NEW(mp) INT(*(mi.Key()));
+		const ULONG *value = mi.Value();
+		GPOS_ASSERT(NULL != value);
 		
-		ULONG *pulValueRemapped = GPOS_NEW(pmp) ULONG(*(phmulul->PtLookup(pulValue)));
-		phmiulResult->FInsert(piKey, pulValueRemapped);
+		ULONG *remapped_value = GPOS_NEW(mp) ULONG(*(old_new_col_mapping->Find(value)));
+		result_attno_to_colid_mapping->Insert(key, remapped_value);
 	}
 		
-	phmulul->Release();
+	old_new_col_mapping->Release();
 	
-	return phmiulResult;
+	return result_attno_to_colid_mapping;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::PhmiulRemapColIds
+//		CTranslatorQueryToDXL::RemapColIds
 //
 //	@doc:
 //		True iff this query or one of its ancestors is a DML query
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorQueryToDXL::FDMLQuery()
+CTranslatorQueryToDXL::IsDMLQuery()
 {
-	return (m_fTopDMLQuery || m_pquery->resultRelation != 0);
+	return (m_is_top_query_dml || m_query->resultRelation != 0);
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -76,7 +76,7 @@ using namespace gpopt;
 
 
 static 
-const ULONG rgulCmpTypeMappings[][2] = 
+const ULONG cmp_type_mappings[][2] =
 {
 	{IMDType::EcmptEq, CmptEq},
 	{IMDType::EcmptNEq, CmptNEq},
@@ -88,124 +88,124 @@ const ULONG rgulCmpTypeMappings[][2] =
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pimdobj
+//		CTranslatorRelcacheToDXL::RetrieveObject
 //
 //	@doc:
 //		Retrieve a metadata object from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 IMDCacheObject *
-CTranslatorRelcacheToDXL::Pimdobj
+CTranslatorRelcacheToDXL::RetrieveObject
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid
 	)
 {
-	IMDCacheObject *pmdcacheobj = NULL;
-	GPOS_ASSERT(NULL != pmda);
+	IMDCacheObject *md_obj = NULL;
+	GPOS_ASSERT(NULL != md_accessor);
 
 #ifdef FAULT_INJECTOR
-	gpdb::OptTasksFaultInjector(OptRelcacheTranslatorCatalogAccess);
+	gpdb::InjectFaultInOptTasks(OptRelcacheTranslatorCatalogAccess);
 #endif // FAULT_INJECTOR
 
-	switch(pmdid->Emdidt())
+	switch(mdid->MdidType())
 	{
 		case IMDId::EmdidGPDB:
-			pmdcacheobj = PimdobjGPDB(pmp, pmda, pmdid);
+			md_obj = RetrieveObjectGPDB(mp, md_accessor, mdid);
 			break;
 		
 		case IMDId::EmdidRelStats:
-			pmdcacheobj = PimdobjRelStats(pmp, pmdid);
+			md_obj = RetrieveRelStats(mp, mdid);
 			break;
 		
 		case IMDId::EmdidColStats:
-			pmdcacheobj = PimdobjColStats(pmp, pmda, pmdid);
+			md_obj = RetrieveColStats(mp, md_accessor, mdid);
 			break;
 		
 		case IMDId::EmdidCastFunc:
-			pmdcacheobj = PimdobjCast(pmp, pmdid);
+			md_obj = RetrieveCast(mp, mdid);
 			break;
 		
 		case IMDId::EmdidScCmp:
-			pmdcacheobj = PmdobjScCmp(pmp, pmdid);
+			md_obj = RetrieveScCmp(mp, mdid);
 			break;
 			
 		default:
 			break;
 	}
 
-	if (NULL == pmdcacheobj)
+	if (NULL == md_obj)
 	{
 		// no match found
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	return pmdcacheobj;
+	return md_obj;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PimdobjGPDB
+//		CTranslatorRelcacheToDXL::RetrieveMDObjGPDB
 //
 //	@doc:
 //		Retrieve a GPDB metadata object from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 IMDCacheObject *
-CTranslatorRelcacheToDXL::PimdobjGPDB
+CTranslatorRelcacheToDXL::RetrieveObjectGPDB
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid
 	)
 {
-	GPOS_ASSERT(pmdid->Emdidt() == CMDIdGPDB::EmdidGPDB);
+	GPOS_ASSERT(mdid->MdidType() == CMDIdGPDB::EmdidGPDB);
 
-	OID oid = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
+	OID oid = CMDIdGPDB::CastMdid(mdid)->Oid();
 
 	GPOS_ASSERT(0 != oid);
 
 	// find out what type of object this oid stands for
 
-	if (gpdb::FIndexExists(oid))
+	if (gpdb::IndexExists(oid))
 	{
-		return Pmdindex(pmp, pmda, pmdid);
+		return RetrieveIndex(mp, md_accessor, mdid);
 	}
 
-	if (gpdb::FTypeExists(oid))
+	if (gpdb::TypeExists(oid))
 	{
-		return Pmdtype(pmp, pmdid);
+		return RetrieveType(mp, mdid);
 	}
 
-	if (gpdb::FRelationExists(oid))
+	if (gpdb::RelationExists(oid))
 	{
-		return Pmdrel(pmp, pmda, pmdid);
+		return RetrieveRel(mp, md_accessor, mdid);
 	}
 
-	if (gpdb::FOperatorExists(oid))
+	if (gpdb::OperatorExists(oid))
 	{
-		return Pmdscop(pmp, pmdid);
+		return RetrieveScOp(mp, mdid);
 	}
 
-	if (gpdb::FAggregateExists(oid))
+	if (gpdb::AggregateExists(oid))
 	{
-		return Pmdagg(pmp, pmdid);
+		return RetrieveAgg(mp, mdid);
 	}
 
-	if (gpdb::FFunctionExists(oid))
+	if (gpdb::FunctionExists(oid))
 	{
-		return Pmdfunc(pmp, pmdid);
+		return RetrieveFunc(mp, mdid);
 	}
 
-	if (gpdb::FTriggerExists(oid))
+	if (gpdb::TriggerExists(oid))
 	{
-		return Pmdtrigger(pmp, pmdid);
+		return RetrieveTrigger(mp, mdid);
 	}
 
-	if (gpdb::FCheckConstraintExists(oid))
+	if (gpdb::CheckConstraintExists(oid))
 	{
-		return Pmdcheckconstraint(pmp, pmda, pmdid);
+		return RetrieveCheckConstraints(mp, md_accessor, mdid);
 	}
 
 	// no match found
@@ -215,221 +215,221 @@ CTranslatorRelcacheToDXL::PimdobjGPDB
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PmdnameRel
+//		CTranslatorRelcacheToDXL::GetRelName
 //
 //	@doc:
 //		Return a relation name
 //
 //---------------------------------------------------------------------------
 CMDName *
-CTranslatorRelcacheToDXL::PmdnameRel
+CTranslatorRelcacheToDXL::GetRelName
 	(
-	IMemoryPool *pmp,
+	IMemoryPool *mp,
 	Relation rel
 	)
 {
 	GPOS_ASSERT(NULL != rel);
-	CHAR *szRelName = NameStr(rel->rd_rel->relname);
-	CWStringDynamic *pstrRelName = CDXLUtils::PstrFromSz(pmp, szRelName);
-	CMDName *pmdname = GPOS_NEW(pmp) CMDName(pmp, pstrRelName);
-	GPOS_DELETE(pstrRelName);
-	return pmdname;
+	CHAR *relname = NameStr(rel->rd_rel->relname);
+	CWStringDynamic *relname_str = CDXLUtils::CreateDynamicStringFromCharArray(mp, relname);
+	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, relname_str);
+	GPOS_DELETE(relname_str);
+	return mdname;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpmdRelIndexInfo
+//		CTranslatorRelcacheToDXL::RetrieveRelIndexInfo
 //
 //	@doc:
 //		Return the indexes defined on the given relation
 //
 //---------------------------------------------------------------------------
-DrgPmdIndexInfo *
-CTranslatorRelcacheToDXL::PdrgpmdRelIndexInfo
+CMDIndexInfoArray *
+CTranslatorRelcacheToDXL::RetrieveRelIndexInfo
 	(
-	IMemoryPool *pmp,
+	IMemoryPool *mp,
 	Relation rel
 	)
 {
 	GPOS_ASSERT(NULL != rel);
 
-	if (gpdb::FRelPartIsNone(rel->rd_id) || gpdb::FLeafPartition(rel->rd_id))
+	if (gpdb::RelPartIsNone(rel->rd_id) || gpdb::IsLeafPartition(rel->rd_id))
 	{
-		return PdrgpmdRelIndexInfoNonPartTable(pmp, rel);
+		return RetrieveRelIndexInfoForNonPartTable(mp, rel);
 	}
-	else if (gpdb::FRelPartIsRoot(rel->rd_id))
+	else if (gpdb::RelPartIsRoot(rel->rd_id))
 	{
-		return PdrgpmdRelIndexInfoPartTable(pmp, rel);
+		return RetrieveRelIndexInfoForPartTable(mp, rel);
 	}
 	else  
 	{
 		// interior partition: do not consider indexes
-		DrgPmdIndexInfo *pdrgpmdIndexInfo = GPOS_NEW(pmp) DrgPmdIndexInfo(pmp);
-		return pdrgpmdIndexInfo;
+		CMDIndexInfoArray *md_index_info_array = GPOS_NEW(mp) CMDIndexInfoArray(mp);
+		return md_index_info_array;
 	}
 }
 
 // return index info list of indexes defined on a partitioned table
-DrgPmdIndexInfo *
-CTranslatorRelcacheToDXL::PdrgpmdRelIndexInfoPartTable
+CMDIndexInfoArray *
+CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForPartTable
 	(
-	IMemoryPool *pmp,
-	Relation relRoot
+	IMemoryPool *mp,
+	Relation root_rel
 	)
 {
-	DrgPmdIndexInfo *pdrgpmdIndexInfo = GPOS_NEW(pmp) DrgPmdIndexInfo(pmp);
+	CMDIndexInfoArray *md_index_info_array = GPOS_NEW(mp) CMDIndexInfoArray(mp);
 
 	// root of partitioned table: aggregate index information across different parts
-	List *plLogicalIndexInfo = PlIndexInfoPartTable(relRoot);
+	List *plLogicalIndexInfo = RetrievePartTableIndexInfo(root_rel);
 
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 
-	ForEach (plc, plLogicalIndexInfo)
+	ForEach (lc, plLogicalIndexInfo)
 	{
-		LogicalIndexInfo *logicalIndexInfo = (LogicalIndexInfo *) lfirst(plc);
-		OID oidIndex = logicalIndexInfo->logicalIndexOid;
+		LogicalIndexInfo *logicalIndexInfo = (LogicalIndexInfo *) lfirst(lc);
+		OID index_oid = logicalIndexInfo->logicalIndexOid;
 
 		// only add supported indexes
-		Relation relIndex = gpdb::RelGetRelation(oidIndex);
+		Relation index_rel = gpdb::GetRelation(index_oid);
 
-		if (NULL == relIndex)
+		if (NULL == index_rel)
 		{
-			WCHAR wsz[1024];
-			CWStringStatic str(wsz, 1024);
+			WCHAR wstr[1024];
+			CWStringStatic str(wstr, 1024);
 			COstreamString oss(&str);
-			oss << (ULONG) oidIndex;
-			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, str.Wsz());
+			oss << (ULONG) index_oid;
+			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, str.GetBuffer());
 		}
 
-		GPOS_ASSERT(NULL != relIndex->rd_indextuple);
+		GPOS_ASSERT(NULL != index_rel->rd_indextuple);
 
 		GPOS_TRY
 		{
-			if (FIndexSupported(relIndex))
+			if (IsIndexSupported(index_rel))
 			{
-				CMDIdGPDB *pmdidIndex = GPOS_NEW(pmp) CMDIdGPDB(oidIndex);
-				BOOL fPartial = (NULL != logicalIndexInfo->partCons) || (NIL != logicalIndexInfo->defaultLevels);
-				CMDIndexInfo *pmdIndexInfo = GPOS_NEW(pmp) CMDIndexInfo(pmdidIndex, fPartial);
-				pdrgpmdIndexInfo->Append(pmdIndexInfo);
+				CMDIdGPDB *mdid_index = GPOS_NEW(mp) CMDIdGPDB(index_oid);
+				BOOL is_partial = (NULL != logicalIndexInfo->partCons) || (NIL != logicalIndexInfo->defaultLevels);
+				CMDIndexInfo *md_index_info = GPOS_NEW(mp) CMDIndexInfo(mdid_index, is_partial);
+				md_index_info_array->Append(md_index_info);
 			}
 
-			gpdb::CloseRelation(relIndex);
+			gpdb::CloseRelation(index_rel);
 		}
 		GPOS_CATCH_EX(ex)
 		{
-			gpdb::CloseRelation(relIndex);
+			gpdb::CloseRelation(index_rel);
 			GPOS_RETHROW(ex);
 		}
 		GPOS_CATCH_END;
 	}
-	return pdrgpmdIndexInfo;
+	return md_index_info_array;
 }
 
 // return index info list of indexes defined on regular, external tables or leaf partitions
-DrgPmdIndexInfo *
-CTranslatorRelcacheToDXL::PdrgpmdRelIndexInfoNonPartTable
+CMDIndexInfoArray *
+CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForNonPartTable
 	(
-	IMemoryPool *pmp,
+	IMemoryPool *mp,
 	Relation rel
 	)
 {
-	DrgPmdIndexInfo *pdrgpmdIndexInfo = GPOS_NEW(pmp) DrgPmdIndexInfo(pmp);
+	CMDIndexInfoArray *md_index_info_array = GPOS_NEW(mp) CMDIndexInfoArray(mp);
 
 	// not a partitioned table: obtain indexes directly from the catalog
-	List *plIndexOids = gpdb::PlRelationIndexes(rel);
+	List *index_oids = gpdb::GetRelationIndexes(rel);
 
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 
-	ForEach (plc, plIndexOids)
+	ForEach (lc, index_oids)
 	{
-		OID oidIndex = lfirst_oid(plc);
+		OID index_oid = lfirst_oid(lc);
 
 		// only add supported indexes
-		Relation relIndex = gpdb::RelGetRelation(oidIndex);
+		Relation index_rel = gpdb::GetRelation(index_oid);
 
-		if (NULL == relIndex)
+		if (NULL == index_rel)
 		{
-			WCHAR wsz[1024];
-			CWStringStatic str(wsz, 1024);
+			WCHAR wstr[1024];
+			CWStringStatic str(wstr, 1024);
 			COstreamString oss(&str);
-			oss << (ULONG) oidIndex;
-			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, str.Wsz());
+			oss << (ULONG) index_oid;
+			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, str.GetBuffer());
 		}
 
-		GPOS_ASSERT(NULL != relIndex->rd_indextuple);
+		GPOS_ASSERT(NULL != index_rel->rd_indextuple);
 
 		GPOS_TRY
 		{
-			if (FIndexSupported(relIndex))
+			if (IsIndexSupported(index_rel))
 			{
-				CMDIdGPDB *pmdidIndex = GPOS_NEW(pmp) CMDIdGPDB(oidIndex);
+				CMDIdGPDB *mdid_index = GPOS_NEW(mp) CMDIdGPDB(index_oid);
 				// for a regular table, external table or leaf partition, an index is always complete
-				CMDIndexInfo *pmdIndexInfo = GPOS_NEW(pmp) CMDIndexInfo(pmdidIndex, false /* fPartial */);
-				pdrgpmdIndexInfo->Append(pmdIndexInfo);
+				CMDIndexInfo *md_index_info = GPOS_NEW(mp) CMDIndexInfo(mdid_index, false /* is_partial */);
+				md_index_info_array->Append(md_index_info);
 			}
 
-			gpdb::CloseRelation(relIndex);
+			gpdb::CloseRelation(index_rel);
 		}
 		GPOS_CATCH_EX(ex)
 		{
-			gpdb::CloseRelation(relIndex);
+			gpdb::CloseRelation(index_rel);
 			GPOS_RETHROW(ex);
 		}
 		GPOS_CATCH_END;
 	}
 
-	return pdrgpmdIndexInfo;
+	return md_index_info_array;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PlIndexInfoPartTable
+//		CTranslatorRelcacheToDXL::RetrievePartTableIndexInfo
 //
 //	@doc:
 //		Return the index info list of on a partitioned table
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorRelcacheToDXL::PlIndexInfoPartTable
+CTranslatorRelcacheToDXL::RetrievePartTableIndexInfo
 	(
 	Relation rel
 	)
 {
-	List *plgidxinfo = NIL;
+	List *index_info_list = NIL;
 	
-	LogicalIndexes *plgidx = gpdb::Plgidx(rel->rd_id);
+	LogicalIndexes *logical_indexes = gpdb::GetLogicalPartIndexes(rel->rd_id);
 
-	if (NULL == plgidx)
+	if (NULL == logical_indexes)
 	{
 		return NIL;
 	}
-	GPOS_ASSERT(NULL != plgidx);
-	GPOS_ASSERT(0 <= plgidx->numLogicalIndexes);
+	GPOS_ASSERT(NULL != logical_indexes);
+	GPOS_ASSERT(0 <= logical_indexes->numLogicalIndexes);
 	
-	const ULONG ulIndexes = (ULONG) plgidx->numLogicalIndexes;
-	for (ULONG ul = 0; ul < ulIndexes; ul++)
+	const ULONG num_indexes = (ULONG) logical_indexes->numLogicalIndexes;
+	for (ULONG ul = 0; ul < num_indexes; ul++)
 	{
-		LogicalIndexInfo *pidxinfo = (plgidx->logicalIndexInfo)[ul];
-		plgidxinfo = gpdb::PlAppendElement(plgidxinfo, pidxinfo);
+		LogicalIndexInfo *index_info = (logical_indexes->logicalIndexInfo)[ul];
+		index_info_list = gpdb::LAppend(index_info_list, index_info);
 	}
 	
-	gpdb::GPDBFree(plgidx);
+	gpdb::GPDBFree(logical_indexes);
 	
-	return plgidxinfo;
+	return index_info_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpmdidTriggers
+//		CTranslatorRelcacheToDXL::RetrieveRelTriggers
 //
 //	@doc:
 //		Return the triggers defined on the given relation
 //
 //---------------------------------------------------------------------------
-DrgPmdid *
-CTranslatorRelcacheToDXL::PdrgpmdidTriggers
+IMdIdArray *
+CTranslatorRelcacheToDXL::RetrieveRelTriggers
 	(
-	IMemoryPool *pmp,
+	IMemoryPool *mp,
 	Relation rel
 	)
 {
@@ -443,48 +443,49 @@ CTranslatorRelcacheToDXL::PdrgpmdidTriggers
 		}
 	}
 
-	DrgPmdid *pdrgpmdidTriggers = GPOS_NEW(pmp) DrgPmdid(pmp);
+	IMdIdArray *mdid_triggers_array = GPOS_NEW(mp) IMdIdArray(mp);
 	const ULONG ulTriggers = rel->rd_rel->reltriggers;
 
-	for (ULONG ul = 0; ul < ulTriggers; ul++)
-	{
-		Trigger trigger = rel->trigdesc->triggers[ul];
-		OID oidTrigger = trigger.tgoid;
-		CMDIdGPDB *pmdidTrigger = GPOS_NEW(pmp) CMDIdGPDB(oidTrigger);
-		pdrgpmdidTriggers->Append(pmdidTrigger);
+		for (ULONG ul = 0; ul < ulTriggers; ul++)
+		{
+			Trigger trigger = rel->trigdesc->triggers[ul];
+			OID trigger_oid = trigger.tgoid;
+			CMDIdGPDB *mdid_trigger = GPOS_NEW(mp) CMDIdGPDB(trigger_oid);
+			mdid_triggers_array->Append(mdid_trigger);
+
 	}
 
-	return pdrgpmdidTriggers;
+	return mdid_triggers_array;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpmdidCheckConstraints
+//		CTranslatorRelcacheToDXL::RetrieveRelCheckConstraints
 //
 //	@doc:
 //		Return the check constraints defined on the relation with the given oid
 //
 //---------------------------------------------------------------------------
-DrgPmdid *
-CTranslatorRelcacheToDXL::PdrgpmdidCheckConstraints
+IMdIdArray *
+CTranslatorRelcacheToDXL::RetrieveRelCheckConstraints
 	(
-	IMemoryPool *pmp,
+	IMemoryPool *mp,
 	OID oid
 	)
 {
-	DrgPmdid *pdrgpmdidCheckConstraints = GPOS_NEW(pmp) DrgPmdid(pmp);
-	List *plOidCheckConstraints = gpdb::PlCheckConstraint(oid);
+	IMdIdArray *check_constraint_mdids = GPOS_NEW(mp) IMdIdArray(mp);
+	List *check_constraints = gpdb::GetCheckConstraintOids(oid);
 
-	ListCell *plcOid = NULL;
-	ForEach (plcOid, plOidCheckConstraints)
+	ListCell *lc = NULL;
+	ForEach (lc, check_constraints)
 	{
-		OID oidCheckConstraint = lfirst_oid(plcOid);
-		GPOS_ASSERT(0 != oidCheckConstraint);
-		CMDIdGPDB *pmdidCheckConstraint = GPOS_NEW(pmp) CMDIdGPDB(oidCheckConstraint);
-		pdrgpmdidCheckConstraints->Append(pmdidCheckConstraint);
+		OID check_constraint_oid = lfirst_oid(lc);
+		GPOS_ASSERT(0 != check_constraint_oid);
+		CMDIdGPDB *mdid_check_constraint = GPOS_NEW(mp) CMDIdGPDB(check_constraint_oid);
+		check_constraint_mdids->Append(mdid_check_constraint);
 	}
 
-	return pdrgpmdidCheckConstraints;
+	return check_constraint_mdids;
 }
 
 //---------------------------------------------------------------------------
@@ -498,30 +499,30 @@ CTranslatorRelcacheToDXL::PdrgpmdidCheckConstraints
 void
 CTranslatorRelcacheToDXL::CheckUnsupportedRelation
 	(
-	OID oidRel
+	OID rel_oid
 	)
 {
-	if (gpdb::FRelPartIsInterior(oidRel))
+	if (gpdb::RelPartIsInterior(rel_oid))
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Query on intermediate partition"));
 	}
 
-	List *plPartKeys = gpdb::PlPartitionAttrs(oidRel);
-	ULONG ulLevels = gpdb::UlListLength(plPartKeys);
+	List *part_keys = gpdb::GetPartitionAttrs(rel_oid);
+	ULONG num_of_levels = gpdb::ListLength(part_keys);
 
-	if (0 == ulLevels && gpdb::FHasSubclass(oidRel))
+	if (0 == num_of_levels && gpdb::FHasSubclass(rel_oid))
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Inherited tables"));
 	}
 
-	if (1 < ulLevels)
+	if (1 < num_of_levels)
 	{
 		if (!optimizer_multilevel_partitioning)
 		{
 			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Multi-level partitioned tables"));
 		}
 
-		if (!gpdb::FMultilevelPartitionUniform(oidRel))
+		if (!gpdb::IsMultilevelPartitionUniform(rel_oid))
 		{
 			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Multi-level partitioned tables with non-uniform partitioning structure"));
 		}
@@ -530,115 +531,115 @@ CTranslatorRelcacheToDXL::CheckUnsupportedRelation
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pmdrel
+//		CTranslatorRelcacheToDXL::RetrieveRel
 //
 //	@doc:
 //		Retrieve a relation from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 IMDRelation *
-CTranslatorRelcacheToDXL::Pmdrel
+CTranslatorRelcacheToDXL::RetrieveRel
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid
 	)
 {
-	OID oid = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
+	OID oid = CMDIdGPDB::CastMdid(mdid)->Oid();
 	GPOS_ASSERT(InvalidOid != oid);
 
 	CheckUnsupportedRelation(oid);
 
-	Relation rel = gpdb::RelGetRelation(oid);
+	Relation rel = gpdb::GetRelation(oid);
 
 	if (NULL == rel)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	CMDName *pmdname = NULL;
-	IMDRelation::Erelstoragetype erelstorage = IMDRelation::ErelstorageSentinel;
-	DrgPmdcol *pdrgpmdcol = NULL;
-	IMDRelation::Ereldistrpolicy ereldistribution = IMDRelation::EreldistrSentinel;
-	DrgPul *pdrpulDistrCols = NULL;
-	DrgPmdIndexInfo *pdrgpmdIndexInfo = NULL;
-	DrgPmdid *pdrgpmdidTriggers = NULL;
-	DrgPul *pdrgpulPartKeys = NULL;
-	DrgPsz *pdrgpszPartTypes = NULL;
-	ULONG ulLeafPartitions = 0;
-	BOOL fConvertHashToRandom = false;
-	DrgPdrgPul *pdrgpdrgpulKeys = NULL;
-	DrgPmdid *pdrgpmdidCheckConstraints = NULL;
-	BOOL fTemporary = false;
-	BOOL fHasOids = false;
-	BOOL fPartitioned = false;
-	IMDRelation *pmdrel = NULL;
+	CMDName *mdname = NULL;
+	IMDRelation::Erelstoragetype rel_storage_type = IMDRelation::ErelstorageSentinel;
+	CMDColumnArray *mdcol_array = NULL;
+	IMDRelation::Ereldistrpolicy dist = IMDRelation::EreldistrSentinel;
+	ULongPtrArray *distr_cols = NULL;
+	CMDIndexInfoArray *md_index_info_array = NULL;
+	IMdIdArray *mdid_triggers_array = NULL;
+	ULongPtrArray *part_keys = NULL;
+	CharPtrArray *part_types = NULL;
+	ULONG num_leaf_partitions = 0;
+	BOOL convert_hash_to_random = false;
+	ULongPtr2dArray *keyset_array = NULL;
+	IMdIdArray *check_constraint_mdids = NULL;
+	BOOL is_temporary = false;
+	BOOL has_oids = false;
+	BOOL is_partitioned = false;
+	IMDRelation *md_rel = NULL;
 
 
 	GPOS_TRY
 	{
 		// get rel name
-		pmdname = PmdnameRel(pmp, rel);
+		mdname = GetRelName(mp, rel);
 
 		// get storage type
-		erelstorage = Erelstorage(rel->rd_rel->relstorage);
+		rel_storage_type = RetrieveRelStorageType(rel->rd_rel->relstorage);
 
 		// get relation columns
-		pdrgpmdcol = Pdrgpmdcol(pmp, pmda, rel, erelstorage);
-		const ULONG ulMaxCols = GPDXL_SYSTEM_COLUMNS + (ULONG) rel->rd_att->natts + 1;
-		ULONG *pulAttnoMapping = PulAttnoMapping(pmp, pdrgpmdcol, ulMaxCols);
+		mdcol_array = RetrieveRelColumns(mp, md_accessor, rel, rel_storage_type);
+		const ULONG max_cols = GPDXL_SYSTEM_COLUMNS + (ULONG) rel->rd_att->natts + 1;
+		ULONG *attno_mapping = ConstructAttnoMapping(mp, mdcol_array, max_cols);
 
 		// get distribution policy
-		GpPolicy *pgppolicy = gpdb::Pdistrpolicy(rel);
-		ereldistribution = Ereldistribution(pgppolicy);
+		GpPolicy *gp_policy = gpdb::GetDistributionPolicy(rel);
+		dist = GetRelDistribution(gp_policy);
 
 		// get distribution columns
-		if (IMDRelation::EreldistrHash == ereldistribution)
+		if (IMDRelation::EreldistrHash == dist)
 		{
-			pdrpulDistrCols = PdrpulDistrCols(pmp, pgppolicy, pdrgpmdcol, ulMaxCols);
+			distr_cols = RetrieveRelDistrbutionCols(mp, gp_policy, mdcol_array, max_cols);
 		}
 
-		fConvertHashToRandom = gpdb::FChildPartDistributionMismatch(rel);
+		convert_hash_to_random = gpdb::IsChildPartDistributionMismatched(rel);
 
 		// collect relation indexes
-		pdrgpmdIndexInfo = PdrgpmdRelIndexInfo(pmp, rel);
+		md_index_info_array = RetrieveRelIndexInfo(mp, rel);
 
 		// collect relation triggers
-		pdrgpmdidTriggers = PdrgpmdidTriggers(pmp, rel);
+		mdid_triggers_array = RetrieveRelTriggers(mp, rel);
 
 		// get partition keys
-		if (IMDRelation::ErelstorageExternal != erelstorage)
+		if (IMDRelation::ErelstorageExternal != rel_storage_type)
 		{
-			GetPartKeysAndTypes(pmp, rel, oid, &pdrgpulPartKeys, &pdrgpszPartTypes);
+			RetrievePartKeysAndTypes(mp, rel, oid, &part_keys, &part_types);
 		}
-		fPartitioned = (NULL != pdrgpulPartKeys && 0 < pdrgpulPartKeys->UlLength());
+		is_partitioned = (NULL != part_keys && 0 < part_keys->Size());
 
-		if (fPartitioned && IMDRelation::ErelstorageAppendOnlyParquet != erelstorage && IMDRelation::ErelstorageExternal != erelstorage)
+		if (is_partitioned && IMDRelation::ErelstorageAppendOnlyParquet != rel_storage_type && IMDRelation::ErelstorageExternal != rel_storage_type)
 		{
 			// mark relation as Parquet if one of its children is parquet
-			if (gpdb::FHasParquetChildren(oid))
+			if (gpdb::HasParquetChildren(oid))
 			{
-				erelstorage = IMDRelation::ErelstorageAppendOnlyParquet;
+				rel_storage_type = IMDRelation::ErelstorageAppendOnlyParquet;
 			}
 		}
 
 		// get number of leaf partitions
-		if (gpdb::FRelPartIsRoot(oid))
+		if (gpdb::RelPartIsRoot(oid))
 		{
-			ulLeafPartitions = gpdb::UlLeafPartitions(oid);
+			num_leaf_partitions = gpdb::CountLeafPartTables(oid);
 		}
 
 		// get key sets
-		BOOL fAddDefaultKeys = FHasSystemColumns(rel->rd_rel->relkind);
-		pdrgpdrgpulKeys = PdrgpdrgpulKeys(pmp, oid, fAddDefaultKeys, fPartitioned, pulAttnoMapping);
+		BOOL should_add_default_keys = RelHasSystemColumns(rel->rd_rel->relkind);
+		keyset_array = RetrieveRelKeysets(mp, oid, should_add_default_keys, is_partitioned, attno_mapping);
 
 		// collect all check constraints
-		pdrgpmdidCheckConstraints = PdrgpmdidCheckConstraints(pmp, oid);
+		check_constraint_mdids = RetrieveRelCheckConstraints(mp, oid);
 
-		fTemporary = rel->rd_istemp;
-		fHasOids = rel->rd_rel->relhasoids;
+		is_temporary = rel->rd_istemp;
+		has_oids = rel->rd_rel->relhasoids;
 	
-		GPOS_DELETE_ARRAY(pulAttnoMapping);
+		GPOS_DELETE_ARRAY(attno_mapping);
 		gpdb::CloseRelation(rel);
 	}
 	GPOS_CATCH_EX(ex)
@@ -648,35 +649,35 @@ CTranslatorRelcacheToDXL::Pmdrel
 	}
 	GPOS_CATCH_END;
 
-	GPOS_ASSERT(IMDRelation::ErelstorageSentinel != erelstorage);
-	GPOS_ASSERT(IMDRelation::EreldistrSentinel != ereldistribution);
+	GPOS_ASSERT(IMDRelation::ErelstorageSentinel != rel_storage_type);
+	GPOS_ASSERT(IMDRelation::EreldistrSentinel != dist);
 
-	pmdid->AddRef();
+	mdid->AddRef();
 
-	if (IMDRelation::ErelstorageExternal == erelstorage)
+	if (IMDRelation::ErelstorageExternal == rel_storage_type)
 	{
-		ExtTableEntry *extentry = gpdb::Pexttable(oid);
+		ExtTableEntry *extentry = gpdb::GetExternalTableEntry(oid);
 
 		// get format error table id
 		IMDId *pmdidFmtErrTbl = NULL;
 		if (InvalidOid != extentry->fmterrtbl)
 		{
-			pmdidFmtErrTbl = GPOS_NEW(pmp) CMDIdGPDB(extentry->fmterrtbl);
+			pmdidFmtErrTbl = GPOS_NEW(mp) CMDIdGPDB(extentry->fmterrtbl);
 		}
 
-		pmdrel = GPOS_NEW(pmp) CMDRelationExternalGPDB
+		md_rel = GPOS_NEW(mp) CMDRelationExternalGPDB
 							(
-							pmp,
-							pmdid,
-							pmdname,
-							ereldistribution,
-							pdrgpmdcol,
-							pdrpulDistrCols,
-							fConvertHashToRandom,
-							pdrgpdrgpulKeys,
-							pdrgpmdIndexInfo,
-							pdrgpmdidTriggers,
-							pdrgpmdidCheckConstraints,
+							mp,
+							mdid,
+							mdname,
+							dist,
+							mdcol_array,
+							distr_cols,
+							convert_hash_to_random,
+							keyset_array,
+							md_index_info_array,
+							mdid_triggers_array,
+							check_constraint_mdids,
 							extentry->rejectlimit,
 							('r' == extentry->rejectlimittype),
 							pmdidFmtErrTbl
@@ -684,73 +685,73 @@ CTranslatorRelcacheToDXL::Pmdrel
 	}
 	else
 	{
-		CMDPartConstraintGPDB *pmdpartcnstr = NULL;
+		CMDPartConstraintGPDB *mdpart_constraint = NULL;
 
 		// retrieve the part constraints if relation is partitioned
-		if (fPartitioned)
-			pmdpartcnstr = PmdpartcnstrRelation(pmp, pmda, oid, pdrgpmdcol, pdrgpmdIndexInfo->UlLength() > 0 /*fhasIndex*/);
+		if (is_partitioned)
+			mdpart_constraint = RetrievePartConstraintForRel(mp, md_accessor, oid, mdcol_array, md_index_info_array->Size() > 0 /*has_index*/);
 
-		pmdrel = GPOS_NEW(pmp) CMDRelationGPDB
+		md_rel = GPOS_NEW(mp) CMDRelationGPDB
 							(
-							pmp,
-							pmdid,
-							pmdname,
-							fTemporary,
-							erelstorage,
-							ereldistribution,
-							pdrgpmdcol,
-							pdrpulDistrCols,
-							pdrgpulPartKeys,
-							pdrgpszPartTypes,
-							ulLeafPartitions,
-							fConvertHashToRandom,
-							pdrgpdrgpulKeys,
-							pdrgpmdIndexInfo,
-							pdrgpmdidTriggers,
-							pdrgpmdidCheckConstraints,
-							pmdpartcnstr,
-							fHasOids
+							mp,
+							mdid,
+							mdname,
+							is_temporary,
+							rel_storage_type,
+							dist,
+							mdcol_array,
+							distr_cols,
+							part_keys,
+							part_types,
+							num_leaf_partitions,
+							convert_hash_to_random,
+							keyset_array,
+							md_index_info_array,
+							mdid_triggers_array,
+							check_constraint_mdids,
+							mdpart_constraint,
+							has_oids
 							);
 	}
 
-	return pmdrel;
+	return md_rel;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pdrgpmdcol
+//		CTranslatorRelcacheToDXL::RetrieveRelColumns
 //
 //	@doc:
 //		Get relation columns
 //
 //---------------------------------------------------------------------------
-DrgPmdcol *
-CTranslatorRelcacheToDXL::Pdrgpmdcol
+CMDColumnArray *
+CTranslatorRelcacheToDXL::RetrieveRelColumns
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
 	Relation rel,
-	IMDRelation::Erelstoragetype erelstorage
+	IMDRelation::Erelstoragetype rel_storage_type
 	)
 {
-	DrgPmdcol *pdrgpmdcol = GPOS_NEW(pmp) DrgPmdcol(pmp);
+	CMDColumnArray *mdcol_array = GPOS_NEW(mp) CMDColumnArray(mp);
 
 	for (ULONG ul = 0;  ul < (ULONG) rel->rd_att->natts; ul++)
 	{
 		Form_pg_attribute att = rel->rd_att->attrs[ul];
-		CMDName *pmdnameCol = CDXLUtils::PmdnameFromSz(pmp, NameStr(att->attname));
+		CMDName *md_colname = CDXLUtils::CreateMDNameFromCharArray(mp, NameStr(att->attname));
 	
 		// translate the default column value
-		CDXLNode *pdxlnDefault = NULL;
+		CDXLNode *dxl_default_col_val = NULL;
 		
 		if (!att->attisdropped)
 		{
-			pdxlnDefault = PdxlnDefaultColumnValue(pmp, pmda, rel->rd_att, att->attnum);
+			dxl_default_col_val = GetDefaultColumnValue(mp, md_accessor, rel->rd_att, att->attnum);
 		}
 
-		ULONG ulColLen = gpos::ulong_max;
-		CMDIdGPDB *pmdidCol = GPOS_NEW(pmp) CMDIdGPDB(att->atttypid);
-		HeapTuple heaptupleStats = gpdb::HtAttrStats(rel->rd_id, ul+1);
+		ULONG col_len = gpos::ulong_max;
+		CMDIdGPDB *mdid_col = GPOS_NEW(mp) CMDIdGPDB(att->atttypid);
+		HeapTuple stats_tup = gpdb::GetAttStats(rel->rd_id, ul+1);
 
 		// Column width priority:
 		// 1. If there is average width kept in the stats for that column, pick that value.
@@ -759,154 +760,153 @@ CTranslatorRelcacheToDXL::Pdrgpmdcol
 		// 3. Else if it not dropped and a fixed length type such as int4, assign the fixed
 		//    length.
 		// 4. Otherwise, assign it to default column width which is 8.
-		if(HeapTupleIsValid(heaptupleStats))
+		if(HeapTupleIsValid(stats_tup))
 		{
-			Form_pg_statistic fpsStats = (Form_pg_statistic) GETSTRUCT(heaptupleStats);
+			Form_pg_statistic form_pg_stats = (Form_pg_statistic) GETSTRUCT(stats_tup);
 
 			// column width
-			ulColLen = fpsStats->stawidth;
-			gpdb::FreeHeapTuple(heaptupleStats);
+			col_len = form_pg_stats->stawidth;
+			gpdb::FreeHeapTuple(stats_tup);
 		}
-		else if ((pmdidCol->FEquals(&CMDIdGPDB::m_mdidBPChar) || pmdidCol->FEquals(&CMDIdGPDB::m_mdidVarChar)) && (VARHDRSZ < att->atttypmod))
+		else if ((mdid_col->Equals(&CMDIdGPDB::m_mdid_bpchar) || mdid_col->Equals(&CMDIdGPDB::m_mdid_varchar)) && (VARHDRSZ < att->atttypmod))
 		{
-			ulColLen = (ULONG) att->atttypmod - VARHDRSZ;
+			col_len = (ULONG) att->atttypmod - VARHDRSZ;
 		}
 		else
 		{
-			DOUBLE dWidth = CStatistics::DDefaultColumnWidth.DVal();
-			ulColLen = (ULONG) dWidth;
+			DOUBLE width = CStatistics::DefaultColumnWidth.Get();
+			col_len = (ULONG) width;
 
 			if (!att->attisdropped)
 			{
-				IMDType *pmdtype = CTranslatorRelcacheToDXL::Pmdtype(pmp, pmdidCol);
-				if(pmdtype->FFixedLength())
+				IMDType *md_type = CTranslatorRelcacheToDXL::RetrieveType(mp, mdid_col);
+				if(md_type->IsFixedLength())
 				{
-					ulColLen = pmdtype->UlLength();
+					col_len = md_type->Length();
 				}
-				pmdtype->Release();
+				md_type->Release();
 			}
 		}
 
-		CMDColumn *pmdcol = GPOS_NEW(pmp) CMDColumn
+		CMDColumn *md_col = GPOS_NEW(mp) CMDColumn
 										(
-										pmdnameCol,
+										md_colname,
 										att->attnum,
-										pmdidCol,
+										mdid_col,
 										att->atttypmod,
 										!att->attnotnull,
 										att->attisdropped,
-										pdxlnDefault /* default value */,
-										ulColLen
+										dxl_default_col_val /* default value */,
+										col_len
 										);
 
-		pdrgpmdcol->Append(pmdcol);
+		mdcol_array->Append(md_col);
 	}
 
 	// add system columns
-	if (FHasSystemColumns(rel->rd_rel->relkind))
+	if (RelHasSystemColumns(rel->rd_rel->relkind))
 	{
-		BOOL fAOTable = IMDRelation::ErelstorageAppendOnlyRows == erelstorage ||
-				IMDRelation::ErelstorageAppendOnlyCols == erelstorage;
-		AddSystemColumns(pmp, pdrgpmdcol, rel, fAOTable);
+		BOOL is_ao_table = IMDRelation::ErelstorageAppendOnlyRows == rel_storage_type ||
+				IMDRelation::ErelstorageAppendOnlyCols == rel_storage_type;
+		AddSystemColumns(mp, mdcol_array, rel, is_ao_table);
 	}
 
-	return pdrgpmdcol;
+	return mdcol_array;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdxlnDefaultColumnValue
+//		CTranslatorRelcacheToDXL::GetDefaultColumnValue
 //
 //	@doc:
 //		Return the dxl representation of column's default value
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorRelcacheToDXL::PdxlnDefaultColumnValue
+CTranslatorRelcacheToDXL::GetDefaultColumnValue
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
 	TupleDesc rd_att,
 	AttrNumber attno
 	)
 {
 	GPOS_ASSERT(attno > 0);
 
-	Node *pnode = NULL;
+	Node *node = NULL;
 
 	// Scan to see if relation has a default for this column
 	if (NULL != rd_att->constr && 0 < rd_att->constr->num_defval)
 	{
 		AttrDefault *defval = rd_att->constr->defval;
-		INT	iNumDef = rd_att->constr->num_defval;
+		INT	num_def = rd_att->constr->num_defval;
 
 		GPOS_ASSERT(NULL != defval);
-		for (ULONG ulCounter = 0; ulCounter < (ULONG) iNumDef; ulCounter++)
+		for (ULONG ul = 0; ul < (ULONG) num_def; ul++)
 		{
-			if (attno == defval[ulCounter].adnum)
+			if (attno == defval[ul].adnum)
 			{
 				// found it, convert string representation to node tree.
-				pnode = gpdb::Pnode(defval[ulCounter].adbin);
+				node = gpdb::StringToNode(defval[ul].adbin);
 				break;
 			}
 		}
 	}
 
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		// get the default value for the type
 		Form_pg_attribute att_tup = rd_att->attrs[attno - 1];
-		Oid	oidAtttype = att_tup->atttypid;
-		pnode = gpdb::PnodeTypeDefault(oidAtttype);
+		node = gpdb::GetTypeDefault(att_tup->atttypid);
 	}
 
-	if (NULL == pnode)
+	if (NULL == node)
 	{
 		return NULL;
 	}
 
 	// translate the default value expression
-	CTranslatorScalarToDXL sctranslator
+	CTranslatorScalarToDXL scalar_translator
 							(
-							pmp,
-							pmda,
+							mp,
+							md_accessor,
 							NULL, /* pulidgtorCol */
 							NULL, /* pulidgtorCTE */
-							0, /* ulQueryLevel */
+							0, /* query_level */
 							true, /* m_fQuery */
-							NULL, /* phmulCTEEntries */
-							NULL /* pdrgpdxlnCTE */
+							NULL, /* query_level_to_cte_map */
+							NULL /* cte_dxlnode_array */
 							);
 
-	return sctranslator.PdxlnScOpFromExpr
+	return scalar_translator.TranslateScalarToDXL
 							(
-							(Expr *) pnode,
-							NULL /* pmapvarcolid --- subquery or external variable are not supported in default expression */
+							(Expr *) node,
+							NULL /* var_colid_mapping --- subquery or external variable are not supported in default expression */
 							);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Ereldistribution
+//		CTranslatorRelcacheToDXL::GetRelDistribution
 //
 //	@doc:
 //		Return the distribution policy of the relation
 //
 //---------------------------------------------------------------------------
 IMDRelation::Ereldistrpolicy
-CTranslatorRelcacheToDXL::Ereldistribution
+CTranslatorRelcacheToDXL::GetRelDistribution
 	(
-	GpPolicy *pgppolicy
+	GpPolicy *gp_policy
 	)
 {
-	if (NULL == pgppolicy)
+	if (NULL == gp_policy)
 	{
 		return IMDRelation::EreldistrMasterOnly;
 	}
 
-	if (POLICYTYPE_PARTITIONED == pgppolicy->ptype)
+	if (POLICYTYPE_PARTITIONED == gp_policy->ptype)
 	{
-		if (0 == pgppolicy->nattrs)
+		if (0 == gp_policy->nattrs)
 		{
 			return IMDRelation::EreldistrRandom;
 		}
@@ -914,7 +914,7 @@ CTranslatorRelcacheToDXL::Ereldistribution
 		return IMDRelation::EreldistrHash;
 	}
 
-	if (POLICYTYPE_ENTRY == pgppolicy->ptype)
+	if (POLICYTYPE_ENTRY == gp_policy->ptype)
 	{
 		return IMDRelation::EreldistrMasterOnly;
 	}
@@ -925,42 +925,42 @@ CTranslatorRelcacheToDXL::Ereldistribution
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrpulDistrCols
+//		CTranslatorRelcacheToDXL::RetrieveRelDistrbutionCols
 //
 //	@doc:
 //		Get distribution columns
 //
 //---------------------------------------------------------------------------
-DrgPul *
-CTranslatorRelcacheToDXL::PdrpulDistrCols
+ULongPtrArray *
+CTranslatorRelcacheToDXL::RetrieveRelDistrbutionCols
 	(
-	IMemoryPool *pmp,
-	GpPolicy *pgppolicy,
-	DrgPmdcol *pdrgpmdcol,
-	ULONG ulSize
+	IMemoryPool *mp,
+	GpPolicy *gp_policy,
+	CMDColumnArray *mdcol_array,
+	ULONG size
 	)
 {
-	ULONG *pul = GPOS_NEW_ARRAY(pmp , ULONG, ulSize);
+	ULONG *attno_mapping = GPOS_NEW_ARRAY(mp , ULONG, size);
 
-	for (ULONG ul = 0;  ul < pdrgpmdcol->UlLength(); ul++)
+	for (ULONG ul = 0;  ul < mdcol_array->Size(); ul++)
 	{
-		const IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
-		INT iAttno = pmdcol->IAttno();
+		const IMDColumn *md_col = (*mdcol_array)[ul];
+		INT attno = md_col->AttrNum();
 
-		ULONG ulIndex = (ULONG) (GPDXL_SYSTEM_COLUMNS + iAttno);
-		pul[ulIndex] = ul;
+		ULONG idx = (ULONG) (GPDXL_SYSTEM_COLUMNS + attno);
+		attno_mapping[idx] = ul;
 	}
 
-	DrgPul *pdrpulDistrCols = GPOS_NEW(pmp) DrgPul(pmp);
+	ULongPtrArray *distr_cols = GPOS_NEW(mp) ULongPtrArray(mp);
 
-	for (ULONG ul = 0; ul < (ULONG) pgppolicy->nattrs; ul++)
+	for (ULONG ul = 0; ul < (ULONG) gp_policy->nattrs; ul++)
 	{
-		AttrNumber attno = pgppolicy->attrs[ul];
-		pdrpulDistrCols->Append(GPOS_NEW(pmp) ULONG(UlPosition(attno, pul)));
+		AttrNumber attno = gp_policy->attrs[ul];
+		distr_cols->Append(GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
 	}
 
-	GPOS_DELETE_ARRAY(pul);
-	return pdrpulDistrCols;
+	GPOS_DELETE_ARRAY(attno_mapping);
+	return distr_cols;
 }
 
 //---------------------------------------------------------------------------
@@ -974,57 +974,57 @@ CTranslatorRelcacheToDXL::PdrpulDistrCols
 void
 CTranslatorRelcacheToDXL::AddSystemColumns
 	(
-	IMemoryPool *pmp,
-	DrgPmdcol *pdrgpmdcol,
+	IMemoryPool *mp,
+	CMDColumnArray *mdcol_array,
 	Relation rel,
-	BOOL fAOTable
+	BOOL is_ao_table
 	)
 {
-	BOOL fHasOid = rel->rd_att->tdhasoid;
-	fAOTable = fAOTable || gpdb::FAppendOnlyPartitionTable(rel->rd_id);
+	BOOL has_oids = rel->rd_att->tdhasoid;
+	is_ao_table = is_ao_table || gpdb::IsAppendOnlyPartitionTable(rel->rd_id);
 
 	for (INT i= SelfItemPointerAttributeNumber; i > FirstLowInvalidHeapAttributeNumber; i--)
 	{
 		AttrNumber attno = AttrNumber(i);
 		GPOS_ASSERT(0 != attno);
 
-		if (ObjectIdAttributeNumber == i && !fHasOid)
+		if (ObjectIdAttributeNumber == i && !has_oids)
 		{
 			continue;
 		}
 
-		if (FTransactionVisibilityAttribute(i) && fAOTable)
+		if (IsTransactionVisibilityAttribute(i) && is_ao_table)
 		{
 			// skip transaction attrbutes like xmin, xmax, cmin, cmax for AO tables
 			continue;
 		}
 
 		// get system name for that attribute
-		const CWStringConst *pstrSysColName = CTranslatorUtils::PstrSystemColName(attno);
-		GPOS_ASSERT(NULL != pstrSysColName);
+		const CWStringConst *sys_colname = CTranslatorUtils::GetSystemColName(attno);
+		GPOS_ASSERT(NULL != sys_colname);
 
 		// copy string into column name
-		CMDName *pmdnameCol = GPOS_NEW(pmp) CMDName(pmp, pstrSysColName);
+		CMDName *md_colname = GPOS_NEW(mp) CMDName(mp, sys_colname);
 
-		CMDColumn *pmdcol = GPOS_NEW(pmp) CMDColumn
+		CMDColumn *md_col = GPOS_NEW(mp) CMDColumn
 										(
-										pmdnameCol, 
+										md_colname,
 										attno, 
-										CTranslatorUtils::PmdidSystemColType(pmp, attno),
-										IDefaultTypeModifier,
-										false,	// fNullable
-										false,	// fDropped
+										CTranslatorUtils::GetSystemColType(mp, attno),
+										default_type_modifier,
+										false,	// is_nullable
+										false,	// is_dropped
 										NULL,	// default value
-										CTranslatorUtils::UlSystemColLength(attno)
+										CTranslatorUtils::GetSystemColLength(attno)
 										);
 
-		pdrgpmdcol->Append(pmdcol);
+		mdcol_array->Append(md_col);
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::FTransactionVisibilityAttribute
+//		CTranslatorRelcacheToDXL::IsTransactionVisibilityAttribute
 //
 //	@doc:
 //		Check if attribute number is one of the system attributes related to 
@@ -1032,157 +1032,157 @@ CTranslatorRelcacheToDXL::AddSystemColumns
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorRelcacheToDXL::FTransactionVisibilityAttribute
+CTranslatorRelcacheToDXL::IsTransactionVisibilityAttribute
 	(
-	INT iAttNo
+	INT attno
 	)
 {
-	return iAttNo == MinTransactionIdAttributeNumber || iAttNo == MaxTransactionIdAttributeNumber || 
-			iAttNo == MinCommandIdAttributeNumber || iAttNo == MaxCommandIdAttributeNumber;
+	return attno == MinTransactionIdAttributeNumber || attno == MaxTransactionIdAttributeNumber ||
+			attno == MinCommandIdAttributeNumber || attno == MaxCommandIdAttributeNumber;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pmdindex
+//		CTranslatorRelcacheToDXL::RetrieveIndex
 //
 //	@doc:
 //		Retrieve an index from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 IMDIndex *
-CTranslatorRelcacheToDXL::Pmdindex
+CTranslatorRelcacheToDXL::RetrieveIndex
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdidIndex
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid_index
 	)
 {
-	OID oidIndex = CMDIdGPDB::PmdidConvert(pmdidIndex)->OidObjectId();
-	GPOS_ASSERT(0 != oidIndex);
-	Relation relIndex = gpdb::RelGetRelation(oidIndex);
+	OID index_oid = CMDIdGPDB::CastMdid(mdid_index)->Oid();
+	GPOS_ASSERT(0 != index_oid);
+	Relation index_rel = gpdb::GetRelation(index_oid);
 
-	if (NULL == relIndex)
+	if (NULL == index_rel)
 	{
-		 GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdidIndex->Wsz());
+		 GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid_index->GetBuffer());
 	}
 
-	const IMDRelation *pmdrel = NULL;
-	Form_pg_index pgIndex = NULL;
-	CMDName *pmdname = NULL;
-	IMDIndex::EmdindexType emdindt = IMDIndex::EmdindSentinel;
-	IMDId *pmdidItemType = NULL;
+	const IMDRelation *md_rel = NULL;
+	Form_pg_index form_pg_index = NULL;
+	CMDName *mdname = NULL;
+	IMDIndex::EmdindexType index_type = IMDIndex::EmdindSentinel;
+	IMDId *mdid_item_type = NULL;
 
 	GPOS_TRY
 	{
-		if (!FIndexSupported(relIndex))
+		if (!IsIndexSupported(index_rel))
 		{
 			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Index type"));
 		}
 
-		pgIndex = relIndex->rd_index;
-		GPOS_ASSERT (NULL != pgIndex);
+		form_pg_index = index_rel->rd_index;
+		GPOS_ASSERT (NULL != form_pg_index);
 
-		OID oidRel = pgIndex->indrelid;
+		OID rel_oid = form_pg_index->indrelid;
 
-		if (gpdb::FLeafPartition(oidRel))
+		if (gpdb::IsLeafPartition(rel_oid))
 		{
-			oidRel = gpdb::OidRootPartition(oidRel);
+			rel_oid = gpdb::GetRootPartition(rel_oid);
 		}
 
-		CMDIdGPDB *pmdidRel = GPOS_NEW(pmp) CMDIdGPDB(oidRel);
+		CMDIdGPDB *mdid_rel = GPOS_NEW(mp) CMDIdGPDB(rel_oid);
 
-		pmdrel = pmda->Pmdrel(pmdidRel);
+		md_rel = md_accessor->RetrieveRel(mdid_rel);
 	
-		if (pmdrel->FPartitioned())
+		if (md_rel->IsPartitioned())
 		{
-			LogicalIndexes *plgidx = gpdb::Plgidx(oidRel);
-			GPOS_ASSERT(NULL != plgidx);
+			LogicalIndexes *logical_indexes = gpdb::GetLogicalPartIndexes(rel_oid);
+			GPOS_ASSERT(NULL != logical_indexes);
 
-			IMDIndex *pmdindex = PmdindexPartTable(pmp, pmda, pmdidIndex, pmdrel, plgidx);
+			IMDIndex *index = RetrievePartTableIndex(mp, md_accessor, mdid_index, md_rel, logical_indexes);
 
 			// cleanup
-			gpdb::GPDBFree(plgidx);
+			gpdb::GPDBFree(logical_indexes);
 
-			if (NULL != pmdindex)
+			if (NULL != index)
 			{
-				pmdidRel->Release();
-				gpdb::CloseRelation(relIndex);
-				return pmdindex;
+				mdid_rel->Release();
+				gpdb::CloseRelation(index_rel);
+				return index;
 			}
 		}
 	
-		emdindt = IMDIndex::EmdindBtree;
-		IMDRelation::Erelstoragetype erelstorage = pmdrel->Erelstorage();
-		if (GIST_AM_OID == relIndex->rd_rel->relam)
+		index_type = IMDIndex::EmdindBtree;
+		IMDRelation::Erelstoragetype rel_storage_type = md_rel->RetrieveRelStorageType();
+		if (GIST_AM_OID == index_rel->rd_rel->relam)
 		{
-			emdindt = IMDIndex::EmdindGist;
-			pmdidItemType = GPOS_NEW(pmp) CMDIdGPDB(GPDB_ANY);
+			index_type = IMDIndex::EmdindGist;
+			mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
 		}
-		else if (BITMAP_AM_OID == relIndex->rd_rel->relam || IMDRelation::ErelstorageAppendOnlyRows == erelstorage || IMDRelation::ErelstorageAppendOnlyCols == erelstorage)
+		else if (BITMAP_AM_OID == index_rel->rd_rel->relam || IMDRelation::ErelstorageAppendOnlyRows == rel_storage_type || IMDRelation::ErelstorageAppendOnlyCols == rel_storage_type)
 		{
-			emdindt = IMDIndex::EmdindBitmap;
-			pmdidItemType = GPOS_NEW(pmp) CMDIdGPDB(GPDB_ANY);
+			index_type = IMDIndex::EmdindBitmap;
+			mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
 		}
 
 		// get the index name
-		CHAR *szIndexName = NameStr(relIndex->rd_rel->relname);
-		CWStringDynamic *pstrName = CDXLUtils::PstrFromSz(pmp, szIndexName);
-		pmdname = GPOS_NEW(pmp) CMDName(pmp, pstrName);
-		GPOS_DELETE(pstrName);
-		pmdidRel->Release();
-		gpdb::CloseRelation(relIndex);
+		CHAR *index_name = NameStr(index_rel->rd_rel->relname);
+		CWStringDynamic *str_name = CDXLUtils::CreateDynamicStringFromCharArray(mp, index_name);
+		mdname = GPOS_NEW(mp) CMDName(mp, str_name);
+		GPOS_DELETE(str_name);
+		mdid_rel->Release();
+		gpdb::CloseRelation(index_rel);
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		gpdb::CloseRelation(relIndex);
+		gpdb::CloseRelation(index_rel);
 		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
 	
-	Relation relTable = gpdb::RelGetRelation(CMDIdGPDB::PmdidConvert(pmdrel->Pmdid())->OidObjectId());
-	ULONG ulRgSize = GPDXL_SYSTEM_COLUMNS + (ULONG) relTable->rd_att->natts + 1;
-	gpdb::CloseRelation(relTable); // close relation as early as possible
+	Relation table = gpdb::GetRelation(CMDIdGPDB::CastMdid(md_rel->MDId())->Oid());
+	ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) table->rd_att->natts + 1;
+	gpdb::CloseRelation(table); // close relation as early as possible
 
-	ULONG *pul = PulAttnoPositionMap(pmp, pmdrel, ulRgSize);
+	ULONG *attno_mapping = PopulateAttnoPositionMap(mp, md_rel, size);
 
-	DrgPul *pdrgpulIncludeCols = PdrgpulIndexIncludedColumns(pmp, pmdrel);
+	ULongPtrArray *included_cols = ComputeIncludedCols(mp, md_rel);
 
 	// extract the position of the key columns
-	DrgPul *pdrgpulKeyCols = GPOS_NEW(pmp) DrgPul(pmp);
-	ULONG ulKeys = pgIndex->indnatts;
-	for (ULONG ul = 0; ul < ulKeys; ul++)
-	{
-		INT iAttno = pgIndex->indkey.values[ul];
-		GPOS_ASSERT(0 != iAttno && "Index expressions not supported");
+	ULongPtrArray *index_key_cols_array = GPOS_NEW(mp) ULongPtrArray(mp);
 
-		pdrgpulKeyCols->Append(GPOS_NEW(pmp) ULONG(UlPosition(iAttno, pul)));
+	for (ULONG ul = 0; ul < form_pg_index->indnatts; ul++)
+	{
+		INT attno = form_pg_index->indkey.values[ul];
+		GPOS_ASSERT(0 != attno && "Index expressions not supported");
+
+		index_key_cols_array->Append(GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
 	}
 
-	pmdidIndex->AddRef();	
-	DrgPmdid *pdrgpmdidOpFamilies = PdrgpmdidIndexOpFamilies(pmp, pmdidIndex);
+	mdid_index->AddRef();
+	IMdIdArray *op_families_mdids = RetrieveIndexOpFamilies(mp, mdid_index);
 	
-	CMDIndexGPDB *pmdindex = GPOS_NEW(pmp) CMDIndexGPDB
+	CMDIndexGPDB *index = GPOS_NEW(mp) CMDIndexGPDB
 										(
-										pmp,
-										pmdidIndex,
-										pmdname,
-										pgIndex->indisclustered,
-										emdindt,
-										pmdidItemType,
-										pdrgpulKeyCols,
-										pdrgpulIncludeCols,
-										pdrgpmdidOpFamilies,
-										NULL // pmdpartcnstr
+										mp,
+										mdid_index,
+										mdname,
+										form_pg_index->indisclustered,
+										index_type,
+										mdid_item_type,
+										index_key_cols_array,
+										included_cols,
+										op_families_mdids,
+										NULL // mdpart_constraint
 										);
 
-	GPOS_DELETE_ARRAY(pul);
+	GPOS_DELETE_ARRAY(attno_mapping);
 
-	return pmdindex;
+	return index;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PmdindexPartTable
+//		CTranslatorRelcacheToDXL::RetrievePartTableIndex
 //
 //	@doc:
 //		Retrieve an index over a partitioned table from the relcache given its 
@@ -1190,55 +1190,55 @@ CTranslatorRelcacheToDXL::Pmdindex
 //
 //---------------------------------------------------------------------------
 IMDIndex *
-CTranslatorRelcacheToDXL::PmdindexPartTable
+CTranslatorRelcacheToDXL::RetrievePartTableIndex
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdidIndex,
-	const IMDRelation *pmdrel,
-	LogicalIndexes *plind
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid_index,
+	const IMDRelation *md_rel,
+	LogicalIndexes *logical_indexes
 	)
 {
-	GPOS_ASSERT(NULL != plind);
-	GPOS_ASSERT(0 < plind->numLogicalIndexes);
+	GPOS_ASSERT(NULL != logical_indexes);
+	GPOS_ASSERT(0 < logical_indexes->numLogicalIndexes);
 	
-	OID oid = CMDIdGPDB::PmdidConvert(pmdidIndex)->OidObjectId();
+	OID oid = CMDIdGPDB::CastMdid(mdid_index)->Oid();
 	
-	LogicalIndexInfo *pidxinfo = PidxinfoLookup(plind, oid);
-	if (NULL == pidxinfo)
+	LogicalIndexInfo *index_info = LookupLogicalIndexById(logical_indexes, oid);
+	if (NULL == index_info)
 	{
 		 return NULL;
 	}
 	
-	return PmdindexPartTable(pmp, pmda, pidxinfo, pmdidIndex, pmdrel);
+	return RetrievePartTableIndex(mp, md_accessor, index_info, mdid_index, md_rel);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PidxinfoLookup
+//		CTranslatorRelcacheToDXL::LookupLogicalIndexById
 //
 //	@doc:
 //		Lookup an index given its id from the logical indexes structure
 //
 //---------------------------------------------------------------------------
 LogicalIndexInfo *
-CTranslatorRelcacheToDXL::PidxinfoLookup
+CTranslatorRelcacheToDXL::LookupLogicalIndexById
 	(
-	LogicalIndexes *plind, 
+	LogicalIndexes *logical_indexes,
 	OID oid
 	)
 {
-	GPOS_ASSERT(NULL != plind && 0 <= plind->numLogicalIndexes);
+	GPOS_ASSERT(NULL != logical_indexes && 0 <= logical_indexes->numLogicalIndexes);
 	
-	const ULONG ulIndexes = plind->numLogicalIndexes;
+	const ULONG num_index = logical_indexes->numLogicalIndexes;
 	
-	for (ULONG ul = 0; ul < ulIndexes; ul++)
+	for (ULONG ul = 0; ul < num_index; ul++)
 	{
-		LogicalIndexInfo *pidxinfo = (plind->logicalIndexInfo)[ul];
+		LogicalIndexInfo *index_info = (logical_indexes->logicalIndexInfo)[ul];
 		
-		if (oid == pidxinfo->logicalIndexOid)
+		if (oid == index_info->logicalIndexOid)
 		{
-			return pidxinfo;
+			return index_info;
 		}
 	}
 	
@@ -1247,71 +1247,71 @@ CTranslatorRelcacheToDXL::PidxinfoLookup
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PmdindexPartTable
+//		CTranslatorRelcacheToDXL::RetrievePartTableIndex
 //
 //	@doc:
 //		Construct an MD cache index object given its logical index representation
 //
 //---------------------------------------------------------------------------
 IMDIndex *
-CTranslatorRelcacheToDXL::PmdindexPartTable
+CTranslatorRelcacheToDXL::RetrievePartTableIndex
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	LogicalIndexInfo *pidxinfo,
-	IMDId *pmdidIndex,
-	const IMDRelation *pmdrel
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	LogicalIndexInfo *index_info,
+	IMDId *mdid_index,
+	const IMDRelation *md_rel
 	)
 {
-	OID oidIndex = pidxinfo->logicalIndexOid;
+	OID index_oid = index_info->logicalIndexOid;
 	
-	Relation relIndex = gpdb::RelGetRelation(oidIndex);
+	Relation index_rel = gpdb::GetRelation(index_oid);
 
-	if (NULL == relIndex)
+	if (NULL == index_rel)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdidIndex->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid_index->GetBuffer());
 	}
 
-	if (!FIndexSupported(relIndex))
+	if (!IsIndexSupported(index_rel))
 	{
-		gpdb::CloseRelation(relIndex);
+		gpdb::CloseRelation(index_rel);
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Index type"));
 	}
 	
 	// get the index name
-	GPOS_ASSERT(NULL != relIndex->rd_index);
-	Form_pg_index pgIndex = relIndex->rd_index;
+	GPOS_ASSERT(NULL != index_rel->rd_index);
+	Form_pg_index form_pg_index = index_rel->rd_index;
 	
-	CHAR *szIndexName = NameStr(relIndex->rd_rel->relname);
-	CMDName *pmdname = CDXLUtils::PmdnameFromSz(pmp, szIndexName);
-	gpdb::CloseRelation(relIndex);
+	CHAR *index_name = NameStr(index_rel->rd_rel->relname);
+	CMDName *mdname = CDXLUtils::CreateMDNameFromCharArray(mp, index_name);
+	gpdb::CloseRelation(index_rel);
 
-	OID oidRel = CMDIdGPDB::PmdidConvert(pmdrel->Pmdid())->OidObjectId();
-	Relation relTable = gpdb::RelGetRelation(oidRel);
-	ULONG ulRgSize = GPDXL_SYSTEM_COLUMNS + (ULONG) relTable->rd_att->natts + 1;
-	gpdb::CloseRelation(relTable);
+	OID rel_oid = CMDIdGPDB::CastMdid(md_rel->MDId())->Oid();
+	Relation table = gpdb::GetRelation(rel_oid);
+	ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) table->rd_att->natts + 1;
+	gpdb::CloseRelation(table);
 
-	ULONG *pulAttrMap = PulAttnoPositionMap(pmp, pmdrel, ulRgSize);
+	ULONG *attno_mapping = PopulateAttnoPositionMap(mp, md_rel, size);
 
-	DrgPul *pdrgpulIncludeCols = PdrgpulIndexIncludedColumns(pmp, pmdrel);
+	ULongPtrArray *included_cols = ComputeIncludedCols(mp, md_rel);
 
 	// extract the position of the key columns
-	DrgPul *pdrgpulKeyCols = GPOS_NEW(pmp) DrgPul(pmp);
-	const ULONG ulKeys = pidxinfo->nColumns;
-	for (ULONG ul = 0; ul < ulKeys; ul++)
-	{
-		INT iAttno = pidxinfo->indexKeys[ul];
-		GPOS_ASSERT(0 != iAttno && "Index expressions not supported");
+	ULongPtrArray *index_key_cols_array = GPOS_NEW(mp) ULongPtrArray(mp);
 
-		pdrgpulKeyCols->Append(GPOS_NEW(pmp) ULONG(UlPosition(iAttno, pulAttrMap)));
+	for (ULONG ul = 0; ul < index_info->nColumns; ul++)
+	{
+		INT attno = index_info->indexKeys[ul];
+		GPOS_ASSERT(0 != attno && "Index expressions not supported");
+
+		index_key_cols_array->Append(GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
 	}
 	
 	/*
-	 * If an index exists only on a leaf part, pnodePartCnstr refers to the expression
+	 * If an index exists only on a leaf part, part_constraint refers to the expression
 	 * identifying the path to reach the partition holding the index. For indexes
 	 * available on all parts it is set to NULL.
 	 */
-	Node *pnodePartCnstr = pidxinfo->partCons;
+	Node *part_constraint = index_info->partCons;
 	
 	/*
 	 * If an index exists all on the parts including default, the logical index
@@ -1319,128 +1319,128 @@ CTranslatorRelcacheToDXL::PmdindexPartTable
 	 * leaf parts plDefaultLevel contains the default part level which come across while
 	 * reaching to the leaf part from root.
 	 */
-	List *plDefaultLevels = pidxinfo->defaultLevels;
+	List *default_levels = index_info->defaultLevels;
 	
 	// get number of partitioning levels
-	List *plPartKeys = gpdb::PlPartitionAttrs(oidRel);
-	const ULONG ulLevels = gpdb::UlListLength(plPartKeys);
-	gpdb::FreeList(plPartKeys);
+	List *part_keys = gpdb::GetPartitionAttrs(rel_oid);
+	const ULONG num_of_levels = gpdb::ListLength(part_keys);
+	gpdb::ListFree(part_keys);
 
 	/* get relation constraints
-	 * plDefaultLevelsRel indicates the levels on which default partitions exists
+	 * default_levels_rel indicates the levels on which default partitions exists
 	 * for the partitioned table
 	 */
-	List *plDefaultLevelsRel = NIL;
-	Node *pnodePartCnstrRel = gpdb::PnodePartConstraintRel(oidRel, &plDefaultLevelsRel);
+	List *default_levels_rel = NIL;
+	Node *part_constraints_rel = gpdb::GetRelationPartContraints(rel_oid, &default_levels_rel);
 
-	BOOL fUnbounded = (NULL == pnodePartCnstr) && (NIL == plDefaultLevels);
-	for (ULONG ul = 0; ul < ulLevels; ul++)
+	BOOL is_unbounded = (NULL == part_constraint) && (NIL == default_levels);
+	for (ULONG ul = 0; ul < num_of_levels; ul++)
 	{
-		fUnbounded = fUnbounded && FDefaultPartition(plDefaultLevelsRel, ul);
+		is_unbounded = is_unbounded && LevelHasDefaultPartition(default_levels_rel, ul);
 	}
 
 	/*
-	 * If pnodePartCnstr is NULL and plDefaultLevels is NIL,
+	 * If part_constraint is NULL and default_levels is NIL,
 	 * it indicates that the index is available on all the parts including
 	 * default part. So, we can say that levels on which default partitions
 	 * exists for the relation applies to the index as well and the relative
 	 * scan will not be partial.
 	 */
-	List *plDefaultLevelsDerived = NIL;
-	if (NULL == pnodePartCnstr && NIL == plDefaultLevels)
-		plDefaultLevelsDerived = plDefaultLevelsRel;
+	List *default_levels_derived_list = NIL;
+	if (NULL == part_constraint && NIL == default_levels)
+		default_levels_derived_list = default_levels_rel;
 	else
-		plDefaultLevelsDerived = plDefaultLevels;
+		default_levels_derived_list = default_levels;
 	
-	DrgPul *pdrgpulDefaultLevels = GPOS_NEW(pmp) DrgPul(pmp);
-	for (ULONG ul = 0; ul < ulLevels; ul++)
+	ULongPtrArray *default_levels_derived = GPOS_NEW(mp) ULongPtrArray(mp);
+	for (ULONG ul = 0; ul < num_of_levels; ul++)
 	{
-		if (fUnbounded || FDefaultPartition(plDefaultLevelsDerived, ul))
+		if (is_unbounded || LevelHasDefaultPartition(default_levels_derived_list, ul))
 		{
-			pdrgpulDefaultLevels->Append(GPOS_NEW(pmp) ULONG(ul));
+			default_levels_derived->Append(GPOS_NEW(mp) ULONG(ul));
 		}
 	}
-	gpdb::FreeList(plDefaultLevelsDerived);
+	gpdb::ListFree(default_levels_derived_list);
 
-	if (NULL == pnodePartCnstr)
+	if (NULL == part_constraint)
 	{
-		if (NIL == plDefaultLevels)
+		if (NIL == default_levels)
 		{
 			// NULL part constraints means all non-default partitions -> get constraint from the part table
-			pnodePartCnstr = pnodePartCnstrRel;
+			part_constraint = part_constraints_rel;
 		}
 		else
 		{
-			pnodePartCnstr = gpdb::PnodeMakeBoolConst(false /*value*/, false /*isull*/);
+			part_constraint = gpdb::MakeBoolConst(false /*value*/, false /*isull*/);
 		}
 	}
 		
-	CMDPartConstraintGPDB *pmdpartcnstr = PmdpartcnstrIndex(pmp, pmda, pmdrel, pnodePartCnstr, pdrgpulDefaultLevels, fUnbounded);
+	CMDPartConstraintGPDB *mdpart_constraint = RetrievePartConstraintForIndex(mp, md_accessor, md_rel, part_constraint, default_levels_derived, is_unbounded);
 
-	pdrgpulDefaultLevels->Release();
-	pmdidIndex->AddRef();
-
-	GPOS_ASSERT(INDTYPE_BITMAP == pidxinfo->indType || INDTYPE_BTREE == pidxinfo->indType || INDTYPE_GIST == pidxinfo->indType);
-
-	IMDIndex::EmdindexType emdindt = IMDIndex::EmdindBtree;
-	IMDId *pmdidItemType = NULL;
-	if (INDTYPE_BITMAP == pidxinfo->indType)
+	default_levels_derived->Release();
+	mdid_index->AddRef();
+	
+	GPOS_ASSERT(INDTYPE_BITMAP == index_info->indType || INDTYPE_BTREE == index_info->indType || INDTYPE_GIST == index_info->indType);
+	
+	IMDIndex::EmdindexType index_type = IMDIndex::EmdindBtree;
+	IMDId *mdid_item_type = NULL;
+	if (INDTYPE_BITMAP == index_info->indType)
 	{
-		emdindt = IMDIndex::EmdindBitmap;
-		pmdidItemType = GPOS_NEW(pmp) CMDIdGPDB(GPDB_ANY);
+		index_type = IMDIndex::EmdindBitmap;
+		mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
 	}
-	else if (INDTYPE_GIST == pidxinfo->indType)
+	else if (INDTYPE_GIST == index_info->indType)
 	{
-		emdindt = IMDIndex::EmdindGist;
-		pmdidItemType = GPOS_NEW(pmp) CMDIdGPDB(GPDB_ANY);
+		index_type = IMDIndex::EmdindGist;
+		mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
 	}
 	
-	DrgPmdid *pdrgpmdidOpFamilies = PdrgpmdidIndexOpFamilies(pmp, pmdidIndex);
+	IMdIdArray *pdrgpmdidOpFamilies = RetrieveIndexOpFamilies(mp, mdid_index);
 	
-	CMDIndexGPDB *pmdindex = GPOS_NEW(pmp) CMDIndexGPDB
+	CMDIndexGPDB *index = GPOS_NEW(mp) CMDIndexGPDB
 										(
-										pmp,
-										pmdidIndex,
-										pmdname,
-										pgIndex->indisclustered,
-										emdindt,
-										pmdidItemType,
-										pdrgpulKeyCols,
-										pdrgpulIncludeCols,
+										mp,
+										mdid_index,
+										mdname,
+										form_pg_index->indisclustered,
+										index_type,
+										mdid_item_type,
+										index_key_cols_array,
+										included_cols,
 										pdrgpmdidOpFamilies,
-										pmdpartcnstr
+										mdpart_constraint
 										);
 	
-	GPOS_DELETE_ARRAY(pulAttrMap);
+	GPOS_DELETE_ARRAY(attno_mapping);
 	
-	return pmdindex;
+	return index;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::FDefaultPartition
+//		CTranslatorRelcacheToDXL::LevelHasDefaultPartition
 //
 //	@doc:
 //		Check whether the default partition at level one is included
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorRelcacheToDXL::FDefaultPartition
+CTranslatorRelcacheToDXL::LevelHasDefaultPartition
 	(
-	List *plDefaultLevels,
-	ULONG ulLevel
+	List *default_levels,
+	ULONG level
 	)
 {
-	if (NIL == plDefaultLevels)
+	if (NIL == default_levels)
 	{
 		return false;
 	}
 	
-	ListCell *plc = NULL;
-	ForEach (plc, plDefaultLevels)
+	ListCell *lc = NULL;
+	ForEach (lc, default_levels)
 	{
-		ULONG ulDefaultLevel = (ULONG) lfirst_int(plc);
-		if (ulLevel == ulDefaultLevel)
+		ULONG default_level = (ULONG) lfirst_int(lc);
+		if (level == default_level)
 		{
 			return true;
 		}
@@ -1451,216 +1451,216 @@ CTranslatorRelcacheToDXL::FDefaultPartition
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpulIndexIncludedColumns
+//		CTranslatorRelcacheToDXL::ComputeIncludedCols
 //
 //	@doc:
 //		Compute the included colunms in an index
 //
 //---------------------------------------------------------------------------
-DrgPul *
-CTranslatorRelcacheToDXL::PdrgpulIndexIncludedColumns
+ULongPtrArray *
+CTranslatorRelcacheToDXL::ComputeIncludedCols
 	(
-	IMemoryPool *pmp,
-	const IMDRelation *pmdrel
+	IMemoryPool *mp,
+	const IMDRelation *md_rel
 	)
 {
 	// TODO: 3/19/2012; currently we assume that all the columns
 	// in the table are available from the index.
 
-	DrgPul *pdrgpulIncludeCols = GPOS_NEW(pmp) DrgPul(pmp);
-	const ULONG ulIncludedCols = pmdrel->UlColumns();
-	for (ULONG ul = 0;  ul < ulIncludedCols; ul++)
+	ULongPtrArray *included_cols = GPOS_NEW(mp) ULongPtrArray(mp);
+	const ULONG num_included_cols = md_rel->ColumnCount();
+	for (ULONG ul = 0;  ul < num_included_cols; ul++)
 	{
-		if (!pmdrel->Pmdcol(ul)->FDropped())
+		if (!md_rel->GetMdCol(ul)->IsDropped())
 		{
-			pdrgpulIncludeCols->Append(GPOS_NEW(pmp) ULONG(ul));
+			included_cols->Append(GPOS_NEW(mp) ULONG(ul));
 		}
 	}
 	
-	return pdrgpulIncludeCols;
+	return included_cols;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::UlPosition
+//		CTranslatorRelcacheToDXL::GetAttributePosition
 //
 //	@doc:
 //		Return the position of a given attribute
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorRelcacheToDXL::UlPosition
+CTranslatorRelcacheToDXL::GetAttributePosition
 	(
-	INT iAttno,
-	ULONG *pul
+	INT attno,
+	ULONG *GetAttributePosition
 	)
 {
-	ULONG ulIndex = (ULONG) (GPDXL_SYSTEM_COLUMNS + iAttno);
-	ULONG ulPos = pul[ulIndex];
-	GPOS_ASSERT(gpos::ulong_max != ulPos);
+	ULONG idx = (ULONG) (GPDXL_SYSTEM_COLUMNS + attno);
+	ULONG pos = GetAttributePosition[idx];
+	GPOS_ASSERT(gpos::ulong_max != pos);
 
-	return ulPos;
+	return pos;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PulAttnoPositionMap
+//		CTranslatorRelcacheToDXL::PopulateAttnoPositionMap
 //
 //	@doc:
 //		Populate the attribute to position mapping
 //
 //---------------------------------------------------------------------------
 ULONG *
-CTranslatorRelcacheToDXL::PulAttnoPositionMap
+CTranslatorRelcacheToDXL::PopulateAttnoPositionMap
 	(
-	IMemoryPool *pmp,
-	const IMDRelation *pmdrel,
-	ULONG ulSize
+	IMemoryPool *mp,
+	const IMDRelation *md_rel,
+	ULONG size
 	)
 {
-	GPOS_ASSERT(NULL != pmdrel);
-	const ULONG ulIncludedCols = pmdrel->UlColumns();
+	GPOS_ASSERT(NULL != md_rel);
+	const ULONG num_included_cols = md_rel->ColumnCount();
 
-	GPOS_ASSERT(ulIncludedCols <= ulSize);
-	ULONG *pul = GPOS_NEW_ARRAY(pmp , ULONG, ulSize);
+	GPOS_ASSERT(num_included_cols <= size);
+	ULONG *attno_mapping = GPOS_NEW_ARRAY(mp , ULONG, size);
 
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	for (ULONG ul = 0; ul < size; ul++)
 	{
-		pul[ul] = gpos::ulong_max;
+		attno_mapping[ul] = gpos::ulong_max;
 	}
 
-	for (ULONG ul = 0;  ul < ulIncludedCols; ul++)
+	for (ULONG ul = 0;  ul < num_included_cols; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
+		const IMDColumn *md_col = md_rel->GetMdCol(ul);
 
-		INT iAttno = pmdcol->IAttno();
+		INT attno = md_col->AttrNum();
 
-		ULONG ulIndex = (ULONG) (GPDXL_SYSTEM_COLUMNS + iAttno);
-		GPOS_ASSERT(ulSize > ulIndex);
-		pul[ulIndex] = ul;
+		ULONG idx = (ULONG) (GPDXL_SYSTEM_COLUMNS + attno);
+		GPOS_ASSERT(size > idx);
+		attno_mapping[idx] = ul;
 	}
 
-	return pul;
+	return attno_mapping;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pmdtype
+//		CTranslatorRelcacheToDXL::RetrieveType
 //
 //	@doc:
 //		Retrieve a type from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 IMDType *
-CTranslatorRelcacheToDXL::Pmdtype
+CTranslatorRelcacheToDXL::RetrieveType
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	OID oidType = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
-	GPOS_ASSERT(InvalidOid != oidType);
+	OID oid_type = CMDIdGPDB::CastMdid(mdid)->Oid();
+	GPOS_ASSERT(InvalidOid != oid_type);
 	
 	// check for supported base types
-	switch (oidType)
+	switch (oid_type)
 	{
 		case GPDB_INT2_OID:
-			return GPOS_NEW(pmp) CMDTypeInt2GPDB(pmp);
+			return GPOS_NEW(mp) CMDTypeInt2GPDB(mp);
 
 		case GPDB_INT4_OID:
-			return GPOS_NEW(pmp) CMDTypeInt4GPDB(pmp);
+			return GPOS_NEW(mp) CMDTypeInt4GPDB(mp);
 
 		case GPDB_INT8_OID:
-			return GPOS_NEW(pmp) CMDTypeInt8GPDB(pmp);
+			return GPOS_NEW(mp) CMDTypeInt8GPDB(mp);
 
 		case GPDB_BOOL:
-			return GPOS_NEW(pmp) CMDTypeBoolGPDB(pmp);
+			return GPOS_NEW(mp) CMDTypeBoolGPDB(mp);
 
 		case GPDB_OID_OID:
-			return GPOS_NEW(pmp) CMDTypeOidGPDB(pmp);
+			return GPOS_NEW(mp) CMDTypeOidGPDB(mp);
 	}
 
 	// continue to construct a generic type
 	INT iFlags = TYPECACHE_EQ_OPR | TYPECACHE_LT_OPR | TYPECACHE_GT_OPR |
 				 TYPECACHE_CMP_PROC | TYPECACHE_EQ_OPR_FINFO | TYPECACHE_CMP_PROC_FINFO | TYPECACHE_TUPDESC;
 
-	TypeCacheEntry *ptce = gpdb::PtceLookup(oidType, iFlags);
+	TypeCacheEntry *ptce = gpdb::LookupTypeCache(oid_type, iFlags);
 
 	// get type name
-	CMDName *pmdname = PmdnameType(pmp, pmdid);
+	CMDName *mdname = GetTypeName(mp, mdid);
 
-	BOOL fFixedLength = false;
-	ULONG ulLength = 0;
+	BOOL is_fixed_length = false;
+	ULONG length = 0;
 
 	if (0 < ptce->typlen)
 	{
-		fFixedLength = true;
-		ulLength = ptce->typlen;
+		is_fixed_length = true;
+		length = ptce->typlen;
 	}
 
-	BOOL fByValue = ptce->typbyval;
+	BOOL is_passed_by_value = ptce->typbyval;
 
 	// collect ids of different comparison operators for types
-	CMDIdGPDB *pmdidOpEq = GPOS_NEW(pmp) CMDIdGPDB(ptce->eq_opr);
-	CMDIdGPDB *pmdidOpNEq = GPOS_NEW(pmp) CMDIdGPDB(gpdb::OidInverseOp(ptce->eq_opr));
-	CMDIdGPDB *pmdidOpLT = GPOS_NEW(pmp) CMDIdGPDB(ptce->lt_opr);
-	CMDIdGPDB *pmdidOpLEq = GPOS_NEW(pmp) CMDIdGPDB(gpdb::OidInverseOp(ptce->gt_opr));
-	CMDIdGPDB *pmdidOpGT = GPOS_NEW(pmp) CMDIdGPDB(ptce->gt_opr);
-	CMDIdGPDB *pmdidOpGEq = GPOS_NEW(pmp) CMDIdGPDB(gpdb::OidInverseOp(ptce->lt_opr));
-	CMDIdGPDB *pmdidOpComp = GPOS_NEW(pmp) CMDIdGPDB(ptce->cmp_proc);
-	BOOL fHashable = gpdb::FOpHashJoinable(ptce->eq_opr);
-	BOOL fComposite = gpdb::FCompositeType(oidType);
+	CMDIdGPDB *mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(ptce->eq_opr);
+	CMDIdGPDB *mdid_op_neq = GPOS_NEW(mp) CMDIdGPDB(gpdb::GetInverseOp(ptce->eq_opr));
+	CMDIdGPDB *mdid_op_lt = GPOS_NEW(mp) CMDIdGPDB(ptce->lt_opr);
+	CMDIdGPDB *mdid_op_leq = GPOS_NEW(mp) CMDIdGPDB(gpdb::GetInverseOp(ptce->gt_opr));
+	CMDIdGPDB *mdid_op_gt = GPOS_NEW(mp) CMDIdGPDB(ptce->gt_opr);
+	CMDIdGPDB *mdid_op_geq = GPOS_NEW(mp) CMDIdGPDB(gpdb::GetInverseOp(ptce->lt_opr));
+	CMDIdGPDB *mdid_op_cmp = GPOS_NEW(mp) CMDIdGPDB(ptce->cmp_proc);
+	BOOL is_hashable = gpdb::IsOpHashJoinable(ptce->eq_opr);
+	BOOL is_composite_type = gpdb::IsCompositeType(oid_type);
 
 	// get standard aggregates
-	CMDIdGPDB *pmdidMin = GPOS_NEW(pmp) CMDIdGPDB(gpdb::OidAggregate("min", oidType));
-	CMDIdGPDB *pmdidMax = GPOS_NEW(pmp) CMDIdGPDB(gpdb::OidAggregate("max", oidType));
-	CMDIdGPDB *pmdidAvg = GPOS_NEW(pmp) CMDIdGPDB(gpdb::OidAggregate("avg", oidType));
-	CMDIdGPDB *pmdidSum = GPOS_NEW(pmp) CMDIdGPDB(gpdb::OidAggregate("sum", oidType));
+	CMDIdGPDB *mdid_min = GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("min", oid_type));
+	CMDIdGPDB *mdid_max = GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("max", oid_type));
+	CMDIdGPDB *mdid_avg = GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("avg", oid_type));
+	CMDIdGPDB *mdid_sum = GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("sum", oid_type));
 	
 	// count aggregate is the same for all types
-	CMDIdGPDB *pmdidCount = GPOS_NEW(pmp) CMDIdGPDB(COUNT_ANY_OID);
+	CMDIdGPDB *mdid_count = GPOS_NEW(mp) CMDIdGPDB(COUNT_ANY_OID);
 	
 	// check if type is composite
-	CMDIdGPDB *pmdidTypeRelid = NULL;
-	if (fComposite)
+	CMDIdGPDB *mdid_type_relid = NULL;
+	if (is_composite_type)
 	{
-		pmdidTypeRelid = GPOS_NEW(pmp) CMDIdGPDB(gpdb::OidTypeRelid(oidType));
+		mdid_type_relid = GPOS_NEW(mp) CMDIdGPDB(gpdb::GetTypeRelid(oid_type));
 	}
 
 	// get array type mdid
-	CMDIdGPDB *pmdidTypeArray = GPOS_NEW(pmp) CMDIdGPDB(gpdb::OidArrayType(oidType));
+	CMDIdGPDB *mdid_type_array = GPOS_NEW(mp) CMDIdGPDB(gpdb::GetArrayType(oid_type));
 
-	BOOL fRedistributable = gpdb::FGreenplumDbHashable(oidType);
+	BOOL is_redistributable = gpdb::IsGreenplumDbHashable(oid_type);
 
-	pmdid->AddRef();
+	mdid->AddRef();
 
-	return GPOS_NEW(pmp) CMDTypeGenericGPDB
+	return GPOS_NEW(mp) CMDTypeGenericGPDB
 						 (
-						 pmp,
-						 pmdid,
-						 pmdname,
-						 fRedistributable,
-						 fFixedLength,
-						 ulLength,
-						 fByValue,
-						 pmdidOpEq,
-						 pmdidOpNEq,
-						 pmdidOpLT,
-						 pmdidOpLEq,
-						 pmdidOpGT,
-						 pmdidOpGEq,
-						 pmdidOpComp,
-						 pmdidMin,
-						 pmdidMax,
-						 pmdidAvg,
-						 pmdidSum,
-						 pmdidCount,
-						 fHashable,
-						 fComposite,
-						 pmdidTypeRelid,
-						 pmdidTypeArray,
+						 mp,
+						 mdid,
+						 mdname,
+						 is_redistributable,
+						 is_fixed_length,
+						 length,
+						 is_passed_by_value,
+						 mdid_op_eq,
+						 mdid_op_neq,
+						 mdid_op_lt,
+						 mdid_op_leq,
+						 mdid_op_gt,
+						 mdid_op_geq,
+						 mdid_op_cmp,
+						 mdid_min,
+						 mdid_max,
+						 mdid_avg,
+						 mdid_sum,
+						 mdid_count,
+						 is_hashable,
+						 is_composite_type,
+						 mdid_type_relid,
+						 mdid_type_array,
 						 ptce->typlen
 						 );
 }
@@ -1668,107 +1668,107 @@ CTranslatorRelcacheToDXL::Pmdtype
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pmdscop
+//		CTranslatorRelcacheToDXL::RetrieveScOp
 //
 //	@doc:
 //		Retrieve a scalar operator from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 CMDScalarOpGPDB *
-CTranslatorRelcacheToDXL::Pmdscop
+CTranslatorRelcacheToDXL::RetrieveScOp
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	OID oidOp = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
+	OID op_oid = CMDIdGPDB::CastMdid(mdid)->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidOp);
+	GPOS_ASSERT(InvalidOid != op_oid);
 
 	// get operator name
-	CHAR *szName = gpdb::SzOpName(oidOp);
+	CHAR *name = gpdb::GetOpName(op_oid);
 
-	if (NULL == szName)
+	if (NULL == name)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	CMDName *pmdname = CDXLUtils::PmdnameFromSz(pmp, szName);
+	CMDName *mdname = CDXLUtils::CreateMDNameFromCharArray(mp, name);
 	
-	OID oidLeft = InvalidOid;
-	OID oidRight = InvalidOid;
+	OID left_oid = InvalidOid;
+	OID right_oid = InvalidOid;
 
 	// get operator argument types
-	gpdb::GetOpInputTypes(oidOp, &oidLeft, &oidRight);
+	gpdb::GetOpInputTypes(op_oid, &left_oid, &right_oid);
 
-	CMDIdGPDB *pmdidTypeLeft = NULL;
-	CMDIdGPDB *pmdidTypeRight = NULL;
+	CMDIdGPDB *mdid_type_left = NULL;
+	CMDIdGPDB *mdid_type_right = NULL;
 
-	if (InvalidOid != oidLeft)
+	if (InvalidOid != left_oid)
 	{
-		pmdidTypeLeft = GPOS_NEW(pmp) CMDIdGPDB(oidLeft);
+		mdid_type_left = GPOS_NEW(mp) CMDIdGPDB(left_oid);
 	}
 
-	if (InvalidOid != oidRight)
+	if (InvalidOid != right_oid)
 	{
-		pmdidTypeRight = GPOS_NEW(pmp) CMDIdGPDB(oidRight);
+		mdid_type_right = GPOS_NEW(mp) CMDIdGPDB(right_oid);
 	}
 
 	// get comparison type
-	CmpType cmpt = (CmpType) gpdb::UlCmpt(oidOp, oidLeft, oidRight);
-	IMDType::ECmpType ecmpt = Ecmpt(cmpt);
+	CmpType cmpt = (CmpType) gpdb::GetComparisonType(op_oid, left_oid, right_oid);
+	IMDType::ECmpType cmp_type = ParseCmpType(cmpt);
 	
 	// get func oid
-	OID oidFunc = gpdb::OidOpFunc(oidOp);
-	GPOS_ASSERT(InvalidOid != oidFunc);
+	OID func_oid = gpdb::GetOpFunc(op_oid);
+	GPOS_ASSERT(InvalidOid != func_oid);
 
-	CMDIdGPDB *pmdidFunc = GPOS_NEW(pmp) CMDIdGPDB(oidFunc);
+	CMDIdGPDB *mdid_func = GPOS_NEW(mp) CMDIdGPDB(func_oid);
 
 	// get result type
-	OID oidResult = gpdb::OidFuncRetType(oidFunc);
+	OID result_oid = gpdb::GetFuncRetType(func_oid);
 
-	GPOS_ASSERT(InvalidOid != oidResult);
+	GPOS_ASSERT(InvalidOid != result_oid);
 
-	CMDIdGPDB *pmdidTypeResult = GPOS_NEW(pmp) CMDIdGPDB(oidResult);
+	CMDIdGPDB *result_type_mdid = GPOS_NEW(mp) CMDIdGPDB(result_oid);
 
 	// get commutator and inverse
-	CMDIdGPDB *pmdidOpCommute = NULL;
+	CMDIdGPDB *mdid_commute_opr = NULL;
 
-	OID oidCommute = gpdb::OidCommutatorOp(oidOp);
+	OID commute_oid = gpdb::GetCommutatorOp(op_oid);
 
-	if(InvalidOid != oidCommute)
+	if(InvalidOid != commute_oid)
 	{
-		pmdidOpCommute = GPOS_NEW(pmp) CMDIdGPDB(oidCommute);
+		mdid_commute_opr = GPOS_NEW(mp) CMDIdGPDB(commute_oid);
 	}
 
-	CMDIdGPDB *pmdidOpInverse = NULL;
+	CMDIdGPDB *m_mdid_inverse_opr = NULL;
 
-	OID oidInverse = gpdb::OidInverseOp(oidOp);
+	OID inverse_oid = gpdb::GetInverseOp(op_oid);
 
-	if(InvalidOid != oidInverse)
+	if(InvalidOid != inverse_oid)
 	{
-		pmdidOpInverse = GPOS_NEW(pmp) CMDIdGPDB(oidInverse);
+		m_mdid_inverse_opr = GPOS_NEW(mp) CMDIdGPDB(inverse_oid);
 	}
 
-	BOOL fReturnsNullOnNullInput = gpdb::FOpStrict(oidOp);
+	BOOL returns_null_on_null_input = gpdb::IsOpStrict(op_oid);
 
-	pmdid->AddRef();
-	CMDScalarOpGPDB *pmdscop = GPOS_NEW(pmp) CMDScalarOpGPDB
+	mdid->AddRef();
+	CMDScalarOpGPDB *md_scalar_op = GPOS_NEW(mp) CMDScalarOpGPDB
 											(
-											pmp,
-											pmdid,
-											pmdname,
-											pmdidTypeLeft,
-											pmdidTypeRight,
-											pmdidTypeResult,
-											pmdidFunc,
-											pmdidOpCommute,
-											pmdidOpInverse,
-											ecmpt,
-											fReturnsNullOnNullInput,
-											PdrgpmdidScOpOpFamilies(pmp, pmdid)
+											mp,
+											mdid,
+											mdname,
+											mdid_type_left,
+											mdid_type_right,
+											result_type_mdid,
+											mdid_func,
+											mdid_commute_opr,
+											m_mdid_inverse_opr,
+											cmp_type,
+											returns_null_on_null_input,
+											RetrieveScOpOpFamilies(mp, mdid)
 											);
-	return pmdscop;
+	return md_scalar_op;
 }
 
 
@@ -1783,378 +1783,378 @@ CTranslatorRelcacheToDXL::Pmdscop
 void
 CTranslatorRelcacheToDXL::LookupFuncProps
 	(
-	OID oidFunc,
-	IMDFunction::EFuncStbl *pefs, // output: function stability
-	IMDFunction::EFuncDataAcc *pefda, // output: function datya access
-	BOOL *fStrict, // output: is function strict?
-	BOOL *fReturnsSet // output: does function return set?
+	OID func_oid,
+	IMDFunction::EFuncStbl *stability, // output: function stability
+	IMDFunction::EFuncDataAcc *access, // output: function datya access
+	BOOL *is_strict, // output: is function strict?
+	BOOL *returns_set // output: does function return set?
 	)
 {
-	GPOS_ASSERT(NULL != pefs);
-	GPOS_ASSERT(NULL != pefda);
-	GPOS_ASSERT(NULL != fStrict);
-	GPOS_ASSERT(NULL != fReturnsSet);
+	GPOS_ASSERT(NULL != stability);
+	GPOS_ASSERT(NULL != access);
+	GPOS_ASSERT(NULL != is_strict);
+	GPOS_ASSERT(NULL != returns_set);
 
-	CHAR cFuncStability = gpdb::CFuncStability(oidFunc);
-	*pefs = EFuncStability(cFuncStability);
+	CHAR cFuncStability = gpdb::FuncStability(func_oid);
+	*stability = GetFuncStability(cFuncStability);
 
-	CHAR cFuncDataAccess = gpdb::CFuncDataAccess(oidFunc);
-	*pefda = EFuncDataAccess(cFuncDataAccess);
+	CHAR cFuncDataAccess = gpdb::FuncDataAccess(func_oid);
+	*access = GetEFuncDataAccess(cFuncDataAccess);
 
-	*fReturnsSet = gpdb::FFuncRetset(oidFunc);
-	*fStrict = gpdb::FFuncStrict(oidFunc);
+	*returns_set = gpdb::GetFuncRetset(func_oid);
+	*is_strict = gpdb::FuncStrict(func_oid);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pmdfunc
+//		CTranslatorRelcacheToDXL::RetrieveFunc
 //
 //	@doc:
 //		Retrieve a function from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 CMDFunctionGPDB *
-CTranslatorRelcacheToDXL::Pmdfunc
+CTranslatorRelcacheToDXL::RetrieveFunc
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	OID oidFunc = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
+	OID func_oid = CMDIdGPDB::CastMdid(mdid)->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidFunc);
+	GPOS_ASSERT(InvalidOid != func_oid);
 
 	// get func name
-	CHAR *szName = gpdb::SzFuncName(oidFunc);
+	CHAR *name = gpdb::GetFuncName(func_oid);
 
-	if (NULL == szName)
+	if (NULL == name)
 	{
 
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	CWStringDynamic *pstrFuncName = CDXLUtils::PstrFromSz(pmp, szName);
-	CMDName *pmdname = GPOS_NEW(pmp) CMDName(pmp, pstrFuncName);
+	CWStringDynamic *func_name_str = CDXLUtils::CreateDynamicStringFromCharArray(mp, name);
+	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, func_name_str);
 
 	// CMDName ctor created a copy of the string
-	GPOS_DELETE(pstrFuncName);
+	GPOS_DELETE(func_name_str);
 
 	// get result type
-	OID oidResult = gpdb::OidFuncRetType(oidFunc);
+	OID result_oid = gpdb::GetFuncRetType(func_oid);
 
-	GPOS_ASSERT(InvalidOid != oidResult);
+	GPOS_ASSERT(InvalidOid != result_oid);
 
-	CMDIdGPDB *pmdidTypeResult = GPOS_NEW(pmp) CMDIdGPDB(oidResult);
+	CMDIdGPDB *result_type_mdid = GPOS_NEW(mp) CMDIdGPDB(result_oid);
 
 	// get output argument types if any
-	List *plOutArgTypes = gpdb::PlFuncOutputArgTypes(oidFunc);
+	List *out_arg_types_list = gpdb::GetFuncOutputArgTypes(func_oid);
 
-	DrgPmdid *pdrgpmdidArgTypes = NULL;
-	if (NULL != plOutArgTypes)
+	IMdIdArray *arg_type_mdids = NULL;
+	if (NULL != out_arg_types_list)
 	{
-		ListCell *plc = NULL;
-		pdrgpmdidArgTypes = GPOS_NEW(pmp) DrgPmdid(pmp);
+		ListCell *lc = NULL;
+		arg_type_mdids = GPOS_NEW(mp) IMdIdArray(mp);
 
-		ForEach (plc, plOutArgTypes)
+		ForEach (lc, out_arg_types_list)
 		{
-			OID oidArgType = lfirst_oid(plc);
+			OID oidArgType = lfirst_oid(lc);
 			GPOS_ASSERT(InvalidOid != oidArgType);
-			CMDIdGPDB *pmdidArgType = GPOS_NEW(pmp) CMDIdGPDB(oidArgType);
-			pdrgpmdidArgTypes->Append(pmdidArgType);
+			CMDIdGPDB *pmdidArgType = GPOS_NEW(mp) CMDIdGPDB(oidArgType);
+			arg_type_mdids->Append(pmdidArgType);
 		}
 
-		gpdb::GPDBFree(plOutArgTypes);
+		gpdb::GPDBFree(out_arg_types_list);
 	}
 
-	IMDFunction::EFuncStbl efs = IMDFunction::EfsImmutable;
-	IMDFunction::EFuncDataAcc efda = IMDFunction::EfdaNoSQL;
-	BOOL fStrict = true;
-	BOOL fReturnsSet = true;
-	LookupFuncProps(oidFunc, &efs, &efda, &fStrict, &fReturnsSet);
+	IMDFunction::EFuncStbl stability = IMDFunction::EfsImmutable;
+	IMDFunction::EFuncDataAcc access = IMDFunction::EfdaNoSQL;
+	BOOL is_strict = true;
+	BOOL returns_set = true;
+	LookupFuncProps(func_oid, &stability, &access, &is_strict, &returns_set);
 
-	pmdid->AddRef();
-	CMDFunctionGPDB *pmdfunc = GPOS_NEW(pmp) CMDFunctionGPDB
+	mdid->AddRef();
+	CMDFunctionGPDB *md_func = GPOS_NEW(mp) CMDFunctionGPDB
 											(
-											pmp,
-											pmdid,
-											pmdname,
-											pmdidTypeResult,
-											pdrgpmdidArgTypes,
-											fReturnsSet,
-											efs,
-											efda,
-											fStrict
+											mp,
+											mdid,
+											mdname,
+											result_type_mdid,
+											arg_type_mdids,
+											returns_set,
+											stability,
+											access,
+											is_strict
 											);
 
-	return pmdfunc;
+	return md_func;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pmdagg
+//		CTranslatorRelcacheToDXL::RetrieveAgg
 //
 //	@doc:
 //		Retrieve an aggregate from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 CMDAggregateGPDB *
-CTranslatorRelcacheToDXL::Pmdagg
+CTranslatorRelcacheToDXL::RetrieveAgg
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	OID oidAgg = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
+	OID agg_oid = CMDIdGPDB::CastMdid(mdid)->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidAgg);
+	GPOS_ASSERT(InvalidOid != agg_oid);
 
 	// get agg name
-	CHAR *szName = gpdb::SzFuncName(oidAgg);
+	CHAR *name = gpdb::GetFuncName(agg_oid);
 
-	if (NULL == szName)
+	if (NULL == name)
 	{
 
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	CWStringDynamic *pstrAggName = CDXLUtils::PstrFromSz(pmp, szName);
-	CMDName *pmdname = GPOS_NEW(pmp) CMDName(pmp, pstrAggName);
+	CWStringDynamic *agg_name_str = CDXLUtils::CreateDynamicStringFromCharArray(mp, name);
+	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, agg_name_str);
 
 	// CMDName ctor created a copy of the string
-	GPOS_DELETE(pstrAggName);
+	GPOS_DELETE(agg_name_str);
 
 	// get result type
-	OID oidResult = gpdb::OidFuncRetType(oidAgg);
+	OID result_oid = gpdb::GetFuncRetType(agg_oid);
 
-	GPOS_ASSERT(InvalidOid != oidResult);
+	GPOS_ASSERT(InvalidOid != result_oid);
 
-	CMDIdGPDB *pmdidTypeResult = GPOS_NEW(pmp) CMDIdGPDB(oidResult);
-	IMDId *pmdidTypeIntermediate = PmdidAggIntermediateResultType(pmp, pmdid);
+	CMDIdGPDB *result_type_mdid = GPOS_NEW(mp) CMDIdGPDB(result_oid);
+	IMDId *intermediate_result_type_mdid = RetrieveAggIntermediateResultType(mp, mdid);
 
-	pmdid->AddRef();
+	mdid->AddRef();
 	
-	BOOL fOrdered = gpdb::FOrderedAgg(oidAgg);
+	BOOL is_ordered = gpdb::IsOrderedAgg(agg_oid);
 	
 	// GPDB does not support splitting of ordered aggs and aggs without a
 	// preliminary function
-	BOOL fSplittable = !fOrdered && gpdb::FAggHasPrelimFunc(oidAgg);
+	BOOL is_splittable = !is_ordered && gpdb::AggHasPrelimFunc(agg_oid);
 	
 	// cannot use hash agg for ordered aggs or aggs without a prelim func
 	// due to the fact that hashAgg may spill
-	BOOL fHashAggCapable = !fOrdered && gpdb::FAggHasPrelimFunc(oidAgg);
+	BOOL is_hash_agg_capable = !is_ordered && gpdb::AggHasPrelimFunc(agg_oid);
 
-	CMDAggregateGPDB *pmdagg = GPOS_NEW(pmp) CMDAggregateGPDB
+	CMDAggregateGPDB *pmdagg = GPOS_NEW(mp) CMDAggregateGPDB
 											(
-											pmp,
-											pmdid,
-											pmdname,
-											pmdidTypeResult,
-											pmdidTypeIntermediate,
-											fOrdered,
-											fSplittable,
-											fHashAggCapable
+											mp,
+											mdid,
+											mdname,
+											result_type_mdid,
+											intermediate_result_type_mdid,
+											is_ordered,
+											is_splittable,
+											is_hash_agg_capable
 											);
 	return pmdagg;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pmdtrigger
+//		CTranslatorRelcacheToDXL::RetrieveTrigger
 //
 //	@doc:
 //		Retrieve a trigger from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 CMDTriggerGPDB *
-CTranslatorRelcacheToDXL::Pmdtrigger
+CTranslatorRelcacheToDXL::RetrieveTrigger
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	OID oidTrigger = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
+	OID trigger_oid = CMDIdGPDB::CastMdid(mdid)->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidTrigger);
+	GPOS_ASSERT(InvalidOid != trigger_oid);
 
 	// get trigger name
-	CHAR *szName = gpdb::SzTriggerName(oidTrigger);
+	CHAR *name = gpdb::GetTriggerName(trigger_oid);
 
-	if (NULL == szName)
+	if (NULL == name)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	CWStringDynamic *pstrTriggerName = CDXLUtils::PstrFromSz(pmp, szName);
-	CMDName *pmdname = GPOS_NEW(pmp) CMDName(pmp, pstrTriggerName);
-	GPOS_DELETE(pstrTriggerName);
+	CWStringDynamic *trigger_name_str = CDXLUtils::CreateDynamicStringFromCharArray(mp, name);
+	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, trigger_name_str);
+	GPOS_DELETE(trigger_name_str);
 
 	// get relation oid
-	OID oidRel = gpdb::OidTriggerRelid(oidTrigger);
-	GPOS_ASSERT(InvalidOid != oidRel);
-	CMDIdGPDB *pmdidRel = GPOS_NEW(pmp) CMDIdGPDB(oidRel);
+	OID rel_oid = gpdb::GetTriggerRelid(trigger_oid);
+	GPOS_ASSERT(InvalidOid != rel_oid);
+	CMDIdGPDB *mdid_rel = GPOS_NEW(mp) CMDIdGPDB(rel_oid);
 
 	// get function oid
-	OID oidFunc = gpdb::OidTriggerFuncid(oidTrigger);
-	GPOS_ASSERT(InvalidOid != oidFunc);
-	CMDIdGPDB *pmdidFunc = GPOS_NEW(pmp) CMDIdGPDB(oidFunc);
+	OID func_oid = gpdb::GetTriggerFuncid(trigger_oid);
+	GPOS_ASSERT(InvalidOid != func_oid);
+	CMDIdGPDB *mdid_func = GPOS_NEW(mp) CMDIdGPDB(func_oid);
 
 	// get type
-	INT iType = gpdb::ITriggerType(oidTrigger);
+	INT trigger_type = gpdb::GetTriggerType(trigger_oid);
 
 	// is trigger enabled
-	BOOL fEnabled = gpdb::FTriggerEnabled(oidTrigger);
+	BOOL is_enabled = gpdb::IsTriggerEnabled(trigger_oid);
 
-	pmdid->AddRef();
-	CMDTriggerGPDB *pmdtrigger = GPOS_NEW(pmp) CMDTriggerGPDB
+	mdid->AddRef();
+	CMDTriggerGPDB *pmdtrigger = GPOS_NEW(mp) CMDTriggerGPDB
 											(
-											pmp,
-											pmdid,
-											pmdname,
-											pmdidRel,
-											pmdidFunc,
-											iType,
-											fEnabled
+											mp,
+											mdid,
+											mdname,
+											mdid_rel,
+											mdid_func,
+											trigger_type,
+											is_enabled
 											);
 	return pmdtrigger;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pmdcheckconstraint
+//		CTranslatorRelcacheToDXL::RetrieveCheckConstraints
 //
 //	@doc:
 //		Retrieve a check constraint from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 CMDCheckConstraintGPDB *
-CTranslatorRelcacheToDXL::Pmdcheckconstraint
+CTranslatorRelcacheToDXL::RetrieveCheckConstraints
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid
 	)
 {
-	OID oidCheckConstraint = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
-	GPOS_ASSERT(InvalidOid != oidCheckConstraint);
+	OID check_constraint_oid = CMDIdGPDB::CastMdid(mdid)->Oid();
+	GPOS_ASSERT(InvalidOid != check_constraint_oid);
 
 	// get name of the check constraint
-	CHAR *szName = gpdb::SzCheckConstraintName(oidCheckConstraint);
-	if (NULL == szName)
+	CHAR *name = gpdb::GetCheckConstraintName(check_constraint_oid);
+	if (NULL == name)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
-	CWStringDynamic *pstrCheckConstraintName = CDXLUtils::PstrFromSz(pmp, szName);
-	CMDName *pmdname = GPOS_NEW(pmp) CMDName(pmp, pstrCheckConstraintName);
-	GPOS_DELETE(pstrCheckConstraintName);
+	CWStringDynamic *check_constr_name = CDXLUtils::CreateDynamicStringFromCharArray(mp, name);
+	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, check_constr_name);
+	GPOS_DELETE(check_constr_name);
 
 	// get relation oid associated with the check constraint
-	OID oidRel = gpdb::OidCheckConstraintRelid(oidCheckConstraint);
-	GPOS_ASSERT(InvalidOid != oidRel);
-	CMDIdGPDB *pmdidRel = GPOS_NEW(pmp) CMDIdGPDB(oidRel);
+	OID rel_oid = gpdb::GetCheckConstraintRelid(check_constraint_oid);
+	GPOS_ASSERT(InvalidOid != rel_oid);
+	CMDIdGPDB *mdid_rel = GPOS_NEW(mp) CMDIdGPDB(rel_oid);
 
 	// translate the check constraint expression
-	Node *pnode = gpdb::PnodeCheckConstraint(oidCheckConstraint);
-	GPOS_ASSERT(NULL != pnode);
+	Node *node = gpdb::PnodeCheckConstraint(check_constraint_oid);
+	GPOS_ASSERT(NULL != node);
 
-	CTranslatorScalarToDXL sctranslator
+	CTranslatorScalarToDXL scalar_translator
 							(
-							pmp,
-							pmda,
+							mp,
+							md_accessor,
 							NULL, /* pulidgtorCol */
 							NULL, /* pulidgtorCTE */
-							0, /* ulQueryLevel */
+							0, /* query_level */
 							true, /* m_fQuery */
-							NULL, /* phmulCTEEntries */
-							NULL /* pdrgpdxlnCTE */
+							NULL, /* query_level_to_cte_map */
+							NULL /* cte_dxlnode_array */
 							);
 
 	// generate a mock mapping between var to column information
-	CMappingVarColId *pmapvarcolid = GPOS_NEW(pmp) CMappingVarColId(pmp);
-	DrgPdxlcd *pdrgpdxlcd = GPOS_NEW(pmp) DrgPdxlcd(pmp);
-	const IMDRelation *pmdrel = pmda->Pmdrel(pmdidRel);
-	const ULONG ulLen = pmdrel->UlColumns();
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
+	CDXLColDescrArray *dxl_col_descr_array = GPOS_NEW(mp) CDXLColDescrArray(mp);
+	const IMDRelation *md_rel = md_accessor->RetrieveRel(mdid_rel);
+	const ULONG length = md_rel->ColumnCount();
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		CMDName *pmdnameCol = GPOS_NEW(pmp) CMDName(pmp, pmdcol->Mdname().Pstr());
-		CMDIdGPDB *pmdidColType = CMDIdGPDB::PmdidConvert(pmdcol->PmdidType());
-		pmdidColType->AddRef();
+		const IMDColumn *md_col = md_rel->GetMdCol(ul);
+		CMDName *md_colname = GPOS_NEW(mp) CMDName(mp, md_col->Mdname().GetMDName());
+		CMDIdGPDB *mdid_col_type = CMDIdGPDB::CastMdid(md_col->MdidType());
+		mdid_col_type->AddRef();
 
 		// create a column descriptor for the column
-		CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
+		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr
 										(
-										pmp,
-										pmdnameCol,
-										ul + 1 /*ulColId*/,
-										pmdcol->IAttno(),
-										pmdidColType,
-										pmdcol->ITypeModifier(),
+										mp,
+										md_colname,
+										ul + 1 /*colid*/,
+										md_col->AttrNum(),
+										mdid_col_type,
+										md_col->TypeModifier(),
 										false /* fColDropped */
 										);
-		pdrgpdxlcd->Append(pdxlcd);
+		dxl_col_descr_array->Append(dxl_col_descr);
 	}
-	pmapvarcolid->LoadColumns(0 /*ulQueryLevel */, 1 /* rteIndex */, pdrgpdxlcd);
+	var_colid_mapping->LoadColumns(0 /*query_level */, 1 /* rteIndex */, dxl_col_descr_array);
 
 	// translate the check constraint expression
-	CDXLNode *pdxlnScalar = sctranslator.PdxlnScOpFromExpr((Expr *) pnode, pmapvarcolid);
+	CDXLNode *scalar_dxlnode = scalar_translator.TranslateScalarToDXL((Expr *) node, var_colid_mapping);
 
 	// cleanup
-	pdrgpdxlcd->Release();
-	GPOS_DELETE(pmapvarcolid);
+	dxl_col_descr_array->Release();
+	GPOS_DELETE(var_colid_mapping);
 
-	pmdid->AddRef();
+	mdid->AddRef();
 
-	return GPOS_NEW(pmp) CMDCheckConstraintGPDB
+	return GPOS_NEW(mp) CMDCheckConstraintGPDB
 						(
-						pmp,
-						pmdid,
-						pmdname,
-						pmdidRel,
-						pdxlnScalar
+						mp,
+						mdid,
+						mdname,
+						mdid_rel,
+						scalar_dxlnode
 						);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PmdnameType
+//		CTranslatorRelcacheToDXL::GetTypeName
 //
 //	@doc:
 //		Retrieve a type's name from the relcache given its metadata id.
 //
 //---------------------------------------------------------------------------
 CMDName *
-CTranslatorRelcacheToDXL::PmdnameType
+CTranslatorRelcacheToDXL::GetTypeName
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	OID oidType = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
+	OID oid_type = CMDIdGPDB::CastMdid(mdid)->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidType);
+	GPOS_ASSERT(InvalidOid != oid_type);
 
-	CHAR *szTypeName = gpdb::SzTypeName(oidType);
-	GPOS_ASSERT(NULL != szTypeName);
+	CHAR *typename_str = gpdb::GetTypeName(oid_type);
+	GPOS_ASSERT(NULL != typename_str);
 
-	CWStringDynamic *pstrName = CDXLUtils::PstrFromSz(pmp, szTypeName);
-	CMDName *pmdname = GPOS_NEW(pmp) CMDName(pmp, pstrName);
+	CWStringDynamic *str_name = CDXLUtils::CreateDynamicStringFromCharArray(mp, typename_str);
+	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, str_name);
 
 	// cleanup
-	GPOS_DELETE(pstrName);
-	return pmdname;
+	GPOS_DELETE(str_name);
+	return mdname;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::EFuncStability
+//		CTranslatorRelcacheToDXL::GetFuncStability
 //
 //	@doc:
 //		Get function stability property from the GPDB character representation
 //
 //---------------------------------------------------------------------------
 CMDFunctionGPDB::EFuncStbl
-CTranslatorRelcacheToDXL::EFuncStability
+CTranslatorRelcacheToDXL::GetFuncStability
 	(
 	CHAR c
 	)
@@ -2181,33 +2181,33 @@ CTranslatorRelcacheToDXL::EFuncStability
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::EFuncDataAccess
+//		CTranslatorRelcacheToDXL::GetEFuncDataAccess
 //
 //	@doc:
 //		Get function data access property from the GPDB character representation
 //
 //---------------------------------------------------------------------------
 CMDFunctionGPDB::EFuncDataAcc
-CTranslatorRelcacheToDXL::EFuncDataAccess
+CTranslatorRelcacheToDXL::GetEFuncDataAccess
 	(
 	CHAR c
 	)
 {
-	CMDFunctionGPDB::EFuncDataAcc efda = CMDFunctionGPDB::EfdaSentinel;
+	CMDFunctionGPDB::EFuncDataAcc access = CMDFunctionGPDB::EfdaSentinel;
 
 	switch (c)
 	{
 		case 'n':
-			efda = CMDFunctionGPDB::EfdaNoSQL;
+			access = CMDFunctionGPDB::EfdaNoSQL;
 			break;
 		case 'c':
-			efda = CMDFunctionGPDB::EfdaContainsSQL;
+			access = CMDFunctionGPDB::EfdaContainsSQL;
 			break;
 		case 'r':
-			efda = CMDFunctionGPDB::EfdaReadsSQLData;
+			access = CMDFunctionGPDB::EfdaReadsSQLData;
 			break;
 		case 'm':
-			efda = CMDFunctionGPDB::EfdaModifiesSQLData;
+			access = CMDFunctionGPDB::EfdaModifiesSQLData;
 			break;
 		case 's':
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("unknown data access"));
@@ -2215,91 +2215,88 @@ CTranslatorRelcacheToDXL::EFuncDataAccess
 			GPOS_ASSERT(!"Invalid data access property");
 	}
 
-	return efda;
+	return access;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PmdidAggIntermediateResultType
+//		CTranslatorRelcacheToDXL::RetrieveAggIntermediateResultType
 //
 //	@doc:
 //		Retrieve the type id of an aggregate's intermediate results
 //
 //---------------------------------------------------------------------------
 IMDId *
-CTranslatorRelcacheToDXL::PmdidAggIntermediateResultType
+CTranslatorRelcacheToDXL::RetrieveAggIntermediateResultType
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	OID oidAgg = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
+	OID agg_oid = CMDIdGPDB::CastMdid(mdid)->Oid();
 
-	GPOS_ASSERT(InvalidOid != oidAgg);
-
-	OID oidTypeIntermediateResult = gpdb::OidAggIntermediateResultType(oidAgg);
-	return GPOS_NEW(pmp) CMDIdGPDB(oidTypeIntermediateResult);
+	GPOS_ASSERT(InvalidOid != agg_oid);
+	return GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggIntermediateResultType(agg_oid));
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PimdobjRelStats
+//		CTranslatorRelcacheToDXL::RetrieveRelStats
 //
 //	@doc:
 //		Retrieve relation statistics from relcache
 //
 //---------------------------------------------------------------------------
 IMDCacheObject *
-CTranslatorRelcacheToDXL::PimdobjRelStats
+CTranslatorRelcacheToDXL::RetrieveRelStats
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	CMDIdRelStats *pmdidRelStats = CMDIdRelStats::PmdidConvert(pmdid);
-	IMDId *pmdidRel = pmdidRelStats->PmdidRel();
-	OID oidRelation = CMDIdGPDB::PmdidConvert(pmdidRel)->OidObjectId();
+	CMDIdRelStats *m_rel_stats_mdid = CMDIdRelStats::CastMdid(mdid);
+	IMDId *mdid_rel = m_rel_stats_mdid->GetRelMdId();
+	OID rel_oid = CMDIdGPDB::CastMdid(mdid_rel)->Oid();
 
-	Relation rel = gpdb::RelGetRelation(oidRelation);
+	Relation rel = gpdb::GetRelation(rel_oid);
 	if (NULL == rel)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	double rows = 0.0;
-	CMDName *pmdname = NULL;
+	double num_rows = 0.0;
+	CMDName *mdname = NULL;
 
 	GPOS_TRY
 	{
 		// get rel name
-		CHAR *szRelName = NameStr(rel->rd_rel->relname);
-		CWStringDynamic *pstrRelName = CDXLUtils::PstrFromSz(pmp, szRelName);
-		pmdname = GPOS_NEW(pmp) CMDName(pmp, pstrRelName);
+		CHAR *relname = NameStr(rel->rd_rel->relname);
+		CWStringDynamic *relname_str = CDXLUtils::CreateDynamicStringFromCharArray(mp, relname);
+		mdname = GPOS_NEW(mp) CMDName(mp, relname_str);
 		// CMDName ctor created a copy of the string
-		GPOS_DELETE(pstrRelName);
+		GPOS_DELETE(relname_str);
 
 		BlockNumber pages = 0;
-		GpPolicy *pgppolicy = gpdb::Pdistrpolicy(rel);
-		if (!pgppolicy ||pgppolicy->ptype != POLICYTYPE_PARTITIONED)
+		GpPolicy *gp_policy = gpdb::GetDistributionPolicy(rel);
+		if (!gp_policy ||gp_policy->ptype != POLICYTYPE_PARTITIONED)
 		{
-			gpdb::EstimateRelationSize(rel, NULL, &pages, &rows);
+			gpdb::EstimateRelationSize(rel, NULL, &pages, &num_rows);
 		}
 		else
 		{
-			rows = rel->rd_rel->reltuples;
+			num_rows = rel->rd_rel->reltuples;
 
-			if (rows == 0 && gp_enable_relsize_collection)
+			if (num_rows == 0 && gp_enable_relsize_collection)
 			{
 				RelOptInfo *relOptInfo = makeNode(RelOptInfo);
-				relOptInfo->cdbpolicy = gpdb::Pdistrpolicy(rel);
+				relOptInfo->cdbpolicy = gpdb::GetDistributionPolicy(rel);
 				bool default_stats_used = false;
-				gpdb::CdbEstimateRelationSize(relOptInfo, rel, NULL, &pages, &rows, &default_stats_used);
+				gpdb::CdbEstimateRelationSize(relOptInfo, rel, NULL, &pages, &num_rows, &default_stats_used);
 				pfree(relOptInfo);
-
 			}
 		}
 
-		pmdidRelStats->AddRef();
+		m_rel_stats_mdid->AddRef();
 		gpdb::CloseRelation(rel);
 	}
 	GPOS_CATCH_EX(ex)
@@ -2309,23 +2306,23 @@ CTranslatorRelcacheToDXL::PimdobjRelStats
 	}
 	GPOS_CATCH_END;
 	
-	BOOL fEmptyStats = false;
-	if (rows == 0.0)
+	BOOL stats_empty = false;
+	if (num_rows == 0.0)
 	{
-		fEmptyStats = true;
+		stats_empty = true;
 	}
 		
-	CDXLRelStats *pdxlrelstats = GPOS_NEW(pmp) CDXLRelStats
+	CDXLRelStats *dxl_rel_stats = GPOS_NEW(mp) CDXLRelStats
 												(
-												pmp,
-												pmdidRelStats,
-												pmdname,
-												CDouble(rows),
-												fEmptyStats
+												mp,
+												m_rel_stats_mdid,
+												mdname,
+												CDouble(num_rows),
+												stats_empty
 												);
 
 
-	return pdxlrelstats;
+	return dxl_rel_stats;
 }
 
 // Retrieve column statistics from relcache
@@ -2334,240 +2331,240 @@ CTranslatorRelcacheToDXL::PimdobjRelStats
 // However, if any statistics are present and not broken,
 // create column statistics using these statistics
 IMDCacheObject *
-CTranslatorRelcacheToDXL::PimdobjColStats
+CTranslatorRelcacheToDXL::RetrieveColStats
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid
 	)
 {
-	CMDIdColStats *pmdidColStats = CMDIdColStats::PmdidConvert(pmdid);
-	IMDId *pmdidRel = pmdidColStats->PmdidRel();
-	ULONG ulPos = pmdidColStats->UlPos();
-	OID oidRelation = CMDIdGPDB::PmdidConvert(pmdidRel)->OidObjectId();
+	CMDIdColStats *mdid_col_stats = CMDIdColStats::CastMdid(mdid);
+	IMDId *mdid_rel = mdid_col_stats->GetRelMdId();
+	ULONG pos = mdid_col_stats->Position();
+	OID rel_oid = CMDIdGPDB::CastMdid(mdid_rel)->Oid();
 
-	Relation rel = gpdb::RelGetRelation(oidRelation);
+	Relation rel = gpdb::GetRelation(rel_oid);
 	if (NULL == rel)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	const IMDRelation *pmdrel = pmda->Pmdrel(pmdidRel);
-	const IMDColumn *pmdcol = pmdrel->Pmdcol(ulPos);
-	AttrNumber attrnum = (AttrNumber) pmdcol->IAttno();
+	const IMDRelation *md_rel = md_accessor->RetrieveRel(mdid_rel);
+	const IMDColumn *md_col = md_rel->GetMdCol(pos);
+	AttrNumber attno = (AttrNumber) md_col->AttrNum();
 
 	// number of rows from pg_class
-	CDouble dRows(rel->rd_rel->reltuples);
+	CDouble num_rows(rel->rd_rel->reltuples);
 
 	// extract column name and type
-	CMDName *pmdnameCol = GPOS_NEW(pmp) CMDName(pmp, pmdcol->Mdname().Pstr());
-	OID oidAttType = CMDIdGPDB::PmdidConvert(pmdcol->PmdidType())->OidObjectId();
+	CMDName *md_colname = GPOS_NEW(mp) CMDName(mp, md_col->Mdname().GetMDName());
+	OID att_type = CMDIdGPDB::CastMdid(md_col->MdidType())->Oid();
 	gpdb::CloseRelation(rel);
 
-	DrgPdxlbucket *pdrgpdxlbucket = GPOS_NEW(pmp) DrgPdxlbucket(pmp);
+	CDXLBucketArray *dxl_stats_bucket_array = GPOS_NEW(mp) CDXLBucketArray(mp);
 
-	if (0 > attrnum)
+	if (0 > attno)
 	{
-		pmdidColStats->AddRef();
-		return PdxlcolstatsSystemColumn
+		mdid_col_stats->AddRef();
+		return GenerateStatsForSystemCols
 				(
-				pmp,
-				oidRelation,
-				pmdidColStats,
-				pmdnameCol,
-				oidAttType,
-				attrnum,
-				pdrgpdxlbucket,
-				dRows
+				mp,
+				rel_oid,
+				mdid_col_stats,
+				md_colname,
+				att_type,
+				attno,
+				dxl_stats_bucket_array,
+				num_rows
 				);
 	}
 
 	// extract out histogram and mcv information from pg_statistic
-	HeapTuple heaptupleStats = gpdb::HtAttrStats(oidRelation, attrnum);
+	HeapTuple stats_tup = gpdb::GetAttStats(rel_oid, attno);
 
 	// if there is no colstats
-	if (!HeapTupleIsValid(heaptupleStats))
+	if (!HeapTupleIsValid(stats_tup))
 	{
-		pdrgpdxlbucket->Release();
-		pmdidColStats->AddRef();
+		dxl_stats_bucket_array->Release();
+		mdid_col_stats->AddRef();
 
-		CDouble dWidth = CStatistics::DDefaultColumnWidth;
+		CDouble width = CStatistics::DefaultColumnWidth;
 
-		if (!pmdcol->FDropped())
+		if (!md_col->IsDropped())
 		{
-			CMDIdGPDB *pmdidAttType = GPOS_NEW(pmp) CMDIdGPDB(oidAttType);
-			IMDType *pmdtype = Pmdtype(pmp, pmdidAttType);
-			dWidth = CStatisticsUtils::DDefaultColumnWidth(pmdtype);
-			pmdtype->Release();
-			pmdidAttType->Release();
+			CMDIdGPDB *mdid_atttype = GPOS_NEW(mp) CMDIdGPDB(att_type);
+			IMDType *md_type = RetrieveType(mp, mdid_atttype);
+			width = CStatisticsUtils::DefaultColumnWidth(md_type);
+			md_type->Release();
+			mdid_atttype->Release();
 		}
 
-		return CDXLColStats::PdxlcolstatsDummy(pmp, pmdidColStats, pmdnameCol, dWidth);
+		return CDXLColStats::CreateDXLDummyColStats(mp, mdid_col_stats, md_colname, width);
 	}
 
-	Form_pg_statistic fpsStats = (Form_pg_statistic) GETSTRUCT(heaptupleStats);
+	Form_pg_statistic form_pg_stats = (Form_pg_statistic) GETSTRUCT(stats_tup);
 
 	// null frequency and NDV
-	CDouble dNullFrequency(0.0);
-	int iNullNDV = 0;
-	if (CStatistics::DEpsilon < fpsStats->stanullfrac)
+	CDouble null_freq(0.0);
+	int null_ndv = 0;
+	if (CStatistics::Epsilon < form_pg_stats->stanullfrac)
 	{
-		dNullFrequency = fpsStats->stanullfrac;
-		iNullNDV = 1;
+		null_freq = form_pg_stats->stanullfrac;
+		null_ndv = 1;
 	}
 
 	// column width
-	CDouble dWidth = CDouble(fpsStats->stawidth);
+	CDouble width = CDouble(form_pg_stats->stawidth);
 
 	// calculate total number of distinct values
-	CDouble dDistinct(1.0);
-	if (fpsStats->stadistinct < 0)
+	CDouble num_distinct(1.0);
+	if (form_pg_stats->stadistinct < 0)
 	{
-		GPOS_ASSERT(fpsStats->stadistinct > -1.01);
-		dDistinct = dRows * CDouble(-fpsStats->stadistinct);
+		GPOS_ASSERT(form_pg_stats->stadistinct > -1.01);
+		num_distinct = num_rows * CDouble(-form_pg_stats->stadistinct);
 	}
 	else
 	{
-		dDistinct = CDouble(fpsStats->stadistinct);
+		num_distinct = CDouble(form_pg_stats->stadistinct);
 	}
-	dDistinct = dDistinct.FpCeil();
+	num_distinct = num_distinct.Ceil();
 
-	BOOL fDummyStats = false;
+	BOOL is_dummy_stats = false;
 	// most common values and their frequencies extracted from the pg_statistic
 	// tuple for a given column
-	AttStatsSlot mcvSlot;
+	AttStatsSlot mcv_slot;
 
-	(void)	gpdb::FGetAttrStatsSlot
+	(void)	gpdb::GetAttrStatsSlot
 			(
-					&mcvSlot,
-					heaptupleStats,
+					&mcv_slot,
+					stats_tup,
 					STATISTIC_KIND_MCV,
 					InvalidOid,
 					ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS
 			);
-	if (InvalidOid != mcvSlot.valuetype && mcvSlot.valuetype != oidAttType)
+	if (InvalidOid != mcv_slot.valuetype && mcv_slot.valuetype != att_type)
 	{
 		char msgbuf[NAMEDATALEN * 2 + 100];
 		snprintf(msgbuf, sizeof(msgbuf), "Type mismatch between attribute %ls of table %ls having type %d and statistic having type %d, please ANALYZE the table again",
-				 pmdcol->Mdname().Pstr()->Wsz(), pmdrel->Mdname().Pstr()->Wsz(), oidAttType, mcvSlot.valuetype);
+				 md_col->Mdname().GetMDName()->GetBuffer(), md_rel->Mdname().GetMDName()->GetBuffer(), att_type, mcv_slot.valuetype);
 		GpdbEreport(ERRCODE_SUCCESSFUL_COMPLETION,
 					NOTICE,
 					msgbuf,
 					NULL);
 
-		gpdb::FreeAttrStatsSlot(&mcvSlot);
-		fDummyStats = true;
+		gpdb::FreeAttrStatsSlot(&mcv_slot);
+		is_dummy_stats = true;
 	}
 
-	else if (mcvSlot.nvalues != mcvSlot.nnumbers)
+	else if (mcv_slot.nvalues != mcv_slot.nnumbers)
 	{
 		char msgbuf[NAMEDATALEN * 2 + 100];
 		snprintf(msgbuf, sizeof(msgbuf), "The number of most common values and frequencies do not match on column %ls of table %ls.",
-				 pmdcol->Mdname().Pstr()->Wsz(), pmdrel->Mdname().Pstr()->Wsz());
+				 md_col->Mdname().GetMDName()->GetBuffer(), md_rel->Mdname().GetMDName()->GetBuffer());
 		GpdbEreport(ERRCODE_SUCCESSFUL_COMPLETION,
 					NOTICE,
 					msgbuf,
 					NULL);
 
 		// if the number of MCVs(nvalues) and number of MCFs(nnumbers) do not match, we discard the MCVs and MCFs
-		gpdb::FreeAttrStatsSlot(&mcvSlot);
-		fDummyStats = true;
+		gpdb::FreeAttrStatsSlot(&mcv_slot);
+		is_dummy_stats = true;
 	}
 	else
 	{
 		// fix mcv and null frequencies (sometimes they can add up to more than 1.0)
-		NormalizeFrequencies(mcvSlot.numbers, (ULONG) mcvSlot.nvalues, &dNullFrequency);
+		NormalizeFrequencies(mcv_slot.numbers, (ULONG) mcv_slot.nvalues, &null_freq);
 
 		// total MCV frequency
-		CDouble dMCFSum = 0.0;
-		for (int i = 0; i < mcvSlot.nvalues; i++)
+		CDouble sum_mcv_freq = 0.0;
+		for (int i = 0; i < mcv_slot.nvalues; i++)
 		{
-			dMCFSum = dMCFSum + CDouble(mcvSlot.numbers[i]);
+			sum_mcv_freq = sum_mcv_freq + CDouble(mcv_slot.numbers[i]);
 		}
 	}
 
 	// histogram values extracted from the pg_statistic tuple for a given column
-	AttStatsSlot histSlot;
+	AttStatsSlot hist_slot;
 
 	// get histogram datums from pg_statistic entry
-	(void) gpdb::FGetAttrStatsSlot
+	(void) gpdb::GetAttrStatsSlot
 			(
-					&histSlot,
-					heaptupleStats,
+					&hist_slot,
+					stats_tup,
 					STATISTIC_KIND_HISTOGRAM,
 					InvalidOid,
 					ATTSTATSSLOT_VALUES
 			);
 
-	if (InvalidOid != histSlot.valuetype && histSlot.valuetype != oidAttType)
+	if (InvalidOid != hist_slot.valuetype && hist_slot.valuetype != att_type)
 	{
 		char msgbuf[NAMEDATALEN * 2 + 100];
 		snprintf(msgbuf, sizeof(msgbuf), "Type mismatch between attribute %ls of table %ls having type %d and statistic having type %d, please ANALYZE the table again",
-				 pmdcol->Mdname().Pstr()->Wsz(), pmdrel->Mdname().Pstr()->Wsz(), oidAttType, histSlot.valuetype);
+				 md_col->Mdname().GetMDName()->GetBuffer(), md_rel->Mdname().GetMDName()->GetBuffer(), att_type, hist_slot.valuetype);
 		GpdbEreport(ERRCODE_SUCCESSFUL_COMPLETION,
 					NOTICE,
 					msgbuf,
 					NULL);
 
-		gpdb::FreeAttrStatsSlot(&histSlot);
-		fDummyStats = true;
+		gpdb::FreeAttrStatsSlot(&hist_slot);
+		is_dummy_stats = true;
 	}
 
-	if (fDummyStats)
+	if (is_dummy_stats)
 	{
-		pdrgpdxlbucket->Release();
-		pmdidColStats->AddRef();
+		dxl_stats_bucket_array->Release();
+		mdid_col_stats->AddRef();
 
-		CDouble dWidth = CStatistics::DDefaultColumnWidth;
-		gpdb::FreeHeapTuple(heaptupleStats);
-		return CDXLColStats::PdxlcolstatsDummy(pmp, pmdidColStats, pmdnameCol, dWidth);
+		CDouble col_width = CStatistics::DefaultColumnWidth;
+		gpdb::FreeHeapTuple(stats_tup);
+		return CDXLColStats::CreateDXLDummyColStats(mp, mdid_col_stats, md_colname, col_width);
 	}
 
-	CDouble dNDVBuckets(0.0);
-	CDouble dFreqBuckets(0.0);
-	CDouble dDistinctRemain(0.0);
-	CDouble dFreqRemain(0.0);
+	CDouble num_ndv_buckets(0.0);
+	CDouble num_freq_buckets(0.0);
+	CDouble distinct_remaining(0.0);
+	CDouble freq_remaining(0.0);
 
 	// We only want to create statistics buckets if the column is NOT a text, varchar, char or bpchar type
 	// For the above column types we will use NDVRemain and NullFreq to do cardinality estimation.
-	if (CTranslatorUtils::FCreateStatsBucket(oidAttType))
+	if (CTranslatorUtils::ShouldCreateStatsBucket(att_type))
 	{
 		// transform all the bits and pieces from pg_statistic
 		// to a single bucket structure
-		DrgPdxlbucket *pdrgpdxlbucketTransformed =
-		PdrgpdxlbucketTransformStats
+		CDXLBucketArray *dxl_stats_bucket_array_transformed =
+		TransformStatsToDXLBucketArray
 		(
-		 pmp,
-		 oidAttType,
-		 dDistinct,
-		 dNullFrequency,
-		 mcvSlot.values,
-		 mcvSlot.numbers,
-		 ULONG(mcvSlot.nvalues),
-		 histSlot.values,
-		 ULONG(histSlot.nvalues)
+		 mp,
+		 att_type,
+		 num_distinct,
+		 null_freq,
+		 mcv_slot.values,
+		 mcv_slot.numbers,
+		 ULONG(mcv_slot.nvalues),
+		 hist_slot.values,
+		 ULONG(hist_slot.nvalues)
 		 );
 
-		GPOS_ASSERT(NULL != pdrgpdxlbucketTransformed);
+		GPOS_ASSERT(NULL != dxl_stats_bucket_array_transformed);
 
-		const ULONG ulBuckets = pdrgpdxlbucketTransformed->UlLength();
-		for (ULONG ul = 0; ul < ulBuckets; ul++)
+		const ULONG num_buckets = dxl_stats_bucket_array_transformed->Size();
+		for (ULONG ul = 0; ul < num_buckets; ul++)
 		{
-			CDXLBucket *pdxlbucket = (*pdrgpdxlbucketTransformed)[ul];
-			dNDVBuckets = dNDVBuckets + pdxlbucket->DDistinct();
-			dFreqBuckets = dFreqBuckets + pdxlbucket->DFrequency();
+			CDXLBucket *dxl_bucket = (*dxl_stats_bucket_array_transformed)[ul];
+			num_ndv_buckets = num_ndv_buckets + dxl_bucket->GetNumDistinct();
+			num_freq_buckets = num_freq_buckets + dxl_bucket->GetFrequency();
 		}
 
-		CUtils::AddRefAppend(pdrgpdxlbucket, pdrgpdxlbucketTransformed);
-		pdrgpdxlbucketTransformed->Release();
+		CUtils::AddRefAppend(dxl_stats_bucket_array, dxl_stats_bucket_array_transformed);
+		dxl_stats_bucket_array_transformed->Release();
 
 		// there will be remaining tuples if the merged histogram and the NULLS do not cover
 		// the total number of distinct values
-		if ((1 - CStatistics::DEpsilon > dFreqBuckets + dNullFrequency) &&
-			(0 < dDistinct - dNDVBuckets - iNullNDV))
+		if ((1 - CStatistics::Epsilon > num_freq_buckets + null_freq) &&
+			(0 < num_distinct - num_ndv_buckets - null_ndv))
 		{
-			dDistinctRemain = std::max(CDouble(0.0), (dDistinct - dNDVBuckets - iNullNDV));
-			dFreqRemain = std::max(CDouble(0.0), (1 - dFreqBuckets - dNullFrequency));
+			distinct_remaining = std::max(CDouble(0.0), (num_distinct - num_ndv_buckets - null_ndv));
+			freq_remaining = std::max(CDouble(0.0), (1 - num_freq_buckets - null_freq));
 		}
 	}
 	else
@@ -2575,95 +2572,95 @@ CTranslatorRelcacheToDXL::PimdobjColStats
 		// in case of text, varchar, char or bpchar, there are no stats buckets, so the
 		// remaining frequency is everything excluding NULLs, and distinct remaining is the
 		// stadistinct as available in pg_statistic
-		dDistinctRemain = dDistinct;
- 		dFreqRemain = 1 - dNullFrequency;
+		distinct_remaining = num_distinct;
+ 		freq_remaining = 1 - null_freq;
 	}
 
 	// free up allocated datum and float4 arrays
-	gpdb::FreeAttrStatsSlot(&mcvSlot);
-	gpdb::FreeAttrStatsSlot(&histSlot);
+	gpdb::FreeAttrStatsSlot(&mcv_slot);
+	gpdb::FreeAttrStatsSlot(&hist_slot);
 
-	gpdb::FreeHeapTuple(heaptupleStats);
+	gpdb::FreeHeapTuple(stats_tup);
 
 	// create col stats object
-	pmdidColStats->AddRef();
-	CDXLColStats *pdxlcolstats = GPOS_NEW(pmp) CDXLColStats
+	mdid_col_stats->AddRef();
+	CDXLColStats *dxl_col_stats = GPOS_NEW(mp) CDXLColStats
 											(
-											pmp,
-											pmdidColStats,
-											pmdnameCol,
-											dWidth,
-											dNullFrequency,
-											dDistinctRemain,
-											dFreqRemain,
-											pdrgpdxlbucket,
-											false /* fColStatsMissing */
+											mp,
+											mdid_col_stats,
+											md_colname,
+											width,
+											null_freq,
+											distinct_remaining,
+											freq_remaining,
+											dxl_stats_bucket_array,
+											false /* is_col_stats_missing */
 											);
 
-	return pdxlcolstats;
+	return dxl_col_stats;
 }
 
 
 //---------------------------------------------------------------------------
 //      @function:
-//              CTranslatorRelcacheToDXL::PdxlcolstatsSystemColumn
+//              CTranslatorRelcacheToDXL::GenerateStatsForSystemCols
 //
 //      @doc:
 //              Generate statistics for the system level columns
 //
 //---------------------------------------------------------------------------
 CDXLColStats *
-CTranslatorRelcacheToDXL::PdxlcolstatsSystemColumn
+CTranslatorRelcacheToDXL::GenerateStatsForSystemCols
        (
-       IMemoryPool *pmp,
-       OID oidRelation,
-       CMDIdColStats *pmdidColStats,
-       CMDName *pmdnameCol,
-       OID oidAttType,
-       AttrNumber attrnum,
-       DrgPdxlbucket *pdrgpdxlbucket,
-       CDouble dRows
+       IMemoryPool *mp,
+       OID rel_oid,
+       CMDIdColStats *mdid_col_stats,
+       CMDName *md_colname,
+       OID att_type,
+       AttrNumber attno,
+       CDXLBucketArray *dxl_stats_bucket_array,
+       CDouble num_rows
        )
 {
-       GPOS_ASSERT(NULL != pmdidColStats);
-       GPOS_ASSERT(NULL != pmdnameCol);
-       GPOS_ASSERT(InvalidOid != oidAttType);
-       GPOS_ASSERT(0 > attrnum);
-       GPOS_ASSERT(NULL != pdrgpdxlbucket);
+       GPOS_ASSERT(NULL != mdid_col_stats);
+       GPOS_ASSERT(NULL != md_colname);
+       GPOS_ASSERT(InvalidOid != att_type);
+       GPOS_ASSERT(0 > attno);
+       GPOS_ASSERT(NULL != dxl_stats_bucket_array);
 
-       CMDIdGPDB *pmdidAttType = GPOS_NEW(pmp) CMDIdGPDB(oidAttType);
-       IMDType *pmdtype = Pmdtype(pmp, pmdidAttType);
-       GPOS_ASSERT(pmdtype->FFixedLength());
+       CMDIdGPDB *mdid_atttype = GPOS_NEW(mp) CMDIdGPDB(att_type);
+       IMDType *md_type = RetrieveType(mp, mdid_atttype);
+       GPOS_ASSERT(md_type->IsFixedLength());
 
-       BOOL fColStatsMissing = true;
-       CDouble dNullFrequency(0.0);
-       CDouble dWidth(pmdtype->UlLength());
-       CDouble dDistinctRemain(0.0);
-       CDouble dFreqRemain(0.0);
+       BOOL is_col_stats_missing = true;
+       CDouble null_freq(0.0);
+       CDouble width(md_type->Length());
+       CDouble distinct_remaining(0.0);
+       CDouble freq_remaining(0.0);
 
-       if (CStatistics::DMinRows <= dRows)
+       if (CStatistics::MinRows <= num_rows)
 	   {
-		   switch(attrnum)
+		   switch(attno)
 			{
 				case GpSegmentIdAttributeNumber: // gp_segment_id
 					{
-						fColStatsMissing = false;
-						dFreqRemain = CDouble(1.0);
-						dDistinctRemain = CDouble(gpdb::UlSegmentCountGP());
+						is_col_stats_missing = false;
+						freq_remaining = CDouble(1.0);
+						distinct_remaining = CDouble(gpdb::GetGPSegmentCount());
 						break;
 					}
 				case TableOidAttributeNumber: // tableoid
 					{
-						fColStatsMissing = false;
-						dFreqRemain = CDouble(1.0);
-						dDistinctRemain = CDouble(UlTableCount(oidRelation));
+						is_col_stats_missing = false;
+						freq_remaining = CDouble(1.0);
+						distinct_remaining = CDouble(RetrieveNumChildPartitions(rel_oid));
 						break;
 					}
 				case SelfItemPointerAttributeNumber: // ctid
 					{
-						fColStatsMissing = false;
-						dFreqRemain = CDouble(1.0);
-						dDistinctRemain = dRows;
+						is_col_stats_missing = false;
+						freq_remaining = CDouble(1.0);
+						distinct_remaining = num_rows;
 						break;
 					}
 				default:
@@ -2672,27 +2669,27 @@ CTranslatorRelcacheToDXL::PdxlcolstatsSystemColumn
         }
 
        // cleanup
-       pmdidAttType->Release();
-       pmdtype->Release();
+       mdid_atttype->Release();
+       md_type->Release();
 
-       return GPOS_NEW(pmp) CDXLColStats
+       return GPOS_NEW(mp) CDXLColStats
                        (
-                       pmp,
-                       pmdidColStats,
-                       pmdnameCol,
-                       dWidth,
-                       dNullFrequency,
-                       dDistinctRemain,
-                       dFreqRemain,
-                       pdrgpdxlbucket,
-                       fColStatsMissing
+                       mp,
+                       mdid_col_stats,
+                       md_colname,
+                       width,
+                       null_freq,
+                       distinct_remaining,
+                       freq_remaining,
+                       dxl_stats_bucket_array,
+                       is_col_stats_missing
                        );
 }
 
 
 //---------------------------------------------------------------------------
 //     @function:
-//     CTranslatorRelcacheToDXL::UlTableCount
+//     CTranslatorRelcacheToDXL::RetrieveNumChildPartitions
 //
 //  @doc:
 //      For non-leaf partition tables return the number of child partitions
@@ -2700,393 +2697,389 @@ CTranslatorRelcacheToDXL::PdxlcolstatsSystemColumn
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorRelcacheToDXL::UlTableCount
+CTranslatorRelcacheToDXL::RetrieveNumChildPartitions
        (
-       OID oidRelation
+       OID rel_oid
        )
 {
-       GPOS_ASSERT(InvalidOid != oidRelation);
+       GPOS_ASSERT(InvalidOid != rel_oid);
 
-       ULONG ulTableCount = gpos::ulong_max;
-       if (gpdb::FRelPartIsNone(oidRelation))
+       ULONG num_part_tables = gpos::ulong_max;
+       if (gpdb::RelPartIsNone(rel_oid))
        {
     	   // not a partitioned table
-            ulTableCount = 1;
+            num_part_tables = 1;
        }
-       else if (gpdb::FLeafPartition(oidRelation))
+       else if (gpdb::IsLeafPartition(rel_oid))
        {
            // leaf partition
-           ulTableCount = 1;
+           num_part_tables = 1;
        }
        else
        {
-           ulTableCount = gpdb::UlLeafPartitions(oidRelation);
+           num_part_tables = gpdb::CountLeafPartTables(rel_oid);
        }
-       GPOS_ASSERT(gpos::ulong_max != ulTableCount);
+       GPOS_ASSERT(gpos::ulong_max != num_part_tables);
 
-       return ulTableCount;
+       return num_part_tables;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PimdobjCast
+//		CTranslatorRelcacheToDXL::RetrieveCast
 //
 //	@doc:
 //		Retrieve a cast function from relcache
 //
 //---------------------------------------------------------------------------
 IMDCacheObject *
-CTranslatorRelcacheToDXL::PimdobjCast
+CTranslatorRelcacheToDXL::RetrieveCast
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	CMDIdCast *pmdidCast = CMDIdCast::PmdidConvert(pmdid);
-	IMDId *pmdidSrc = pmdidCast->PmdidSrc();
-	IMDId *pmdidDest = pmdidCast->PmdidDest();
+	CMDIdCast *mdid_cast = CMDIdCast::CastMdid(mdid);
+	IMDId *mdid_src = mdid_cast->MdidSrc();
+	IMDId *mdid_dest = mdid_cast->MdidDest();
 	IMDCast::EmdCoercepathType coercePathType;
 
-	OID oidSrc = CMDIdGPDB::PmdidConvert(pmdidSrc)->OidObjectId();
-	OID oidDest = CMDIdGPDB::PmdidConvert(pmdidDest)->OidObjectId();
+	OID src_oid = CMDIdGPDB::CastMdid(mdid_src)->Oid();
+	OID dest_oid = CMDIdGPDB::CastMdid(mdid_dest)->Oid();
 	CoercionPathType	pathtype;
 
-	OID oidCastFunc = 0;
-	BOOL fBinaryCoercible = false;
+	OID cast_fn_oid = 0;
+	BOOL is_binary_coercible = false;
 	
-	BOOL fCastExists = gpdb::FCastFunc(oidSrc, oidDest, &fBinaryCoercible, &oidCastFunc, &pathtype);
+	BOOL cast_exists = gpdb::GetCastFunc(src_oid, dest_oid, &is_binary_coercible, &cast_fn_oid, &pathtype);
 	
-	if (!fCastExists)
+	if (!cast_exists)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	} 
 	
-	CHAR *szFuncName = NULL;
-	if (InvalidOid != oidCastFunc)
+	CHAR *func_name = NULL;
+	if (InvalidOid != cast_fn_oid)
 	{
-		szFuncName = gpdb::SzFuncName(oidCastFunc);
+		func_name = gpdb::GetFuncName(cast_fn_oid);
 	}
 	else
 	{
 		// no explicit cast function: use the destination type name as the cast name
-		szFuncName = gpdb::SzTypeName(oidDest);
+		func_name = gpdb::GetTypeName(dest_oid);
 	}
 	
-	if (NULL == szFuncName)
+	if (NULL == func_name)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	pmdid->AddRef();
-	pmdidSrc->AddRef();
-	pmdidDest->AddRef();
+	mdid->AddRef();
+	mdid_src->AddRef();
+	mdid_dest->AddRef();
 
-	CMDName *pmdname = CDXLUtils::PmdnameFromSz(pmp, szFuncName);
+	CMDName *mdname = CDXLUtils::CreateMDNameFromCharArray(mp, func_name);
 	
 	switch (pathtype) {
 		case COERCION_PATH_ARRAYCOERCE:
 		{
 			coercePathType = IMDCast::EmdtArrayCoerce;
-			return GPOS_NEW(pmp) CMDArrayCoerceCastGPDB(pmp, pmdid, pmdname, pmdidSrc, pmdidDest, fBinaryCoercible, GPOS_NEW(pmp) CMDIdGPDB(oidCastFunc), IMDCast::EmdtArrayCoerce, IDefaultTypeModifier, false, EdxlcfImplicitCast, -1);
+			return GPOS_NEW(mp) CMDArrayCoerceCastGPDB(mp, mdid, mdname, mdid_src, mdid_dest, is_binary_coercible, GPOS_NEW(mp) CMDIdGPDB(cast_fn_oid), IMDCast::EmdtArrayCoerce, default_type_modifier, false, EdxlcfImplicitCast, -1);
 		}
 			break;
 		case COERCION_PATH_FUNC:
-			return GPOS_NEW(pmp) CMDCastGPDB(pmp, pmdid, pmdname, pmdidSrc, pmdidDest, fBinaryCoercible, GPOS_NEW(pmp) CMDIdGPDB(oidCastFunc), IMDCast::EmdtFunc);
+			return GPOS_NEW(mp) CMDCastGPDB(mp, mdid, mdname, mdid_src, mdid_dest, is_binary_coercible, GPOS_NEW(mp) CMDIdGPDB(cast_fn_oid), IMDCast::EmdtFunc);
 			break;
 		default:
 			break;
 	}
 
 	// fall back for none path types
-	return GPOS_NEW(pmp) CMDCastGPDB(pmp, pmdid, pmdname, pmdidSrc, pmdidDest, fBinaryCoercible, GPOS_NEW(pmp) CMDIdGPDB(oidCastFunc));
+	return GPOS_NEW(mp) CMDCastGPDB(mp, mdid, mdname, mdid_src, mdid_dest, is_binary_coercible, GPOS_NEW(mp) CMDIdGPDB(cast_fn_oid));
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PmdobjScCmp
+//		CTranslatorRelcacheToDXL::RetrieveScCmp
 //
 //	@doc:
 //		Retrieve a scalar comparison from relcache
 //
 //---------------------------------------------------------------------------
 IMDCacheObject *
-CTranslatorRelcacheToDXL::PmdobjScCmp
+CTranslatorRelcacheToDXL::RetrieveScCmp
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	IMDId *mdid
 	)
 {
-	CMDIdScCmp *pmdidScCmp = CMDIdScCmp::PmdidConvert(pmdid);
-	IMDId *pmdidLeft = pmdidScCmp->PmdidLeft();
-	IMDId *pmdidRight = pmdidScCmp->PmdidRight();
+	CMDIdScCmp *mdid_scalar_cmp = CMDIdScCmp::CastMdid(mdid);
+	IMDId *mdid_left = mdid_scalar_cmp->GetLeftMdid();
+	IMDId *mdid_right = mdid_scalar_cmp->GetRightMdid();
 	
-	IMDType::ECmpType ecmpt = pmdidScCmp->Ecmpt();
+	IMDType::ECmpType cmp_type = mdid_scalar_cmp->ParseCmpType();
 
-	OID oidLeft = CMDIdGPDB::PmdidConvert(pmdidLeft)->OidObjectId();
-	OID oidRight = CMDIdGPDB::PmdidConvert(pmdidRight)->OidObjectId();
-	CmpType cmpt = (CmpType) UlCmpt(ecmpt);
+	OID left_oid = CMDIdGPDB::CastMdid(mdid_left)->Oid();
+	OID right_oid = CMDIdGPDB::CastMdid(mdid_right)->Oid();
+	CmpType cmpt = (CmpType) GetComparisonType(cmp_type);
 	
-	OID oidScCmp = gpdb::OidScCmp(oidLeft, oidRight, cmpt);
+	OID scalar_cmp_oid = gpdb::GetComparisonOperator(left_oid, right_oid, cmpt);
 	
-	if (InvalidOid == oidScCmp)
+	if (InvalidOid == scalar_cmp_oid)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	} 
 
-	CHAR *szName = gpdb::SzOpName(oidScCmp);
+	CHAR *name = gpdb::GetOpName(scalar_cmp_oid);
 
-	if (NULL == szName)
+	if (NULL == name)
 	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, pmdid->Wsz());
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
 
-	pmdid->AddRef();
-	pmdidLeft->AddRef();
-	pmdidRight->AddRef();
+	mdid->AddRef();
+	mdid_left->AddRef();
+	mdid_right->AddRef();
 
-	CMDName *pmdname = CDXLUtils::PmdnameFromSz(pmp, szName);
+	CMDName *mdname = CDXLUtils::CreateMDNameFromCharArray(mp, name);
 
-	return GPOS_NEW(pmp) CMDScCmpGPDB(pmp, pmdid, pmdname, pmdidLeft, pmdidRight, ecmpt, GPOS_NEW(pmp) CMDIdGPDB(oidScCmp));
+	return GPOS_NEW(mp) CMDScCmpGPDB(mp, mdid, mdname, mdid_left, mdid_right, cmp_type, GPOS_NEW(mp) CMDIdGPDB(scalar_cmp_oid));
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpdxlbucketTransformStats
+//		CTranslatorRelcacheToDXL::TransformStatsToDXLBucketArray
 //
 //	@doc:
 //		transform stats from pg_stats form to optimizer's preferred form
 //
 //---------------------------------------------------------------------------
-DrgPdxlbucket *
-CTranslatorRelcacheToDXL::PdrgpdxlbucketTransformStats
+CDXLBucketArray *
+CTranslatorRelcacheToDXL::TransformStatsToDXLBucketArray
 	(
-	IMemoryPool *pmp,
-	OID oidAttType,
-	CDouble dDistinct,
-	CDouble dNullFreq,
-	const Datum *pdrgdatumMCVValues,
-	const float4 *pdrgfMCVFrequencies,
-	ULONG ulNumMCVValues,
-	const Datum *pdrgdatumHistValues,
-	ULONG ulNumHistValues
+	IMemoryPool *mp,
+	OID att_type,
+	CDouble num_distinct,
+	CDouble null_freq,
+	const Datum *mcv_values,
+	const float4 *mcv_frequencies,
+	ULONG num_mcv_values,
+	const Datum *hist_values,
+	ULONG num_hist_values
 	)
 {
-	CMDIdGPDB *pmdidAttType = GPOS_NEW(pmp) CMDIdGPDB(oidAttType);
-	IMDType *pmdtype = Pmdtype(pmp, pmdidAttType);
+	CMDIdGPDB *mdid_atttype = GPOS_NEW(mp) CMDIdGPDB(att_type);
+	IMDType *md_type = RetrieveType(mp, mdid_atttype);
 
 	// translate MCVs to Orca histogram. Create an empty histogram if there are no MCVs.
-	CHistogram *phistGPDBMCV = PhistTransformGPDBMCV
+	CHistogram *gpdb_mcv_hist = TransformMcvToOrcaHistogram
 							(
-							pmp,
-							pmdtype,
-							pdrgdatumMCVValues,
-							pdrgfMCVFrequencies,
-							ulNumMCVValues
+							mp,
+							md_type,
+							mcv_values,
+							mcv_frequencies,
+							num_mcv_values
 							);
 
-	GPOS_ASSERT(phistGPDBMCV->FValid());
+	GPOS_ASSERT(gpdb_mcv_hist->IsValid());
 
-	CDouble dMCVFreq = phistGPDBMCV->DFrequency();
-	BOOL fHasMCV = 0 < ulNumMCVValues && CStatistics::DEpsilon < dMCVFreq;
+	CDouble mcv_freq = gpdb_mcv_hist->GetFrequency();
+	BOOL has_mcv = 0 < num_mcv_values && CStatistics::Epsilon < mcv_freq;
 
-	CDouble dHistFreq = 0.0;
-	if (1 < ulNumHistValues)
+	CDouble hist_freq = 0.0;
+	if (1 < num_hist_values)
 	{
-		dHistFreq = CDouble(1.0) - dNullFreq - dMCVFreq;
+		hist_freq = CDouble(1.0) - null_freq - mcv_freq;
 	}
-	BOOL fHasHist = 1 < ulNumHistValues && CStatistics::DEpsilon < dHistFreq;
+	BOOL has_hist = 1 < num_hist_values && CStatistics::Epsilon < hist_freq;
 
-	CHistogram *phistGPDBHist = NULL;
+	CHistogram *histogram = NULL;
 
 	// if histogram has any significant information, then extract it
-	if (fHasHist)
+	if (has_hist)
 	{
 		// histogram from gpdb histogram
-		phistGPDBHist = PhistTransformGPDBHist
+		histogram = TransformHistToOrcaHistogram
 						(
-						pmp,
-						pmdtype,
-						pdrgdatumHistValues,
-						ulNumHistValues,
-						dDistinct,
-						dHistFreq
+						mp,
+						md_type,
+						hist_values,
+						num_hist_values,
+						num_distinct,
+						hist_freq
 						);
-		if (0 == phistGPDBHist->UlBuckets())
+		if (0 == histogram->Buckets())
 		{
-			fHasHist = false;
+			has_hist = false;
 		}
 	}
 
-	DrgPdxlbucket *pdrgpdxlbucket = NULL;
+	CDXLBucketArray *dxl_stats_bucket_array = NULL;
 
-	if (fHasHist && !fHasMCV)
+	if (has_hist && !has_mcv)
 	{
 		// if histogram exists and dominates, use histogram only
-		pdrgpdxlbucket = Pdrgpdxlbucket(pmp, pmdtype, phistGPDBHist);
+		dxl_stats_bucket_array = TransformHistogramToDXLBucketArray(mp, md_type, histogram);
 	}
-	else if (!fHasHist && fHasMCV)
+	else if (!has_hist && has_mcv)
 	{
 		// if MCVs exist and dominate, use MCVs only
-		pdrgpdxlbucket = Pdrgpdxlbucket(pmp, pmdtype, phistGPDBMCV);
+		dxl_stats_bucket_array = TransformHistogramToDXLBucketArray(mp, md_type, gpdb_mcv_hist);
 	}
-	else if (fHasHist && fHasMCV)
+	else if (has_hist && has_mcv)
 	{
 		// both histogram and MCVs exist and have significant info, merge MCV and histogram buckets
-		CHistogram *phistMerged = CStatisticsUtils::PhistMergeMcvHist(pmp, phistGPDBMCV, phistGPDBHist);
-		pdrgpdxlbucket = Pdrgpdxlbucket(pmp, pmdtype, phistMerged);
-		GPOS_DELETE(phistMerged);
+		CHistogram *merged_hist = CStatisticsUtils::MergeMCVHist(mp, gpdb_mcv_hist, histogram);
+		dxl_stats_bucket_array = TransformHistogramToDXLBucketArray(mp, md_type, merged_hist);
+		GPOS_DELETE(merged_hist);
 	}
 	else
 	{
 		// no MCVs nor histogram
-		GPOS_ASSERT(!fHasHist && !fHasMCV);
-		pdrgpdxlbucket = GPOS_NEW(pmp) DrgPdxlbucket(pmp);
+		GPOS_ASSERT(!has_hist && !has_mcv);
+		dxl_stats_bucket_array = GPOS_NEW(mp) CDXLBucketArray(mp);
 	}
 
 	// cleanup
-	pmdidAttType->Release();
-	pmdtype->Release();
-	GPOS_DELETE(phistGPDBMCV);
+	mdid_atttype->Release();
+	md_type->Release();
+	GPOS_DELETE(gpdb_mcv_hist);
 
-	if (NULL != phistGPDBHist)
+	if (NULL != histogram)
 	{
-		GPOS_DELETE(phistGPDBHist);
+		GPOS_DELETE(histogram);
 	}
 
-	return pdrgpdxlbucket;
+	return dxl_stats_bucket_array;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PhistTransformGPDBMCV
+//		CTranslatorRelcacheToDXL::TransformMcvToOrcaHistogram
 //
 //	@doc:
 //		Transform gpdb's mcv info to optimizer histogram
 //
 //---------------------------------------------------------------------------
 CHistogram *
-CTranslatorRelcacheToDXL::PhistTransformGPDBMCV
+CTranslatorRelcacheToDXL::TransformMcvToOrcaHistogram
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	const Datum *pdrgdatumMCVValues,
-	const float4 *pdrgfMCVFrequencies,
-	ULONG ulNumMCVValues
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	const Datum *mcv_values,
+	const float4 *mcv_frequencies,
+	ULONG num_mcv_values
 	)
 {
-	DrgPdatum *pdrgpdatum = GPOS_NEW(pmp) DrgPdatum(pmp);
-	DrgPdouble *pdrgpdFreq = GPOS_NEW(pmp) DrgPdouble(pmp);
+	IDatumArray *datums = GPOS_NEW(mp) IDatumArray(mp);
+	CDoubleArray *freqs = GPOS_NEW(mp) CDoubleArray(mp);
 
-	for (ULONG ul = 0; ul < ulNumMCVValues; ul++)
+	for (ULONG ul = 0; ul < num_mcv_values; ul++)
 	{
-		Datum datumMCV = pdrgdatumMCVValues[ul];
-		IDatum *pdatum = CTranslatorScalarToDXL::Pdatum(pmp, pmdtype, false /* fNull */, datumMCV);
-		pdrgpdatum->Append(pdatum);
-		pdrgpdFreq->Append(GPOS_NEW(pmp) CDouble(pdrgfMCVFrequencies[ul]));
+		Datum datumMCV = mcv_values[ul];
+		IDatum *datum = CTranslatorScalarToDXL::CreateIDatumFromGpdbDatum(mp, md_type, false /* is_null */, datumMCV);
+		datums->Append(datum);
+		freqs->Append(GPOS_NEW(mp) CDouble(mcv_frequencies[ul]));
 
-		if (!pdatum->FStatsComparable(pdatum))
+		if (!datum->StatsAreComparable(datum))
 		{
 			// if less than operation is not supported on this datum, then no point
 			// building a histogram. return an empty histogram
-			pdrgpdatum->Release();
-			pdrgpdFreq->Release();
-			return GPOS_NEW(pmp) CHistogram(GPOS_NEW(pmp) DrgPbucket(pmp));
+			datums->Release();
+			freqs->Release();
+			return GPOS_NEW(mp) CHistogram(GPOS_NEW(mp) CBucketArray(mp));
 		}
 	}
 
-	CHistogram *phist = CStatisticsUtils::PhistTransformMCV
+	CHistogram *hist = CStatisticsUtils::TransformMCVToHist
 												(
-												pmp,
-												pmdtype,
-												pdrgpdatum,
-												pdrgpdFreq,
-												ulNumMCVValues
+												mp,
+												md_type,
+												datums,
+												freqs,
+												num_mcv_values
 												);
 
-	pdrgpdatum->Release();
-	pdrgpdFreq->Release();
-	return phist;
+	datums->Release();
+	freqs->Release();
+	return hist;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PhistTransformGPDBHist
+//		CTranslatorRelcacheToDXL::TransformHistToOrcaHistogram
 //
 //	@doc:
 //		Transform GPDB's hist info to optimizer's histogram
 //
 //---------------------------------------------------------------------------
 CHistogram *
-CTranslatorRelcacheToDXL::PhistTransformGPDBHist
+CTranslatorRelcacheToDXL::TransformHistToOrcaHistogram
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	const Datum *pdrgdatumHistValues,
-	ULONG ulNumHistValues,
-	CDouble dDistinctHist,
-	CDouble dFreqHist
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	const Datum *hist_values,
+	ULONG num_hist_values,
+	CDouble num_distinct,
+	CDouble hist_freq
 	)
 {
-	GPOS_ASSERT(1 < ulNumHistValues);
+	GPOS_ASSERT(1 < num_hist_values);
 
-	ULONG ulNumBuckets = ulNumHistValues - 1;
-	CDouble dDistinctPerBucket = dDistinctHist / CDouble(ulNumBuckets);
-	CDouble dFreqPerBucket = dFreqHist / CDouble(ulNumBuckets);
+	const ULONG num_buckets = num_hist_values - 1;
+	CDouble distinct_per_bucket = num_distinct / CDouble(num_buckets);
+	CDouble freq_per_bucket = hist_freq / CDouble(num_buckets);
 
-	const ULONG ulBuckets = ulNumHistValues - 1;
-	BOOL fLastBucketWasSingleton = false;
+	BOOL last_bucket_was_singleton = false;
 	// create buckets
-	DrgPbucket *pdrgppbucket = GPOS_NEW(pmp) DrgPbucket(pmp);
-	for (ULONG ul = 0; ul < ulBuckets; ul++)
+	CBucketArray *buckets = GPOS_NEW(mp) CBucketArray(mp);
+	for (ULONG ul = 0; ul < num_buckets; ul++)
 	{
-		Datum datumMin = pdrgdatumHistValues[ul];
-		IDatum *pdatumMin = CTranslatorScalarToDXL::Pdatum(pmp, pmdtype, false /* fNull */, datumMin);
+		IDatum *min_datum = CTranslatorScalarToDXL::CreateIDatumFromGpdbDatum(mp, md_type, false /* is_null */, hist_values[ul]);
+		IDatum *max_datum = CTranslatorScalarToDXL::CreateIDatumFromGpdbDatum(mp, md_type, false /* is_null */, hist_values[ul + 1]);
+		BOOL is_lower_closed, is_upper_closed;
 
-		Datum datumMax = pdrgdatumHistValues[ul + 1];
-		IDatum *pdatumMax = CTranslatorScalarToDXL::Pdatum(pmp, pmdtype, false /* fNull */, datumMax);
-		BOOL fLowerClosed, fUpperClosed;
-
-		if (pdatumMin->FStatsEqual(pdatumMax))
+		if (min_datum->StatsAreEqual(max_datum))
 		{
 			// Singleton bucket !!!!!!!!!!!!!
-			fLowerClosed = true;
-			fUpperClosed = true;
-			fLastBucketWasSingleton = true;
+			is_lower_closed = true;
+			is_upper_closed = true;
+			last_bucket_was_singleton = true;
 		}
-		else if (fLastBucketWasSingleton)
+		else if (last_bucket_was_singleton)
 		{
 			// Last bucket was a singleton, so lower must be open now.
-			fLowerClosed = false;
-			fUpperClosed = false;
-			fLastBucketWasSingleton = false;
+			is_lower_closed = false;
+			is_upper_closed = false;
+			last_bucket_was_singleton = false;
 		}
 		else
 		{
 			// Normal bucket
 			// GPDB histograms assumes lower bound to be closed and upper bound to be open
-			fLowerClosed = true;
-			fUpperClosed = false;
+			is_lower_closed = true;
+			is_upper_closed = false;
 		}
 
-		if (ul == ulBuckets - 1)
+		if (ul == num_buckets - 1)
 		{
 			// last bucket upper bound is also closed
-			fUpperClosed = true;
+			is_upper_closed = true;
 		}
 
-		CBucket *pbucket = GPOS_NEW(pmp) CBucket
+		CBucket *bucket = GPOS_NEW(mp) CBucket
 									(
-									GPOS_NEW(pmp) CPoint(pdatumMin),
-									GPOS_NEW(pmp) CPoint(pdatumMax),
-									fLowerClosed,
-									fUpperClosed,
-									dFreqPerBucket,
-									dDistinctPerBucket
+									GPOS_NEW(mp) CPoint(min_datum),
+									GPOS_NEW(mp) CPoint(max_datum),
+									is_lower_closed,
+									is_upper_closed,
+									freq_per_bucket,
+									distinct_per_bucket
 									);
-		pdrgppbucket->Append(pbucket);
+		buckets->Append(bucket);
 
-		if (!pdatumMin->FStatsComparable(pdatumMin) || !pdatumMin->FStatsLessThan(pdatumMax))
+		if (!min_datum->StatsAreComparable(max_datum) || !min_datum->StatsAreLessThan(max_datum))
 		{
 			// if less than operation is not supported on this datum,
 			// or the translated histogram does not conform to GPDB sort order (e.g. text column in Linux platform),
@@ -3095,99 +3088,99 @@ CTranslatorRelcacheToDXL::PhistTransformGPDBHist
 			// TODO: 03/01/2014 translate histogram into Orca even if sort
 			// order is different in GPDB, and use const expression eval to compare
 			// datums in Orca (MPP-22780)
-			pdrgppbucket->Release();
-			return GPOS_NEW(pmp) CHistogram(GPOS_NEW(pmp) DrgPbucket(pmp));
+			buckets->Release();
+			return GPOS_NEW(mp) CHistogram(GPOS_NEW(mp) CBucketArray(mp));
 		}
 	}
 
-	CHistogram *phist = GPOS_NEW(pmp) CHistogram(pdrgppbucket);
-	return phist;
+	CHistogram *hist = GPOS_NEW(mp) CHistogram(buckets);
+	return hist;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Pdrgpdxlbucket
+//		CTranslatorRelcacheToDXL::TransformHistogramToDXLBucketArray
 //
 //	@doc:
 //		Histogram to array of dxl buckets
 //
 //---------------------------------------------------------------------------
-DrgPdxlbucket *
-CTranslatorRelcacheToDXL::Pdrgpdxlbucket
+CDXLBucketArray *
+CTranslatorRelcacheToDXL::TransformHistogramToDXLBucketArray
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	const CHistogram *phist
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	const CHistogram *hist
 	)
 {
-	DrgPdxlbucket *pdrgpdxlbucket = GPOS_NEW(pmp) DrgPdxlbucket(pmp);
-	const DrgPbucket *pdrgpbucket = phist->Pdrgpbucket();
-	ULONG ulNumBuckets = pdrgpbucket->UlLength();
-	for (ULONG ul = 0; ul < ulNumBuckets; ul++)
+	CDXLBucketArray *dxl_stats_bucket_array = GPOS_NEW(mp) CDXLBucketArray(mp);
+	const CBucketArray *buckets = hist->ParseDXLToBucketsArray();
+	ULONG num_buckets = buckets->Size();
+	for (ULONG ul = 0; ul < num_buckets; ul++)
 	{
-		CBucket *pbucket = (*pdrgpbucket)[ul];
-		IDatum *pdatumLB = pbucket->PpLower()->Pdatum();
-		CDXLDatum *pdxldatumLB = pmdtype->Pdxldatum(pmp, pdatumLB);
-		IDatum *pdatumUB = pbucket->PpUpper()->Pdatum();
-		CDXLDatum *pdxldatumUB = pmdtype->Pdxldatum(pmp, pdatumUB);
-		CDXLBucket *pdxlbucket = GPOS_NEW(pmp) CDXLBucket
+		CBucket *bucket = (*buckets)[ul];
+		IDatum *datum_lower = bucket->GetLowerBound()->GetDatum();
+		CDXLDatum *dxl_lower = md_type->GetDatumVal(mp, datum_lower);
+		IDatum *datum_upper = bucket->GetUpperBound()->GetDatum();
+		CDXLDatum *dxl_upper = md_type->GetDatumVal(mp, datum_upper);
+		CDXLBucket *dxl_bucket = GPOS_NEW(mp) CDXLBucket
 											(
-											pdxldatumLB,
-											pdxldatumUB,
-											pbucket->FLowerClosed(),
-											pbucket->FUpperClosed(),
-											pbucket->DFrequency(),
-											pbucket->DDistinct()
+											dxl_lower,
+											dxl_upper,
+											bucket->IsLowerClosed(),
+											bucket->IsUpperClosed(),
+											bucket->GetFrequency(),
+											bucket->GetNumDistinct()
 											);
-		pdrgpdxlbucket->Append(pdxlbucket);
+		dxl_stats_bucket_array->Append(dxl_bucket);
 	}
-	return pdrgpdxlbucket;
+	return dxl_stats_bucket_array;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Erelstorage
+//		CTranslatorRelcacheToDXL::RetrieveRelStorageType
 //
 //	@doc:
 //		Get relation storage type
 //
 //---------------------------------------------------------------------------
 IMDRelation::Erelstoragetype
-CTranslatorRelcacheToDXL::Erelstorage
+CTranslatorRelcacheToDXL::RetrieveRelStorageType
 	(
-	CHAR cStorageType
+	CHAR storage_type
 	)
 {
-	IMDRelation::Erelstoragetype erelstorage = IMDRelation::ErelstorageSentinel;
+	IMDRelation::Erelstoragetype rel_storage_type = IMDRelation::ErelstorageSentinel;
 
-	switch (cStorageType)
+	switch (storage_type)
 	{
 		case RELSTORAGE_HEAP:
-			erelstorage = IMDRelation::ErelstorageHeap;
+			rel_storage_type = IMDRelation::ErelstorageHeap;
 			break;
 		case RELSTORAGE_AOCOLS:
-			erelstorage = IMDRelation::ErelstorageAppendOnlyCols;
+			rel_storage_type = IMDRelation::ErelstorageAppendOnlyCols;
 			break;
 		case RELSTORAGE_AOROWS:
-			erelstorage = IMDRelation::ErelstorageAppendOnlyRows;
+			rel_storage_type = IMDRelation::ErelstorageAppendOnlyRows;
 			break;
 		case RELSTORAGE_VIRTUAL:
-			erelstorage = IMDRelation::ErelstorageVirtual;
+			rel_storage_type = IMDRelation::ErelstorageVirtual;
 			break;
 		case RELSTORAGE_EXTERNAL:
-			erelstorage = IMDRelation::ErelstorageExternal;
+			rel_storage_type = IMDRelation::ErelstorageExternal;
 			break;
 		default:
 			GPOS_ASSERT(!"Unsupported relation type");
 	}
 
-	return erelstorage;
+	return rel_storage_type;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::GetPartKeysAndTypes
+//		CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes
 //
 //	@doc:
 //		Get partition keys and types for relation or NULL if relation not partitioned.
@@ -3195,168 +3188,168 @@ CTranslatorRelcacheToDXL::Erelstorage
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorRelcacheToDXL::GetPartKeysAndTypes
+CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes
 	(
-	IMemoryPool *pmp,
+	IMemoryPool *mp,
 	Relation rel,
 	OID oid,
-	DrgPul **pdrgpulPartKeys,
-	DrgPsz **pdrgpszPartTypes
+	ULongPtrArray **part_keys,
+	CharPtrArray **part_types
 	)
 {
 	GPOS_ASSERT(NULL != rel);
 
-	if (!gpdb::FRelPartIsRoot(oid))
+	if (!gpdb::RelPartIsRoot(oid))
 	{
 		// not a partitioned table
-		*pdrgpulPartKeys = NULL;
-		*pdrgpszPartTypes = NULL;
+		*part_keys = NULL;
+		*part_types = NULL;
 		return;
 	}
 
 	// TODO: Feb 23, 2012; support intermediate levels
 
-	*pdrgpulPartKeys = GPOS_NEW(pmp) DrgPul(pmp);
-	*pdrgpszPartTypes = GPOS_NEW(pmp) DrgPsz(pmp);
+	*part_keys = GPOS_NEW(mp) ULongPtrArray(mp);
+	*part_types = GPOS_NEW(mp) CharPtrArray(mp);
 
-	PartitionNode *pn = gpdb::PpnParts(oid, 0 /*level*/, 0 /*parent*/, false /*inctemplate*/, true /*includesubparts*/);
+	PartitionNode *pn = gpdb::GetParts(oid, 0 /*level*/, 0 /*parent*/, false /*inctemplate*/, true /*includesubparts*/);
 	GPOS_ASSERT(NULL != pn);
-	
+
 	if (gpdb::FHashPartitioned(pn->part->parkind))
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Hash partitioning"));
 	}
-	
-	List *plPartKeys = NIL;
-	List *plPartTypes = NIL;
-	gpdb::GetOrderedPartKeysAndKinds(oid, &plPartKeys, &plPartTypes);
 
-	ListCell *plcKey = NULL;
-	ListCell *plcType = NULL;
-	ForBoth (plcKey, plPartKeys, plcType, plPartTypes)
+	List *part_keys_list = NIL;
+	List *part_types_list = NIL;
+	gpdb::GetOrderedPartKeysAndKinds(oid, &part_keys_list, &part_types_list);
+
+	ListCell *lc_key = NULL;
+	ListCell *lc_type = NULL;
+	ForBoth (lc_key, part_keys_list, lc_type, part_types_list)
 	{
-		List *plPartKey = (List *) lfirst(plcKey);
+		List *part_key = (List *) lfirst(lc_key);
 
-		if (1 < gpdb::UlListLength(plPartKey))
+		if (1 < gpdb::ListLength(part_key))
 		{
 			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Composite part key"));
 		}
 
-		INT iAttno = linitial_int(plPartKey);
-		CHAR partType = (CHAR) lfirst_int(plcType);
-		GPOS_ASSERT(0 < iAttno);
-		(*pdrgpulPartKeys)->Append(GPOS_NEW(pmp) ULONG(iAttno - 1));
-		(*pdrgpszPartTypes)->Append(GPOS_NEW(pmp) CHAR(partType));
+		INT attno = linitial_int(part_key);
+		CHAR part_type = (CHAR) lfirst_int(lc_type);
+		GPOS_ASSERT(0 < attno);
+		(*part_keys)->Append(GPOS_NEW(mp) ULONG(attno - 1));
+		(*part_types)->Append(GPOS_NEW(mp) CHAR(part_type));
 	}
 
-	gpdb::FreeList(plPartKeys);
-	gpdb::FreeList(plPartTypes);
+	gpdb::ListFree(part_keys_list);
+	gpdb::ListFree(part_types_list);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PulAttnoMapping
+//		CTranslatorRelcacheToDXL::ConstructAttnoMapping
 //
 //	@doc:
 //		Construct a mapping for GPDB attnos to positions in the columns array
 //
 //---------------------------------------------------------------------------
 ULONG *
-CTranslatorRelcacheToDXL::PulAttnoMapping
+CTranslatorRelcacheToDXL::ConstructAttnoMapping
 	(
-	IMemoryPool *pmp,
-	DrgPmdcol *pdrgpmdcol,
-	ULONG ulMaxCols
+	IMemoryPool *mp,
+	CMDColumnArray *mdcol_array,
+	ULONG max_cols
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpmdcol);
-	GPOS_ASSERT(0 < pdrgpmdcol->UlLength());
-	GPOS_ASSERT(ulMaxCols > pdrgpmdcol->UlLength());
+	GPOS_ASSERT(NULL != mdcol_array);
+	GPOS_ASSERT(0 < mdcol_array->Size());
+	GPOS_ASSERT(max_cols > mdcol_array->Size());
 
 	// build a mapping for attnos->positions
-	const ULONG ulCols = pdrgpmdcol->UlLength();
-	ULONG *pul = GPOS_NEW_ARRAY(pmp, ULONG, ulMaxCols);
+	const ULONG num_of_cols = mdcol_array->Size();
+	ULONG *attno_mapping = GPOS_NEW_ARRAY(mp, ULONG, max_cols);
 
 	// initialize all positions to gpos::ulong_max
-	for (ULONG ul = 0;  ul < ulMaxCols; ul++)
+	for (ULONG ul = 0;  ul < max_cols; ul++)
 	{
-		pul[ul] = gpos::ulong_max;
+		attno_mapping[ul] = gpos::ulong_max;
 	}
 	
-	for (ULONG ul = 0;  ul < ulCols; ul++)
+	for (ULONG ul = 0;  ul < num_of_cols; ul++)
 	{
-		const IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
-		INT iAttno = pmdcol->IAttno();
+		const IMDColumn *md_col = (*mdcol_array)[ul];
+		INT attno = md_col->AttrNum();
 
-		ULONG ulIndex = (ULONG) (GPDXL_SYSTEM_COLUMNS + iAttno);
-		pul[ulIndex] = ul;
+		ULONG idx = (ULONG) (GPDXL_SYSTEM_COLUMNS + attno);
+		attno_mapping[idx] = ul;
 	}
 
-	return pul;
+	return attno_mapping;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpdrgpulKeys
+//		CTranslatorRelcacheToDXL::RetrieveRelKeysets
 //
 //	@doc:
 //		Get key sets for relation
 //
 //---------------------------------------------------------------------------
-DrgPdrgPul *
-CTranslatorRelcacheToDXL::PdrgpdrgpulKeys
+ULongPtr2dArray *
+CTranslatorRelcacheToDXL::RetrieveRelKeysets
 	(
-	IMemoryPool *pmp,
+	IMemoryPool *mp,
 	OID oid,
-	BOOL fAddDefaultKeys,
-	BOOL fPartitioned,
-	ULONG *pulMapping
+	BOOL should_add_default_keys,
+	BOOL is_partitioned,
+	ULONG *attno_mapping
 	)
 {
-	DrgPdrgPul *pdrgpdrgpul = GPOS_NEW(pmp) DrgPdrgPul(pmp);
+	ULongPtr2dArray *key_sets = GPOS_NEW(mp) ULongPtr2dArray(mp);
 
-	List *plKeys = gpdb::PlRelationKeys(oid);
+	List *rel_keys = gpdb::GetRelationKeys(oid);
 
-	ListCell *plcKey = NULL;
-	ForEach (plcKey, plKeys)
+	ListCell *lc_key = NULL;
+	ForEach (lc_key, rel_keys)
 	{
-		List *plKey = (List *) lfirst(plcKey);
+		List *key_elem_list = (List *) lfirst(lc_key);
 
-		DrgPul *pdrgpulKey = GPOS_NEW(pmp) DrgPul(pmp);
+		ULongPtrArray *key_set = GPOS_NEW(mp) ULongPtrArray(mp);
 
-		ListCell *plcKeyElem = NULL;
-		ForEach (plcKeyElem, plKey)
+		ListCell *lc_key_elem = NULL;
+		ForEach (lc_key_elem, key_elem_list)
 		{
-			INT iKey = lfirst_int(plcKeyElem);
-			ULONG ulPos = UlPosition(iKey, pulMapping);
-			pdrgpulKey->Append(GPOS_NEW(pmp) ULONG(ulPos));
+			INT key_idx = lfirst_int(lc_key_elem);
+			ULONG pos = GetAttributePosition(key_idx, attno_mapping);
+			key_set->Append(GPOS_NEW(mp) ULONG(pos));
 		}
-		GPOS_ASSERT(0 < pdrgpulKey->UlLength());
+		GPOS_ASSERT(0 < key_set->Size());
 
-		pdrgpdrgpul->Append(pdrgpulKey);
+		key_sets->Append(key_set);
 	}
 	
 	// add {segid, ctid} as a key
 	
-	if (fAddDefaultKeys)
+	if (should_add_default_keys)
 	{
-		DrgPul *pdrgpulKey = GPOS_NEW(pmp) DrgPul(pmp);
-		if (fPartitioned)
+		ULongPtrArray *key_set = GPOS_NEW(mp) ULongPtrArray(mp);
+		if (is_partitioned)
 		{
 			// TableOid is part of default key for partitioned tables
-			ULONG ulPosTableOid = UlPosition(TableOidAttributeNumber, pulMapping);
-			pdrgpulKey->Append(GPOS_NEW(pmp) ULONG(ulPosTableOid));
+			ULONG table_oid_pos = GetAttributePosition(TableOidAttributeNumber, attno_mapping);
+			key_set->Append(GPOS_NEW(mp) ULONG(table_oid_pos));
 		}
-		ULONG ulPosSegid= UlPosition(GpSegmentIdAttributeNumber, pulMapping);
-		ULONG ulPosCtid = UlPosition(SelfItemPointerAttributeNumber, pulMapping);
-		pdrgpulKey->Append(GPOS_NEW(pmp) ULONG(ulPosSegid));
-		pdrgpulKey->Append(GPOS_NEW(pmp) ULONG(ulPosCtid));
+		ULONG seg_id_pos= GetAttributePosition(GpSegmentIdAttributeNumber, attno_mapping);
+		ULONG ctid_pos = GetAttributePosition(SelfItemPointerAttributeNumber, attno_mapping);
+		key_set->Append(GPOS_NEW(mp) ULONG(seg_id_pos));
+		key_set->Append(GPOS_NEW(mp) ULONG(ctid_pos));
 		
-		pdrgpdrgpul->Append(pdrgpulKey);
+		key_sets->Append(key_set);
 	}
 	
-	return pdrgpdrgpul;
+	return key_sets;
 }
 
 //---------------------------------------------------------------------------
@@ -3371,263 +3364,263 @@ CTranslatorRelcacheToDXL::PdrgpdrgpulKeys
 void
 CTranslatorRelcacheToDXL::NormalizeFrequencies
 	(
-	float4 *pdrgf,
-	ULONG ulLength,
-	CDouble *pdNullFrequency
+	float4 *freqs,
+	ULONG length,
+	CDouble *null_freq
 	)
 {
-	if (ulLength == 0 && (*pdNullFrequency) < 1.0)
+	if (length == 0 && (*null_freq) < 1.0)
 	{
 		return;
 	}
 
-	CDouble dTotal = *pdNullFrequency;
-	for (ULONG ul = 0; ul < ulLength; ul++)
+	CDouble total = *null_freq;
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		dTotal = dTotal + CDouble(pdrgf[ul]);
+		total = total + CDouble(freqs[ul]);
 	}
 
-	if (dTotal > CDouble(1.0))
+	if (total > CDouble(1.0))
 	{
-		float4 fDenom = (float4) (dTotal + CStatistics::DEpsilon).DVal();
+		float4 denom = (float4) (total + CStatistics::Epsilon).Get();
 
 		// divide all values by the total
-		for (ULONG ul = 0; ul < ulLength; ul++)
+		for (ULONG ul = 0; ul < length; ul++)
 		{
-			pdrgf[ul] = pdrgf[ul] / fDenom;
+			freqs[ul] = freqs[ul] / denom;
 		}
-		*pdNullFrequency = *pdNullFrequency / fDenom;
+		*null_freq = *null_freq / denom;
 	}
 
 #ifdef GPOS_DEBUG
 	// recheck
-	CDouble dTotalRecheck = *pdNullFrequency;
-	for (ULONG ul = 0; ul < ulLength; ul++)
+	CDouble recheck_total = *null_freq;
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		dTotalRecheck = dTotalRecheck + CDouble(pdrgf[ul]);
+		recheck_total = recheck_total + CDouble(freqs[ul]);
 	}
-	GPOS_ASSERT(dTotalRecheck <= CDouble(1.0));
+	GPOS_ASSERT(recheck_total <= CDouble(1.0));
 #endif
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::FIndexSupported
+//		CTranslatorRelcacheToDXL::IsIndexSupported
 //
 //	@doc:
 //		Check if index type is supported
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorRelcacheToDXL::FIndexSupported
+CTranslatorRelcacheToDXL::IsIndexSupported
 	(
-	Relation relIndex
+	Relation index_rel
 	)
 {
-	HeapTupleData *pht = relIndex->rd_indextuple;
+	HeapTupleData *tup = index_rel->rd_indextuple;
 	
 	// index expressions and index constraints not supported
-	return gpdb::FHeapAttIsNull(pht, Anum_pg_index_indexprs) &&
-		gpdb::FHeapAttIsNull(pht, Anum_pg_index_indpred) && 
-		(BTREE_AM_OID == relIndex->rd_rel->relam || BITMAP_AM_OID == relIndex->rd_rel->relam || GIST_AM_OID == relIndex->rd_rel->relam);
+	return gpdb::HeapAttIsNull(tup, Anum_pg_index_indexprs) &&
+		gpdb::HeapAttIsNull(tup, Anum_pg_index_indpred) &&
+		(BTREE_AM_OID == index_rel->rd_rel->relam || BITMAP_AM_OID == index_rel->rd_rel->relam  || GIST_AM_OID == index_rel->rd_rel->relam);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PmdpartcnstrIndex
+//		CTranslatorRelcacheToDXL::RetrievePartConstraintForIndex
 //
 //	@doc:
 //		Retrieve part constraint for index
 //
 //---------------------------------------------------------------------------
 CMDPartConstraintGPDB *
-CTranslatorRelcacheToDXL::PmdpartcnstrIndex
+CTranslatorRelcacheToDXL::RetrievePartConstraintForIndex
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const IMDRelation *pmdrel,
-	Node *pnodePartCnstr,
-	DrgPul *pdrgpulDefaultParts,
-	BOOL fUnbounded
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const IMDRelation *md_rel,
+	Node *part_constraint,
+	ULongPtrArray *level_with_default_part_array,
+	BOOL is_unbounded
 	)
 {
-	DrgPdxlcd *pdrgpdxlcd = GPOS_NEW(pmp) DrgPdxlcd(pmp);
-	const ULONG ulColumns = pmdrel->UlColumns();
+	CDXLColDescrArray *dxl_col_descr_array = GPOS_NEW(mp) CDXLColDescrArray(mp);
+	const ULONG num_columns = md_rel->ColumnCount();
 	
-	for (ULONG ul = 0; ul < ulColumns; ul++)
+	for (ULONG ul = 0; ul < num_columns; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		CMDName *pmdnameCol = GPOS_NEW(pmp) CMDName(pmp, pmdcol->Mdname().Pstr());
-		CMDIdGPDB *pmdidColType = CMDIdGPDB::PmdidConvert(pmdcol->PmdidType());
-		pmdidColType->AddRef();
+		const IMDColumn *md_col = md_rel->GetMdCol(ul);
+		CMDName *md_colname = GPOS_NEW(mp) CMDName(mp, md_col->Mdname().GetMDName());
+		CMDIdGPDB *mdid_col_type = CMDIdGPDB::CastMdid(md_col->MdidType());
+		mdid_col_type->AddRef();
 
 		// create a column descriptor for the column
-		CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
+		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr
 										(
-										pmp,
-										pmdnameCol,
-										ul + 1, // ulColId
-										pmdcol->IAttno(),
-										pmdidColType,
-										pmdcol->ITypeModifier(),
+										mp,
+										md_colname,
+										ul + 1, // colid
+										md_col->AttrNum(),
+										mdid_col_type,
+										md_col->TypeModifier(),
 										false // fColDropped
 										);
-		pdrgpdxlcd->Append(pdxlcd);
+		dxl_col_descr_array->Append(dxl_col_descr);
 	}
-	
-	CMDPartConstraintGPDB *pmdpartcnstr = PmdpartcnstrFromNode(pmp, pmda, pdrgpdxlcd, pnodePartCnstr, pdrgpulDefaultParts, fUnbounded);
-	
-	pdrgpdxlcd->Release();
 
-	return pmdpartcnstr;
+	CMDPartConstraintGPDB *mdpart_constraint = RetrievePartConstraintFromNode(mp, md_accessor, dxl_col_descr_array, part_constraint, level_with_default_part_array, is_unbounded);
+	
+	dxl_col_descr_array->Release();
+
+	return mdpart_constraint;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PmdpartcnstrRelation
+//		CTranslatorRelcacheToDXL::RetrievePartConstraintForRel
 //
 //	@doc:
 //		Retrieve part constraint for relation
 //
 //---------------------------------------------------------------------------
 CMDPartConstraintGPDB *
-CTranslatorRelcacheToDXL::PmdpartcnstrRelation
+CTranslatorRelcacheToDXL::RetrievePartConstraintForRel
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	OID oidRel,
-	DrgPmdcol *pdrgpmdcol,
-	bool fhasIndex
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	OID rel_oid,
+	CMDColumnArray *mdcol_array,
+	bool has_index
 	)
 {
 	// get the part constraints
-	List *plDefaultLevelsRel = NIL;
-	Node *pnode = gpdb::PnodePartConstraintRel(oidRel, &plDefaultLevelsRel);
+	List *default_levels_rel = NIL;
+	Node *node = gpdb::GetRelationPartContraints(rel_oid, &default_levels_rel);
 
 	// don't retrieve part constraints if there are no indices
 	// and no default partitions at any level
-	if (!fhasIndex && NIL == plDefaultLevelsRel)
+	if (!has_index && NIL == default_levels_rel)
 	{
 		return NULL;
 	}
 
-	List *plPartKeys = gpdb::PlPartitionAttrs(oidRel);
-	const ULONG ulLevels = gpdb::UlListLength(plPartKeys);
-	gpdb::FreeList(plPartKeys);
+	List *part_keys = gpdb::GetPartitionAttrs(rel_oid);
+	const ULONG num_of_levels = gpdb::ListLength(part_keys);
+	gpdb::ListFree(part_keys);
 
-	BOOL fUnbounded = true;
-	DrgPul *pdrgpulDefaultLevels = GPOS_NEW(pmp) DrgPul(pmp);
-	for (ULONG ul = 0; ul < ulLevels; ul++)
+	BOOL is_unbounded = true;
+	ULongPtrArray *default_levels_derived = GPOS_NEW(mp) ULongPtrArray(mp);
+	for (ULONG ul = 0; ul < num_of_levels; ul++)
 	{
-		if (FDefaultPartition(plDefaultLevelsRel, ul))
+		if (LevelHasDefaultPartition(default_levels_rel, ul))
 		{
-			pdrgpulDefaultLevels->Append(GPOS_NEW(pmp) ULONG(ul));
+			default_levels_derived->Append(GPOS_NEW(mp) ULONG(ul));
 		}
 		else
 		{
-			fUnbounded = false;
+			is_unbounded = false;
 		}
 	}
 
-	CMDPartConstraintGPDB *pmdpartcnstr = NULL;
+	CMDPartConstraintGPDB *mdpart_constraint = NULL;
 
-	if (!fhasIndex)
+	if (!has_index)
 	{
 		// if there are no indices then we don't need to construct the partition constraint
 		// expression since ORCA is never going to use it.
 		// only send the default partition information.
-		pdrgpulDefaultLevels->AddRef();
-		pmdpartcnstr = GPOS_NEW(pmp) CMDPartConstraintGPDB(pmp, pdrgpulDefaultLevels, fUnbounded, NULL);
+		default_levels_derived->AddRef();
+		mdpart_constraint = GPOS_NEW(mp) CMDPartConstraintGPDB(mp, default_levels_derived, is_unbounded, NULL);
 	}
 	else
 	{
-		DrgPdxlcd *pdrgpdxlcd = GPOS_NEW(pmp) DrgPdxlcd(pmp);
-		const ULONG ulColumns = pdrgpmdcol->UlLength();
-		for (ULONG ul = 0; ul < ulColumns; ul++)
+		CDXLColDescrArray *dxl_col_descr_array = GPOS_NEW(mp) CDXLColDescrArray(mp);
+		const ULONG num_columns = mdcol_array->Size();
+		for (ULONG ul = 0; ul < num_columns; ul++)
 		{
-			const IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
-			CMDName *pmdnameCol = GPOS_NEW(pmp) CMDName(pmp, pmdcol->Mdname().Pstr());
-			CMDIdGPDB *pmdidColType = CMDIdGPDB::PmdidConvert(pmdcol->PmdidType());
-			pmdidColType->AddRef();
+			const IMDColumn *md_col = (*mdcol_array)[ul];
+			CMDName *md_colname = GPOS_NEW(mp) CMDName(mp, md_col->Mdname().GetMDName());
+			CMDIdGPDB *mdid_col_type = CMDIdGPDB::CastMdid(md_col->MdidType());
+			mdid_col_type->AddRef();
 
 			// create a column descriptor for the column
-			CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
+			CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr
 											(
-											pmp,
-											pmdnameCol,
-											ul + 1, // ulColId
-											pmdcol->IAttno(),
-											pmdidColType,
-											pmdcol->ITypeModifier(),
+											mp,
+											md_colname,
+											ul + 1, // colid
+											md_col->AttrNum(),
+											mdid_col_type,
+											md_col->TypeModifier(),
 											false // fColDropped
 											);
-			pdrgpdxlcd->Append(pdxlcd);
+			dxl_col_descr_array->Append(dxl_col_descr);
 		}
 
-		pmdpartcnstr = PmdpartcnstrFromNode(pmp, pmda, pdrgpdxlcd, pnode, pdrgpulDefaultLevels, fUnbounded);
-		pdrgpdxlcd->Release();
+		mdpart_constraint = RetrievePartConstraintFromNode(mp, md_accessor, dxl_col_descr_array, node, default_levels_derived, is_unbounded);
+		dxl_col_descr_array->Release();
 	}
 
-	gpdb::FreeList(plDefaultLevelsRel);
-	pdrgpulDefaultLevels->Release();
+	gpdb::ListFree(default_levels_rel);
+	default_levels_derived->Release();
 
-	return pmdpartcnstr;
+	return mdpart_constraint;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PmdpartcnstrFromNode
+//		CTranslatorRelcacheToDXL::RetrievePartConstraintFromNode
 //
 //	@doc:
 //		Retrieve part constraint from GPDB node
 //
 //---------------------------------------------------------------------------
 CMDPartConstraintGPDB *
-CTranslatorRelcacheToDXL::PmdpartcnstrFromNode
+CTranslatorRelcacheToDXL::RetrievePartConstraintFromNode
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	DrgPdxlcd *pdrgpdxlcd,
-	Node *pnodeCnstr,
-	DrgPul *pdrgpulDefaultParts,
-	BOOL fUnbounded
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	CDXLColDescrArray *dxl_col_descr_array,
+	Node *part_constraints,
+	ULongPtrArray *level_with_default_part_array,
+	BOOL is_unbounded
 	)
 {
-	if (NULL == pnodeCnstr)
+	if (NULL == part_constraints)
 	{
 		return NULL;
 	}
 
-	CTranslatorScalarToDXL sctranslator
+	CTranslatorScalarToDXL scalar_translator
 							(
-							pmp,
-							pmda,
+							mp,
+							md_accessor,
 							NULL, // pulidgtorCol
 							NULL, // pulidgtorCTE
-							0, // ulQueryLevel
+							0, // query_level
 							true, // m_fQuery
-							NULL, // phmulCTEEntries
-							NULL // pdrgpdxlnCTE
+							NULL, // query_level_to_cte_map
+							NULL // cte_dxlnode_array
 							);
 
 	// generate a mock mapping between var to column information
-	CMappingVarColId *pmapvarcolid = GPOS_NEW(pmp) CMappingVarColId(pmp);
+	CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
 
-	pmapvarcolid->LoadColumns(0 /*ulQueryLevel */, 1 /* rteIndex */, pdrgpdxlcd);
+	var_colid_mapping->LoadColumns(0 /*query_level */, 1 /* rteIndex */, dxl_col_descr_array);
 
 	// translate the check constraint expression
-	CDXLNode *pdxlnScalar = sctranslator.PdxlnScOpFromExpr((Expr *) pnodeCnstr, pmapvarcolid);
+	CDXLNode *scalar_dxlnode = scalar_translator.TranslateScalarToDXL((Expr *) part_constraints, var_colid_mapping);
 
 	// cleanup
-	GPOS_DELETE(pmapvarcolid);
+	GPOS_DELETE(var_colid_mapping);
 
-	pdrgpulDefaultParts->AddRef();
-	return GPOS_NEW(pmp) CMDPartConstraintGPDB(pmp, pdrgpulDefaultParts, fUnbounded, pdxlnScalar);
+	level_with_default_part_array->AddRef();
+	return GPOS_NEW(mp) CMDPartConstraintGPDB(mp, level_with_default_part_array, is_unbounded, scalar_dxlnode);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::FHasSystemColumns
+//		CTranslatorRelcacheToDXL::RelHasSystemColumns
 //
 //	@doc:
 //		Does given relation type have system columns.
@@ -3636,37 +3629,37 @@ CTranslatorRelcacheToDXL::PmdpartcnstrFromNode
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorRelcacheToDXL::FHasSystemColumns
+CTranslatorRelcacheToDXL::RelHasSystemColumns
 	(
-	char cRelKind
+	char rel_kind
 	)
 {
-	return RELKIND_RELATION == cRelKind || 
-			RELKIND_SEQUENCE == cRelKind || 
-			RELKIND_AOSEGMENTS == cRelKind ||
-			RELKIND_TOASTVALUE == cRelKind;
+	return RELKIND_RELATION == rel_kind ||
+			RELKIND_SEQUENCE == rel_kind ||
+			RELKIND_AOSEGMENTS == rel_kind ||
+			RELKIND_TOASTVALUE == rel_kind;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::Ecmpt
+//		CTranslatorRelcacheToDXL::ParseCmpType
 //
 //	@doc:
 //		Translate GPDB comparison types into optimizer comparison types
 //
 //---------------------------------------------------------------------------
 IMDType::ECmpType
-CTranslatorRelcacheToDXL::Ecmpt
+CTranslatorRelcacheToDXL::ParseCmpType
 	(
-	ULONG ulCmpt
+	ULONG cmpt
 	)
 {
-	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(rgulCmpTypeMappings); ul++)
+	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(cmp_type_mappings); ul++)
 	{
-		const ULONG *pul = rgulCmpTypeMappings[ul];
-		if (pul[1] == ulCmpt)
+		const ULONG *mapping = cmp_type_mappings[ul];
+		if (mapping[1] == cmpt)
 		{
-			return (IMDType::ECmpType) pul[0];
+			return (IMDType::ECmpType) mapping[0];
 		}
 	}
 	
@@ -3675,24 +3668,24 @@ CTranslatorRelcacheToDXL::Ecmpt
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::UlCmpt
+//		CTranslatorRelcacheToDXL::GetComparisonType
 //
 //	@doc:
 //		Translate optimizer comparison types into GPDB comparison types
 //
 //---------------------------------------------------------------------------
 ULONG 
-CTranslatorRelcacheToDXL::UlCmpt
+CTranslatorRelcacheToDXL::GetComparisonType
 	(
-	IMDType::ECmpType ecmpt
+	IMDType::ECmpType cmp_type
 	)
 {
-	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(rgulCmpTypeMappings); ul++)
+	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(cmp_type_mappings); ul++)
 	{
-		const ULONG *pul = rgulCmpTypeMappings[ul];
-		if (pul[0] == ecmpt)
+		const ULONG *mapping = cmp_type_mappings[ul];
+		if (mapping[0] == cmp_type)
 		{
-			return (ULONG) pul[1];
+			return (ULONG) mapping[1];
 		}
 	}
 	
@@ -3701,60 +3694,60 @@ CTranslatorRelcacheToDXL::UlCmpt
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpmdidIndexOpFamilies
+//		CTranslatorRelcacheToDXL::RetrieveIndexOpFamilies
 //
 //	@doc:
 //		Retrieve the opfamilies for the keys of the given index
 //
 //---------------------------------------------------------------------------
-DrgPmdid * 
-CTranslatorRelcacheToDXL::PdrgpmdidIndexOpFamilies
+IMdIdArray *
+CTranslatorRelcacheToDXL::RetrieveIndexOpFamilies
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdidIndex
+	IMemoryPool *mp,
+	IMDId *mdid_index
 	)
 {
-	List *plOpFamilies = gpdb::PlIndexOpFamilies(CMDIdGPDB::PmdidConvert(pmdidIndex)->OidObjectId());
-	DrgPmdid *pdrgpmdid = GPOS_NEW(pmp) DrgPmdid(pmp);
+	List *op_families = gpdb::GetIndexOpFamilies(CMDIdGPDB::CastMdid(mdid_index)->Oid());
+	IMdIdArray *input_col_mdids = GPOS_NEW(mp) IMdIdArray(mp);
 	
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 	
-	ForEach(plc, plOpFamilies)
+	ForEach(lc, op_families)
 	{
-		OID oidOpFamily = lfirst_oid(plc);
-		pdrgpmdid->Append(GPOS_NEW(pmp) CMDIdGPDB(oidOpFamily));
+		OID op_family_oid = lfirst_oid(lc);
+		input_col_mdids->Append(GPOS_NEW(mp) CMDIdGPDB(op_family_oid));
 	}
 	
-	return pdrgpmdid;
+	return input_col_mdids;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpmdidScOpOpFamilies
+//		CTranslatorRelcacheToDXL::RetrieveScOpOpFamilies
 //
 //	@doc:
 //		Retrieve the families for the keys of the given scalar operator
 //
 //---------------------------------------------------------------------------
-DrgPmdid * 
-CTranslatorRelcacheToDXL::PdrgpmdidScOpOpFamilies
+IMdIdArray *
+CTranslatorRelcacheToDXL::RetrieveScOpOpFamilies
 	(
-	IMemoryPool *pmp,
-	IMDId *pmdidScOp
+	IMemoryPool *mp,
+	IMDId *mdid_scalar_op
 	)
 {
-	List *plOpFamilies = gpdb::PlScOpOpFamilies(CMDIdGPDB::PmdidConvert(pmdidScOp)->OidObjectId());
-	DrgPmdid *pdrgpmdid = GPOS_NEW(pmp) DrgPmdid(pmp);
+	List *op_families = gpdb::GetOpFamiliesForScOp(CMDIdGPDB::CastMdid(mdid_scalar_op)->Oid());
+	IMdIdArray *input_col_mdids = GPOS_NEW(mp) IMdIdArray(mp);
 	
-	ListCell *plc = NULL;
+	ListCell *lc = NULL;
 	
-	ForEach(plc, plOpFamilies)
+	ForEach(lc, op_families)
 	{
-		OID oidOpFamily = lfirst_oid(plc);
-		pdrgpmdid->Append(GPOS_NEW(pmp) CMDIdGPDB(oidOpFamily));
+		OID op_family_oid = lfirst_oid(lc);
+		input_col_mdids->Append(GPOS_NEW(mp) CMDIdGPDB(op_family_oid));
 	}
 	
-	return pdrgpmdid;
+	return input_col_mdids;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -63,26 +63,26 @@ using namespace gpopt;
 //---------------------------------------------------------------------------
 CTranslatorScalarToDXL::CTranslatorScalarToDXL
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	CIdGenerator *pulidgtorCol,
-	CIdGenerator *pulidgtorCTE,
-	ULONG ulQueryLevel,
-	BOOL fQuery,
-	HMUlCTEListEntry *phmulCTEEntries,
-	DrgPdxln *pdrgpdxlnCTE
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	CIdGenerator *colid_generator,
+	CIdGenerator *cte_id_generator,
+	ULONG query_level,
+	BOOL is_query_mode,
+	HMUlCTEListEntry *cte_entries,
+	CDXLNodeArray *cte_dxlnode_array
 	)
 	:
-	m_pmp(pmp),
-	m_pmda(pmda),
-	m_pidgtorCol(pulidgtorCol),
-	m_pidgtorCTE(pulidgtorCTE),
-	m_ulQueryLevel(ulQueryLevel),
-	m_fHasDistributedTables(false),
-	m_fQuery(fQuery),
-	m_eplsphoptype(EpspotNone),
-	m_phmulCTEEntries(phmulCTEEntries),
-	m_pdrgpdxlnCTE(pdrgpdxlnCTE)
+	m_mp(mp),
+	m_md_accessor(md_accessor),
+	m_colid_generator(colid_generator),
+	m_cte_id_generator(cte_id_generator),
+	m_query_level(query_level),
+	m_has_distributed_tables(false),
+	m_is_query_mode(is_query_mode),
+	m_op_type(EpspotNone),
+	m_cte_entries(cte_entries),
+	m_cte_producers(cte_dxlnode_array)
 {
 }
 
@@ -100,34 +100,34 @@ CTranslatorScalarToDXL::EdxlbooltypeFromGPDBBoolType
 	)
 	const
 {
-	static ULONG rgrgulMapping[][2] =
+	static ULONG mapping[][2] =
 		{
 		{NOT_EXPR, Edxlnot},
 		{AND_EXPR, Edxland},
 		{OR_EXPR, Edxlor},
 		};
 
-	EdxlBoolExprType edxlbt = EdxlBoolExprTypeSentinel;
+	EdxlBoolExprType type = EdxlBoolExprTypeSentinel;
 
-	const ULONG ulArity = GPOS_ARRAY_SIZE(rgrgulMapping);
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = GPOS_ARRAY_SIZE(mapping);
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		ULONG *pulElem = rgrgulMapping[ul];
-		if ((ULONG) boolexprtype == pulElem[0])
+		ULONG *elem = mapping[ul];
+		if ((ULONG) boolexprtype == elem[0])
 		{
-			edxlbt = (EdxlBoolExprType) pulElem[1];
+			type = (EdxlBoolExprType) elem[1];
 			break;
 		}
 	}
 
-	GPOS_ASSERT(EdxlBoolExprTypeSentinel != edxlbt && "Invalid bool expr type");
+	GPOS_ASSERT(EdxlBoolExprTypeSentinel != type && "Invalid bool expr type");
 
-	return edxlbt;
+	return type;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScIdFromVar
+//		CTranslatorScalarToDXL::TranslateVarToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar ident expression from a GPDB Var expression.
@@ -137,62 +137,62 @@ CTranslatorScalarToDXL::EdxlbooltypeFromGPDBBoolType
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScIdFromVar
+CTranslatorScalarToDXL::TranslateVarToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, Var));
-	const Var * pvar = (Var *) pexpr;
+	GPOS_ASSERT(IsA(expr, Var));
+	const Var * var = (Var *) expr;
 
-	if (pvar->varattno == 0)
+	if (var->varattno == 0)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Whole-row variable"));
 	}
 
 	// column name
-	const CWStringBase *pstr = pmapvarcolid->PstrColName(m_ulQueryLevel, pvar, m_eplsphoptype);
+	const CWStringBase *str = var_colid_mapping->GetOptColName(m_query_level, var, m_op_type);
 
 	// column id
-	ULONG ulId;
+	ULONG id;
 
-	if(pvar->varattno != 0 || EpspotIndexScan == m_eplsphoptype || EpspotIndexOnlyScan == m_eplsphoptype)
+	if(var->varattno != 0 || EpspotIndexScan == m_op_type || EpspotIndexOnlyScan == m_op_type)
 	{
-		ulId = pmapvarcolid->UlColId(m_ulQueryLevel, pvar, m_eplsphoptype);
+		id = var_colid_mapping->GetColId(m_query_level, var, m_op_type);
 	}
 	else
 	{
-		ulId = m_pidgtorCol->UlNextId();
+		id = m_colid_generator->next_id();
 	}
-	CMDName *pmdname = GPOS_NEW(m_pmp) CMDName(m_pmp, pstr);
+	CMDName *mdname = GPOS_NEW(m_mp) CMDName(m_mp, str);
 
 	// create a column reference for the given var
-	CDXLColRef *pdxlcr = GPOS_NEW(m_pmp) CDXLColRef
+	CDXLColRef *dxl_colref = GPOS_NEW(m_mp) CDXLColRef
 												(
-												m_pmp,
-												pmdname,
-												ulId,
-												GPOS_NEW(m_pmp) CMDIdGPDB(pvar->vartype),
-												pvar->vartypmod
+												m_mp,
+												mdname,
+												id,
+												GPOS_NEW(m_mp) CMDIdGPDB(var->vartype),
+												var->vartypmod
 												);
 
 	// create the scalar ident operator
-	CDXLScalarIdent *pdxlopIdent = GPOS_NEW(m_pmp) CDXLScalarIdent
+	CDXLScalarIdent *scalar_ident = GPOS_NEW(m_mp) CDXLScalarIdent
 													(
-													m_pmp,
-													pdxlcr
+													m_mp,
+													dxl_colref
 													);
 
 	// create the DXL node holding the scalar ident operator
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopIdent);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, scalar_ident);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScOpFromExpr
+//		CTranslatorScalarToDXL::TranslateScalarToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar expression from a GPDB expression node.
@@ -202,87 +202,87 @@ CTranslatorScalarToDXL::PdxlnScIdFromVar
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScOpFromExpr
+CTranslatorScalarToDXL::TranslateScalarToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid,
-	BOOL *pfHasDistributedTables // output
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping,
+	BOOL *has_distributed_tables // output
 	)
 {
-	static const STranslatorElem rgTranslators[] =
+	static const STranslatorElem translators[] =
 	{
-		{T_Var, &CTranslatorScalarToDXL::PdxlnScIdFromVar},
-		{T_OpExpr, &CTranslatorScalarToDXL::PdxlnScOpExprFromExpr},
-		{T_ScalarArrayOpExpr, &CTranslatorScalarToDXL::PdxlnArrayOpExpr},
-		{T_DistinctExpr, &CTranslatorScalarToDXL::PdxlnScDistCmpFromDistExpr},
-		{T_Const, &CTranslatorScalarToDXL::PdxlnScConstFromExpr},
-		{T_BoolExpr, &CTranslatorScalarToDXL::PdxlnScBoolExprFromExpr},
-		{T_BooleanTest, &CTranslatorScalarToDXL::PdxlnScBooleanTestFromExpr},
-		{T_CaseExpr, &CTranslatorScalarToDXL::PdxlnScCaseStmtFromExpr},
-		{T_CaseTestExpr, &CTranslatorScalarToDXL::PdxlnScCaseTestFromExpr},
-		{T_CoalesceExpr, &CTranslatorScalarToDXL::PdxlnScCoalesceFromExpr},
-		{T_MinMaxExpr, &CTranslatorScalarToDXL::PdxlnScMinMaxFromExpr},
-		{T_FuncExpr, &CTranslatorScalarToDXL::PdxlnScFuncExprFromFuncExpr},
-		{T_Aggref, &CTranslatorScalarToDXL::PdxlnScAggrefFromAggref},
-		{T_WindowRef, &CTranslatorScalarToDXL::PdxlnScWindowref},
-		{T_NullTest, &CTranslatorScalarToDXL::PdxlnScNullTestFromNullTest},
-		{T_NullIfExpr, &CTranslatorScalarToDXL::PdxlnScNullIfFromExpr},
-		{T_RelabelType, &CTranslatorScalarToDXL::PdxlnScCastFromRelabelType},
-		{T_CoerceToDomain, &CTranslatorScalarToDXL::PdxlnScCoerceFromCoerce},
-		{T_CoerceViaIO, &CTranslatorScalarToDXL::PdxlnScCoerceFromCoerceViaIO},
-		{T_ArrayCoerceExpr, &CTranslatorScalarToDXL::PdxlnScArrayCoerceExprFromExpr},
-		{T_SubLink, &CTranslatorScalarToDXL::PdxlnFromSublink},
-		{T_ArrayExpr, &CTranslatorScalarToDXL::PdxlnArray},
-		{T_ArrayRef, &CTranslatorScalarToDXL::PdxlnArrayRef},
+		{T_Var, &CTranslatorScalarToDXL::TranslateVarToDXL},
+		{T_OpExpr, &CTranslatorScalarToDXL::TranslateOpExprToDXL},
+		{T_ScalarArrayOpExpr, &CTranslatorScalarToDXL::TranslateScalarArrayOpExprToDXL},
+		{T_DistinctExpr, &CTranslatorScalarToDXL::TranslateDistinctExprToDXL},
+		{T_Const, &CTranslatorScalarToDXL::TranslateConstToDXL},
+		{T_BoolExpr, &CTranslatorScalarToDXL::TranslateBoolExprToDXL},
+		{T_BooleanTest, &CTranslatorScalarToDXL::TranslateBooleanTestToDXL},
+		{T_CaseExpr, &CTranslatorScalarToDXL::TranslateCaseExprToDXL},
+		{T_CaseTestExpr, &CTranslatorScalarToDXL::TranslateCaseTestExprToDXL},
+		{T_CoalesceExpr, &CTranslatorScalarToDXL::TranslateCoalesceExprToDXL},
+		{T_MinMaxExpr, &CTranslatorScalarToDXL::TranslateMinMaxExprToDXL},
+		{T_FuncExpr, &CTranslatorScalarToDXL::TranslateFuncExprToDXL},
+		{T_Aggref, &CTranslatorScalarToDXL::TranslateAggrefToDXL},
+		{T_WindowRef, &CTranslatorScalarToDXL::TranslateWindowRefToDXL},
+		{T_NullTest, &CTranslatorScalarToDXL::TranslateNullTestToDXL},
+		{T_NullIfExpr, &CTranslatorScalarToDXL::TranslateNullIfExprToDXL},
+		{T_RelabelType, &CTranslatorScalarToDXL::TranslateRelabelTypeToDXL},
+		{T_CoerceToDomain, &CTranslatorScalarToDXL::TranslateCoerceToDomainToDXL},
+		{T_CoerceViaIO, &CTranslatorScalarToDXL::TranslateCoerceViaIOToDXL},
+		{T_ArrayCoerceExpr, &CTranslatorScalarToDXL::TranslateArrayCoerceExprToDXL},
+		{T_SubLink, &CTranslatorScalarToDXL::TranslateSubLinkToDXL},
+		{T_ArrayExpr, &CTranslatorScalarToDXL::TranslateArrayExprToDXL},
+		{T_ArrayRef, &CTranslatorScalarToDXL::TranslateArrayRefToDXL},
 	};
 
-	const ULONG ulTranslators = GPOS_ARRAY_SIZE(rgTranslators);
-	NodeTag ent = pexpr->type;
+	const ULONG num_translators = GPOS_ARRAY_SIZE(translators);
+	NodeTag tag = expr->type;
 
 	// if an output variable is provided, we need to reset the member variable
-	if (NULL != pfHasDistributedTables)
+	if (NULL != has_distributed_tables)
 	{
-		m_fHasDistributedTables = false;
+		m_has_distributed_tables = false;
 	}
 
 	// save old value for distributed tables flag
-	BOOL fHasDistributedTablesOld = m_fHasDistributedTables;
+	BOOL has_distributed_tables_old = m_has_distributed_tables;
 
 	// find translator for the expression type
-	PfPdxln pf = NULL;
-	for (ULONG ul = 0; ul < ulTranslators; ul++)
+	ExprToDXLFn func_ptr = NULL;
+	for (ULONG ul = 0; ul < num_translators; ul++)
 	{
-		STranslatorElem elem = rgTranslators[ul];
-		if (ent == elem.ent)
+		STranslatorElem elem = translators[ul];
+		if (tag == elem.tag)
 		{
-			pf = elem.pf;
+			func_ptr = elem.func_ptr;
 			break;
 		}
 	}
 
-	if (NULL == pf)
+	if (NULL == func_ptr)
 	{
-		CHAR *sz = (CHAR*) gpdb::SzNodeToString(const_cast<Expr*>(pexpr));
-		CWStringDynamic *pstr = CDXLUtils::PstrFromSz(m_pmp, sz);
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion, pstr->Wsz());
+		CHAR *str = (CHAR*) gpdb::NodeToString(const_cast<Expr*>(expr));
+		CWStringDynamic *wcstr = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, str);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion, wcstr->GetBuffer());
 	}
 
-	CDXLNode *pdxlnReturn = (this->*pf)(pexpr, pmapvarcolid);
+	CDXLNode *return_node = (this->*func_ptr)(expr, var_colid_mapping);
 
 	// combine old and current values for distributed tables flag
-	m_fHasDistributedTables = m_fHasDistributedTables || fHasDistributedTablesOld;
+	m_has_distributed_tables = m_has_distributed_tables || has_distributed_tables_old;
 
-	if (NULL != pfHasDistributedTables && m_fHasDistributedTables)
+	if (NULL != has_distributed_tables && m_has_distributed_tables)
 	{
-		*pfHasDistributedTables = true;
+		*has_distributed_tables = true;
 	}
 
-	return pdxlnReturn;
+	return return_node;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScDistCmpFromDistExpr
+//		CTranslatorScalarToDXL::TranslateDistinctExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar distinct comparison expression from a GPDB
@@ -293,52 +293,52 @@ CTranslatorScalarToDXL::PdxlnScOpFromExpr
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScDistCmpFromDistExpr
+CTranslatorScalarToDXL::TranslateDistinctExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, DistinctExpr));
-	const DistinctExpr *pdistexpr = (DistinctExpr *) pexpr;
+	GPOS_ASSERT(IsA(expr, DistinctExpr));
+	const DistinctExpr *distinct_expr = (DistinctExpr *) expr;
 
 	// process arguments of op expr
-	GPOS_ASSERT(2 == gpdb::UlListLength(pdistexpr->args));
+	GPOS_ASSERT(2 == gpdb::ListLength(distinct_expr->args));
 
-	CDXLNode *pdxlnLeft = PdxlnScOpFromExpr
+	CDXLNode *left_node = TranslateScalarToDXL
 							(
-							(Expr *) gpdb::PvListNth(pdistexpr->args, 0),
-							pmapvarcolid
+							(Expr *) gpdb::ListNth(distinct_expr->args, 0),
+							var_colid_mapping
 							);
 
-	CDXLNode *pdxlnRight = PdxlnScOpFromExpr
+	CDXLNode *right_node = TranslateScalarToDXL
 							(
-							(Expr *) gpdb::PvListNth(pdistexpr->args, 1),
-							pmapvarcolid
+							(Expr *) gpdb::ListNth(distinct_expr->args, 1),
+							var_colid_mapping
 							);
 
-	GPOS_ASSERT(NULL != pdxlnLeft);
-	GPOS_ASSERT(NULL != pdxlnRight);
+	GPOS_ASSERT(NULL != left_node);
+	GPOS_ASSERT(NULL != right_node);
 
-	CDXLScalarDistinctComp *pdxlop = GPOS_NEW(m_pmp) CDXLScalarDistinctComp
+	CDXLScalarDistinctComp *dxlop = GPOS_NEW(m_mp) CDXLScalarDistinctComp
 														(
-														m_pmp,
-														GPOS_NEW(m_pmp) CMDIdGPDB(pdistexpr->opno)
+														m_mp,
+														GPOS_NEW(m_mp) CMDIdGPDB(distinct_expr->opno)
 														);
 
 	// create the DXL node holding the scalar distinct comparison operator
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
 	// add children in the right order
-	pdxln->AddChild(pdxlnLeft);
-	pdxln->AddChild(pdxlnRight);
+	dxlnode->AddChild(left_node);
+	dxlnode->AddChild(right_node);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScCmpFromOpExpr
+//		CTranslatorScalarToDXL::CreateScalarCmpFromOpExpr
 //
 //	@doc:
 //		Create a DXL node for a scalar comparison expression from a GPDB OpExpr.
@@ -348,47 +348,47 @@ CTranslatorScalarToDXL::PdxlnScDistCmpFromDistExpr
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScCmpFromOpExpr
+CTranslatorScalarToDXL::CreateScalarCmpFromOpExpr
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, OpExpr));
-	const OpExpr *popexpr = (OpExpr *) pexpr;
+	GPOS_ASSERT(IsA(expr, OpExpr));
+	const OpExpr *op_expr = (OpExpr *) expr;
 
 	// process arguments of op expr
-	GPOS_ASSERT(2 == gpdb::UlListLength(popexpr->args));
+	GPOS_ASSERT(2 == gpdb::ListLength(op_expr->args));
 
-	Expr *pexprLeft = (Expr *) gpdb::PvListNth(popexpr->args, 0);
-	Expr *pexprRight = (Expr *) gpdb::PvListNth(popexpr->args, 1);
+	Expr *left_expr = (Expr *) gpdb::ListNth(op_expr->args, 0);
+	Expr *right_expr = (Expr *) gpdb::ListNth(op_expr->args, 1);
 
-	CDXLNode *pdxlnLeft = PdxlnScOpFromExpr(pexprLeft, pmapvarcolid);
-	CDXLNode *pdxlnRight = PdxlnScOpFromExpr(pexprRight, pmapvarcolid);
+	CDXLNode *left_node = TranslateScalarToDXL(left_expr, var_colid_mapping);
+	CDXLNode *right_node = TranslateScalarToDXL(right_expr, var_colid_mapping);
 
-	GPOS_ASSERT(NULL != pdxlnLeft);
-	GPOS_ASSERT(NULL != pdxlnRight);
+	GPOS_ASSERT(NULL != left_node);
+	GPOS_ASSERT(NULL != right_node);
 
-	CMDIdGPDB *pmdid = GPOS_NEW(m_pmp) CMDIdGPDB(popexpr->opno);
+	CMDIdGPDB *mdid = GPOS_NEW(m_mp) CMDIdGPDB(op_expr->opno);
 
 	// get operator name
-	const CWStringConst *pstr = PstrOpName(pmdid);
+	const CWStringConst *str = GetDXLArrayCmpType(mdid);
 
-	CDXLScalarComp *pdxlop = GPOS_NEW(m_pmp) CDXLScalarComp(m_pmp, pmdid, GPOS_NEW(m_pmp) CWStringConst(pstr->Wsz()));
+	CDXLScalarComp *dxlop = GPOS_NEW(m_mp) CDXLScalarComp(m_mp, mdid, GPOS_NEW(m_mp) CWStringConst(str->GetBuffer()));
 
 	// create the DXL node holding the scalar comparison operator
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
 	// add children in the right order
-	pdxln->AddChild(pdxlnLeft);
-	pdxln->AddChild(pdxlnRight);
+	dxlnode->AddChild(left_node);
+	dxlnode->AddChild(right_node);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScOpExprFromExpr
+//		CTranslatorScalarToDXL::TranslateOpExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar opexpr from a GPDB OpExpr.
@@ -398,232 +398,232 @@ CTranslatorScalarToDXL::PdxlnScCmpFromOpExpr
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScOpExprFromExpr
+CTranslatorScalarToDXL::TranslateOpExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, OpExpr));
+	GPOS_ASSERT(IsA(expr, OpExpr));
 
-	const OpExpr *popexpr = (OpExpr *) pexpr;
+	const OpExpr *op_expr = (OpExpr *) expr;
 
 	// check if this is a scalar comparison
-	CMDIdGPDB *pmdidReturnType = GPOS_NEW(m_pmp) CMDIdGPDB(((OpExpr *) pexpr)->opresulttype);
-	const IMDType *pmdtype= m_pmda->Pmdtype(pmdidReturnType);
+	CMDIdGPDB *return_type_mdid = GPOS_NEW(m_mp) CMDIdGPDB(((OpExpr *) expr)->opresulttype);
+	const IMDType *md_type= m_md_accessor->RetrieveType(return_type_mdid);
 
-	const ULONG ulArgs = gpdb::UlListLength(popexpr->args);
+	const ULONG num_args = gpdb::ListLength(op_expr->args);
 
-	if (IMDType::EtiBool ==  pmdtype->Eti() && 2 == ulArgs)
+	if (IMDType::EtiBool ==  md_type->GetDatumType() && 2 == num_args)
 	{
-		pmdidReturnType->Release();
-		return PdxlnScCmpFromOpExpr(pexpr, pmapvarcolid);
+		return_type_mdid->Release();
+		return CreateScalarCmpFromOpExpr(expr, var_colid_mapping);
 	}
 
 	// get operator name and id
-	IMDId *pmdid = GPOS_NEW(m_pmp) CMDIdGPDB(popexpr->opno);
-	const CWStringConst *pstr = PstrOpName(pmdid);
+	IMDId *mdid = GPOS_NEW(m_mp) CMDIdGPDB(op_expr->opno);
+	const CWStringConst *str = GetDXLArrayCmpType(mdid);
 
-	CDXLScalarOpExpr *pdxlop = GPOS_NEW(m_pmp) CDXLScalarOpExpr(m_pmp, pmdid, pmdidReturnType, GPOS_NEW(m_pmp) CWStringConst(pstr->Wsz()));
+	CDXLScalarOpExpr *dxlop = GPOS_NEW(m_mp) CDXLScalarOpExpr(m_mp, mdid, return_type_mdid, GPOS_NEW(m_mp) CWStringConst(str->GetBuffer()));
 
 	// create the DXL node holding the scalar opexpr
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
 	// process arguments
-	TranslateScalarChildren(pdxln, popexpr->args, pmapvarcolid);
+	TranslateScalarChildren(dxlnode, op_expr->args, var_colid_mapping);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScNullIfFromExpr
+//		CTranslatorScalarToDXL::TranslateNullIfExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar nullif from a GPDB Expr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScNullIfFromExpr
+CTranslatorScalarToDXL::TranslateNullIfExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, NullIfExpr));
-	const NullIfExpr *pnullifexpr = (NullIfExpr *) pexpr;
+	GPOS_ASSERT(IsA(expr, NullIfExpr));
+	const NullIfExpr *null_if_expr = (NullIfExpr *) expr;
 
-	GPOS_ASSERT(2 == gpdb::UlListLength(pnullifexpr->args));
+	GPOS_ASSERT(2 == gpdb::ListLength(null_if_expr->args));
 
-	CDXLScalarNullIf *pdxlop = GPOS_NEW(m_pmp) CDXLScalarNullIf(m_pmp, GPOS_NEW(m_pmp) CMDIdGPDB(pnullifexpr->opno), GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType((Node *)pnullifexpr)));
+	CDXLScalarNullIf *dxlop = GPOS_NEW(m_mp) CDXLScalarNullIf(m_mp, GPOS_NEW(m_mp) CMDIdGPDB(null_if_expr->opno), GPOS_NEW(m_mp) CMDIdGPDB(gpdb::ExprType((Node *)null_if_expr)));
 
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
 	// process arguments
-	TranslateScalarChildren(pdxln, pnullifexpr->args, pmapvarcolid);
+	TranslateScalarChildren(dxlnode, null_if_expr->args, var_colid_mapping);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnArrayOpExpr
+//		CTranslatorScalarToDXL::TranslateScalarArrayOpExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar array expression from a GPDB OpExpr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnArrayOpExpr
+CTranslatorScalarToDXL::TranslateScalarArrayOpExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	return PdxlnScArrayCompFromExpr(pexpr, pmapvarcolid);
+	return CreateScalarArrayCompFromExpr(expr, var_colid_mapping);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScArrayCompFromExpr
+//		CTranslatorScalarToDXL::CreateScalarArrayCompFromExpr
 //
 //	@doc:
 //		Create a DXL node for a scalar array comparison from a GPDB OpExpr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScArrayCompFromExpr
+CTranslatorScalarToDXL::CreateScalarArrayCompFromExpr
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, ScalarArrayOpExpr));
-	const ScalarArrayOpExpr *pscarrayopexpr = (ScalarArrayOpExpr *) pexpr;
+	GPOS_ASSERT(IsA(expr, ScalarArrayOpExpr));
+	const ScalarArrayOpExpr *scalar_array_op_expr = (ScalarArrayOpExpr *) expr;
 
 	// process arguments of op expr
-	GPOS_ASSERT(2 == gpdb::UlListLength(pscarrayopexpr->args));
+	GPOS_ASSERT(2 == gpdb::ListLength(scalar_array_op_expr->args));
 
-	Expr *pexprLeft = (Expr*) gpdb::PvListNth(pscarrayopexpr->args, 0);
-	CDXLNode *pdxlnLeft = PdxlnScOpFromExpr(pexprLeft, pmapvarcolid);
+	Expr *left_expr = (Expr*) gpdb::ListNth(scalar_array_op_expr->args, 0);
+	CDXLNode *left_node = TranslateScalarToDXL(left_expr, var_colid_mapping);
 
-	Expr *pexprRight = (Expr*) gpdb::PvListNth(pscarrayopexpr->args, 1);
+	Expr *right_expr = (Expr*) gpdb::ListNth(scalar_array_op_expr->args, 1);
 
 	// If the argument array is an array Const, try to transform it to an
 	// ArrayExpr, to allow ORCA to optimize it better. (ORCA knows how to
 	// extract elements of an ArrayExpr, but doesn't currently know how
 	// to do it from an array-typed Const.)
-	if (IsA(pexprRight, Const))
-		pexprRight = gpdb::PexprTransformArrayConstToArrayExpr((Const *) pexprRight);
+	if (IsA(right_expr, Const))
+		right_expr = gpdb::TransformArrayConstToArrayExpr((Const *) right_expr);
 
-	CDXLNode *pdxlnRight = PdxlnScOpFromExpr(pexprRight, pmapvarcolid);
+	CDXLNode *right_node = TranslateScalarToDXL(right_expr, var_colid_mapping);
 
-	GPOS_ASSERT(NULL != pdxlnLeft);
-	GPOS_ASSERT(NULL != pdxlnRight);
+	GPOS_ASSERT(NULL != left_node);
+	GPOS_ASSERT(NULL != right_node);
 
 	// get operator name
-	CMDIdGPDB *pmdidOp = GPOS_NEW(m_pmp) CMDIdGPDB(pscarrayopexpr->opno);
-	const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pmdidOp);
-	pmdidOp->Release();
+	CMDIdGPDB *mdid_op = GPOS_NEW(m_mp) CMDIdGPDB(scalar_array_op_expr->opno);
+	const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(mdid_op);
+	mdid_op->Release();
 
-	const CWStringConst *pstr = pmdscop->Mdname().Pstr();
-	GPOS_ASSERT(NULL != pstr);
+	const CWStringConst *op_name = md_scalar_op->Mdname().GetMDName();
+	GPOS_ASSERT(NULL != op_name);
 
-	EdxlArrayCompType edxlarraycomptype = Edxlarraycomptypeany;
+	EdxlArrayCompType type = Edxlarraycomptypeany;
 
-	if(!pscarrayopexpr->useOr)
+	if(!scalar_array_op_expr->useOr)
 	{
-		edxlarraycomptype = Edxlarraycomptypeall;
+		type = Edxlarraycomptypeall;
 	}
 
-	CDXLScalarArrayComp *pdxlop = GPOS_NEW(m_pmp) CDXLScalarArrayComp(m_pmp, GPOS_NEW(m_pmp) CMDIdGPDB(pscarrayopexpr->opno), GPOS_NEW(m_pmp) CWStringConst(pstr->Wsz()), edxlarraycomptype);
+	CDXLScalarArrayComp *dxlop = GPOS_NEW(m_mp) CDXLScalarArrayComp(m_mp, GPOS_NEW(m_mp) CMDIdGPDB(scalar_array_op_expr->opno), GPOS_NEW(m_mp) CWStringConst(op_name->GetBuffer()), type);
 
 	// create the DXL node holding the scalar opexpr
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
 	// add children in the right order
-	pdxln->AddChild(pdxlnLeft);
-	pdxln->AddChild(pdxlnRight);
+	dxlnode->AddChild(left_node);
+	dxlnode->AddChild(right_node);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScConstFromExpr
+//		CTranslatorScalarToDXL::TranslateConstToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar const value from a GPDB Const
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScConstFromExpr
+CTranslatorScalarToDXL::TranslateConstToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId * // pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId * // var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, Const));
-	const Const *pconst = (Const *) pexpr;
+	GPOS_ASSERT(IsA(expr, Const));
+	const Const *constant = (Const *) expr;
 
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode
 									(
-									m_pmp,
-									GPOS_NEW(m_pmp) CDXLScalarConstValue
+									m_mp,
+									GPOS_NEW(m_mp) CDXLScalarConstValue
 												(
-												m_pmp,
-												Pdxldatum(pconst)
+												m_mp,
+												TranslateConstToDXL(constant)
 												)
 									);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::Pdxldatum
+//		CTranslatorScalarToDXL::TranslateConstToDXL
 //
 //	@doc:
 //		Create a DXL datum from a GPDB Const
 //---------------------------------------------------------------------------
 CDXLDatum *
-CTranslatorScalarToDXL::Pdxldatum
+CTranslatorScalarToDXL::TranslateConstToDXL
 	(
-	IMemoryPool *pmp,
+	IMemoryPool *mp,
 	CMDAccessor *mda,
-	const Const *pconst
+	const Const *constant
 	)
 {
-	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(pconst->consttype);
-	const IMDType *pmdtype= mda->Pmdtype(pmdid);
-	pmdid->Release();
+	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(constant->consttype);
+	const IMDType *md_type= mda->RetrieveType(mdid);
+	mdid->Release();
 
  	// translate gpdb datum into a DXL datum
-	CDXLDatum *pdxldatum = CTranslatorScalarToDXL::Pdxldatum(pmp, pmdtype, pconst->consttypmod, pconst->constisnull,
-															 pconst->constlen,
-															 pconst->constvalue);
+	CDXLDatum *datum_dxl = CTranslatorScalarToDXL::TranslateDatumToDXL(mp, md_type, constant->consttypmod, constant->constisnull,
+															 constant->constlen,
+															 constant->constvalue);
 
-	return pdxldatum;
+	return datum_dxl;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::Pdxldatum
+//		CTranslatorScalarToDXL::TranslateConstToDXL
 //
 //	@doc:
 //		Create a DXL datum from a GPDB Const
 //---------------------------------------------------------------------------
 CDXLDatum *
-CTranslatorScalarToDXL::Pdxldatum
+CTranslatorScalarToDXL::TranslateConstToDXL
 	(
-	const Const *pconst
+	const Const *constant
 	)
 	const
 {
-	return Pdxldatum(m_pmp, m_pmda, pconst);
+	return TranslateConstToDXL(m_mp, m_md_accessor, constant);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScBoolExprFromExpr
+//		CTranslatorScalarToDXL::TranslateBoolExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar boolean expression from a GPDB OpExpr.
@@ -633,25 +633,25 @@ CTranslatorScalarToDXL::Pdxldatum
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScBoolExprFromExpr
+CTranslatorScalarToDXL::TranslateBoolExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, BoolExpr));
-	const BoolExpr *pboolexpr = (BoolExpr *) pexpr;
-	GPOS_ASSERT(0 < gpdb::UlListLength(pboolexpr->args));
+	GPOS_ASSERT(IsA(expr, BoolExpr));
+	const BoolExpr *bool_expr = (BoolExpr *) expr;
+	GPOS_ASSERT(0 < gpdb::ListLength(bool_expr->args));
 
-	EdxlBoolExprType boolexptype = EdxlbooltypeFromGPDBBoolType(pboolexpr->boolop);
-	GPOS_ASSERT(EdxlBoolExprTypeSentinel != boolexptype);
+	EdxlBoolExprType type = EdxlbooltypeFromGPDBBoolType(bool_expr->boolop);
+	GPOS_ASSERT(EdxlBoolExprTypeSentinel != type);
 
 	// create the DXL node holding the scalar boolean operator
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarBoolExpr(m_pmp, boolexptype));
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarBoolExpr(m_mp, type));
 
-	ULONG ulCount = gpdb::UlListLength(pboolexpr->args);
+	ULONG count = gpdb::ListLength(bool_expr->args);
 
-	if ((NOT_EXPR != pboolexpr->boolop) && (2 > ulCount))
+	if ((NOT_EXPR != bool_expr->boolop) && (2 > count))
 	{
 		GPOS_RAISE
 			(
@@ -660,7 +660,7 @@ CTranslatorScalarToDXL::PdxlnScBoolExprFromExpr
 			GPOS_WSZ_LIT("Boolean Expression (OR / AND): Incorrect Number of Children ")
 			);
 	}
-	else if ((NOT_EXPR == pboolexpr->boolop) && (1 != ulCount))
+	else if ((NOT_EXPR == bool_expr->boolop) && (1 != count))
 	{
 		GPOS_RAISE
 			(
@@ -670,14 +670,14 @@ CTranslatorScalarToDXL::PdxlnScBoolExprFromExpr
 			);
 	}
 
-	TranslateScalarChildren(pdxln, pboolexpr->args, pmapvarcolid);
+	TranslateScalarChildren(dxlnode, bool_expr->args, var_colid_mapping);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScBooleanTestFromExpr
+//		CTranslatorScalarToDXL::TranslateBooleanTestToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar boolean test from a GPDB OpExpr.
@@ -687,19 +687,19 @@ CTranslatorScalarToDXL::PdxlnScBoolExprFromExpr
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScBooleanTestFromExpr
+CTranslatorScalarToDXL::TranslateBooleanTestToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, BooleanTest));
+	GPOS_ASSERT(IsA(expr, BooleanTest));
 
-	const BooleanTest *pbooleantest = (BooleanTest *) pexpr;
+	const BooleanTest *boolean_test = (BooleanTest *) expr;
 
-	GPOS_ASSERT(NULL != pbooleantest->arg);
+	GPOS_ASSERT(NULL != boolean_test->arg);
 
-	static ULONG rgrgulMapping[][2] =
+	static ULONG mapping[][2] =
 		{
 		{IS_TRUE, EdxlbooleantestIsTrue},
 		{IS_NOT_TRUE, EdxlbooleantestIsNotTrue},
@@ -709,144 +709,144 @@ CTranslatorScalarToDXL::PdxlnScBooleanTestFromExpr
 		{IS_NOT_UNKNOWN, EdxlbooleantestIsNotUnknown},
 		};
 
-	EdxlBooleanTestType edxlbt = EdxlbooleantestSentinel;
-	const ULONG ulArity = GPOS_ARRAY_SIZE(rgrgulMapping);
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	EdxlBooleanTestType type = EdxlbooleantestSentinel;
+	const ULONG arity = GPOS_ARRAY_SIZE(mapping);
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		ULONG *pulElem = rgrgulMapping[ul];
-		if ((ULONG) pbooleantest->booltesttype == pulElem[0])
+		ULONG *elem = mapping[ul];
+		if ((ULONG) boolean_test->booltesttype == elem[0])
 		{
-			edxlbt = (EdxlBooleanTestType) pulElem[1];
+			type = (EdxlBooleanTestType) elem[1];
 			break;
 		}
 	}
-	GPOS_ASSERT(EdxlbooleantestSentinel != edxlbt && "Invalid boolean test type");
+	GPOS_ASSERT(EdxlbooleantestSentinel != type && "Invalid boolean test type");
 
 	// create the DXL node holding the scalar boolean test operator
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode
 									(
-									m_pmp,
-									GPOS_NEW(m_pmp) CDXLScalarBooleanTest(m_pmp,edxlbt)
+									m_mp,
+									GPOS_NEW(m_mp) CDXLScalarBooleanTest(m_mp,type)
 									);
 
-	CDXLNode *pdxlnArg = PdxlnScOpFromExpr(pbooleantest->arg, pmapvarcolid);
-	GPOS_ASSERT(NULL != pdxlnArg);
+	CDXLNode *dxlnode_arg = TranslateScalarToDXL(boolean_test->arg, var_colid_mapping);
+	GPOS_ASSERT(NULL != dxlnode_arg);
 
-	pdxln->AddChild(pdxlnArg);
+	dxlnode->AddChild(dxlnode_arg);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScNullTestFromNullTest
+//		CTranslatorScalarToDXL::TranslateNullTestToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar nulltest expression from a GPDB OpExpr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScNullTestFromNullTest
+CTranslatorScalarToDXL::TranslateNullTestToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, NullTest));
-	const NullTest *pnulltest = (NullTest *) pexpr;
+	GPOS_ASSERT(IsA(expr, NullTest));
+	const NullTest *null_test = (NullTest *) expr;
 
-	GPOS_ASSERT(NULL != pnulltest->arg);
-	CDXLNode *pdxlnChild = PdxlnScOpFromExpr(pnulltest->arg, pmapvarcolid);
+	GPOS_ASSERT(NULL != null_test->arg);
+	CDXLNode *child_node = TranslateScalarToDXL(null_test->arg, var_colid_mapping);
 
-	GPOS_ASSERT(NULL != pdxlnChild);
-	GPOS_ASSERT(IS_NULL == pnulltest->nulltesttype || IS_NOT_NULL == pnulltest->nulltesttype);
+	GPOS_ASSERT(NULL != child_node);
+	GPOS_ASSERT(IS_NULL == null_test->nulltesttype || IS_NOT_NULL == null_test->nulltesttype);
 
-	BOOL fIsNull = false;
-	if (IS_NULL == pnulltest->nulltesttype)
+	BOOL is_null = false;
+	if (IS_NULL == null_test->nulltesttype)
 	{
-		fIsNull = true;
+		is_null = true;
 	}
 
 	// create the DXL node holding the scalar NullTest operator
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarNullTest(m_pmp, fIsNull));
-	pdxln->AddChild(pdxlnChild);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarNullTest(m_mp, is_null));
+	dxlnode->AddChild(child_node);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScCoalesceFromExpr
+//		CTranslatorScalarToDXL::TranslateCoalesceExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a coalesce function from a GPDB OpExpr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScCoalesceFromExpr
+CTranslatorScalarToDXL::TranslateCoalesceExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, CoalesceExpr));
+	GPOS_ASSERT(IsA(expr, CoalesceExpr));
 
-	CoalesceExpr *pcoalesceexpr = (CoalesceExpr *) pexpr;
-	GPOS_ASSERT(NULL != pcoalesceexpr->args);
+	CoalesceExpr *coalesce_expr = (CoalesceExpr *) expr;
+	GPOS_ASSERT(NULL != coalesce_expr->args);
 
-	CDXLScalarCoalesce *pdxlop = GPOS_NEW(m_pmp) CDXLScalarCoalesce
+	CDXLScalarCoalesce *dxlop = GPOS_NEW(m_mp) CDXLScalarCoalesce
 											(
-											m_pmp,
-											GPOS_NEW(m_pmp) CMDIdGPDB(pcoalesceexpr->coalescetype)
+											m_mp,
+											GPOS_NEW(m_mp) CMDIdGPDB(coalesce_expr->coalescetype)
 											);
 
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
-	TranslateScalarChildren(pdxln, pcoalesceexpr->args, pmapvarcolid);
+	TranslateScalarChildren(dxlnode, coalesce_expr->args, var_colid_mapping);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScMinMaxFromExpr
+//		CTranslatorScalarToDXL::TranslateMinMaxExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a min/max operator from a GPDB OpExpr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScMinMaxFromExpr
+CTranslatorScalarToDXL::TranslateMinMaxExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, MinMaxExpr));
+	GPOS_ASSERT(IsA(expr, MinMaxExpr));
 
-	MinMaxExpr *pminmaxexpr = (MinMaxExpr *) pexpr;
-	GPOS_ASSERT(NULL != pminmaxexpr->args);
+	MinMaxExpr *min_max_expr = (MinMaxExpr *) expr;
+	GPOS_ASSERT(NULL != min_max_expr->args);
 
-	CDXLScalarMinMax::EdxlMinMaxType emmt = CDXLScalarMinMax::EmmtSentinel;
-	if (IS_GREATEST == pminmaxexpr->op)
+	CDXLScalarMinMax::EdxlMinMaxType min_max_type = CDXLScalarMinMax::EmmtSentinel;
+	if (IS_GREATEST == min_max_expr->op)
 	{
-		emmt = CDXLScalarMinMax::EmmtMax;
+		min_max_type = CDXLScalarMinMax::EmmtMax;
 	}
 	else
 	{
-		GPOS_ASSERT(IS_LEAST == pminmaxexpr->op);
-		emmt = CDXLScalarMinMax::EmmtMin;
+		GPOS_ASSERT(IS_LEAST == min_max_expr->op);
+		min_max_type = CDXLScalarMinMax::EmmtMin;
 	}
 
-	CDXLScalarMinMax *pdxlop = GPOS_NEW(m_pmp) CDXLScalarMinMax
+	CDXLScalarMinMax *dxlop = GPOS_NEW(m_mp) CDXLScalarMinMax
 											(
-											m_pmp,
-											GPOS_NEW(m_pmp) CMDIdGPDB(pminmaxexpr->minmaxtype),
-											emmt
+											m_mp,
+											GPOS_NEW(m_mp) CMDIdGPDB(min_max_expr->minmaxtype),
+											min_max_type
 											);
 
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
-	TranslateScalarChildren(pdxln, pminmaxexpr->args, pmapvarcolid);
+	TranslateScalarChildren(dxlnode, min_max_expr->args, var_colid_mapping);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
@@ -859,25 +859,25 @@ CTranslatorScalarToDXL::PdxlnScMinMaxFromExpr
 void
 CTranslatorScalarToDXL::TranslateScalarChildren
 	(
-	CDXLNode *pdxln,
-	List *plist,
-	const CMappingVarColId* pmapvarcolid,
-	BOOL *pfHasDistributedTables // output
+	CDXLNode *dxlnode,
+	List *list,
+	const CMappingVarColId* var_colid_mapping,
+	BOOL *has_distributed_tables // output
 	)
 {
-	ListCell *plc = NULL;
-	ForEach (plc, plist)
+	ListCell *lc = NULL;
+	ForEach (lc, list)
 	{
-		Expr *pexprChild = (Expr *) lfirst(plc);
-		CDXLNode *pdxlnChild = PdxlnScOpFromExpr(pexprChild, pmapvarcolid, pfHasDistributedTables);
-		GPOS_ASSERT(NULL != pdxlnChild);
-		pdxln->AddChild(pdxlnChild);
+		Expr *child_expr = (Expr *) lfirst(lc);
+		CDXLNode *child_node = TranslateScalarToDXL(child_expr, var_colid_mapping, has_distributed_tables);
+		GPOS_ASSERT(NULL != child_node);
+		dxlnode->AddChild(child_node);
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScCaseStmtFromExpr
+//		CTranslatorScalarToDXL::TranslateCaseExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a case statement from a GPDB OpExpr.
@@ -887,17 +887,17 @@ CTranslatorScalarToDXL::TranslateScalarChildren
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScCaseStmtFromExpr
+CTranslatorScalarToDXL::TranslateCaseExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, CaseExpr));
+	GPOS_ASSERT(IsA(expr, CaseExpr));
 
-	const CaseExpr *pcaseexpr = (CaseExpr *) pexpr;
+	const CaseExpr *case_expr = (CaseExpr *) expr;
 
-	if (NULL == pcaseexpr->args)
+	if (NULL == case_expr->args)
 	{
 			GPOS_RAISE
 				(
@@ -908,332 +908,332 @@ CTranslatorScalarToDXL::PdxlnScCaseStmtFromExpr
 			return NULL;
 	}
 
-	if (NULL == pcaseexpr->arg)
+	if (NULL == case_expr->arg)
 	{
-		return PdxlnScIfStmtFromCaseExpr(pcaseexpr, pmapvarcolid);
+		return CreateScalarIfStmtFromCaseExpr(case_expr, var_colid_mapping);
 	}
 
-	return PdxlnScSwitchFromCaseExpr(pcaseexpr, pmapvarcolid);
+	return CreateScalarSwitchFromCaseExpr(case_expr, var_colid_mapping);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScSwitchFromCaseExpr
+//		CTranslatorScalarToDXL::CreateScalarSwitchFromCaseExpr
 //
 //	@doc:
 //		Create a DXL Switch node from a GPDB CaseExpr.
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScSwitchFromCaseExpr
+CTranslatorScalarToDXL::CreateScalarSwitchFromCaseExpr
 	(
-	const CaseExpr *pcaseexpr,
-	const CMappingVarColId* pmapvarcolid
+	const CaseExpr *case_expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT (NULL != pcaseexpr->arg);
+	GPOS_ASSERT (NULL != case_expr->arg);
 
-	CDXLScalarSwitch *pdxlop = GPOS_NEW(m_pmp) CDXLScalarSwitch
+	CDXLScalarSwitch *dxlop = GPOS_NEW(m_mp) CDXLScalarSwitch
 												(
-												m_pmp,
-												GPOS_NEW(m_pmp) CMDIdGPDB(pcaseexpr->casetype)
+												m_mp,
+												GPOS_NEW(m_mp) CMDIdGPDB(case_expr->casetype)
 												);
-	CDXLNode *pdxlnSwitch = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *switch_node = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
 	// translate the switch expression
-	CDXLNode *pdxlnArg = PdxlnScOpFromExpr(pcaseexpr->arg, pmapvarcolid);
-	pdxlnSwitch->AddChild(pdxlnArg);
+	CDXLNode *dxlnode_arg = TranslateScalarToDXL(case_expr->arg, var_colid_mapping);
+	switch_node->AddChild(dxlnode_arg);
 
 	// translate the cases
-	ListCell *plc = NULL;
-	ForEach (plc, pcaseexpr->args)
+	ListCell *lc = NULL;
+	ForEach (lc, case_expr->args)
 	{
-		CaseWhen *pexpr = (CaseWhen *) lfirst(plc);
+		CaseWhen *expr = (CaseWhen *) lfirst(lc);
 
-		CDXLScalarSwitchCase *pdxlopCase = GPOS_NEW(m_pmp) CDXLScalarSwitchCase(m_pmp);
-		CDXLNode *pdxlnCase = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopCase);
+		CDXLScalarSwitchCase *swtich_case = GPOS_NEW(m_mp) CDXLScalarSwitchCase(m_mp);
+		CDXLNode *switch_case_node = GPOS_NEW(m_mp) CDXLNode(m_mp, swtich_case);
 
-		CDXLNode *pdxlnCmpExpr = PdxlnScOpFromExpr(pexpr->expr, pmapvarcolid);
-		GPOS_ASSERT(NULL != pdxlnCmpExpr);
+		CDXLNode *cmp_expr_node = TranslateScalarToDXL(expr->expr, var_colid_mapping);
+		GPOS_ASSERT(NULL != cmp_expr_node);
 
-		CDXLNode *pdxlnResult = PdxlnScOpFromExpr(pexpr->result, pmapvarcolid);
-		GPOS_ASSERT(NULL != pdxlnResult);
+		CDXLNode *result_node = TranslateScalarToDXL(expr->result, var_colid_mapping);
+		GPOS_ASSERT(NULL != result_node);
 
-		pdxlnCase->AddChild(pdxlnCmpExpr);
-		pdxlnCase->AddChild(pdxlnResult);
+		switch_case_node->AddChild(cmp_expr_node);
+		switch_case_node->AddChild(result_node);
 
 		// add current case to switch node
-		pdxlnSwitch->AddChild(pdxlnCase);
+		switch_node->AddChild(switch_case_node);
 	}
 
 	// translate the "else" clause
-	if (NULL != pcaseexpr->defresult)
+	if (NULL != case_expr->defresult)
 	{
-		CDXLNode *pdxlnDefaultResult = PdxlnScOpFromExpr(pcaseexpr->defresult, pmapvarcolid);
-		GPOS_ASSERT(NULL != pdxlnDefaultResult);
+		CDXLNode *default_result_node = TranslateScalarToDXL(case_expr->defresult, var_colid_mapping);
+		GPOS_ASSERT(NULL != default_result_node);
 
-		pdxlnSwitch->AddChild(pdxlnDefaultResult);
+		switch_node->AddChild(default_result_node);
 
 	}
 
-	return pdxlnSwitch;
+	return switch_node;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScCaseTestFromExpr
+//		CTranslatorScalarToDXL::TranslateCaseTestExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a case test from a GPDB Expr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScCaseTestFromExpr
+CTranslatorScalarToDXL::TranslateCaseTestExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* //pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* //var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, CaseTestExpr));
-	const CaseTestExpr *pcasetestexpr = (CaseTestExpr *) pexpr;
-	CDXLScalarCaseTest *pdxlop = GPOS_NEW(m_pmp) CDXLScalarCaseTest
+	GPOS_ASSERT(IsA(expr, CaseTestExpr));
+	const CaseTestExpr *case_test_expr = (CaseTestExpr *) expr;
+	CDXLScalarCaseTest *dxlop = GPOS_NEW(m_mp) CDXLScalarCaseTest
 												(
-												m_pmp,
-												GPOS_NEW(m_pmp) CMDIdGPDB(pcasetestexpr->typeId)
+												m_mp,
+												GPOS_NEW(m_mp) CMDIdGPDB(case_test_expr->typeId)
 												);
 
-	return GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScIfStmtFromCaseExpr
+//		CTranslatorScalarToDXL::CreateScalarIfStmtFromCaseExpr
 //
 //	@doc:
 //		Create a DXL If node from a GPDB CaseExpr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScIfStmtFromCaseExpr
+CTranslatorScalarToDXL::CreateScalarIfStmtFromCaseExpr
 	(
-	const CaseExpr *pcaseexpr,
-	const CMappingVarColId* pmapvarcolid
+	const CaseExpr *case_expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT (NULL == pcaseexpr->arg);
-	const ULONG ulWhenClauseCount = gpdb::UlListLength(pcaseexpr->args);
+	GPOS_ASSERT (NULL == case_expr->arg);
+	const ULONG when_clause_count = gpdb::ListLength(case_expr->args);
 
-	CDXLNode *pdxlnRootIfTree = NULL;
-	CDXLNode *pdxlnCurr = NULL;
+	CDXLNode *root_if_tree_node = NULL;
+	CDXLNode *cur_node = NULL;
 
-	for (ULONG ul = 0; ul < ulWhenClauseCount; ul++)
+	for (ULONG ul = 0; ul < when_clause_count; ul++)
 	{
-		CDXLScalarIfStmt *pdxlopIfstmtNew = GPOS_NEW(m_pmp) CDXLScalarIfStmt
+		CDXLScalarIfStmt *if_stmt_new_dxl = GPOS_NEW(m_mp) CDXLScalarIfStmt
 															(
-															m_pmp,
-															GPOS_NEW(m_pmp) CMDIdGPDB(pcaseexpr->casetype)
+															m_mp,
+															GPOS_NEW(m_mp) CMDIdGPDB(case_expr->casetype)
 															);
 
-		CDXLNode *pdxlnIfStmtNew = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopIfstmtNew);
+		CDXLNode *if_stmt_new_node = GPOS_NEW(m_mp) CDXLNode(m_mp, if_stmt_new_dxl);
 
-		CaseWhen *pexpr = (CaseWhen *) gpdb::PvListNth(pcaseexpr->args, ul);
-		GPOS_ASSERT(IsA(pexpr, CaseWhen));
+		CaseWhen *expr = (CaseWhen *) gpdb::ListNth(case_expr->args, ul);
+		GPOS_ASSERT(IsA(expr, CaseWhen));
 
-		CDXLNode *pdxlnCond = PdxlnScOpFromExpr(pexpr->expr, pmapvarcolid);
-		CDXLNode *pdxlnResult = PdxlnScOpFromExpr(pexpr->result, pmapvarcolid);
+		CDXLNode *cond_node = TranslateScalarToDXL(expr->expr, var_colid_mapping);
+		CDXLNode *result_node = TranslateScalarToDXL(expr->result, var_colid_mapping);
 
-		GPOS_ASSERT(NULL != pdxlnCond);
-		GPOS_ASSERT(NULL != pdxlnResult);
+		GPOS_ASSERT(NULL != cond_node);
+		GPOS_ASSERT(NULL != result_node);
 
-		pdxlnIfStmtNew->AddChild(pdxlnCond);
-		pdxlnIfStmtNew->AddChild(pdxlnResult);
+		if_stmt_new_node->AddChild(cond_node);
+		if_stmt_new_node->AddChild(result_node);
 
-		if(NULL == pdxlnRootIfTree)
+		if(NULL == root_if_tree_node)
 		{
-			pdxlnRootIfTree = pdxlnIfStmtNew;
+			root_if_tree_node = if_stmt_new_node;
 		}
 		else
 		{
-			pdxlnCurr->AddChild(pdxlnIfStmtNew);
+			cur_node->AddChild(if_stmt_new_node);
 		}
-		pdxlnCurr = pdxlnIfStmtNew;
+		cur_node = if_stmt_new_node;
 	}
 
-	if (NULL != pcaseexpr->defresult)
+	if (NULL != case_expr->defresult)
 	{
-		CDXLNode *pdxlnDefaultResult = PdxlnScOpFromExpr(pcaseexpr->defresult, pmapvarcolid);
-		GPOS_ASSERT(NULL != pdxlnDefaultResult);
-		pdxlnCurr->AddChild(pdxlnDefaultResult);
+		CDXLNode *default_result_node = TranslateScalarToDXL(case_expr->defresult, var_colid_mapping);
+		GPOS_ASSERT(NULL != default_result_node);
+		cur_node->AddChild(default_result_node);
 	}
 
-	return pdxlnRootIfTree;
+	return root_if_tree_node;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScCastFromRelabelType
+//		CTranslatorScalarToDXL::TranslateRelabelTypeToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar RelabelType expression from a GPDB RelabelType
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScCastFromRelabelType
+CTranslatorScalarToDXL::TranslateRelabelTypeToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, RelabelType));
+	GPOS_ASSERT(IsA(expr, RelabelType));
 
-	const RelabelType *prelabeltype = (RelabelType *) pexpr;
+	const RelabelType *relabel_type = (RelabelType *) expr;
 
-	GPOS_ASSERT(NULL != prelabeltype->arg);
+	GPOS_ASSERT(NULL != relabel_type->arg);
 
-	CDXLNode *pdxlnChild = PdxlnScOpFromExpr(prelabeltype->arg, pmapvarcolid);
+	CDXLNode *child_node = TranslateScalarToDXL(relabel_type->arg, var_colid_mapping);
 
-	GPOS_ASSERT(NULL != pdxlnChild);
+	GPOS_ASSERT(NULL != child_node);
 
 	// create the DXL node holding the scalar boolean operator
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode
 									(
-									m_pmp,
-									GPOS_NEW(m_pmp) CDXLScalarCast
+									m_mp,
+									GPOS_NEW(m_mp) CDXLScalarCast
 												(
-												m_pmp,
-												GPOS_NEW(m_pmp) CMDIdGPDB(prelabeltype->resulttype),
-												GPOS_NEW(m_pmp) CMDIdGPDB(0) // casting function oid
+												m_mp,
+												GPOS_NEW(m_mp) CMDIdGPDB(relabel_type->resulttype),
+												GPOS_NEW(m_mp) CMDIdGPDB(0) // casting function oid
 												)
 									);
-	pdxln->AddChild(pdxlnChild);
+	dxlnode->AddChild(child_node);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //      @function:
-//              CTranslatorScalarToDXL::PdxlnScCoerceFromCoerce
+//              CTranslatorScalarToDXL::TranslateCoerceToDomainToDXL
 //
 //      @doc:
 //              Create a DXL node for a scalar coerce expression from a
 //             GPDB coerce expression
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScCoerceFromCoerce
+CTranslatorScalarToDXL::TranslateCoerceToDomainToDXL
         (
-        const Expr *pexpr,
-        const CMappingVarColId* pmapvarcolid
+        const Expr *expr,
+        const CMappingVarColId* var_colid_mapping
         )
 {
-        GPOS_ASSERT(IsA(pexpr, CoerceToDomain));
+        GPOS_ASSERT(IsA(expr, CoerceToDomain));
 
-        const CoerceToDomain *pcoerce = (CoerceToDomain *) pexpr;
+        const CoerceToDomain *coerce = (CoerceToDomain *) expr;
 
-        GPOS_ASSERT(NULL != pcoerce->arg);
+        GPOS_ASSERT(NULL != coerce->arg);
 
-        CDXLNode *pdxlnChild = PdxlnScOpFromExpr(pcoerce->arg, pmapvarcolid);
+        CDXLNode *child_node = TranslateScalarToDXL(coerce->arg, var_colid_mapping);
 
-        GPOS_ASSERT(NULL != pdxlnChild);
+        GPOS_ASSERT(NULL != child_node);
 
         // create the DXL node holding the scalar boolean operator
-        CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode
+        CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode
                                                                         (
-                                                                        m_pmp,
-                                                                        GPOS_NEW(m_pmp) CDXLScalarCoerceToDomain
+                                                                        m_mp,
+                                                                        GPOS_NEW(m_mp) CDXLScalarCoerceToDomain
                                                                                                 (
-                                                                                                m_pmp,
-                                                                                                GPOS_NEW(m_pmp) CMDIdGPDB(pcoerce->resulttype),
-                                                                                               pcoerce->resulttypmod,
-                                                                                               (EdxlCoercionForm) pcoerce->coercionformat,
-                                                                                               pcoerce->location
+                                                                                                m_mp,
+                                                                                                GPOS_NEW(m_mp) CMDIdGPDB(coerce->resulttype),
+                                                                                               coerce->resulttypmod,
+                                                                                               (EdxlCoercionForm) coerce->coercionformat,
+                                                                                               coerce->location
                                                                                                 )
                                                                         );
-        pdxln->AddChild(pdxlnChild);
+        dxlnode->AddChild(child_node);
 
-        return pdxln;
+        return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //      @function:
-//              CTranslatorScalarToDXL::PdxlnScCoerceFromCoerceViaIO
+//              CTranslatorScalarToDXL::TranslateCoerceViaIOToDXL
 //
 //      @doc:
 //              Create a DXL node for a scalar coerce expression from a
 //             GPDB coerce expression
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScCoerceFromCoerceViaIO
+CTranslatorScalarToDXL::TranslateCoerceViaIOToDXL
         (
-        const Expr *pexpr,
-        const CMappingVarColId* pmapvarcolid
+        const Expr *expr,
+        const CMappingVarColId* var_colid_mapping
         )
 {
-        GPOS_ASSERT(IsA(pexpr, CoerceViaIO));
+        GPOS_ASSERT(IsA(expr, CoerceViaIO));
 
-        const CoerceViaIO *pcoerce = (CoerceViaIO *) pexpr;
+        const CoerceViaIO *coerce = (CoerceViaIO *) expr;
 
-        GPOS_ASSERT(NULL != pcoerce->arg);
+        GPOS_ASSERT(NULL != coerce->arg);
 
-        CDXLNode *pdxlnChild = PdxlnScOpFromExpr(pcoerce->arg, pmapvarcolid);
+        CDXLNode *child_node = TranslateScalarToDXL(coerce->arg, var_colid_mapping);
 
-        GPOS_ASSERT(NULL != pdxlnChild);
+        GPOS_ASSERT(NULL != child_node);
 
         // create the DXL node holding the scalar boolean operator
-        CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode
+        CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode
                                                                         (
-                                                                        m_pmp,
-                                                                        GPOS_NEW(m_pmp) CDXLScalarCoerceViaIO
+                                                                        m_mp,
+                                                                        GPOS_NEW(m_mp) CDXLScalarCoerceViaIO
                                                                                                 (
-                                                                                                m_pmp,
-                                                                                                GPOS_NEW(m_pmp) CMDIdGPDB(pcoerce->resulttype),
+                                                                                                m_mp,
+                                                                                                GPOS_NEW(m_mp) CMDIdGPDB(coerce->resulttype),
                                                                                                -1,
-                                                                                               (EdxlCoercionForm) pcoerce->coerceformat,
-                                                                                               pcoerce->location
+                                                                                               (EdxlCoercionForm) coerce->coerceformat,
+                                                                                               coerce->location
                                                                                                 )
                                                                         );
-        pdxln->AddChild(pdxlnChild);
+        dxlnode->AddChild(child_node);
 
-        return pdxln;
+        return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScArrayCoerceExprFromExpr
+//		CTranslatorScalarToDXL::TranslateArrayCoerceExprToDXL
 //	@doc:
 //		Create a DXL node for a scalar array coerce expression from a
 // 		GPDB Array Coerce expression
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScArrayCoerceExprFromExpr
+CTranslatorScalarToDXL::TranslateArrayCoerceExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, ArrayCoerceExpr));
-	const ArrayCoerceExpr *parraycoerce = (ArrayCoerceExpr *) pexpr;
+	GPOS_ASSERT(IsA(expr, ArrayCoerceExpr));
+	const ArrayCoerceExpr *array_coerce_expr = (ArrayCoerceExpr *) expr;
 	
-	GPOS_ASSERT(NULL != parraycoerce->arg);
+	GPOS_ASSERT(NULL != array_coerce_expr->arg);
 	
-	CDXLNode *pdxlnChild = PdxlnScOpFromExpr(parraycoerce->arg, pmapvarcolid);
+	CDXLNode *child_node = TranslateScalarToDXL(array_coerce_expr->arg, var_colid_mapping);
 	
-	GPOS_ASSERT(NULL != pdxlnChild);
+	GPOS_ASSERT(NULL != child_node);
 	
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode
 					(
-					m_pmp,
-					GPOS_NEW(m_pmp) CDXLScalarArrayCoerceExpr
+					m_mp,
+					GPOS_NEW(m_mp) CDXLScalarArrayCoerceExpr
 							(
-							m_pmp,
-							GPOS_NEW(m_pmp) CMDIdGPDB(parraycoerce->elemfuncid),
-							GPOS_NEW(m_pmp) CMDIdGPDB(parraycoerce->resulttype),
-							parraycoerce->resulttypmod,
-							parraycoerce->isExplicit,
-							(EdxlCoercionForm) parraycoerce->coerceformat,
-							parraycoerce->location
+							m_mp,
+							GPOS_NEW(m_mp) CMDIdGPDB(array_coerce_expr->elemfuncid),
+							GPOS_NEW(m_mp) CMDIdGPDB(array_coerce_expr->resulttype),
+							array_coerce_expr->resulttypmod,
+							array_coerce_expr->isExplicit,
+							(EdxlCoercionForm) array_coerce_expr->coerceformat,
+							array_coerce_expr->location
 							)
 					);
 	
-        pdxln->AddChild(pdxlnChild);
+        dxlnode->AddChild(child_node);
 
-        return pdxln;
+        return dxlnode;
 }
 
 
@@ -1241,46 +1241,46 @@ CTranslatorScalarToDXL::PdxlnScArrayCoerceExprFromExpr
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScFuncExprFromFuncExpr
+//		CTranslatorScalarToDXL::TranslateFuncExprToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar funcexpr from a GPDB FuncExpr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScFuncExprFromFuncExpr
+CTranslatorScalarToDXL::TranslateFuncExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, FuncExpr));
-	const FuncExpr *pfuncexpr = (FuncExpr *) pexpr;
-	int32 iTypeModifier = gpdb::IExprTypeMod((Node *) pexpr);
+	GPOS_ASSERT(IsA(expr, FuncExpr));
+	const FuncExpr *func_expr = (FuncExpr *) expr;
+	int32 type_modifier = gpdb::ExprTypeMod((Node *) expr);
 
-	CMDIdGPDB *pmdidFunc = GPOS_NEW(m_pmp) CMDIdGPDB(pfuncexpr->funcid);
+	CMDIdGPDB *mdid_func = GPOS_NEW(m_mp) CMDIdGPDB(func_expr->funcid);
 
 	// create the DXL node holding the scalar funcexpr
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode
 									(
-									m_pmp,
-									GPOS_NEW(m_pmp) CDXLScalarFuncExpr
+									m_mp,
+									GPOS_NEW(m_mp) CDXLScalarFuncExpr
 												(
-												m_pmp,
-												pmdidFunc,
-												GPOS_NEW(m_pmp) CMDIdGPDB(pfuncexpr->funcresulttype),
-												iTypeModifier,
-												pfuncexpr->funcretset
+												m_mp,
+												mdid_func,
+												GPOS_NEW(m_mp) CMDIdGPDB(func_expr->funcresulttype),
+												type_modifier,
+												func_expr->funcretset
 												)
 									);
 
-	const IMDFunction *pmdfunc = m_pmda->Pmdfunc(pmdidFunc);
-	if (IMDFunction::EfsVolatile == pmdfunc->EfsStability())
+	const IMDFunction *md_func = m_md_accessor->RetrieveFunc(mdid_func);
+	if (IMDFunction::EfsVolatile == md_func->GetFuncStability())
 	{
-		ListCell *plc = NULL;
-		ForEach (plc, pfuncexpr->args)
+		ListCell *lc = NULL;
+		ForEach (lc, func_expr->args)
 		{
-			Node *pnodeArg = (Node *) lfirst(plc);
-			if (CTranslatorUtils::FHasSubquery(pnodeArg))
+			Node *arg_node = (Node *) lfirst(lc);
+			if (CTranslatorUtils::HasSubquery(arg_node))
 			{
 				GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 						GPOS_WSZ_LIT("Volatile functions with subqueries in arguments"));
@@ -1288,29 +1288,29 @@ CTranslatorScalarToDXL::PdxlnScFuncExprFromFuncExpr
 		}
 	}
 
-	TranslateScalarChildren(pdxln, pfuncexpr->args, pmapvarcolid);
+	TranslateScalarChildren(dxlnode, func_expr->args, var_colid_mapping);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
+//		CTranslatorScalarToDXL::TranslateAggrefToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar aggref from a GPDB FuncExpr
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
+CTranslatorScalarToDXL::TranslateAggrefToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, Aggref));
-	const Aggref *paggref = (Aggref *) pexpr;
+	GPOS_ASSERT(IsA(expr, Aggref));
+	const Aggref *aggref = (Aggref *) expr;
 
-	static ULONG rgrgulMapping[][2] =
+	static ULONG mapping[][2] =
 		{
 		{AGGSTAGE_NORMAL, EdxlaggstageNormal},
 		{AGGSTAGE_PARTIAL, EdxlaggstagePartial},
@@ -1318,25 +1318,25 @@ CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
 		{AGGSTAGE_FINAL, EdxlaggstageFinal},
 		};
 
-	EdxlAggrefStage edxlaggstage = EdxlaggstageSentinel;
-	const ULONG ulArity = GPOS_ARRAY_SIZE(rgrgulMapping);
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	EdxlAggrefStage agg_stage = EdxlaggstageSentinel;
+	const ULONG arity = GPOS_ARRAY_SIZE(mapping);
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		ULONG *pulElem = rgrgulMapping[ul];
-		if ((ULONG) paggref->aggstage == pulElem[0])
+		ULONG *elem = mapping[ul];
+		if ((ULONG) aggref->aggstage == elem[0])
 		{
-			edxlaggstage = (EdxlAggrefStage) pulElem[1];
+			agg_stage = (EdxlAggrefStage) elem[1];
 			break;
 		}
 	}
-	GPOS_ASSERT(EdxlaggstageSentinel != edxlaggstage && "Invalid agg stage");
+	GPOS_ASSERT(EdxlaggstageSentinel != agg_stage && "Invalid agg stage");
 
-	CMDIdGPDB *pmdidAgg = GPOS_NEW(m_pmp) CMDIdGPDB(paggref->aggfnoid);
-	const IMDAggregate *pmdagg = m_pmda->Pmdagg(pmdidAgg);
+	CMDIdGPDB *agg_mdid = GPOS_NEW(m_mp) CMDIdGPDB(aggref->aggfnoid);
+	const IMDAggregate *md_agg = m_md_accessor->RetrieveAgg(agg_mdid);
 
-	if (pmdagg->FOrdered())
+	if (md_agg->IsOrdered())
 	{
-		GPOS_ASSERT_IMP(NULL == paggref->aggorder, pmdagg->FOrdered());
+		GPOS_ASSERT_IMP(NULL == aggref->aggorder, md_agg->IsOrdered());
 		GPOS_RAISE
 			(
 			gpdxl::ExmaDXL,
@@ -1345,28 +1345,28 @@ CTranslatorScalarToDXL::PdxlnScAggrefFromAggref
 			);
 	}
 
-	if (0 != paggref->agglevelsup)
+	if (0 != aggref->agglevelsup)
 	{
 		// TODO: Feb 05 2015, remove temporary fix to avoid erroring out during execution
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("Aggregate functions with outer references"));
 	}
 
-	IMDId *pmdidRetType = CScalarAggFunc::PmdidLookupReturnType(pmdidAgg, (EdxlaggstageNormal == edxlaggstage), m_pmda);
-	IMDId *pmdidResolvedRetType = NULL;
-	if (m_pmda->Pmdtype(pmdidRetType)->FAmbiguous())
+	IMDId *mdid_return_type = CScalarAggFunc::PmdidLookupReturnType(agg_mdid, (EdxlaggstageNormal == agg_stage), m_md_accessor);
+	IMDId *resolved_ret_type = NULL;
+	if (m_md_accessor->RetrieveType(mdid_return_type)->IsAmbiguous())
 	{
 		// if return type given by MD cache is ambiguous, use type provided by aggref node
-		pmdidResolvedRetType = GPOS_NEW(m_pmp) CMDIdGPDB(paggref->aggtype);
+		resolved_ret_type = GPOS_NEW(m_mp) CMDIdGPDB(aggref->aggtype);
 	}
 
-	CDXLScalarAggref *pdxlopAggref = GPOS_NEW(m_pmp) CDXLScalarAggref(m_pmp, pmdidAgg, pmdidResolvedRetType, paggref->aggdistinct, edxlaggstage);
+	CDXLScalarAggref *aggref_scalar = GPOS_NEW(m_mp) CDXLScalarAggref(m_mp,agg_mdid, resolved_ret_type, aggref->aggdistinct, agg_stage);
 
 	// create the DXL node holding the scalar aggref
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopAggref);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, aggref_scalar);
 
-	TranslateScalarChildren(pdxln, paggref->args, pmapvarcolid);
+	TranslateScalarChildren(dxlnode, aggref->args, var_colid_mapping);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
@@ -1424,31 +1424,31 @@ CTranslatorScalarToDXL::Edxlfb
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::Pdxlwf
+//		CTranslatorScalarToDXL::GetWindowFrame
 //
 //	@doc:
 //		Create a DXL window frame from a GPDB WindowFrame
 //---------------------------------------------------------------------------
 CDXLWindowFrame *
-CTranslatorScalarToDXL::Pdxlwf
+CTranslatorScalarToDXL::GetWindowFrame
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid,
-	CDXLNode *pdxlnNewChildScPrL,
-	BOOL *pfHasDistributedTables // output
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping,
+	CDXLNode *new_scalar_proj_list,
+	BOOL *has_distributed_tables // output
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, WindowFrame));
-	const WindowFrame *pwindowframe = (WindowFrame *) pexpr;
+	GPOS_ASSERT(IsA(expr, WindowFrame));
+	const WindowFrame *pwindowframe = (WindowFrame *) expr;
 
-	EdxlFrameSpec edxlfs = EdxlfsRow;
+	EdxlFrameSpec frame_spec = EdxlfsRow;
 	if (!pwindowframe->is_rows)
 	{
-		edxlfs = EdxlfsRange;
+		frame_spec = EdxlfsRange;
 	}
 
-	EdxlFrameBoundary edxlfbLead = Edxlfb(pwindowframe->lead->kind, pwindowframe->lead->val);
-	EdxlFrameBoundary edxlfbTrail = Edxlfb(pwindowframe->trail->kind, pwindowframe->trail->val);
+	EdxlFrameBoundary leading_boundary = Edxlfb(pwindowframe->lead->kind, pwindowframe->lead->val);
+	EdxlFrameBoundary trailing_boundary = Edxlfb(pwindowframe->trail->kind, pwindowframe->trail->val);
 
 	static ULONG rgrgulExclusionMapping[][2] =
 			{
@@ -1460,136 +1460,136 @@ CTranslatorScalarToDXL::Pdxlwf
 			};
 
 	const ULONG ulArityExclusion = GPOS_ARRAY_SIZE(rgrgulExclusionMapping);
-	EdxlFrameExclusionStrategy edxlfes = EdxlfesSentinel;
+	EdxlFrameExclusionStrategy strategy = EdxlfesSentinel;
 	for (ULONG ul = 0; ul < ulArityExclusion; ul++)
 	{
 		ULONG *pulElem = rgrgulExclusionMapping[ul];
 		if ((ULONG) pwindowframe->exclude == pulElem[0])
 		{
-			edxlfes = (EdxlFrameExclusionStrategy) pulElem[1];
+			strategy = (EdxlFrameExclusionStrategy) pulElem[1];
 			break;
 		}
 	}
-	GPOS_ASSERT(EdxlfesSentinel != edxlfes && "Invalid window frame exclusion");
+	GPOS_ASSERT(EdxlfesSentinel != strategy && "Invalid window frame exclusion");
 
-	CDXLNode *pdxlnLeadEdge = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarWindowFrameEdge(m_pmp, true /* fLeading */, edxlfbLead));
-	CDXLNode *pdxlnTrailEdge = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarWindowFrameEdge(m_pmp, false /* fLeading */, edxlfbTrail));
+	CDXLNode *lead_edge = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarWindowFrameEdge(m_mp, true /* fLeading */, leading_boundary));
+	CDXLNode *trail_edge = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarWindowFrameEdge(m_mp, false /* fLeading */, trailing_boundary));
 
 	// translate the lead and trail value
 	if (NULL != pwindowframe->lead->val)
 	{
-		pdxlnLeadEdge->AddChild(PdxlnWindowFrameEdgeVal(pwindowframe->lead->val, pmapvarcolid, pdxlnNewChildScPrL, pfHasDistributedTables));
+		lead_edge->AddChild(TranslateWindowFrameEdgeToDXL(pwindowframe->lead->val, var_colid_mapping, new_scalar_proj_list, has_distributed_tables));
 	}
 
 	if (NULL != pwindowframe->trail->val)
 	{
-		pdxlnTrailEdge->AddChild(PdxlnWindowFrameEdgeVal(pwindowframe->trail->val, pmapvarcolid, pdxlnNewChildScPrL, pfHasDistributedTables));
+		trail_edge->AddChild(TranslateWindowFrameEdgeToDXL(pwindowframe->trail->val, var_colid_mapping, new_scalar_proj_list, has_distributed_tables));
 	}
 
-	CDXLWindowFrame *pdxlWf = GPOS_NEW(m_pmp) CDXLWindowFrame(m_pmp, edxlfs, edxlfes, pdxlnLeadEdge, pdxlnTrailEdge);
+	CDXLWindowFrame *window_frame_dxl = GPOS_NEW(m_mp) CDXLWindowFrame(m_mp, frame_spec, strategy, lead_edge, trail_edge);
 
-	return pdxlWf;
+	return window_frame_dxl;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnWindowFrameEdgeVal
+//		CTranslatorScalarToDXL::TranslateWindowFrameEdgeToDXL
 //
 //	@doc:
 //		Translate the window frame edge, if the column used in the edge is a
 // 		computed column then add it to the project list
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnWindowFrameEdgeVal
+CTranslatorScalarToDXL::TranslateWindowFrameEdgeToDXL
 	(
-	const Node *pnode,
-	const CMappingVarColId* pmapvarcolid,
-	CDXLNode *pdxlnNewChildScPrL,
-	BOOL *pfHasDistributedTables
+	const Node *node,
+	const CMappingVarColId* var_colid_mapping,
+	CDXLNode *new_scalar_proj_list,
+	BOOL *has_distributed_tables
 	)
 {
-	CDXLNode *pdxlnVal = PdxlnScOpFromExpr((Expr *) pnode, pmapvarcolid, pfHasDistributedTables);
+	CDXLNode *val_node = TranslateScalarToDXL((Expr *) node, var_colid_mapping, has_distributed_tables);
 
-	if (m_fQuery && !IsA(pnode, Var) && !IsA(pnode, Const))
+	if (m_is_query_mode && !IsA(node, Var) && !IsA(node, Const))
 	{
-		GPOS_ASSERT(NULL != pdxlnNewChildScPrL);
-		CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
-		CMDName *pmdnameAlias = GPOS_NEW(m_pmp) CMDName(m_pmp, &strUnnamedCol);
-		ULONG ulPrElId = m_pidgtorCol->UlNextId();
+		GPOS_ASSERT(NULL != new_scalar_proj_list);
+		CWStringConst unnamed_col(GPOS_WSZ_LIT("?column?"));
+		CMDName *alias_mdname = GPOS_NEW(m_mp) CMDName(m_mp, &unnamed_col);
+		ULONG project_element_id = m_colid_generator->next_id();
 
 		// construct a projection element
-		CDXLNode *pdxlnPrEl = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarProjElem(m_pmp, ulPrElId, pmdnameAlias));
-		pdxlnPrEl->AddChild(pdxlnVal);
+		CDXLNode *project_element_node = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjElem(m_mp, project_element_id, alias_mdname));
+		project_element_node->AddChild(val_node);
 
 		// add it to the computed columns project list
-		pdxlnNewChildScPrL->AddChild(pdxlnPrEl);
+		new_scalar_proj_list->AddChild(project_element_node);
 
 		// construct a new scalar ident
-		CDXLScalarIdent *pdxlopIdent = GPOS_NEW(m_pmp) CDXLScalarIdent
+		CDXLScalarIdent *scalar_ident = GPOS_NEW(m_mp) CDXLScalarIdent
 													(
-													m_pmp,
-													GPOS_NEW(m_pmp) CDXLColRef
+													m_mp,
+													GPOS_NEW(m_mp) CDXLColRef
 																(
-																m_pmp,
-																GPOS_NEW(m_pmp) CMDName(m_pmp, &strUnnamedCol),
-																ulPrElId,
-																GPOS_NEW(m_pmp) CMDIdGPDB(gpdb::OidExprType(const_cast<Node*>(pnode))),
-																gpdb::IExprTypeMod(const_cast<Node*>(pnode))
+																m_mp,
+																GPOS_NEW(m_mp) CMDName(m_mp, &unnamed_col),
+																project_element_id,
+																GPOS_NEW(m_mp) CMDIdGPDB(gpdb::ExprType(const_cast<Node*>(node))),
+																gpdb::ExprTypeMod(const_cast<Node*>(node))
 																)
 													);
 
-		pdxlnVal = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopIdent);
+		val_node = GPOS_NEW(m_mp) CDXLNode(m_mp, scalar_ident);
 	}
 
-	return pdxlnVal;
+	return val_node;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScWindowref
+//		CTranslatorScalarToDXL::TranslateWindowRefToDXL
 //
 //	@doc:
 //		Create a DXL node for a scalar window ref from a GPDB WindowRef
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScWindowref
+CTranslatorScalarToDXL::TranslateWindowRefToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, WindowRef));
+	GPOS_ASSERT(IsA(expr, WindowRef));
 
-	const WindowRef *pwindowref = (WindowRef *) pexpr;
+	const WindowRef *pwindowref = (WindowRef *) expr;
 
-	static ULONG rgrgulMapping[][2] =
+	static ULONG mapping[][2] =
 		{
 		{WINSTAGE_IMMEDIATE, EdxlwinstageImmediate},
 		{WINSTAGE_PRELIMINARY, EdxlwinstagePreliminary},
 		{WINSTAGE_ROWKEY, EdxlwinstageRowKey},
 		};
 
-	const ULONG ulArity = GPOS_ARRAY_SIZE(rgrgulMapping);
-	EdxlWinStage edxlwinstage = EdxlwinstageSentinel;
+	const ULONG arity = GPOS_ARRAY_SIZE(mapping);
+	EdxlWinStage dxl_win_stage = EdxlwinstageSentinel;
 
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		ULONG *pulElem = rgrgulMapping[ul];
+		ULONG *pulElem = mapping[ul];
 		if ((ULONG) pwindowref->winstage == pulElem[0])
 		{
-			edxlwinstage = (EdxlWinStage) pulElem[1];
+			dxl_win_stage = (EdxlWinStage) pulElem[1];
 			break;
 		}
 	}
 
-	ULONG ulWinSpecPos = (ULONG) pwindowref->winlevel;
-	if (m_fQuery)
+	ULONG win_spec_pos = (ULONG) pwindowref->winlevel;
+	if (m_is_query_mode)
 	{
-		ulWinSpecPos = (ULONG) pwindowref->winspec;
+		win_spec_pos = (ULONG) pwindowref->winspec;
 	}
 
-	GPOS_ASSERT(EdxlwinstageSentinel != edxlwinstage && "Invalid window stage");
+	GPOS_ASSERT(EdxlwinstageSentinel != dxl_win_stage && "Invalid window stage");
 
 	// fallback if window function is not supported
 	if (WINDOW_PERCENT_RANK == pwindowref->winfnoid)
@@ -1607,29 +1607,29 @@ CTranslatorScalarToDXL::PdxlnScWindowref
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("NTILE Window Functions"));
 	}
 
-	CDXLScalarWindowRef *pdxlopWinref = GPOS_NEW(m_pmp) CDXLScalarWindowRef
+	CDXLScalarWindowRef *winref_dxlop = GPOS_NEW(m_mp) CDXLScalarWindowRef
 													(
-													m_pmp,
-													GPOS_NEW(m_pmp) CMDIdGPDB(pwindowref->winfnoid),
-													GPOS_NEW(m_pmp) CMDIdGPDB(pwindowref->restype),
+													m_mp,
+													GPOS_NEW(m_mp) CMDIdGPDB(pwindowref->winfnoid),
+													GPOS_NEW(m_mp) CMDIdGPDB(pwindowref->restype),
 													pwindowref->windistinct,
 													false,
 													false,
-													edxlwinstage,
-													ulWinSpecPos
+													dxl_win_stage,
+													win_spec_pos
 													);
 
 	// create the DXL node holding the scalar aggref
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopWinref);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, winref_dxlop);
 
-	TranslateScalarChildren(pdxln, pwindowref->args, pmapvarcolid);
+	TranslateScalarChildren(dxlnode, pwindowref->args, var_colid_mapping);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScCondFromQual
+//		CTranslatorScalarToDXL::CreateScalarCondFromQual
 //
 //	@doc:
 //		Create a DXL scalar boolean operator node from a GPDB qual list.
@@ -1637,38 +1637,38 @@ CTranslatorScalarToDXL::PdxlnScWindowref
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScCondFromQual
+CTranslatorScalarToDXL::CreateScalarCondFromQual
 	(
-	List *plQual,
-	const CMappingVarColId* pmapvarcolid,
-	BOOL *pfHasDistributedTables
+	List *quals,
+	const CMappingVarColId* var_colid_mapping,
+	BOOL *has_distributed_tables
 	)
 {
-	if (NULL == plQual || 0 == gpdb::UlListLength(plQual))
+	if (NULL == quals || 0 == gpdb::ListLength(quals))
 	{
 		return NULL;
 	}
 
-	if (1 == gpdb::UlListLength(plQual))
+	if (1 == gpdb::ListLength(quals))
 	{
-		Expr *pexpr = (Expr *) gpdb::PvListNth(plQual, 0);
-		return PdxlnScOpFromExpr(pexpr, pmapvarcolid, pfHasDistributedTables);
+		Expr *expr = (Expr *) gpdb::ListNth(quals, 0);
+		return TranslateScalarToDXL(expr, var_colid_mapping, has_distributed_tables);
 	}
 	else
 	{
 		// GPDB assumes that if there are a list of qual conditions then it is an implicit AND operation
 		// Here we build the left deep AND tree
-		CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarBoolExpr(m_pmp, Edxland));
+		CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarBoolExpr(m_mp, Edxland));
 
-		TranslateScalarChildren(pdxln, plQual, pmapvarcolid, pfHasDistributedTables);
+		TranslateScalarChildren(dxlnode, quals, var_colid_mapping, has_distributed_tables);
 
-		return pdxln;
+		return dxlnode;
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnFilterFromQual
+//		CTranslatorScalarToDXL::CreateFilterFromQual
 //
 //	@doc:
 //		Create a DXL scalar filter node from a GPDB qual list.
@@ -1676,73 +1676,73 @@ CTranslatorScalarToDXL::PdxlnScCondFromQual
 //		is responsible for freeing it
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnFilterFromQual
+CTranslatorScalarToDXL::CreateFilterFromQual
 	(
-	List *plQual,
-	const CMappingVarColId* pmapvarcolid,
-	Edxlopid edxlopFilterType,
-	BOOL *pfHasDistributedTables // output
+	List *quals,
+	const CMappingVarColId* var_colid_mapping,
+	Edxlopid filter_type,
+	BOOL *has_distributed_tables // output
 	)
 {
-	CDXLScalarFilter *pdxlop = NULL;
+	CDXLScalarFilter *dxlop = NULL;
 
-	switch (edxlopFilterType)
+	switch (filter_type)
 	{
 		case EdxlopScalarFilter:
-			pdxlop = GPOS_NEW(m_pmp) CDXLScalarFilter(m_pmp);
+			dxlop = GPOS_NEW(m_mp) CDXLScalarFilter(m_mp);
 			break;
 		case EdxlopScalarJoinFilter:
-			pdxlop = GPOS_NEW(m_pmp) CDXLScalarJoinFilter(m_pmp);
+			dxlop = GPOS_NEW(m_mp) CDXLScalarJoinFilter(m_mp);
 			break;
 		case EdxlopScalarOneTimeFilter:
-			pdxlop = GPOS_NEW(m_pmp) CDXLScalarOneTimeFilter(m_pmp);
+			dxlop = GPOS_NEW(m_mp) CDXLScalarOneTimeFilter(m_mp);
 			break;
 		default:
 			GPOS_ASSERT(!"Unrecognized filter type");
 	}
 
 
-	CDXLNode *pdxlnFilter = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *filter_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
-	CDXLNode *pdxlnCond = PdxlnScCondFromQual(plQual, pmapvarcolid, pfHasDistributedTables);
+	CDXLNode *cond_node = CreateScalarCondFromQual(quals, var_colid_mapping, has_distributed_tables);
 
-	if (NULL != pdxlnCond)
+	if (NULL != cond_node)
 	{
-		pdxlnFilter->AddChild(pdxlnCond);
+		filter_dxlnode->AddChild(cond_node);
 	}
 
-	return pdxlnFilter;
+	return filter_dxlnode;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnFromSublink
+//		CTranslatorScalarToDXL::TranslateSubLinkToDXL
 //
 //	@doc:
 //		Create a DXL node from a GPDB sublink node.
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnFromSublink
+CTranslatorScalarToDXL::TranslateSubLinkToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	const SubLink *psublink = (SubLink *) pexpr;
+	const SubLink *sublink = (SubLink *) expr;
 
-	switch (psublink->subLinkType)
+	switch (sublink->subLinkType)
 	{
 		case EXPR_SUBLINK:
-			return PdxlnScSubqueryFromSublink(psublink, pmapvarcolid);
+			return CreateScalarSubqueryFromSublink(sublink, var_colid_mapping);
 
 		case ALL_SUBLINK:
 		case ANY_SUBLINK:
-			return PdxlnQuantifiedSubqueryFromSublink(psublink, pmapvarcolid);
+			return CreateQuantifiedSubqueryFromSublink(sublink, var_colid_mapping);
 
 		case EXISTS_SUBLINK:
-			return PdxlnExistSubqueryFromSublink(psublink, pmapvarcolid);
+			return CreateExistSubqueryFromSublink(sublink, var_colid_mapping);
 
 		default:
 			{
@@ -1755,251 +1755,251 @@ CTranslatorScalarToDXL::PdxlnFromSublink
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnQuantifiedSubqueryFromSublink
+//		CTranslatorScalarToDXL::CreateQuantifiedSubqueryFromSublink
 //
 //	@doc:
 //		Create ANY / ALL quantified sub query from a GPDB sublink node
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnQuantifiedSubqueryFromSublink
+CTranslatorScalarToDXL::CreateQuantifiedSubqueryFromSublink
 	(
-	const SubLink *psublink,
-	const CMappingVarColId* pmapvarcolid
+	const SubLink *sublink,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	CMappingVarColId *pmapvarcolidCopy = pmapvarcolid->PmapvarcolidCopy(m_pmp);
+	CMappingVarColId *var_colid_map_copy = var_colid_mapping->CopyMapColId(m_mp);
 
-	CAutoP<CTranslatorQueryToDXL> ptrquerytodxl;
-	ptrquerytodxl = CTranslatorQueryToDXL::PtrquerytodxlInstance
+	CAutoP<CTranslatorQueryToDXL> query_to_dxl_translator;
+	query_to_dxl_translator = CTranslatorQueryToDXL::QueryToDXLInstance
 							(
-							m_pmp,
-							m_pmda,
-							m_pidgtorCol,
-							m_pidgtorCTE,
-							pmapvarcolidCopy,
-							(Query *) psublink->subselect,
-							m_ulQueryLevel + 1,
-							m_phmulCTEEntries
+							m_mp,
+							m_md_accessor,
+							m_colid_generator,
+							m_cte_id_generator,
+							var_colid_map_copy,
+							(Query *) sublink->subselect,
+							m_query_level + 1,
+							m_cte_entries
 							);
 
-	CDXLNode *pdxlnInner = ptrquerytodxl->PdxlnFromQueryInternal();
+	CDXLNode *inner_dxlnode = query_to_dxl_translator->TranslateSelectQueryToDXL();
 
-	DrgPdxln *pdrgpdxlnQueryOutput = ptrquerytodxl->PdrgpdxlnQueryOutput();
-	DrgPdxln *pdrgpdxlnCTE = ptrquerytodxl->PdrgpdxlnCTE();
-	CUtils::AddRefAppend(m_pdrgpdxlnCTE, pdrgpdxlnCTE);
+	CDXLNodeArray *query_output_dxlnode_array = query_to_dxl_translator->GetQueryOutputCols();
+	CDXLNodeArray *cte_dxlnode_array = query_to_dxl_translator->GetCTEs();
+	CUtils::AddRefAppend(m_cte_producers, cte_dxlnode_array);
 
-	if (1 != pdrgpdxlnQueryOutput->UlLength())
+	if (1 != query_output_dxlnode_array->Size())
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Non-Scalar Subquery"));
 	}
 
-	m_fHasDistributedTables = m_fHasDistributedTables || ptrquerytodxl->FHasDistributedTables();
+	m_has_distributed_tables = m_has_distributed_tables || query_to_dxl_translator->HasDistributedTables();
 
-	CDXLNode *pdxlnIdent = (*pdrgpdxlnQueryOutput)[0];
-	GPOS_ASSERT(NULL != pdxlnIdent);
+	CDXLNode *dxl_sc_ident = (*query_output_dxlnode_array)[0];
+	GPOS_ASSERT(NULL != dxl_sc_ident);
 
 	// get dxl scalar identifier
-	CDXLScalarIdent *pdxlopIdent = dynamic_cast<CDXLScalarIdent *>(pdxlnIdent->Pdxlop());
+	CDXLScalarIdent *scalar_ident = dynamic_cast<CDXLScalarIdent *>(dxl_sc_ident->GetOperator());
 
 	// get the dxl column reference
-	const CDXLColRef *pdxlcr = pdxlopIdent->Pdxlcr();
-	const ULONG ulColId = pdxlcr->UlID();
+	const CDXLColRef *dxl_colref = scalar_ident->GetDXLColRef();
+	const ULONG colid = dxl_colref->Id();
 
 	// get the test expression
-	GPOS_ASSERT(IsA(psublink->testexpr, OpExpr));
-	OpExpr *popexpr = (OpExpr*) psublink->testexpr;
+	GPOS_ASSERT(IsA(sublink->testexpr, OpExpr));
+	OpExpr *op_expr = (OpExpr*) sublink->testexpr;
 
-	IMDId *pmdid = GPOS_NEW(m_pmp) CMDIdGPDB(popexpr->opno);
+	IMDId *mdid = GPOS_NEW(m_mp) CMDIdGPDB(op_expr->opno);
 
 	// get operator name
-	const CWStringConst *pstr = PstrOpName(pmdid);
+	const CWStringConst *str = GetDXLArrayCmpType(mdid);
 
 	// translate left hand side of the expression
-	GPOS_ASSERT(NULL != popexpr->args);
-	Expr* pexprLHS = (Expr*) gpdb::PvListNth(popexpr->args, 0);
+	GPOS_ASSERT(NULL != op_expr->args);
+	Expr* LHS_expr = (Expr*) gpdb::ListNth(op_expr->args, 0);
 
-	CDXLNode *pdxlnOuter = PdxlnScOpFromExpr(pexprLHS, pmapvarcolid);
+	CDXLNode *outer_dxlnode = TranslateScalarToDXL(LHS_expr, var_colid_mapping);
 
-	CDXLNode *pdxln = NULL;
-	CDXLScalar *pdxlopSubquery = NULL;
+	CDXLNode *dxlnode = NULL;
+	CDXLScalar *subquery = NULL;
 
-	GPOS_ASSERT(ALL_SUBLINK == psublink->subLinkType || ANY_SUBLINK == psublink->subLinkType);
-	if (ALL_SUBLINK == psublink->subLinkType)
+	GPOS_ASSERT(ALL_SUBLINK == sublink->subLinkType || ANY_SUBLINK == sublink->subLinkType);
+	if (ALL_SUBLINK == sublink->subLinkType)
 	{
-		pdxlopSubquery = GPOS_NEW(m_pmp) CDXLScalarSubqueryAll
+		subquery = GPOS_NEW(m_mp) CDXLScalarSubqueryAll
 								(
-								m_pmp,
-								pmdid,
-								GPOS_NEW(m_pmp) CMDName(m_pmp, pstr),
-								ulColId
+								m_mp,
+								mdid,
+								GPOS_NEW(m_mp) CMDName(m_mp, str),
+								colid
 								);
 
 	}
 	else
 	{
-		pdxlopSubquery = GPOS_NEW(m_pmp) CDXLScalarSubqueryAny
+		subquery = GPOS_NEW(m_mp) CDXLScalarSubqueryAny
 								(
-								m_pmp,
-								pmdid,
-								GPOS_NEW(m_pmp) CMDName(m_pmp, pstr),
-								ulColId
+								m_mp,
+								mdid,
+								GPOS_NEW(m_mp) CMDName(m_mp, str),
+								colid
 								);
 	}
 
-	pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopSubquery);
+	dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, subquery);
 
-	pdxln->AddChild(pdxlnOuter);
-	pdxln->AddChild(pdxlnInner);
+	dxlnode->AddChild(outer_dxlnode);
+	dxlnode->AddChild(inner_dxlnode);
 
 #ifdef GPOS_DEBUG
-	pdxln->Pdxlop()->AssertValid(pdxln, false /* fValidateChildren */);
+	dxlnode->GetOperator()->AssertValid(dxlnode, false /* fValidateChildren */);
 #endif
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnScSubqueryFromSublink
+//		CTranslatorScalarToDXL::CreateScalarSubqueryFromSublink
 //
 //	@doc:
 //		Create a scalar subquery from a GPDB sublink node
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnScSubqueryFromSublink
+CTranslatorScalarToDXL::CreateScalarSubqueryFromSublink
 	(
-	const SubLink *psublink,
-	const CMappingVarColId *pmapvarcolid
+	const SubLink *sublink,
+	const CMappingVarColId *var_colid_mapping
 	)
 {
-	CMappingVarColId *pmapvarcolidCopy = pmapvarcolid->PmapvarcolidCopy(m_pmp);
+	CMappingVarColId *var_colid_map_copy = var_colid_mapping->CopyMapColId(m_mp);
 
-	Query *pquerySublink = (Query *) psublink->subselect;
-	CAutoP<CTranslatorQueryToDXL> ptrquerytodxl;
-	ptrquerytodxl = CTranslatorQueryToDXL::PtrquerytodxlInstance
+	Query *subselect = (Query *) sublink->subselect;
+	CAutoP<CTranslatorQueryToDXL> query_to_dxl_translator;
+	query_to_dxl_translator = CTranslatorQueryToDXL::QueryToDXLInstance
 							(
-							m_pmp,
-							m_pmda,
-							m_pidgtorCol,
-							m_pidgtorCTE,
-							pmapvarcolidCopy,
-							pquerySublink,
-							m_ulQueryLevel + 1,
-							m_phmulCTEEntries
+							m_mp,
+							m_md_accessor,
+							m_colid_generator,
+							m_cte_id_generator,
+							var_colid_map_copy,
+							subselect,
+							m_query_level + 1,
+							m_cte_entries
 							);
-	CDXLNode *pdxlnSubQuery = ptrquerytodxl->PdxlnFromQueryInternal();
+	CDXLNode *subquery_dxlnode = query_to_dxl_translator->TranslateSelectQueryToDXL();
 
-	DrgPdxln *pdrgpdxlnQueryOutput = ptrquerytodxl->PdrgpdxlnQueryOutput();
+	CDXLNodeArray *query_output_dxlnode_array = query_to_dxl_translator->GetQueryOutputCols();
 
-	GPOS_ASSERT(1 == pdrgpdxlnQueryOutput->UlLength());
+	GPOS_ASSERT(1 == query_output_dxlnode_array->Size());
 
-	DrgPdxln *pdrgpdxlnCTE = ptrquerytodxl->PdrgpdxlnCTE();
-	CUtils::AddRefAppend(m_pdrgpdxlnCTE, pdrgpdxlnCTE);
-	m_fHasDistributedTables = m_fHasDistributedTables || ptrquerytodxl->FHasDistributedTables();
+	CDXLNodeArray *cte_dxlnode_array = query_to_dxl_translator->GetCTEs();
+	CUtils::AddRefAppend(m_cte_producers, cte_dxlnode_array);
+	m_has_distributed_tables = m_has_distributed_tables || query_to_dxl_translator->HasDistributedTables();
 
 	// get dxl scalar identifier
-	CDXLNode *pdxlnIdent = (*pdrgpdxlnQueryOutput)[0];
-	GPOS_ASSERT(NULL != pdxlnIdent);
+	CDXLNode *dxl_sc_ident = (*query_output_dxlnode_array)[0];
+	GPOS_ASSERT(NULL != dxl_sc_ident);
 
-	CDXLScalarIdent *pdxlopIdent = CDXLScalarIdent::PdxlopConvert(pdxlnIdent->Pdxlop());
+	CDXLScalarIdent *scalar_ident = CDXLScalarIdent::Cast(dxl_sc_ident->GetOperator());
 
 	// get the dxl column reference
-	const CDXLColRef *pdxlcr = pdxlopIdent->Pdxlcr();
-	const ULONG ulColId = pdxlcr->UlID();
+	const CDXLColRef *dxl_colref = scalar_ident->GetDXLColRef();
+	const ULONG colid = dxl_colref->Id();
 
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarSubquery(m_pmp, ulColId));
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarSubquery(m_mp, colid));
 
-	pdxln->AddChild(pdxlnSubQuery);
+	dxlnode->AddChild(subquery_dxlnode);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnArray
+//		CTranslatorScalarToDXL::TranslateArrayExprToDXL
 //
 //	@doc:
 //		Translate array
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnArray
+CTranslatorScalarToDXL::TranslateArrayExprToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, ArrayExpr));
+	GPOS_ASSERT(IsA(expr, ArrayExpr));
 
-	const ArrayExpr *parrayexpr = (ArrayExpr *) pexpr;
+	const ArrayExpr *parrayexpr = (ArrayExpr *) expr;
 
-	CDXLScalarArray *pdxlop =
-			GPOS_NEW(m_pmp) CDXLScalarArray
+	CDXLScalarArray *dxlop =
+			GPOS_NEW(m_mp) CDXLScalarArray
 						(
-						m_pmp,
-						GPOS_NEW(m_pmp) CMDIdGPDB(parrayexpr->element_typeid),
-						GPOS_NEW(m_pmp) CMDIdGPDB(parrayexpr->array_typeid),
+						m_mp,
+						GPOS_NEW(m_mp) CMDIdGPDB(parrayexpr->element_typeid),
+						GPOS_NEW(m_mp) CMDIdGPDB(parrayexpr->array_typeid),
 						parrayexpr->multidims
 						);
 
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
-	TranslateScalarChildren(pdxln, parrayexpr->elements, pmapvarcolid);
+	TranslateScalarChildren(dxlnode, parrayexpr->elements, var_colid_mapping);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnArrayRef
+//		CTranslatorScalarToDXL::TranslateArrayRefToDXL
 //
 //	@doc:
 //		Translate arrayref
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnArrayRef
+CTranslatorScalarToDXL::TranslateArrayRefToDXL
 	(
-	const Expr *pexpr,
-	const CMappingVarColId* pmapvarcolid
+	const Expr *expr,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, ArrayRef));
+	GPOS_ASSERT(IsA(expr, ArrayRef));
 
-	const ArrayRef *parrayref = (ArrayRef *) pexpr;
+	const ArrayRef *parrayref = (ArrayRef *) expr;
 	Oid restype;
 
-	INT iTypeModifier = parrayref->reftypmod;
+	INT type_modifier = parrayref->reftypmod;
 	/* slice and/or store operations yield the array type */
 	if (parrayref->reflowerindexpr || parrayref->refassgnexpr)
 		restype = parrayref->refarraytype;
 	else
 		restype = parrayref->refelemtype;
 
-	CDXLScalarArrayRef *pdxlop =
-			GPOS_NEW(m_pmp) CDXLScalarArrayRef
+	CDXLScalarArrayRef *dxlop =
+			GPOS_NEW(m_mp) CDXLScalarArrayRef
 						(
-						m_pmp,
-						GPOS_NEW(m_pmp) CMDIdGPDB(parrayref->refelemtype),
-						iTypeModifier,
-						GPOS_NEW(m_pmp) CMDIdGPDB(parrayref->refarraytype),
-						GPOS_NEW(m_pmp) CMDIdGPDB(restype)
+						m_mp,
+						GPOS_NEW(m_mp) CMDIdGPDB(parrayref->refelemtype),
+						type_modifier,
+						GPOS_NEW(m_mp) CMDIdGPDB(parrayref->refarraytype),
+						GPOS_NEW(m_mp) CMDIdGPDB(restype)
 						);
 
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 
 	// add children
-	AddArrayIndexList(pdxln, parrayref->reflowerindexpr, CDXLScalarArrayRefIndexList::EilbLower, pmapvarcolid);
-	AddArrayIndexList(pdxln, parrayref->refupperindexpr, CDXLScalarArrayRefIndexList::EilbUpper, pmapvarcolid);
+	AddArrayIndexList(dxlnode, parrayref->reflowerindexpr, CDXLScalarArrayRefIndexList::EilbLower, var_colid_mapping);
+	AddArrayIndexList(dxlnode, parrayref->refupperindexpr, CDXLScalarArrayRefIndexList::EilbUpper, var_colid_mapping);
 
-	pdxln->AddChild(PdxlnScOpFromExpr(parrayref->refexpr, pmapvarcolid));
+	dxlnode->AddChild(TranslateScalarToDXL(parrayref->refexpr, var_colid_mapping));
 
 	if (NULL != parrayref->refassgnexpr)
 	{
-		pdxln->AddChild(PdxlnScOpFromExpr(parrayref->refassgnexpr, pmapvarcolid));
+		dxlnode->AddChild(TranslateScalarToDXL(parrayref->refassgnexpr, var_colid_mapping));
 	}
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
@@ -2013,352 +2013,352 @@ CTranslatorScalarToDXL::PdxlnArrayRef
 void
 CTranslatorScalarToDXL::AddArrayIndexList
 	(
-	CDXLNode *pdxln,
-	List *plist,
-	CDXLScalarArrayRefIndexList::EIndexListBound eilb,
-	const CMappingVarColId* pmapvarcolid
+	CDXLNode *dxlnode,
+	List *list,
+	CDXLScalarArrayRefIndexList::EIndexListBound index_list_bound,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(NULL != pdxln);
-	GPOS_ASSERT(EdxlopScalarArrayRef == pdxln->Pdxlop()->Edxlop());
-	GPOS_ASSERT(CDXLScalarArrayRefIndexList::EilbSentinel > eilb);
+	GPOS_ASSERT(NULL != dxlnode);
+	GPOS_ASSERT(EdxlopScalarArrayRef == dxlnode->GetOperator()->GetDXLOperator());
+	GPOS_ASSERT(CDXLScalarArrayRefIndexList::EilbSentinel > index_list_bound);
 
-	CDXLNode *pdxlnIndexList =
-			GPOS_NEW(m_pmp) CDXLNode
+	CDXLNode *index_list_dxlnode =
+			GPOS_NEW(m_mp) CDXLNode
 					(
-					m_pmp,
-					GPOS_NEW(m_pmp) CDXLScalarArrayRefIndexList(m_pmp, eilb)
+					m_mp,
+					GPOS_NEW(m_mp) CDXLScalarArrayRefIndexList(m_mp, index_list_bound)
 					);
 
-	TranslateScalarChildren(pdxlnIndexList, plist, pmapvarcolid);
-	pdxln->AddChild(pdxlnIndexList);
+	TranslateScalarChildren(index_list_dxlnode, list, var_colid_mapping);
+	dxlnode->AddChild(index_list_dxlnode);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PstrOpName
+//		CTranslatorScalarToDXL::GetDXLArrayCmpType
 //
 //	@doc:
 //		Get the operator name
 //
 //---------------------------------------------------------------------------
 const CWStringConst *
-CTranslatorScalarToDXL::PstrOpName
+CTranslatorScalarToDXL::GetDXLArrayCmpType
 	(
-	IMDId *pmdid
+	IMDId *mdid
 	)
 	const
 {
 	// get operator name
-	const IMDScalarOp *pmdscop = m_pmda->Pmdscop(pmdid);
+	const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(mdid);
 
-	const CWStringConst *pstr = pmdscop->Mdname().Pstr();
+	const CWStringConst *str = md_scalar_op->Mdname().GetMDName();
 
-	return pstr;
+	return str;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxlnExistSubqueryFromSublink
+//		CTranslatorScalarToDXL::CreateExistSubqueryFromSublink
 //
 //	@doc:
 //		Create a DXL EXISTS subquery node from the respective GPDB
 //		sublink node
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::PdxlnExistSubqueryFromSublink
+CTranslatorScalarToDXL::CreateExistSubqueryFromSublink
 	(
-	const SubLink *psublink,
-	const CMappingVarColId* pmapvarcolid
+	const SubLink *sublink,
+	const CMappingVarColId* var_colid_mapping
 	)
 {
-	GPOS_ASSERT(NULL != psublink);
-	CMappingVarColId *pmapvarcolidCopy = pmapvarcolid->PmapvarcolidCopy(m_pmp);
+	GPOS_ASSERT(NULL != sublink);
+	CMappingVarColId *var_colid_map_copy = var_colid_mapping->CopyMapColId(m_mp);
 
-	CAutoP<CTranslatorQueryToDXL> ptrquerytodxl;
-	ptrquerytodxl = CTranslatorQueryToDXL::PtrquerytodxlInstance
+	CAutoP<CTranslatorQueryToDXL> query_to_dxl_translator;
+	query_to_dxl_translator = CTranslatorQueryToDXL::QueryToDXLInstance
 							(
-							m_pmp,
-							m_pmda,
-							m_pidgtorCol,
-							m_pidgtorCTE,
-							pmapvarcolidCopy,
-							(Query *) psublink->subselect,
-							m_ulQueryLevel + 1,
-							m_phmulCTEEntries
+							m_mp,
+							m_md_accessor,
+							m_colid_generator,
+							m_cte_id_generator,
+							var_colid_map_copy,
+							(Query *) sublink->subselect,
+							m_query_level + 1,
+							m_cte_entries
 							);
-	CDXLNode *pdxlnRoot = ptrquerytodxl->PdxlnFromQueryInternal();
+	CDXLNode *root_dxlnode = query_to_dxl_translator->TranslateSelectQueryToDXL();
 	
-	DrgPdxln *pdrgpdxlnCTE = ptrquerytodxl->PdrgpdxlnCTE();
-	CUtils::AddRefAppend(m_pdrgpdxlnCTE, pdrgpdxlnCTE);
-	m_fHasDistributedTables = m_fHasDistributedTables || ptrquerytodxl->FHasDistributedTables();
+	CDXLNodeArray *cte_dxlnode_array = query_to_dxl_translator->GetCTEs();
+	CUtils::AddRefAppend(m_cte_producers, cte_dxlnode_array);
+	m_has_distributed_tables = m_has_distributed_tables || query_to_dxl_translator->HasDistributedTables();
 	
-	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarSubqueryExists(m_pmp));
-	pdxln->AddChild(pdxlnRoot);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarSubqueryExists(m_mp));
+	dxlnode->AddChild(root_dxlnode);
 
-	return pdxln;
+	return dxlnode;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::Pdatum
+//		CTranslatorScalarToDXL::TranslateDatumToDXL
 //
 //	@doc:
 //		Create CDXLDatum from GPDB datum
 //---------------------------------------------------------------------------
 CDXLDatum *
-CTranslatorScalarToDXL::Pdxldatum
+CTranslatorScalarToDXL::TranslateDatumToDXL
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	INT iTypeModifier,
-	BOOL fNull,
-	ULONG ulLen,
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	INT type_modifier,
+	BOOL is_null,
+	ULONG len,
 	Datum datum
 	)
 {
-	static const SDXLDatumTranslatorElem rgTranslators[] =
+	static const SDXLDatumTranslatorElem translators[] =
 		{
-			{IMDType::EtiInt2  , &CTranslatorScalarToDXL::PdxldatumInt2},
-			{IMDType::EtiInt4  , &CTranslatorScalarToDXL::PdxldatumInt4},
-			{IMDType::EtiInt8 , &CTranslatorScalarToDXL::PdxldatumInt8},
-			{IMDType::EtiBool , &CTranslatorScalarToDXL::PdxldatumBool},
-			{IMDType::EtiOid  , &CTranslatorScalarToDXL::PdxldatumOid},
+			{IMDType::EtiInt2  , &CTranslatorScalarToDXL::TranslateInt2DatumToDXL},
+			{IMDType::EtiInt4  , &CTranslatorScalarToDXL::TranslateInt4DatumToDXL},
+			{IMDType::EtiInt8 , &CTranslatorScalarToDXL::TranslateInt8DatumToDXL},
+			{IMDType::EtiBool , &CTranslatorScalarToDXL::TranslateBoolDatumToDXL},
+			{IMDType::EtiOid  , &CTranslatorScalarToDXL::TranslateOidDatumToDXL},
 		};
 
-	const ULONG ulTranslators = GPOS_ARRAY_SIZE(rgTranslators);
+	const ULONG num_translators = GPOS_ARRAY_SIZE(translators);
 	// find translator for the datum type
-	PfPdxldatumFromDatum *pf = NULL;
-	for (ULONG ul = 0; ul < ulTranslators; ul++)
+	DxlDatumFromDatum *func_ptr = NULL;
+	for (ULONG ul = 0; ul < num_translators; ul++)
 	{
-		SDXLDatumTranslatorElem elem = rgTranslators[ul];
-		if (pmdtype->Eti() == elem.eti)
+		SDXLDatumTranslatorElem elem = translators[ul];
+		if (md_type->GetDatumType() == elem.type_info)
 		{
-			pf = elem.pf;
+			func_ptr = elem.func_ptr;
 			break;
 		}
 	}
 
-	if (NULL == pf)
+	if (NULL == func_ptr)
 	{
 		// generate a datum of generic type
-		return PdxldatumGeneric(pmp, pmdtype, iTypeModifier, fNull, ulLen, datum);
+		return TranslateGenericDatumToDXL(mp, md_type, type_modifier, is_null, len, datum);
 	}
 	else
 	{
-		return (*pf)(pmp, pmdtype, fNull, ulLen, datum);
+		return (*func_ptr)(mp, md_type, is_null, len, datum);
 	}
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxldatumGeneric
+//		CTranslatorScalarToDXL::TranslateGenericDatumToDXL
 //
 //	@doc:
 //		Translate a datum of generic type
 //---------------------------------------------------------------------------
 CDXLDatum *
-CTranslatorScalarToDXL::PdxldatumGeneric
+CTranslatorScalarToDXL::TranslateGenericDatumToDXL
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	INT iTypeModifier,
-	BOOL fNull,
-	ULONG ulLen,
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	INT type_modifier,
+	BOOL is_null,
+	ULONG len,
 	Datum datum
 	)
 {
-	CMDIdGPDB *pmdidMDC = CMDIdGPDB::PmdidConvert(pmdtype->Pmdid());
-	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(*pmdidMDC);
+	CMDIdGPDB *mdid_old = CMDIdGPDB::CastMdid(md_type->MDId());
+	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(*mdid_old);
 
-	BOOL fConstByVal = pmdtype->FByValue();
-	BYTE *pba = Pba(pmp, pmdtype, fNull, ulLen, datum);
-	ULONG ulLength = 0;
-	if (!fNull)
+	BOOL is_const_by_val = md_type->IsPassedByValue();
+	BYTE *bytes = ExtractByteArrayFromDatum(mp, md_type, is_null, len, datum);
+	ULONG length = 0;
+	if (!is_null)
 	{
-		ulLength = (ULONG) gpdb::SDatumSize(datum, pmdtype->FByValue(), ulLen);
+		length = (ULONG) gpdb::DatumSize(datum, md_type->IsPassedByValue(), len);
 	}
 
-	CDouble dValue(0);
-	if (CMDTypeGenericGPDB::FHasByteDoubleMapping(pmdid))
+	CDouble double_value(0);
+	if (CMDTypeGenericGPDB::HasByte2DoubleMapping(mdid))
 	{
-		dValue = DValue(pmdid, fNull, pba, datum);
+		double_value = ExtractDoubleValueFromDatum(mdid, is_null, bytes, datum);
 	}
 
-	LINT lValue = 0;
-	if (CMDTypeGenericGPDB::FHasByteLintMapping(pmdid))
+	LINT lint_value = 0;
+	if (CMDTypeGenericGPDB::HasByte2IntMapping(mdid))
 	{
-		lValue = LValue(pmdid, fNull, pba, ulLength);
+		lint_value = ExtractLintValueFromDatum(mdid, is_null, bytes, length);
 	}
 
-	return CMDTypeGenericGPDB::Pdxldatum(pmp, pmdid, iTypeModifier, fConstByVal, fNull, pba, ulLength, lValue, dValue);
+	return CMDTypeGenericGPDB::CreateDXLDatumVal(mp, mdid, type_modifier, is_const_by_val, is_null, bytes, length, lint_value, double_value);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxldatumBool
+//		CTranslatorScalarToDXL::TranslateBoolDatumToDXL
 //
 //	@doc:
 //		Translate a datum of type bool
 //---------------------------------------------------------------------------
 CDXLDatum *
-CTranslatorScalarToDXL::PdxldatumBool
+CTranslatorScalarToDXL::TranslateBoolDatumToDXL
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	BOOL fNull,
-	ULONG , //ulLen,
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	BOOL is_null,
+	ULONG , //len,
 	Datum datum
 	)
 {
-	GPOS_ASSERT(pmdtype->FByValue());
-	CMDIdGPDB *pmdidMDC = CMDIdGPDB::PmdidConvert(pmdtype->Pmdid());
-	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(*pmdidMDC);
+	GPOS_ASSERT(md_type->IsPassedByValue());
+	CMDIdGPDB *mdid_old = CMDIdGPDB::CastMdid(md_type->MDId());
+	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(*mdid_old);
 
-	return GPOS_NEW(pmp) CDXLDatumBool(pmp, pmdid, fNull, gpdb::FBoolFromDatum(datum));
+	return GPOS_NEW(mp) CDXLDatumBool(mp, mdid, is_null, gpdb::BoolFromDatum(datum));
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxldatumOid
+//		CTranslatorScalarToDXL::TranslateOidDatumToDXL
 //
 //	@doc:
 //		Translate a datum of type oid
 //---------------------------------------------------------------------------
 CDXLDatum *
-CTranslatorScalarToDXL::PdxldatumOid
+CTranslatorScalarToDXL::TranslateOidDatumToDXL
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	BOOL fNull,
-	ULONG , //ulLen,
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	BOOL is_null,
+	ULONG , //len,
 	Datum datum
 	)
 {
-	GPOS_ASSERT(pmdtype->FByValue());
-	CMDIdGPDB *pmdidMDC = CMDIdGPDB::PmdidConvert(pmdtype->Pmdid());
-	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(*pmdidMDC);
+	GPOS_ASSERT(md_type->IsPassedByValue());
+	CMDIdGPDB *mdid_old = CMDIdGPDB::CastMdid(md_type->MDId());
+	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(*mdid_old);
 
-	return GPOS_NEW(pmp) CDXLDatumOid(pmp, pmdid, fNull, gpdb::OidFromDatum(datum));
+	return GPOS_NEW(mp) CDXLDatumOid(mp, mdid, is_null, gpdb::OidFromDatum(datum));
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxldatumInt2
+//		CTranslatorScalarToDXL::TranslateInt2DatumToDXL
 //
 //	@doc:
 //		Translate a datum of type int2
 //---------------------------------------------------------------------------
 CDXLDatum *
-CTranslatorScalarToDXL::PdxldatumInt2
+CTranslatorScalarToDXL::TranslateInt2DatumToDXL
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	BOOL fNull,
-	ULONG , //ulLen,
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	BOOL is_null,
+	ULONG , //len,
 	Datum datum
 	)
 {
-	GPOS_ASSERT(pmdtype->FByValue());
-	CMDIdGPDB *pmdidMDC = CMDIdGPDB::PmdidConvert(pmdtype->Pmdid());
-	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(*pmdidMDC);
+	GPOS_ASSERT(md_type->IsPassedByValue());
+	CMDIdGPDB *mdid_old = CMDIdGPDB::CastMdid(md_type->MDId());
+	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(*mdid_old);
 
-	return GPOS_NEW(pmp) CDXLDatumInt2(pmp, pmdid, fNull, gpdb::SInt16FromDatum(datum));
+	return GPOS_NEW(mp) CDXLDatumInt2(mp, mdid, is_null, gpdb::Int16FromDatum(datum));
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxldatumInt4
+//		CTranslatorScalarToDXL::TranslateInt4DatumToDXL
 //
 //	@doc:
 //		Translate a datum of type int4
 //---------------------------------------------------------------------------
 CDXLDatum *
-CTranslatorScalarToDXL::PdxldatumInt4
+CTranslatorScalarToDXL::TranslateInt4DatumToDXL
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	BOOL fNull,
-	ULONG , //ulLen,
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	BOOL is_null,
+	ULONG , //len,
 	Datum datum
 	)
 {
-	GPOS_ASSERT(pmdtype->FByValue());
-	CMDIdGPDB *pmdidMDC = CMDIdGPDB::PmdidConvert(pmdtype->Pmdid());
-	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(*pmdidMDC);
+	GPOS_ASSERT(md_type->IsPassedByValue());
+	CMDIdGPDB *mdid_old = CMDIdGPDB::CastMdid(md_type->MDId());
+	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(*mdid_old);
 
-	return GPOS_NEW(pmp) CDXLDatumInt4(pmp, pmdid, fNull, gpdb::IInt32FromDatum(datum));
+	return GPOS_NEW(mp) CDXLDatumInt4(mp, mdid, is_null, gpdb::Int32FromDatum(datum));
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::PdxldatumInt8
+//		CTranslatorScalarToDXL::TranslateInt8DatumToDXL
 //
 //	@doc:
 //		Translate a datum of type int8
 //---------------------------------------------------------------------------
 CDXLDatum *
-CTranslatorScalarToDXL::PdxldatumInt8
+CTranslatorScalarToDXL::TranslateInt8DatumToDXL
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	BOOL fNull,
-	ULONG , //ulLen,
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	BOOL is_null,
+	ULONG , //len,
 	Datum datum
 	)
 {
-	GPOS_ASSERT(pmdtype->FByValue());
-	CMDIdGPDB *pmdidMDC = CMDIdGPDB::PmdidConvert(pmdtype->Pmdid());
-	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(*pmdidMDC);
+	GPOS_ASSERT(md_type->IsPassedByValue());
+	CMDIdGPDB *mdid_old = CMDIdGPDB::CastMdid(md_type->MDId());
+	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(*mdid_old);
 
-	return GPOS_NEW(pmp) CDXLDatumInt8(pmp, pmdid, fNull, gpdb::LlInt64FromDatum(datum));
+	return GPOS_NEW(mp) CDXLDatumInt8(mp, mdid, is_null, gpdb::Int64FromDatum(datum));
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::DValue
+//		CTranslatorScalarToDXL::ExtractDoubleValueFromDatum
 //
 //	@doc:
 //		Extract the double value of the datum
 //---------------------------------------------------------------------------
 CDouble
-CTranslatorScalarToDXL::DValue
+CTranslatorScalarToDXL::ExtractDoubleValueFromDatum
 	(
-	IMDId *pmdid,
-	BOOL fNull,
-	BYTE *pba,
+	IMDId *mdid,
+	BOOL is_null,
+	BYTE *bytes,
 	Datum datum
 	)
 {
-	GPOS_ASSERT(CMDTypeGenericGPDB::FHasByteDoubleMapping(pmdid));
+	GPOS_ASSERT(CMDTypeGenericGPDB::HasByte2DoubleMapping(mdid));
 
 	double d = 0;
 
-	if (fNull)
+	if (is_null)
 	{
 		return CDouble(d);
 	}
 
-	if (pmdid->FEquals(&CMDIdGPDB::m_mdidNumeric))
+	if (mdid->Equals(&CMDIdGPDB::m_mdid_numeric))
 	{
-		Numeric num = (Numeric) (pba);
+		Numeric num = (Numeric) (bytes);
 		if (NUMERIC_IS_NAN(num))
 		{
 			// in GPDB NaN is considered the largest numeric number.
 			return CDouble(GPOS_FP_ABS_MAX);
 		}
 
-		d = gpdb::DNumericToDoubleNoOverflow(num);
+		d = gpdb::NumericToDoubleNoOverflow(num);
 	}
-	else if (pmdid->FEquals(&CMDIdGPDB::m_mdidFloat4))
+	else if (mdid->Equals(&CMDIdGPDB::m_mdid_float4))
 	{
-		float4 f = gpdb::FpFloat4FromDatum(datum);
+		float4 f = gpdb::Float4FromDatum(datum);
 
 		if (isnan(f))
 		{
@@ -2369,22 +2369,22 @@ CTranslatorScalarToDXL::DValue
 			d = (double) f;
 		}
 	}
-	else if (pmdid->FEquals(&CMDIdGPDB::m_mdidFloat8))
+	else if (mdid->Equals(&CMDIdGPDB::m_mdid_float8))
 	{
-		d = gpdb::DFloat8FromDatum(datum);
+		d = gpdb::Float8FromDatum(datum);
 
 		if (isnan(d))
 		{
 			d = GPOS_FP_ABS_MAX;
 		}
 	}
-	else if (CMDTypeGenericGPDB::FTimeRelatedType(pmdid))
+	else if (CMDTypeGenericGPDB::IsTimeRelatedType(mdid))
 	{
-		d = gpdb::DConvertTimeValueToScalar(datum, CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId());
+		d = gpdb::ConvertTimeValueToScalar(datum, CMDIdGPDB::CastMdid(mdid)->Oid());
 	}
-	else if (CMDTypeGenericGPDB::FNetworkRelatedType(pmdid))
+	else if (CMDTypeGenericGPDB::IsNetworkRelatedType(mdid))
 	{
-		d = gpdb::DConvertNetworkToScalar(datum, CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId());
+		d = gpdb::ConvertNetworkToScalar(datum, CMDIdGPDB::CastMdid(mdid)->Oid());
 	}
 
 	return CDouble(d);
@@ -2393,133 +2393,133 @@ CTranslatorScalarToDXL::DValue
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::Pba
+//		CTranslatorScalarToDXL::ExtractByteArrayFromDatum
 //
 //	@doc:
 //		Extract the byte array value of the datum. The result is NULL if datum is NULL
 //---------------------------------------------------------------------------
 BYTE *
-CTranslatorScalarToDXL::Pba
+CTranslatorScalarToDXL::ExtractByteArrayFromDatum
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	BOOL fNull,
-	ULONG ulLen,
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	BOOL is_null,
+	ULONG len,
 	Datum datum
 	)
 {
-	ULONG ulLength = 0;
-	BYTE *pba = NULL;
+	ULONG length = 0;
+	BYTE *bytes = NULL;
 
-	if (fNull)
+	if (is_null)
 	{
-		return pba;
+		return bytes;
 	}
 
-	ulLength = (ULONG) gpdb::SDatumSize(datum, pmdtype->FByValue(), ulLen);
-	GPOS_ASSERT(ulLength > 0);
+	length = (ULONG) gpdb::DatumSize(datum, md_type->IsPassedByValue(), len);
+	GPOS_ASSERT(length > 0);
 
-	pba = GPOS_NEW_ARRAY(pmp, BYTE, ulLength);
+	bytes = GPOS_NEW_ARRAY(mp, BYTE, length);
 
-	if (pmdtype->FByValue())
+	if (md_type->IsPassedByValue())
 	{
-		GPOS_ASSERT(ulLength <= ULONG(sizeof(Datum)));
-		clib::PvMemCpy(pba, &datum, ulLength);
+		GPOS_ASSERT(length <= ULONG(sizeof(Datum)));
+		clib::Memcpy(bytes, &datum, length);
 	}
 	else
 	{
-		clib::PvMemCpy(pba, gpdb::PvPointerFromDatum(datum), ulLength);
+		clib::Memcpy(bytes, gpdb::PointerFromDatum(datum), length);
 	}
 
-	return pba;
+	return bytes;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::LValue
+//		CTranslatorScalarToDXL::ExtractLintValueFromDatum
 //
 //	@doc:
 //		Extract the long int value of a datum
 //---------------------------------------------------------------------------
 LINT
-CTranslatorScalarToDXL::LValue
+CTranslatorScalarToDXL::ExtractLintValueFromDatum
 	(
-	IMDId *pmdid,
-	BOOL fNull,
-	BYTE *pba,
-	ULONG ulLength
+	IMDId *mdid,
+	BOOL is_null,
+	BYTE *bytes,
+	ULONG length
 	)
 {
-	GPOS_ASSERT(CMDTypeGenericGPDB::FHasByteLintMapping(pmdid));
+	GPOS_ASSERT(CMDTypeGenericGPDB::HasByte2IntMapping(mdid));
 
-	LINT lValue = 0;
-	if (fNull)
+	LINT lint_value = 0;
+	if (is_null)
 	{
-		return lValue;
+		return lint_value;
 	}
 
-	if (pmdid->FEquals(&CMDIdGPDB::m_mdidCash))
+	if (mdid->Equals(&CMDIdGPDB::m_mdid_cash))
 	{
 		// cash is a pass-by-ref type
 		Datum datumConstVal = (Datum) 0;
-		clib::PvMemCpy(&datumConstVal, pba, ulLength);
+		clib::Memcpy(&datumConstVal, bytes, length);
 		// Date is internally represented as an int32
-		lValue = (LINT) (gpdb::IInt32FromDatum(datumConstVal));
+		lint_value = (LINT) (gpdb::Int32FromDatum(datumConstVal));
 
 	}
 	else
 	{
 		// use hash value
-		ULONG ulHash = 0;
-		if (fNull)
+		ULONG hash = 0;
+		if (is_null)
 		{
-			ulHash = gpos::UlHash<ULONG>(&ulHash);
+			hash = gpos::HashValue<ULONG>(&hash);
 		}
 		else
 		{
-			ulHash = gpos::UlHash<BYTE>(pba);
-			for (ULONG ul = 1; ul < ulLength; ul++)
+			hash = gpos::HashValue<BYTE>(bytes);
+			for (ULONG ul = 1; ul < length; ul++)
 			{
-				ulHash = gpos::UlCombineHashes(ulHash, gpos::UlHash<BYTE>(&pba[ul]));
+				hash = gpos::CombineHashes(hash, gpos::HashValue<BYTE>(&bytes[ul]));
 			}
 		}
 
-		lValue = (LINT) (ulHash / 4);
+		lint_value = (LINT) (hash / 4);
 	}
 
-	return lValue;
+	return lint_value;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorScalarToDXL::Pdatum
+//		CTranslatorScalarToDXL::CreateIDatumFromGpdbDatum
 //
 //	@doc:
 //		Create IDatum from GPDB datum
 //---------------------------------------------------------------------------
 IDatum *
-CTranslatorScalarToDXL::Pdatum
+CTranslatorScalarToDXL::CreateIDatumFromGpdbDatum
 	(
-	IMemoryPool *pmp,
-	const IMDType *pmdtype,
-	BOOL fNull,
-	Datum datum
+	IMemoryPool *mp,
+	const IMDType *md_type,
+	BOOL is_null,
+	Datum gpdb_datum
 	)
 {
-	ULONG ulLength = pmdtype->UlLength();
-	if (!pmdtype->FByValue() && !fNull)
+	ULONG length = md_type->Length();
+	if (!md_type->IsPassedByValue() && !is_null)
 	{
-		INT iLen = dynamic_cast<const CMDTypeGenericGPDB *>(pmdtype)->ILength();
-		ulLength = (ULONG) gpdb::SDatumSize(datum, pmdtype->FByValue(), iLen);
+		INT len = dynamic_cast<const CMDTypeGenericGPDB *>(md_type)->GetGPDBLength();
+		length = (ULONG) gpdb::DatumSize(gpdb_datum, md_type->IsPassedByValue(), len);
 	}
-	GPOS_ASSERT(fNull || ulLength > 0);
+	GPOS_ASSERT(is_null || length > 0);
 
-	CDXLDatum *pdxldatum = CTranslatorScalarToDXL::Pdxldatum(pmp, pmdtype, gpmd::IDefaultTypeModifier, fNull, ulLength, datum);
-	IDatum *pdatum = pmdtype->Pdatum(pmp, pdxldatum);
-	pdxldatum->Release();
-	return pdatum;
+	CDXLDatum *datum_dxl = CTranslatorScalarToDXL::TranslateDatumToDXL(mp, md_type, gpmd::default_type_modifier, is_null, length, gpdb_datum);
+	IDatum *datum = md_type->GetDatumForDXLDatum(mp, datum_dxl);
+	datum_dxl->Release();
+	return datum;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -82,120 +82,120 @@ extern bool optimizer_multilevel_partitioning;
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::Pdxlid
+//		CTranslatorUtils::GetIndexDescr
 //
 //	@doc:
 //		Create a DXL index descriptor from an index MD id
 //
 //---------------------------------------------------------------------------
 CDXLIndexDescr *
-CTranslatorUtils::Pdxlid
+CTranslatorUtils::GetIndexDescr
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid
 	)
 {
-	const IMDIndex *pmdindex = pmda->Pmdindex(pmdid);
-	const CWStringConst *pstrIndexName = pmdindex->Mdname().Pstr();
-	CMDName *pmdnameIdx = GPOS_NEW(pmp) CMDName(pmp, pstrIndexName);
+	const IMDIndex *index = md_accessor->RetrieveIndex(mdid);
+	const CWStringConst *index_name = index->Mdname().GetMDName();
+	CMDName *index_mdname = GPOS_NEW(mp) CMDName(mp, index_name);
 
-	return GPOS_NEW(pmp) CDXLIndexDescr(pmp, pmdid, pmdnameIdx);
+	return GPOS_NEW(mp) CDXLIndexDescr(mp, mdid, index_mdname);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::Pdxltabdesc
+//		CTranslatorUtils::GetTableDescr
 //
 //	@doc:
 //		Create a DXL table descriptor from a GPDB range table entry
 //
 //---------------------------------------------------------------------------
 CDXLTableDescr *
-CTranslatorUtils::Pdxltabdesc
+CTranslatorUtils::GetTableDescr
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	CIdGenerator *pidgtor,
-	const RangeTblEntry *prte,
-	BOOL *pfDistributedTable // output
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	CIdGenerator *id_generator,
+	const RangeTblEntry *rte,
+	BOOL *is_distributed_table // output
 	)
 {
 	// generate an MDId for the table desc.
-	OID oidRel = prte->relid;
+	OID rel_oid = rte->relid;
 
-	if (gpdb::FHasExternalPartition(oidRel))
+	if (gpdb::HasExternalPartition(rel_oid))
 	{
 		// fall back to the planner for queries with partition tables that has an external table in one of its leaf
 		// partitions.
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Query over external partitions"));
 	}
 
-	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(oidRel);
+	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(rel_oid);
 
-	const IMDRelation *pmdrel = pmda->Pmdrel(pmdid);
+	const IMDRelation *rel = md_accessor->RetrieveRel(mdid);
 	
 	// look up table name
-	const CWStringConst *pstrTblName = pmdrel->Mdname().Pstr();
-	CMDName *pmdnameTbl = GPOS_NEW(pmp) CMDName(pmp, pstrTblName);
+	const CWStringConst *tablename = rel->Mdname().GetMDName();
+	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
 
-	CDXLTableDescr *pdxltabdesc = GPOS_NEW(pmp) CDXLTableDescr(pmp, pmdid, pmdnameTbl, prte->checkAsUser);
+	CDXLTableDescr *table_descr = GPOS_NEW(mp) CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser);
 
-	const ULONG ulLen = pmdrel->UlColumns();
+	const ULONG len = rel->ColumnCount();
 
-	IMDRelation::Ereldistrpolicy ereldist = pmdrel->Ereldistribution();
+	IMDRelation::Ereldistrpolicy distribution_policy = rel->GetRelDistribution();
 
-	if (NULL != pfDistributedTable &&
-		(IMDRelation::EreldistrHash == ereldist || IMDRelation::EreldistrRandom == ereldist))
+	if (NULL != is_distributed_table &&
+		(IMDRelation::EreldistrHash == distribution_policy || IMDRelation::EreldistrRandom == distribution_policy))
 	{
-		*pfDistributedTable = true;
+		*is_distributed_table = true;
 	}
-	else if (!optimizer_enable_master_only_queries && (IMDRelation::EreldistrMasterOnly == ereldist))
+	else if (!optimizer_enable_master_only_queries && (IMDRelation::EreldistrMasterOnly == distribution_policy))
 		{
 			// fall back to the planner for queries on master-only table if they are disabled with Orca. This is due to
 			// the fact that catalog tables (master-only) are not analyzed often and will result in Orca producing
 			// inferior plans.
 
-			GPOS_THROW_EXCEPTION(gpdxl::ExmaDXL, // ulMajor
-								 gpdxl::ExmiQuery2DXLUnsupportedFeature, // ulMinor
+			GPOS_THROW_EXCEPTION(gpdxl::ExmaDXL, // major
+								 gpdxl::ExmiQuery2DXLUnsupportedFeature, // minor
 								 CException::ExsevDebug1, // ulSeverityLevel mapped to GPDB severity level
 								 GPOS_WSZ_LIT("Queries on master-only tables"));
 		}
 
 	// add columns from md cache relation object to table descriptor
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	for (ULONG ul = 0; ul < len; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		if (pmdcol->FDropped())
+		const IMDColumn *md_col = rel->GetMdCol(ul);
+		if (md_col->IsDropped())
 		{
 			continue;
 		}
 		
-		CMDName *pmdnameCol = GPOS_NEW(pmp) CMDName(pmp, pmdcol->Mdname().Pstr());
-		CMDIdGPDB *pmdidColType = CMDIdGPDB::PmdidConvert(pmdcol->PmdidType());
-		pmdidColType->AddRef();
+		CMDName *col = GPOS_NEW(mp) CMDName(mp, md_col->Mdname().GetMDName());
+		CMDIdGPDB *col_type = CMDIdGPDB::CastMdid(md_col->MdidType());
+		col_type->AddRef();
 
 		// create a column descriptor for the column
-		CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
+		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr
 											(
-											pmp,
-											pmdnameCol,
-											pidgtor->UlNextId(),
-											pmdcol->IAttno(),
-											pmdidColType,
-											pmdcol->ITypeModifier(), /* iTypeModifier */
+											mp,
+											col,
+											id_generator->next_id(),
+											md_col->AttrNum(),
+											col_type,
+											md_col->TypeModifier(), /* type_modifier */
 											false, /* fColDropped */
-											pmdcol->UlLength()
+											md_col->Length()
 											);
-		pdxltabdesc->AddColumnDescr(pdxlcd);
+		table_descr->AddColumnDescr(dxl_col_descr);
 	}
 
-	return pdxltabdesc;
+	return table_descr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FSirvFunc
+//		CTranslatorUtils::IsSirvFunc
 //
 //	@doc:
 //		Check if the given function is a SIRV (single row volatile) that reads
@@ -203,187 +203,187 @@ CTranslatorUtils::Pdxltabdesc
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FSirvFunc
+CTranslatorUtils::IsSirvFunc
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	OID oidFunc
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	OID func_oid
 	)
 {
 	// we exempt the following 3 functions to avoid falling back to the planner
 	// for DML on tables with sequences. The same exemption is also in the planner
-	if (GPDB_NEXTVAL == oidFunc ||
-		GPDB_CURRVAL == oidFunc ||
-		GPDB_SETVAL == oidFunc)
+	if (GPDB_NEXTVAL == func_oid ||
+		GPDB_CURRVAL == func_oid ||
+		GPDB_SETVAL == func_oid)
 	{
 		return false;
 	}
 
-	CMDIdGPDB *pmdidFunc = GPOS_NEW(pmp) CMDIdGPDB(oidFunc);
-	const IMDFunction *pmdfunc = pmda->Pmdfunc(pmdidFunc);
+	CMDIdGPDB *mdid_func = GPOS_NEW(mp) CMDIdGPDB(func_oid);
+	const IMDFunction *func = md_accessor->RetrieveFunc(mdid_func);
 
-	BOOL fSirv = (!pmdfunc->FReturnsSet() &&
-				  IMDFunction::EfsVolatile == pmdfunc->EfsStability());
+	BOOL is_sirv = (!func->ReturnsSet() &&
+				  IMDFunction::EfsVolatile == func->GetFuncStability());
 
-	pmdidFunc->Release();
+	mdid_func->Release();
 
-	return fSirv;
+	return is_sirv;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FHasSubquery
+//		CTranslatorUtils::HasSubquery
 //
 //	@doc:
 //		Check if the given tree contains a subquery
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FHasSubquery
+CTranslatorUtils::HasSubquery
 	(
-	Node *pnode
+	Node *node
 	)
 {
-	List *plUnsupported = ListMake1Int(T_SubLink);
-	INT iUnsupported = gpdb::IFindNodes(pnode, plUnsupported);
-	gpdb::GPDBFree(plUnsupported);
+	List *unsupported_list = ListMake1Int(T_SubLink);
+	INT unsupported = gpdb::FindNodes(node, unsupported_list);
+	gpdb::GPDBFree(unsupported_list);
 
-	return (0 <= iUnsupported);
+	return (0 <= unsupported);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::Pdxltvf
+//		CTranslatorUtils::ConvertToCDXLLogicalTVF
 //
 //	@doc:
 //		Create a DXL logical TVF from a GPDB range table entry
 //
 //---------------------------------------------------------------------------
 CDXLLogicalTVF *
-CTranslatorUtils::Pdxltvf
+CTranslatorUtils::ConvertToCDXLLogicalTVF
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	CIdGenerator *pidgtor,
-	const RangeTblEntry *prte
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	CIdGenerator *id_generator,
+	const RangeTblEntry *rte
 	)
 {
-	GPOS_ASSERT(NULL != prte->funcexpr);
-	FuncExpr *pfuncexpr = (FuncExpr *)prte->funcexpr;
+	GPOS_ASSERT(NULL != rte->funcexpr);
+	FuncExpr *funcexpr = (FuncExpr *)rte->funcexpr;
 
 	// get function id
-	CMDIdGPDB *pmdidFunc = GPOS_NEW(pmp) CMDIdGPDB(pfuncexpr->funcid);
-	CMDIdGPDB *pmdidRetType =  GPOS_NEW(pmp) CMDIdGPDB(pfuncexpr->funcresulttype);
-	const IMDType *pmdType = pmda->Pmdtype(pmdidRetType);
+	CMDIdGPDB *mdid_func = GPOS_NEW(mp) CMDIdGPDB(funcexpr->funcid);
+	CMDIdGPDB *mdid_return_type =  GPOS_NEW(mp) CMDIdGPDB(funcexpr->funcresulttype);
+	const IMDType *type = md_accessor->RetrieveType(mdid_return_type);
 
 	// In the planner, scalar functions that are volatile (SIRV) or read or modify SQL
 	// data get patched into an InitPlan. This is not supported in the optimizer
-	if (FSirvFunc(pmp, pmda, pfuncexpr->funcid))
+	if (IsSirvFunc(mp, md_accessor, funcexpr->funcid))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("SIRV functions"));
 	}
 
 	// get function from MDcache
-	const IMDFunction *pmdfunc = pmda->Pmdfunc(pmdidFunc);
+	const IMDFunction *func = md_accessor->RetrieveFunc(mdid_func);
 
-	DrgPmdid *pdrgpmdidOutArgTypes = pmdfunc->PdrgpmdidOutputArgTypes();
+	IMdIdArray *out_arg_types = func->OutputArgTypesMdidArray();
 
-	DrgPdxlcd *pdrgdxlcd = NULL;
+	CDXLColDescrArray *column_descrs = NULL;
 
-	if (NULL != prte->funccoltypes)
+	if (NULL != rte->funccoltypes)
 	{
 		// function returns record - use col names and types from query
-		pdrgdxlcd = PdrgdxlcdRecord(pmp, pidgtor, prte->eref->colnames, prte->funccoltypes, prte->funccoltypmods);
+		column_descrs = GetColumnDescriptorsFromRecord(mp, id_generator, rte->eref->colnames, rte->funccoltypes, rte->funccoltypmods);
 	}
-	else if (pmdType->FComposite() && IMDId::FValid(pmdType->PmdidBaseRelation()))
+	else if (type->IsComposite() && IMDId::IsValid(type->GetBaseRelMdid()))
 	{
 		// function returns a "table" type or a user defined type
-		pdrgdxlcd = PdrgdxlcdComposite(pmp, pmda, pidgtor, pmdType);
+		column_descrs = GetColumnDescriptorsFromComposite(mp, md_accessor, id_generator, type);
 	}
-	else if (NULL != pdrgpmdidOutArgTypes)
+	else if (NULL != out_arg_types)
 	{
 		// function returns record - but output col types are defined in catalog
-		pdrgpmdidOutArgTypes->AddRef();
-		if (FContainsPolymorphicTypes(pdrgpmdidOutArgTypes))
+		out_arg_types->AddRef();
+		if (ContainsPolymorphicTypes(out_arg_types))
 		{
 			// resolve polymorphic types (anyelement/anyarray) using the
 			// argument types from the query
-			List *plArgTypes = gpdb::PlFuncArgTypes(pfuncexpr->funcid);
-			DrgPmdid *pdrgpmdidResolved = PdrgpmdidResolvePolymorphicTypes
+			List *arg_types = gpdb::GetFuncArgTypes(funcexpr->funcid);
+			IMdIdArray *resolved_types = ResolvePolymorphicTypes
 												(
-												pmp,
-												pdrgpmdidOutArgTypes,
-												plArgTypes,
-												pfuncexpr
+												mp,
+												out_arg_types,
+												arg_types,
+												funcexpr
 												);
-			pdrgpmdidOutArgTypes->Release();
-			pdrgpmdidOutArgTypes = pdrgpmdidResolved;
+			out_arg_types->Release();
+			out_arg_types = resolved_types;
 		}
 
-		pdrgdxlcd = PdrgdxlcdRecord(pmp, pidgtor, prte->eref->colnames, pdrgpmdidOutArgTypes);
-		pdrgpmdidOutArgTypes->Release();
+		column_descrs = GetColumnDescriptorsFromRecord(mp, id_generator, rte->eref->colnames, out_arg_types);
+		out_arg_types->Release();
 	}
 	else
 	{
 		// function returns base type
-		CMDName mdnameFunc = pmdfunc->Mdname();
+		CMDName func_mdname = func->Mdname();
 		// table valued functions don't describe the returned column type modifiers, hence the -1
-		pdrgdxlcd = PdrgdxlcdBase(pmp, pidgtor, pmdidRetType, IDefaultTypeModifier, &mdnameFunc);
+		column_descrs = GetColumnDescriptorsFromBase(mp, id_generator, mdid_return_type, default_type_modifier, &func_mdname);
 	}
 
-	CMDName *pmdfuncname = GPOS_NEW(pmp) CMDName(pmp, pmdfunc->Mdname().Pstr());
+	CMDName *pmdfuncname = GPOS_NEW(mp) CMDName(mp, func->Mdname().GetMDName());
 
-	CDXLLogicalTVF *pdxlopTVF = GPOS_NEW(pmp) CDXLLogicalTVF(pmp, pmdidFunc, pmdidRetType, pmdfuncname, pdrgdxlcd);
+	CDXLLogicalTVF *tvf_dxl = GPOS_NEW(mp) CDXLLogicalTVF(mp, mdid_func, mdid_return_type, pmdfuncname, column_descrs);
 
-	return pdxlopTVF;
+	return tvf_dxl;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgpmdidResolvePolymorphicTypes
+//		CTranslatorUtils::ResolvePolymorphicTypes
 //
 //	@doc:
 //		Resolve polymorphic types in the given array of type ids, replacing
 //		them with the actual types obtained from the query
 //
 //---------------------------------------------------------------------------
-DrgPmdid *
-CTranslatorUtils::PdrgpmdidResolvePolymorphicTypes
+IMdIdArray *
+CTranslatorUtils::ResolvePolymorphicTypes
 	(
-	IMemoryPool *pmp,
-	DrgPmdid *pdrgpmdidTypes,
-	List *plArgTypes,
-	FuncExpr *pfuncexpr
+	IMemoryPool *mp,
+	IMdIdArray *mdid_array,
+	List *arg_types_list,
+	FuncExpr *funcexpr
 	)
 {
-	ULONG ulArgIndex = 0;
+	ULONG arg_index = 0;
 
-	const ULONG ulArgTypes = gpdb::UlListLength(plArgTypes);
-	const ULONG ulArgsFromQuery = gpdb::UlListLength(pfuncexpr->args);
-	const ULONG ulNumReturnArgs = pdrgpmdidTypes->UlLength();
-	const ULONG ulNumArgs = ulArgTypes < ulArgsFromQuery ? ulArgTypes : ulArgsFromQuery;
-	const ULONG ulTotalArgs = ulNumArgs + ulNumReturnArgs;
+	const ULONG num_arg_types = gpdb::ListLength(arg_types_list);
+	const ULONG num_args_from_query = gpdb::ListLength(funcexpr->args);
+	const ULONG num_return_args = mdid_array->Size();
+	const ULONG num_args = num_arg_types < num_args_from_query ? num_arg_types : num_args_from_query;
+	const ULONG total_args = num_args + num_return_args;
 
-	OID argTypes[ulNumArgs];
-	char argModes[ulTotalArgs];
+	OID arg_types[num_args];
+	char arg_modes[total_args];
 
 	// copy function argument types
-	ListCell *plcArgType = NULL;
-	ForEach (plcArgType, plArgTypes)
+	ListCell *arg_type = NULL;
+	ForEach (arg_type, arg_types_list)
 	{
-		argTypes[ulArgIndex] = lfirst_oid(plcArgType);
-		argModes[ulArgIndex++] = PROARGMODE_IN;
+		arg_types[arg_index] = lfirst_oid(arg_type);
+		arg_modes[arg_index++] = PROARGMODE_IN;
 	}
 
 	// copy function return types
-	for (ULONG ul = 0; ul < ulNumReturnArgs; ul++)
+	for (ULONG ul = 0; ul < num_return_args; ul++)
 	{
-		IMDId *pmdid = (*pdrgpmdidTypes)[ul];
-		argTypes[ulArgIndex] = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
-		argModes[ulArgIndex++] = PROARGMODE_TABLE;
+		IMDId *mdid = (*mdid_array)[ul];
+		arg_types[arg_index] = CMDIdGPDB::CastMdid(mdid)->Oid();
+		arg_modes[arg_index++] = PROARGMODE_TABLE;
 	}
 
-	if(!gpdb::FResolvePolymorphicType(ulTotalArgs, argTypes, argModes, pfuncexpr))
+	if(!gpdb::ResolvePolymorphicArgType(total_args, arg_types, arg_modes, funcexpr))
 	{
 		GPOS_RAISE
 				(
@@ -394,23 +394,23 @@ CTranslatorUtils::PdrgpmdidResolvePolymorphicTypes
 	}
 
 	// generate a new array of mdids based on the resolved types
-	DrgPmdid *pdrgpmdidResolved = GPOS_NEW(pmp) DrgPmdid(pmp);
+	IMdIdArray *resolved_types = GPOS_NEW(mp) IMdIdArray(mp);
 
 	// get the resolved return types
-	for (ULONG ul = ulNumArgs; ul < ulTotalArgs ; ul++)
+	for (ULONG ul = num_args; ul < total_args ; ul++)
 	{
 
-		IMDId *pmdidResolved = NULL;
-		pmdidResolved = GPOS_NEW(pmp) CMDIdGPDB(argTypes[ul]);
-		pdrgpmdidResolved->Append(pmdidResolved);
+		IMDId *resolved_mdid = NULL;
+		resolved_mdid = GPOS_NEW(mp) CMDIdGPDB(arg_types[ul]);
+		resolved_types->Append(resolved_mdid);
 	}
 
-	return pdrgpmdidResolved;
+	return resolved_types;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FContainsPolymorphicTypes
+//		CTranslatorUtils::ContainsPolymorphicTypes
 //
 //	@doc:
 //		Check if the given mdid array contains any of the polymorphic
@@ -418,17 +418,17 @@ CTranslatorUtils::PdrgpmdidResolvePolymorphicTypes
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FContainsPolymorphicTypes
+CTranslatorUtils::ContainsPolymorphicTypes
 	(
-	DrgPmdid *pdrgpmdidTypes
+	IMdIdArray *mdid_array
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpmdidTypes);
-	const ULONG ulLen = pdrgpmdidTypes->UlLength();
-	for (ULONG ul = 0; ul < ulLen; ul++)
+	GPOS_ASSERT(NULL != mdid_array);
+	const ULONG len = mdid_array->Size();
+	for (ULONG ul = 0; ul < len; ul++)
 	{
-		IMDId *pmdidType = (*pdrgpmdidTypes)[ul];
-		if (IsPolymorphicType(CMDIdGPDB::PmdidConvert(pmdidType)->OidObjectId()))
+		IMDId *mdid_type = (*mdid_array)[ul];
+		if (IsPolymorphicType(CMDIdGPDB::CastMdid(mdid_type)->Oid()))
 		{
 			return true;
 		}
@@ -439,199 +439,199 @@ CTranslatorUtils::FContainsPolymorphicTypes
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgdxlcdRecord
+//		CTranslatorUtils::GetColumnDescriptorsFromRecord
 //
 //	@doc:
 //		Get column descriptors from a record type
 //
 //---------------------------------------------------------------------------
-DrgPdxlcd *
-CTranslatorUtils::PdrgdxlcdRecord
+CDXLColDescrArray *
+CTranslatorUtils::GetColumnDescriptorsFromRecord
 	(
-	IMemoryPool *pmp,
-	CIdGenerator *pidgtor,
-	List *plColNames,
-	List *plColTypes,
-	List *plColTypeModifiers
+	IMemoryPool *mp,
+	CIdGenerator *id_generator,
+	List *col_names,
+	List *col_types,
+	List *col_type_modifiers
 	)
 {
-	ListCell *plcColName = NULL;
-	ListCell *plcColType = NULL;
-	ListCell *plcColTypeModifier = NULL;
+	ListCell *col_name = NULL;
+	ListCell *col_type = NULL;
+	ListCell *col_type_modifier = NULL;
 
 	ULONG ul = 0;
-	DrgPdxlcd *pdrgdxlcd = GPOS_NEW(pmp) DrgPdxlcd(pmp);
+	CDXLColDescrArray *column_descrs = GPOS_NEW(mp) CDXLColDescrArray(mp);
 
-	ForThree (plcColName, plColNames,
-			plcColType, plColTypes,
-			plcColTypeModifier, plColTypeModifiers)
+	ForThree (col_name, col_names,
+			col_type, col_types,
+			col_type_modifier, col_type_modifiers)
 	{
-		Value *pvalue = (Value *) lfirst(plcColName);
-		Oid coltype = lfirst_oid(plcColType);
-		INT iTypeModifier = lfirst_int(plcColTypeModifier);
+		Value *value = (Value *) lfirst(col_name);
+		Oid coltype = lfirst_oid(col_type);
+		INT type_modifier = lfirst_int(col_type_modifier);
 
-		CHAR *szColName = strVal(pvalue);
-		CWStringDynamic *pstrColName = CDXLUtils::PstrFromSz(pmp, szColName);
-		CMDName *pmdColName = GPOS_NEW(pmp) CMDName(pmp, pstrColName);
-		GPOS_DELETE(pstrColName);
+		CHAR *col_name_char_array = strVal(value);
+		CWStringDynamic *column_name = CDXLUtils::CreateDynamicStringFromCharArray(mp, col_name_char_array);
+		CMDName *col_mdname = GPOS_NEW(mp) CMDName(mp, column_name);
+		GPOS_DELETE(column_name);
 
-		IMDId *pmdidColType = GPOS_NEW(pmp) CMDIdGPDB(coltype);
+		IMDId *col_type = GPOS_NEW(mp) CMDIdGPDB(coltype);
 
-		CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
+		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr
 										(
-										pmp,
-										pmdColName,
-										pidgtor->UlNextId(),
-										INT(ul + 1) /* iAttno */,
-										pmdidColType,
-										iTypeModifier,
+										mp,
+										col_mdname,
+										id_generator->next_id(),
+										INT(ul + 1) /* attno */,
+										col_type,
+										type_modifier,
 										false /* fColDropped */
 										);
-		pdrgdxlcd->Append(pdxlcd);
+		column_descrs->Append(dxl_col_descr);
 		ul++;
 	}
 
-	return pdrgdxlcd;
+	return column_descrs;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgdxlcdRecord
+//		CTranslatorUtils::GetColumnDescriptorsFromRecord
 //
 //	@doc:
 //		Get column descriptors from a record type
 //
 //---------------------------------------------------------------------------
-DrgPdxlcd *
-CTranslatorUtils::PdrgdxlcdRecord
+CDXLColDescrArray *
+CTranslatorUtils::GetColumnDescriptorsFromRecord
 	(
-	IMemoryPool *pmp,
-	CIdGenerator *pidgtor,
-	List *plColNames,
-	DrgPmdid *pdrgpmdidOutArgTypes
+	IMemoryPool *mp,
+	CIdGenerator *id_generator,
+	List *col_names,
+	IMdIdArray *out_arg_types
 	)
 {
-	GPOS_ASSERT(pdrgpmdidOutArgTypes->UlLength() == (ULONG) gpdb::UlListLength(plColNames));
-	ListCell *plcColName = NULL;
+	GPOS_ASSERT(out_arg_types->Size() == (ULONG) gpdb::ListLength(col_names));
+	ListCell *col_name = NULL;
 
 	ULONG ul = 0;
-	DrgPdxlcd *pdrgdxlcd = GPOS_NEW(pmp) DrgPdxlcd(pmp);
+	CDXLColDescrArray *column_descrs = GPOS_NEW(mp) CDXLColDescrArray(mp);
 
-	ForEach (plcColName, plColNames)
+	ForEach (col_name, col_names)
 	{
-		Value *pvalue = (Value *) lfirst(plcColName);
+		Value *value = (Value *) lfirst(col_name);
 
-		CHAR *szColName = strVal(pvalue);
-		CWStringDynamic *pstrColName = CDXLUtils::PstrFromSz(pmp, szColName);
-		CMDName *pmdColName = GPOS_NEW(pmp) CMDName(pmp, pstrColName);
-		GPOS_DELETE(pstrColName);
+		CHAR *col_name_char_array = strVal(value);
+		CWStringDynamic *column_name = CDXLUtils::CreateDynamicStringFromCharArray(mp, col_name_char_array);
+		CMDName *col_mdname = GPOS_NEW(mp) CMDName(mp, column_name);
+		GPOS_DELETE(column_name);
 
-		IMDId *pmdidColType = (*pdrgpmdidOutArgTypes)[ul];
-		pmdidColType->AddRef();
+		IMDId *col_type = (*out_arg_types)[ul];
+		col_type->AddRef();
 
 		// This function is only called to construct column descriptors for table-valued functions
 		// which won't have type modifiers for columns of the returned table
-		CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
+		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr
 										(
-										pmp,
-										pmdColName,
-										pidgtor->UlNextId(),
-										INT(ul + 1) /* iAttno */,
-										pmdidColType,
-										IDefaultTypeModifier,
+										mp,
+										col_mdname,
+										id_generator->next_id(),
+										INT(ul + 1) /* attno */,
+										col_type,
+										default_type_modifier,
 										false /* fColDropped */
 										);
-		pdrgdxlcd->Append(pdxlcd);
+		column_descrs->Append(dxl_col_descr);
 		ul++;
 	}
 
-	return pdrgdxlcd;
+	return column_descrs;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgdxlcdBase
+//		CTranslatorUtils::GetColumnDescriptorsFromBase
 //
 //	@doc:
 //		Get column descriptor from a base type
 //
 //---------------------------------------------------------------------------
-DrgPdxlcd *
-CTranslatorUtils::PdrgdxlcdBase
+CDXLColDescrArray *
+CTranslatorUtils::GetColumnDescriptorsFromBase
 	(
-	IMemoryPool *pmp,
-	CIdGenerator *pidgtor,
-	IMDId *pmdidRetType,
-	INT iTypeModifier,
+	IMemoryPool *mp,
+	CIdGenerator *id_generator,
+	IMDId *mdid_return_type,
+	INT type_modifier,
 	CMDName *pmdName
 	)
 {
-	DrgPdxlcd *pdrgdxlcd = GPOS_NEW(pmp) DrgPdxlcd(pmp);
+	CDXLColDescrArray *column_descrs = GPOS_NEW(mp) CDXLColDescrArray(mp);
 
-	pmdidRetType->AddRef();
-	CMDName *pmdColName = GPOS_NEW(pmp) CMDName(pmp, pmdName->Pstr());
+	mdid_return_type->AddRef();
+	CMDName *col_mdname = GPOS_NEW(mp) CMDName(mp, pmdName->GetMDName());
 
-	CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
+	CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr
 									(
-									pmp,
-									pmdColName,
-									pidgtor->UlNextId(),
-									INT(1) /* iAttno */,
-									pmdidRetType,
-									iTypeModifier, /* iTypeModifier */
+									mp,
+									col_mdname,
+									id_generator->next_id(),
+									INT(1) /* attno */,
+									mdid_return_type,
+									type_modifier, /* type_modifier */
 									false /* fColDropped */
 									);
 
-	pdrgdxlcd->Append(pdxlcd);
+	column_descrs->Append(dxl_col_descr);
 
-	return pdrgdxlcd;
+	return column_descrs;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgdxlcdComposite
+//		CTranslatorUtils::GetColumnDescriptorsFromComposite
 //
 //	@doc:
 //		Get column descriptors from a composite type
 //
 //---------------------------------------------------------------------------
-DrgPdxlcd *
-CTranslatorUtils::PdrgdxlcdComposite
+CDXLColDescrArray *
+CTranslatorUtils::GetColumnDescriptorsFromComposite
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	CIdGenerator *pidgtor,
-	const IMDType *pmdType
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	CIdGenerator *id_generator,
+	const IMDType *type
 	)
 {
-	DrgPmdcol *pdrgPmdCol = ExpandCompositeType(pmp, pmda, pmdType);
+	CMDColumnArray *col_ptr_arr = ExpandCompositeType(mp, md_accessor, type);
 
-	DrgPdxlcd *pdrgdxlcd = GPOS_NEW(pmp) DrgPdxlcd(pmp);
+	CDXLColDescrArray *column_descrs = GPOS_NEW(mp) CDXLColDescrArray(mp);
 
-	for (ULONG ul = 0; ul < pdrgPmdCol->UlLength(); ul++)
+	for (ULONG ul = 0; ul < col_ptr_arr->Size(); ul++)
 	{
-		IMDColumn *pmdcol = (*pdrgPmdCol)[ul];
+		IMDColumn *md_col = (*col_ptr_arr)[ul];
 
-		CMDName *pmdColName = GPOS_NEW(pmp) CMDName(pmp, pmdcol->Mdname().Pstr());
-		IMDId *pmdidColType = pmdcol->PmdidType();
+		CMDName *col_mdname = GPOS_NEW(mp) CMDName(mp, md_col->Mdname().GetMDName());
+		IMDId *col_type = md_col->MdidType();
 
-		pmdidColType->AddRef();
-		CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
+		col_type->AddRef();
+		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr
 										(
-										pmp,
-										pmdColName,
-										pidgtor->UlNextId(),
-										INT(ul + 1) /* iAttno */,
-										pmdidColType,
-										pmdcol->ITypeModifier(), /* iTypeModifier */
+										mp,
+										col_mdname,
+										id_generator->next_id(),
+										INT(ul + 1) /* attno */,
+										col_type,
+										md_col->TypeModifier(), /* type_modifier */
 										false /* fColDropped */
 										);
-		pdrgdxlcd->Append(pdxlcd);
+		column_descrs->Append(dxl_col_descr);
 	}
 
-	pdrgPmdCol->Release();
+	col_ptr_arr->Release();
 
-	return pdrgdxlcd;
+	return column_descrs;
 }
 
 //---------------------------------------------------------------------------
@@ -642,31 +642,31 @@ CTranslatorUtils::PdrgdxlcdComposite
 //		Expand a composite type into an array of IMDColumns
 //
 //---------------------------------------------------------------------------
-DrgPmdcol *
+CMDColumnArray *
 CTranslatorUtils::ExpandCompositeType
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const IMDType *pmdType
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const IMDType *type
 	)
 {
-	GPOS_ASSERT(NULL != pmdType);
-	GPOS_ASSERT(pmdType->FComposite());
+	GPOS_ASSERT(NULL != type);
+	GPOS_ASSERT(type->IsComposite());
 
-	IMDId *pmdidRel = pmdType->PmdidBaseRelation();
-	const IMDRelation *pmdrel = pmda->Pmdrel(pmdidRel);
-	GPOS_ASSERT(NULL != pmdrel);
+	IMDId *rel_mdid = type->GetBaseRelMdid();
+	const IMDRelation *rel = md_accessor->RetrieveRel(rel_mdid);
+	GPOS_ASSERT(NULL != rel);
 
-	DrgPmdcol *pdrgPmdcol = GPOS_NEW(pmp) DrgPmdcol(pmp);
+	CMDColumnArray *pdrgPmdcol = GPOS_NEW(mp) CMDColumnArray(mp);
 
-	for(ULONG ul = 0; ul < pmdrel->UlColumns(); ul++)
+	for(ULONG ul = 0; ul < rel->ColumnCount(); ul++)
 	{
-		CMDColumn *pmdcol = (CMDColumn *) pmdrel->Pmdcol(ul);
+		CMDColumn *md_col = (CMDColumn *) rel->GetMdCol(ul);
 
-		if (!pmdcol->FSystemColumn())
+		if (!md_col->IsSystemColumn())
 		{
-			pmdcol->AddRef();
-			pdrgPmdcol->Append(pmdcol);
+			md_col->AddRef();
+			pdrgPmdcol->Append(md_col);
 		}
 	}
 
@@ -675,129 +675,129 @@ CTranslatorUtils::ExpandCompositeType
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::EdxljtFromJoinType
+//		CTranslatorUtils::ConvertToDXLJoinType
 //
 //	@doc:
 //		Translates the join type from its GPDB representation into the DXL one
 //
 //---------------------------------------------------------------------------
 EdxlJoinType
-CTranslatorUtils::EdxljtFromJoinType
+CTranslatorUtils::ConvertToDXLJoinType
 	(
 	JoinType jt
 	)
 {
-	EdxlJoinType edxljt = EdxljtSentinel;
+	EdxlJoinType join_type = EdxljtSentinel;
 
 	switch (jt)
 	{
 		case JOIN_INNER:
-			edxljt = EdxljtInner;
+			join_type = EdxljtInner;
 			break;
 
 		case JOIN_LEFT:
-			edxljt = EdxljtLeft;
+			join_type = EdxljtLeft;
 			break;
 
 		case JOIN_FULL:
-			edxljt = EdxljtFull;
+			join_type = EdxljtFull;
 			break;
 
 		case JOIN_RIGHT:
-			edxljt = EdxljtRight;
+			join_type = EdxljtRight;
 			break;
 
 		case JOIN_IN:
-			edxljt = EdxljtIn;
+			join_type = EdxljtIn;
 			break;
 
 		case JOIN_LASJ:
-			edxljt = EdxljtLeftAntiSemijoin;
+			join_type = EdxljtLeftAntiSemijoin;
 			break;
 
 		case JOIN_LASJ_NOTIN:
-			edxljt = EdxljtLeftAntiSemijoinNotIn;
+			join_type = EdxljtLeftAntiSemijoinNotIn;
 			break;
 
 		default:
 			GPOS_ASSERT(!"Unrecognized join type");
 	}
 
-	GPOS_ASSERT(EdxljtSentinel > edxljt);
+	GPOS_ASSERT(EdxljtSentinel > join_type);
 
-	return edxljt;
+	return join_type;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::EdxlIndexDirection
+//		CTranslatorUtils::ConvertToDXLIndexScanDirection
 //
 //	@doc:
 //		Translates the DXL index scan direction from GPDB representation
 //
 //---------------------------------------------------------------------------
 EdxlIndexScanDirection
-CTranslatorUtils::EdxlIndexDirection
+CTranslatorUtils::ConvertToDXLIndexScanDirection
 	(
 	ScanDirection sd
 	)
 {
-	EdxlIndexScanDirection edxlisd = EdxlisdSentinel;
+	EdxlIndexScanDirection idx_scan_direction = EdxlisdSentinel;
 
 	switch (sd)
 	{
 		case BackwardScanDirection:
-			edxlisd = EdxlisdBackward;
+			idx_scan_direction = EdxlisdBackward;
 			break;
 
 		case ForwardScanDirection:
-			edxlisd = EdxlisdForward;
+			idx_scan_direction = EdxlisdForward;
 			break;
 
 		case NoMovementScanDirection:
-			edxlisd = EdxlisdNoMovement;
+			idx_scan_direction = EdxlisdNoMovement;
 			break;
 
 		default:
 			GPOS_ASSERT(!"Unrecognized index scan direction");
 	}
 
-	GPOS_ASSERT(EdxlisdSentinel > edxlisd);
+	GPOS_ASSERT(EdxlisdSentinel > idx_scan_direction);
 
-	return edxlisd;
+	return idx_scan_direction;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::Pdxlcd
+//		CTranslatorUtils::GetColumnDescrAt
 //
 //	@doc:
 //		Find the n-th col descr entry
 //
 //---------------------------------------------------------------------------
 const CDXLColDescr *
-CTranslatorUtils::Pdxlcd
+CTranslatorUtils::GetColumnDescrAt
 	(
-	const CDXLTableDescr *pdxltabdesc,
-	ULONG ulPos
+	const CDXLTableDescr *table_descr,
+	ULONG pos
 	)
 {
-	GPOS_ASSERT(0 != ulPos);
-	GPOS_ASSERT(ulPos < pdxltabdesc->UlArity());
+	GPOS_ASSERT(0 != pos);
+	GPOS_ASSERT(pos < table_descr->Arity());
 
-	return pdxltabdesc->Pdxlcd(ulPos);
+	return table_descr->GetColumnDescrAt(pos);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PstrSystemColName
+//		CTranslatorUtils::GetSystemColName
 //
 //	@doc:
 //		Return the name for the system attribute with the given attribute number.
 //
 //---------------------------------------------------------------------------
 const CWStringConst *
-CTranslatorUtils::PstrSystemColName
+CTranslatorUtils::GetSystemColName
 	(
 	AttrNumber attno
 	)
@@ -807,28 +807,28 @@ CTranslatorUtils::PstrSystemColName
 	switch (attno)
 	{
 		case SelfItemPointerAttributeNumber:
-			return CDXLTokens::PstrToken(EdxltokenCtidColName);
+			return CDXLTokens::GetDXLTokenStr(EdxltokenCtidColName);
 
 		case ObjectIdAttributeNumber:
-			return CDXLTokens::PstrToken(EdxltokenOidColName);
+			return CDXLTokens::GetDXLTokenStr(EdxltokenOidColName);
 
 		case MinTransactionIdAttributeNumber:
-			return CDXLTokens::PstrToken(EdxltokenXminColName);
+			return CDXLTokens::GetDXLTokenStr(EdxltokenXminColName);
 
 		case MinCommandIdAttributeNumber:
-			return CDXLTokens::PstrToken(EdxltokenCminColName);
+			return CDXLTokens::GetDXLTokenStr(EdxltokenCminColName);
 
 		case MaxTransactionIdAttributeNumber:
-			return CDXLTokens::PstrToken(EdxltokenXmaxColName);
+			return CDXLTokens::GetDXLTokenStr(EdxltokenXmaxColName);
 
 		case MaxCommandIdAttributeNumber:
-			return CDXLTokens::PstrToken(EdxltokenCmaxColName);
+			return CDXLTokens::GetDXLTokenStr(EdxltokenCmaxColName);
 
 		case TableOidAttributeNumber:
-			return CDXLTokens::PstrToken(EdxltokenTableOidColName);
+			return CDXLTokens::GetDXLTokenStr(EdxltokenTableOidColName);
 
 		case GpSegmentIdAttributeNumber:
-			return CDXLTokens::PstrToken(EdxltokenGpSegmentIdColName);
+			return CDXLTokens::GetDXLTokenStr(EdxltokenGpSegmentIdColName);
 
 		default:
 			GPOS_RAISE
@@ -843,16 +843,16 @@ CTranslatorUtils::PstrSystemColName
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PmdidSystemColType
+//		CTranslatorUtils::GetSystemColType
 //
 //	@doc:
 //		Return the type id for the system attribute with the given attribute number.
 //
 //---------------------------------------------------------------------------
 CMDIdGPDB *
-CTranslatorUtils::PmdidSystemColType
+CTranslatorUtils::GetSystemColType
 	(
-	IMemoryPool *pmp,
+	IMemoryPool *mp,
 	AttrNumber attno
 	)
 {
@@ -862,26 +862,26 @@ CTranslatorUtils::PmdidSystemColType
 	{
 		case SelfItemPointerAttributeNumber:
 			// tid type
-			return GPOS_NEW(pmp) CMDIdGPDB(GPDB_TID);
+			return GPOS_NEW(mp) CMDIdGPDB(GPDB_TID);
 
 		case ObjectIdAttributeNumber:
 		case TableOidAttributeNumber:
 			// OID type
-			return GPOS_NEW(pmp) CMDIdGPDB(GPDB_OID);
+			return GPOS_NEW(mp) CMDIdGPDB(GPDB_OID);
 
 		case MinTransactionIdAttributeNumber:
 		case MaxTransactionIdAttributeNumber:
 			// xid type
-			return GPOS_NEW(pmp) CMDIdGPDB(GPDB_XID);
+			return GPOS_NEW(mp) CMDIdGPDB(GPDB_XID);
 
 		case MinCommandIdAttributeNumber:
 		case MaxCommandIdAttributeNumber:
 			// cid type
-			return GPOS_NEW(pmp) CMDIdGPDB(GPDB_CID);
+			return GPOS_NEW(mp) CMDIdGPDB(GPDB_CID);
 
 		case GpSegmentIdAttributeNumber:
 			// int4
-			return GPOS_NEW(pmp) CMDIdGPDB(GPDB_INT4);
+			return GPOS_NEW(mp) CMDIdGPDB(GPDB_INT4);
 
 		default:
 			GPOS_RAISE
@@ -897,7 +897,7 @@ CTranslatorUtils::PmdidSystemColType
 
 // Returns the length for the system column with given attno number
 const ULONG
-CTranslatorUtils::UlSystemColLength
+CTranslatorUtils::GetSystemColLength
 	(
 	AttrNumber attno
 	)
@@ -939,7 +939,7 @@ CTranslatorUtils::UlSystemColLength
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::Scandirection
+//		CTranslatorUtils::GetScanDirection
 //
 //	@doc:
 //		Return the GPDB specific scan direction from its corresponding DXL
@@ -947,17 +947,17 @@ CTranslatorUtils::UlSystemColLength
 //
 //---------------------------------------------------------------------------
 ScanDirection
-CTranslatorUtils::Scandirection
+CTranslatorUtils::GetScanDirection
 	(
-	EdxlIndexScanDirection edxlisd
+	EdxlIndexScanDirection idx_scan_direction
 	)
 {
-	if (EdxlisdBackward == edxlisd)
+	if (EdxlisdBackward == idx_scan_direction)
 	{
 		return BackwardScanDirection;
 	}
 
-	if (EdxlisdForward == edxlisd)
+	if (EdxlisdForward == idx_scan_direction)
 	{
 		return ForwardScanDirection;
 	}
@@ -976,21 +976,21 @@ CTranslatorUtils::Scandirection
 OID
 CTranslatorUtils::OidCmpOperator
 	(
-	Expr* pexpr
+	Expr* expr
 	)
 {
-	GPOS_ASSERT(IsA(pexpr, OpExpr) || IsA(pexpr, ScalarArrayOpExpr) || IsA(pexpr, RowCompareExpr));
+	GPOS_ASSERT(IsA(expr, OpExpr) || IsA(expr, ScalarArrayOpExpr) || IsA(expr, RowCompareExpr));
 
-	switch (pexpr->type)
+	switch (expr->type)
 	{
 		case T_OpExpr:
-			return ((OpExpr *) pexpr)->opno;
+			return ((OpExpr *) expr)->opno;
 			
 		case T_ScalarArrayOpExpr:
-			return ((ScalarArrayOpExpr*) pexpr)->opno;
+			return ((ScalarArrayOpExpr*) expr)->opno;
 
 		case T_RowCompareExpr:
-			return LInitialOID(((RowCompareExpr *) pexpr)->opnos);
+			return LInitialOID(((RowCompareExpr *) expr)->opnos);
 			
 		default:
 			GPOS_RAISE
@@ -1005,55 +1005,55 @@ CTranslatorUtils::OidCmpOperator
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::OidIndexQualOpFamily
+//		CTranslatorUtils::GetOpFamilyForIndexQual
 //
 //	@doc:
 //		Extract comparison operator family for the given index column
 //
 //---------------------------------------------------------------------------
 OID
-CTranslatorUtils::OidIndexQualOpFamily
+CTranslatorUtils::GetOpFamilyForIndexQual
 	(
-	INT iAttno,
-	OID oidIndex
+	INT attno,
+	OID index_oid
 	)
 {
-	Relation relIndex = gpdb::RelGetRelation(oidIndex);
-	GPOS_ASSERT(NULL != relIndex);
-	GPOS_ASSERT(iAttno <= relIndex->rd_index->indnatts);
+	Relation rel = gpdb::GetRelation(index_oid);
+	GPOS_ASSERT(NULL != rel);
+	GPOS_ASSERT(attno <= rel->rd_index->indnatts);
 	
-	OID oidOpfamily = relIndex->rd_opfamily[iAttno - 1];
-	gpdb::CloseRelation(relIndex);
+	OID op_family_oid = rel->rd_opfamily[attno - 1];
+	gpdb::CloseRelation(rel);
 	
-	return oidOpfamily;
+	return op_family_oid;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::Edxlsetop
+//		CTranslatorUtils::GetSetOpType
 //
 //	@doc:
 //		Return the DXL representation of the set operation
 //
 //---------------------------------------------------------------------------
 EdxlSetOpType
-CTranslatorUtils::Edxlsetop
+CTranslatorUtils::GetSetOpType
 	(
 	SetOperation setop,
-	BOOL fAll
+	BOOL is_all
 	)
 {
-	if (SETOP_UNION == setop && fAll)
+	if (SETOP_UNION == setop && is_all)
 	{
 		return EdxlsetopUnionAll;
 	}
 
-	if (SETOP_INTERSECT == setop && fAll)
+	if (SETOP_INTERSECT == setop && is_all)
 	{
 		return EdxlsetopIntersectAll;
 	}
 
-	if (SETOP_EXCEPT == setop && fAll)
+	if (SETOP_EXCEPT == setop && is_all)
 	{
 		return EdxlsetopDifferenceAll;
 	}
@@ -1164,187 +1164,187 @@ CTranslatorUtils::Windowboundkind
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgpulGroupingCols
+//		CTranslatorUtils::GetGroupingColidArray
 //
 //	@doc:
 //		Construct a dynamic array of column ids for the given set of grouping
 // 		col attnos
 //
 //---------------------------------------------------------------------------
-DrgPul *
-CTranslatorUtils::PdrgpulGroupingCols
+ULongPtrArray *
+CTranslatorUtils::GetGroupingColidArray
 	(
-	IMemoryPool *pmp,
-	CBitSet *pbsGroupByCols,
-	HMIUl *phmiulSortGrpColsColId
+	IMemoryPool *mp,
+	CBitSet *group_by_cols,
+	IntToUlongMap *sort_group_cols_to_colid_map
 	)
 {
-	DrgPul *pdrgpul = GPOS_NEW(pmp) DrgPul(pmp);
+	ULongPtrArray *colids = GPOS_NEW(mp) ULongPtrArray(mp);
 
-	if (NULL != pbsGroupByCols)
+	if (NULL != group_by_cols)
 	{
-		CBitSetIter bsi(*pbsGroupByCols);
+		CBitSetIter bsi(*group_by_cols);
 
-		while (bsi.FAdvance())
+		while (bsi.Advance())
 		{
-			const ULONG ulColId = UlColId(bsi.UlBit(), phmiulSortGrpColsColId);
-			pdrgpul->Append(GPOS_NEW(pmp) ULONG(ulColId));
+			const ULONG colid = GetColId(bsi.Bit(), sort_group_cols_to_colid_map);
+			colids->Append(GPOS_NEW(mp) ULONG(colid));
 		}
 	}
 
-	return pdrgpul;
+	return colids;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgpbsGroupBy
+//		CTranslatorUtils::GetColumnAttnosForGroupBy
 //
 //	@doc:
 //		Construct a dynamic array of sets of column attnos corresponding to the
 // 		group by clause
 //
 //---------------------------------------------------------------------------
-DrgPbs *
-CTranslatorUtils::PdrgpbsGroupBy
+CBitSetArray *
+CTranslatorUtils::GetColumnAttnosForGroupBy
 	(
-	IMemoryPool *pmp,
-	List *plGroupClause,
-	ULONG ulCols,
-	HMUlUl *phmululGrpColPos,	// mapping of grouping col positions to SortGroupRef ids
-	CBitSet *pbsGrpCols			// existing uniqueue grouping columns
+	IMemoryPool *mp,
+	List *group_clause_list,
+	ULONG num_cols,
+	UlongToUlongMap *group_col_pos,	// mapping of grouping col positions to SortGroupRef ids
+	CBitSet *group_cols			// existing uniqueue grouping columns
 	)
 {
-	GPOS_ASSERT(NULL != plGroupClause);
-	GPOS_ASSERT(0 < gpdb::UlListLength(plGroupClause));
-	GPOS_ASSERT(NULL != phmululGrpColPos);
+	GPOS_ASSERT(NULL != group_clause_list);
+	GPOS_ASSERT(0 < gpdb::ListLength(group_clause_list));
+	GPOS_ASSERT(NULL != group_col_pos);
 
-	Node *pnode = (Node*) LInitial(plGroupClause);
+	Node *node = (Node*) LInitial(group_clause_list);
 
-	if (NULL == pnode || IsA(pnode, GroupClause))
+	if (NULL == node || IsA(node, GroupClause))
 	{
 		// simple group by
-		CBitSet *pbsGroupingSet = PbsGroupingSet(pmp, plGroupClause, ulCols, phmululGrpColPos, pbsGrpCols);
-		DrgPbs *pdrgpbs = GPOS_NEW(pmp) DrgPbs(pmp);
-		pdrgpbs->Append(pbsGroupingSet);
-		return pdrgpbs;
+		CBitSet *col_attnos = CreateAttnoSetForGroupingSet(mp, group_clause_list, num_cols, group_col_pos, group_cols);
+		CBitSetArray *col_attnos_arr = GPOS_NEW(mp) CBitSetArray(mp);
+		col_attnos_arr->Append(col_attnos);
+		return col_attnos_arr;
 	}
 
-	if (!IsA(pnode, GroupingClause))
+	if (!IsA(node, GroupingClause))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Group by clause"));
 	}
 
-	const ULONG ulGroupClause = gpdb::UlListLength(plGroupClause);
-	GPOS_ASSERT(0 < ulGroupClause);
-	if (1 < ulGroupClause)
+	const ULONG num_group_clauses = gpdb::ListLength(group_clause_list);
+	GPOS_ASSERT(0 < num_group_clauses);
+	if (1 < num_group_clauses)
 	{
 		// multiple grouping sets
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Multiple grouping sets specifications"));
 	}
 
-	GroupingClause *pgrcl = (GroupingClause *) pnode;
+	GroupingClause *grouping_clause = (GroupingClause *) node;
 
-	if (GROUPINGTYPE_ROLLUP == pgrcl->groupType)
+	if (GROUPINGTYPE_ROLLUP == grouping_clause->groupType)
 	{
-		return PdrgpbsRollup(pmp, pgrcl, ulCols, phmululGrpColPos, pbsGrpCols);
+		return CreateGroupingSetsForRollup(mp, grouping_clause, num_cols, group_col_pos, group_cols);
 	}
 
-	if (GROUPINGTYPE_CUBE == pgrcl->groupType)
+	if (GROUPINGTYPE_CUBE == grouping_clause->groupType)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Cube"));
 	}
 
-	DrgPbs *pdrgpbs = GPOS_NEW(pmp) DrgPbs(pmp);
+	CBitSetArray *col_attnos_arr = GPOS_NEW(mp) CBitSetArray(mp);
 
-	ListCell *plcGroupingSet = NULL;
-	ForEach (plcGroupingSet, pgrcl->groupsets)
+	ListCell *grouping_set = NULL;
+	ForEach (grouping_set, grouping_clause->groupsets)
 	{
-		Node *pnodeGroupingSet = (Node *) lfirst(plcGroupingSet);
+		Node *grouping_set_node = (Node *) lfirst(grouping_set);
 
-		CBitSet *pbs = NULL;
-		if (IsA(pnodeGroupingSet, GroupClause))
+		CBitSet *bset = NULL;
+		if (IsA(grouping_set_node, GroupClause))
 		{
 			// grouping set contains a single grouping column
-			pbs = GPOS_NEW(pmp) CBitSet(pmp, ulCols);
-			ULONG ulSortGrpRef = ((GroupClause *) pnodeGroupingSet)->tleSortGroupRef;
-			pbs->FExchangeSet(ulSortGrpRef);
-			UpdateGrpColMapping(pmp, phmululGrpColPos, pbsGrpCols, ulSortGrpRef);
+			bset = GPOS_NEW(mp) CBitSet(mp, num_cols);
+			ULONG sort_group_ref = ((GroupClause *) grouping_set_node)->tleSortGroupRef;
+			bset->ExchangeSet(sort_group_ref);
+			UpdateGrpColMapping(mp, group_col_pos, group_cols, sort_group_ref);
 		}
-		else if (IsA(pnodeGroupingSet, GroupingClause))
+		else if (IsA(grouping_set_node, GroupingClause))
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Multiple grouping sets specifications"));
 		}
 		else
 		{
 			// grouping set contains a list of columns
-			GPOS_ASSERT(IsA(pnodeGroupingSet, List));
+			GPOS_ASSERT(IsA(grouping_set_node, List));
 
-			List *plGroupingSet = (List *) pnodeGroupingSet;
-			pbs = PbsGroupingSet(pmp, plGroupingSet, ulCols, phmululGrpColPos, pbsGrpCols);
+			List *grouping_set_list = (List *) grouping_set_node;
+			bset = CreateAttnoSetForGroupingSet(mp, grouping_set_list, num_cols, group_col_pos, group_cols);
 		}
-		pdrgpbs->Append(pbs);
+		col_attnos_arr->Append(bset);
 	}
 
-	return pdrgpbs;
+	return col_attnos_arr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgpbsRollup
+//		CTranslatorUtils::CreateGroupingSetsForRollup
 //
 //	@doc:
 //		Construct a dynamic array of sets of column attnos for a rollup
 //
 //---------------------------------------------------------------------------
-DrgPbs *
-CTranslatorUtils::PdrgpbsRollup
+CBitSetArray *
+CTranslatorUtils::CreateGroupingSetsForRollup
 	(
-	IMemoryPool *pmp,
-	GroupingClause *pgrcl,
-	ULONG ulCols,
-	HMUlUl *phmululGrpColPos,	// mapping of grouping col positions to SortGroupRef ids,
-	CBitSet *pbsGrpCols			// existing grouping columns
+	IMemoryPool *mp,
+	GroupingClause *grouping_clause,
+	ULONG num_cols,
+	UlongToUlongMap *group_col_pos,	// mapping of grouping col positions to SortGroupRef ids,
+	CBitSet *group_cols			// existing grouping columns
 	)
 {
-	GPOS_ASSERT(NULL != pgrcl);
+	GPOS_ASSERT(NULL != grouping_clause);
 
-	DrgPbs *pdrgpbsGroupingSets = GPOS_NEW(pmp) DrgPbs(pmp);
-	ListCell *plcGroupingSet = NULL;
-	ForEach (plcGroupingSet, pgrcl->groupsets)
+	CBitSetArray *grouping_sets = GPOS_NEW(mp) CBitSetArray(mp);
+	ListCell *grouping_set = NULL;
+	ForEach (grouping_set, grouping_clause->groupsets)
 	{
-		Node *pnode = (Node *) lfirst(plcGroupingSet);
-		CBitSet *pbs = GPOS_NEW(pmp) CBitSet(pmp);
-		if (IsA(pnode, GroupClause))
+		Node *node = (Node *) lfirst(grouping_set);
+		CBitSet *bs = GPOS_NEW(mp) CBitSet(mp);
+		if (IsA(node, GroupClause))
 		{
 			// simple group clause, create a singleton grouping set
-			GroupClause *pgrpcl = (GroupClause *) pnode;
-			ULONG ulSortGrpRef = pgrpcl->tleSortGroupRef;
-			(void) pbs->FExchangeSet(ulSortGrpRef);
-			pdrgpbsGroupingSets->Append(pbs);
-			UpdateGrpColMapping(pmp, phmululGrpColPos, pbsGrpCols, ulSortGrpRef);
+			GroupClause *sort_group_clause = (GroupClause *) node;
+			ULONG sort_group_ref = sort_group_clause->tleSortGroupRef;
+			(void) bs->ExchangeSet(sort_group_ref);
+			grouping_sets->Append(bs);
+			UpdateGrpColMapping(mp, group_col_pos, group_cols, sort_group_ref);
 		}
-		else if (IsA(pnode, List))
+		else if (IsA(node, List))
 		{
 			// list of group clauses, add all clauses into one grouping set
 			// for example, rollup((a,b),(c,d));
-			List *plist = (List *) pnode;
-			ListCell *plcGrpCl = NULL;
-			ForEach (plcGrpCl, plist)
+			List *list = (List *) node;
+			ListCell *group_clause = NULL;
+			ForEach (group_clause, list)
 			{
-				Node *pnodeGrpCl = (Node *) lfirst(plcGrpCl);
-				if (!IsA(pnodeGrpCl, GroupClause))
+				Node *group_clause_node = (Node *) lfirst(group_clause);
+				if (!IsA(group_clause_node, GroupClause))
 				{
 					// each list entry must be a group clause
 					// for example, rollup((a,b),(c,(d,e)));
 					GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Nested grouping sets"));
 				}
 
-				GroupClause *pgrpcl = (GroupClause *) pnodeGrpCl;
-				ULONG ulSortGrpRef = pgrpcl->tleSortGroupRef;
-				(void) pbs->FExchangeSet(ulSortGrpRef);
-				UpdateGrpColMapping(pmp, phmululGrpColPos, pbsGrpCols, ulSortGrpRef);
+				GroupClause *sort_group_clause = (GroupClause *) group_clause_node;
+				ULONG sort_group_ref = sort_group_clause->tleSortGroupRef;
+				(void) bs->ExchangeSet(sort_group_ref);
+				UpdateGrpColMapping(mp, group_col_pos, group_cols, sort_group_ref);
 			}
-			pdrgpbsGroupingSets->Append(pbs);
+			grouping_sets->Append(bs);
 		}
 		else
 		{
@@ -1353,141 +1353,141 @@ CTranslatorUtils::PdrgpbsRollup
 		}
 	}
 
-	const ULONG ulGroupingSets = pdrgpbsGroupingSets->UlLength();
-	DrgPbs *pdrgpbs = GPOS_NEW(pmp) DrgPbs(pmp);
+	const ULONG num_grouping_sets = grouping_sets->Size();
+	CBitSetArray * col_attnos_arr = GPOS_NEW(mp) CBitSetArray(mp);
 
 	// compute prefixes of grouping sets array
-	for (ULONG ulPrefix = 0; ulPrefix <= ulGroupingSets; ulPrefix++)
+	for (ULONG ulPrefix = 0; ulPrefix <= num_grouping_sets; ulPrefix++)
 	{
-		CBitSet *pbs = GPOS_NEW(pmp) CBitSet(pmp);
-		for (ULONG ulIdx = 0; ulIdx < ulPrefix; ulIdx++)
+		CBitSet *bs = GPOS_NEW(mp) CBitSet(mp);
+		for (ULONG idx = 0; idx < ulPrefix; idx++)
 		{
-			CBitSet *pbsCurrent = (*pdrgpbsGroupingSets)[ulIdx];
-			pbs->Union(pbsCurrent);
+			CBitSet *current = (*grouping_sets)[idx];
+			bs->Union(current);
 		}
-		pdrgpbs->Append(pbs);
+		col_attnos_arr->Append(bs);
 	}
-	pdrgpbsGroupingSets->Release();
+	grouping_sets->Release();
 
-	return pdrgpbs;
+	return col_attnos_arr;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PbsGroupingSet
+//		CTranslatorUtils::CreateAttnoSetForGroupingSet
 //
 //	@doc:
 //		Construct a set of column attnos corresponding to a grouping set
 //
 //---------------------------------------------------------------------------
 CBitSet *
-CTranslatorUtils::PbsGroupingSet
+CTranslatorUtils::CreateAttnoSetForGroupingSet
 	(
-	IMemoryPool *pmp,
-	List *plGroupElems,
-	ULONG ulCols,
-	HMUlUl *phmululGrpColPos,	// mapping of grouping col positions to SortGroupRef ids,
-	CBitSet *pbsGrpCols			// existing grouping columns
+	IMemoryPool *mp,
+	List *group_elems,
+	ULONG num_cols,
+	UlongToUlongMap *group_col_pos,	// mapping of grouping col positions to SortGroupRef ids,
+	CBitSet *group_cols			// existing grouping columns
 	)
 {
-	GPOS_ASSERT(NULL != plGroupElems);
-	GPOS_ASSERT(0 < gpdb::UlListLength(plGroupElems));
+	GPOS_ASSERT(NULL != group_elems);
+	GPOS_ASSERT(0 < gpdb::ListLength(group_elems));
 
-	CBitSet *pbs = GPOS_NEW(pmp) CBitSet(pmp, ulCols);
+	CBitSet *bs = GPOS_NEW(mp) CBitSet(mp, num_cols);
 
-	ListCell *plc = NULL;
-	ForEach (plc, plGroupElems)
+	ListCell *lc = NULL;
+	ForEach (lc, group_elems)
 	{
-		Node *pnodeElem = (Node*) lfirst(plc);
+		Node *elem_node = (Node*) lfirst(lc);
 
-		if (NULL == pnodeElem)
+		if (NULL == elem_node)
 		{
 			continue;
 		}
 
-		if (!IsA(pnodeElem, GroupClause))
+		if (!IsA(elem_node, GroupClause))
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Mixing grouping sets with simple group by lists"));
 		}
 
-		ULONG ulSortGrpRef = ((GroupClause *) pnodeElem)->tleSortGroupRef;
-		pbs->FExchangeSet(ulSortGrpRef);
+		ULONG sort_group_ref = ((GroupClause *) elem_node)->tleSortGroupRef;
+		bs->ExchangeSet(sort_group_ref);
 		
-		UpdateGrpColMapping(pmp, phmululGrpColPos, pbsGrpCols, ulSortGrpRef);
+		UpdateGrpColMapping(mp, group_col_pos, group_cols, sort_group_ref);
 	}
 	
-	return pbs;
+	return bs;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgpulGenerateColIds
+//		CTranslatorUtils::GenerateColIds
 //
 //	@doc:
 //		Construct an array of DXL column identifiers for a target list
 //
 //---------------------------------------------------------------------------
-DrgPul *
-CTranslatorUtils::PdrgpulGenerateColIds
+ULongPtrArray *
+CTranslatorUtils::GenerateColIds
 	(
-	IMemoryPool *pmp,
-	List *plTargetList,
-	DrgPmdid *pdrgpmdidInput,
-	DrgPul *pdrgpulInput,
-	BOOL *pfOuterRef,  // array of flags indicating if input columns are outer references
-	CIdGenerator *pidgtorColId
+	IMemoryPool *mp,
+	List *target_list,
+	IMdIdArray *input_mdid_arr,
+	ULongPtrArray *input_colids,
+	BOOL *is_outer_ref,  // array of flags indicating if input columns are outer references
+	CIdGenerator *colid_generator
 	)
 {
-	GPOS_ASSERT(NULL != plTargetList);
-	GPOS_ASSERT(NULL != pdrgpmdidInput);
-	GPOS_ASSERT(NULL != pdrgpulInput);
-	GPOS_ASSERT(NULL != pfOuterRef);
-	GPOS_ASSERT(NULL != pidgtorColId);
+	GPOS_ASSERT(NULL != target_list);
+	GPOS_ASSERT(NULL != input_mdid_arr);
+	GPOS_ASSERT(NULL != input_colids);
+	GPOS_ASSERT(NULL != is_outer_ref);
+	GPOS_ASSERT(NULL != colid_generator);
 
-	GPOS_ASSERT(pdrgpmdidInput->UlLength() == pdrgpulInput->UlLength());
+	GPOS_ASSERT(input_mdid_arr->Size() == input_colids->Size());
 
-	ULONG ulColPos = 0;
-	ListCell *plcTE = NULL;
-	DrgPul *pdrgpul = GPOS_NEW(pmp) DrgPul(pmp);
+	ULONG col_pos = 0;
+	ListCell *target_entry_cell = NULL;
+	ULongPtrArray *colid_array = GPOS_NEW(mp) ULongPtrArray(mp);
 
-	ForEach (plcTE, plTargetList)
+	ForEach (target_entry_cell, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(NULL != pte->expr);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(target_entry_cell);
+		GPOS_ASSERT(NULL != target_entry->expr);
 
-		OID oidExprType = gpdb::OidExprType((Node*) pte->expr);
-		if (!pte->resjunk)
+		OID expr_type_oid = gpdb::ExprType((Node*) target_entry->expr);
+		if (!target_entry->resjunk)
 		{
-			ULONG ulColId = gpos::ulong_max;
-			IMDId *pmdid = (*pdrgpmdidInput)[ulColPos];
-			if (CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId() != oidExprType || 
-				pfOuterRef[ulColPos])
+			ULONG colid = gpos::ulong_max;
+			IMDId *mdid = (*input_mdid_arr)[col_pos];
+			if (CMDIdGPDB::CastMdid(mdid)->Oid() != expr_type_oid ||
+				is_outer_ref[col_pos])
 			{
 				// generate a new column when:
 				//  (1) the type of input column does not match that of the output column, or
 				//  (2) input column is an outer reference 
-				ulColId = pidgtorColId->UlNextId();
+				colid = colid_generator->next_id();
 			}
 			else
 			{
 				// use the column identifier of the input
-				ulColId = *(*pdrgpulInput)[ulColPos];
+				colid = *(*input_colids)[col_pos];
 			}
-			GPOS_ASSERT(gpos::ulong_max != ulColId);
+			GPOS_ASSERT(gpos::ulong_max != colid);
 			
-			pdrgpul->Append(GPOS_NEW(pmp) ULONG(ulColId));
+			colid_array->Append(GPOS_NEW(mp) ULONG(colid));
 
-			ulColPos++;
+			col_pos++;
 		}
 	}
 
-	return pdrgpul;
+	return colid_array;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PqueryFixUnknownTypeConstant
+//		CTranslatorUtils::FixUnknownTypeConstant
 //
 //	@doc:
 //		If the query has constant of unknown type, then return a copy of the
@@ -1495,97 +1495,97 @@ CTranslatorUtils::PdrgpulGenerateColIds
 //		of the output target list; otherwise return the original query
 //---------------------------------------------------------------------------
 Query *
-CTranslatorUtils::PqueryFixUnknownTypeConstant
+CTranslatorUtils::FixUnknownTypeConstant
 	(
-	Query *pqueryOld,
-	List *plTargetListOutput
+	Query *old_query,
+	List *output_target_list
 	)
 {
-	GPOS_ASSERT(NULL != pqueryOld);
-	GPOS_ASSERT(NULL != plTargetListOutput);
+	GPOS_ASSERT(NULL != old_query);
+	GPOS_ASSERT(NULL != output_target_list);
 
-	Query *pqueryNew = NULL;
+	Query *new_query = NULL;
 
-	ULONG ulPos = 0;
-	ULONG ulColPos = 0;
-	ListCell *plcTE = NULL;
-	ForEach (plcTE, pqueryOld->targetList)
+	ULONG pos = 0;
+	ULONG col_pos = 0;
+	ListCell *target_entry_cell = NULL;
+	ForEach (target_entry_cell, old_query->targetList)
 	{
-		TargetEntry *pteOld = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(NULL != pteOld->expr);
+		TargetEntry *old_target_entry = (TargetEntry *) lfirst(target_entry_cell);
+		GPOS_ASSERT(NULL != old_target_entry->expr);
 
-		if (!pteOld->resjunk)
+		if (!old_target_entry->resjunk)
 		{
-			if (IsA(pteOld->expr, Const) && (GPDB_UNKNOWN == gpdb::OidExprType((Node*) pteOld->expr) ))
+			if (IsA(old_target_entry->expr, Const) && (GPDB_UNKNOWN == gpdb::ExprType((Node*) old_target_entry->expr) ))
 			{
-				if (NULL == pqueryNew)
+				if (NULL == new_query)
 				{
-					pqueryNew = (Query*) gpdb::PvCopyObject(const_cast<Query*>(pqueryOld));
+					new_query = (Query*) gpdb::CopyObject(const_cast<Query*>(old_query));
 				}
 
-				TargetEntry *pteNew = (TargetEntry *) gpdb::PvListNth(pqueryNew->targetList, ulPos);
-				GPOS_ASSERT(pteOld->resno == pteNew->resno);
+				TargetEntry *new_target_entry = (TargetEntry *) gpdb::ListNth(new_query->targetList, pos);
+				GPOS_ASSERT(old_target_entry->resno == new_target_entry->resno);
 				// implicitly cast the unknown constants to the target data type
-				OID oidTargetType = OidTargetListReturnType(plTargetListOutput, ulColPos);
-				GPOS_ASSERT(InvalidOid != oidTargetType);
-				Node *pnodeOld = (Node *) pteNew->expr;
-				pteNew->expr = (Expr*) gpdb::PnodeCoerceToCommonType
+				OID target_type_oid = GetTargetListReturnTypeOid(output_target_list, col_pos);
+				GPOS_ASSERT(InvalidOid != target_type_oid);
+				Node *old_node = (Node *) new_target_entry->expr;
+				new_target_entry->expr = (Expr*) gpdb::CoerceToCommonType
 											(
 											NULL,	/* pstate */
-											(Node *) pnodeOld,
-											oidTargetType,
+											(Node *) old_node,
+											target_type_oid,
 											"UNION/INTERSECT/EXCEPT"
 											);
 
-				gpdb::GPDBFree(pnodeOld);
+				gpdb::GPDBFree(old_node);
 			}
-			ulColPos++;
+			col_pos++;
 		}
 
-		ulPos++;
+		pos++;
 	}
 
-	if (NULL == pqueryNew)
+	if (NULL == new_query)
 	{
-		return pqueryOld;
+		return old_query;
 	}
 
-	gpdb::GPDBFree(pqueryOld);
+	gpdb::GPDBFree(old_query);
 
-	return pqueryNew;
+	return new_query;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::OidTargetListReturnType
+//		CTranslatorUtils::GetTargetListReturnTypeOid
 //
 //	@doc:
 //		Return the type of the nth non-resjunked target list entry
 //
 //---------------------------------------------------------------------------
 OID
-CTranslatorUtils::OidTargetListReturnType
+CTranslatorUtils::GetTargetListReturnTypeOid
 	(
-	List *plTargetList,
-	ULONG ulColPos
+	List *target_list,
+	ULONG col_pos
 	)
 {
-	ULONG ulColIdx = 0;
-	ListCell *plcTE = NULL;
+	ULONG col_idx = 0;
+	ListCell *target_entry_cell = NULL;
 
-	ForEach (plcTE, plTargetList)
+	ForEach (target_entry_cell, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		GPOS_ASSERT(NULL != pte->expr);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(target_entry_cell);
+		GPOS_ASSERT(NULL != target_entry->expr);
 
-		if (!pte->resjunk)
+		if (!target_entry->resjunk)
 		{
-			if (ulColIdx == ulColPos)
+			if (col_idx == col_pos)
 			{
-				return gpdb::OidExprType((Node*) pte->expr);
+				return gpdb::ExprType((Node*) target_entry->expr);
 			}
 
-			ulColIdx++;
+			col_idx++;
 		}
 	}
 
@@ -1594,303 +1594,303 @@ CTranslatorUtils::OidTargetListReturnType
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::Pdrgpdxlcd
+//		CTranslatorUtils::GetDXLColumnDescrArray
 //
 //	@doc:
 //		Construct an array of DXL column descriptors for a target list using the
 // 		column ids in the given array
 //
 //---------------------------------------------------------------------------
-DrgPdxlcd *
-CTranslatorUtils::Pdrgpdxlcd
+CDXLColDescrArray *
+CTranslatorUtils::GetDXLColumnDescrArray
 	(
-	IMemoryPool *pmp,
-	List *plTargetList,
-	DrgPul *pdrgpulColIds,
-	BOOL fKeepResjunked
+	IMemoryPool *mp,
+	List *target_list,
+	ULongPtrArray *colids,
+	BOOL keep_res_junked
 	)
 {
-	GPOS_ASSERT(NULL != plTargetList);
-	GPOS_ASSERT(NULL != pdrgpulColIds);
+	GPOS_ASSERT(NULL != target_list);
+	GPOS_ASSERT(NULL != colids);
 
-	ListCell *plcTE = NULL;
-	DrgPdxlcd *pdrgpdxlcd = GPOS_NEW(pmp) DrgPdxlcd(pmp);
+	ListCell *target_entry_cell = NULL;
+	CDXLColDescrArray *dxl_col_descrs = GPOS_NEW(mp) CDXLColDescrArray(mp);
 	ULONG ul = 0;
-	ForEach (plcTE, plTargetList)
+	ForEach (target_entry_cell, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(target_entry_cell);
 
-		if (pte->resjunk && !fKeepResjunked)
+		if (target_entry->resjunk && !keep_res_junked)
 		{
 			continue;
 		}
 
-		ULONG ulColId = *(*pdrgpulColIds)[ul];
-		CDXLColDescr *pdxlcd = Pdxlcd(pmp, pte, ulColId, ul+1 /*ulPos*/);
-		pdrgpdxlcd->Append(pdxlcd);
+		ULONG colid = *(*colids)[ul];
+		CDXLColDescr *dxl_col_descr = GetColumnDescrAt(mp, target_entry, colid, ul+1 /*pos*/);
+		dxl_col_descrs->Append(dxl_col_descr);
 		ul++;
 	}
 
-	GPOS_ASSERT(pdrgpdxlcd->UlLength() == pdrgpulColIds->UlLength());
+	GPOS_ASSERT(dxl_col_descrs->Size() == colids->Size());
 
-	return pdrgpdxlcd;
+	return dxl_col_descrs;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgpulPosInTargetList
+//		CTranslatorUtils::GetPosInTargetList
 //
 //	@doc:
 //		Return the positions of the target list entries included in the output
 //		target list
 //---------------------------------------------------------------------------
-DrgPul *
-CTranslatorUtils::PdrgpulPosInTargetList
+ULongPtrArray *
+CTranslatorUtils::GetPosInTargetList
 	(
-	IMemoryPool *pmp,
-	List *plTargetList,
-	BOOL fKeepResjunked
+	IMemoryPool *mp,
+	List *target_list,
+	BOOL keep_res_junked
 	)
 {
-	GPOS_ASSERT(NULL != plTargetList);
+	GPOS_ASSERT(NULL != target_list);
 
-	ListCell *plcTE = NULL;
-	DrgPul *pdrgul = GPOS_NEW(pmp) DrgPul(pmp);
+	ListCell *target_entry_cell = NULL;
+	ULongPtrArray *positions = GPOS_NEW(mp) ULongPtrArray(mp);
 	ULONG ul = 0;
-	ForEach (plcTE, plTargetList)
+	ForEach (target_entry_cell, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(target_entry_cell);
 
-		if (pte->resjunk && !fKeepResjunked)
+		if (target_entry->resjunk && !keep_res_junked)
 		{
 			continue;
 		}
 
-		pdrgul->Append(GPOS_NEW(pmp) ULONG(ul));
+		positions->Append(GPOS_NEW(mp) ULONG(ul));
 		ul++;
 	}
 
-	return pdrgul;
+	return positions;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::Pdxlcd
+//		CTranslatorUtils::GetColumnDescrAt
 //
 //	@doc:
 //		Construct a column descriptor from the given target entry and column
 //		identifier
 //---------------------------------------------------------------------------
 CDXLColDescr *
-CTranslatorUtils::Pdxlcd
+CTranslatorUtils::GetColumnDescrAt
 	(
-	IMemoryPool *pmp,
-	TargetEntry *pte,
-	ULONG ulColId,
-	ULONG ulPos
+	IMemoryPool *mp,
+	TargetEntry *target_entry,
+	ULONG colid,
+	ULONG pos
 	)
 {
-	GPOS_ASSERT(NULL != pte);
-	GPOS_ASSERT(gpos::ulong_max != ulColId);
+	GPOS_ASSERT(NULL != target_entry);
+	GPOS_ASSERT(gpos::ulong_max != colid);
 
-	CMDName *pmdname = NULL;
-	if (NULL == pte->resname)
+	CMDName *mdname = NULL;
+	if (NULL == target_entry->resname)
 	{
-		CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
-		pmdname = GPOS_NEW(pmp) CMDName(pmp, &strUnnamedCol);
+		CWStringConst unnamed_col(GPOS_WSZ_LIT("?column?"));
+		mdname = GPOS_NEW(mp) CMDName(mp, &unnamed_col);
 	}
 	else
 	{
-		CWStringDynamic *pstrAlias = CDXLUtils::PstrFromSz(pmp, pte->resname);
-		pmdname = GPOS_NEW(pmp) CMDName(pmp, pstrAlias);
+		CWStringDynamic *alias = CDXLUtils::CreateDynamicStringFromCharArray(mp, target_entry->resname);
+		mdname = GPOS_NEW(mp) CMDName(mp, alias);
 		// CName constructor copies string
-		GPOS_DELETE(pstrAlias);
+		GPOS_DELETE(alias);
 	}
 
 	// create a column descriptor
-	OID oidType = gpdb::OidExprType((Node *) pte->expr);
-	INT iTypeModifier = gpdb::IExprTypeMod((Node *) pte->expr);
-	CMDIdGPDB *pmdidColType = GPOS_NEW(pmp) CMDIdGPDB(oidType);
-	CDXLColDescr *pdxlcd = GPOS_NEW(pmp) CDXLColDescr
+	OID type_oid = gpdb::ExprType((Node *) target_entry->expr);
+	INT type_modifier = gpdb::ExprTypeMod((Node *) target_entry->expr);
+	CMDIdGPDB *col_type = GPOS_NEW(mp) CMDIdGPDB(type_oid);
+	CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr
 									(
-									pmp,
-									pmdname,
-									ulColId,
-									ulPos, /* attno */
-									pmdidColType,
-									iTypeModifier, /* iTypeModifier */
+									mp,
+									mdname,
+									colid,
+									pos, /* attno */
+									col_type,
+									type_modifier, /* type_modifier */
 									false /* fColDropped */
 									);
 
-	return pdxlcd;
+	return dxl_col_descr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdxlnDummyPrElem
+//		CTranslatorUtils::CreateDummyProjectElem
 //
 //	@doc:
 //		Create a dummy project element to rename the input column identifier
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorUtils::PdxlnDummyPrElem
+CTranslatorUtils::CreateDummyProjectElem
 	(
-	IMemoryPool *pmp,
-	ULONG ulColIdInput,
-	ULONG ulColIdOutput,
-	CDXLColDescr *pdxlcdOutput
+	IMemoryPool *mp,
+	ULONG colid_input,
+	ULONG colid_output,
+	CDXLColDescr *dxl_col_descr
 	)
 {
-	CMDIdGPDB *pmdidOriginal = CMDIdGPDB::PmdidConvert(pdxlcdOutput->PmdidType());
-	CMDIdGPDB *pmdidCopy = GPOS_NEW(pmp) CMDIdGPDB(pmdidOriginal->OidObjectId(), pmdidOriginal->UlVersionMajor(), pmdidOriginal->UlVersionMinor());
+	CMDIdGPDB *original_mdid = CMDIdGPDB::CastMdid(dxl_col_descr->MdidType());
+	CMDIdGPDB *copy_mdid = GPOS_NEW(mp) CMDIdGPDB(original_mdid->Oid(), original_mdid->VersionMajor(), original_mdid->VersionMinor());
 
 	// create a column reference for the scalar identifier to be casted
-	CMDName *pmdname = GPOS_NEW(pmp) CMDName(pmp, pdxlcdOutput->Pmdname()->Pstr());
-	CDXLColRef *pdxlcr = GPOS_NEW(pmp) CDXLColRef(pmp, pmdname, ulColIdInput, pmdidCopy, pdxlcdOutput->ITypeModifier());
-	CDXLScalarIdent *pdxlopIdent = GPOS_NEW(pmp) CDXLScalarIdent(pmp, pdxlcr);
+	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, dxl_col_descr->MdName()->GetMDName());
+	CDXLColRef *dxl_colref = GPOS_NEW(mp) CDXLColRef(mp, mdname, colid_input, copy_mdid, dxl_col_descr->TypeModifier());
+	CDXLScalarIdent *dxl_scalar_ident = GPOS_NEW(mp) CDXLScalarIdent(mp, dxl_colref);
 
-	CDXLNode *pdxlnPrEl = GPOS_NEW(pmp) CDXLNode
+	CDXLNode *dxl_project_element = GPOS_NEW(mp) CDXLNode
 										(
-										pmp,
-										GPOS_NEW(pmp) CDXLScalarProjElem
+										mp,
+										GPOS_NEW(mp) CDXLScalarProjElem
 													(
-													pmp,
-													ulColIdOutput,
-													GPOS_NEW(pmp) CMDName(pmp, pdxlcdOutput->Pmdname()->Pstr())
+													mp,
+													colid_output,
+													GPOS_NEW(mp) CMDName(mp, dxl_col_descr->MdName()->GetMDName())
 													),
-										GPOS_NEW(pmp) CDXLNode(pmp, pdxlopIdent)
+										GPOS_NEW(mp) CDXLNode(mp, dxl_scalar_ident)
 										);
 
-	return pdxlnPrEl;
+	return dxl_project_element;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdrgpulColIds
+//		CTranslatorUtils::GetOutputColIdsArray
 //
 //	@doc:
 //		Construct an array of colids for the given target list
 //
 //---------------------------------------------------------------------------
-DrgPul *
-CTranslatorUtils::PdrgpulColIds
+ULongPtrArray *
+CTranslatorUtils::GetOutputColIdsArray
 	(
-	IMemoryPool *pmp,
-	List *plTargetList,
-	HMIUl *phmiulAttnoColId
+	IMemoryPool *mp,
+	List *target_list,
+	IntToUlongMap *attno_to_colid_map
 	)
 {
-	GPOS_ASSERT(NULL != plTargetList);
-	GPOS_ASSERT(NULL != phmiulAttnoColId);
+	GPOS_ASSERT(NULL != target_list);
+	GPOS_ASSERT(NULL != attno_to_colid_map);
 
-	DrgPul *pdrgpul = GPOS_NEW(pmp) DrgPul(pmp);
+	ULongPtrArray *colids = GPOS_NEW(mp) ULongPtrArray(mp);
 
-	ListCell *plcTE = NULL;
-	ForEach (plcTE, plTargetList)
+	ListCell *target_entry_cell = NULL;
+	ForEach (target_entry_cell, target_list)
 	{
-		TargetEntry *pte = (TargetEntry *) lfirst(plcTE);
-		ULONG ulResNo = (ULONG) pte->resno;
-		INT iAttno = (INT) pte->resno;
-		const ULONG *pul = phmiulAttnoColId->PtLookup(&iAttno);
+		TargetEntry *target_entry = (TargetEntry *) lfirst(target_entry_cell);
+		ULONG resno = (ULONG) target_entry->resno;
+		INT attno = (INT) target_entry->resno;
+		const ULONG *ul = attno_to_colid_map->Find(&attno);
 
-		if (NULL == pul)
+		if (NULL == ul)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLAttributeNotFound, ulResNo);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLAttributeNotFound, resno);
 		}
 
-		pdrgpul->Append(GPOS_NEW(pmp) ULONG(*pul));
+		colids->Append(GPOS_NEW(mp) ULONG(*ul));
 	}
 
-	return pdrgpul;
+	return colids;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::UlColId
+//		CTranslatorUtils::GetColId
 //
 //	@doc:
 //		Return the corresponding ColId for the given index into the target list
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorUtils::UlColId
+CTranslatorUtils::GetColId
 	(
-	INT iIndex,
-	HMIUl *phmiulColId
+	INT index,
+	IntToUlongMap *colid_map
 	)
 {
-	GPOS_ASSERT(0 < iIndex);
+	GPOS_ASSERT(0 < index);
 
-	const ULONG *pul = phmiulColId->PtLookup(&iIndex);
+	const ULONG *ul = colid_map->Find(&index);
 
-	if (NULL == pul)
+	if (NULL == ul)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLAttributeNotFound, iIndex);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLAttributeNotFound, index);
 	}
 
-	return *pul;
+	return *ul;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::UlColId
+//		CTranslatorUtils::GetColId
 //
 //	@doc:
 //		Return the corresponding ColId for the given varno, varattno and querylevel
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorUtils::UlColId
+CTranslatorUtils::GetColId
 	(
-	ULONG ulQueryLevel,
-	INT iVarno,
-	INT iVarAttno,
-	IMDId *pmdid,
-	CMappingVarColId *pmapvarcolid
+	ULONG query_level,
+	INT varno,
+	INT var_attno,
+	IMDId *mdid,
+	CMappingVarColId *var_colid_mapping
 	)
 {
-	OID oid = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
-	Var *pvar = gpdb::PvarMakeVar(iVarno, iVarAttno, oid, -1, 0);
-	ULONG ulColId = pmapvarcolid->UlColId(ulQueryLevel, pvar, EpspotNone);
-	gpdb::GPDBFree(pvar);
+	OID oid = CMDIdGPDB::CastMdid(mdid)->Oid();
+	Var *var = gpdb::MakeVar(varno, var_attno, oid, -1, 0);
+	ULONG colid = var_colid_mapping->GetColId(query_level, var, EpspotNone);
+	gpdb::GPDBFree(var);
 
-	return ulColId;
+	return colid;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PteWindowSpec
+//		CTranslatorUtils::GetWindowSpecTargetEntry
 //
 //	@doc:
 //		Extract a matching target entry that is a window spec
 //		
 //---------------------------------------------------------------------------
 TargetEntry *
-CTranslatorUtils::PteWindowSpec
+CTranslatorUtils::GetWindowSpecTargetEntry
 	(
-	Node *pnode,
-	List *plWindowClause,
-	List *plTargetList
+	Node *node,
+	List *window_clause_list,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
-	List *plTargetListSubset = gpdb::PteMembers(pnode, plTargetList);
+	GPOS_ASSERT(NULL != node);
+	List *target_list_subset = gpdb::FindMatchingMembersInTargetList(node, target_list);
 
-	ListCell *plcTE = NULL;
-	ForEach (plcTE, plTargetListSubset)
+	ListCell *target_entry_cell = NULL;
+	ForEach (target_entry_cell, target_list_subset)
 	{
-		TargetEntry *pteCurr = (TargetEntry*) lfirst(plcTE);
-		if (FWindowSpec(pteCurr, plWindowClause))
+		TargetEntry *cur_target_entry = (TargetEntry*) lfirst(target_entry_cell);
+		if (IsWindowSpec(cur_target_entry, window_clause_list))
 		{
-			gpdb::GPDBFree(plTargetListSubset);
-			return pteCurr;
+			gpdb::GPDBFree(target_list_subset);
+			return cur_target_entry;
 		}
 	}
 
-	if (NIL != plTargetListSubset)
+	if (NIL != target_list_subset)
 	{
-		gpdb::GPDBFree(plTargetListSubset);
+		gpdb::GPDBFree(target_list_subset);
 	}
 	return NULL;
 }
@@ -1898,46 +1898,46 @@ CTranslatorUtils::PteWindowSpec
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FWindowSpec
+//		CTranslatorUtils::IsWindowSpec
 //
 //	@doc:
 //		Check if the expression has a matching target entry that is a window spec
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FWindowSpec
+CTranslatorUtils::IsWindowSpec
 	(
-	Node *pnode,
-	List *plWindowClause,
-	List *plTargetList
+	Node *node,
+	List *window_clause_list,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 	
-	TargetEntry *pteWindoSpec = PteWindowSpec(pnode, plWindowClause, plTargetList);
+	TargetEntry *window_spec = GetWindowSpecTargetEntry(node, window_clause_list, target_list);
 
-	return (NULL != pteWindoSpec);
+	return (NULL != window_spec);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FWindowSpec
+//		CTranslatorUtils::IsWindowSpec
 //
 //	@doc:
 //		Check if the TargetEntry is a used in the window specification
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FWindowSpec
+CTranslatorUtils::IsWindowSpec
 	(
-	const TargetEntry *pte,
-	List *plWindowClause
+	const TargetEntry *target_entry,
+	List *window_clause_list
 	)
 {
-	ListCell *plcWindowCl = NULL;
-	ForEach (plcWindowCl, plWindowClause)
+	ListCell *window_clause_cell = NULL;
+	ForEach (window_clause_cell, window_clause_list)
 	{
-		WindowSpec *pwindowspec = (WindowSpec*) lfirst(plcWindowCl);
-		if (FSortingColumn(pte, pwindowspec->order) || FSortingColumn(pte, pwindowspec->partition))
+		WindowSpec *window_spec = (WindowSpec*) lfirst(window_clause_cell);
+		if (IsSortingColumn(target_entry, window_spec->order) || IsSortingColumn(target_entry, window_spec->partition))
 		{
 			return true;
 		}
@@ -1947,51 +1947,51 @@ CTranslatorUtils::FWindowSpec
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdxlnInt8Const
+//		CTranslatorUtils::CreateDXLProjElemFromInt8Const
 //
 //	@doc:
 // 		Construct a scalar const value expression for the given BIGINT value
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorUtils::PdxlnInt8Const
+CTranslatorUtils::CreateDXLProjElemFromInt8Const
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	INT iVal
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	INT val
 	)
 {
-	GPOS_ASSERT(NULL != pmp);
-	const IMDTypeInt8 *pmdtypeint8 = pmda->PtMDType<IMDTypeInt8>();
-	pmdtypeint8->Pmdid()->AddRef();
+	GPOS_ASSERT(NULL != mp);
+	const IMDTypeInt8 *md_type_int8 = md_accessor->PtMDType<IMDTypeInt8>();
+	md_type_int8->MDId()->AddRef();
 
-	CDXLDatumInt8 *pdxldatum = GPOS_NEW(pmp) CDXLDatumInt8(pmp, pmdtypeint8->Pmdid(), false /*fConstNull*/, iVal);
+	CDXLDatumInt8 *datum_dxl = GPOS_NEW(mp) CDXLDatumInt8(mp, md_type_int8->MDId(), false /*fConstNull*/, val);
 
-	CDXLScalarConstValue *pdxlConst = GPOS_NEW(pmp) CDXLScalarConstValue(pmp, pdxldatum);
+	CDXLScalarConstValue *dxl_scalar_const = GPOS_NEW(mp) CDXLScalarConstValue(mp, datum_dxl);
 
-	return GPOS_NEW(pmp) CDXLNode(pmp, pdxlConst);
+	return GPOS_NEW(mp) CDXLNode(mp, dxl_scalar_const);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FSortingColumn
+//		CTranslatorUtils::IsSortingColumn
 //
 //	@doc:
 //		Check if the TargetEntry is a sorting column
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FSortingColumn
+CTranslatorUtils::IsSortingColumn
 	(
-	const TargetEntry *pte,
-	List *plSortCl
+	const TargetEntry *target_entry,
+	List *sort_clause_list
 	)
 {
-	ListCell *plcSortCl = NULL;
-	ForEach (plcSortCl, plSortCl)
+	ListCell *sort_clause_cell = NULL;
+	ForEach (sort_clause_cell, sort_clause_list)
 	{
-		Node *pnodeSortCl = (Node*) lfirst(plcSortCl);
-		if (IsA(pnodeSortCl, SortClause) && pte->ressortgroupref == ((SortClause *) pnodeSortCl)->tleSortGroupRef)
+		Node *sort_clause = (Node*) lfirst(sort_clause_cell);
+		if (IsA(sort_clause, SortClause) && target_entry->ressortgroupref == ((SortClause *) sort_clause)->tleSortGroupRef)
 		{
 			return true;
 		}
@@ -2003,36 +2003,36 @@ CTranslatorUtils::FSortingColumn
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PteGroupingColumn
+//		CTranslatorUtils::GetGroupingColumnTargetEntry
 //
 //	@doc:
 //		Extract a matching target entry that is a grouping column
 //---------------------------------------------------------------------------
 TargetEntry *
-CTranslatorUtils::PteGroupingColumn
+CTranslatorUtils::GetGroupingColumnTargetEntry
 	(
-	Node *pnode,
-	List *plGrpCl,
-	List *plTargetList
+	Node *node,
+	List *group_clause,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
-	List *plTargetListSubset = gpdb::PteMembers(pnode, plTargetList);
+	GPOS_ASSERT(NULL != node);
+	List *target_list_subset = gpdb::FindMatchingMembersInTargetList(node, target_list);
 
-	ListCell *plcTE = NULL;
-	ForEach (plcTE, plTargetListSubset)
+	ListCell *target_entry_cell = NULL;
+	ForEach (target_entry_cell, target_list_subset)
 	{
-		TargetEntry *pteNext = (TargetEntry*) lfirst(plcTE);
-		if (FGroupingColumn(pteNext, plGrpCl))
+		TargetEntry *next_target_entry = (TargetEntry*) lfirst(target_entry_cell);
+		if (IsGroupingColumn(next_target_entry, group_clause))
 		{
-			gpdb::GPDBFree(plTargetListSubset);
-			return pteNext;
+			gpdb::GPDBFree(target_list_subset);
+			return next_target_entry;
 		}
 	}
 
-	if (NIL != plTargetListSubset)
+	if (NIL != target_list_subset)
 	{
-		gpdb::GPDBFree(plTargetListSubset);
+		gpdb::GPDBFree(target_list_subset);
 	}
 	return NULL;
 }
@@ -2040,71 +2040,71 @@ CTranslatorUtils::PteGroupingColumn
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FGroupingColumn
+//		CTranslatorUtils::IsGroupingColumn
 //
 //	@doc:
 //		Check if the expression has a matching target entry that is a grouping column
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FGroupingColumn
+CTranslatorUtils::IsGroupingColumn
 	(
-	Node *pnode,
-	List *plGrpCl,
-	List *plTargetList
+	Node *node,
+	List *group_clause,
+	List *target_list
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
+	GPOS_ASSERT(NULL != node);
 
-	TargetEntry *pteGroupingCol = PteGroupingColumn(pnode, plGrpCl, plTargetList);
+	TargetEntry *grouping_col_target_etnry = GetGroupingColumnTargetEntry(node, group_clause, target_list);
 
-	return (NULL != pteGroupingCol);
+	return (NULL != grouping_col_target_etnry);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FGroupingColumn
+//		CTranslatorUtils::IsGroupingColumn
 //
 //	@doc:
 //		Check if the TargetEntry is a grouping column
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FGroupingColumn
+CTranslatorUtils::IsGroupingColumn
 	(
-	const TargetEntry *pte,
-	List *plGrpCl
+	const TargetEntry *target_entry,
+	List *group_clause
 	)
 {
-	ListCell *plcGrpCl = NULL;
-	ForEach (plcGrpCl, plGrpCl)
+	ListCell *group_clause_cell = NULL;
+	ForEach (group_clause_cell, group_clause)
 	{
-		Node *pnodeGrpCl = (Node*) lfirst(plcGrpCl);
+		Node *group_clause_node = (Node*) lfirst(group_clause_cell);
 
-		if (NULL == pnodeGrpCl)
+		if (NULL == group_clause_node)
 		{
 			continue;
 		}
 
-		if (IsA(pnodeGrpCl, GroupClause) && FGroupingColumn(pte, (GroupClause*) pnodeGrpCl))
+		if (IsA(group_clause_node, GroupClause) && IsGroupingColumn(target_entry, (GroupClause*) group_clause_node))
 		{
 			return true;
 		}
 
-		if (IsA(pnodeGrpCl, GroupingClause))
+		if (IsA(group_clause_node, GroupingClause))
 		{
-			GroupingClause *pgrcl = (GroupingClause *) pnodeGrpCl;
+			GroupingClause *grouping_clause = (GroupingClause *) group_clause_node;
 
-			ListCell *plcGroupingSet = NULL;
-			ForEach (plcGroupingSet, pgrcl->groupsets)
+			ListCell *grouping_set = NULL;
+			ForEach (grouping_set, grouping_clause->groupsets)
 			{
-				Node *pnodeGroupingSet = (Node *) lfirst(plcGroupingSet);
+				Node *grouping_set_node = (Node *) lfirst(grouping_set);
 
-				if (IsA(pnodeGroupingSet, GroupClause) && FGroupingColumn(pte, ((GroupClause *) pnodeGroupingSet)))
+				if (IsA(grouping_set_node, GroupClause) && IsGroupingColumn(target_entry, ((GroupClause *) grouping_set_node)))
 				{
 					return true;
 				}
 
-				if (IsA(pnodeGroupingSet, List) && FGroupingColumn(pte, (List *) pnodeGroupingSet))
+				if (IsA(grouping_set_node, List) && IsGroupingColumn(target_entry, (List *) grouping_set_node))
 				{
 					return true;
 				}
@@ -2117,45 +2117,45 @@ CTranslatorUtils::FGroupingColumn
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FGroupingColumn
+//		CTranslatorUtils::IsGroupingColumn
 //
 //	@doc:
 //		Check if the TargetEntry is a grouping column
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FGroupingColumn
+CTranslatorUtils::IsGroupingColumn
 	(
-	const TargetEntry *pte,
-	const GroupClause *pgrcl
+	const TargetEntry *target_entry,
+	const GroupClause *grouping_clause
 	)
 {
-	GPOS_ASSERT(NULL != pgrcl);
+	GPOS_ASSERT(NULL != grouping_clause);
 
-	return (pte->ressortgroupref == pgrcl->tleSortGroupRef);
+	return (target_entry->ressortgroupref == grouping_clause->tleSortGroupRef);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FGroupingColumn
+//		CTranslatorUtils::IsGroupingColumn
 //
 //	@doc:
 //		Check if the sorting column is a grouping column
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FGroupingColumn
+CTranslatorUtils::IsGroupingColumn
 	(
-	const SortClause *psortcl,
-	List *plGrpCl
+	const SortClause *sort_group_clause,
+	List *group_clause
 	)
 {
-	ListCell *plcGrpCl = NULL;
-	ForEach (plcGrpCl, plGrpCl)
+	ListCell *group_clause_cell = NULL;
+	ForEach (group_clause_cell, group_clause)
 	{
-		Node *pnodeGrpCl = (Node*) lfirst(plcGrpCl);
-		GPOS_ASSERT(IsA(pnodeGrpCl, GroupClause) && "We currently do not support grouping sets.");
+		Node *group_clause_node = (Node*) lfirst(group_clause_cell);
+		GPOS_ASSERT(IsA(group_clause_node, GroupClause) && "We currently do not support grouping sets.");
 
-		GroupClause *pgrpcl = (GroupClause*) pnodeGrpCl;
-		if (psortcl->tleSortGroupRef == pgrpcl->tleSortGroupRef)
+		GroupClause *sort_group_clause = (GroupClause*) group_clause_node;
+		if (sort_group_clause->tleSortGroupRef == sort_group_clause->tleSortGroupRef)
 		{
 			return true;
 		}
@@ -2173,154 +2173,154 @@ CTranslatorUtils::FGroupingColumn
 //		the mappings in the provided context
 //---------------------------------------------------------------------------
 List *
-CTranslatorUtils::PlAttnosFromColids
+CTranslatorUtils::ConvertColidToAttnos
 	(
-	DrgPul *pdrgpul,
-	CDXLTranslateContext *pdxltrctx
+	ULongPtrArray *colids,
+	CDXLTranslateContext *translate_ctxt
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpul);
-	GPOS_ASSERT(NULL != pdxltrctx);
+	GPOS_ASSERT(NULL != colids);
+	GPOS_ASSERT(NULL != translate_ctxt);
 	
-	List *plResult = NIL;
+	List *result = NIL;
 	
-	const ULONG ulLength = pdrgpul->UlLength();
-	for (ULONG ul = 0; ul < ulLength; ul++)
+	const ULONG length = colids->Size();
+	for (ULONG ul = 0; ul < length; ul++)
 	{
-		ULONG ulColId = *((*pdrgpul)[ul]);
-		const TargetEntry *pte = pdxltrctx->Pte(ulColId);
-		GPOS_ASSERT(NULL != pte);
-		plResult = gpdb::PlAppendInt(plResult, pte->resno);
+		ULONG colid = *((*colids)[ul]);
+		const TargetEntry *target_entry = translate_ctxt->GetTargetEntry(colid);
+		GPOS_ASSERT(NULL != target_entry);
+		result = gpdb::LAppendInt(result, target_entry->resno);
 	}
 	
-	return plResult;
+	return result;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::LFromStr
+//		CTranslatorUtils::GetLongFromStr
 //
 //	@doc:
 //		Parses a long integer value from a string
 //
 //---------------------------------------------------------------------------
 LINT
-CTranslatorUtils::LFromStr
+CTranslatorUtils::GetLongFromStr
 	(
-	const CWStringBase *pstr
+	const CWStringBase *wcstr
 	)
 {
-	CHAR *sz = SzFromWsz(pstr->Wsz());
-	CHAR *pcEnd = NULL;
-	return gpos::clib::LStrToL(sz, &pcEnd, 10);
+	CHAR *str = CreateMultiByteCharStringFromWCString(wcstr->GetBuffer());
+	CHAR *end = NULL;
+	return gpos::clib::Strtol(str, &end, 10);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::IFromStr
+//		CTranslatorUtils::GetIntFromStr
 //
 //	@doc:
 //		Parses an integer value from a string
 //
 //---------------------------------------------------------------------------
 INT
-CTranslatorUtils::IFromStr
+CTranslatorUtils::GetIntFromStr
 	(
-	const CWStringBase *pstr
+	const CWStringBase *wcstr
 	)
 {
-	return (INT) LFromStr(pstr);
+	return (INT) GetLongFromStr(wcstr);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::SzFromWsz
+//		CTranslatorUtils::CreateMultiByteCharStringFromWCString
 //
 //	@doc:
 //		Converts a wide character string into a character array
 //
 //---------------------------------------------------------------------------
 CHAR *
-CTranslatorUtils::SzFromWsz
+CTranslatorUtils::CreateMultiByteCharStringFromWCString
 	(
-	const WCHAR *wsz
+	const WCHAR *wcstr
 	)
 {
-	GPOS_ASSERT(NULL != wsz);
+	GPOS_ASSERT(NULL != wcstr);
 
-	ULONG ulMaxLength = GPOS_WSZ_LENGTH(wsz) * GPOS_SIZEOF(WCHAR) + 1;
-	CHAR *sz = (CHAR *) gpdb::GPDBAlloc(ulMaxLength);
+	ULONG max_len = GPOS_WSZ_LENGTH(wcstr) * GPOS_SIZEOF(WCHAR) + 1;
+	CHAR *str = (CHAR *) gpdb::GPDBAlloc(max_len);
 #ifdef GPOS_DEBUG
 	LINT li = (INT)
 #endif
-	clib::LWcsToMbs(sz, const_cast<WCHAR *>(wsz), ulMaxLength);
+	clib::Wcstombs(str, const_cast<WCHAR *>(wcstr), max_len);
 	GPOS_ASSERT(0 <= li);
 
-	sz[ulMaxLength - 1] = '\0';
+	str[max_len - 1] = '\0';
 
-	return sz;
+	return str;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PhmululMap
+//		CTranslatorUtils::MakeNewToOldColMapping
 //
 //	@doc:
 //		Create a mapping from old columns to the corresponding new column
 //
 //---------------------------------------------------------------------------
-HMUlUl *
-CTranslatorUtils::PhmululMap
+UlongToUlongMap *
+CTranslatorUtils::MakeNewToOldColMapping
 	(
-	IMemoryPool *pmp,
-	DrgPul *pdrgpulOld,
-	DrgPul *pdrgpulNew
+	IMemoryPool *mp,
+	ULongPtrArray *old_colids,
+	ULongPtrArray *new_colids
 	)
 {
-	GPOS_ASSERT(NULL != pdrgpulOld);
-	GPOS_ASSERT(NULL != pdrgpulNew);
-	GPOS_ASSERT(pdrgpulNew->UlLength() == pdrgpulOld->UlLength());
+	GPOS_ASSERT(NULL != old_colids);
+	GPOS_ASSERT(NULL != new_colids);
+	GPOS_ASSERT(new_colids->Size() == old_colids->Size());
 	
-	HMUlUl *phmulul = GPOS_NEW(pmp) HMUlUl(pmp);
-	const ULONG ulCols = pdrgpulOld->UlLength();
-	for (ULONG ul = 0; ul < ulCols; ul++)
+	UlongToUlongMap *old_new_col_mapping = GPOS_NEW(mp) UlongToUlongMap(mp);
+	const ULONG num_cols = old_colids->Size();
+	for (ULONG ul = 0; ul < num_cols; ul++)
 	{
-		ULONG ulColIdOld = *((*pdrgpulOld)[ul]);
-		ULONG ulColIdNew = *((*pdrgpulNew)[ul]);
+		ULONG old_colid = *((*old_colids)[ul]);
+		ULONG new_colid = *((*new_colids)[ul]);
 #ifdef GPOS_DEBUG
-		BOOL fResult = 
+		BOOL result =
 #endif // GPOS_DEBUG
-		phmulul->FInsert(GPOS_NEW(pmp) ULONG(ulColIdOld), GPOS_NEW(pmp) ULONG(ulColIdNew));
-		GPOS_ASSERT(fResult);
+		old_new_col_mapping->Insert(GPOS_NEW(mp) ULONG(old_colid), GPOS_NEW(mp) ULONG(new_colid));
+		GPOS_ASSERT(result);
 	}
 	
-	return phmulul;
+	return old_new_col_mapping;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FDuplicateSensitiveMotion
+//		CTranslatorUtils::IsDuplicateSensitiveMotion
 //
 //	@doc:
 //		Is this a motion sensitive to duplicates
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FDuplicateSensitiveMotion
+CTranslatorUtils::IsDuplicateSensitiveMotion
 	(
-	CDXLPhysicalMotion *pdxlopMotion
+	CDXLPhysicalMotion *dxl_motion
 	)
 {
-	Edxlopid edxlopid = pdxlopMotion->Edxlop();
+	Edxlopid dxl_opid = dxl_motion->GetDXLOperator();
 	
-	if (EdxlopPhysicalMotionRedistribute == edxlopid)
+	if (EdxlopPhysicalMotionRedistribute == dxl_opid)
 	{
-		return CDXLPhysicalRedistributeMotion::PdxlopConvert(pdxlopMotion)->FDuplicateSensitive();
+		return CDXLPhysicalRedistributeMotion::Cast(dxl_motion)->IsDuplicateSensitive();
 	}
 	
-	if (EdxlopPhysicalMotionRandom == edxlopid)
+	if (EdxlopPhysicalMotionRandom == dxl_opid)
 	{
-		return CDXLPhysicalRandomMotion::PdxlopConvert(pdxlopMotion)->FDuplicateSensitive();
+		return CDXLPhysicalRandomMotion::Cast(dxl_motion)->IsDuplicateSensitive();
 	}
 	
 	// other motion operators are not sensitive to duplicates
@@ -2329,7 +2329,7 @@ CTranslatorUtils::FDuplicateSensitiveMotion
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FHasProjElem
+//		CTranslatorUtils::HasProjElem
 //
 //	@doc:
 //		Check whether the given project list has a project element of the given
@@ -2337,24 +2337,24 @@ CTranslatorUtils::FDuplicateSensitiveMotion
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FHasProjElem
+CTranslatorUtils::HasProjElem
 	(
-	CDXLNode *pdxlnPrL,
-	Edxlopid edxlopid
+	CDXLNode *project_list_dxlnode,
+	Edxlopid dxl_opid
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnPrL);
-	GPOS_ASSERT(EdxlopScalarProjectList == pdxlnPrL->Pdxlop()->Edxlop());
-	GPOS_ASSERT(EdxlopSentinel > edxlopid);
+	GPOS_ASSERT(NULL != project_list_dxlnode);
+	GPOS_ASSERT(EdxlopScalarProjectList == project_list_dxlnode->GetOperator()->GetDXLOperator());
+	GPOS_ASSERT(EdxlopSentinel > dxl_opid);
 
-	const ULONG ulArity = pdxlnPrL->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = project_list_dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		CDXLNode *pdxlnPrEl = (*pdxlnPrL)[ul];
-		GPOS_ASSERT(EdxlopScalarProjectElem == pdxlnPrEl->Pdxlop()->Edxlop());
+		CDXLNode *dxl_project_element = (*project_list_dxlnode)[ul];
+		GPOS_ASSERT(EdxlopScalarProjectElem == dxl_project_element->GetOperator()->GetDXLOperator());
 
-		CDXLNode *pdxlnChild = (*pdxlnPrEl)[0];
-		if (edxlopid == pdxlnChild->Pdxlop()->Edxlop())
+		CDXLNode *dxl_child_node = (*dxl_project_element)[0];
+		if (dxl_opid == dxl_child_node->GetOperator()->GetDXLOperator())
 		{
 			return true;
 		}
@@ -2365,7 +2365,7 @@ CTranslatorUtils::FHasProjElem
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdxlnPrElNull
+//		CTranslatorUtils::CreateDXLProjElemConstNULL
 //
 //	@doc:
 //		Create a DXL project element node with a Const NULL of type provided
@@ -2374,129 +2374,129 @@ CTranslatorUtils::FHasProjElem
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorUtils::PdxlnPrElNull
+CTranslatorUtils::CreateDXLProjElemConstNULL
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
 	CIdGenerator *pidgtorCol,
-	const IMDColumn *pmdcol
+	const IMDColumn *md_col
 	)
 {
-	GPOS_ASSERT(NULL != pmdcol);
-	GPOS_ASSERT(!pmdcol->FSystemColumn());
+	GPOS_ASSERT(NULL != md_col);
+	GPOS_ASSERT(!md_col->IsSystemColumn());
 
-	const WCHAR *wszColName = pmdcol->Mdname().Pstr()->Wsz();
-	if (!pmdcol->FNullable())
+	const WCHAR *col_name = md_col->Mdname().GetMDName()->GetBuffer();
+	if (!md_col->IsNullable())
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLNotNullViolation, wszColName);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLNotNullViolation, col_name);
 	}
 
-	ULONG ulColId = pidgtorCol->UlNextId();
-	CDXLNode *pdxlnPrE = PdxlnPrElNull(pmp, pmda, pmdcol->PmdidType(), ulColId, wszColName);
+	ULONG colid = pidgtorCol->next_id();
+	CDXLNode *dxl_project_element = CreateDXLProjElemConstNULL(mp, md_accessor, md_col->MdidType(), colid, col_name);
 
-	return pdxlnPrE;
+	return dxl_project_element;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdxlnPrElNull
+//		CTranslatorUtils::CreateDXLProjElemConstNULL
 //
 //	@doc:
 //		Create a DXL project element node with a Const NULL expression
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorUtils::PdxlnPrElNull
+CTranslatorUtils::CreateDXLProjElemConstNULL
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid,
-	ULONG ulColId,
-	const WCHAR *wszColName
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid,
+	ULONG colid,
+	const WCHAR *col_name
 	)
 {
-	CHAR *szColumnName = CDXLUtils::SzFromWsz(pmp, wszColName);
-	CDXLNode *pdxlnPrE = PdxlnPrElNull(pmp, pmda, pmdid, ulColId, szColumnName);
+	CHAR *column_name = CDXLUtils::CreateMultiByteCharStringFromWCString(mp, col_name);
+	CDXLNode *dxl_project_element = CreateDXLProjElemConstNULL(mp, md_accessor, mdid, colid, column_name);
 
-	GPOS_DELETE_ARRAY(szColumnName);
+	GPOS_DELETE_ARRAY(column_name);
 
-	return pdxlnPrE;
+	return dxl_project_element;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PdxlnPrElNull
+//		CTranslatorUtils::CreateDXLProjElemConstNULL
 //
 //	@doc:
 //		Create a DXL project element node with a Const NULL expression
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorUtils::PdxlnPrElNull
+CTranslatorUtils::CreateDXLProjElemConstNULL
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	IMDId *pmdid,
-	ULONG ulColId,
-	CHAR *szAliasName
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMDId *mdid,
+	ULONG colid,
+	CHAR *alias_name
 	)
 {
-	BOOL fByValue = pmda->Pmdtype(pmdid)->FByValue();
+	BOOL is_passed_by_value = md_accessor->RetrieveType(mdid)->IsPassedByValue();
 
 	// get the id and alias for the proj elem
-	CMDName *pmdnameAlias = NULL;
+	CMDName *alias_mdname = NULL;
 
-	if (NULL == szAliasName)
+	if (NULL == alias_name)
 	{
-		CWStringConst strUnnamedCol(GPOS_WSZ_LIT("?column?"));
-		pmdnameAlias = GPOS_NEW(pmp) CMDName(pmp, &strUnnamedCol);
+		CWStringConst unnamed_col(GPOS_WSZ_LIT("?column?"));
+		alias_mdname = GPOS_NEW(mp) CMDName(mp, &unnamed_col);
 	}
 	else
 	{
-		CWStringDynamic *pstrAlias = CDXLUtils::PstrFromSz(pmp, szAliasName);
-		pmdnameAlias = GPOS_NEW(pmp) CMDName(pmp, pstrAlias);
-		GPOS_DELETE(pstrAlias);
+		CWStringDynamic *alias = CDXLUtils::CreateDynamicStringFromCharArray(mp, alias_name);
+		alias_mdname = GPOS_NEW(mp) CMDName(mp, alias);
+		GPOS_DELETE(alias);
 	}
 
-	pmdid->AddRef();
-	CDXLDatum *pdxldatum = NULL;
-	if (pmdid->FEquals(&CMDIdGPDB::m_mdidInt2))
+	mdid->AddRef();
+	CDXLDatum *datum_dxl = NULL;
+	if (mdid->Equals(&CMDIdGPDB::m_mdid_int2))
 	{
-		pdxldatum = GPOS_NEW(pmp) CDXLDatumInt2(pmp, pmdid, true /*fConstNull*/, 0 /*value*/);
+		datum_dxl = GPOS_NEW(mp) CDXLDatumInt2(mp, mdid, true /*fConstNull*/, 0 /*value*/);
 	}
-	else if (pmdid->FEquals(&CMDIdGPDB::m_mdidInt4))
+	else if (mdid->Equals(&CMDIdGPDB::m_mdid_int4))
 	{
-		pdxldatum = GPOS_NEW(pmp) CDXLDatumInt4(pmp, pmdid, true /*fConstNull*/, 0 /*value*/);
+		datum_dxl = GPOS_NEW(mp) CDXLDatumInt4(mp, mdid, true /*fConstNull*/, 0 /*value*/);
 	}
-	else if (pmdid->FEquals(&CMDIdGPDB::m_mdidInt8))
+	else if (mdid->Equals(&CMDIdGPDB::m_mdid_int8))
 	{
-		pdxldatum = GPOS_NEW(pmp) CDXLDatumInt8(pmp, pmdid, true /*fConstNull*/, 0 /*value*/);
+		datum_dxl = GPOS_NEW(mp) CDXLDatumInt8(mp, mdid, true /*fConstNull*/, 0 /*value*/);
 	}
-	else if (pmdid->FEquals(&CMDIdGPDB::m_mdidBool))
+	else if (mdid->Equals(&CMDIdGPDB::m_mdid_bool))
 	{
-		pdxldatum = GPOS_NEW(pmp) CDXLDatumBool(pmp, pmdid, true /*fConstNull*/, 0 /*value*/);
+		datum_dxl = GPOS_NEW(mp) CDXLDatumBool(mp, mdid, true /*fConstNull*/, 0 /*value*/);
 	}
-	else if (pmdid->FEquals(&CMDIdGPDB::m_mdidOid))
+	else if (mdid->Equals(&CMDIdGPDB::m_mdid_oid))
 	{
-		pdxldatum = GPOS_NEW(pmp) CDXLDatumOid(pmp, pmdid, true /*fConstNull*/, 0 /*value*/);
+		datum_dxl = GPOS_NEW(mp) CDXLDatumOid(mp, mdid, true /*fConstNull*/, 0 /*value*/);
 	}
 	else
 	{
-		pdxldatum = CMDTypeGenericGPDB::Pdxldatum
+		datum_dxl = CMDTypeGenericGPDB::CreateDXLDatumVal
 										(
-										pmp,
-										pmdid,
-										IDefaultTypeModifier,
-										fByValue /*fConstByVal*/,
+										mp,
+										mdid,
+										default_type_modifier,
+										is_passed_by_value /*fConstByVal*/,
 										true /*fConstNull*/,
 										NULL, /*pba */
-										0 /*ulLength*/,
-										0 /*lValue*/,
+										0 /*length*/,
+										0 /*l_value*/,
 										0 /*dValue*/
 										);
 	}
 
-	CDXLNode *pdxlnConst = GPOS_NEW(pmp) CDXLNode(pmp, GPOS_NEW(pmp) CDXLScalarConstValue(pmp, pdxldatum));
+	CDXLNode *dxl_const_node = GPOS_NEW(mp) CDXLNode(mp, GPOS_NEW(mp) CDXLScalarConstValue(mp, datum_dxl));
 
-	return GPOS_NEW(pmp) CDXLNode(pmp, GPOS_NEW(pmp) CDXLScalarProjElem(pmp, ulColId, pmdnameAlias), pdxlnConst);
+	return GPOS_NEW(mp) CDXLNode(mp, GPOS_NEW(mp) CDXLScalarProjElem(mp, colid, alias_mdname), dxl_const_node);
 }
 
 
@@ -2511,10 +2511,10 @@ CTranslatorUtils::PdxlnPrElNull
 void
 CTranslatorUtils::CheckRTEPermissions
 	(
-	List *plRangeTable
+	List *range_table_list
 	)
 {
-	gpdb::CheckRTPermissions(plRangeTable);
+	gpdb::CheckRTPermissions(range_table_list);
 }
 
 //---------------------------------------------------------------------------
@@ -2529,15 +2529,15 @@ CTranslatorUtils::CheckRTEPermissions
 void
 CTranslatorUtils::CheckAggregateWindowFn
 	(
-	Node *pnode
+	Node *node
 	)
 {
-	GPOS_ASSERT(NULL != pnode);
-	GPOS_ASSERT(IsA(pnode, WindowRef));
+	GPOS_ASSERT(NULL != node);
+	GPOS_ASSERT(IsA(node, WindowRef));
 
-	WindowRef *pwinref = (WindowRef*) pnode;
+	WindowRef *win_ref = (WindowRef*) node;
 
-	if (gpdb::FAggregateExists(pwinref->winfnoid) && !gpdb::FAggHasPrelimOrInvPrelimFunc(pwinref->winfnoid))
+	if (gpdb::AggregateExists(win_ref->winfnoid) && !gpdb::AggHasPrelimOrInvPrelimFunc(win_ref->winfnoid))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				GPOS_WSZ_LIT("Aggregate window function without prelim or inverse prelim function"));
@@ -2556,20 +2556,20 @@ CTranslatorUtils::CheckAggregateWindowFn
 void
 CTranslatorUtils::UpdateGrpColMapping
 	(
-	IMemoryPool *pmp,
-	HMUlUl *phmululGrpColPos, 
-	CBitSet *pbsGrpCols,
-	ULONG ulSortGrpRef
+	IMemoryPool *mp,
+	UlongToUlongMap *group_col_pos,
+	CBitSet *group_cols,
+	ULONG sort_group_ref
 	)
 {
-	GPOS_ASSERT(NULL != phmululGrpColPos);
-	GPOS_ASSERT(NULL != pbsGrpCols);
+	GPOS_ASSERT(NULL != group_col_pos);
+	GPOS_ASSERT(NULL != group_cols);
 		
-	if (!pbsGrpCols->FBit(ulSortGrpRef))
+	if (!group_cols->Get(sort_group_ref))
 	{
-		ULONG ulUniqueGrpCols = pbsGrpCols->CElements();
-		phmululGrpColPos->FInsert(GPOS_NEW(pmp) ULONG (ulUniqueGrpCols), GPOS_NEW(pmp) ULONG(ulSortGrpRef));
-		(void) pbsGrpCols->FExchangeSet(ulSortGrpRef);
+		ULONG num_unique_grouping_cols = group_cols->Size();
+		group_col_pos->Insert(GPOS_NEW(mp) ULONG (num_unique_grouping_cols), GPOS_NEW(mp) ULONG(sort_group_ref));
+		(void) group_cols->ExchangeSet(sort_group_ref);
 	}
 }
 
@@ -2585,51 +2585,51 @@ CTranslatorUtils::UpdateGrpColMapping
 void
 CTranslatorUtils::MarkOuterRefs
 	(
-	ULONG *pulColId,  // array of column ids to be checked
-	BOOL *pfOuterRef,  // array of outer ref indicators, initially all set to true by caller 
-	ULONG ulColumns,  // number of columns
-	CDXLNode *pdxln
+	ULONG *colids,  // array of column ids to be checked
+	BOOL *is_outer_ref,  // array of outer ref indicators, initially all set to true by caller
+	ULONG num_columns,  // number of columns
+	CDXLNode *dxlnode
 	)
 {
-	GPOS_ASSERT(NULL != pulColId);
-	GPOS_ASSERT(NULL != pfOuterRef);
-	GPOS_ASSERT(NULL != pdxln);
+	GPOS_ASSERT(NULL != colids);
+	GPOS_ASSERT(NULL != is_outer_ref);
+	GPOS_ASSERT(NULL != dxlnode);
 	
-	const CDXLOperator *pdxlop = pdxln->Pdxlop();
-	for (ULONG ulCol = 0; ulCol < ulColumns; ulCol++)
+	const CDXLOperator *dxl_op = dxlnode->GetOperator();
+	for (ULONG ulCol = 0; ulCol < num_columns; ulCol++)
 	{
-		ULONG ulColId = pulColId[ulCol];
-		if (pfOuterRef[ulCol] && pdxlop->FDefinesColumn(ulColId))
+		ULONG colid = colids[ulCol];
+		if (is_outer_ref[ulCol] && dxl_op->IsColDefined(colid))
 		{
 			// column is defined by operator, reset outer reference flag
-			pfOuterRef[ulCol] = false;
+			is_outer_ref[ulCol] = false;
 		}
 	}
 
 	// recursively process children
-	const ULONG ulArity = pdxln->UlArity();
-	for (ULONG ul = 0; ul < ulArity; ul++)
+	const ULONG arity = dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
 	{
-		MarkOuterRefs(pulColId, pfOuterRef, ulColumns, (*pdxln)[ul]);
+		MarkOuterRefs(colids, is_outer_ref, num_columns, (*dxlnode)[ul]);
 	}
 }
 
 //---------------------------------------------------------------------------
 //      @function:
-//              CTranslatorUtils::Slink
+//              CTranslatorUtils::MapDXLSubplanToSublinkType
 //
 //      @doc:
 //              Map DXL Subplan type to GPDB SubLinkType
 //
 //---------------------------------------------------------------------------
 SubLinkType
-CTranslatorUtils::Slink
+CTranslatorUtils::MapDXLSubplanToSublinkType
         (
-        EdxlSubPlanType edxlsubplantype
+        EdxlSubPlanType dxl_subplan_type
         )
 {
-        GPOS_ASSERT(EdxlSubPlanTypeSentinel > edxlsubplantype);
-        ULONG rgrgulMapping[][2] =
+        GPOS_ASSERT(EdxlSubPlanTypeSentinel > dxl_subplan_type);
+        ULONG mapping[][2] =
                 {
                 {EdxlSubPlanTypeScalar, EXPR_SUBLINK},
                 {EdxlSubPlanTypeExists, EXISTS_SUBLINK},
@@ -2638,21 +2638,21 @@ CTranslatorUtils::Slink
                 {EdxlSubPlanTypeAll, ALL_SUBLINK}
                 };
 
-        const ULONG ulArity = GPOS_ARRAY_SIZE(rgrgulMapping);
+        const ULONG arity = GPOS_ARRAY_SIZE(mapping);
         SubLinkType slink = EXPR_SUBLINK;
-	BOOL fFound = false;
-        for (ULONG ul = 0; ul < ulArity; ul++)
+		BOOL found = false;
+        for (ULONG ul = 0; ul < arity; ul++)
         {
-                ULONG *pulElem = rgrgulMapping[ul];
-                if ((ULONG) edxlsubplantype == pulElem[0])
+                ULONG *elem = mapping[ul];
+                if ((ULONG) dxl_subplan_type == elem[0])
                 {
-                        slink = (SubLinkType) pulElem[1];
-                        fFound = true;
+                        slink = (SubLinkType) elem[1];
+                        found = true;
 			break;
                 }
         }
 
-	GPOS_ASSERT(fFound && "Invalid SubPlanType");
+	GPOS_ASSERT(found && "Invalid SubPlanType");
 
         return slink;
 }
@@ -2660,19 +2660,19 @@ CTranslatorUtils::Slink
 
 //---------------------------------------------------------------------------
 //      @function:
-//              CTranslatorUtils::Edxlsubplantype
+//              CTranslatorUtils::MapSublinkTypeToDXLSubplan
 //
 //      @doc:
 //              Map GPDB SubLinkType to DXL subplan type
 //
 //---------------------------------------------------------------------------
 EdxlSubPlanType
-CTranslatorUtils::Edxlsubplantype
+CTranslatorUtils::MapSublinkTypeToDXLSubplan
         (
         SubLinkType slink
         )
 {
-        ULONG rgrgulMapping[][2] =
+        ULONG mapping[][2] =
                 {
                 {EXPR_SUBLINK, EdxlSubPlanTypeScalar},
                 {EXISTS_SUBLINK , EdxlSubPlanTypeExists},
@@ -2681,28 +2681,28 @@ CTranslatorUtils::Edxlsubplantype
                 {ALL_SUBLINK, EdxlSubPlanTypeAll}
                 };
 
-        const ULONG ulArity = GPOS_ARRAY_SIZE(rgrgulMapping);
-        EdxlSubPlanType edxlsubplantype = EdxlSubPlanTypeScalar;
-	BOOL fFound = false;
-        for (ULONG ul = 0; ul < ulArity; ul++)
+        const ULONG arity = GPOS_ARRAY_SIZE(mapping);
+        EdxlSubPlanType dxl_subplan_type = EdxlSubPlanTypeScalar;
+		BOOL found = false;
+        for (ULONG ul = 0; ul < arity; ul++)
         {
-                ULONG *pulElem = rgrgulMapping[ul];
-                if ((ULONG) slink == pulElem[0])
+                ULONG *elem = mapping[ul];
+                if ((ULONG) slink == elem[0])
                 {
-                        edxlsubplantype = (EdxlSubPlanType) pulElem[1];
-                        fFound = true;
+                        dxl_subplan_type = (EdxlSubPlanType) elem[1];
+                        found = true;
 			break;
                 }
         }
 
-	 GPOS_ASSERT(fFound && "Invalid SubLinkType");
+	 GPOS_ASSERT(found && "Invalid SubLinkType");
 
-        return edxlsubplantype;
+        return dxl_subplan_type;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FRelHasTriggers
+//		CTranslatorUtils::RelHasTriggers
 //
 //	@doc:
 //		Check whether there are triggers for the given operation on
@@ -2710,95 +2710,95 @@ CTranslatorUtils::Edxlsubplantype
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FRelHasTriggers
+CTranslatorUtils::RelHasTriggers
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const IMDRelation *pmdrel,
-	const EdxlDmlType edxldmltype
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const IMDRelation *rel,
+	const EdxlDmlType dml_type_dxl
 	)
 {
-	const ULONG ulTriggers = pmdrel->UlTriggers();
-	for (ULONG ul = 0; ul < ulTriggers; ul++)
+	const ULONG num_triggers = rel->TriggerCount();
+	for (ULONG ul = 0; ul < num_triggers; ul++)
 	{
-		if (FApplicableTrigger(pmda, pmdrel->PmdidTrigger(ul), edxldmltype))
+		if (IsApplicableTrigger(md_accessor, rel->TriggerMDidAt(ul), dml_type_dxl))
 		{
 			return true;
 		}
 	}
 
 	// if table is partitioned, check for triggers on child partitions as well
-	INT iType = 0;
-	if (Edxldmlinsert == edxldmltype)
+	INT type = 0;
+	if (Edxldmlinsert == dml_type_dxl)
 	{
-		iType = TRIGGER_TYPE_INSERT;
+		type = TRIGGER_TYPE_INSERT;
 	}
-	else if (Edxldmldelete == edxldmltype)
+	else if (Edxldmldelete == dml_type_dxl)
 	{
-		iType = TRIGGER_TYPE_DELETE;
+		type = TRIGGER_TYPE_DELETE;
 	}
 	else
 	{
-		GPOS_ASSERT(Edxldmlupdate == edxldmltype);
-		iType = TRIGGER_TYPE_UPDATE;
+		GPOS_ASSERT(Edxldmlupdate == dml_type_dxl);
+		type = TRIGGER_TYPE_UPDATE;
 	}
 
-	OID oidRel = CMDIdGPDB::PmdidConvert(pmdrel->Pmdid())->OidObjectId();
-	return gpdb::FChildTriggers(oidRel, iType);
+	OID rel_oid = CMDIdGPDB::CastMdid(rel->MDId())->Oid();
+	return gpdb::ChildPartHasTriggers(rel_oid, type);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FApplicableTrigger
+//		CTranslatorUtils::IsApplicableTrigger
 //
 //	@doc:
 //		Check whether the given trigger is applicable to the given DML operation
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FApplicableTrigger
+CTranslatorUtils::IsApplicableTrigger
 	(
-	CMDAccessor *pmda,
-	IMDId *pmdidTrigger,
-	const EdxlDmlType edxldmltype
+	CMDAccessor *md_accessor,
+	IMDId *trigger_mdid,
+	const EdxlDmlType dml_type_dxl
 	)
 {
-	const IMDTrigger *pmdtrigger = pmda->Pmdtrigger(pmdidTrigger);
-	if (!pmdtrigger->FEnabled())
+	const IMDTrigger *trigger = md_accessor->RetrieveTrigger(trigger_mdid);
+	if (!trigger->IsEnabled())
 	{
 		return false;
 	}
 
-	return ((Edxldmlinsert == edxldmltype && pmdtrigger->FInsert()) ||
-			(Edxldmldelete == edxldmltype && pmdtrigger->FDelete()) ||
-			(Edxldmlupdate == edxldmltype && pmdtrigger->FUpdate()));
+	return ((Edxldmlinsert == dml_type_dxl && trigger->IsInsert()) ||
+			(Edxldmldelete == dml_type_dxl && trigger->IsDelete()) ||
+			(Edxldmlupdate == dml_type_dxl && trigger->IsUpdate()));
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::FRelHasConstraints
+//		CTranslatorUtils::RelHasConstraints
 //
 //	@doc:
 //		Check whether there are constraints for the given relation
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::FRelHasConstraints
+CTranslatorUtils::RelHasConstraints
 	(
-	const IMDRelation *pmdrel
+	const IMDRelation *rel
 	)
 {
-	if (0 < pmdrel->UlCheckConstraints())
+	if (0 < rel->CheckConstraintCount())
 	{
 		return true;
 	}
 	
-	const ULONG ulCols = pmdrel->UlColumns();
+	const ULONG num_cols = rel->ColumnCount();
 	
-	for (ULONG ul = 0; ul < ulCols; ul++)
+	for (ULONG ul = 0; ul < num_cols; ul++)
 	{
-		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		if (!pmdcol->FSystemColumn() && !pmdcol->FNullable())
+		const IMDColumn *md_col = rel->GetMdCol(ul);
+		if (!md_col->IsSystemColumn() && !md_col->IsNullable())
 		{
 			return true;
 		}
@@ -2809,76 +2809,76 @@ CTranslatorUtils::FRelHasConstraints
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::PlAssertErrorMsgs
+//		CTranslatorUtils::GetAssertErrorMsgs
 //
 //	@doc:
 //		Construct a list of error messages from a list of assert constraints 
 //
 //---------------------------------------------------------------------------
 List *
-CTranslatorUtils::PlAssertErrorMsgs
+CTranslatorUtils::GetAssertErrorMsgs
 	(
-	CDXLNode *pdxlnAssertConstraintList
+	CDXLNode *assert_constraint_list
 	)
 {
-	GPOS_ASSERT(NULL != pdxlnAssertConstraintList);
-	GPOS_ASSERT(EdxlopScalarAssertConstraintList == pdxlnAssertConstraintList->Pdxlop()->Edxlop());
+	GPOS_ASSERT(NULL != assert_constraint_list);
+	GPOS_ASSERT(EdxlopScalarAssertConstraintList == assert_constraint_list->GetOperator()->GetDXLOperator());
 	
-	List *plErrorMsgs = NIL;
-	const ULONG ulConstraints = pdxlnAssertConstraintList->UlArity();
+	List *error_msgs_list = NIL;
+	const ULONG num_constraints = assert_constraint_list->Arity();
 	
-	for (ULONG ul = 0; ul < ulConstraints; ul++)
+	for (ULONG ul = 0; ul < num_constraints; ul++)
 	{
-		CDXLNode *pdxlnConstraint = (*pdxlnAssertConstraintList)[ul];
-		CDXLScalarAssertConstraint *pdxlopConstraint = CDXLScalarAssertConstraint::PdxlopConvert(pdxlnConstraint->Pdxlop());
-		CWStringBase *pstrErrorMsg = pdxlopConstraint->PstrErrorMsg();
-		plErrorMsgs = gpdb::PlAppendElement(plErrorMsgs, gpdb::PvalMakeString(SzFromWsz(pstrErrorMsg->Wsz())));
+		CDXLNode *dxl_constraint_node = (*assert_constraint_list)[ul];
+		CDXLScalarAssertConstraint *dxl_constraint_op = CDXLScalarAssertConstraint::Cast(dxl_constraint_node->GetOperator());
+		CWStringBase *error_msg = dxl_constraint_op->GetErrorMsgStr();
+		error_msgs_list = gpdb::LAppend(error_msgs_list, gpdb::MakeStringValue(CreateMultiByteCharStringFromWCString(error_msg->GetBuffer())));
 	}
 	
-	return plErrorMsgs;
+	return error_msgs_list;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::UlNonSystemColumns
+//		CTranslatorUtils::GetNumNonSystemColumns
 //
 //	@doc:
 //		Return the count of non-system columns in the relation
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorUtils::UlNonSystemColumns
+CTranslatorUtils::GetNumNonSystemColumns
 	(
-	const IMDRelation *pmdrel
+	const IMDRelation *rel
 	)
 {
-	GPOS_ASSERT(NULL != pmdrel);
+	GPOS_ASSERT(NULL != rel);
 
-	ULONG ulNonSystemCols = 0;
+	ULONG num_non_system_cols = 0;
 
-	const ULONG ulCols = pmdrel->UlColumns();
-	for (ULONG ul = 0; ul < ulCols; ul++)
+	const ULONG num_cols = rel->ColumnCount();
+	for (ULONG ul = 0; ul < num_cols; ul++)
 	{
-		const IMDColumn *pmdcol  = pmdrel->Pmdcol(ul);
+		const IMDColumn *md_col  = rel->GetMdCol(ul);
 
-		if (!pmdcol->FSystemColumn())
+		if (!md_col->IsSystemColumn())
 		{
-			ulNonSystemCols++;
+			num_non_system_cols++;
 		}
 	}
 
-	return ulNonSystemCols;
+	return num_non_system_cols;
 }
 
 // Function to check if we should create stats bucket in DXL
 // Returns true if column datatype is not text/char/varchar/bpchar
 BOOL
-CTranslatorUtils::FCreateStatsBucket
+CTranslatorUtils::ShouldCreateStatsBucket
 	(
-	OID oidAttType
+	OID att_type_oid
 	)
 {
-	if (oidAttType != TEXTOID && oidAttType != CHAROID && oidAttType != VARCHAROID && oidAttType != BPCHAROID)
+	if (att_type_oid != TEXTOID && att_type_oid != CHAROID && att_type_oid != VARCHAROID && att_type_oid != BPCHAROID)
 		return true;
 
 	return false;

--- a/src/backend/gpopt/utils/CCatalogUtils.cpp
+++ b/src/backend/gpopt/utils/CCatalogUtils.cpp
@@ -17,57 +17,57 @@
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CCatalogUtils::PlRelationOids
+//		CCatalogUtils::GetRelationOids
 //
 //	@doc:
 //		Return list of relation oids from the catalog
 //
 //---------------------------------------------------------------------------
 List *
-CCatalogUtils::PlRelationOids()
+CCatalogUtils::GetRelationOids()
 {
 	return relation_oids();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CCatalogUtils::PlOperatorOids
+//		CCatalogUtils::GetOperatorOids
 //
 //	@doc:
 //		Return list of operator oids from the catalog
 //
 //---------------------------------------------------------------------------
 List *
-CCatalogUtils::PlOperatorOids()
+CCatalogUtils::GetOperatorOids()
 {
 	return operator_oids();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CCatalogUtils::PlFunctionOids
+//		CCatalogUtils::GetFunctionOids
 //
 //	@doc:
-//		Return list of function plOids from the catalog
+//		Return list of function oids_list from the catalog
 //
 //---------------------------------------------------------------------------
 List *
-CCatalogUtils::PlFunctionOids()
+CCatalogUtils::GetFunctionOids()
 {
 	return function_oids();
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CCatalogUtils::PlAllOids
+//		CCatalogUtils::GetAllOids
 //
 //	@doc:
-//		Return list of all plOids from the catalog
+//		Return list of all oids_list from the catalog
 //
 //---------------------------------------------------------------------------
-List *CCatalogUtils::PlAllOids()
+List *CCatalogUtils::GetAllOids()
 {
-	return list_concat(list_concat(PlRelationOids(), PlOperatorOids()), PlFunctionOids());
+	return list_concat(list_concat(GetRelationOids(), GetOperatorOids()), GetFunctionOids());
 }
 
 // EOF

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -99,10 +99,10 @@ using namespace gpdbcost;
 #define F_WINDOW_RANK_OID 7001
 
 // default id for the source system
-const CSystemId sysidDefault(IMDId::EmdidGPDB, GPOS_WSZ_STR_LENGTH("GPDB"));
+const CSystemId default_sysid(IMDId::EmdidGPDB, GPOS_WSZ_STR_LENGTH("GPDB"));
 
 // array of optimizer minor exception types that trigger expected fallback to the planner
-const ULONG rgulExpectedOptFallback[] =
+const ULONG expected_opt_fallback[] =
 	{
 		gpopt::ExmiInvalidPlanAlternative,		// chosen plan id is outside range of possible plans
 		gpopt::ExmiUnsupportedOp,				// unsupported operator
@@ -111,7 +111,7 @@ const ULONG rgulExpectedOptFallback[] =
 	};
 
 // array of DXL minor exception types that trigger expected fallback to the planner
-const ULONG rgulExpectedDXLFallback[] =
+const ULONG expected_dxl_fallback[] =
 	{
 		gpdxl::ExmiMDObjUnsupported,			// unsupported metadata object
 		gpdxl::ExmiQuery2DXLUnsupportedFeature,	// unsupported feature during algebrization
@@ -120,7 +120,7 @@ const ULONG rgulExpectedDXLFallback[] =
 	};
 
 // array of DXL minor exception types that error out and NOT fallback to the planner
-const ULONG rgulExpectedDXLErrors[] =
+const ULONG expected_dxl_errors[] =
 	{
 		gpdxl::ExmiDXL2PlStmtExternalScanError,	// external table error
 		gpdxl::ExmiQuery2DXLNotNullViolation,	// not null violation
@@ -137,14 +137,14 @@ const ULONG rgulExpectedDXLErrors[] =
 //---------------------------------------------------------------------------
 SOptContext::SOptContext()
 	:
-	m_szQueryDXL(NULL),
-	m_pquery(NULL),
-	m_szPlanDXL(NULL),
-	m_pplstmt(NULL),
-	m_fGeneratePlStmt(false),
-	m_fSerializePlanDXL(false),
-	m_fUnexpectedFailure(false),
-	m_szErrorMsg(NULL)
+	m_query_dxl(NULL),
+	m_query(NULL),
+	m_plan_dxl(NULL),
+	m_plan_stmt(NULL),
+	m_should_generate_plan_stmt(false),
+	m_should_serialize_plan_dxl(false),
+	m_is_unexpected_failure(false),
+	m_error_msg(NULL)
 {}
 
 //---------------------------------------------------------------------------
@@ -158,11 +158,11 @@ SOptContext::SOptContext()
 void
 SOptContext::HandleError
 	(
-	BOOL *pfUnexpectedFailure
+	BOOL *has_unexpected_failure
 	)
 {
-	*pfUnexpectedFailure = m_fUnexpectedFailure;
-	if (NULL != m_szErrorMsg)
+	*has_unexpected_failure = m_is_unexpected_failure;
+	if (NULL != m_error_msg)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiOptimizerError);
 	}
@@ -174,40 +174,40 @@ SOptContext::HandleError
 //		SOptContext::Free
 //
 //	@doc:
-//		Free all members except those pointed to by either epinInput or
-//		epinOutput
+//		Free all members except those pointed to by either input or
+//		output
 //
 //---------------------------------------------------------------------------
 void
 SOptContext::Free
 	(
-	SOptContext::EPin epinInput,
-	SOptContext::EPin epinOutput
+	SOptContext::EPin input,
+	SOptContext::EPin output
 	)
 {
-	if (NULL != m_szQueryDXL && epinQueryDXL != epinInput && epinQueryDXL != epinOutput)
+	if (NULL != m_query_dxl && epinQueryDXL != input && epinQueryDXL != output)
 	{
-		gpdb::GPDBFree(m_szQueryDXL);
+		gpdb::GPDBFree(m_query_dxl);
 	}
 	
-	if (NULL != m_pquery && epinQuery != epinInput && epinQuery != epinOutput)
+	if (NULL != m_query && epinQuery != input && epinQuery != output)
 	{
-		gpdb::GPDBFree(m_pquery);
+		gpdb::GPDBFree(m_query);
 	}
 	
-	if (NULL != m_szPlanDXL && epinPlanDXL != epinInput && epinPlanDXL != epinOutput)
+	if (NULL != m_plan_dxl && epinPlanDXL != input && epinPlanDXL != output)
 	{
-		gpdb::GPDBFree(m_szPlanDXL);
+		gpdb::GPDBFree(m_plan_dxl);
 	}
 	
-	if (NULL != m_pplstmt && epinPlStmt != epinInput && epinPlStmt != epinOutput)
+	if (NULL != m_plan_stmt && epinPlStmt != input && epinPlStmt != output)
 	{
-		gpdb::GPDBFree(m_pplstmt);
+		gpdb::GPDBFree(m_plan_stmt);
 	}
 	
-	if (NULL != m_szErrorMsg && epinErrorMsg != epinInput && epinErrorMsg != epinOutput)
+	if (NULL != m_error_msg && epinErrorMsg != input && epinErrorMsg != output)
 	{
-		gpdb::GPDBFree(m_szErrorMsg);
+		gpdb::GPDBFree(m_error_msg);
 	}
 }
 
@@ -216,7 +216,7 @@ SOptContext::Free
 //		SOptContext::CloneErrorMsg
 //
 //	@doc:
-//		Clone m_szErrorMsg to given memory context. Return NULL if there is no
+//		Clone m_error_msg to given memory context. Return NULL if there is no
 //		error message.
 //
 //---------------------------------------------------------------------------
@@ -227,31 +227,31 @@ SOptContext::CloneErrorMsg
 	)
 {
 	if (NULL == context ||
-		NULL == m_szErrorMsg)
+		NULL == m_error_msg)
 	{
 		return NULL;
 	}
-	return gpdb::SzMemoryContextStrdup(context, m_szErrorMsg);
+	return gpdb::MemCtxtStrdup(context, m_error_msg);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		SOptContext::PoptctxtConvert
+//		SOptContext::Cast
 //
 //	@doc:
 //		Casting function
 //
 //---------------------------------------------------------------------------
 SOptContext *
-SOptContext::PoptctxtConvert
+SOptContext::Cast
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	return reinterpret_cast<SOptContext*>(pv);
+	return reinterpret_cast<SOptContext*>(ptr);
 }
 
 
@@ -265,35 +265,35 @@ SOptContext::PoptctxtConvert
 //---------------------------------------------------------------------------
 COptTasks::SContextRelcacheToDXL::SContextRelcacheToDXL
 	(
-	List *plistOids,
-	ULONG ulCmpt,
-	const char *szFilename
+	List *oid_list,
+	ULONG cmp_type,
+	const char *filename
 	)
 	:
-	m_plistOids(plistOids),
-	m_ulCmpt(ulCmpt),
-	m_szFilename(szFilename)
+	m_oid_list(oid_list),
+	m_cmp_type(cmp_type),
+	m_filename(filename)
 {
-	GPOS_ASSERT(NULL != plistOids);
+	GPOS_ASSERT(NULL != oid_list);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::SContextRelcacheToDXL::PctxrelcacheConvert
+//		COptTasks::SContextRelcacheToDXL::RelcacheConvert
 //
 //	@doc:
 //		Casting function
 //
 //---------------------------------------------------------------------------
 COptTasks::SContextRelcacheToDXL *
-COptTasks::SContextRelcacheToDXL::PctxrelcacheConvert
+COptTasks::SContextRelcacheToDXL::RelcacheConvert
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	return reinterpret_cast<SContextRelcacheToDXL*>(pv);
+	return reinterpret_cast<SContextRelcacheToDXL*>(ptr);
 }
 
 
@@ -308,12 +308,12 @@ COptTasks::SContextRelcacheToDXL::PctxrelcacheConvert
 COptTasks::SEvalExprContext *
 COptTasks::SEvalExprContext::PevalctxtConvert
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	return reinterpret_cast<SEvalExprContext*>(pv);
+	return reinterpret_cast<SEvalExprContext*>(ptr);
 }
 
 
@@ -326,14 +326,14 @@ COptTasks::SEvalExprContext::PevalctxtConvert
 //
 //---------------------------------------------------------------------------
 COptTasks::SOptimizeMinidumpContext *
-COptTasks::SOptimizeMinidumpContext::PoptmdpConvert
+COptTasks::SOptimizeMinidumpContext::Cast
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	return reinterpret_cast<SOptimizeMinidumpContext*>(pv);
+	return reinterpret_cast<SOptimizeMinidumpContext*>(ptr);
 }
 
 //---------------------------------------------------------------------------
@@ -357,7 +357,7 @@ COptTasks::SzAllocate
 		// allocation of string buffer may happen outside gpos_exec() function,
 		// we must guard against system OOM here
 #ifdef FAULT_INJECTOR
-		gpdb::OptTasksFaultInjector(OptTaskAllocateStringBuffer);
+		gpdb::InjectFaultInOptTasks(OptTaskAllocateStringBuffer);
 #endif // FAULT_INJECTOR
 
 		if (NULL == pmp)
@@ -381,85 +381,85 @@ COptTasks::SzAllocate
 
 //---------------------------------------------------------------------------
 //	@function:
-//		SzFromWsz
+//		CreateMultiByteCharStringFromWCString
 //
 //	@doc:
 //		Return regular string from wide-character string
 //
 //---------------------------------------------------------------------------
 CHAR *
-COptTasks::SzFromWsz
+COptTasks::CreateMultiByteCharStringFromWCString
 	(
-	const WCHAR *wsz
+	const WCHAR *wcstr
 	)
 {
-	GPOS_ASSERT(NULL != wsz);
+	GPOS_ASSERT(NULL != wcstr);
 
-	const ULONG ulInputLength = GPOS_WSZ_LENGTH(wsz);
-	const ULONG ulWCHARSize = GPOS_SIZEOF(WCHAR);
-	const ULONG ulMaxLength = (ulInputLength + 1) * ulWCHARSize;
+	const ULONG input_len = GPOS_WSZ_LENGTH(wcstr);
+	const ULONG wchar_size = GPOS_SIZEOF(WCHAR);
+	const ULONG max_len = (input_len + 1) * wchar_size;
 
-	CHAR *sz = SzAllocate(NULL, ulMaxLength);
+	CHAR *str = SzAllocate(NULL, max_len);
 
-	gpos::clib::LWcsToMbs(sz, const_cast<WCHAR *>(wsz), ulMaxLength);
-	sz[ulMaxLength - 1] = '\0';
+	gpos::clib::Wcstombs(str, const_cast<WCHAR *>(wcstr), max_len);
+	str[max_len - 1] = '\0';
 
-	return sz;
+	return str;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PvMDCast
+//		COptTasks::ConvertToDXLFromMDCast
 //
 //	@doc:
 //		Task that dumps the relcache info for a cast object into DXL
 //
 //---------------------------------------------------------------------------
 void*
-COptTasks::PvMDCast
+COptTasks::ConvertToDXLFromMDCast
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	SContextRelcacheToDXL *pctxrelcache = SContextRelcacheToDXL::PctxrelcacheConvert(pv);
-	GPOS_ASSERT(NULL != pctxrelcache);
+	SContextRelcacheToDXL *relcache_ctxt = SContextRelcacheToDXL::RelcacheConvert(ptr);
+	GPOS_ASSERT(NULL != relcache_ctxt);
 
-	GPOS_ASSERT(2 == gpdb::UlListLength(pctxrelcache->m_plistOids));
-	Oid oidSrc = gpdb::OidListNth(pctxrelcache->m_plistOids, 0);
-	Oid oidDest = gpdb::OidListNth(pctxrelcache->m_plistOids, 1);
+	GPOS_ASSERT(2 == gpdb::ListLength(relcache_ctxt->m_oid_list));
+	Oid src_oid = gpdb::ListNthOid(relcache_ctxt->m_oid_list, 0);
+	Oid dest_oid = gpdb::ListNthOid(relcache_ctxt->m_oid_list, 1);
 
 	CAutoMemoryPool amp(CAutoMemoryPool::ElcExc);
-	IMemoryPool *pmp = amp.Pmp();
+	IMemoryPool *mp = amp.Pmp();
 
-	DrgPimdobj *pdrgpmdobj = GPOS_NEW(pmp) DrgPimdobj(pmp);
+	IMDCacheObjectArray *mdcache_obj_array = GPOS_NEW(mp) IMDCacheObjectArray(mp);
 
-	IMDId *pmdidCast = GPOS_NEW(pmp) CMDIdCast(GPOS_NEW(pmp) CMDIdGPDB(oidSrc), GPOS_NEW(pmp) CMDIdGPDB(oidDest));
+	IMDId *cast = GPOS_NEW(mp) CMDIdCast(GPOS_NEW(mp) CMDIdGPDB(src_oid), GPOS_NEW(mp) CMDIdGPDB(dest_oid));
 
 	// relcache MD provider
-	CMDProviderRelcache *pmdpr = GPOS_NEW(pmp) CMDProviderRelcache(pmp);
+	CMDProviderRelcache *relcache_provider = GPOS_NEW(mp) CMDProviderRelcache(mp);
 	
 	{
-		CAutoMDAccessor amda(pmp, pmdpr, sysidDefault);
+		CAutoMDAccessor md_accessor(mp, relcache_provider, default_sysid);
 	
-		IMDCacheObject *pmdobj = CTranslatorRelcacheToDXL::Pimdobj(pmp, amda.Pmda(), pmdidCast);
-		GPOS_ASSERT(NULL != pmdobj);
+		IMDCacheObject *md_obj = CTranslatorRelcacheToDXL::RetrieveObject(mp, md_accessor.Pmda(), cast);
+		GPOS_ASSERT(NULL != md_obj);
 	
-		pdrgpmdobj->Append(pmdobj);
-		pmdidCast->Release();
+		mdcache_obj_array->Append(md_obj);
+		cast->Release();
 	
-		CWStringDynamic str(pmp);
-		COstreamString oss(&str);
+		CWStringDynamic wcstr(mp);
+		COstreamString oss(&wcstr);
 
-		CDXLUtils::SerializeMetadata(pmp, pdrgpmdobj, oss, true /*fSerializeHeaderFooter*/, true /*fIndent*/);
-		CHAR *sz = SzFromWsz(str.Wsz());
-		GPOS_ASSERT(NULL != sz);
+		CDXLUtils::SerializeMetadata(mp, mdcache_obj_array, oss, true /*serialize_header_footer*/, true /*indentation*/);
+		CHAR *str = CreateMultiByteCharStringFromWCString(wcstr.GetBuffer());
+		GPOS_ASSERT(NULL != str);
 
-		pctxrelcache->m_szDXL = sz;
+		relcache_ctxt->m_dxl = str;
 		
 		// cleanup
-		pdrgpmdobj->Release();
+		mdcache_obj_array->Release();
 	}
 	
 	return NULL;
@@ -467,59 +467,59 @@ COptTasks::PvMDCast
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PvMDScCmp
+//		COptTasks::ConvertToDXLFromMDScalarCmp
 //
 //	@doc:
 //		Task that dumps the relcache info for a scalar comparison object into DXL
 //
 //---------------------------------------------------------------------------
 void*
-COptTasks::PvMDScCmp
+COptTasks::ConvertToDXLFromMDScalarCmp
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	SContextRelcacheToDXL *pctxrelcache = SContextRelcacheToDXL::PctxrelcacheConvert(pv);
-	GPOS_ASSERT(NULL != pctxrelcache);
-	GPOS_ASSERT(CmptOther > pctxrelcache->m_ulCmpt && "Incorrect comparison type specified");
+	SContextRelcacheToDXL *relcache_ctxt = SContextRelcacheToDXL::RelcacheConvert(ptr);
+	GPOS_ASSERT(NULL != relcache_ctxt);
+	GPOS_ASSERT(CmptOther > relcache_ctxt->m_cmp_type && "Incorrect comparison type specified");
 
-	GPOS_ASSERT(2 == gpdb::UlListLength(pctxrelcache->m_plistOids));
-	Oid oidLeft = gpdb::OidListNth(pctxrelcache->m_plistOids, 0);
-	Oid oidRight = gpdb::OidListNth(pctxrelcache->m_plistOids, 1);
-	CmpType cmpt = (CmpType) pctxrelcache->m_ulCmpt;
+	GPOS_ASSERT(2 == gpdb::ListLength(relcache_ctxt->m_oid_list));
+	Oid left_oid = gpdb::ListNthOid(relcache_ctxt->m_oid_list, 0);
+	Oid right_oid = gpdb::ListNthOid(relcache_ctxt->m_oid_list, 1);
+	CmpType cmpt = (CmpType) relcache_ctxt->m_cmp_type;
 	
 	CAutoMemoryPool amp(CAutoMemoryPool::ElcExc);
-	IMemoryPool *pmp = amp.Pmp();
+	IMemoryPool *mp = amp.Pmp();
 
-	DrgPimdobj *pdrgpmdobj = GPOS_NEW(pmp) DrgPimdobj(pmp);
+	IMDCacheObjectArray *mdcache_obj_array = GPOS_NEW(mp) IMDCacheObjectArray(mp);
 
-	IMDId *pmdidScCmp = GPOS_NEW(pmp) CMDIdScCmp(GPOS_NEW(pmp) CMDIdGPDB(oidLeft), GPOS_NEW(pmp) CMDIdGPDB(oidRight), CTranslatorRelcacheToDXL::Ecmpt(cmpt));
+	IMDId *scalar_cmp = GPOS_NEW(mp) CMDIdScCmp(GPOS_NEW(mp) CMDIdGPDB(left_oid), GPOS_NEW(mp) CMDIdGPDB(right_oid), CTranslatorRelcacheToDXL::ParseCmpType(cmpt));
 
 	// relcache MD provider
-	CMDProviderRelcache *pmdpr = GPOS_NEW(pmp) CMDProviderRelcache(pmp);
+	CMDProviderRelcache *relcache_provider = GPOS_NEW(mp) CMDProviderRelcache(mp);
 	
 	{
-		CAutoMDAccessor amda(pmp, pmdpr, sysidDefault);
+		CAutoMDAccessor md_accessor(mp, relcache_provider, default_sysid);
 	
-		IMDCacheObject *pmdobj = CTranslatorRelcacheToDXL::Pimdobj(pmp, amda.Pmda(), pmdidScCmp);
-		GPOS_ASSERT(NULL != pmdobj);
+		IMDCacheObject *md_obj = CTranslatorRelcacheToDXL::RetrieveObject(mp, md_accessor.Pmda(), scalar_cmp);
+		GPOS_ASSERT(NULL != md_obj);
 	
-		pdrgpmdobj->Append(pmdobj);
-		pmdidScCmp->Release();
+		mdcache_obj_array->Append(md_obj);
+		scalar_cmp->Release();
 	
-		CWStringDynamic str(pmp);
-		COstreamString oss(&str);
+		CWStringDynamic wcstr(mp);
+		COstreamString oss(&wcstr);
 
-		CDXLUtils::SerializeMetadata(pmp, pdrgpmdobj, oss, true /*fSerializeHeaderFooter*/, true /*fIndent*/);
-		CHAR *sz = SzFromWsz(str.Wsz());
-		GPOS_ASSERT(NULL != sz);
+		CDXLUtils::SerializeMetadata(mp, mdcache_obj_array, oss, true /*serialize_header_footer*/, true /*indentation*/);
+		CHAR *str = CreateMultiByteCharStringFromWCString(wcstr.GetBuffer());
+		GPOS_ASSERT(NULL != str);
 
-		pctxrelcache->m_szDXL = sz;
+		relcache_ctxt->m_dxl = str;
 		
 		// cleanup
-		pdrgpmdobj->Release();
+		mdcache_obj_array->Release();
 	}
 	
 	return NULL;
@@ -537,11 +537,11 @@ COptTasks::PvMDScCmp
 void
 COptTasks::Execute
 	(
-	void *(*pfunc) (void *) ,
-	void *pfuncArg
+	void *(*func) (void *) ,
+	void *func_arg
 	)
 {
-	Assert(pfunc);
+	Assert(func);
 
 	CHAR *err_buf = (CHAR *) palloc(GPOPT_ERROR_BUFFER_SIZE);
 	err_buf[0] = '\0';
@@ -554,8 +554,8 @@ COptTasks::Execute
 	CAutoMemoryPool amp(CAutoMemoryPool::ElcNone, CMemoryPoolManager::EatTracker, false /* fThreadSafe */);
 
 	gpos_exec_params params;
-	params.func = pfunc;
-	params.arg = pfuncArg;
+	params.func = func;
+	params.arg = func_arg;
 	params.stack_start = &params;
 	params.error_buffer = err_buf;
 	params.error_buffer_size = GPOPT_ERROR_BUFFER_SIZE;
@@ -568,7 +568,7 @@ COptTasks::Execute
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		LogExceptionMessageAndDelete(err_buf, ex.UlSeverityLevel());
+		LogExceptionMessageAndDelete(err_buf, ex.SeverityLevel());
 		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
@@ -576,19 +576,19 @@ COptTasks::Execute
 }
 
 void
-COptTasks::LogExceptionMessageAndDelete(CHAR* err_buf, ULONG ulSeverityLevel)
+COptTasks::LogExceptionMessageAndDelete(CHAR* err_buf, ULONG severity_level)
 {
 
 	if ('\0' != err_buf[0])
 	{
-		int ulGpdbSeverityLevel;
+		int gpdb_severity_level;
 
-		if (ulSeverityLevel == CException::ExsevDebug1)
-			ulGpdbSeverityLevel = DEBUG1;
+		if (severity_level == CException::ExsevDebug1)
+			gpdb_severity_level = DEBUG1;
 		else
-			ulGpdbSeverityLevel = LOG;
+			gpdb_severity_level = LOG;
 
-		elog(ulGpdbSeverityLevel, "%s", SzFromWsz((WCHAR *)err_buf));
+		elog(gpdb_severity_level, "%s", CreateMultiByteCharStringFromWCString((WCHAR *)err_buf));
 	}
 
 	pfree(err_buf);
@@ -597,77 +597,77 @@ COptTasks::LogExceptionMessageAndDelete(CHAR* err_buf, ULONG ulSeverityLevel)
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PvDXLFromQueryTask
+//		COptTasks::ConvertToDXLFromQueryTask
 //
 //	@doc:
 //		task that does the translation from query to XML
 //
 //---------------------------------------------------------------------------
 void*
-COptTasks::PvDXLFromQueryTask
+COptTasks::ConvertToDXLFromQueryTask
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	SOptContext *poctx = SOptContext::PoptctxtConvert(pv);
+	SOptContext *opt_ctxt = SOptContext::Cast(ptr);
 
-	GPOS_ASSERT(NULL != poctx->m_pquery);
-	GPOS_ASSERT(NULL == poctx->m_szQueryDXL);
+	GPOS_ASSERT(NULL != opt_ctxt->m_query);
+	GPOS_ASSERT(NULL == opt_ctxt->m_query_dxl);
 
 	AUTO_MEM_POOL(amp);
-	IMemoryPool *pmp = amp.Pmp();
+	IMemoryPool *mp = amp.Pmp();
 
 	// ColId generator
-	CIdGenerator *pidgtorCol = GPOS_NEW(pmp) CIdGenerator(GPDXL_COL_ID_START);
-	CIdGenerator *pidgtorCTE = GPOS_NEW(pmp) CIdGenerator(GPDXL_CTE_ID_START);
+	CIdGenerator *colid_generator = GPOS_NEW(mp) CIdGenerator(GPDXL_COL_ID_START);
+	CIdGenerator *cteid_generator = GPOS_NEW(mp) CIdGenerator(GPDXL_CTE_ID_START);
 
 	// map that stores gpdb att to optimizer col mapping
-	CMappingVarColId *pmapvarcolid = GPOS_NEW(pmp) CMappingVarColId(pmp);
+	CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
 
 	// relcache MD provider
-	CMDProviderRelcache *pmdpr = GPOS_NEW(pmp) CMDProviderRelcache(pmp);
+	CMDProviderRelcache *relcache_provider = GPOS_NEW(mp) CMDProviderRelcache(mp);
 
 	{
-		CAutoMDAccessor amda(pmp, pmdpr, sysidDefault);
+		CAutoMDAccessor md_accessor(mp, relcache_provider, default_sysid);
 
-		CAutoP<CTranslatorQueryToDXL> ptrquerytodxl;
-		ptrquerytodxl = CTranslatorQueryToDXL::PtrquerytodxlInstance
+		CAutoP<CTranslatorQueryToDXL> query_to_dxl_translator;
+		query_to_dxl_translator = CTranslatorQueryToDXL::QueryToDXLInstance
 						(
-						pmp,
-						amda.Pmda(),
-						pidgtorCol,
-						pidgtorCTE,
-						pmapvarcolid,
-						(Query*)poctx->m_pquery,
-						0 /* ulQueryLevel */
+						mp,
+						md_accessor.Pmda(),
+						colid_generator,
+						cteid_generator,
+						var_colid_mapping,
+						(Query*)opt_ctxt->m_query,
+						0 /* query_level */
 						);
-		CDXLNode *pdxlnQuery = ptrquerytodxl->PdxlnFromQuery();
-		DrgPdxln *pdrgpdxlnQueryOutput = ptrquerytodxl->PdrgpdxlnQueryOutput();
-		DrgPdxln *pdrgpdxlnCTE = ptrquerytodxl->PdrgpdxlnCTE();
-		GPOS_ASSERT(NULL != pdrgpdxlnQueryOutput);
+		CDXLNode *query_dxl = query_to_dxl_translator->TranslateQueryToDXL();
+		CDXLNodeArray *query_output_dxlnode_array = query_to_dxl_translator->GetQueryOutputCols();
+		CDXLNodeArray *cte_dxlnode_array = query_to_dxl_translator->GetCTEs();
+		GPOS_ASSERT(NULL != query_output_dxlnode_array);
 
-		GPOS_DELETE(pidgtorCol);
-		GPOS_DELETE(pidgtorCTE);
+		GPOS_DELETE(colid_generator);
+		GPOS_DELETE(cteid_generator);
 
-		CWStringDynamic str(pmp);
-		COstreamString oss(&str);
+		CWStringDynamic wcstr(mp);
+		COstreamString oss(&wcstr);
 
 		CDXLUtils::SerializeQuery
 						(
-						pmp,
+						mp,
 						oss,
-						pdxlnQuery,
-						pdrgpdxlnQueryOutput,
-						pdrgpdxlnCTE,
-						true, // fSerializeHeaderFooter
-						true // fIndent
+						query_dxl,
+						query_output_dxlnode_array,
+						cte_dxlnode_array,
+						true, // serialize_header_footer
+						true // indentation
 						);
-		poctx->m_szQueryDXL = SzFromWsz(str.Wsz());
+		opt_ctxt->m_query_dxl = CreateMultiByteCharStringFromWCString(wcstr.GetBuffer());
 
 		// clean up
-		pdxlnQuery->Release();
+		query_dxl->Release();
 	}
 
 	return NULL;
@@ -676,77 +676,77 @@ COptTasks::PvDXLFromQueryTask
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::Pplstmt
+//		COptTasks::ConvertToPlanStmtFromDXL
 //
 //	@doc:
 //		Translate a DXL tree into a planned statement
 //
 //---------------------------------------------------------------------------
 PlannedStmt *
-COptTasks::Pplstmt
+COptTasks::ConvertToPlanStmtFromDXL
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	const CDXLNode *pdxln,
-	bool canSetTag
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	const CDXLNode *dxlnode,
+	bool can_set_tag
 	)
 {
 
-	GPOS_ASSERT(NULL != pmda);
-	GPOS_ASSERT(NULL != pdxln);
+	GPOS_ASSERT(NULL != md_accessor);
+	GPOS_ASSERT(NULL != dxlnode);
 
-	CIdGenerator idgtorPlanId(1 /* ulStartId */);
-	CIdGenerator idgtorMotionId(1 /* ulStartId */);
-	CIdGenerator idgtorParamId(0 /* ulStartId */);
+	CIdGenerator plan_id_generator(1 /* ulStartId */);
+	CIdGenerator motion_id_generator(1 /* ulStartId */);
+	CIdGenerator param_id_generator(0 /* ulStartId */);
 
-	List *plRTable = NULL;
-	List *plSubplans = NULL;
+	List *table_list = NULL;
+	List *subplans_list = NULL;
 
-	CContextDXLToPlStmt ctxdxltoplstmt
+	CContextDXLToPlStmt dxl_to_plan_stmt_ctxt
 							(
-							pmp,
-							&idgtorPlanId,
-							&idgtorMotionId,
-							&idgtorParamId,
-							&plRTable,
-							&plSubplans
+							mp,
+							&plan_id_generator,
+							&motion_id_generator,
+							&param_id_generator,
+							&table_list,
+							&subplans_list
 							);
 	
 	// translate DXL -> PlannedStmt
-	CTranslatorDXLToPlStmt trdxltoplstmt(pmp, pmda, &ctxdxltoplstmt, gpdb::UlSegmentCountGP());
-	return trdxltoplstmt.PplstmtFromDXL(pdxln, canSetTag);
+	CTranslatorDXLToPlStmt dxl_to_plan_stmt_translator(mp, md_accessor, &dxl_to_plan_stmt_ctxt, gpdb::GetGPSegmentCount());
+	return dxl_to_plan_stmt_translator.GetPlannedStmtFromDXL(dxlnode, can_set_tag);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PdrgPssLoad
+//		COptTasks::LoadSearchStrategy
 //
 //	@doc:
 //		Load search strategy from given file
 //
 //---------------------------------------------------------------------------
-DrgPss *
-COptTasks::PdrgPssLoad
+CSearchStageArray *
+COptTasks::LoadSearchStrategy
 	(
-	IMemoryPool *pmp,
-	char *szPath
+	IMemoryPool *mp,
+	char *path
 	)
 {
-	DrgPss *pdrgpss = NULL;
-	CParseHandlerDXL *pphDXL = NULL;
+	CSearchStageArray *search_strategy_arr = NULL;
+	CParseHandlerDXL *dxl_parse_handler = NULL;
 
 	GPOS_TRY
 	{
-		if (NULL != szPath)
+		if (NULL != path)
 		{
-			pphDXL = CDXLUtils::PphdxlParseDXLFile(pmp, szPath, NULL);
-			if (NULL != pphDXL)
+			dxl_parse_handler = CDXLUtils::GetParseHandlerForDXLFile(mp, path, NULL);
+			if (NULL != dxl_parse_handler)
 			{
-				elog(DEBUG2, "\n[OPT]: Using search strategy in (%s)", szPath);
+				elog(DEBUG2, "\n[OPT]: Using search strategy in (%s)", path);
 
-				pdrgpss = pphDXL->Pdrgpss();
-				pdrgpss->AddRef();
+				search_strategy_arr = dxl_parse_handler->GetSearchStageArray();
+				search_strategy_arr->AddRef();
 			}
 		}
 	}
@@ -760,94 +760,94 @@ COptTasks::PdrgPssLoad
 	}
 	GPOS_CATCH_END;
 
-	GPOS_DELETE(pphDXL);
+	GPOS_DELETE(dxl_parse_handler);
 
-	return pdrgpss;
+	return search_strategy_arr;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PoconfCreate
+//		COptTasks::CreateOptimizerConfig
 //
 //	@doc:
 //		Create the optimizer configuration
 //
 //---------------------------------------------------------------------------
 COptimizerConfig *
-COptTasks::PoconfCreate
+COptTasks::CreateOptimizerConfig
 	(
-	IMemoryPool *pmp,
-	ICostModel *pcm
+	IMemoryPool *mp,
+	ICostModel *cost_model
 	)
 {
 	// get chosen plan number, cost threshold
-	ULLONG ullPlanId = (ULLONG) optimizer_plan_id;
-	ULLONG ullSamples = (ULLONG) optimizer_samples_number;
-	DOUBLE dCostThreshold = (DOUBLE) optimizer_cost_threshold;
+	ULLONG plan_id = (ULLONG) optimizer_plan_id;
+	ULLONG num_samples = (ULLONG) optimizer_samples_number;
+	DOUBLE cost_threshold = (DOUBLE) optimizer_cost_threshold;
 
-	DOUBLE dDampingFactorFilter = (DOUBLE) optimizer_damping_factor_filter;
-	DOUBLE dDampingFactorJoin = (DOUBLE) optimizer_damping_factor_join;
-	DOUBLE dDampingFactorGroupBy = (DOUBLE) optimizer_damping_factor_groupby;
+	DOUBLE damping_factor_filter = (DOUBLE) optimizer_damping_factor_filter;
+	DOUBLE damping_factor_join = (DOUBLE) optimizer_damping_factor_join;
+	DOUBLE damping_factor_groupby = (DOUBLE) optimizer_damping_factor_groupby;
 
-	ULONG ulCTEInliningCutoff = (ULONG) optimizer_cte_inlining_bound;
-	ULONG ulJoinArityForAssociativityCommutativity = (ULONG) optimizer_join_arity_for_associativity_commutativity;
-	ULONG ulArrayExpansionThreshold = (ULONG) optimizer_array_expansion_threshold;
-	ULONG ulJoinOrderThreshold = (ULONG) optimizer_join_order_threshold;
-	ULONG ulBroadcastThreshold = (ULONG) optimizer_penalize_broadcast_threshold;
+	ULONG cte_inlining_cutoff = (ULONG) optimizer_cte_inlining_bound;
+	ULONG join_arity_for_associativity_commutativity = (ULONG) optimizer_join_arity_for_associativity_commutativity;
+	ULONG array_expansion_threshold = (ULONG) optimizer_array_expansion_threshold;
+	ULONG join_order_threshold = (ULONG) optimizer_join_order_threshold;
+	ULONG broadcast_threshold = (ULONG) optimizer_penalize_broadcast_threshold;
 
-	return GPOS_NEW(pmp) COptimizerConfig
+	return GPOS_NEW(mp) COptimizerConfig
 						(
-						GPOS_NEW(pmp) CEnumeratorConfig(pmp, ullPlanId, ullSamples, dCostThreshold),
-						GPOS_NEW(pmp) CStatisticsConfig(pmp, dDampingFactorFilter, dDampingFactorJoin, dDampingFactorGroupBy),
-						GPOS_NEW(pmp) CCTEConfig(ulCTEInliningCutoff),
-						pcm,
-						GPOS_NEW(pmp) CHint
+						GPOS_NEW(mp) CEnumeratorConfig(mp, plan_id, num_samples, cost_threshold),
+						GPOS_NEW(mp) CStatisticsConfig(mp, damping_factor_filter, damping_factor_join, damping_factor_groupby),
+						GPOS_NEW(mp) CCTEConfig(cte_inlining_cutoff),
+						cost_model,
+						GPOS_NEW(mp) CHint
 								(
 								gpos::int_max /* optimizer_parts_to_force_sort_on_insert */,
-								ulJoinArityForAssociativityCommutativity,
-								ulArrayExpansionThreshold,
-								ulJoinOrderThreshold,
-								ulBroadcastThreshold,
+								join_arity_for_associativity_commutativity,
+								array_expansion_threshold,
+								join_order_threshold,
+								broadcast_threshold,
 								false /* don't create Assert nodes for constraints, we'll
 								      * enforce them ourselves in the executor */
 								),
-						GPOS_NEW(pmp) CWindowOids(OID(F_WINDOW_DUMMY), OID(F_WINDOW_RANK_OID))
+						GPOS_NEW(mp) CWindowOids(OID(F_WINDOW_DUMMY), OID(F_WINDOW_RANK_OID))
 						);
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::FExceptionFound
+//		COptTasks::FoundException
 //
 //	@doc:
 //		Lookup given exception type in the given array
 //
 //---------------------------------------------------------------------------
 BOOL
-COptTasks::FExceptionFound
+COptTasks::FoundException
 	(
 	gpos::CException &exc,
-	const ULONG *pulExceptions,
-	ULONG ulSize
+	const ULONG *exceptions,
+	ULONG size
 	)
 {
-	GPOS_ASSERT(NULL != pulExceptions);
+	GPOS_ASSERT(NULL != exceptions);
 
-	ULONG ulMinor = exc.UlMinor();
-	BOOL fFound = false;
-	for (ULONG ul = 0; !fFound && ul < ulSize; ul++)
+	ULONG minor = exc.Minor();
+	BOOL found = false;
+	for (ULONG ul = 0; !found && ul < size; ul++)
 	{
-		fFound = (pulExceptions[ul] == ulMinor);
+		found = (exceptions[ul] == minor);
 	}
 
-	return fFound;
+	return found;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::FUnexpectedFailure
+//		COptTasks::IsUnexpectedFailure
 //
 //	@doc:
 //		Check if given exception is an unexpected reason for failing to
@@ -855,41 +855,41 @@ COptTasks::FExceptionFound
 //
 //---------------------------------------------------------------------------
 BOOL
-COptTasks::FUnexpectedFailure
+COptTasks::IsUnexpectedFailure
 	(
 	gpos::CException &exc
 	)
 {
-	ULONG ulMajor = exc.UlMajor();
+	ULONG major = exc.Major();
 
-	BOOL fExpectedOptFailure =
-		gpopt::ExmaGPOPT == ulMajor &&
-		FExceptionFound(exc, rgulExpectedOptFallback, GPOS_ARRAY_SIZE(rgulExpectedOptFallback));
+	BOOL is_opt_failure_expected =
+		gpopt::ExmaGPOPT == major &&
+		FoundException(exc, expected_opt_fallback, GPOS_ARRAY_SIZE(expected_opt_fallback));
 
-	BOOL fExpectedDXLFailure =
-		(gpdxl::ExmaDXL == ulMajor || gpdxl::ExmaMD == ulMajor) &&
-		FExceptionFound(exc, rgulExpectedDXLFallback, GPOS_ARRAY_SIZE(rgulExpectedDXLFallback));
+	BOOL is_dxl_failure_expected =
+		(gpdxl::ExmaDXL == major || gpdxl::ExmaMD == major) &&
+		FoundException(exc, expected_dxl_fallback, GPOS_ARRAY_SIZE(expected_dxl_fallback));
 
-	return (!fExpectedOptFailure && !fExpectedDXLFailure);
+	return (!is_opt_failure_expected && !is_dxl_failure_expected);
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::FErrorOut
+//		COptTasks::ShouldErrorOut
 //
 //	@doc:
 //		Check if given exception should error out
 //
 //---------------------------------------------------------------------------
 BOOL
-COptTasks::FErrorOut
+COptTasks::ShouldErrorOut
 	(
 	gpos::CException &exc
 	)
 {
 	return
-		gpdxl::ExmaDXL == exc.UlMajor() &&
-		FExceptionFound(exc, rgulExpectedDXLErrors, GPOS_ARRAY_SIZE(rgulExpectedDXLErrors));
+		gpdxl::ExmaDXL == exc.Major() &&
+		FoundException(exc, expected_dxl_errors, GPOS_ARRAY_SIZE(expected_dxl_errors));
 }
 
 //---------------------------------------------------------------------------
@@ -903,37 +903,37 @@ COptTasks::FErrorOut
 void
 COptTasks::SetCostModelParams
 	(
-	ICostModel *pcm
+	ICostModel *cost_model
 	)
 {
-	GPOS_ASSERT(NULL != pcm);
+	GPOS_ASSERT(NULL != cost_model);
 
 	if (optimizer_nestloop_factor > 1.0)
 	{
 		// change NLJ cost factor
-		ICostModelParams::SCostParam *pcp = NULL;
+		ICostModelParams::SCostParam *cost_param = NULL;
 		if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model)
 		{
-			pcp = pcm->Pcp()->PcpLookup(CCostModelParamsGPDB::EcpNLJFactor);
+			cost_param = cost_model->GetCostModelParams()->PcpLookup(CCostModelParamsGPDB::EcpNLJFactor);
 		}
 		else
 		{
-			pcp = pcm->Pcp()->PcpLookup(CCostModelParamsGPDBLegacy::EcpNLJFactor);
+			cost_param = cost_model->GetCostModelParams()->PcpLookup(CCostModelParamsGPDBLegacy::EcpNLJFactor);
 		}
-		CDouble dNLJFactor(optimizer_nestloop_factor);
-		pcm->Pcp()->SetParam(pcp->UlId(), dNLJFactor, dNLJFactor - 0.5, dNLJFactor + 0.5);
+		CDouble nlj_factor(optimizer_nestloop_factor);
+		cost_model->GetCostModelParams()->SetParam(cost_param->Id(), nlj_factor, nlj_factor - 0.5, nlj_factor + 0.5);
 	}
 
 	if (optimizer_sort_factor > 1.0 || optimizer_sort_factor < 1.0)
 	{
 		// change sort cost factor
-		ICostModelParams::SCostParam *pcp = NULL;
+		ICostModelParams::SCostParam *cost_param = NULL;
 		if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model)
 		{
-			pcp = pcm->Pcp()->PcpLookup(CCostModelParamsGPDB::EcpSortTupWidthCostUnit);
+			cost_param = cost_model->GetCostModelParams()->PcpLookup(CCostModelParamsGPDB::EcpSortTupWidthCostUnit);
 
-			CDouble dSortFactor(optimizer_sort_factor);
-			pcm->Pcp()->SetParam(pcp->UlId(), pcp->DVal() * optimizer_sort_factor, pcp->DLowerBound() * optimizer_sort_factor, pcp->DUpperBound() * optimizer_sort_factor);
+			CDouble sort_factor(optimizer_sort_factor);
+			cost_model->GetCostModelParams()->SetParam(cost_param->Id(), cost_param->Get() * optimizer_sort_factor, cost_param->GetLowerBoundVal() * optimizer_sort_factor, cost_param->GetUpperBoundVal() * optimizer_sort_factor);
 		}
 	}
 }
@@ -941,68 +941,68 @@ COptTasks::SetCostModelParams
 
 //---------------------------------------------------------------------------
 //      @function:
-//			COptTasks::Pcm
+//			COptTasks::GetCostModel
 //
 //      @doc:
 //			Generate an instance of optimizer cost model
 //
 //---------------------------------------------------------------------------
 ICostModel *
-COptTasks::Pcm
+COptTasks::GetCostModel
 	(
-	IMemoryPool *pmp,
-	ULONG ulSegments
+	IMemoryPool *mp,
+	ULONG num_segments
 	)
 {
-	ICostModel *pcm = NULL;
+	ICostModel *cost_model = NULL;
 	if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model)
 	{
-		pcm = GPOS_NEW(pmp) CCostModelGPDB(pmp, ulSegments);
+		cost_model = GPOS_NEW(mp) CCostModelGPDB(mp, num_segments);
 	}
 	else
 	{
-		pcm = GPOS_NEW(pmp) CCostModelGPDBLegacy(pmp, ulSegments);
+		cost_model = GPOS_NEW(mp) CCostModelGPDBLegacy(mp, num_segments);
 	}
 
-	SetCostModelParams(pcm);
+	SetCostModelParams(cost_model);
 
-	return pcm;
+	return cost_model;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PvOptimizeTask
+//		COptTasks::OptimizeTask
 //
 //	@doc:
 //		task that does the optimizes query to physical DXL
 //
 //---------------------------------------------------------------------------
 void*
-COptTasks::PvOptimizeTask
+COptTasks::OptimizeTask
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
-	SOptContext *poctx = SOptContext::PoptctxtConvert(pv);
+	GPOS_ASSERT(NULL != ptr);
+	SOptContext *opt_ctxt = SOptContext::Cast(ptr);
 
-	GPOS_ASSERT(NULL != poctx->m_pquery);
-	GPOS_ASSERT(NULL == poctx->m_szPlanDXL);
-	GPOS_ASSERT(NULL == poctx->m_pplstmt);
+	GPOS_ASSERT(NULL != opt_ctxt->m_query);
+	GPOS_ASSERT(NULL == opt_ctxt->m_plan_dxl);
+	GPOS_ASSERT(NULL == opt_ctxt->m_plan_stmt);
 
 	// initially assume no unexpected failure
-	poctx->m_fUnexpectedFailure = false;
+	opt_ctxt->m_is_unexpected_failure = false;
 
 	AUTO_MEM_POOL(amp);
-	IMemoryPool *pmp = amp.Pmp();
+	IMemoryPool *mp = amp.Pmp();
 
 	// Does the metadatacache need to be reset?
 	//
 	// On the first call, before the cache has been initialized, we
-	// don't care about the return value of FMDCacheNeedsReset(). But
+	// don't care about the return value of MDCacheNeedsReset(). But
 	// we need to call it anyway, to give it a chance to initialize
 	// the invalidation mechanism.
-	bool reset_mdcache = gpdb::FMDCacheNeedsReset();
+	bool reset_mdcache = gpdb::MDCacheNeedsReset();
 
 	// initialize metadata cache, or purge if needed, or change size if requested
 	if (!CMDCache::FInitialized())
@@ -1022,151 +1022,151 @@ COptTasks::PvOptimizeTask
 
 
 	// load search strategy
-	DrgPss *pdrgpss = PdrgPssLoad(pmp, optimizer_search_strategy_path);
+	CSearchStageArray *search_strategy_arr = LoadSearchStrategy(mp, optimizer_search_strategy_path);
 
-	CBitSet *pbsTraceFlags = NULL;
-	CBitSet *pbsEnabled = NULL;
-	CBitSet *pbsDisabled = NULL;
-	CDXLNode *pdxlnPlan = NULL;
+	CBitSet *trace_flags = NULL;
+	CBitSet *enabled_trace_flags = NULL;
+	CBitSet *disabled_trace_flags = NULL;
+	CDXLNode *plan_dxl = NULL;
 
-	DrgPmdid *pdrgmdidCol = NULL;
-	HSMDId *phsmdidRel = NULL;
+	IMdIdArray *col_stats = NULL;
+	MdidHashSet *rel_stats = NULL;
 
 	GPOS_TRY
 	{
 		// set trace flags
-		pbsTraceFlags = CConfigParamMapping::PbsPack(pmp, CXform::ExfSentinel);
-		SetTraceflags(pmp, pbsTraceFlags, &pbsEnabled, &pbsDisabled);
+		trace_flags = CConfigParamMapping::PackConfigParamInBitset(mp, CXform::ExfSentinel);
+		SetTraceflags(mp, trace_flags, &enabled_trace_flags, &disabled_trace_flags);
 
 		// set up relcache MD provider
-		CMDProviderRelcache *pmdpRelcache = GPOS_NEW(pmp) CMDProviderRelcache(pmp);
+		CMDProviderRelcache *relcache_provider = GPOS_NEW(mp) CMDProviderRelcache(mp);
 
 		{
 			// scope for MD accessor
-			CMDAccessor mda(pmp, CMDCache::Pcache(), sysidDefault, pmdpRelcache);
+			CMDAccessor mda(mp, CMDCache::Pcache(), default_sysid, relcache_provider);
 
 			// ColId generator
-			CIdGenerator idgtorColId(GPDXL_COL_ID_START);
-			CIdGenerator idgtorCTE(GPDXL_CTE_ID_START);
+			CIdGenerator colid_generator(GPDXL_COL_ID_START);
+			CIdGenerator cteid_generator(GPDXL_CTE_ID_START);
 
 			// map that stores gpdb att to optimizer col mapping
-			CMappingVarColId *pmapvarcolid = GPOS_NEW(pmp) CMappingVarColId(pmp);
+			CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
 
-			ULONG ulSegments = gpdb::UlSegmentCountGP();
-			ULONG ulSegmentsForCosting = optimizer_segments;
-			if (0 == ulSegmentsForCosting)
+			ULONG num_segments = gpdb::GetGPSegmentCount();
+			ULONG num_segments_for_costing = optimizer_segments;
+			if (0 == num_segments_for_costing)
 			{
-				ulSegmentsForCosting = ulSegments;
+				num_segments_for_costing = num_segments;
 			}
 
-			CAutoP<CTranslatorQueryToDXL> ptrquerytodxl;
-			ptrquerytodxl = CTranslatorQueryToDXL::PtrquerytodxlInstance
+			CAutoP<CTranslatorQueryToDXL> query_to_dxl_translator;
+			query_to_dxl_translator = CTranslatorQueryToDXL::QueryToDXLInstance
 							(
-							pmp,
+							mp,
 							&mda,
-							&idgtorColId,
-							&idgtorCTE,
-							pmapvarcolid,
-							(Query*) poctx->m_pquery,
-							0 /* ulQueryLevel */
+							&colid_generator,
+							&cteid_generator,
+							var_colid_mapping,
+							(Query*) opt_ctxt->m_query,
+							0 /* query_level */
 							);
 
-			ICostModel *pcm = Pcm(pmp, ulSegmentsForCosting);
-			COptimizerConfig *pocconf = PoconfCreate(pmp, pcm);
-			CConstExprEvaluatorProxy ceevalproxy(pmp, &mda);
-			IConstExprEvaluator *pceeval =
-					GPOS_NEW(pmp) CConstExprEvaluatorDXL(pmp, &mda, &ceevalproxy);
+			ICostModel *cost_model = GetCostModel(mp, num_segments_for_costing);
+			COptimizerConfig *optimizer_config = CreateOptimizerConfig(mp, cost_model);
+			CConstExprEvaluatorProxy expr_eval_proxy(mp, &mda);
+			IConstExprEvaluator *expr_evaluator =
+					GPOS_NEW(mp) CConstExprEvaluatorDXL(mp, &mda, &expr_eval_proxy);
 
-			CDXLNode *pdxlnQuery = ptrquerytodxl->PdxlnFromQuery();
-			DrgPdxln *pdrgpdxlnQueryOutput = ptrquerytodxl->PdrgpdxlnQueryOutput();
-			DrgPdxln *pdrgpdxlnCTE = ptrquerytodxl->PdrgpdxlnCTE();
-			GPOS_ASSERT(NULL != pdrgpdxlnQueryOutput);
+			CDXLNode *query_dxl = query_to_dxl_translator->TranslateQueryToDXL();
+			CDXLNodeArray *query_output_dxlnode_array = query_to_dxl_translator->GetQueryOutputCols();
+			CDXLNodeArray *cte_dxlnode_array = query_to_dxl_translator->GetCTEs();
+			GPOS_ASSERT(NULL != query_output_dxlnode_array);
 
-			BOOL fMasterOnly = !optimizer_enable_motions ||
-						(!optimizer_enable_motions_masteronly_queries && !ptrquerytodxl->FHasDistributedTables());
-			CAutoTraceFlag atf(EopttraceDisableMotions, fMasterOnly);
+			BOOL is_master_only = !optimizer_enable_motions ||
+						(!optimizer_enable_motions_masteronly_queries && !query_to_dxl_translator->HasDistributedTables());
+			CAutoTraceFlag atf(EopttraceDisableMotions, is_master_only);
 
-			pdxlnPlan = COptimizer::PdxlnOptimize
+			plan_dxl = COptimizer::PdxlnOptimize
 									(
-									pmp,
+									mp,
 									&mda,
-									pdxlnQuery,
-									pdrgpdxlnQueryOutput,
-									pdrgpdxlnCTE,
-									pceeval,
-									ulSegments,
+									query_dxl,
+									query_output_dxlnode_array,
+									cte_dxlnode_array,
+									expr_evaluator,
+									num_segments,
 									gp_session_id,
 									gp_command_count,
-									pdrgpss,
-									pocconf
+									search_strategy_arr,
+									optimizer_config
 									);
 
-			if (poctx->m_fSerializePlanDXL)
+			if (opt_ctxt->m_should_serialize_plan_dxl)
 			{
 				// serialize DXL to xml
-				CWStringDynamic strPlan(pmp);
-				COstreamString oss(&strPlan);
-				CDXLUtils::SerializePlan(pmp, oss, pdxlnPlan, pocconf->Pec()->UllPlanId(), pocconf->Pec()->UllPlanSpaceSize(), true /*fSerializeHeaderFooter*/, true /*fIndent*/);
-				poctx->m_szPlanDXL = SzFromWsz(strPlan.Wsz());
+				CWStringDynamic plan_str(mp);
+				COstreamString oss(&plan_str);
+				CDXLUtils::SerializePlan(mp, oss, plan_dxl, optimizer_config->GetEnumeratorCfg()->GetPlanId(), optimizer_config->GetEnumeratorCfg()->GetPlanSpaceSize(), true /*serialize_header_footer*/, true /*indentation*/);
+				opt_ctxt->m_plan_dxl = CreateMultiByteCharStringFromWCString(plan_str.GetBuffer());
 			}
 
 			// translate DXL->PlStmt only when needed
-			if (poctx->m_fGeneratePlStmt)
+			if (opt_ctxt->m_should_generate_plan_stmt)
 			{
-				// always use poctx->m_pquery->canSetTag as the ptrquerytodxl->Pquery() is a mutated Query object
-				// that may not have the correct canSetTag
-				poctx->m_pplstmt = (PlannedStmt *) gpdb::PvCopyObject(Pplstmt(pmp, &mda, pdxlnPlan, poctx->m_pquery->canSetTag));
+				// always use opt_ctxt->m_query->can_set_tag as the query_to_dxl_translator->Pquery() is a mutated Query object
+				// that may not have the correct can_set_tag
+				opt_ctxt->m_plan_stmt = (PlannedStmt *) gpdb::CopyObject(ConvertToPlanStmtFromDXL(mp, &mda, plan_dxl, opt_ctxt->m_query->canSetTag));
 			}
 
-			CStatisticsConfig *pstatsconf = pocconf->Pstatsconf();
-			pdrgmdidCol = GPOS_NEW(pmp) DrgPmdid(pmp);
-			pstatsconf->CollectMissingStatsColumns(pdrgmdidCol);
+			CStatisticsConfig *stats_conf = optimizer_config->GetStatsConf();
+			col_stats = GPOS_NEW(mp) IMdIdArray(mp);
+			stats_conf->CollectMissingStatsColumns(col_stats);
 
-			phsmdidRel = GPOS_NEW(pmp) HSMDId(pmp);
-			PrintMissingStatsWarning(pmp, &mda, pdrgmdidCol, phsmdidRel);
+			rel_stats = GPOS_NEW(mp) MdidHashSet(mp);
+			PrintMissingStatsWarning(mp, &mda, col_stats, rel_stats);
 
-			phsmdidRel->Release();
-			pdrgmdidCol->Release();
+			rel_stats->Release();
+			col_stats->Release();
 
-			pceeval->Release();
-			pdxlnQuery->Release();
-			pocconf->Release();
-			pdxlnPlan->Release();
+			expr_evaluator->Release();
+			query_dxl->Release();
+			optimizer_config->Release();
+			plan_dxl->Release();
 		}
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		ResetTraceflags(pbsEnabled, pbsDisabled);
-		CRefCount::SafeRelease(phsmdidRel);
-		CRefCount::SafeRelease(pdrgmdidCol);
-		CRefCount::SafeRelease(pbsEnabled);
-		CRefCount::SafeRelease(pbsDisabled);
-		CRefCount::SafeRelease(pbsTraceFlags);
-		CRefCount::SafeRelease(pdxlnPlan);
+		ResetTraceflags(enabled_trace_flags, disabled_trace_flags);
+		CRefCount::SafeRelease(rel_stats);
+		CRefCount::SafeRelease(col_stats);
+		CRefCount::SafeRelease(enabled_trace_flags);
+		CRefCount::SafeRelease(disabled_trace_flags);
+		CRefCount::SafeRelease(trace_flags);
+		CRefCount::SafeRelease(plan_dxl);
 		CMDCache::Shutdown();
 
 		if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
 		{
 			elog(DEBUG1, "GPDB Exception. Please check log for more information.");
 		}
-		else if (FErrorOut(ex))
+		else if (ShouldErrorOut(ex))
 		{
-			IErrorContext *perrctxt = CTask::PtskSelf()->Perrctxt();
-			poctx->m_szErrorMsg = SzFromWsz(perrctxt->WszMsg());
+			IErrorContext *errctxt = CTask::Self()->GetErrCtxt();
+			opt_ctxt->m_error_msg = CreateMultiByteCharStringFromWCString(errctxt->GetErrorMsg());
 		}
 		else
 		{
-			poctx->m_fUnexpectedFailure = FUnexpectedFailure(ex);
+			opt_ctxt->m_is_unexpected_failure = IsUnexpectedFailure(ex);
 		}
 		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
 
 	// cleanup
-	ResetTraceflags(pbsEnabled, pbsDisabled);
-	CRefCount::SafeRelease(pbsEnabled);
-	CRefCount::SafeRelease(pbsDisabled);
-	CRefCount::SafeRelease(pbsTraceFlags);
+	ResetTraceflags(enabled_trace_flags, disabled_trace_flags);
+	CRefCount::SafeRelease(enabled_trace_flags);
+	CRefCount::SafeRelease(disabled_trace_flags);
+	CRefCount::SafeRelease(trace_flags);
 	if (!optimizer_metadata_caching)
 	{
 		CMDCache::Shutdown();
@@ -1187,47 +1187,47 @@ COptTasks::PvOptimizeTask
 void
 COptTasks::PrintMissingStatsWarning
 	(
-	IMemoryPool *pmp,
-	CMDAccessor *pmda,
-	DrgPmdid *pdrgmdidCol,
-	HSMDId *phsmdidRel
+	IMemoryPool *mp,
+	CMDAccessor *md_accessor,
+	IMdIdArray *col_stats,
+	MdidHashSet *rel_stats
 	)
 {
-	GPOS_ASSERT(NULL != pmda);
-	GPOS_ASSERT(NULL != pdrgmdidCol);
-	GPOS_ASSERT(NULL != phsmdidRel);
+	GPOS_ASSERT(NULL != md_accessor);
+	GPOS_ASSERT(NULL != col_stats);
+	GPOS_ASSERT(NULL != rel_stats);
 
-	CWStringDynamic str(pmp);
-	COstreamString oss(&str);
+	CWStringDynamic wcstr(mp);
+	COstreamString oss(&wcstr);
 
-	const ULONG ulMissingColStats = pdrgmdidCol->UlLength();
-	for (ULONG ul = 0; ul < ulMissingColStats; ul++)
+	const ULONG num_missing_col_stats = col_stats->Size();
+	for (ULONG ul = 0; ul < num_missing_col_stats; ul++)
 	{
-		IMDId *pmdid = (*pdrgmdidCol)[ul];
-		CMDIdColStats *pmdidColStats = CMDIdColStats::PmdidConvert(pmdid);
+		IMDId *mdid = (*col_stats)[ul];
+		CMDIdColStats *mdid_col_stats = CMDIdColStats::CastMdid(mdid);
 
-		IMDId *pmdidRel = pmdidColStats->PmdidRel();
-		const ULONG ulPos = pmdidColStats->UlPos();
-		const IMDRelation *pmdrel = pmda->Pmdrel(pmdidRel);
+		IMDId *rel_mdid = mdid_col_stats->GetRelMdId();
+		const ULONG pos = mdid_col_stats->Position();
+		const IMDRelation *rel = md_accessor->RetrieveRel(rel_mdid);
 
-		if (IMDRelation::ErelstorageExternal != pmdrel->Erelstorage())
+		if (IMDRelation::ErelstorageExternal != rel->RetrieveRelStorageType())
 		{
-			if (!phsmdidRel->FExists(pmdidRel))
+			if (!rel_stats->Contains(rel_mdid))
 			{
 				if (0 != ul)
 				{
 					oss << ", ";
 				}
 
-				pmdidRel->AddRef();
-				phsmdidRel->FInsert(pmdidRel);
-				oss << pmdrel->Mdname().Pstr()->Wsz();
+				rel_mdid->AddRef();
+				rel_stats->Insert(rel_mdid);
+				oss << rel->Mdname().GetMDName()->GetBuffer();
 			}
 
-			CMDName mdname = pmdrel->Pmdcol(ulPos)->Mdname();
+			CMDName mdname = rel->GetMdCol(pos)->Mdname();
 
 			char msgbuf[NAMEDATALEN * 2 + 100];
-			snprintf(msgbuf, sizeof(msgbuf), "Missing statistics for column: %s.%s", SzFromWsz(pmdrel->Mdname().Pstr()->Wsz()), SzFromWsz(mdname.Pstr()->Wsz()));
+			snprintf(msgbuf, sizeof(msgbuf), "Missing statistics for column: %s.%s", CreateMultiByteCharStringFromWCString(rel->Mdname().GetMDName()->GetBuffer()), CreateMultiByteCharStringFromWCString(mdname.GetMDName()->GetBuffer()));
 			GpdbEreport(ERRCODE_SUCCESSFUL_COMPLETION,
 						   LOG,
 						   msgbuf,
@@ -1235,11 +1235,11 @@ COptTasks::PrintMissingStatsWarning
 		}
 	}
 
-	if (0 < phsmdidRel->UlEntries())
+	if (0 < rel_stats->Size())
 	{
-		int length = NAMEDATALEN * phsmdidRel->UlEntries() + 200;
+		int length = NAMEDATALEN * rel_stats->Size() + 200;
 		char msgbuf[length];
-		snprintf(msgbuf, sizeof(msgbuf), "One or more columns in the following table(s) do not have statistics: %s", SzFromWsz(str.Wsz()));
+		snprintf(msgbuf, sizeof(msgbuf), "One or more columns in the following table(s) do not have statistics: %s", CreateMultiByteCharStringFromWCString(wcstr.GetBuffer()));
 		GpdbEreport(ERRCODE_SUCCESSFUL_COMPLETION,
 					   NOTICE,
 					   msgbuf,
@@ -1253,208 +1253,208 @@ COptTasks::PrintMissingStatsWarning
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PvOptimizeMinidumpTask
+//		COptTasks::OptimizeMinidumpTask
 //
 //	@doc:
 //		Task that loads and optimizes a minidump and returns the result as string-serialized DXL
 //
 //---------------------------------------------------------------------------
 void*
-COptTasks::PvOptimizeMinidumpTask
+COptTasks::OptimizeMinidumpTask
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	SOptimizeMinidumpContext *poptmdpctxt = SOptimizeMinidumpContext::PoptmdpConvert(pv);
-	GPOS_ASSERT(NULL != poptmdpctxt->m_szFileName);
-	GPOS_ASSERT(NULL == poptmdpctxt->m_szDXLResult);
+	SOptimizeMinidumpContext *minidump_ctxt = SOptimizeMinidumpContext::Cast(ptr);
+	GPOS_ASSERT(NULL != minidump_ctxt->m_szFileName);
+	GPOS_ASSERT(NULL == minidump_ctxt->m_dxl_result);
 
 	AUTO_MEM_POOL(amp);
-	IMemoryPool *pmp = amp.Pmp();
+	IMemoryPool *mp = amp.Pmp();
 
-	ULONG ulSegments = gpdb::UlSegmentCountGP();
-	ULONG ulSegmentsForCosting = optimizer_segments;
-	if (0 == ulSegmentsForCosting)
+	ULONG num_segments = gpdb::GetGPSegmentCount();
+	ULONG num_segments_for_costing = optimizer_segments;
+	if (0 == num_segments_for_costing)
 	{
-		ulSegmentsForCosting = ulSegments;
+		num_segments_for_costing = num_segments;
 	}
 
-	ICostModel *pcm = Pcm(pmp, ulSegmentsForCosting);
-	COptimizerConfig *pocconf = PoconfCreate(pmp, pcm);
-	CDXLNode *pdxlnResult = NULL;
+	ICostModel *cost_model = GetCostModel(mp, num_segments_for_costing);
+	COptimizerConfig *optimizer_config = CreateOptimizerConfig(mp, cost_model);
+	CDXLNode *result_dxl = NULL;
 
 	GPOS_TRY
 	{
-		pdxlnResult = CMinidumperUtils::PdxlnExecuteMinidump(pmp, poptmdpctxt->m_szFileName, ulSegments, gp_session_id, gp_command_count, pocconf);
+		result_dxl = CMinidumperUtils::PdxlnExecuteMinidump(mp, minidump_ctxt->m_szFileName, num_segments, gp_session_id, gp_command_count, optimizer_config);
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		CRefCount::SafeRelease(pdxlnResult);
-		CRefCount::SafeRelease(pocconf);
+		CRefCount::SafeRelease(result_dxl);
+		CRefCount::SafeRelease(optimizer_config);
 		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
 
-	CWStringDynamic strDXL(pmp);
-	COstreamString oss(&strDXL);
+	CWStringDynamic wcstr(mp);
+	COstreamString oss(&wcstr);
 	CDXLUtils::SerializePlan
 					(
-					pmp,
+					mp,
 					oss,
-					pdxlnResult,
-					0,  // ullPlanId
-					0,  // ullPlanSpaceSize
-					true, // fSerializeHeaderFooter
-					true // fIndent
+					result_dxl,
+					0,  // plan_id
+					0,  // plan_space_size
+					true, // serialize_header_footer
+					true // indentation
 					);
-	poptmdpctxt->m_szDXLResult = SzFromWsz(strDXL.Wsz());
-	CRefCount::SafeRelease(pdxlnResult);
-	pocconf->Release();
+	minidump_ctxt->m_dxl_result = CreateMultiByteCharStringFromWCString(wcstr.GetBuffer());
+	CRefCount::SafeRelease(result_dxl);
+	optimizer_config->Release();
 
 	return NULL;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PvPlstmtFromDXLTask
+//		COptTasks::ConvertToPlanStmtFromDXLTask
 //
 //	@doc:
-//		task that does the translation from xml to dxl to pplstmt
+//		task that does the translation from xml to dxl to planned_stmt
 //
 //---------------------------------------------------------------------------
 void*
-COptTasks::PvPlstmtFromDXLTask
+COptTasks::ConvertToPlanStmtFromDXLTask
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	SOptContext *poctx = SOptContext::PoptctxtConvert(pv);
+	SOptContext *opt_ctxt = SOptContext::Cast(ptr);
 
-	GPOS_ASSERT(NULL == poctx->m_pquery);
-	GPOS_ASSERT(NULL != poctx->m_szPlanDXL);
+	GPOS_ASSERT(NULL == opt_ctxt->m_query);
+	GPOS_ASSERT(NULL != opt_ctxt->m_plan_dxl);
 
 	AUTO_MEM_POOL(amp);
-	IMemoryPool *pmp = amp.Pmp();
+	IMemoryPool *mp = amp.Pmp();
 
-	CWStringDynamic str(pmp);
-	COstreamString oss(&str);
+	CWStringDynamic wcstr(mp);
+	COstreamString oss(&wcstr);
 
-	ULLONG ullPlanId = 0;
-	ULLONG ullPlanSpaceSize = 0;
-	CDXLNode *pdxlnOriginal =
-		CDXLUtils::PdxlnParsePlan(pmp, poctx->m_szPlanDXL, NULL /*XSD location*/, &ullPlanId, &ullPlanSpaceSize);
+	ULLONG plan_id = 0;
+	ULLONG plan_space_size = 0;
+	CDXLNode *original_plan_dxl =
+		CDXLUtils::GetPlanDXLNode(mp, opt_ctxt->m_plan_dxl, NULL /*XSD location*/, &plan_id, &plan_space_size);
 
-	CIdGenerator idgtorPlanId(1);
-	CIdGenerator idgtorMotionId(1);
-	CIdGenerator idgtorParamId(0);
+	CIdGenerator plan_id_generator(1);
+	CIdGenerator motion_id_generator(1);
+	CIdGenerator param_id_generator(0);
 
-	List *plRTable = NULL;
-	List *plSubplans = NULL;
+	List *table_list = NULL;
+	List *subplans_list = NULL;
 
-	CContextDXLToPlStmt ctxdxlplstmt
+	CContextDXLToPlStmt dxl_to_plan_stmt_ctxt
 							(
-							pmp,
-							&idgtorPlanId,
-							&idgtorMotionId,
-							&idgtorParamId,
-							&plRTable,
-							&plSubplans
+							mp,
+							&plan_id_generator,
+							&motion_id_generator,
+							&param_id_generator,
+							&table_list,
+							&subplans_list
 							);
 
 	// relcache MD provider
-	CMDProviderRelcache *pmdpr = GPOS_NEW(pmp) CMDProviderRelcache(pmp);
+	CMDProviderRelcache *relcache_provider = GPOS_NEW(mp) CMDProviderRelcache(mp);
 
 	{
-		CAutoMDAccessor amda(pmp, pmdpr, sysidDefault);
+		CAutoMDAccessor md_accessor(mp, relcache_provider, default_sysid);
 
 		// translate DXL -> PlannedStmt
-		CTranslatorDXLToPlStmt trdxltoplstmt(pmp, amda.Pmda(), &ctxdxlplstmt, gpdb::UlSegmentCountGP());
-		PlannedStmt *pplstmt = trdxltoplstmt.PplstmtFromDXL(pdxlnOriginal, poctx->m_pquery->canSetTag);
+		CTranslatorDXLToPlStmt dxl_to_plan_stmt_translator(mp, md_accessor.Pmda(), &dxl_to_plan_stmt_ctxt, gpdb::GetGPSegmentCount());
+		PlannedStmt *plan_stmt = dxl_to_plan_stmt_translator.GetPlannedStmtFromDXL(original_plan_dxl, opt_ctxt->m_query->canSetTag);
 		if (optimizer_print_plan)
 		{
-			elog(NOTICE, "Plstmt: %s", gpdb::SzNodeToString(pplstmt));
+			elog(NOTICE, "Plstmt: %s", gpdb::NodeToString(plan_stmt));
 		}
 
-		GPOS_ASSERT(NULL != pplstmt);
+		GPOS_ASSERT(NULL != plan_stmt);
 		GPOS_ASSERT(NULL != CurrentMemoryContext);
 
-		poctx->m_pplstmt = (PlannedStmt *) gpdb::PvCopyObject(pplstmt);
+		opt_ctxt->m_plan_stmt = (PlannedStmt *) gpdb::CopyObject(plan_stmt);
 	}
 
 	// cleanup
-	pdxlnOriginal->Release();
+	original_plan_dxl->Release();
 
 	return NULL;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PvDXLFromMDObjsTask
+//		COptTasks::ConvertToDXLFromMDObjsTask
 //
 //	@doc:
 //		task that does dumps the relcache info for an object into DXL
 //
 //---------------------------------------------------------------------------
 void*
-COptTasks::PvDXLFromMDObjsTask
+COptTasks::ConvertToDXLFromMDObjsTask
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	SContextRelcacheToDXL *pctxrelcache = SContextRelcacheToDXL::PctxrelcacheConvert(pv);
-	GPOS_ASSERT(NULL != pctxrelcache);
+	SContextRelcacheToDXL *relcache_ctxt = SContextRelcacheToDXL::RelcacheConvert(ptr);
+	GPOS_ASSERT(NULL != relcache_ctxt);
 
 	AUTO_MEM_POOL(amp);
-	IMemoryPool *pmp = amp.Pmp();
+	IMemoryPool *mp = amp.Pmp();
 
-	DrgPimdobj *pdrgpmdobj = GPOS_NEW(pmp) DrgPimdobj(pmp, 1024, 1024);
+	IMDCacheObjectArray *mdcache_obj_array = GPOS_NEW(mp) IMDCacheObjectArray(mp, 1024, 1024);
 
 	// relcache MD provider
-	CMDProviderRelcache *pmdp = GPOS_NEW(pmp) CMDProviderRelcache(pmp);
+	CMDProviderRelcache *md_provider = GPOS_NEW(mp) CMDProviderRelcache(mp);
 	{
-		CAutoMDAccessor amda(pmp, pmdp, sysidDefault);
-		ListCell *plc = NULL;
-		ForEach (plc, pctxrelcache->m_plistOids)
+		CAutoMDAccessor md_accessor(mp, md_provider, default_sysid);
+		ListCell *lc = NULL;
+		ForEach (lc, relcache_ctxt->m_oid_list)
 		{
-			Oid oid = lfirst_oid(plc);
+			Oid oid = lfirst_oid(lc);
 			// get object from relcache
-			CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(oid, 1 /* major */, 0 /* minor */);
+			CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(oid, 1 /* major */, 0 /* minor */);
 
-			IMDCacheObject *pimdobj = CTranslatorRelcacheToDXL::Pimdobj(pmp, amda.Pmda(), pmdid);
-			GPOS_ASSERT(NULL != pimdobj);
+			IMDCacheObject *mdobj = CTranslatorRelcacheToDXL::RetrieveObject(mp, md_accessor.Pmda(), mdid);
+			GPOS_ASSERT(NULL != mdobj);
 
-			pdrgpmdobj->Append(pimdobj);
-			pmdid->Release();
+			mdcache_obj_array->Append(mdobj);
+			mdid->Release();
 		}
 
-		if (pctxrelcache->m_szFilename)
+		if (relcache_ctxt->m_filename)
 		{
-			COstreamFile cofs(pctxrelcache->m_szFilename);
+			COstreamFile cofs(relcache_ctxt->m_filename);
 
-			CDXLUtils::SerializeMetadata(pmp, pdrgpmdobj, cofs, true /*fSerializeHeaderFooter*/, true /*fIndent*/);
+			CDXLUtils::SerializeMetadata(mp, mdcache_obj_array, cofs, true /*serialize_header_footer*/, true /*indentation*/);
 		}
 		else
 		{
-			CWStringDynamic str(pmp);
-			COstreamString oss(&str);
+			CWStringDynamic wcstr(mp);
+			COstreamString oss(&wcstr);
 
-			CDXLUtils::SerializeMetadata(pmp, pdrgpmdobj, oss, true /*fSerializeHeaderFooter*/, true /*fIndent*/);
+			CDXLUtils::SerializeMetadata(mp, mdcache_obj_array, oss, true /*serialize_header_footer*/, true /*indentation*/);
 
-			CHAR *sz = SzFromWsz(str.Wsz());
+			CHAR *str = CreateMultiByteCharStringFromWCString(wcstr.GetBuffer());
 
-			GPOS_ASSERT(NULL != sz);
+			GPOS_ASSERT(NULL != str);
 
-			pctxrelcache->m_szDXL = sz;
+			relcache_ctxt->m_dxl = str;
 		}
 	}
 	// cleanup
-	pdrgpmdobj->Release();
+	mdcache_obj_array->Release();
 
 	return NULL;
 }
@@ -1462,88 +1462,88 @@ COptTasks::PvDXLFromMDObjsTask
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PvDXLFromRelStatsTask
+//		COptTasks::ConvertToDXLFromRelStatsTask
 //
 //	@doc:
 //		task that dumps relstats info for a table in DXL
 //
 //---------------------------------------------------------------------------
 void*
-COptTasks::PvDXLFromRelStatsTask
+COptTasks::ConvertToDXLFromRelStatsTask
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
+	GPOS_ASSERT(NULL != ptr);
 
-	SContextRelcacheToDXL *pctxrelcache = SContextRelcacheToDXL::PctxrelcacheConvert(pv);
-	GPOS_ASSERT(NULL != pctxrelcache);
+	SContextRelcacheToDXL *relcache_ctxt = SContextRelcacheToDXL::RelcacheConvert(ptr);
+	GPOS_ASSERT(NULL != relcache_ctxt);
 
 	AUTO_MEM_POOL(amp);
-	IMemoryPool *pmp = amp.Pmp();
+	IMemoryPool *mp = amp.Pmp();
 
 	// relcache MD provider
-	CMDProviderRelcache *pmdpr = GPOS_NEW(pmp) CMDProviderRelcache(pmp);
-	CAutoMDAccessor amda(pmp, pmdpr, sysidDefault);
-	ICostModel *pcm = Pcm(pmp, gpdb::UlSegmentCountGP());
-	CAutoOptCtxt aoc(pmp, amda.Pmda(), NULL /*pceeval*/, pcm);
+	CMDProviderRelcache *relcache_provider = GPOS_NEW(mp) CMDProviderRelcache(mp);
+	CAutoMDAccessor md_accessor(mp, relcache_provider, default_sysid);
+	ICostModel *cost_model = GetCostModel(mp, gpdb::GetGPSegmentCount());
+	CAutoOptCtxt aoc(mp, md_accessor.Pmda(), NULL /*expr_evaluator*/, cost_model);
 
-	DrgPimdobj *pdrgpmdobj = GPOS_NEW(pmp) DrgPimdobj(pmp);
+	IMDCacheObjectArray *mdcache_obj_array = GPOS_NEW(mp) IMDCacheObjectArray(mp);
 
-	ListCell *plc = NULL;
-	ForEach (plc, pctxrelcache->m_plistOids)
+	ListCell *lc = NULL;
+	ForEach (lc, relcache_ctxt->m_oid_list)
 	{
-		Oid oidRelation = lfirst_oid(plc);
+		Oid relation_oid = lfirst_oid(lc);
 
 		// get object from relcache
-		CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(oidRelation, 1 /* major */, 0 /* minor */);
+		CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(relation_oid, 1 /* major */, 0 /* minor */);
 
 		// generate mdid for relstats
-		CMDIdRelStats *pmdidRelStats = GPOS_NEW(pmp) CMDIdRelStats(pmdid);
-		IMDRelStats *pimdobjrelstats = const_cast<IMDRelStats *>(amda.Pmda()->Pmdrelstats(pmdidRelStats));
-		pdrgpmdobj->Append(dynamic_cast<IMDCacheObject *>(pimdobjrelstats));
+		CMDIdRelStats *m_rel_stats_mdid = GPOS_NEW(mp) CMDIdRelStats(mdid);
+		IMDRelStats *mdobj_rel_stats = const_cast<IMDRelStats *>(md_accessor.Pmda()->Pmdrelstats(m_rel_stats_mdid));
+		mdcache_obj_array->Append(dynamic_cast<IMDCacheObject *>(mdobj_rel_stats));
 
 		// extract out column stats for this relation
-		Relation rel = gpdb::RelGetRelation(oidRelation);
-		ULONG ulPosCounter = 0;
+		Relation rel = gpdb::GetRelation(relation_oid);
+		ULONG pos_counter = 0;
 		for (ULONG ul = 0; ul < ULONG(rel->rd_att->natts); ul++)
 		{
 			if (!rel->rd_att->attrs[ul]->attisdropped)
 			{
-				pmdid->AddRef();
-				CMDIdColStats *pmdidColStats = GPOS_NEW(pmp) CMDIdColStats(pmdid, ulPosCounter);
-				ulPosCounter++;
-				IMDColStats *pimdobjcolstats = const_cast<IMDColStats *>(amda.Pmda()->Pmdcolstats(pmdidColStats));
-				pdrgpmdobj->Append(dynamic_cast<IMDCacheObject *>(pimdobjcolstats));
-				pmdidColStats->Release();
+				mdid->AddRef();
+				CMDIdColStats *mdid_col_stats = GPOS_NEW(mp) CMDIdColStats(mdid, pos_counter);
+				pos_counter++;
+				IMDColStats *mdobj_col_stats = const_cast<IMDColStats *>(md_accessor.Pmda()->Pmdcolstats(mdid_col_stats));
+				mdcache_obj_array->Append(dynamic_cast<IMDCacheObject *>(mdobj_col_stats));
+				mdid_col_stats->Release();
 			}
 		}
 		gpdb::CloseRelation(rel);
-		pmdidRelStats->Release();
+		m_rel_stats_mdid->Release();
 	}
 
-	if (pctxrelcache->m_szFilename)
+	if (relcache_ctxt->m_filename)
 	{
-		COstreamFile cofs(pctxrelcache->m_szFilename);
+		COstreamFile cofs(relcache_ctxt->m_filename);
 
-		CDXLUtils::SerializeMetadata(pmp, pdrgpmdobj, cofs, true /*fSerializeHeaderFooter*/, true /*fIndent*/);
+		CDXLUtils::SerializeMetadata(mp, mdcache_obj_array, cofs, true /*serialize_header_footer*/, true /*indentation*/);
 	}
 	else
 	{
-		CWStringDynamic str(pmp);
-		COstreamString oss(&str);
+		CWStringDynamic wcstr(mp);
+		COstreamString oss(&wcstr);
 
-		CDXLUtils::SerializeMetadata(pmp, pdrgpmdobj, oss, true /*fSerializeHeaderFooter*/, true /*fIndent*/);
+		CDXLUtils::SerializeMetadata(mp, mdcache_obj_array, oss, true /*serialize_header_footer*/, true /*indentation*/);
 
-		CHAR *sz = SzFromWsz(str.Wsz());
+		CHAR *str = CreateMultiByteCharStringFromWCString(wcstr.GetBuffer());
 
-		GPOS_ASSERT(NULL != sz);
+		GPOS_ASSERT(NULL != str);
 
-		pctxrelcache->m_szDXL = sz;
+		relcache_ctxt->m_dxl = str;
 	}
 
 	// cleanup
-	pdrgpmdobj->Release();
+	mdcache_obj_array->Release();
 
 	return NULL;
 }
@@ -1551,7 +1551,7 @@ COptTasks::PvDXLFromRelStatsTask
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PvEvalExprFromDXLTask
+//		COptTasks::EvalExprFromDXLTask
 //
 //	@doc:
 //		Task that parses an XML representation of a DXL constant expression,
@@ -1559,40 +1559,40 @@ COptTasks::PvDXLFromRelStatsTask
 //
 //---------------------------------------------------------------------------
 void*
-COptTasks::PvEvalExprFromDXLTask
+COptTasks::EvalExprFromDXLTask
 	(
-	void *pv
+	void *ptr
 	)
 {
-	GPOS_ASSERT(NULL != pv);
-	SEvalExprContext *pevalctxt = SEvalExprContext::PevalctxtConvert(pv);
+	GPOS_ASSERT(NULL != ptr);
+	SEvalExprContext *eval_expr_ctxt = SEvalExprContext::PevalctxtConvert(ptr);
 
-	GPOS_ASSERT(NULL != pevalctxt->m_szDXL);
-	GPOS_ASSERT(NULL == pevalctxt->m_szDXLResult);
+	GPOS_ASSERT(NULL != eval_expr_ctxt->m_dxl);
+	GPOS_ASSERT(NULL == eval_expr_ctxt->m_dxl_result);
 
 	AUTO_MEM_POOL(amp);
-	IMemoryPool *pmp = amp.Pmp();
+	IMemoryPool *mp = amp.Pmp();
 
-	CDXLNode *pdxlnInput = CDXLUtils::PdxlnParseScalarExpr(pmp, pevalctxt->m_szDXL, NULL /*szXSDPath*/);
-	GPOS_ASSERT(NULL != pdxlnInput);
+	CDXLNode *input_dxl = CDXLUtils::ParseDXLToScalarExprDXLNode(mp, eval_expr_ctxt->m_dxl, NULL /*xsd_file_path*/);
+	GPOS_ASSERT(NULL != input_dxl);
 
-	CDXLNode *pdxlnResult = NULL;
-	BOOL fReleaseCache = false;
+	CDXLNode *result_dxl = NULL;
+	BOOL should_release_cache = false;
 
 	// Does the metadatacache need to be reset?
 	//
 	// On the first call, before the cache has been initialized, we
-	// don't care about the return value of FMDCacheNeedsReset(). But
+	// don't care about the return value of MDCacheNeedsReset(). But
 	// we need to call it anyway, to give it a chance to initialize
 	// the invalidation mechanism.
-	bool reset_mdcache = gpdb::FMDCacheNeedsReset();
+	bool reset_mdcache = gpdb::MDCacheNeedsReset();
 
 	// initialize metadata cache, or purge if needed, or change size if requested
 	if (!CMDCache::FInitialized())
 	{
 		CMDCache::Init();
 		CMDCache::SetCacheQuota(optimizer_mdcache_size * 1024L);
-		fReleaseCache = true;
+		should_release_cache = true;
 	}
 	else if (reset_mdcache)
 	{
@@ -1607,48 +1607,48 @@ COptTasks::PvEvalExprFromDXLTask
 	GPOS_TRY
 	{
 		// set up relcache MD provider
-		CMDProviderRelcache *pmdpRelcache = GPOS_NEW(pmp) CMDProviderRelcache(pmp);
+		CMDProviderRelcache *relcache_provider = GPOS_NEW(mp) CMDProviderRelcache(mp);
 		{
 			// scope for MD accessor
-			CMDAccessor mda(pmp, CMDCache::Pcache(), sysidDefault, pmdpRelcache);
+			CMDAccessor mda(mp, CMDCache::Pcache(), default_sysid, relcache_provider);
 
-			CConstExprEvaluatorProxy ceeval(pmp, &mda);
-			pdxlnResult = ceeval.PdxlnEvaluateExpr(pdxlnInput);
+			CConstExprEvaluatorProxy expr_eval_proxy(mp, &mda);
+			result_dxl = expr_eval_proxy.EvaluateExpr(input_dxl);
 		}
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		CRefCount::SafeRelease(pdxlnResult);
-		CRefCount::SafeRelease(pdxlnInput);
-		if (fReleaseCache)
+		CRefCount::SafeRelease(result_dxl);
+		CRefCount::SafeRelease(input_dxl);
+		if (should_release_cache)
 		{
 			CMDCache::Shutdown();
 		}
-		if (FErrorOut(ex))
+		if (ShouldErrorOut(ex))
 		{
-			IErrorContext *perrctxt = CTask::PtskSelf()->Perrctxt();
-			char *szErrorMsg = SzFromWsz(perrctxt->WszMsg());
-			elog(DEBUG1, "%s", szErrorMsg);
-			gpdb::GPDBFree(szErrorMsg);
+			IErrorContext *errctxt = CTask::Self()->GetErrCtxt();
+			char *serialized_error_msg = CreateMultiByteCharStringFromWCString(errctxt->GetErrorMsg());
+			elog(DEBUG1, "%s", serialized_error_msg);
+			gpdb::GPDBFree(serialized_error_msg);
 		}
 		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
 
-	CWStringDynamic *pstrDXL =
-			CDXLUtils::PstrSerializeScalarExpr
+	CWStringDynamic *dxl_string =
+			CDXLUtils::SerializeScalarExpr
 						(
-						pmp,
-						pdxlnResult,
-						true, // fSerializeHeaderFooter
-						true // fIndent
+						mp,
+						result_dxl,
+						true, // serialize_header_footer
+						true // indentation
 						);
-	pevalctxt->m_szDXLResult = SzFromWsz(pstrDXL->Wsz());
-	GPOS_DELETE(pstrDXL);
-	CRefCount::SafeRelease(pdxlnResult);
-	pdxlnInput->Release();
+	eval_expr_ctxt->m_dxl_result = CreateMultiByteCharStringFromWCString(dxl_string->GetBuffer());
+	GPOS_DELETE(dxl_string);
+	CRefCount::SafeRelease(result_dxl);
+	input_dxl->Release();
 
-	if (fReleaseCache)
+	if (should_release_cache)
 	{
 		CMDCache::Shutdown();
 	}
@@ -1659,119 +1659,119 @@ COptTasks::PvEvalExprFromDXLTask
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::SzOptimize
+//		COptTasks::Optimize
 //
 //	@doc:
 //		optimizes a query to physical DXL
 //
 //---------------------------------------------------------------------------
 char *
-COptTasks::SzOptimize
+COptTasks::Optimize
 	(
-	Query *pquery
+	Query *query
 	)
 {
-	Assert(pquery);
+	Assert(query);
 
-	SOptContext octx;
-	octx.m_pquery = pquery;
-	octx.m_fSerializePlanDXL = true;
-	Execute(&PvOptimizeTask, &octx);
+	SOptContext gpopt_context;
+	gpopt_context.m_query = query;
+	gpopt_context.m_should_serialize_plan_dxl = true;
+	Execute(&OptimizeTask, &gpopt_context);
 
 	// clean up context
-	octx.Free(octx.epinQuery, octx.epinPlanDXL);
+	gpopt_context.Free(gpopt_context.epinQuery, gpopt_context.epinPlanDXL);
 
-	return octx.m_szPlanDXL;
+	return gpopt_context.m_plan_dxl;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PplstmtOptimize
+//		COptTasks::GPOPTOptimizedPlan
 //
 //	@doc:
 //		optimizes a query to plannedstmt
 //
 //---------------------------------------------------------------------------
 PlannedStmt *
-COptTasks::PplstmtOptimize
+COptTasks::GPOPTOptimizedPlan
 	(
-	Query *pquery,
-	SOptContext *octx,
-	BOOL *pfUnexpectedFailure // output : set to true if optimizer unexpectedly failed to produce plan
+	Query *query,
+	SOptContext *gpopt_context,
+	BOOL *has_unexpected_failure // output : set to true if optimizer unexpectedly failed to produce plan
 	)
 {
-	Assert(pquery);
-	Assert(octx);
+	Assert(query);
+	Assert(gpopt_context);
 
-	octx->m_pquery = pquery;
-	octx->m_fGeneratePlStmt= true;
+	gpopt_context->m_query = query;
+	gpopt_context->m_should_generate_plan_stmt= true;
 	GPOS_TRY
 	{
-		Execute(&PvOptimizeTask, octx);
+		Execute(&OptimizeTask, gpopt_context);
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		*pfUnexpectedFailure = octx->m_fUnexpectedFailure;
+		*has_unexpected_failure = gpopt_context->m_is_unexpected_failure;
 		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
-	octx->HandleError(pfUnexpectedFailure);
-	return octx->m_pplstmt;
+	gpopt_context->HandleError(has_unexpected_failure);
+	return gpopt_context->m_plan_stmt;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::SzDXL
+//		COptTasks::ConvertQueryToDXL
 //
 //	@doc:
 //		serializes query to DXL
 //
 //---------------------------------------------------------------------------
 char *
-COptTasks::SzDXL
+COptTasks::ConvertQueryToDXL
 	(
-	Query *pquery
+	Query *query
 	)
 {
-	Assert(pquery);
+	Assert(query);
 
-	SOptContext octx;
-	octx.m_pquery = pquery;
-	Execute(&PvDXLFromQueryTask, &octx);
+	SOptContext gpopt_context;
+	gpopt_context.m_query = query;
+	Execute(&ConvertToDXLFromQueryTask, &gpopt_context);
 
 	// clean up context
-	octx.Free(octx.epinQuery, octx.epinQueryDXL);
+	gpopt_context.Free(gpopt_context.epinQuery, gpopt_context.epinQueryDXL);
 
-	return octx.m_szQueryDXL;
+	return gpopt_context.m_query_dxl;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::PplstmtFromXML
+//		COptTasks::ConvertToiPlanStmtFromXML
 //
 //	@doc:
 //		deserializes planned stmt from DXL
 //
 //---------------------------------------------------------------------------
 PlannedStmt *
-COptTasks::PplstmtFromXML
+COptTasks::ConvertToiPlanStmtFromXML
 	(
-	char *szDXL
+	char *dxl_string
 	)
 {
-	Assert(NULL != szDXL);
+	Assert(NULL != dxl_string);
 
-	SOptContext octx;
-	octx.m_szPlanDXL = szDXL;
-	Execute(&PvPlstmtFromDXLTask, &octx);
+	SOptContext gpopt_context;
+	gpopt_context.m_plan_dxl = dxl_string;
+	Execute(&ConvertToPlanStmtFromDXLTask, &gpopt_context);
 
 	// clean up context
-	octx.Free(octx.epinPlanDXL, octx.epinPlStmt);
+	gpopt_context.Free(gpopt_context.epinPlanDXL, gpopt_context.epinPlStmt);
 
-	return octx.m_pplstmt;
+	return gpopt_context.m_plan_stmt;
 }
 
 
@@ -1786,12 +1786,12 @@ COptTasks::PplstmtFromXML
 void
 COptTasks::DumpMDObjs
 	(
-	List *plistOids,
-	const char *szFilename
+	List *oid_list,
+	const char *filename
 	)
 {
-	SContextRelcacheToDXL ctxrelcache(plistOids, gpos::ulong_max /*ulCmpt*/, szFilename);
-	Execute(&PvDXLFromMDObjsTask, &ctxrelcache);
+	SContextRelcacheToDXL relcache_ctxt(oid_list, gpos::ulong_max /*cmp_type*/, filename);
+	Execute(&ConvertToDXLFromMDObjsTask, &relcache_ctxt);
 }
 
 
@@ -1806,96 +1806,96 @@ COptTasks::DumpMDObjs
 char *
 COptTasks::SzMDObjs
 	(
-	List *plistOids
+	List *oid_list
 	)
 {
-	SContextRelcacheToDXL ctxrelcache(plistOids, gpos::ulong_max /*ulCmpt*/, NULL /*szFilename*/);
-	Execute(&PvDXLFromMDObjsTask, &ctxrelcache);
+	SContextRelcacheToDXL relcache_ctxt(oid_list, gpos::ulong_max /*cmp_type*/, NULL /*filename*/);
+	Execute(&ConvertToDXLFromMDObjsTask, &relcache_ctxt);
 
-	return ctxrelcache.m_szDXL;
+	return relcache_ctxt.m_dxl;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::SzMDCast
+//		COptTasks::DumpMDCast
 //
 //	@doc:
 //		Dump cast object into DXL string
 //
 //---------------------------------------------------------------------------
 char *
-COptTasks::SzMDCast
+COptTasks::DumpMDCast
 	(
-	List *plistOids
+	List *oid_list
 	)
 {
-	SContextRelcacheToDXL ctxrelcache(plistOids, gpos::ulong_max /*ulCmpt*/, NULL /*szFilename*/);
-	Execute(&PvMDCast, &ctxrelcache);
+	SContextRelcacheToDXL relcache_ctxt(oid_list, gpos::ulong_max /*cmp_type*/, NULL /*filename*/);
+	Execute(&ConvertToDXLFromMDCast, &relcache_ctxt);
 
-	return ctxrelcache.m_szDXL;
+	return relcache_ctxt.m_dxl;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::SzMDScCmp
+//		COptTasks::DumpMDScalarCmp
 //
 //	@doc:
 //		Dump scalar comparison object into DXL string
 //
 //---------------------------------------------------------------------------
 char *
-COptTasks::SzMDScCmp
+COptTasks::DumpMDScalarCmp
 	(
-	List *plistOids,
-	char *szCmpType
+	List *oid_list,
+	char *cmp_type
 	)
 {
-	SContextRelcacheToDXL ctxrelcache(plistOids, UlCmpt(szCmpType), NULL /*szFilename*/);
-	Execute(&PvMDScCmp, &ctxrelcache);
+	SContextRelcacheToDXL relcache_ctxt(oid_list, GetComparisonType(cmp_type), NULL /*filename*/);
+	Execute(&ConvertToDXLFromMDScalarCmp, &relcache_ctxt);
 
-	return ctxrelcache.m_szDXL;
+	return relcache_ctxt.m_dxl;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::SzRelStats
+//		COptTasks::DumpRelStats
 //
 //	@doc:
 //		Dump statistics objects into DXL string
 //
 //---------------------------------------------------------------------------
 char *
-COptTasks::SzRelStats
+COptTasks::DumpRelStats
 	(
-	List *plistOids
+	List *oid_list
 	)
 {
-	SContextRelcacheToDXL ctxrelcache(plistOids, gpos::ulong_max /*ulCmpt*/, NULL /*szFilename*/);
-	Execute(&PvDXLFromRelStatsTask, &ctxrelcache);
+	SContextRelcacheToDXL relcache_ctxt(oid_list, gpos::ulong_max /*cmp_type*/, NULL /*filename*/);
+	Execute(&ConvertToDXLFromRelStatsTask, &relcache_ctxt);
 
-	return ctxrelcache.m_szDXL;
+	return relcache_ctxt.m_dxl;
 }
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::FSetXform
+//		COptTasks::SetXform
 //
 //	@doc:
 //		Enable/Disable a given xform
 //
 //---------------------------------------------------------------------------
 bool
-COptTasks::FSetXform
+COptTasks::SetXform
 	(
-	char *szXform,
-	bool fDisable
+	char *xform_str,
+	bool should_disable
 	)
 {
-	CXform *pxform = CXformFactory::Pxff()->Pxf(szXform);
-	if (NULL != pxform)
+	CXform *xform = CXformFactory::Pxff()->Pxf(xform_str);
+	if (NULL != xform)
 	{
-		optimizer_xforms[pxform->Exfid()] = fDisable;
+		optimizer_xforms[xform->Exfid()] = should_disable;
 
 		return true;
 	}
@@ -1905,27 +1905,27 @@ COptTasks::FSetXform
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::UlCmpt
+//		COptTasks::GetComparisonType
 //
 //	@doc:
 //		Find the comparison type code given its string representation
 //
 //---------------------------------------------------------------------------
 ULONG
-COptTasks::UlCmpt
+COptTasks::GetComparisonType
 	(
-	char *szCmpType
+	char *cmp_type
 	)
 {
-	const ULONG ulCmpTypes = 6;
-	const CmpType rgcmpt[] = {CmptEq, CmptNEq, CmptLT, CmptGT, CmptLEq, CmptGEq};
-	const CHAR *rgszCmpTypes[] = {"Eq", "NEq", "LT", "GT", "LEq", "GEq"};
+	const ULONG num_cmp_types = 6;
+	const CmpType cmp_types[] = {CmptEq, CmptNEq, CmptLT, CmptGT, CmptLEq, CmptGEq};
+	const CHAR *cmp_types_str_arr[] = {"Eq", "NEq", "LT", "GT", "LEq", "GEq"};
 	
-	for (ULONG ul = 0; ul < ulCmpTypes; ul++)
+	for (ULONG ul = 0; ul < num_cmp_types; ul++)
 	{		
-		if (0 == strcasecmp(szCmpType, rgszCmpTypes[ul]))
+		if (0 == strcasecmp(cmp_type, cmp_types_str_arr[ul]))
 		{
-			return rgcmpt[ul];
+			return cmp_types[ul];
 		}
 	}
 
@@ -1936,33 +1936,33 @@ COptTasks::UlCmpt
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::SzEvalExprFromXML
+//		COptTasks::EvalExprFromXML
 //
 //	@doc:
 //		Converts XML string to DXL and evaluates the expression. Caller keeps
-//		ownership of 'szXmlString' and takes ownership of the returned result.
+//		ownership of 'xml_string' and takes ownership of the returned result.
 //
 //---------------------------------------------------------------------------
 char *
-COptTasks::SzEvalExprFromXML
+COptTasks::EvalExprFromXML
 	(
-	char *szXmlString
+	char *xml_string
 	)
 {
-	GPOS_ASSERT(NULL != szXmlString);
+	GPOS_ASSERT(NULL != xml_string);
 
 	SEvalExprContext evalctxt;
-	evalctxt.m_szDXL = szXmlString;
-	evalctxt.m_szDXLResult = NULL;
+	evalctxt.m_dxl = xml_string;
+	evalctxt.m_dxl_result = NULL;
 
-	Execute(&PvEvalExprFromDXLTask, &evalctxt);
-	return evalctxt.m_szDXLResult;
+	Execute(&EvalExprFromDXLTask, &evalctxt);
+	return evalctxt.m_dxl_result;
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		COptTasks::SzOptimizeMinidumpFromFile
+//		COptTasks::OptimizeMinidumpFromFile
 //
 //	@doc:
 //		Loads a minidump from the given file path, optimizes it and returns
@@ -1970,18 +1970,18 @@ COptTasks::SzEvalExprFromXML
 //
 //---------------------------------------------------------------------------
 char *
-COptTasks::SzOptimizeMinidumpFromFile
+COptTasks::OptimizeMinidumpFromFile
 	(
-	char *szFileName
+	char *file_name
 	)
 {
-	GPOS_ASSERT(NULL != szFileName);
+	GPOS_ASSERT(NULL != file_name);
 	SOptimizeMinidumpContext optmdpctxt;
-	optmdpctxt.m_szFileName = szFileName;
-	optmdpctxt.m_szDXLResult = NULL;
+	optmdpctxt.m_szFileName = file_name;
+	optmdpctxt.m_dxl_result = NULL;
 
-	Execute(&PvOptimizeMinidumpTask, &optmdpctxt);
-	return optmdpctxt.m_szDXLResult;
+	Execute(&OptimizeMinidumpTask, &optmdpctxt);
+	return optmdpctxt.m_dxl_result;
 }
 
 // EOF

--- a/src/backend/gpopt/utils/funcs.cpp
+++ b/src/backend/gpopt/utils/funcs.cpp
@@ -43,12 +43,12 @@ Datum
 DisableXform(PG_FUNCTION_ARGS)
 {
 	char *szXform = text_to_cstring(PG_GETARG_TEXT_P(0));
-	bool fResult = COptTasks::FSetXform(szXform, true /*fDisable*/);
+	bool is_result = COptTasks::SetXform(szXform, true /*fDisable*/);
 
 	StringInfoData str;
 	initStringInfo(&str);
 
-	if (fResult)
+	if (is_result)
 	{
 		appendStringInfo(&str, "%s is disabled", szXform);
 	}
@@ -76,12 +76,12 @@ Datum
 EnableXform(PG_FUNCTION_ARGS)
 {
 	char *szXform = text_to_cstring(PG_GETARG_TEXT_P(0));
-	bool fResult = COptTasks::FSetXform(szXform, false /*fDisable*/);
+	bool is_result = COptTasks::SetXform(szXform, false /*fDisable*/);
 
 	StringInfoData str;
 	initStringInfo(&str);
 
-	if (fResult)
+	if (is_result)
 	{
 		appendStringInfo(&str, "%s is enabled", szXform);
 	}

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -33,7 +33,7 @@
 #include "utils/lsyscache.h"
 
 /* GPORCA entry point */
-extern PlannedStmt * PplstmtOptimize(Query *parse, bool *pfUnexpectedFailure);
+extern PlannedStmt * GPOPTOptimizedPlan(Query *parse, bool *had_unexpected_failure);
 
 /*
  * Logging of optimization outcome
@@ -132,7 +132,7 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 	pqueryCopy = preprocess_query_optimizer(glob, pqueryCopy, boundParams);
 
 	/* Ok, invoke ORCA. */
-	result = PplstmtOptimize(pqueryCopy, &fUnexpectedFailure);
+	result = GPOPTOptimizedPlan(pqueryCopy, &fUnexpectedFailure);
 
 	log_optimizer(result, fUnexpectedFailure);
 

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -26,15 +26,15 @@ class CGPOptimizer
 
 		// optimize given query using GP optimizer
 		static
-		PlannedStmt *PplstmtOptimize
+		PlannedStmt *GPOPTOptimizedPlan
 			(
-			Query *pquery,
-			bool *pfUnexpectedFailure // output : set to true if optimizer unexpectedly failed to produce plan
+			Query *query,
+			bool *had_unexpected_failure // output : set to true if optimizer unexpectedly failed to produce plan
 			);
 
 		// serialize planned statement into DXL
 		static
-		char *SzDXLPlan(Query *pquery);
+		char *SerializeDXLPlan(Query *query);
 
     // gpopt initialize and terminate
     static

--- a/src/include/gpopt/config/CConfigParamMapping.h
+++ b/src/include/gpopt/config/CConfigParamMapping.h
@@ -48,20 +48,20 @@ namespace gpdxl
 			struct SConfigMappingElem
 			{
 				// trace flag
-				EOptTraceFlag m_etf;
+				EOptTraceFlag m_trace_flag;
 
 				// config param address
-				BOOL *m_pfParam;
+				BOOL *m_is_param;
 
 				// if true, we negate the config param value before setting traceflag value
-				BOOL m_fNegate;
+				BOOL m_negate_param;
 
 				// description
-				const WCHAR *wszDescription;
+				const WCHAR *description_str;
 			};
 
 			// array of mapping elements
-			static SConfigMappingElem m_elem[];
+			static SConfigMappingElem m_elements[];
 
 			// private ctor
 			CConfigParamMapping(const CConfigParamMapping &);
@@ -69,7 +69,7 @@ namespace gpdxl
 		public:
 			// pack enabled optimizer config params in a traceflag bitset
 			static
-			CBitSet *PbsPack(IMemoryPool *pmp, ULONG ulXforms);
+			CBitSet *PackConfigParamInBitset(IMemoryPool *mp, ULONG xform_id);
 	};
 }
 

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -58,367 +58,363 @@ struct ArrayExpr;
 namespace gpdb {
 
 	// convert datum to bool
-	bool FBoolFromDatum(Datum d);
+	bool BoolFromDatum(Datum d);
 
 	// convert bool to datum
-	Datum DDatumFromBool(bool b);
+	Datum DatumFromBool(bool b);
 
 	// convert datum to char
-	char CCharFromDatum(Datum d);
+	char CharFromDatum(Datum d);
 
 	// convert char to datum
-	Datum DDatumFromChar(char c);
+	Datum DatumFromChar(char c);
 
 	// convert datum to int8
-	int8 CInt8FromDatum(Datum d);
+	int8 Int8FromDatum(Datum d);
 
 	// convert int8 to datum
-	Datum DDatumFromInt8(int8 i8);
+	Datum DatumFromInt8(int8 i8);
 
 	// convert datum to uint8
-	uint8 UcUint8FromDatum(Datum d);
+	uint8 Uint8FromDatum(Datum d);
 
 	// convert uint8 to datum
-	Datum DDatumFromUint8(uint8 ui8);
+	Datum DatumFromUint8(uint8 ui8);
 
 	// convert datum to int16
-	int16 SInt16FromDatum(Datum d);
+	int16 Int16FromDatum(Datum d);
 
 	// convert int16 to datum
-	Datum DDatumFromInt16(int16 i16);
+	Datum DatumFromInt16(int16 i16);
 
 	// convert datum to uint16
-	uint16 UsUint16FromDatum(Datum d);
+	uint16 Uint16FromDatum(Datum d);
 
 	// convert uint16 to datum
-	Datum DDatumFromUint16(uint16 ui16);
+	Datum DatumFromUint16(uint16 ui16);
 
 	// convert datum to int32
-	int32 IInt32FromDatum(Datum d);
+	int32 Int32FromDatum(Datum d);
 
 	// convert int32 to datum
-	Datum DDatumFromInt32(int32 i32);
+	Datum DatumFromInt32(int32 i32);
 
 	// convert datum to uint32
-	uint32 UlUint32FromDatum(Datum d);
+	uint32 lUint32FromDatum(Datum d);
 
 	// convert uint32 to datum
-	Datum DDatumFromUint32(uint32 ui32);
+	Datum DatumFromUint32(uint32 ui32);
 
 	// convert datum to int64
-	int64 LlInt64FromDatum(Datum d);
+	int64 Int64FromDatum(Datum d);
 
 	// convert int64 to datum
-	Datum DDatumFromInt64(int64 i64);
+	Datum DatumFromInt64(int64 i64);
 
 	// convert datum to uint64
-	uint64 UllUint64FromDatum(Datum d);
+	uint64 Uint64FromDatum(Datum d);
 
 	// convert uint64 to datum
-	Datum DDatumFromUint64(uint64 ui64);
+	Datum DatumFromUint64(uint64 ui64);
 
 	// convert datum to oid
 	Oid OidFromDatum(Datum d);
 
 	// convert datum to generic object with pointer handle
-	void *PvPointerFromDatum(Datum d);
+	void *PointerFromDatum(Datum d);
 
 	// convert datum to float4
-	float4 FpFloat4FromDatum(Datum d);
+	float4 Float4FromDatum(Datum d);
 
 	// convert datum to float8
-	float8 DFloat8FromDatum(Datum d);
+	float8 Float8FromDatum(Datum d);
 
 	// convert pointer to datum
-	Datum DDatumFromPointer(const void *p);
+	Datum DatumFromPointer(const void *p);
 
 	// does an aggregate exist with the given oid
-	bool FAggregateExists(Oid oid);
+	bool AggregateExists(Oid oid);
 
 	// add member to Bitmapset
-	Bitmapset *PbmsAddMember(Bitmapset *a, int x);
+	Bitmapset *BmsAddMember(Bitmapset *a, int x);
 
 	// create a copy of an object
-	void *PvCopyObject(void *from);
+	void *CopyObject(void *from);
 
 	// datum size
-	Size SDatumSize(Datum value, bool typByVal, int typLen);
+	Size DatumSize(Datum value, bool type_by_val, int type_len);
 
 	// expression type
-	Oid OidExprType(Node *expr);
+	Oid ExprType(Node *expr);
 
 	// expression type modifier
-	int32 IExprTypeMod(Node *expr);
+	int32 ExprTypeMod(Node *expr);
 
 	// extract nodes with specific tag from a plan tree
-	List *PlExtractNodesPlan(Plan *pl, int nodeTag, bool descendIntoSubqueries);
+	List *ExtractNodesPlan(Plan *pl, int node_tag, bool descend_into_subqueries);
 
 	// extract nodes with specific tag from an expression tree
-	List *PlExtractNodesExpression(Node *node, int nodeTag, bool descendIntoSubqueries);
+	List *ExtractNodesExpression(Node *node, int node_tag, bool descend_into_subqueries);
 	
 	// intermediate result type of given aggregate
-	Oid OidAggIntermediateResultType(Oid aggid);
+	Oid GetAggIntermediateResultType(Oid aggid);
 
 	// replace Vars that reference JOIN outputs with references to the original
 	// relation variables instead
-	Query *PqueryFlattenJoinAliasVar(Query *pquery, gpos::ULONG ulQueryLevel);
+	Query *FlattenJoinAliasVar(Query *query, gpos::ULONG query_level);
 
 	// is aggregate ordered
-	bool FOrderedAgg(Oid aggid);
+	bool IsOrderedAgg(Oid aggid);
 	
 	// does aggregate have a preliminary function
-	bool FAggHasPrelimFunc(Oid aggid);
+	bool AggHasPrelimFunc(Oid aggid);
 
 	// does aggregate have a prelim or inverse prelim function
-	bool FAggHasPrelimOrInvPrelimFunc(Oid aggid);
+	bool AggHasPrelimOrInvPrelimFunc(Oid aggid);
 
 	// intermediate result type of given aggregate
-	Oid OidAggregate(const char*szArg, Oid oidType);
+	Oid GetAggregate(const char* agg, Oid type_oid);
 
 	// array type oid
-	Oid OidArrayType(Oid typid);
+	Oid GetArrayType(Oid typid);
 
 	// deconstruct array
 	void DeconstructArray(struct ArrayType *array, Oid elmtype, int elmlen, bool elmbyval,
 			char elmalign, Datum **elemsp, bool **nullsp, int *nelemsp);
 
 	// attribute stats slot
-	bool FGetAttrStatsSlot(AttStatsSlot *sslot, HeapTuple statstuple, int reqkind,
+	bool GetAttrStatsSlot(AttStatsSlot *sslot, HeapTuple statstuple, int reqkind,
 			Oid reqop, int flags);
 
 	// free attribute stats slot
 	void FreeAttrStatsSlot(AttStatsSlot *sslot);
 
 	// attribute statistics
-	HeapTuple HtAttrStats(Oid relid, AttrNumber attnum);
+	HeapTuple GetAttStats(Oid relid, AttrNumber attnum);
 
 	// function oids
-	List *PlFunctionOids(void);
+	List *FunctionOids(void);
 
 	// does a function exist with the given oid
-	bool FFunctionExists(Oid oid);
+	bool FunctionExists(Oid oid);
 
 	// is the given function strict
-	bool FFuncStrict(Oid funcid);
+	bool FuncStrict(Oid funcid);
 
 	// stability property of given function
-	char CFuncStability(Oid funcid);
+	char FuncStability(Oid funcid);
 
 	// data access property of given function
-	char CFuncDataAccess(Oid funcid);
+	char FuncDataAccess(Oid funcid);
 
 	// trigger name
-	char *SzTriggerName(Oid triggerid);
+	char *GetTriggerName(Oid triggerid);
 
 	// trigger relid
-	Oid OidTriggerRelid(Oid triggerid);
+	Oid GetTriggerRelid(Oid triggerid);
 
 	// trigger funcid
-	Oid OidTriggerFuncid(Oid triggerid);
+	Oid GetTriggerFuncid(Oid triggerid);
 
 	// trigger type
-	int32 ITriggerType(Oid triggerid);
+	int32 GetTriggerType(Oid triggerid);
 
 	// is trigger enabled
-	bool FTriggerEnabled(Oid triggerid);
+	bool IsTriggerEnabled(Oid triggerid);
 
 	// does trigger exist
-	bool FTriggerExists(Oid oid);
+	bool TriggerExists(Oid oid);
 
 	// does check constraint exist
-	bool FCheckConstraintExists(Oid oidCheckConstraint);
+	bool CheckConstraintExists(Oid check_constraint_oid);
 
 	// check constraint name
-	char *SzCheckConstraintName(Oid oidCheckConstraint);
+	char *GetCheckConstraintName(Oid check_constraint_oid);
 
 	// check constraint relid
-	Oid OidCheckConstraintRelid(Oid oidCheckConstraint);
+	Oid GetCheckConstraintRelid(Oid check_constraint_oid);
 
 	// check constraint expression tree
-	Node *PnodeCheckConstraint(Oid oidCheckConstraint);
+	Node *PnodeCheckConstraint(Oid check_constraint_oid);
 
 	// get the list of check constraints for a given relation
-	List *PlCheckConstraint(Oid oidRel);
+	List *GetCheckConstraintOids(Oid rel_oid);
 
 	// part constraint expression tree
-	Node *PnodePartConstraintRel(Oid oidRel, List **pplDefaultLevels);
+	Node *GetRelationPartContraints(Oid rel_oid, List **default_levels);
 
 	// get the cast function for the specified source and destination types
-	bool FCastFunc(Oid oidSrc, Oid oidDest, bool *is_binary_coercible, Oid *oidCastFunc, CoercionPathType *pathtype);
+	bool GetCastFunc(Oid src_oid, Oid dest_oid, bool *is_binary_coercible, Oid *cast_fn_oid, CoercionPathType *pathtype);
 	
 	// get type of operator
-	unsigned int UlCmpt(Oid oidOp, Oid oidLeft, Oid oidRight);
+	unsigned int GetComparisonType(Oid op_oid, Oid left_oid, Oid right_oid);
 	
 	// get scalar comparison between given types
-	Oid OidScCmp(Oid oidLeft, Oid oidRight, unsigned int ulCmpt);
+	Oid GetComparisonOperator(Oid left_oid, Oid right_oid, unsigned int cmpt);
 
 	// get equality operator for given type
-	Oid OidEqualityOp(Oid oidType);
+	Oid GetEqualityOp(Oid type_oid);
 
 	// function name
-	char *SzFuncName(Oid funcid);
+	char *GetFuncName(Oid funcid);
 
 	// output argument types of the given function
-	List *PlFuncOutputArgTypes(Oid funcid);
+	List *GetFuncOutputArgTypes(Oid funcid);
 
 	// argument types of the given function
-	List *PlFuncArgTypes(Oid funcid);
+	List *GetFuncArgTypes(Oid funcid);
 
 	// does a function return a set of rows
-	bool FFuncRetset(Oid funcid);
+	bool GetFuncRetset(Oid funcid);
 
 	// return type of the given function
-	Oid OidFuncRetType(Oid funcid);
+	Oid GetFuncRetType(Oid funcid);
 
 	// commutator operator of the given operator
-	Oid OidCommutatorOp(Oid opno);
+	Oid GetCommutatorOp(Oid opno);
 
 	// inverse operator of the given operator
-	Oid OidInverseOp(Oid opno);
+	Oid GetInverseOp(Oid opno);
 
 	// function oid corresponding to the given operator oid
-	RegProcedure OidOpFunc(Oid opno);
+	RegProcedure GetOpFunc(Oid opno);
 
 	// operator name
-	char *SzOpName(Oid opno);
+	char *GetOpName(Oid opno);
 
 	// parts of a partitioned table
-	bool FLeafPartition(Oid oid);
+	bool IsLeafPartition(Oid oid);
 
 	// partition table has an external partition
-	bool FHasExternalPartition(Oid oid);
+	bool HasExternalPartition(Oid oid);
 
 	// find the oid of the root partition given partition oid belongs to
-	Oid OidRootPartition(Oid oid);
+	Oid GetRootPartition(Oid oid);
 	
 	// partition attributes
-	List *PlPartitionAttrs(Oid oid);
+	List *GetPartitionAttrs(Oid oid);
 
 	// get partition keys and kinds ordered by partition level
 	void GetOrderedPartKeysAndKinds(Oid oid, List **pkeys, List **pkinds);
 
 	// parts of a partitioned table
-	PartitionNode *PpnParts(Oid relid, int2 level, Oid parent, bool inctemplate, bool includesubparts);
+	PartitionNode *GetParts(Oid relid, int2 level, Oid parent, bool inctemplate, bool includesubparts);
 
 	// keys of the relation with the given oid
-	List *PlRelationKeys(Oid relid);
+	List *GetRelationKeys(Oid relid);
 
 	// relid of a composite type
-	Oid OidTypeRelid(Oid typid);
+	Oid GetTypeRelid(Oid typid);
 
 	// name of the type with the given oid
-	char *SzTypeName(Oid typid);
+	char *GetTypeName(Oid typid);
 
 	// number of GP segments
-	int UlSegmentCountGP(void);
+	int GetGPSegmentCount(void);
 
 	// heap attribute is null
-	bool FHeapAttIsNull(HeapTuple tup, int attnum);
+	bool HeapAttIsNull(HeapTuple tup, int attnum);
 
 	// free heap tuple
 	void FreeHeapTuple(HeapTuple htup);
 
 	// does an index exist with the given oid
-	bool FIndexExists(Oid oid);
+	bool IndexExists(Oid oid);
 
 	// check if given oid is hashable internally in Greenplum Database
-	bool FGreenplumDbHashable(Oid typid);
+	bool IsGreenplumDbHashable(Oid typid);
 
 	// append an element to a list
-	List *PlAppendElement(List *list, void *datum);
+	List *LAppend(List *list, void *datum);
 
 	// append an integer to a list
-	List *PlAppendInt(List *list, int datum);
+	List *LAppendInt(List *list, int datum);
 
 	// append an oid to a list
-	List *PlAppendOid(List *list, Oid datum);
+	List *LAppendOid(List *list, Oid datum);
 
 	// prepend a new element to the list
-	List *PlPrependElement(void *datum, List *list);
+	List *LPrepend(void *datum, List *list);
 
 	// prepend an integer to the list
-	List *PlPrependInt(int datum, List *list);
+	List *LPrependInt(int datum, List *list);
 
 	// prepend an oid to a list
-	List *PlPrependOid(Oid datum, List *list);
+	List *LPrependOid(Oid datum, List *list);
 
 	// concatenate lists
-	List *PlConcat(List *list1, List *list2);
+	List *ListConcat(List *list1, List *list2);
 
 	// copy list
-	List *PlCopy(List *list);
+	List *ListCopy(List *list);
 
 	// first cell in a list
-	ListCell *PlcListHead(List *l);
+	ListCell *ListHead(List *l);
 
 	// last cell in a list
-	ListCell *PlcListTail(List *l);
+	ListCell *ListTail(List *l);
 
 	// number of items in a list
-	uint32 UlListLength(List *l);
+	uint32 ListLength(List *l);
 
 	// return the nth element in a list of pointers
-	void *PvListNth(List *list, int n);
+	void *ListNth(List *list, int n);
 
 	// return the nth element in a list of ints
-	int IListNth(List *list, int n);
+	int ListNthInt(List *list, int n);
 
 	// return the nth element in a list of oids
-	Oid OidListNth(List *list, int n);
+	Oid ListNthOid(List *list, int n);
 
 	// check whether the given oid is a member of the given list
-	bool FMemberOid(List *list, Oid oid);
+	bool ListMemberOid(List *list, Oid oid);
 
 	// free list
-	void FreeList(List *plist);
+	void ListFree(List *list);
 	
 	// deep free of a list
-	void FreeListDeep(List *plist);
-
-	// if pplist is non-NULL, and *pplist is non-NULL then free the list and set
-	// *pplist to NULL
-	void FreeListAndNull(List **pplist);
+	void ListFreeDeep(List *list);
 
 	// is this a Gather motion
-	bool FMotionGather(const Motion *pmotion);
+	bool IsMotionGather(const Motion *motion);
 
 	// does a partition table have an appendonly child
-	bool FAppendOnlyPartitionTable(Oid rootOid);
+	bool IsAppendOnlyPartitionTable(Oid root_oid);
 
 	// does a multi-level partitioned table have uniform partitioning hierarchy
-	bool FMultilevelPartitionUniform(Oid rootOid);
+	bool IsMultilevelPartitionUniform(Oid root_oid);
 
 	// lookup type cache
-	TypeCacheEntry *PtceLookup(Oid type_id, int flags);
+	TypeCacheEntry *LookupTypeCache(Oid type_id, int flags);
 
 	// create a value node for a string
-	Value *PvalMakeString(char *str);
+	Value *MakeStringValue(char *str);
 
 	// create a value node for an integer
-	Value *PvalMakeInteger(long i);
+	Value *MakeIntegerValue(long i);
 
 	// create a bool constant
-	Node *PnodeMakeBoolConst(bool value, bool isnull);
+	Node *MakeBoolConst(bool value, bool isnull);
 
 	// make a NULL constant of the given type
-	Node *PnodeMakeNULLConst(Oid oidType);
+	Node *MakeNULLConst(Oid type_oid);
 	
 	// create a new target entry
-	TargetEntry *PteMakeTargetEntry(Expr *expr, AttrNumber resno, char *resname, bool resjunk);
+	TargetEntry *MakeTargetEntry(Expr *expr, AttrNumber resno, char *resname, bool resjunk);
 
 	// create a new var node
-	Var *PvarMakeVar(Index varno, AttrNumber varattno, Oid vartype, int32 vartypmod, Index varlevelsup);
+	Var *MakeVar(Index varno, AttrNumber varattno, Oid vartype, int32 vartypmod, Index varlevelsup);
 
 	// memory allocation functions
-	void *PvMemoryContextAllocImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
-	void *PvMemoryContextAllocZeroAlignedImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
-	void *PvMemoryContextAllocZeroImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
-	void *PvMemoryContextReallocImpl(void *pointer, Size size, const char* file, const char * func, int line);
+	void *MemCtxtAllocImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
+	void *MemCtxtAllocZeroAlignedImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
+	void *MemCtxtAllocZeroImpl(MemoryContext context, Size size, const char* file, const char * func, int line);
+	void *MemCtxtReallocImpl(void *pointer, Size size, const char* file, const char * func, int line);
 	void *GPDBAlloc(Size size);
 	void GPDBFree(void *ptr);
 
 	// create a duplicate of the given string in the given memory context
-	char *SzMemoryContextStrdup(MemoryContext context, const char *string);
+	char *MemCtxtStrdup(MemoryContext context, const char *string);
 
 	// similar to ereport for logging messages
 	void GpdbEreportImpl(int xerrcode, int severitylevel, const char *xerrmsg, const char *xerrhint, const char *filename, int lineno, const char *funcname);
@@ -426,91 +422,91 @@ namespace gpdb {
 	gpdb::GpdbEreportImpl(xerrcode, severitylevel, xerrmsg, xerrhint , __FILE__, __LINE__, PG_FUNCNAME_MACRO)
 
 	// string representation of a node
-	char *SzNodeToString(void *obj);
+	char *NodeToString(void *obj);
 
 	// node representation from a string
-	Node *Pnode(char *string);
+	Node *StringToNode(char *string);
 
 	// return the default value of the type
-	Node *PnodeTypeDefault(Oid typid);
+	Node *GetTypeDefault(Oid typid);
 
 	// convert numeric to double; if out of range, return +/- HUGE_VAL
-	double DNumericToDoubleNoOverflow(Numeric num);
+	double NumericToDoubleNoOverflow(Numeric num);
 
 	// convert time-related datums to double for stats purpose
-	double DConvertTimeValueToScalar(Datum datum, Oid typid);
+	double ConvertTimeValueToScalar(Datum datum, Oid typid);
 
 	// convert network-related datums to double for stats purpose
-	double DConvertNetworkToScalar(Datum datum, Oid typid);
+	double ConvertNetworkToScalar(Datum datum, Oid typid);
 
 	// is the given operator hash-joinable
-	bool FOpHashJoinable(Oid opno);
+	bool IsOpHashJoinable(Oid opno);
 
 	// is the given operator strict
-	bool FOpStrict(Oid opno);
+	bool IsOpStrict(Oid opno);
 
 	// get input types for a given operator
 	void GetOpInputTypes(Oid opno, Oid *lefttype, Oid *righttype);
 
 	// does an operator exist with the given oid
-	bool FOperatorExists(Oid oid);
+	bool OperatorExists(Oid oid);
 
 	// fetch detoasted copies of toastable datatypes
-	struct varlena *PvlenDetoastDatum(struct varlena * datum);
+	struct varlena *DetoastDatum(struct varlena * datum);
 
 	// expression tree walker
-	bool FWalkExpressionTree(Node *node, bool(*walker)(), void *context);
+	bool WalkExpressionTree(Node *node, bool(*walker)(), void *context);
 
 	// query or expression tree walker
-	bool FWalkQueryOrExpressionTree(Node *node, bool(*walker)(), void *context, int flags);
+	bool WalkQueryOrExpressionTree(Node *node, bool(*walker)(), void *context, int flags);
 
 	// modify a query tree
-	Query *PqueryMutateQueryTree(Query *query, Node *(*mutator)(), void *context, int flags);
+	Query *MutateQueryTree(Query *query, Node *(*mutator)(), void *context, int flags);
 
 	// modify an expression tree
-	Node *PnodeMutateExpressionTree(Node *node, Node *(*mutator)(), void *context);
+	Node *MutateExpressionTree(Node *node, Node *(*mutator)(), void *context);
 
 	// modify a query or an expression tree
-	Node *PnodeMutateQueryOrExpressionTree(Node *node, Node *(*mutator)(), void *context, int flags);
+	Node *MutateQueryOrExpressionTree(Node *node, Node *(*mutator)(), void *context, int flags);
 
-	// the part of PqueryMutateQueryTree that processes a query's rangetable
-	List *PlMutateRangeTable(List *rtable, Node *(*mutator)(), void *context, int flags);
+	// the part of MutateQueryTree that processes a query's rangetable
+	List *MutateRangeTable(List *rtable, Node *(*mutator)(), void *context, int flags);
 
 	// check whether the part with the given oid is the root of a partition table
-	bool FRelPartIsRoot(Oid relid);
+	bool RelPartIsRoot(Oid relid);
 	
 	// check whether the part with the given oid is an interior subpartition
-	bool FRelPartIsInterior(Oid relid);
+	bool RelPartIsInterior(Oid relid);
 	
 	// check whether table with the given oid is a regular table and not part of a partitioned table
-	bool FRelPartIsNone(Oid relid);
+	bool RelPartIsNone(Oid relid);
 
 	// check whether partitioning type encodes hash partitioning
 	bool FHashPartitioned(char c);
 
 	// check whether a relation is inherited
-	bool FHasSubclass(Oid oidRel);
+	bool FHasSubclass(Oid rel_oid);
 
     // check whether a relation has parquet children
-    bool FHasParquetChildren(Oid oidRel);
+    bool HasParquetChildren(Oid rel_oid);
     
     // return the distribution policy of a relation; if the table is partitioned
     // and the parts are distributed differently, return Random distribution
-    GpPolicy *Pdistrpolicy(Relation rel);
+    GpPolicy *GetDistributionPolicy(Relation rel);
     
     // return true if the table is partitioned and hash-distributed, and one of  
     // the child partitions is randomly distributed
-    gpos::BOOL FChildPartDistributionMismatch(Relation rel);
+    gpos::BOOL IsChildPartDistributionMismatched(Relation rel);
 
     // return true if the table is partitioned and any of the child partitions
     // have a trigger of the given type
-    gpos::BOOL FChildTriggers(Oid oid, int triggerType);
+    gpos::BOOL ChildPartHasTriggers(Oid oid, int trigger_type);
 
 	// does a relation exist with the given oid
-	bool FRelationExists(Oid oid);
+	bool RelationExists(Oid oid);
 
 	// extract all relation oids from the catalog
-	List *PlRelationOids(void);
+	List *GetAllRelationOids(void);
 
 	// estimate the relation size using the real number of blocks and tuple density
 	void EstimateRelationSize(Relation rel,	int32 *attr_widths,	BlockNumber *pages,	double *tuples);
@@ -520,116 +516,116 @@ namespace gpdb {
 	void CloseRelation(Relation rel);
 
 	// return the logical indexes for a partitioned table
-	LogicalIndexes *Plgidx(Oid oid);
+	LogicalIndexes *GetLogicalPartIndexes(Oid oid);
 	
 	// return the logical info structure for a given logical index oid
-	LogicalIndexInfo *Plgidxinfo(Oid rootOid, Oid indexOid);
+	LogicalIndexInfo *GetLogicalIndexInfo(Oid root_oid, Oid index_oid);
 	
 	// return a list of index oids for a given relation
-	List *PlRelationIndexes(Relation relation);
+	List *GetRelationIndexes(Relation relation);
 
 	// build an array of triggers for this relation
 	void BuildRelationTriggers(Relation rel);
 
 	// get relation with given oid
-	Relation RelGetRelation(Oid relationId);
+	Relation GetRelation(Oid rel_oid);
 
 	// get external table entry with given oid
-	ExtTableEntry *Pexttable(Oid relationId);
+	ExtTableEntry *GetExternalTableEntry(Oid rel_oid);
 
 	// return the first member of the given targetlist whose expression is
 	// equal to the given expression, or NULL if no such member exists
-	TargetEntry *PteMember(Node *node, List *targetlist);
+	TargetEntry *FindFirstMatchingMemberInTargetList(Node *node, List *targetlist);
 
 	// return a list of members of the given targetlist whose expression is
 	// equal to the given expression, or NULL if no such member exists
-	List *PteMembers(Node *node, List *targetlist);
+	List *FindMatchingMembersInTargetList(Node *node, List *targetlist);
 
 	// check if two gpdb objects are equal
-	bool FEqual(void *p1, void *p2);
+	bool Equals(void *p1, void *p2);
 
 	// does a type exist with the given oid
-	bool FTypeExists(Oid oid);
+	bool TypeExists(Oid oid);
 
 	// check whether a type is composite
-	bool FCompositeType(Oid typid);
+	bool IsCompositeType(Oid typid);
 
 	// get integer value from an Integer value node
-	int IValue(Node *node);
+	int GetIntFromValue(Node *node);
 
 	// parse external table URI
-	Uri *PuriParseExternalTable(const char *szUri);
+	Uri *ParseExternTableUri(const char *uri);
 	
 	// returns ComponentDatabases
-	CdbComponentDatabases *PcdbComponentDatabases(void);
+	CdbComponentDatabases *GetComponentDatabases(void);
 
 	// compare two strings ignoring case
-	int IStrCmpIgnoreCase(const char *sz1, const char *sz2);
+	int StrCmpIgnoreCase(const char *s1, const char *s2);
 
 	// construct random segment map
-	bool *RgfRandomSegMap(int total_primaries, int total_to_skip);
+	bool *ConstructRandomSegMap(int total_primaries, int total_to_skip);
 
 	// create an empty 'StringInfoData' & return a pointer to it
-	StringInfo SiMakeStringInfo(void);
+	StringInfo MakeStringInfo(void);
 
 	// append the two given strings to the StringInfo object
 	void AppendStringInfo(StringInfo str, const char *str1, const char *str2);
 
 	// look for the given node tags in the given tree and return the index of
 	// the first one found, or -1 if there are none
-	int IFindNodes(Node *node, List *nodeTags);
+	int FindNodes(Node *node, List *nodeTags);
 
-	Node *PnodeCoerceToCommonType(ParseState *pstate, Node *pnode, Oid oidTargetType, const char *context);
+	Node *CoerceToCommonType(ParseState *pstate, Node *node, Oid target_type, const char *context);
 
 	// replace any polymorphic type with correct data type deduced from input arguments
-	bool FResolvePolymorphicType(int numargs, Oid *argtypes, char *argmodes, FuncExpr *call_expr);
+	bool ResolvePolymorphicArgType(int numargs, Oid *argtypes, char *argmodes, FuncExpr *call_expr);
 	
 	// hash a const value with GPDB's hash function
-	int32 ICdbHash(Const *pconst, int iSegments);
+	int32 CdbHashConst(Const *constant, int num_segments);
 	
 	// hash a list of const values with GPDB's hash function
-	int32 ICdbHashList(List *plConsts, int iSegments);
+	int32 CdbHashConstList(List *constants, int num_segments);
 	
 	// check permissions on range table 
-	void CheckRTPermissions(List *plRangeTable);
+	void CheckRTPermissions(List *rtable);
 	
 	// get index operator family properties
 	void IndexOpProperties(Oid opno, Oid opfamily, int *strategy, Oid *subtype, bool *recheck);
 	
 	// get oids of families this operator belongs to
-	List *PlScOpOpFamilies(Oid opno);
+	List *GetOpFamiliesForScOp(Oid opno);
 	
 	// get oids of op classes for the index keys
-	List *PlIndexOpFamilies(Oid oidIndex);
+	List *GetIndexOpFamilies(Oid index_oid);
 
-	// returns the result of evaluating 'pexpr' as an Expr. Caller keeps ownership of 'pexpr'
+	// returns the result of evaluating 'expr' as an Expr. Caller keeps ownership of 'expr'
 	// and takes ownership of the result 
-	Expr *PexprEvaluate(Expr *pexpr, Oid oidResultType, int32 iTypeMod);
+	Expr *EvaluateExpr(Expr *expr, Oid result_type, int32 typmod);
 	
 	// interpret the value of "With oids" option from a list of defelems
-	bool FInterpretOidsOption(List *plOptions);
+	bool InterpretOidsOption(List *options);
 	
 	// extract string value from defelem's value
-	char *SzDefGetString(DefElem *pdefelem);
+	char *DefGetString(DefElem *defelem);
 
 	// transform array Const to an ArrayExpr
-	Expr *PexprTransformArrayConstToArrayExpr(Const *pConst);
+	Expr *TransformArrayConstToArrayExpr(Const *constant);
 
 	// transform array Const to an ArrayExpr
-	Node *PnodeEvalConstExpressions(Node *node);
+	Node *EvalConstExpressions(Node *node);
 
 	// static partition selection given a PartitionSelector node
-	SelectedParts *SpStaticPartitionSelection(PartitionSelector *ps);
+	SelectedParts *RunStaticPartitionSelection(PartitionSelector *ps);
 
 	// simple fault injector used by COptTasks.cpp to inject GPDB fault
-	FaultInjectorType_e OptTasksFaultInjector(FaultInjectorIdentifier_e identifier);
+	FaultInjectorType_e InjectFaultInOptTasks(FaultInjectorIdentifier_e identifier);
 
 	// return the number of leaf partition for a given table oid
-	gpos::ULONG UlLeafPartitions(Oid oidRelation);
+	gpos::ULONG CountLeafPartTables(Oid oidRelation);
 
 	// Does the metadata cache need to be reset (because of a catalog
 	// table has been changed?)
-	bool FMDCacheNeedsReset(void);
+	bool MDCacheNeedsReset(void);
 
 	// functions for tracking ORCA memory consumption
 	void *OptimizerAlloc(size_t size);
@@ -637,45 +633,45 @@ namespace gpdb {
 	void OptimizerFree(void *ptr);
 
 	// returns true if a query cancel is requested in GPDB
-	bool FAbortRequested(void);
+	bool IsAbortRequested(void);
 
 } //namespace gpdb
 
 #define ForEach(cell, l)	\
-	for ((cell) = gpdb::PlcListHead(l); (cell) != NULL; (cell) = lnext(cell))
+	for ((cell) = gpdb::ListHead(l); (cell) != NULL; (cell) = lnext(cell))
 
 #define ForBoth(cell1, list1, cell2, list2)							\
-	for ((cell1) = gpdb::PlcListHead(list1), (cell2) = gpdb::PlcListHead(list2);	\
+	for ((cell1) = gpdb::ListHead(list1), (cell2) = gpdb::ListHead(list2);	\
 		 (cell1) != NULL && (cell2) != NULL;						\
 		 (cell1) = lnext(cell1), (cell2) = lnext(cell2))
 
 #define ForThree(cell1, list1, cell2, list2, cell3, list3)							\
-	for ((cell1) = gpdb::PlcListHead(list1), (cell2) = gpdb::PlcListHead(list2), (cell3) = gpdb::PlcListHead(list3);	\
+	for ((cell1) = gpdb::ListHead(list1), (cell2) = gpdb::ListHead(list2), (cell3) = gpdb::ListHead(list3);	\
 		 (cell1) != NULL && (cell2) != NULL && (cell3) != NULL;						\
 		 (cell1) = lnext(cell1), (cell2) = lnext(cell2), (cell3) = lnext(cell3))
 
 #define ForEachWithCount(cell, list, counter) \
-	for ((cell) = gpdb::PlcListHead(list), (counter)=0; \
+	for ((cell) = gpdb::ListHead(list), (counter)=0; \
 	     (cell) != NULL; \
 	     (cell) = lnext(cell), ++(counter))
 
-#define ListMake1(x1) gpdb::PlPrependElement(x1, NIL)
+#define ListMake1(x1) gpdb::LPrepend(x1, NIL)
 
-#define ListMake2(x1,x2) gpdb::PlPrependElement(x1, ListMake1(x2))
+#define ListMake2(x1,x2) gpdb::LPrepend(x1, ListMake1(x2))
 
-#define ListMake1Int(x1) gpdb::PlPrependInt(x1, NIL)
+#define ListMake1Int(x1) gpdb::LPrependInt(x1, NIL)
 
-#define ListMake1Oid(x1) gpdb::PlPrependOid(x1, NIL)
-#define ListMake2Oid(x1,x2) gpdb::PlPrependOid(x1, ListMake1Oid(x2))
+#define ListMake1Oid(x1) gpdb::LPrependOid(x1, NIL)
+#define ListMake2Oid(x1,x2) gpdb::LPrependOid(x1, ListMake1Oid(x2))
 
-#define LInitial(l) lfirst(gpdb::PlcListHead(l))
+#define LInitial(l) lfirst(gpdb::ListHead(l))
 
-#define LInitialOID(l) lfirst_oid(gpdb::PlcListHead(l))
+#define LInitialOID(l) lfirst_oid(gpdb::ListHead(l))
 
 #define Palloc0Fast(sz) \
 	( MemSetTest(0, (sz)) ? \
-		gpdb::PvMemoryContextAllocZeroAlignedImpl(CurrentMemoryContext, (sz), __FILE__, PG_FUNCNAME_MACRO, __LINE__) : \
-		gpdb::PvMemoryContextAllocZeroImpl(CurrentMemoryContext, (sz), __FILE__, PG_FUNCNAME_MACRO, __LINE__))
+		gpdb::MemCtxtAllocZeroAlignedImpl(CurrentMemoryContext, (sz), __FILE__, PG_FUNCNAME_MACRO, __LINE__) : \
+		gpdb::MemCtxtAllocZeroImpl(CurrentMemoryContext, (sz), __FILE__, PG_FUNCNAME_MACRO, __LINE__))
 
 #ifdef __GNUC__
 
@@ -708,7 +704,7 @@ extern PGDLLIMPORT Node *newNodeMacroHolder;
 
 #define MakeNode(_type_) 		((_type_ *) NewNode(sizeof(_type_),T_##_type_))
 
-#define PStrDup(str) gpdb::SzMemoryContextStrdup(CurrentMemoryContext, (str))
+#define PStrDup(str) gpdb::MemCtxtStrdup(CurrentMemoryContext, (str))
 
 #endif // !GPDB_gpdbwrappers_H
 

--- a/src/include/gpopt/relcache/CMDProviderRelcache.h
+++ b/src/include/gpopt/relcache/CMDProviderRelcache.h
@@ -47,7 +47,7 @@ namespace gpmd
 	{
 		private:
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// private copy ctor
 			CMDProviderRelcache(const CMDProviderRelcache&);
@@ -55,7 +55,7 @@ namespace gpmd
 		public:
 			// ctor/dtor
 			explicit
-			CMDProviderRelcache(IMemoryPool *pmp);
+			CMDProviderRelcache(IMemoryPool *mp);
 
 			~CMDProviderRelcache()
 			{
@@ -63,19 +63,19 @@ namespace gpmd
 
 			// returns the DXL string of the requested metadata object
 			virtual
-			CWStringBase *PstrObject(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid) const;
+			CWStringBase *GetMDObjDXLStr(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *md_id) const;
 
 			// return the mdid for the requested type
 			virtual
-			IMDId *Pmdid
+			IMDId *MDId
 				(
-				IMemoryPool *pmp,
+				IMemoryPool *mp,
 				CSystemId sysid,
-				IMDType::ETypeInfo eti
+				IMDType::ETypeInfo type_info
 				)
 				const
 			{
-				return PmdidTypeGPDB(pmp, sysid, eti);
+				return GetGPDBTypeMdid(mp, sysid, type_info);
 			}
 
 	};

--- a/src/include/gpopt/translate/CCTEListEntry.h
+++ b/src/include/gpopt/translate/CCTEListEntry.h
@@ -35,19 +35,19 @@ namespace gpdxl
 	
 	// hash on character arrays
 	inline
-	ULONG UlHashSz
+	ULONG HashStr
 		(
-		const CHAR *sz
+		const CHAR *str
 		)
 	{
-		return gpos::UlHashByteArray((BYTE *) sz, clib::UlStrLen(sz));
+		return gpos::HashByteArray((BYTE *) str, clib::Strlen(str));
 	}
 	
 	// equality on character arrays
 	inline
-	BOOL FEqualSz(const CHAR *szA, const CHAR *szB)
+	BOOL StrEqual(const CHAR *str_a, const CHAR *str_b)
 	{
-		return (0 == clib::IStrCmp(szA, szB));
+		return (0 == clib::Strcmp(str_a, str_b));
 	}
 	
 
@@ -67,66 +67,66 @@ namespace gpdxl
 			// pair of DXL CTE producer and target list of the original CTE query
 			struct SCTEProducerInfo
 			{
-				const CDXLNode *m_pdxlnCTEProducer;
-				List *m_plTargetList;
+				const CDXLNode *m_cte_producer;
+				List *m_target_list;
 				
 				// ctor
 				SCTEProducerInfo
 					(
-					const CDXLNode *pdxlnCTEProducer,
-					List *plTargetList
+					const CDXLNode *cte_producer,
+					List *target_list
 					)
 					:
-					m_pdxlnCTEProducer(pdxlnCTEProducer),
-					m_plTargetList(plTargetList)
+					m_cte_producer(cte_producer),
+					m_target_list(target_list)
 				{}
 			};
 			
 			// hash maps mapping CHAR *->SCTEProducerInfo
-			typedef CHashMap<CHAR, SCTEProducerInfo, UlHashSz, FEqualSz, CleanupNULL, CleanupDelete > HMSzCTEInfo;
+			typedef CHashMap<CHAR, SCTEProducerInfo, HashStr, StrEqual, CleanupNULL, CleanupDelete > HMSzCTEInfo;
 
 			// query level where the CTEs are defined
-			ULONG m_ulQueryLevel;
+			ULONG m_query_level;
 
 			// CTE producers at that level indexed by their name
-			HMSzCTEInfo *m_phmszcteinfo; 
+			HMSzCTEInfo *m_cte_info; 
 
 		public:
 			// ctor: single CTE 
-			CCTEListEntry(IMemoryPool *pmp, ULONG ulQueryLevel, CommonTableExpr *pcte, CDXLNode *pdxlnCTEProducer);
+			CCTEListEntry(IMemoryPool *mp, ULONG query_level, CommonTableExpr *cte, CDXLNode *cte_producer);
 			
 			// ctor: multiple CTEs
-			CCTEListEntry(IMemoryPool *pmp, ULONG ulQueryLevel, List *plCTE, DrgPdxln *pdrgpdxln);
+			CCTEListEntry(IMemoryPool *mp, ULONG query_level, List *cte_list, CDXLNodeArray *dxlnodes);
 
 			// dtor
 			virtual
 			~CCTEListEntry()
 			{
-				m_phmszcteinfo->Release();
+				m_cte_info->Release();
 			};
 
 			// the query level
-			ULONG UlQueryLevel() const
+			ULONG GetQueryLevel() const
 			{
-				return m_ulQueryLevel;
+				return m_query_level;
 			}
 
 			// lookup CTE producer by its name
-			const CDXLNode *PdxlnCTEProducer(const CHAR *szCTE) const;
+			const CDXLNode *GetCTEProducer(const CHAR *cte_str) const;
 
 			// lookup CTE producer target list by its name
-			List *PlCTEProducerTL(const CHAR *szCTE) const;
+			List *GetCTEProducerTargetList(const CHAR *cte_str) const;
 
 			// add a new CTE producer for this level
-			void AddCTEProducer(IMemoryPool *pmp, CommonTableExpr *pcte, const CDXLNode *pdxlnCTEProducer);
+			void AddCTEProducer(IMemoryPool *mp, CommonTableExpr *cte, const CDXLNode *cte_producer);
 	};
 
 	// hash maps mapping ULONG -> CCTEListEntry
-	typedef CHashMap<ULONG, CCTEListEntry, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>,
+	typedef CHashMap<ULONG, CCTEListEntry, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
 	CleanupDelete<ULONG>, CleanupRelease > HMUlCTEListEntry;
 
 	// iterator
-	typedef CHashMapIter<ULONG, CCTEListEntry, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>,
+	typedef CHashMapIter<ULONG, CCTEListEntry, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
 	CleanupDelete<ULONG>, CleanupRelease > HMIterUlCTEListEntry;
 
 	}

--- a/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
+++ b/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
@@ -44,47 +44,47 @@ namespace gpdxl
 	class CDXLTranslateContextBaseTable
 	{
 		// hash maps mapping ULONG -> INT
-		typedef CHashMap<ULONG, INT, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>,
-			CleanupDelete<ULONG>, CleanupDelete<INT> > HMUlI;
+		typedef CHashMap<ULONG, INT, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			CleanupDelete<ULONG>, CleanupDelete<INT> > UlongToIntMap;
 
 
 		private:
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// oid of the base table
 			OID m_oid;
 
 			// index of the relation in the rtable
-			Index m_iRel;
+			Index m_rel_index;
 
 			// maps a colid of a column to the attribute number of that column in the schema of the underlying relation
-			HMUlI *m_phmuli;
+			UlongToIntMap *m_colid_to_attno_map;
 
 			// private copy ctor
 			CDXLTranslateContextBaseTable(const CDXLTranslateContextBaseTable&);
 
 		public:
 			// ctor/dtor
-			explicit CDXLTranslateContextBaseTable(IMemoryPool *pmp);
+			explicit CDXLTranslateContextBaseTable(IMemoryPool *mp);
 
 
 			~CDXLTranslateContextBaseTable();
 
 			// accessors
-			OID OidRel() const;
+			OID GetOid() const;
 
-			Index IRel() const;
+			Index GetRelIndex() const;
 
 			// return the index of the column in the base relation for the given DXL ColId
-			INT IAttnoForColId(ULONG ulDXLColId) const;
+			INT GetAttnoForColId(ULONG dxl_colid) const;
 
 			// setters
 			void SetOID(OID oid);
 
-			void SetIdx(Index iRel);
+			void SetRelIndex(Index rel_index);
 
 			// store the mapping of the given DXL column id and index in the base relation schema
-			BOOL FInsertMapping(ULONG ulDXLColId, INT iAttno);
+			BOOL InsertMapping(ULONG dxl_colid, INT att_no);
 
 	};
 }

--- a/src/include/gpopt/translate/CGPDBAttInfo.h
+++ b/src/include/gpopt/translate/CGPDBAttInfo.h
@@ -38,21 +38,21 @@ namespace gpdxl
 		private:
 
 			// query level number
-			ULONG m_ulQueryLevel;
+			ULONG m_query_level;
 
 			// varno in the rtable
-			ULONG m_ulVarNo;
+			ULONG m_varno;
 
 			// attno
-			INT	m_iAttNo;
+			INT	m_attno;
 
 			// copy c'tor
 			CGPDBAttInfo(const CGPDBAttInfo&);
 
 		public:
 			// ctor
-			CGPDBAttInfo(ULONG ulQueryLevel, ULONG ulVarNo, INT iAttNo)
-				: m_ulQueryLevel(ulQueryLevel), m_ulVarNo(ulVarNo), m_iAttNo(iAttNo)
+			CGPDBAttInfo(ULONG query_level, ULONG var_no, INT attrnum)
+				: m_query_level(query_level), m_varno(var_no), m_attno(attrnum)
 			{}
 
 			// d'tor
@@ -60,60 +60,60 @@ namespace gpdxl
 			~CGPDBAttInfo() {}
 
 			// accessor
-			ULONG UlQueryLevel() const
+			ULONG GetQueryLevel() const
 			{
-				return m_ulQueryLevel;
+				return m_query_level;
 			}
 
 			// accessor
-			ULONG UlVarNo() const
+			ULONG GetVarNo() const
 			{
-				return m_ulVarNo;
+				return m_varno;
 			}
 
 			// accessor
-			INT IAttNo() const
+			INT GetAttNo() const
 			{
-				return m_iAttNo;
+				return m_attno;
 			}
 
 			// equality check
-			BOOL FEquals(const CGPDBAttInfo& gpdbattinfo) const
+			BOOL Equals(const CGPDBAttInfo& gpdb_att_info) const
 			{
-				return m_ulQueryLevel == gpdbattinfo.m_ulQueryLevel
-						&& m_ulVarNo == gpdbattinfo.m_ulVarNo
-						&& m_iAttNo == gpdbattinfo.m_iAttNo;
+				return m_query_level == gpdb_att_info.m_query_level
+						&& m_varno == gpdb_att_info.m_varno
+						&& m_attno == gpdb_att_info.m_attno;
 			}
 
 			// hash value
-			ULONG UlHash() const
+			ULONG HashValue() const
 			{
-				return gpos::UlCombineHashes(
-						gpos::UlHash(&m_ulQueryLevel),
-						gpos::UlCombineHashes(gpos::UlHash(&m_ulVarNo),
-								gpos::UlHash(&m_iAttNo)));
+				return gpos::CombineHashes(
+						gpos::HashValue(&m_query_level),
+						gpos::CombineHashes(gpos::HashValue(&m_varno),
+								gpos::HashValue(&m_attno)));
 			}
 	};
 
 	// hash function
-	inline ULONG UlHashGPDBAttInfo
+	inline ULONG HashGPDBAttInfo
 		(
-		const CGPDBAttInfo *pgpdbattinfo
+		const CGPDBAttInfo *gpdb_att_info
 		)
 	{
-		GPOS_ASSERT(NULL != pgpdbattinfo);
-		return pgpdbattinfo->UlHash();
+		GPOS_ASSERT(NULL != gpdb_att_info);
+		return gpdb_att_info->HashValue();
 	}
 
 	// equality function
-	inline BOOL FEqualGPDBAttInfo
+	inline BOOL EqualGPDBAttInfo
 		(
-		const CGPDBAttInfo *pgpdbattinfoA,
-		const CGPDBAttInfo *pgpdbattinfoB
+		const CGPDBAttInfo *gpdb_att_info_a,
+		const CGPDBAttInfo *gpdb_att_info_b
 		)
 	{
-		GPOS_ASSERT(NULL != pgpdbattinfoA && NULL != pgpdbattinfoB);
-		return pgpdbattinfoA->FEquals(*pgpdbattinfoB);
+		GPOS_ASSERT(NULL != gpdb_att_info_a && NULL != gpdb_att_info_b);
+		return gpdb_att_info_a->Equals(*gpdb_att_info_b);
 	}
 
 }

--- a/src/include/gpopt/translate/CGPDBAttOptCol.h
+++ b/src/include/gpopt/translate/CGPDBAttOptCol.h
@@ -37,41 +37,41 @@ namespace gpdxl
 		private:
 
 			// gpdb att info
-			CGPDBAttInfo *m_pgpdbattinfo;
+			CGPDBAttInfo *m_gpdb_att_info;
 
 			// optimizer col info
-			COptColInfo *m_poptcolinfo;
+			COptColInfo *m_opt_col_info;
 
 			// copy c'tor
 			CGPDBAttOptCol(const CGPDBAttOptCol&);
 
 		public:
 			// ctor
-			CGPDBAttOptCol(CGPDBAttInfo *pgpdbattinfo, COptColInfo *poptcolinfo)
-				: m_pgpdbattinfo(pgpdbattinfo), m_poptcolinfo(poptcolinfo)
+			CGPDBAttOptCol(CGPDBAttInfo *gpdb_att_info, COptColInfo *opt_col_info)
+				: m_gpdb_att_info(gpdb_att_info), m_opt_col_info(opt_col_info)
 			{
-				GPOS_ASSERT(NULL != m_pgpdbattinfo);
-				GPOS_ASSERT(NULL != m_poptcolinfo);
+				GPOS_ASSERT(NULL != m_gpdb_att_info);
+				GPOS_ASSERT(NULL != m_opt_col_info);
 			}
 
 			// d'tor
 			virtual
 			~CGPDBAttOptCol()
 			{
-				m_pgpdbattinfo->Release();
-				m_poptcolinfo->Release();
+				m_gpdb_att_info->Release();
+				m_opt_col_info->Release();
 			}
 
 			// accessor
-			const CGPDBAttInfo *Pgpdbattinfo() const
+			const CGPDBAttInfo *GetGPDBAttInfo() const
 			{
-				return m_pgpdbattinfo;
+				return m_gpdb_att_info;
 			}
 
 			// accessor
-			const COptColInfo *Poptcolinfo() const
+			const COptColInfo *GetOptColInfo() const
 			{
-				return m_poptcolinfo;
+				return m_opt_col_info;
 			}
 
 	};

--- a/src/include/gpopt/translate/CIndexQualInfo.h
+++ b/src/include/gpopt/translate/CIndexQualInfo.h
@@ -43,35 +43,35 @@ namespace gpdxl
 			AttrNumber m_attno;
 
 			// index qual expression tailored for GPDB
-			Expr *m_pexpr;
+			Expr *m_expr;
 
 			// original index qual expression
-			Expr *m_pexprOriginal;
+			Expr *m_original_expr;
 
 			// index strategy information
-			StrategyNumber m_sn;
+			StrategyNumber m_strategy_num;
 
 			// index subtype
-			OID m_oidIndexSubtype;
+			OID m_index_subtype_oid;
 			
 			// ctor
 			CIndexQualInfo
 				(
 				AttrNumber attno,
-				Expr *pexpr,
-				Expr *pexprOriginal,
-				StrategyNumber sn,
-				OID oidIndexSubtype
+				Expr *expr,
+				Expr *original_expr,
+				StrategyNumber strategy_number,
+				OID index_subtype_oid
 				)
 				:
 				m_attno(attno),
-				m_pexpr(pexpr),
-				m_pexprOriginal(pexprOriginal),
-				m_sn(sn),
-				m_oidIndexSubtype(oidIndexSubtype)
+				m_expr(expr),
+				m_original_expr(original_expr),
+				m_strategy_num(strategy_number),
+				m_index_subtype_oid(index_subtype_oid)
 				{
-					GPOS_ASSERT((IsA(m_pexpr, OpExpr) && IsA(m_pexprOriginal, OpExpr)) ||
-						(IsA(m_pexpr, ScalarArrayOpExpr) && IsA(m_pexprOriginal, ScalarArrayOpExpr)));
+					GPOS_ASSERT((IsA(m_expr, OpExpr) && IsA(m_original_expr, OpExpr)) ||
+						(IsA(m_expr, ScalarArrayOpExpr) && IsA(original_expr, ScalarArrayOpExpr)));
 				}
 
 				// dtor
@@ -80,20 +80,20 @@ namespace gpdxl
 
 				// comparison function for sorting index qualifiers
 				static
-				INT IIndexQualInfoCmp
+				INT IndexQualInfoCmp
 					(
-					const void *pv1,
-					const void *pv2
+					const void *p1,
+					const void *p2
 					)
 				{
-					const CIndexQualInfo *pidxqualinfo1 = *(const CIndexQualInfo **) pv1;
-					const CIndexQualInfo *pidxqualinfo2 = *(const CIndexQualInfo **) pv2;
+					const CIndexQualInfo *qual_info1 = *(const CIndexQualInfo **) p1;
+					const CIndexQualInfo *qual_info2 = *(const CIndexQualInfo **) p2;
 
-					return (INT) pidxqualinfo1->m_attno - (INT) pidxqualinfo2->m_attno;
+					return (INT) qual_info1->m_attno - (INT) qual_info2->m_attno;
 				}
 	};
 	// array of index qual info
-	typedef CDynamicPtrArray<CIndexQualInfo, CleanupDelete> DrgPindexqualinfo;
+	typedef CDynamicPtrArray<CIndexQualInfo, CleanupDelete> CIndexQualInfoArray;
 }
 
 #endif // !GPDXL_CIndexQualInfo_H

--- a/src/include/gpopt/translate/CMappingColIdVar.h
+++ b/src/include/gpopt/translate/CMappingColIdVar.h
@@ -47,7 +47,7 @@ namespace gpdxl
 	{
 		protected:
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 		public:
 
@@ -60,7 +60,7 @@ namespace gpdxl
 
 			// translate DXL ScalarIdent node into GPDB Var node
 			virtual
-			Var *PvarFromDXLNodeScId(const CDXLScalarIdent *) = 0;
+			Var *VarFromDXLNodeScId(const CDXLScalarIdent *) = 0;
 	};
 }
 

--- a/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
+++ b/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
@@ -48,40 +48,40 @@ namespace gpdxl
 	{
 		private:
 
-			const CDXLTranslateContextBaseTable *m_pdxltrctxbt;
+			const CDXLTranslateContextBaseTable *m_base_table_context;
 
 			// the array of translator context (one for each child of the DXL operator)
-			DrgPdxltrctx *m_pdrgpdxltrctx;
+			CDXLTranslationContextArray *m_child_contexts;
 
-			CDXLTranslateContext *m_pdxltrctxOut;
+			CDXLTranslateContext *m_output_context;
 
 			// translator context used to translate initplan and subplans associated
 			// with a param node
-			CContextDXLToPlStmt *m_pctxdxltoplstmt;
+			CContextDXLToPlStmt *m_dxl_to_plstmt_context;
 
 		public:
 
 			CMappingColIdVarPlStmt
 				(
-				IMemoryPool *pmp,
-				const CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut,
-				CContextDXLToPlStmt *pctxdxltoplstmt
+				IMemoryPool *mp,
+				const CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *child_contexts,
+				CDXLTranslateContext *output_context,
+				CContextDXLToPlStmt *dxl_to_plstmt_context
 				);
 
 			// translate DXL ScalarIdent node into GPDB Var node
 			virtual
-			Var *PvarFromDXLNodeScId(const CDXLScalarIdent *pdxlop);
+			Var *VarFromDXLNodeScId(const CDXLScalarIdent *dxlop);
 
 			// translate DXL ScalarIdent node into GPDB Param node
-			Param *PparamFromDXLNodeScId(const CDXLScalarIdent *pdxlop);
+			Param *ParamFromDXLNodeScId(const CDXLScalarIdent *dxlop);
 
 			// get the output translator context
-			CDXLTranslateContext *PpdxltrctxOut();
+			CDXLTranslateContext *GetOutputContext();
 
 			// return the context of the DXL->PlStmt translation
-			CContextDXLToPlStmt *Pctxdxltoplstmt();
+			CContextDXLToPlStmt *GetDXLToPlStmtContext();
 	};
 }
 

--- a/src/include/gpopt/translate/CMappingElementColIdParamId.h
+++ b/src/include/gpopt/translate/CMappingElementColIdParamId.h
@@ -38,46 +38,46 @@ namespace gpdxl
 		private:
 
 			// column identifier that is used as the key
-			ULONG m_ulColId;
+			ULONG m_colid;
 
 			// param identifier
-			ULONG m_ulParamId;
+			ULONG m_paramid;
 
 			// param type
-			IMDId *m_pmdid;
+			IMDId *m_mdid;
 
-			INT m_iTypeModifier;
+			INT m_type_modifier;
 
 		public:
 
 			// ctors and dtor
-			CMappingElementColIdParamId(ULONG ulColId, ULONG ulParamId, IMDId *pmdid, INT iTypeModifier);
+			CMappingElementColIdParamId(ULONG colid, ULONG paramid, IMDId *mdid, INT type_modifier);
 
 			virtual
 			~CMappingElementColIdParamId()
 			{}
 
 			// return the ColId
-			ULONG UlColId() const
+			ULONG GetColId() const
 			{
-				return m_ulColId;
+				return m_colid;
 			}
 
 			// return the ParamId
-			ULONG UlParamId() const
+			ULONG ParamId() const
 			{
-				return m_ulParamId;
+				return m_paramid;
 			}
 
 			// return the type
-			IMDId *PmdidType() const
+			IMDId *MdidType() const
 			{
-				return m_pmdid;
+				return m_mdid;
 			}
 
-			INT ITypeModifier() const
+			INT TypeModifier() const
 			{
-				return m_iTypeModifier;
+				return m_type_modifier;
 			}
 	};
 }

--- a/src/include/gpopt/translate/CMappingElementColIdTE.h
+++ b/src/include/gpopt/translate/CMappingElementColIdTE.h
@@ -44,13 +44,13 @@ namespace gpdxl
 		private:
 
 			// the column identifier that is used as the key
-			ULONG m_ulColId;
+			ULONG m_colid;
 
 			// the query level
-			ULONG m_ulQueryLevel;
+			ULONG m_query_level;
 
 			// the target entry
-			TargetEntry *m_pte;
+			TargetEntry *m_target_entry;
 
 		public:
 
@@ -58,21 +58,21 @@ namespace gpdxl
 			CMappingElementColIdTE(ULONG, ULONG, TargetEntry *);
 
 			// return the ColId
-			ULONG UlColId() const
+			ULONG GetColId() const
 			{
-				return m_ulColId;
+				return m_colid;
 			}
 
 			// return the query level
-			ULONG UlQueryLevel() const
+			ULONG GetQueryLevel() const
 			{
-				return m_ulQueryLevel;
+				return m_query_level;
 			}
 
 			// return the column name for the given attribute no
-			const TargetEntry *Pte() const
+			const TargetEntry *GetTargetEntry() const
 			{
-				return m_pte;
+				return m_target_entry;
 			}
 	};
 }

--- a/src/include/gpopt/translate/CMappingVarColId.h
+++ b/src/include/gpopt/translate/CMappingVarColId.h
@@ -76,31 +76,31 @@ namespace gpdxl
 	{
 		private:
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// hash map structure to store gpdb att -> opt col information
-			typedef CHashMap<CGPDBAttInfo, CGPDBAttOptCol, UlHashGPDBAttInfo, FEqualGPDBAttInfo,
-							CleanupRelease, CleanupRelease > CMVCMap;
+			typedef CHashMap<CGPDBAttInfo, CGPDBAttOptCol, HashGPDBAttInfo, EqualGPDBAttInfo,
+							CleanupRelease, CleanupRelease > GPDBAttOptColHashMap;
 
 			// iterator
-			typedef CHashMapIter<CGPDBAttInfo, CGPDBAttOptCol, UlHashGPDBAttInfo, FEqualGPDBAttInfo,
-							CleanupRelease, CleanupRelease > CMVCMapIter;
+			typedef CHashMapIter<CGPDBAttInfo, CGPDBAttOptCol, HashGPDBAttInfo, EqualGPDBAttInfo,
+							CleanupRelease, CleanupRelease > GPDBAttOptColHashMapIter;
 
 			// map from gpdb att to optimizer col
-			CMVCMap	*m_pmvcmap;
+			GPDBAttOptColHashMap	*m_gpdb_att_opt_col_mapping;
 
 			// insert mapping entry
-			void Insert(ULONG, ULONG, INT, ULONG, CWStringBase *pstr);
+			void Insert(ULONG, ULONG, INT, ULONG, CWStringBase *str);
 
 			// no copy constructor
 			CMappingVarColId(const CMappingVarColId &);
 
 			// helper function to access mapping
-			const CGPDBAttOptCol *Pgpdbattoptcol
+			const CGPDBAttOptCol *GetGPDBAttOptColMapping
 								(
-								ULONG ulCurrentQueryLevel,
-								const Var *pvar,
-								EPlStmtPhysicalOpType eplsphoptype
+								ULONG current_query_level,
+								const Var *var,
+								EPlStmtPhysicalOpType plstmt_physical_op_type
 								)
 								const;
 
@@ -114,62 +114,62 @@ namespace gpdxl
 			virtual
 			~CMappingVarColId()
 			{
-				m_pmvcmap->Release();
+				m_gpdb_att_opt_col_mapping->Release();
 			}
 
 			// given a gpdb attribute, return a column name in optimizer world
 			virtual
-			const CWStringBase *PstrColName
+			const CWStringBase *GetOptColName
 											(
-											ULONG ulCurrentQueryLevel,
-											const Var *pvar,
-											EPlStmtPhysicalOpType eplsphoptype
+											ULONG current_query_level,
+											const Var *var,
+											EPlStmtPhysicalOpType plstmt_physical_op_type
 											)
 											const;
 
 			// given a gpdb attribute, return column id
 			virtual
-			ULONG UlColId
+			ULONG GetColId
 							(
-							ULONG ulCurrentQueryLevel,
-							const Var *pvar,
-							EPlStmtPhysicalOpType eplsphoptype
+							ULONG current_query_level,
+							const Var *var,
+							EPlStmtPhysicalOpType plstmt_physical_op_type
 							)
 							const;
 
 			// load up mapping information from an index
-			void LoadIndexColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const IMDIndex *pmdindex, const CDXLTableDescr *pdxltabdesc);
+			void LoadIndexColumns(ULONG query_level, ULONG RTE_index, const IMDIndex *index, const CDXLTableDescr *table_descr);
 
 			// load up mapping information from table descriptor
-			void LoadTblColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const CDXLTableDescr *pdxltabdesc);
+			void LoadTblColumns(ULONG query_level, ULONG RTE_index, const CDXLTableDescr *table_descr);
 
 			// load up column id mapping information from the array of column descriptors
-			void LoadColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const DrgPdxlcd *pdrgdxlcd);
+			void LoadColumns(ULONG query_level, ULONG RTE_index, const CDXLColDescrArray *column_descrs);
 
 			// load up mapping information from derived table columns
-			void LoadDerivedTblColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const DrgPdxln *pdrgpdxlnDerivedColumns, List *plTargetList);
+			void LoadDerivedTblColumns(ULONG query_level, ULONG RTE_index, const CDXLNodeArray *derived_columns_dxl, List *target_list);
 
 			// load information from CTE columns
-			void LoadCTEColumns(ULONG ulQueryLevel, ULONG ulRTEIndex, const DrgPul *pdrgpulCTE, List *plTargetList);
+			void LoadCTEColumns(ULONG query_level, ULONG RTE_index, const ULongPtrArray *pdrgpulCTE, List *target_list);
 
 			// load up mapping information from scalar projection list
-			void LoadProjectElements(ULONG ulQueryLevel, ULONG ulRTEIndex, const CDXLNode *pdxlnPrL);
+			void LoadProjectElements(ULONG query_level, ULONG RTE_index, const CDXLNode *project_list_dxlnode);
 
 			// load up mapping information from list of column names
-			void Load(ULONG ulQueryLevel, ULONG ulRTEIndex,	CIdGenerator *pidgtor, List *plColNames);
+			void Load(ULONG query_level, ULONG RTE_index,	CIdGenerator *id_generator, List *col_names);
 
 			// create a deep copy
-			CMappingVarColId *PmapvarcolidCopy(IMemoryPool *pmp) const;
+			CMappingVarColId *CopyMapColId(IMemoryPool *mp) const;
 
 			// create a deep copy
-			CMappingVarColId *PmapvarcolidCopy(ULONG ulQueryLevel) const;
+			CMappingVarColId *CopyMapColId(ULONG query_level) const;
 			
 			// create a copy of the mapping replacing old col ids with new ones
-			CMappingVarColId *PmapvarcolidRemap
+			CMappingVarColId *CopyRemapColId
 				(
-				IMemoryPool *pmp,
-				DrgPul *pdrgpulOld,
-				DrgPul *pdrgpulNew
+				IMemoryPool *mp,
+				ULongPtrArray *old_colids,
+				ULongPtrArray *new_colids
 				)
 				const;
 	};

--- a/src/include/gpopt/translate/COptColInfo.h
+++ b/src/include/gpopt/translate/COptColInfo.h
@@ -37,51 +37,51 @@ namespace gpdxl
 		private:
 
 			// column id
-			ULONG m_ulColId;
+			ULONG m_colid;
 
 			// column name
-			CWStringBase *m_pstr;
+			CWStringBase *m_str;
 
 			// private copy c'tor
 			COptColInfo(const COptColInfo&);
 
 		public:
 			// ctor
-			COptColInfo(ULONG ulColId, CWStringBase *pstr)
-				: m_ulColId(ulColId), m_pstr(pstr)
+			COptColInfo(ULONG colid, CWStringBase *str)
+				: m_colid(colid), m_str(str)
 			{
-				GPOS_ASSERT(m_pstr);
+				GPOS_ASSERT(m_str);
 			}
 
 			// dtor
 			virtual
 			~COptColInfo()
 			{
-				GPOS_DELETE(m_pstr);
+				GPOS_DELETE(m_str);
 			}
 
 			// accessors
-			ULONG UlColId() const
+			ULONG GetColId() const
 			{
-				return m_ulColId;
+				return m_colid;
 			}
 
-			CWStringBase* PstrColName() const
+			CWStringBase* GetOptColName() const
 			{
-				return m_pstr;
+				return m_str;
 			}
 
 			// equality check
-			BOOL FEquals(const COptColInfo& optcolinfo) const
+			BOOL Equals(const COptColInfo& optcolinfo) const
 			{
 				// don't need to check name as column id is unique
-				return m_ulColId == optcolinfo.m_ulColId;
+				return m_colid == optcolinfo.m_colid;
 			}
 
 			// hash value
-			ULONG UlHash() const
+			ULONG HashValue() const
 			{
-				return gpos::UlHash(&m_ulColId);
+				return gpos::HashValue(&m_colid);
 			}
 
 	};
@@ -90,23 +90,23 @@ namespace gpdxl
 	inline
 	ULONG UlHashOptColInfo
 		(
-		const COptColInfo *poptcolinfo
+		const COptColInfo *opt_col_info
 		)
 	{
-		GPOS_ASSERT(NULL != poptcolinfo);
-		return poptcolinfo->UlHash();
+		GPOS_ASSERT(NULL != opt_col_info);
+		return opt_col_info->HashValue();
 	}
 
 	// equality function
 	inline
 	BOOL FEqualOptColInfo
 		(
-		const COptColInfo *poptcolinfoA,
-		const COptColInfo *poptcolinfoB
+		const COptColInfo *opt_col_infoA,
+		const COptColInfo *opt_col_infoB
 		)
 	{
-		GPOS_ASSERT(NULL != poptcolinfoA && NULL != poptcolinfoB);
-		return poptcolinfoA->FEquals(*poptcolinfoB);
+		GPOS_ASSERT(NULL != opt_col_infoA && NULL != opt_col_infoB);
+		return opt_col_infoA->Equals(*opt_col_infoB);
 	}
 
 }

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -52,52 +52,56 @@ namespace gpdxl
 	//---------------------------------------------------------------------------
 	class CQueryMutators
 	{
-		typedef Node *(*Pfnode) ();
-		typedef BOOL (*PfFallback) ();
+		typedef Node *(*MutatorWalkerFn) ();
+		typedef BOOL (*FallbackWalkerFn) ();
 
 		typedef struct SContextHavingQualMutator
 		{
 			public:
 				// memory pool
-				IMemoryPool *m_pmp;
+				IMemoryPool *m_mp;
 
 				// MD accessor for function names
-				CMDAccessor *m_pmda;
+				CMDAccessor *m_md_accessor;
 
 				// the counter for Query's total number of target entries
-				ULONG m_ulTECount;
+				ULONG m_num_target_entries;
 
 				// the target list of the new group by query
-				List *m_plTENewGroupByQuery;
+				List *m_groupby_target_list;
 
 				// the current query level
-				ULONG m_ulCurrLevelsUp;
+				ULONG m_current_query_level;
 
 		 	 	// indicate whether we are mutating the argument of an aggregate
-				BOOL m_fAggregateArg;
+				BOOL m_is_mutating_agg_arg;
 
 				// indicate the levels up of the aggregate we are mutating
-				ULONG m_ulAggregateLevelUp;
+				ULONG m_agg_levels_up;
 				
 				// fall back to the planner by raising an expression since we encountered an
 				// expression / attribute that we could not resolve
-				BOOL m_fFallbackToPlanner;
+				BOOL m_should_fallback;
 
 				// ctor
-				SContextHavingQualMutator(IMemoryPool *pmp,
-										  CMDAccessor *pmda,
-										  ULONG ulTECount,
-										  List *plTENewGroupByQuery)
-					: m_pmp(pmp),
-					  m_pmda(pmda),
-					  m_ulTECount(ulTECount),
-					  m_plTENewGroupByQuery(plTENewGroupByQuery),
-					  m_ulCurrLevelsUp(0),
-					  m_fAggregateArg(false),
-					  m_ulAggregateLevelUp(gpos::ulong_max),
-					  m_fFallbackToPlanner(false)
+				SContextHavingQualMutator
+					(
+					IMemoryPool *mp,
+					CMDAccessor *md_accessor,
+					ULONG num_target_entries,
+					List *groupby_target_list
+					)
+					:
+					m_mp(mp),
+					m_md_accessor(md_accessor),
+					m_num_target_entries(num_target_entries),
+					m_groupby_target_list(groupby_target_list),
+					m_current_query_level(0),
+					m_is_mutating_agg_arg(false),
+					m_agg_levels_up(gpos::ulong_max),
+					m_should_fallback(false)
 				{
-					GPOS_ASSERT(NULL != plTENewGroupByQuery);
+					GPOS_ASSERT(NULL != groupby_target_list);
 				}
 
 				// dtor
@@ -111,42 +115,42 @@ namespace gpdxl
 			public:
 
 				// memory pool
-				IMemoryPool *m_pmp;
+				IMemoryPool *m_mp;
 
 				// MD accessor to get the function name
-				CMDAccessor *m_pmda;
+				CMDAccessor *m_md_accessor;
 
 				// original query
-				Query *m_pquery;
+				Query *m_query;
 
 				// the new target list of the group by query
-				List *m_plTENewGroupByQuery;
+				List *m_groupby_target_list;
 
 				// the current query level
-				ULONG m_ulCurrLevelsUp;
+				ULONG m_current_query_level;
 
 				// the sorting / grouping reference of the original target list entry
-				ULONG m_ulRessortgroupref;
+				ULONG m_sort_group_ref;
 
 				// indicate whether we are mutating the argument of an aggregate
-				BOOL m_fAggregateArg;
+				BOOL m_is_mutating_agg_arg;
 
 				// ctor
 				SContextGrpbyPlMutator
 					(
-					IMemoryPool *pmp,
-					CMDAccessor *pmda,
-					Query *pquery,
-					List *plTENewGroupByQuery
+					IMemoryPool *mp,
+					CMDAccessor *md_accessor,
+					Query *query,
+					List *groupby_target_list
 					)
 					:
-					m_pmp(pmp),
-					m_pmda(pmda),
-					m_pquery(pquery),
-					m_plTENewGroupByQuery(plTENewGroupByQuery),
-					m_ulCurrLevelsUp(0),
-					m_ulRessortgroupref(0),
-					m_fAggregateArg(false)
+					m_mp(mp),
+					m_md_accessor(md_accessor),
+					m_query(query),
+					m_groupby_target_list(groupby_target_list),
+					m_current_query_level(0),
+					m_sort_group_ref(0),
+					m_is_mutating_agg_arg(false)
 				{
 				}
 
@@ -161,20 +165,20 @@ namespace gpdxl
 			public:
 
 				// the current query level
-				ULONG m_ulCurrLevelsUp;
+				ULONG m_current_query_level;
 				
 				// fix target list entry of the top level
-				BOOL m_fFixTargetListTopLevel;
+				BOOL m_should_fix_top_level_target_list;
 
 				// ctor
 				SContextIncLevelsupMutator
 					(
-					ULONG ulCurrLevelsUp,
-					BOOL fFixTargetListTopLevel
+					ULONG current_query_level,
+					BOOL should_fix_top_level_target_list
 					)
 					:
-					m_ulCurrLevelsUp(ulCurrLevelsUp),
-					m_fFixTargetListTopLevel(fFixTargetListTopLevel)
+					m_current_query_level(current_query_level),
+					m_should_fix_top_level_target_list(should_fix_top_level_target_list)
 				{
 				}
 
@@ -190,20 +194,20 @@ namespace gpdxl
 					public:
 
 						// list of target list entries in the query
-						List *m_plTE;
+						List *m_target_entries;
 
 						// list of grouping clauses
-						List *m_groupClause;
+						List *m_group_clause;
 
 						// ctor
 						SContextTLWalker
 							(
-							List *plTE,
-							List *groupClause
+							List *target_entries,
+							List *group_clause
 							)
 							:
-							m_plTE(plTE),
-							m_groupClause(groupClause)
+							m_target_entries(target_entries),
+							m_group_clause(group_clause)
 						{
 						}
 
@@ -217,107 +221,107 @@ namespace gpdxl
 
 			// check if the cte levels up needs to be corrected
 			static
-			BOOL FNeedsLevelsUpCorrection(SContextIncLevelsupMutator *pctxinclvlmutator, Index idxCtelevelsup);
+			BOOL NeedsLevelsUpCorrection(SContextIncLevelsupMutator *context, Index cte_levels_up);
 
 		public:
 
 			// fall back during since the target list refers to a attribute which algebrizer at this point cannot resolve
 			static
-			BOOL FNeedsToFallback(Node *pnode, void *pctx);
+			BOOL ShouldFallback(Node *node, SContextTLWalker *context);
 
 			// check if the project list contains expressions on aggregates thereby needing normalization
 			static
-			BOOL FNeedsPrLNormalization(const Query *pquery);
+			BOOL NeedsProjListNormalization(const Query *query);
 
 			// normalize query
 			static
-			Query *PqueryNormalize(IMemoryPool *pmp, CMDAccessor *pmda, const Query *pquery, ULONG ulQueryLevel);
+			Query *NormalizeQuery(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query, ULONG query_level);
 
 			// check if the project list contains expressions on window operators thereby needing normalization
 			static
-			BOOL FNeedsWindowPrLNormalization(const Query *pquery);
+			BOOL NeedsProjListWindowNormalization(const Query *query);
 
 			// flatten expressions in window operation project list
 			static
-			Query *PqueryNormalizeWindowPrL(IMemoryPool *pmp, CMDAccessor *pmda, const Query *pquery);
+			Query *NormalizeWindowProjList(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
 
 			// traverse the project list to extract all window functions in an arbitrarily complex project element
 			static
-			Node *PnodeWindowPrLMutator(Node *pnode, void *ctx);
+			Node *RunWindowProjListMutator(Node *node, SContextGrpbyPlMutator *context);
 
 			// flatten expressions in project list
 			static
-			Query *PqueryNormalizeGrpByPrL(IMemoryPool *pmp, CMDAccessor *pmda, const Query *pquery);
+			Query *NormalizeGroupByProjList(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
 
 			// make a copy of the aggref (minus the arguments)
 			static
-			Aggref *PaggrefFlatCopy(Aggref *paggrefOld);
+			Aggref *FlatCopyAggref(Aggref *aggref);
 
 			// create a new entry in the derived table and return its corresponding var
 			static
-			Var *PvarInsertIntoDerivedTable(Node *pnode, SContextHavingQualMutator *context);
+			Var *MakeVarInDerivedTable(Node *node, SContextHavingQualMutator *context);
 
 			// check if a matching node exists in the list of target entries
 			static
-			Node *PnodeFind(Node *pnode, SContextHavingQualMutator *pctx);
+			Node *FindNodeInTargetEntries(Node *node, SContextHavingQualMutator *context);
 
 			// increment the levels up of outer references
 			static
-			Var *PvarOuterReferenceIncrLevelsUp(Var *pvar);
+			Var *IncrLevelsUpInVar(Var *var);
 
 			// pull up having clause into a select
 			static
-			Query *PqueryNormalizeHaving(IMemoryPool *pmp, CMDAccessor *pmda, const Query *pquery);
+			Query *NormalizeHaving(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
 
 			// traverse the expression and fix the levels up of any outer reference
 			static
-			Node *PnodeIncrementLevelsupMutator(Node *pnode, void *ctx);
+			Node *RunIncrLevelsUpMutator(Node *node, SContextIncLevelsupMutator *context);
 
 			// traverse the expression and fix the levels up of any CTE
 			static
-			Node *PnodeFixCTELevelsupMutator(Node *pnode, void *ctx);
+			Node *RunFixCTELevelsUpMutator(Node *node, SContextIncLevelsupMutator *context);
 
 			// traverse the project list of a groupby operator, to
 			// extract all aggregate functions in an arbitrarily complex project element,
 			static
-			Node *PnodeGrpbyPrLMutator(Node *pnode, void *ctx);
+			Node *RunGroupByProjListMutator(Node *node, SContextGrpbyPlMutator *context);
 
 			// mutate the grouping columns, fix levels up when necessary
 			static
-			Node *PnodeGrpColMutator(Node *pnode, void *pctx);
+			Node *RunGroupingColMutator(Node *node, SContextGrpbyPlMutator *context);
 
 			// fix the level up of grouping columns when necessary
 			static
-			Node *PnodeFixGrpCol(Node *pnode, TargetEntry *pteOriginal, SContextGrpbyPlMutator *pctxGrpByMutator);
+			Node *FixGroupingCols(Node *node, TargetEntry *original, SContextGrpbyPlMutator *context);
 
 			// return a target entry for the aggregate or percentile expression
 			static
-			TargetEntry *PteAggregateOrPercentileExpr(IMemoryPool *pmp, CMDAccessor *pmda, Node *pnode, ULONG ulAttno);
+			TargetEntry *PteAggregateOrPercentileExpr(IMemoryPool *mp, CMDAccessor *md_accessor, Node *node, ULONG attno);
 
 			// traverse the having qual to extract all aggregate functions,
 			// fix correlated vars and return the modified having qual
 			static
-			Node *PnodeHavingQualMutator(Node *pnode, void *ctx);
+			Node *RunHavingQualMutator(Node *node, SContextHavingQualMutator *context);
 
 			// for a given an TE in the derived table, create a new TE to be added to the top level query
 			static
-			TargetEntry *Pte(TargetEntry *pte, ULONG ulVarAttno);
+			TargetEntry *MakeTopLevelTargetEntry(TargetEntry *target_entry, ULONG attno);
 
 			// return the column name of the target entry
 			static
-			CHAR* SzTEName(TargetEntry *pte, Query *pquery);
+			CHAR* GetTargetEntryColName(TargetEntry *target_entry, Query *query);
 
 			// make the input query into a derived table and return a new root query
 			static
-			Query *PqueryConvertToDerivedTable(const Query *pquery, BOOL fFixTargetList, BOOL fFixHavingQual);
+			Query *ConvertToDerivedTable(const Query *query, BOOL should_fix_target_list, BOOL should_fix_having_qual);
 
 			// eliminate distinct clause
 			static
-			Query *PqueryEliminateDistinctClause(const Query *pquery);
+			Query *EliminateDistinctClause(const Query *query);
 
 			// reassign the sorting clause from the derived table to the new top-level query
 			static
-			void ReassignSortClause(Query *pqueryNew, Query *pqueryDrdTbl);
+			void ReassignSortClause(Query *top_level_query, Query *derive_table_query);
 
 			// fix window frame edge boundary when its value is defined by a subquery
 			static

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -87,7 +87,7 @@ namespace gpdxl
 	class CTranslatorDXLToPlStmt
 	{
 		// shorthand for functions for translating DXL operator nodes into planner trees
-		typedef Plan * (CTranslatorDXLToPlStmt::*PfPplan)(const CDXLNode *pdxln, CDXLTranslateContext *pdxltrctxOut, DrgPdxltrctx *pdrgpdxltrctxPrevSiblings);
+		typedef Plan * (CTranslatorDXLToPlStmt::*PfPplan)(const CDXLNode *dxlnode, CDXLTranslateContext *output_context, CDXLTranslationContextArray *ctxt_translation_prev_siblings);
 
 		private:
 
@@ -95,67 +95,67 @@ namespace gpdxl
 			struct STranslatorMapping
 			{
 				// type
-				Edxlopid edxlopid;
+				Edxlopid dxl_op_id;
 
 				// translator function pointer
-				PfPplan pf;
+				PfPplan dxlnode_to_logical_funct;
 			};
 
 			// context for fixing index var attno
 			struct SContextIndexVarAttno
 			{
 				// MD relation
-				const IMDRelation *m_pmdrel;
+				const IMDRelation *m_md_rel;
 
 				// MD index
-				const IMDIndex *m_pmdindex;
+				const IMDIndex *m_md_index;
 
 				// ctor
 				SContextIndexVarAttno
 					(
-					const IMDRelation *pmdrel,
-					const IMDIndex *pmdindex
+					const IMDRelation *md_rel,
+					const IMDIndex *md_index
 					)
 					:
-					m_pmdrel(pmdrel),
-					m_pmdindex(pmdindex)
+					m_md_rel(md_rel),
+					m_md_index(md_index)
 				{
-					GPOS_ASSERT(NULL != pmdrel);
-					GPOS_ASSERT(NULL != pmdindex);
+					GPOS_ASSERT(NULL != md_rel);
+					GPOS_ASSERT(NULL != index);
 				}
 			}; // SContextIndexVarAttno
 
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// meta data accessor
-			CMDAccessor *m_pmda;
+			CMDAccessor *m_md_accessor;
 
 			// DXL operator translators indexed by the operator id
-			PfPplan m_rgpfTranslators[EdxlopSentinel];
+			PfPplan m_dxlop_translator_func_mapping_array[EdxlopSentinel];
 
-			CContextDXLToPlStmt *m_pctxdxltoplstmt;
+			CContextDXLToPlStmt *m_dxl_to_plstmt_context;
 			
-			CTranslatorDXLToScalar *m_pdxlsctranslator;
+			CTranslatorDXLToScalar *m_translator_dxl_to_scalar;
 
 			// command type
-			CmdType m_cmdtype;
+			CmdType m_cmd_type;
 			
 			// is target table distributed, false when in non DML statements
-			BOOL m_fTargetTableDistributed;
+			BOOL m_is_tgt_tbl_distributed;
 			
 			// list of result relations range table indexes for DML statements,
 			// or NULL for select queries
-			List *m_plResultRelations;
+			List *m_result_rel_list;
 			
 			// external scan counter
-			ULONG m_ulExternalScanCounter;
+			ULONG m_external_scan_counter;
 			
 			// number of segments
-			ULONG m_ulSegments;
+			ULONG m_num_of_segments;
 
 			// partition selector counter
-			ULONG m_ulPartitionSelectorCounter;
+			ULONG m_partition_selector_counter;
 
 			// private copy ctor
 			CTranslatorDXLToPlStmt(const CTranslatorDXLToPlStmt&);
@@ -244,28 +244,28 @@ namespace gpdxl
 
 			// walker to set index var attno's
 			static
-			BOOL FSetIndexVarAttno(Node *pnode, SContextIndexVarAttno *pctxtidxvarattno);
+			BOOL SetIndexVarAttnoWalker(Node *node, SContextIndexVarAttno *ctxt_index_var_attno_walker);
 
 		public:
 			// ctor
-			CTranslatorDXLToPlStmt(IMemoryPool *pmp, CMDAccessor *pmda, CContextDXLToPlStmt *pctxdxltoplstmt, ULONG ulSegments);
+			CTranslatorDXLToPlStmt(IMemoryPool *mp, CMDAccessor *md_accessor, CContextDXLToPlStmt *dxl_to_plstmt_context, ULONG num_of_segments);
 
 			// dtor
 			~CTranslatorDXLToPlStmt();
 
 			// translate DXL operator node into a Plan node
-			Plan *PplFromDXL
+			Plan *TranslateDXLOperatorToPlan
 				(
-				const CDXLNode *pdxln,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// main translation routine for DXL tree -> PlannedStmt
-			PlannedStmt *PplstmtFromDXL(const CDXLNode *pdxln, bool canSetTag);
+			PlannedStmt *GetPlannedStmtFromDXL(const CDXLNode *dxlnode, bool can_set_tag);
 
 			// translate the join types from its DXL representation to the GPDB one
-			static JoinType JtFromEdxljt(EdxlJoinType edxljt);
+			static JoinType GetGPDBJoinTypeFromDXLJoinType(EdxlJoinType join_type);
 
 		private:
 
@@ -282,94 +282,94 @@ namespace gpdxl
 			void SetInitPlanVariables(PlannedStmt *);
 
 			// translate DXL table scan node into a SeqScan node
-			Plan *PtsFromDXLTblScan
+			Plan *TranslateDXLTblScan
 				(
-				const CDXLNode *pdxlnTblScan,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *tbl_scan_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL index scan node into a IndexScan node
-			Plan *PisFromDXLIndexScan
+			Plan *TranslateDXLIndexScan
 				(
-				const CDXLNode *pdxlnIndexScan,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *index_scan_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translates a DXL index scan node into a IndexScan node
-			Plan *PisFromDXLIndexScan
+			Plan *TranslateDXLIndexScan
 				(
-				const CDXLNode *pdxlnIndexScan,
-				CDXLPhysicalIndexScan *pdxlopIndexScan,
-				CDXLTranslateContext *pdxltrctxOut,
-				BOOL fIndexOnlyScan,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *index_scan_dxlnode,
+				CDXLPhysicalIndexScan *dxl_physical_idx_scan_op,
+				CDXLTranslateContext *output_context,
+				BOOL is_index_only_scan,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL hash join into a HashJoin node
-			Plan *PhjFromDXLHJ
+			Plan *TranslateDXLHashJoin
 				(
-				const CDXLNode *pdxlnHJ,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *TranslateDXLHashJoin,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL nested loop join into a NestLoop node
-			Plan *PnljFromDXLNLJ
+			Plan *TranslateDXLNLJoin
 				(
-				const CDXLNode *pdxlnNLJ,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *nl_join_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL merge join into a MergeJoin node
-			Plan *PmjFromDXLMJ
+			Plan *TranslateDXLMergeJoin
 				(
-				const CDXLNode *pdxlnMJ,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *merge_join_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL motion node into GPDB Motion plan node
-			Plan *PplanMotionFromDXLMotion
+			Plan *TranslateDXLMotion
 				(
-				const CDXLNode *pdxlnMotion,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *motion_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL motion node
-			Plan *PplanTranslateDXLMotion
+			Plan *TranslateDXLDuplicateSensitiveMotion
 				(
-				const CDXLNode *pdxlnMotion,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *motion_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL duplicate sensitive redistribute motion node into 
 			// GPDB result node with hash filters
-			Plan *PplanResultHashFilters
+			Plan *TranslateDXLRedistributeMotionToResultHashFilters
 				(
-				const CDXLNode *pdxlnMotion,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *motion_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL aggregate node into GPDB Agg plan node
-			Plan *PaggFromDXLAgg
+			Plan *TranslateDXLAgg
 				(
-				const CDXLNode *pdxlnMotion,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *motion_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL window node into GPDB window node
-			Plan *PwindowFromDXLWindow
+			Plan *TranslateDXLWindow
 				(
-				const CDXLNode *pdxlnMotion,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *motion_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate the DXL window frame into GPDB window frame node
@@ -382,239 +382,239 @@ namespace gpdxl
 				);
 
 			// translate DXL sort node into GPDB Sort plan node
-			Plan *PsortFromDXLSort
+			Plan *TranslateDXLSort
 				(
-				const CDXLNode *pdxlnSort,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *sort_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate a DXL node into a Hash node
-			Plan *PhhashFromDXL
+			Plan *TranslateDXLHash
 				(
-				const CDXLNode *pdxln,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL Limit node into a Limit node
-			Plan *PlimitFromDXLLimit
+			Plan *TranslateDXLLimit
 				(
-				const CDXLNode *pdxlnLimit,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *limit_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL TVF into a GPDB Function Scan node
-			Plan *PplanFunctionScanFromDXLTVF
+			Plan *TranslateDXLTvf
 				(
-				const CDXLNode *pdxlnTVF,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *tvf_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
-			Plan *PsubqscanFromDXLSubqScan
+			Plan *TranslateDXLSubQueryScan
 				(
-				const CDXLNode *pdxlnSubqScan,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *subquery_scan_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
-			Plan *PresultFromDXLResult
+			Plan *TranslateDXLResult
 				(
-				const CDXLNode *pdxlnResult,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *result_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
-			Plan *PappendFromDXLAppend
+			Plan *TranslateDXLAppend
 				(
-				const CDXLNode *pdxlnAppend,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *append_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
-			Plan *PmatFromDXLMaterialize
+			Plan *TranslateDXLMaterialize
 				(
-				const CDXLNode *pdxlnMaterialize,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *materialize_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
-			Plan *PshscanFromDXLSharedScan
+			Plan *TranslateDXLSharedScan
 				(
-				const CDXLNode *pdxlnSharedScan,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *shared_scan_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate a sequence operator
-			Plan *PplanSequence
+			Plan *TranslateDXLSequence
 				(
-				const CDXLNode *pdxlnSequence,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *sequence_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate a dynamic table scan operator
-			Plan *PplanDTS
+			Plan *TranslateDXLDynTblScan
 				(
-				const CDXLNode *pdxlnDTS,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *dyn_tbl_scan_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);	
 			
 			// translate a dynamic index scan operator
-			Plan *PplanDIS
+			Plan *TranslateDXLDynIdxScan
 				(
-				const CDXLNode *pdxlnDIS,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *dyn_idx_scan_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 			
 			// translate a DML operator
-			Plan *PplanDML
+			Plan *TranslateDXLDml
 				(
-				const CDXLNode *pdxlnDML,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *dml_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate a Split operator
-			Plan *PplanSplit
+			Plan *TranslateDXLSplit
 				(
-				const CDXLNode *pdxlnSplit,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *split_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 			
 			// translate a row trigger operator
-			Plan *PplanRowTrigger
+			Plan *TranslateDXLRowTrigger
 				(
-				const CDXLNode *pdxlnRowTrigger,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *row_trigger_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate an Assert operator
-			Plan *PplanAssert
+			Plan *TranslateDXLAssert
 				(
-				const CDXLNode *pdxlnAssert,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *assert_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// Initialize spooling information
 			void InitializeSpoolingInfo
 				(
-				Plan *pplan,
-				ULONG ulShareId
+				Plan *plan,
+				ULONG share_id
 				);
 
 			// retrieve the flow of the shared input scan of the cte consumers
-			Flow *PflowCTEConsumer(List *plshscanCTEConsumer);
+			Flow *GetFlowCTEConsumer(List *shared_scan_cte_consumer_list);
 
 			// translate a CTE producer into a GPDB share input scan
-			Plan *PshscanFromDXLCTEProducer
+			Plan *TranslateDXLCTEProducerToSharedScan
 				(
-				const CDXLNode *pdxlnCTEProducer,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *cte_producer_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate a CTE consumer into a GPDB share input scan
-			Plan *PshscanFromDXLCTEConsumer
+			Plan *TranslateDXLCTEConsumerToSharedScan
 				(
-				const CDXLNode *pdxlnCTEConsumer,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *cte_consumer_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate a (dynamic) bitmap table scan operator
-			Plan *PplanBitmapTableScan
+			Plan *TranslateDXLBitmapTblScan
 				(
-				const CDXLNode *pdxlnBitmapScan,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *bitmapscan_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate a DXL PartitionSelector into a GPDB PartitionSelector
-			Plan *PplanPartitionSelector
+			Plan *TranslateDXLPartSelector
 				(
-				const CDXLNode *pdxlnPartitionSelector,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings // translation contexts of previous siblings
+				const CDXLNode *partition_selector_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate a DXL Value Scan into GPDB Value Scan
-			Plan *PplanValueScan
+			Plan *TranslateDXLValueScan
 				(
-				const CDXLNode *pdxlnValueScan,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+				const CDXLNode *value_scan_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings
 				);
 
 			// translate DXL filter list into GPDB filter list
-			List *PlFilterList
+			List *TranslateDXLFilterList
 				(
-				const CDXLNode *pdxlnFilterList,
-				const CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut
+				const CDXLNode *filter_list_dxlnode,
+				const CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *child_contexts,
+				CDXLTranslateContext *output_context
 				);
 
 			// create range table entry from a CDXLPhysicalTVF node
-			RangeTblEntry *PrteFromDXLTVF
+			RangeTblEntry *TranslateDXLTvfToRangeTblEntry
 				(
-				const CDXLNode *pdxlnTVF,
-				CDXLTranslateContext *pdxltrctxOut,
-				CDXLTranslateContextBaseTable *pdxltrctxbt
+				const CDXLNode *tvf_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslateContextBaseTable *base_table_context
 				);
 
 			// create range table entry from a CDXLPhysicalValueScan node
-			RangeTblEntry *PrteFromDXLValueScan
+			RangeTblEntry *TranslateDXLValueScanToRangeTblEntry
 				(
-				const CDXLNode *pdxlnValueScan,
-				CDXLTranslateContext *pdxltrctxOut,
-				CDXLTranslateContextBaseTable *pdxltrctxbt
+				const CDXLNode *value_scan_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslateContextBaseTable *base_table_context
 				);
 
 			// create range table entry from a table descriptor
-			RangeTblEntry *PrteFromTblDescr
+			RangeTblEntry *TranslateDXLTblDescrToRangeTblEntry
 				(
-				const CDXLTableDescr *pdxltabdesc,
-				const CDXLIndexDescr *pdxlid,
-				Index iRel,
-				CDXLTranslateContextBaseTable *pdxltrctxbtOut
+				const CDXLTableDescr *table_descr,
+				const CDXLIndexDescr *index_descr_dxl,
+				Index index,
+				CDXLTranslateContextBaseTable *base_table_context
 				);
 
 			// translate DXL projection list into a target list
-			List *PlTargetListFromProjList
+			List *TranslateDXLProjList
 				(
-				const CDXLNode *pdxlnPrL,
-				const CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut
+				const CDXLNode *project_list_dxlnode,
+				const CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *child_contexts,
+				CDXLTranslateContext *output_context
 				);
 			
 			// insert NULL values for dropped attributes to construct the target list for a DML statement
-			List *PlTargetListWithDroppedCols(List *plTargetList, const IMDRelation *pmdrel);
+			List *CreateTargetListWithNullsForDroppedCols(List *target_list, const IMDRelation *md_rel);
 
 			// create a target list containing column references for a hash node from the
 			// project list of its child node
-			List *PlTargetListForHashNode
+			List *TranslateDXLProjectListToHashTargetList
 				(
-				const CDXLNode *pdxlnPrL,
-				CDXLTranslateContext *pdxltrctxChild,
-				CDXLTranslateContext *pdxltrctxOut
+				const CDXLNode *project_list_dxlnode,
+				CDXLTranslateContext *child_context,
+				CDXLTranslateContext *output_context
 				);
 			
-			List *PlQualFromFilter
+			List *TranslateDXLFilterToQual
 				(
-				const CDXLNode *pdxlnFilter,
-				const CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut
+				const CDXLNode *filter_dxlnode,
+				const CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *child_contexts,
+				CDXLTranslateContext *output_context
 				);
 
 
@@ -622,164 +622,164 @@ namespace gpdxl
 			// used by GPDB
 			void TranslatePlanCosts
 				(
-				const CDXLOperatorCost *pdxlopcost,
-				Cost *pcostStartupOut,
-				Cost *pcostTotalOut,
-				Cost *pcostRowsOut,
-				INT *piWidthOut
+				const CDXLOperatorCost *dxl_operator_cost,
+				Cost *startup_cost_out,
+				Cost *total_cost_out,
+				Cost *cost_rows_out,
+				INT *width_out
 				);
 
 			// shortcut for translating both the projection list and the filter
 			void TranslateProjListAndFilter
 				(
-				const CDXLNode *pdxlnPrL,
-				const CDXLNode *pdxlnFilter,
-				const CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctx,
-				List **pplTargetListOut,
-				List **pplQualOut,
-				CDXLTranslateContext *pdxltrctxOut
+				const CDXLNode *project_list_dxlnode,
+				const CDXLNode *filter_dxlnode,
+				const CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *child_contexts,
+				List **targetlist_out,
+				List **qual_out,
+				CDXLTranslateContext *output_context
 				);
 
 			// translate the hash expr list of a redistribute motion node
 			void TranslateHashExprList
 				(
-				const CDXLNode *pdxlnHashExprList,
-				const CDXLTranslateContext *pdxltrctxChild,
-				List **pplHashExprOut,
-				List **pplHashExprTypesOut,
-				CDXLTranslateContext *pdxltrctxOut
+				const CDXLNode *hash_expr_list_dxlnode,
+				const CDXLTranslateContext *child_context,
+				List **hash_expr_out_list,
+				List **hash_expr_types_out_list,
+				CDXLTranslateContext *output_context
 				);
 
 			// translate the tree of bitmap index operators that are under a (dynamic) bitmap table scan
-			Plan *PplanBitmapAccessPath
+			Plan *TranslateDXLBitmapAccessPath
 				(
-				const CDXLNode *pdxlnBitmapAccessPath,
-				CDXLTranslateContext *pdxltrctxOut,
-				const IMDRelation *pmdrel,
-				const CDXLTableDescr *pdxltabdesc,
-				CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-				BitmapTableScan *pdbts
+				const CDXLNode *bitmap_access_path_dxlnode,
+				CDXLTranslateContext *output_context,
+				const IMDRelation *md_rel,
+				const CDXLTableDescr *table_descr,
+				CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+				BitmapTableScan *bitmap_tbl_scan
 				);
 
 			// translate a bitmap bool op expression
-			Plan *PplanBitmapBoolOp
+			Plan *TranslateDXLBitmapBoolOp
 				(
-				const CDXLNode *pdxlnBitmapBoolOp,
-				CDXLTranslateContext *pdxltrctxOut,
-				const IMDRelation *pmdrel,
-				const CDXLTableDescr *pdxltabdesc,
-				CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-				BitmapTableScan *pdbts
+				const CDXLNode *bitmap_boolop_dxlnode,
+				CDXLTranslateContext *output_context,
+				const IMDRelation *md_rel,
+				const CDXLTableDescr *table_descr,
+				CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+				BitmapTableScan *bitmap_tbl_scan
 				);
 			
 			// translate CDXLScalarBitmapIndexProbe into BitmapIndexScan
-			Plan *PplanBitmapIndexProbe
+			Plan *TranslateDXLBitmapIndexProbe
 				(
-				const CDXLNode *pdxlnBitmapIndexProbe,
-				CDXLTranslateContext *pdxltrctxOut,
-				const IMDRelation *pmdrel,
-				const CDXLTableDescr *pdxltabdesc,
-				CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-				BitmapTableScan *pdbts
+				const CDXLNode *bitmap_index_probe_dxlnode,
+				CDXLTranslateContext *output_context,
+				const IMDRelation *md_rel,
+				const CDXLTableDescr *table_descr,
+				CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+				BitmapTableScan *bitmap_tbl_scan
 				);
 
 			void TranslateSortCols
 				(
-				const CDXLNode *pdxlnSortColList,
-				const CDXLTranslateContext *pdxltrctxChild,
-				AttrNumber *pattnoSortColIds,
-				Oid *poidSortOpIds,
-				bool *pboolNullsFirst
+				const CDXLNode *sort_col_list_dxl,
+				const CDXLTranslateContext *child_context,
+				AttrNumber *att_no_sort_colids,
+				Oid *sort_op_oids,
+				bool *is_nulls_first
 				);
 
-			List *PlQualFromScalarCondNode
+			List *TranslateDXLScCondToQual
 				(
-				const CDXLNode *pdxlnFilter,
-				const CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctx,
-				CDXLTranslateContext *pdxltrctxOut
+				const CDXLNode *filter_dxlnode,
+				const CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *child_contexts,
+				CDXLTranslateContext *output_context
 				);
 
 			// parse string value into a Const
 			static
-			Cost CostFromStr(const CWStringBase *pstr);
+			Cost CostFromStr(const CWStringBase *str);
 
 			// check if the given operator is a DML operator on a distributed table
-			BOOL FTargetTableDistributed(CDXLOperator *pdxlop);
+			BOOL IsTgtTblDistributed(CDXLOperator *dxlop);
 
 			// add a target entry for the given colid to the given target list
-			ULONG UlAddTargetEntryForColId
+			ULONG AddTargetEntryForColId
 				(
-				List **pplTargetList, 
-				CDXLTranslateContext *pdxltrctx, 
-				ULONG ulColId, 
-				BOOL fResjunk
+				List **target_list,
+				CDXLTranslateContext *dxl_translate_ctxt,
+				ULONG colid,
+				BOOL is_resjunk
 				);
 			
 			// translate the index condition list in an Index scan
 			void TranslateIndexConditions
 				(
-				CDXLNode *pdxlnIndexCondList,
-				const CDXLTableDescr *pdxltd,
-				BOOL fIndexOnlyScan,
-				const IMDIndex *pmdindex,
-				const IMDRelation *pmdrel,
-				CDXLTranslateContext *pdxltrctxOut,
-				CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings,
-				List **pplIndexConditions,
-				List **pplIndexOrigConditions,
-				List **pplIndexStratgey,
-				List **pplIndexSubtype
+				CDXLNode *index_cond_list_dxlnode,
+				const CDXLTableDescr *dxl_tbl_descr,
+				BOOL is_index_only_scan,
+				const IMDIndex *index,
+				const IMDRelation *md_rel,
+				CDXLTranslateContext *output_context,
+				CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings,
+				List **index_cond,
+				List **index_orig_cond,
+				List **index_strategy_list,
+				List **index_subtype_list
 				);
 			
 			// translate the index filters
-			List *PlTranslateIndexFilter
+			List *TranslateDXLIndexFilter
 				(
-				CDXLNode *pdxlnFilter,
-				CDXLTranslateContext *pdxltrctxOut,
-				CDXLTranslateContextBaseTable *pdxltrctxbt,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
+				CDXLNode *filter_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslateContextBaseTable *base_table_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings
 				);
 			
 			// translate the assert constraints
-			List *PlTranslateAssertConstraints
+			List *TranslateDXLAssertConstraints
 				(
-				CDXLNode *pdxlnFilter,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctx
+				CDXLNode *filter_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *child_contexts
 				);
 
 			// translate a CTAS operator
-			Plan *PplanCTAS
+			Plan *TranslateDXLCtas
 				(
-				const CDXLNode *pdxlnDML,
-				CDXLTranslateContext *pdxltrctxOut,
-				DrgPdxltrctx *pdrgpdxltrctxPrevSiblings = NULL // translation contexts of previous siblings
+				const CDXLNode *dml_dxlnode,
+				CDXLTranslateContext *output_context,
+				CDXLTranslationContextArray *ctxt_translation_prev_siblings = NULL // translation contexts of previous siblings
 				);
 			
 			// sets the vartypmod fields in the target entries of the given target list
 			static
-			void SetVarTypMod(const CDXLPhysicalCTAS *pdxlop, List *plTargetList);
+			void SetVarTypMod(const CDXLPhysicalCTAS *dxlop, List *target_list);
 
 			// translate the into clause for a DXL physical CTAS operator
-			IntoClause *PintoclFromCtas(const CDXLPhysicalCTAS *pdxlop);
+			IntoClause *TranslateDXLPhyCtasToIntoClause(const CDXLPhysicalCTAS *dxlop);
 			
 			// translate the distribution policy for a DXL physical CTAS operator
-			GpPolicy *PdistrpolicyFromCtas(const CDXLPhysicalCTAS *pdxlop);
+			GpPolicy *TranslateDXLPhyCtasToDistrPolicy(const CDXLPhysicalCTAS *dxlop);
 
 			// translate CTAS storage options
-			List *PlCtasOptions(CDXLCtasStorageOptions::DrgPctasOpt *pdrgpctasopt);
+			List *TranslateDXLCtasStorageOptions(CDXLCtasStorageOptions::CDXLCtasOptionArray *ctas_storage_options);
 			
 			// compute directed dispatch segment ids
-			List *PlDirectDispatchSegIds(CDXLDirectDispatchInfo *pdxlddinfo);
+			List *TranslateDXLDirectDispatchInfo(CDXLDirectDispatchInfo *dxl_direct_dispatch_info);
 			
 			// hash a DXL datum with GPDB's hash function
-			ULONG UlCdbHash(DrgPdxldatum *pdrgpdxldatum);
+			ULONG GetDXLDatumGPDBHash(CDXLDatumArray *dxl_datum_array);
 
 	};
 }

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -74,7 +74,7 @@ namespace gpdxl
 	class CTranslatorDXLToScalar
 	{
 		// shorthand for functions for translating DXL nodes to GPDB expressions
-		typedef Expr * (CTranslatorDXLToScalar::*PfPexpr)(const CDXLNode *pdxln, CMappingColIdVar *pmapcidvar);
+		typedef Expr * (CTranslatorDXLToScalar::*expr_func_ptr)(const CDXLNode *dxlnode, CMappingColIdVar *colid_var);
 
 		private:
 
@@ -82,248 +82,248 @@ namespace gpdxl
 			struct STranslatorElem
 			{
 				Edxlopid eopid;
-				PfPexpr pf;
+				expr_func_ptr translate_func;
 			};
 
 			// shorthand for functions for translating DXL nodes to GPDB expressions
-			typedef Const * (CTranslatorDXLToScalar::*PfPconst)(CDXLDatum *);
+			typedef Const * (CTranslatorDXLToScalar::*const_func_ptr)(CDXLDatum *);
 
 			// pair of DXL datum type and translator function
 			struct SDatumTranslatorElem
 			{
 				CDXLDatum::EdxldatumType edxldt;
-				PfPconst pf;
+				const_func_ptr translate_func;
 			};
 
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// meta data accessor
-			CMDAccessor *m_pmda;
+			CMDAccessor *m_md_accessor;
 
 			// The parent plan needed when translating an initplan
-			Plan *m_pplan;
+			Plan *m_plan;
 
 			// indicates whether a sublink was encountered during translation of the scalar subtree
-			BOOL m_fHasSubqueries;
+			BOOL m_has_subqueries;
 			
 			// number of segments
-			ULONG m_ulSegments; 
+			ULONG m_num_of_segments; 
 
 			// translate a CDXLScalarArrayComp into a GPDB ScalarArrayOpExpr
-			Expr *PstrarrayopexprFromDXLNodeScArrayComp
+			Expr *TranslateDXLScalarArrayCompToScalar
 				(
-				const CDXLNode *pdxlnScArrayComp,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_array_cmp_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PopexprFromDXLNodeScOpExpr
+			Expr *TranslateDXLScalarOpExprToScalar
 				(
-				const CDXLNode *pdxlnScOpExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_op_expr_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PdistexprFromDXLNodeScDistinctComp
+			Expr *TranslateDXLScalarDistinctToScalar
 				(
-				const CDXLNode *pdxlnScDistComp,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_distinct_cmp_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PboolexprFromDXLNodeScBoolExpr
+			Expr *TranslateDXLScalarBoolExprToScalar
 				(
-				const CDXLNode *pdxlnScBoolExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_bool_expr_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PbooleantestFromDXLNodeScBooleanTest
+			Expr *TranslateDXLScalarBooleanTestToScalar
 				(
-				const CDXLNode *pdxlnScBooleanTest,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_boolean_test_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PrelabeltypeFromDXLNodeScCast
+			Expr *TranslateDXLScalarCastToScalar
 				(
-				const CDXLNode *pdxlnScRelabelType,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_relabel_type_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcoerceFromDXLNodeScCoerceToDomain
+			Expr *TranslateDXLScalarCoerceToDomainToScalar
 				(
-				const CDXLNode *pdxlnScCoerceToDomain,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *coerce_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcoerceFromDXLNodeScCoerceViaIO
+			Expr *TranslateDXLScalarCoerceViaIOToScalar
 				(
-				const CDXLNode *pdxlnScCoerceViaIO,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *coerce_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcoerceFromDXLNodeScArrayCoerceExpr
+			Expr *TranslateDXLScalarArrayCoerceExprToScalar
 				(
-				const CDXLNode *pdxlnScArrayCoerceExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *coerce_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PnulltestFromDXLNodeScNullTest
+			Expr *TranslateDXLScalarNullTestToScalar
 				(
-				const CDXLNode *pdxlnScNullTest,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_null_test_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PnullifFromDXLNodeScNullIf
+			Expr *TranslateDXLScalarNullIfToScalar
 				(
-				const CDXLNode *pdxlnScNullIf,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_null_if_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcaseexprFromDXLNodeScIfStmt
+			Expr *TranslateDXLScalarIfStmtToScalar
 				(
-				const CDXLNode *pdxlnScCaseExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_if_stmt_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcaseexprFromDXLNodeScSwitch
+			Expr *TranslateDXLScalarSwitchToScalar
 				(
-				const CDXLNode *pdxlnScSwitch,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_switch_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PcasetestexprFromDXLNodeScCaseTest
+			Expr *TranslateDXLScalarCaseTestToScalar
 				(
-				const CDXLNode *pdxlnScSwitch,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_case_test_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PaggrefFromDXLNodeScAggref
+			Expr *TranslateDXLScalarAggrefToScalar
 				(
-				const CDXLNode *pdxlnAggref,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *aggref_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PwindowrefFromDXLNodeScWindowRef
+			Expr *TranslateDXLScalarWindowRefToScalar
 				(
-				const CDXLNode *pdxlnAggref,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_winref_node,
+				CMappingColIdVar *colid_var
 				);
 
-			Expr *PfuncexprFromDXLNodeScFuncExpr
+			Expr *TranslateDXLScalarFuncExprToScalar
 				(
-				const CDXLNode *pdxlnFuncExpr,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_func_expr_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// return a GPDB subplan from a DXL subplan
-			Expr *PsubplanFromDXLNodeScSubPlan
+			Expr *TranslateDXLScalarSubplanToScalar
 				(
-				const CDXLNode *pdxlnSubPlan,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_sub_plan_node,
+				CMappingColIdVar *colid_var
 				);
 			
 			// build subplan node
-			SubPlan *PsubplanFromChildPlan
+			SubPlan *TranslateSubplanFromChildPlan
 				(
-				Plan *pplanChild,
+				Plan *plan_child,
 				SubLinkType slink,
-				CContextDXLToPlStmt *pctxdxltoplstmt
+				CContextDXLToPlStmt *dxl_to_plstmt_ctxt
 				);
 
 			// translate subplan test expression
-			Expr *PexprSubplanTestExpr
+			Expr *TranslateDXLSubplanTestExprToScalar
 				(
-				CDXLNode *pdxlnTestExpr,
+				CDXLNode *test_expr_node,
 				SubLinkType slink,
-				CMappingColIdVar *pmapcidvar,
-				List **plparamIds
+				CMappingColIdVar *colid_var,
+				List **param_ids_list
 				);
 			
 			// translate subplan parameters
 			void TranslateSubplanParams
         			(
-        			SubPlan *psubplan,
-        			CDXLTranslateContext *pdxltrctx,
-        			const DrgPdxlcr *pdrgdxlcrOuterRefs,
-				CMappingColIdVar *pmapcidvar
+        			SubPlan *sub_plan,
+        			CDXLTranslateContext *dxl_translator_ctxt,
+        			const CDXLColRefArray *outer_refs,
+				CMappingColIdVar *colid_var
        	 			);
 
-			CHAR *SzSubplanAlias(ULONG ulPlanId);
+			CHAR *GetSubplanAlias(ULONG plan_id);
 
-			Param *PparamFromMapping
+			Param *TranslateParamFromMapping
 				(
-				const CMappingElementColIdParamId *pmecolidparamid
+				const CMappingElementColIdParamId *colid_to_param_id_map
 				);
 
 			// translate a scalar coalesce
-			Expr *PcoalesceFromDXLNodeScCoalesce
+			Expr *TranslateDXLScalarCoalesceToScalar
 				(
-				const CDXLNode *pdxlnScCoalesce,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_coalesce_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar minmax
-			Expr *PminmaxFromDXLNodeScMinMax
+			Expr *TranslateDXLScalarMinMaxToScalar
 				(
-				const CDXLNode *pdxlnScMinMax,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_min_max_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scconstval
-			Expr *PconstFromDXLNodeScConst
+			Expr *TranslateDXLScalarConstToScalar
 				(
-				const CDXLNode *pdxlnScConst,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_const_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate an array expression
-			Expr *PexprArray
+			Expr *TranslateDXLScalarArrayToScalar
 				(
-				const CDXLNode *pdxlnArray,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_array_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate an arrayref expression
-			Expr *PexprArrayRef
+			Expr *TranslateDXLScalarArrayRefToScalar
 				(
-				const CDXLNode *pdxlnArrayref,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_array_ref_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate an arrayref index list
-			List *PlTranslateArrayRefIndexList
+			List *TranslateDXLArrayRefIndexListToScalar
 				(
-				const CDXLNode *pdxlnIndexlist,
-				CDXLScalarArrayRefIndexList::EIndexListBound eilb,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *index_list_node,
+				CDXLScalarArrayRefIndexList::EIndexListBound index_list_bound,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a DML action expression
-			Expr *PexprDMLAction
+			Expr *TranslateDXLScalarDMLActionToScalar
 				(
-				const CDXLNode *pdxlnDMLAction,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *dml_action_node,
+				CMappingColIdVar *colid_var
 				);
 			
 			
 			// translate children of DXL node, and add them to list
-			List *PlistTranslateScalarChildren
+			List *TranslateScalarChildren
 				(
-				List *plist,
-				const CDXLNode *pdxln,
-				CMappingColIdVar *pmapcidvar
+				List *list,
+				const CDXLNode *dxlnode,
+				CMappingColIdVar *colid_var
 				);
 
 			// return the operator return type oid for the given func id.
-			OID OidFunctionReturnType(IMDId *pmdid) const;
+			OID GetFunctionReturnTypeOid(IMDId *mdid) const;
 
 			// translate dxldatum to GPDB Const
-			Const *PconstOid(CDXLDatum *pdxldatum);
-			Const *PconstInt2(CDXLDatum *pdxldatum);
-			Const *PconstInt4(CDXLDatum *pdxldatum);
-			Const *PconstInt8(CDXLDatum *pdxldatum);
-			Const *PconstBool(CDXLDatum *pdxldatum);
-			Const *PconstGeneric(CDXLDatum *pdxldatum);
-			Expr *PrelabeltypeOrFuncexprFromDXLNodeScalarCast
+			Const *ConvertDXLDatumToConstOid(CDXLDatum *datum_dxl);
+			Const *ConvertDXLDatumToConstInt2(CDXLDatum *datum_dxl);
+			Const *ConvertDXLDatumToConstInt4(CDXLDatum *datum_dxl);
+			Const *ConvertDXLDatumToConstInt8(CDXLDatum *datum_dxl);
+			Const *ConvertDXLDatumToConstBool(CDXLDatum *datum_dxl);
+			Const *TranslateDXLDatumGenericToScalar(CDXLDatum *datum_dxl);
+			Expr *TranslateRelabelTypeOrFuncExprFromDXL
 				(
-				const CDXLScalarCast *pdxlscalarcast,
+				const CDXLScalarCast *scalar_cast,
 				Expr *pexprChild
 				);
 
@@ -333,98 +333,98 @@ namespace gpdxl
 		public:
 			struct STypeOidAndTypeModifier
 			{
-				OID OidType;
-				INT ITypeModifier;
+				OID oid_type;
+				INT type_modifier;
 			};
 
 			// ctor
-			CTranslatorDXLToScalar(IMemoryPool *pmp, CMDAccessor *pmda, ULONG ulSegments);
+			CTranslatorDXLToScalar(IMemoryPool *mp, CMDAccessor *md_accessor, ULONG num_segments);
 
 			// translate DXL scalar operator node into an Expr expression
 			// This function is called during the translation of DXL->Query or DXL->Query
-			Expr *PexprFromDXLNodeScalar
+			Expr *TranslateDXLToScalar
 				(
-				const CDXLNode *pdxlnScOp,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_op_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part default into an Expr
-			Expr *PexprPartDefault
+			Expr *TranslateDXLScalarPartDefaultToScalar
 				(
-				const CDXLNode *pdxlnPartDefault,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_default_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part bound into an Expr
-			Expr *PexprPartBound
+			Expr *TranslateDXLScalarPartBoundToScalar
 				(
-				const CDXLNode *pdxlnPartBound,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_bound_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part bound inclusion into an Expr
-			Expr *PexprPartBoundInclusion
+			Expr *TranslateDXLScalarPartBoundInclusionToScalar
 				(
-				const CDXLNode *pdxlnPartBoundIncl,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_bound_incl_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part bound openness into an Expr
-			Expr *PexprPartBoundOpen
+			Expr *TranslateDXLScalarPartBoundOpenToScalar
 				(
-				const CDXLNode *pdxlnPartBoundOpen,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_bound_open_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part list values into an Expr
-			Expr *PexprPartListValues
+			Expr *TranslateDXLScalarPartListValuesToScalar
 				(
-				const CDXLNode *pdxlnPartListValues,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_list_values_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar part list null test into an Expr
-			Expr *PexprPartListNullTest
+			Expr *TranslateDXLScalarPartListNullTestToScalar
 				(
-				const CDXLNode *pdxlnPartListNullTest,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *part_list_null_test_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar ident into an Expr
-			Expr *PexprFromDXLNodeScId
+			Expr *TranslateDXLScalarIdentToScalar
 				(
-				const CDXLNode *pdxlnScId,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_id_node,
+				CMappingColIdVar *colid_var
 				);
 
 			// translate a scalar comparison into an Expr
-			Expr *PopexprFromDXLNodeScCmp
+			Expr *TranslateDXLScalarCmpToScalar
 				(
-				const CDXLNode *pdxlnScCmp,
-				CMappingColIdVar *pmapcidvar
+				const CDXLNode *scalar_cmp_node,
+				CMappingColIdVar *colid_var
 				);
 
 
 			// checks if the operator return a boolean result
 			static
-			BOOL FBoolean(CDXLNode *pdxln, CMDAccessor *pmda);
+			BOOL HasBoolResult(CDXLNode *dxlnode, CMDAccessor *md_accessor);
 
 			// check if the operator is a "true" bool constant
 			static
-			BOOL FConstTrue(CDXLNode *pdxln, CMDAccessor *pmda);
+			BOOL HasConstTrue(CDXLNode *dxlnode, CMDAccessor *md_accessor);
 
 			// check if the operator is a NULL constant
 			static
-			BOOL FConstNull(CDXLNode *pdxln);
+			BOOL HasConstNull(CDXLNode *dxlnode);
 
 			// are there subqueries in the tree
-			BOOL FHasSubqueries() const
+			BOOL HasSubqueries() const
 			{
-				return m_fHasSubqueries;
+				return m_has_subqueries;
 			}
 			
 			// translate a DXL datum into GPDB const expression
-			Expr *PconstFromDXLDatum(CDXLDatum *pdxldatum);
+			Expr *TranslateDXLDatumToScalar(CDXLDatum *datum_dxl);
 	};
 }
 #endif // !GPDXL_CTranslatorDXLToScalar_H

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -45,11 +45,11 @@ namespace gpdxl
 	using namespace gpos;
 	using namespace gpopt;
 
-	typedef CHashMap<ULONG, BOOL, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>,
-			CleanupDelete<ULONG>, CleanupDelete<BOOL> > HMUlF;
+	typedef CHashMap<ULONG, BOOL, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			CleanupDelete<ULONG>, CleanupDelete<BOOL> > UlongBoolHashMap;
 
-	typedef CHashMapIter<INT, ULONG, gpos::UlHash<INT>, gpos::FEqual<INT>,
-			CleanupDelete<INT>, CleanupDelete<ULONG> > HMIUlIter;
+	typedef CHashMapIter<INT, ULONG, gpos::HashValue<INT>, gpos::Equals<INT>,
+			CleanupDelete<INT>, CleanupDelete<ULONG> > IntUlongHashmapIter;
 	
 	//---------------------------------------------------------------------------
 	//	@class:
@@ -63,98 +63,98 @@ namespace gpdxl
 	class CTranslatorQueryToDXL
 	{
 		// shorthand for functions for translating DXL nodes to GPDB expressions
-		typedef CDXLNode * (CTranslatorQueryToDXL::*PfPdxlnLogical)(const RangeTblEntry *prte, ULONG ulRTIndex, ULONG ulCurrQueryLevel);
+		typedef CDXLNode * (CTranslatorQueryToDXL::*DXLNodeToLogicalFunc)(const RangeTblEntry *rte, ULONG rti, ULONG current_query_level);
 
 		// mapping RTEKind to WCHARs
 		struct SRTENameElem
 		{
 			RTEKind m_rtekind;
-			const WCHAR *m_wsz;
+			const WCHAR *m_rte_name;
 		};
 
 		// pair of RTEKind and its translators
 		struct SRTETranslator
 		{
 			RTEKind m_rtekind;
-			PfPdxlnLogical pf;
+			DXLNodeToLogicalFunc dxlnode_to_logical_funct;
 		};
 
 		// mapping CmdType to WCHARs
 		struct SCmdNameElem
 		{
-			CmdType m_cmdtype;
-			const WCHAR *m_wsz;
+			CmdType m_cmd_type;
+			const WCHAR *m_cmd_name;
 		};
 
 		// pair of unsupported node tag and feature name
 		struct SUnsupportedFeature
 		{
-			NodeTag ent;
-			const WCHAR *m_wsz;
+			NodeTag node_tag;
+			const WCHAR *m_feature_name;
 		};
 		
 		private:
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// source system id
 			CSystemId m_sysid;
 
 			// meta data accessor
-			CMDAccessor *m_pmda;
+			CMDAccessor *m_md_accessor;
 
 			// counter for generating unique column ids
-			CIdGenerator *m_pidgtorCol;
+			CIdGenerator *m_colid_counter;
 
 			// counter for generating unique CTE ids
-			CIdGenerator *m_pidgtorCTE;
+			CIdGenerator *m_cte_id_counter;
 
 			// scalar translator used to convert scalar operation into DXL.
-			CTranslatorScalarToDXL *m_psctranslator;
+			CTranslatorScalarToDXL *m_scalar_translator;
 
 			// holds the var to col id information mapping
-			CMappingVarColId *m_pmapvarcolid;
+			CMappingVarColId *m_var_to_colid_map;
 
 			// query being translated
-			Query *m_pquery;
+			Query *m_query;
 
 			// absolute level of query being translated
-			ULONG m_ulQueryLevel;
+			ULONG m_query_level;
 
 			// does the query have distributed tables
-			BOOL m_fHasDistributedTables;
+			BOOL m_has_distributed_tables;
 
 			// top query is a DML
-			BOOL m_fTopDMLQuery;
+			BOOL m_is_top_query_dml;
 
 			// this is a CTAS query
-			BOOL m_fCTASQuery;
+			BOOL m_is_ctas_query;
 
 			// hash map that maintains the list of CTEs defined at a particular query level
-			HMUlCTEListEntry *m_phmulCTEEntries;
+			HMUlCTEListEntry *m_query_level_to_cte_map;
 
 			// query output columns
-			DrgPdxln *m_pdrgpdxlnQueryOutput;
+			CDXLNodeArray *m_dxl_query_output_cols;
 			
 			// list of CTE producers
-			DrgPdxln *m_pdrgpdxlnCTE;
+			CDXLNodeArray *m_dxl_cte_producers;
 			
 			// CTE producer IDs defined at the current query level
-			HMUlF *m_phmulfCTEProducers;
+			UlongBoolHashMap *m_cteid_at_current_query_level_map;
 
 			//ctor
-			// private constructor, called from the public factory function PtrquerytodxlInstance
+			// private constructor, called from the public factory function QueryToDXLInstance
 			CTranslatorQueryToDXL
 				(
-				IMemoryPool *pmp,
-				CMDAccessor *pmda,
-				CIdGenerator *pidgtorColId,
-				CIdGenerator *pidgtorCTE,
-				CMappingVarColId *pmapvarcolid,
-				Query *pquery,
-				ULONG ulQueryLevel,
-				BOOL fTopDMLQuery,
-				HMUlCTEListEntry *phmulCTEEntries  // hash map between query level -> list of CTEs defined at that level
+				IMemoryPool *mp,
+				CMDAccessor *md_accessor,
+				CIdGenerator *m_colid_counter,
+				CIdGenerator *cte_id_counter,
+				CMappingVarColId *var_colid_mapping,
+				Query *query,
+				ULONG query_level,
+				BOOL is_top_query_dml,
+				HMUlCTEListEntry *query_level_to_cte_map  // hash map between query level -> list of CTEs defined at that level
 				);
 
 			// private copy ctor
@@ -162,303 +162,302 @@ namespace gpdxl
 
 			// check for unsupported node types, throws an exception if an unsupported
 			// node is found
-			void CheckUnsupportedNodeTypes(Query *pquery);
+			void CheckUnsupportedNodeTypes(Query *query);
 
 			// check for SIRV functions in the targetlist without a FROM clause and
 			// throw an exception when found
-			void CheckSirvFuncsWithoutFromClause(Query *pquery);
+			void CheckSirvFuncsWithoutFromClause(Query *query);
 
 			// check for SIRV functions in the tree rooted at the given node
-			BOOL FHasSirvFunctions (Node *pnode) const;
+			BOOL HasSirvFunctions (Node *node) const;
 
 			// translate FromExpr (in the GPDB query) into a CDXLLogicalJoin or CDXLLogicalGet
-			CDXLNode *PdxlnFromGPDBFromExpr(FromExpr *pfromexpr);
+			CDXLNode *TranslateFromExprToDXL(FromExpr *from_expr);
 
 			// translate set operations
-			CDXLNode *PdxlnFromSetOp(Node *pnodeSetOp, List *plTargetList, HMIUl *phmiulOutputCols);
+			CDXLNode *TranslateSetOpToDXL(Node *setop_node, List *target_list, IntToUlongMap *output_attno_to_colid_mapping);
 
 			// create the set operation given its children, input and output columns
-			CDXLNode *PdxlnSetOp
+			CDXLNode *CreateDXLSetOpFromColumns
 				(
-				EdxlSetOpType edxlsetop,
-				List *plTargetListOutput,
-				DrgPul *pdrgpulOutput,
-				DrgPdrgPul *pdrgpdrgulInputColIds,
-				DrgPdxln *pdrgpdxlnChildren,
-				BOOL fCastAcrossInput,
-				BOOL fKeepResjunked
+				EdxlSetOpType setop_type,
+				List *output_target_list,
+				ULongPtrArray *output_colids,
+				ULongPtr2dArray *input_colids,
+				CDXLNodeArray *children_dxlnodes,
+				BOOL is_cast_across_input,
+				BOOL keep_res_junked
 				)
 				const;
 
 			// check if the set operation need to cast any of its input columns
-			BOOL FCast(List *plTargetList, DrgPmdid *pdrgpmdid) const;
+			BOOL SetOpNeedsCast(List *target_list, IMdIdArray *input_col_mdids) const;
 			// translate a window operator
-			CDXLNode *PdxlnWindow
+			CDXLNode *TranslateWindowToDXL
 				(
-				CDXLNode *pdxlnChild,
-				List *plTargetList,
-				List *plWindowClause,
-				List *plSortClause,
-				HMIUl *phmiulSortColsColId,
-				HMIUl *phmiulOutputCols
+				CDXLNode *child_dxlnode,
+				List *target_list,
+				List *window_clause,
+				List *sort_clause,
+				IntToUlongMap *sort_col_attno_to_colid_mapping,
+				IntToUlongMap *output_attno_to_colid_mapping
 				);
 
 			// translate window spec
-			DrgPdxlws *Pdrgpdxlws(List *plWindowClause, HMIUl *phmiulSortColsColId, CDXLNode *pdxlnScPrL);
+			CDXLWindowSpecArray *TranslateWindowSpecToDXL(List *window_clause, IntToUlongMap *sort_col_attno_to_colid_mapping, CDXLNode *project_list_dxlnode_node);
 
 			// update window spec positions of LEAD/LAG functions
-			void UpdateLeadLagWinSpecPos(CDXLNode *pdxlnPrL, DrgPdxlws *pdrgpdxlwinspec) const;
+			void UpdateLeadLagWinSpecPos(CDXLNode *project_list_dxlnode, CDXLWindowSpecArray *window_specs_dxlnode) const;
 
 			// manufucture window frame for lead/lag functions
-			CDXLWindowFrame *PdxlwfLeadLag(BOOL fLead, CDXLNode *pdxlnOffset) const;
+			CDXLWindowFrame *CreateWindowFramForLeadLag(BOOL is_lead_func, CDXLNode *dxl_offset) const;
 
 			// translate the child of a set operation
-			CDXLNode *PdxlnSetOpChild(Node *pnodeChild, DrgPul *pdrgpul, DrgPmdid *pdrgpmdid, List *plTargetList);
+			CDXLNode *TranslateSetOpChild(Node *child_node, ULongPtrArray *pdrgpul, IMdIdArray *input_col_mdids, List *target_list);
 
 			// return a dummy const table get
-			CDXLNode *PdxlnConstTableGet() const;
+			CDXLNode *DXLDummyConstTableGet() const;
 
 			// translate an Expr into CDXLNode
-			CDXLNode *PdxlnScFromGPDBExpr(Expr *pexpr);
+			CDXLNode *TranslateExprToDXL(Expr *expr);
 
 			// translate the JoinExpr (inside FromExpr) into a CDXLLogicalJoin node
-			CDXLNode *PdxlnLgJoinFromGPDBJoinExpr(JoinExpr *pjoinexpr);
+			CDXLNode *TranslateJoinExprInFromToDXL(JoinExpr *join_expr);
 
 			// construct a group by node for a set of grouping columns
-			CDXLNode *PdxlnSimpleGroupBy
+			CDXLNode *CreateSimpleGroupBy
 				(
-				List *plTargetList,
-				List *plGroupClause,
-				CBitSet *pbs,
-				BOOL fHasAggs,
-				BOOL fGroupingSets,				// is this GB part of a GS query
-				CDXLNode *pdxlnChild,
-				HMIUl *phmiulSortGrpColsColId,  // mapping sortgroupref -> ColId
-				HMIUl *phmiulChild,				// mapping attno->colid in child node
-				HMIUl *phmiulOutputCols			// mapping attno -> ColId for output columns
+				List *target_list,
+				List *group_clause,
+				CBitSet *bitset,
+				BOOL has_aggs,
+				BOOL has_grouping_sets,				// is this GB part of a GS query
+				CDXLNode *child_dxlnode,
+				IntToUlongMap *phmiulSortGrpColsColId,  // mapping sortgroupref -> ColId
+				IntToUlongMap *child_attno_colid_mapping,				// mapping attno->colid in child node
+				IntToUlongMap *output_attno_to_colid_mapping			// mapping attno -> ColId for output columns
 				);
 
 			// check if the argument of a DQA has already being used by another DQA
 			static
-			BOOL FDuplicateDqaArg(List *plDQA, Aggref *paggref);
+			BOOL IsDuplicateDqaArg(List *dqa_list, Aggref *aggref);
 
 			// translate a query with grouping sets
-			CDXLNode *PdxlnGroupingSets
+			CDXLNode *TranslateGroupingSets
 				(
-				FromExpr *pfromexpr,
-				List *plTargetList,
-				List *plGroupClause,
-				BOOL fHasAggs,
-				HMIUl *phmiulSortGrpColsColId,
-				HMIUl *phmiulOutputCols
+				FromExpr *from_expr,
+				List *target_list,
+				List *group_clause,
+				BOOL has_aggs,
+				IntToUlongMap *phmiulSortGrpColsColId,
+				IntToUlongMap *output_attno_to_colid_mapping
 				);
 
 			// expand the grouping sets into a union all operator
-			CDXLNode *PdxlnUnionAllForGroupingSets
+			CDXLNode *CreateDXLUnionAllForGroupingSets
 				(
-				FromExpr *pfromexpr,
-				List *plTargetList,
-				List *plGroupClause,
-				BOOL fHasAggs,
-				DrgPbs *pdrgpbsGroupingSets,
-				HMIUl *phmiulSortGrpColsColId,
-				HMIUl *phmiulOutputCols,
-				HMUlUl *phmululGrpColPos		// mapping pos->unique grouping columns for grouping func arguments
+				FromExpr *from_expr,
+				List *target_list,
+				List *group_clause,
+				BOOL has_aggs,
+				CBitSetArray *pdrgpbsGroupingSets,
+				IntToUlongMap *phmiulSortGrpColsColId,
+				IntToUlongMap *output_attno_to_colid_mapping,
+				UlongToUlongMap *grpcol_index_to_colid_mapping		// mapping pos->unique grouping columns for grouping func arguments
 				);
 
 			// construct a project node with NULL values for columns not included in the grouping set
-			CDXLNode *PdxlnProjectNullsForGroupingSets
+			CDXLNode *CreateDXLProjectNullsForGroupingSets
 				(
-				List *plTargetList, 
-				CDXLNode *pdxlnChild, 
-				CBitSet *pbs, 
-				HMIUl *phmiulSortgrouprefCols, 
-				HMIUl *phmiulOutputCols, 
-				HMUlUl *phmululGrpColPos
+				List *target_list,
+				CDXLNode *child_dxlnode,
+				CBitSet *bitset,
+				IntToUlongMap *sort_grouping_col_mapping,
+				IntToUlongMap *output_attno_to_colid_mapping,
+				UlongToUlongMap *grpcol_index_to_colid_mapping
 				) 
 				const;
 
 			// construct a project node with appropriate values for the grouping funcs in the given target list
-			CDXLNode *PdxlnProjectGroupingFuncs
+			CDXLNode *CreateDXLProjectGroupingFuncs
 				(
-				List *plTargetList,
-				CDXLNode *pdxlnChild,
-				CBitSet *pbs,
-				HMIUl *phmiulOutputCols,
-				HMUlUl *phmululGrpColPos,
-				HMIUl *phmiulSortgrouprefColId
+				List *target_list,
+				CDXLNode *child_dxlnode,
+				CBitSet *bitset,
+				IntToUlongMap *output_attno_to_colid_mapping,
+				UlongToUlongMap *grpcol_index_to_colid_mapping,
+				IntToUlongMap *sort_grpref_to_colid_mapping
 				)
 				const;
 
 			// add sorting and grouping column into the hash map
-			void AddSortingGroupingColumn(TargetEntry *pte, HMIUl *phmiulSortGrpColsColId, ULONG ulColId) const;
+			void AddSortingGroupingColumn(TargetEntry *target_entry, IntToUlongMap *phmiulSortGrpColsColId, ULONG colid) const;
 
 			// translate the list of sorting columns
-			DrgPdxln *PdrgpdxlnSortCol(List *plSortCl, HMIUl *phmiulColColId) const;
+			CDXLNodeArray *TranslateSortColumnsToDXL(List *sort_clause, IntToUlongMap *col_attno_colid_mapping) const;
 
 			// translate the list of partition-by column identifiers
-			DrgPul *PdrgpulPartCol(List *plSortCl, HMIUl *phmiulColColId) const;
+			ULongPtrArray *TranslatePartColumns(List *sort_clause, IntToUlongMap *col_attno_colid_mapping) const;
 
-			CDXLNode *PdxlnLgLimit
+			CDXLNode *TranslateLimitToDXLGroupBy
 				(
 				List *plsortcl, // list of sort clauses
-				Node *pnodeLimitCount, // query node representing the limit count
-				Node *pnodeLimitOffset, // query node representing the limit offset
-				CDXLNode *pdxln, // the dxl node representing the subtree
-				HMIUl *phmiulGrpColsColId // the mapping between the position in the TargetList to the ColId
+				Node *limit_count, // query node representing the limit count
+				Node *limit_offset_node, // query node representing the limit offset
+				CDXLNode *dxlnode, // the dxl node representing the subtree
+				IntToUlongMap *grpcols_to_colid_mapping // the mapping between the position in the TargetList to the ColId
 				);
 
 			// throws an exception when RTE kind not yet supported
 			void UnsupportedRTEKind(RTEKind rtekind) const;
 
 			// translate an entry of the from clause (this can either be FromExpr or JoinExpr)
-			CDXLNode *PdxlnFromGPDBFromClauseEntry(Node *pnode);
+			CDXLNode *TranslateFromClauseToDXL(Node *node);
 
 			// translate the target list entries of the query into a logical project
-			CDXLNode *PdxlnLgProjectFromGPDBTL
+			CDXLNode *TranslateTargetListToDXLProject
 				(
-				List *plTargetList,
-				CDXLNode *pdxlnChild,
-				HMIUl *	phmiulGrpcolColId,
-				HMIUl *phmiulOutputCols,
-				List *plGrpCl,
-				BOOL fExpandAggrrefExpr = false
+				List *target_list,
+				CDXLNode *child_dxlnode,
+				IntToUlongMap *	group_col_to_colid_mapping,
+				IntToUlongMap *output_attno_to_colid_mapping,
+				List *group_clause,
+				BOOL is_aggref_expanded = false
 				);
 
 			// translate a target list entry or a join alias entry into a project element
-			CDXLNode *PdxlnPrEFromGPDBExpr(Expr *pexpr, const CHAR *szAliasName, BOOL fInsistNewColIds = false);
+			CDXLNode *TranslateExprToDXLProject(Expr *expr, const CHAR *alias_name, BOOL insist_new_colids = false);
 
 			// translate a CTE into a DXL logical CTE operator
-			CDXLNode *PdxlnFromCTE
+			CDXLNode *TranslateCTEToDXL
 				(
-				const RangeTblEntry *prte,
-				ULONG ulRTIndex,
-				ULONG ulCurrQueryLevel
+				const RangeTblEntry *rte,
+				ULONG rti,
+				ULONG current_query_level
 				);
 
 			// translate a base table range table entry into a logical get
-			CDXLNode *PdxlnFromRelation
+			CDXLNode *TranslateRTEToDXLLogicalGet
 				(
-				const RangeTblEntry *prte,
-				ULONG ulRTIndex,
-				ULONG //ulCurrQueryLevel
+				const RangeTblEntry *rte,
+				ULONG rti,
+				ULONG //current_query_level
 				);
 
 			// generate a DXL node from column values, where each column value is
 			// either a datum or scalar expression represented as a project element.
-			CDXLNode *PdxlnFromColumnValues
+			CDXLNode *TranslateColumnValuesToDXL
 			 	(
-			 	DrgPdxldatum *pdrgpdxldatum,
-			 	DrgPdxlcd *pdrgpdxlcdCTG,
-			 	DrgPdxln *pdrgpdxlnPE
+			 	CDXLDatumArray *dxl_datum_array,
+			 	CDXLColDescrArray *dxl_column_descriptors,
+			 	CDXLNodeArray *dxl_project_elements
 			    )
 			    const;
 
 			// translate a value scan range table entry
-			CDXLNode *PdxlnFromValues
+			CDXLNode *TranslateValueScanRTEToDXL
 				(
-				const RangeTblEntry *prte,
-				ULONG ulRTIndex,
-				ULONG //ulCurrQueryLevel
+				const RangeTblEntry *rte,
+				ULONG rti,
+				ULONG //current_query_level
 				);
 
 			// create a dxl node from a array of datums and project elements
-			CDXLNode *PdxlnFromTVF
+			CDXLNode *TranslateTVFToDXL
 				(
-				const RangeTblEntry *prte,
-				ULONG ulRTIndex,
-				ULONG //ulCurrQueryLevel
+				const RangeTblEntry *rte,
+				ULONG rti,
+				ULONG //current_query_level
 				);
 
 			// translate a derived table into a DXL logical operator
-			CDXLNode *PdxlnFromDerivedTable
+			CDXLNode *TranslateDerivedTablesToDXL
 						(
-						const RangeTblEntry *prte,
-						ULONG ulRTIndex,
-						ULONG ulCurrQueryLevel
+						const RangeTblEntry *rte,
+						ULONG rti,
+						ULONG current_query_level
 						);
 
 			// create a DXL node representing the scalar constant "true"
-			CDXLNode *PdxlnScConstValueTrue();
+			CDXLNode *CreateDXLConstValueTrue();
 
 			// store mapping attno->colid
-			void StoreAttnoColIdMapping(HMIUl *phmiul, INT iAttno, ULONG ulColId) const;
+			void StoreAttnoColIdMapping(IntToUlongMap *attno_to_colid_mapping, INT attno, ULONG colid) const;
 
 			// construct an array of output columns
-			DrgPdxln *PdrgpdxlnConstructOutputCols(List *plTargetList, HMIUl *phmiulAttnoColId) const;
+			CDXLNodeArray *CreateDXLOutputCols(List *target_list, IntToUlongMap *attno_to_colid_mapping) const;
 
 			// check for support command types, throws an exception when command type not yet supported
-			void CheckSupportedCmdType(Query *pquery);
+			void CheckSupportedCmdType(Query *query);
 
 			// translate a select-project-join expression into DXL
-			CDXLNode *PdxlnSPJ(List *plTargetList, FromExpr *pfromexpr, HMIUl *phmiulSortGroupColsColId, HMIUl *phmiulOutputCols, List *plGroupClause);
+			CDXLNode *TranslateSelectProjectJoinToDXL(List *target_list, FromExpr *from_expr, IntToUlongMap *sort_group_attno_to_colid_mapping, IntToUlongMap *output_attno_to_colid_mapping, List *group_clause);
 
 			// translate a select-project-join expression into DXL and keep variables appearing
 			// in aggregates and grouping columns in the output column map
-			CDXLNode *PdxlnSPJForGroupingSets(List *plTargetList, FromExpr *pfromexpr, HMIUl *phmiulSortGroupColsColId, HMIUl *phmiulOutputCols, List *plGroupClause);
+			CDXLNode *TranslateSelectProjectJoinForGrpSetsToDXL(List *target_list, FromExpr *from_expr, IntToUlongMap *sort_group_attno_to_colid_mapping, IntToUlongMap *output_attno_to_colid_mapping, List *group_clause);
 			
 			// helper to check if OID is included in given array of OIDs
 			static
-			BOOL FOIDFound(OID oid, const OID rgOID[], ULONG ulSize);
+			BOOL OIDFound(OID oid, const OID oids[], ULONG size);
 
 			// check if given operator is lead() window function
 			static
-			BOOL FLeadWindowFunc(CDXLOperator *Pdxlop);
+			BOOL IsLeadWindowFunc(CDXLOperator *dxlop);
 
 			// check if given operator is lag() window function
 			static
-			BOOL FLagWindowFunc(CDXLOperator *pdxlop);
+			BOOL IsLagWindowFunc(CDXLOperator *dxlop);
 
 		    // translate an insert query
-			CDXLNode *PdxlnInsert();
+			CDXLNode *TranslateInsertQueryToDXL();
 
 			// translate a delete query
-			CDXLNode *PdxlnDelete();
+			CDXLNode *TranslateDeleteQueryToDXL();
 
 			// translate an update query
-			CDXLNode *PdxlnUpdate();
+			CDXLNode *TranslateUpdateQueryToDXL();
 
 		    // translate a CTAS query
-			CDXLNode *PdxlnCTAS();
-			
+			CDXLNode *TranslateCTASToDXL();
 			// translate CTAS storage options
-			CDXLCtasStorageOptions::DrgPctasOpt *Pdrgpctasopt(List *plOptions, IMDRelation::Erelstoragetype *perelstoragetype);
+			CDXLCtasStorageOptions::CDXLCtasOptionArray *GetDXLCtasOptionArray(List *options, IMDRelation::Erelstoragetype *storage_type);
 			
 			// extract storage option value from defelem
-			CWStringDynamic *PstrExtractOptionValue(DefElem *pdefelem);
+			CWStringDynamic *ExtractStorageOptionStr(DefElem *def_elem);
 			
 			// return resno -> colId mapping of columns to be updated
-			HMIUl *PhmiulUpdateCols();
+			IntToUlongMap *UpdatedColumnMapping();
 
 			// obtain the ids of the ctid and segmentid columns for the target
 			// table of a DML query
-			void GetCtidAndSegmentId(ULONG *pulCtid, ULONG *pulSegmentId);
+			void GetCtidAndSegmentId(ULONG *ctid, ULONG *segment_id);
 			
 			// obtain the column id for the tuple oid column of the target table
 			// of a DML statement
-			ULONG UlTupleOidColId();
+			ULONG GetTupleOidColId();
 
 			// translate a grouping func expression
-			CDXLNode *PdxlnGroupingFunc(const Expr *pexpr, CBitSet *pbs, HMUlUl *phmululGrpColPos) const;
+			CDXLNode *TranslateGroupingFuncToDXL(const Expr *expr, CBitSet *bitset, UlongToUlongMap *grpcol_index_to_colid_mapping) const;
 
 			// construct a list of CTE producers from the query's CTE list
-			void ConstructCTEProducerList(List *plCTE, ULONG ulQueryLevel);
+			void ConstructCTEProducerList(List *cte_list, ULONG query_level);
 			
 			// construct a stack of CTE anchors for each CTE producer in the given array
-			void ConstructCTEAnchors(DrgPdxln *pdrgpdxln, CDXLNode **ppdxlnCTEAnchorTop, CDXLNode **ppdxlnCTEAnchorBottom);
+			void ConstructCTEAnchors(CDXLNodeArray *dxlnodes, CDXLNode **dxl_cte_anchor_top, CDXLNode **dxl_cte_anchor_bottom);
 			
 			// generate an array of new column ids of the given size
-			DrgPul *PdrgpulGenerateColIds(IMemoryPool *pmp, ULONG ulSize) const;
+			ULongPtrArray *GenerateColIds(IMemoryPool *mp, ULONG size) const;
 
 			// extract an array of colids from the given column mapping
-			DrgPul *PdrgpulExtractColIds(IMemoryPool *pmp, HMIUl *phmiul) const;
+			ULongPtrArray *ExtractColIds(IMemoryPool *mp, IntToUlongMap *attno_to_colid_mapping) const;
 			
 			// construct a new mapping based on the given one by replacing the colid in the "From" list
 			// with the colid at the same position in the "To" list
-			HMIUl *PhmiulRemapColIds(IMemoryPool *pmp, HMIUl *phmiul, DrgPul *pdrgpulFrom, DrgPul *pdrgpulTo) const;
+			IntToUlongMap *RemapColIds(IMemoryPool *mp, IntToUlongMap *attno_to_colid_mapping, ULongPtrArray *from_list_colids, ULongPtrArray *to_list_colids) const;
 
 			// true iff this query or one of its ancestors is a DML query
-			BOOL FDMLQuery();
+			BOOL IsDMLQuery();
 
 		public:
 			// dtor
@@ -467,39 +466,39 @@ namespace gpdxl
 			// query object
 			const Query *Pquery() const
 			{
-				return m_pquery;
+				return m_query;
 			}
 
 			// does query have distributed tables
-			BOOL FHasDistributedTables() const
+			BOOL HasDistributedTables() const
 			{
-				return m_fHasDistributedTables;
+				return m_has_distributed_tables;
 			}
 
 			// main translation routine for Query -> DXL tree
-			CDXLNode *PdxlnFromQueryInternal();
+			CDXLNode *TranslateSelectQueryToDXL();
 
 			// main driver
-			CDXLNode *PdxlnFromQuery();
+			CDXLNode *TranslateQueryToDXL();
 
 			// return the list of output columns
-			DrgPdxln *PdrgpdxlnQueryOutput() const;
+			CDXLNodeArray *GetQueryOutputCols() const;
 
 			// return the list of CTEs
-			DrgPdxln *PdrgpdxlnCTE() const;
+			CDXLNodeArray *GetCTEs() const;
 
 			// factory function
 			static
-			CTranslatorQueryToDXL *PtrquerytodxlInstance
+			CTranslatorQueryToDXL *QueryToDXLInstance
 				(
-				IMemoryPool *pmp,
-				CMDAccessor *pmda,
-				CIdGenerator *pidgtorColId,
-				CIdGenerator *pidgtorCTE,
-				CMappingVarColId *pmapvarcolid,
-				Query *pquery,
-				ULONG ulQueryLevel,
-				HMUlCTEListEntry *phmulCTEEntries = NULL // hash map between query level -> list of CTEs defined at that level
+				IMemoryPool *mp,
+				CMDAccessor *md_accessor,
+				CIdGenerator *m_colid_counter,
+				CIdGenerator *cte_id_counter,
+				CMappingVarColId *var_colid_mapping,
+				Query *query,
+				ULONG query_level,
+				HMUlCTEListEntry *query_level_to_cte_map = NULL // hash map between query level -> list of CTEs defined at that level
 				);
 	};
 }

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -87,16 +87,16 @@ namespace gpdxl
 				OID m_oid;
 
 				// function stability
-				IMDFunction::EFuncStbl m_efs;
+				IMDFunction::EFuncStbl m_stability;
 
 				// function data access
-				IMDFunction::EFuncDataAcc m_efda;
+				IMDFunction::EFuncDataAcc m_access;
 
 				// is function strict?
-				BOOL m_fStrict;
+				BOOL m_is_strict;
 
 				// can the function return multiple rows?
-				BOOL m_fReturnsSet;
+				BOOL m_returns_set;
 
 			public:
 
@@ -104,17 +104,17 @@ namespace gpdxl
 				SFuncProps
 					(
 					OID oid,
-					IMDFunction::EFuncStbl efs,
-					IMDFunction::EFuncDataAcc efda,
-					BOOL fStrict,
-					BOOL fReturnsSet
+					IMDFunction::EFuncStbl stability,
+					IMDFunction::EFuncDataAcc access,
+					BOOL is_strict,
+					BOOL ReturnsSet
 					)
 					:
 					m_oid(oid),
-					m_efs(efs),
-					m_efda(efda),
-					m_fStrict(fStrict),
-					m_fReturnsSet(fReturnsSet)
+					m_stability(stability),
+					m_access(access),
+					m_is_strict(is_strict),
+					m_returns_set(ReturnsSet)
 				{}
 
 				// dtor
@@ -129,340 +129,340 @@ namespace gpdxl
 				}
 
 				// return function stability
-				IMDFunction::EFuncStbl Efs() const
+				IMDFunction::EFuncStbl GetStability() const
 				{
-					return m_efs;
+					return m_stability;
 				}
 
 				// return data access property
-				IMDFunction::EFuncDataAcc Efda() const
+				IMDFunction::EFuncDataAcc GetDataAccess() const
 				{
-					return m_efda;
+					return m_access;
 				}
 
 				// is function strict?
-				BOOL FStrict() const
+				BOOL IsStrict() const
 				{
-					return m_fStrict;
+					return m_is_strict;
 				}
 
 				// does function return set?
-				BOOL FReturnsSet() const
+				BOOL ReturnsSet() const
 				{
-					return m_fReturnsSet;
+					return m_returns_set;
 				}
 
 			}; // struct SFuncProps
 
 			// array of function properties map
 			static
-			const SFuncProps m_rgfp[];
+			const SFuncProps m_func_props[];
 
 			// lookup function properties
 			static
 			void LookupFuncProps
 				(
-				OID oidFunc,
-				IMDFunction::EFuncStbl *pefs, // output: function stability
-				IMDFunction::EFuncDataAcc *pefda, // output: function data access
-				BOOL *fStrict, // output: is function strict?
-				BOOL *fReturnsSet // output: does function return set?
+				OID func_oid,
+				IMDFunction::EFuncStbl *stability, // output: function stability
+				IMDFunction::EFuncDataAcc *access, // output: function data access
+				BOOL *is_strict, // output: is function strict?
+				BOOL *ReturnsSet // output: does function return set?
 				);
 
 			// check and fall back for unsupported relations
 			static
-			void CheckUnsupportedRelation(OID oidRel);
+			void CheckUnsupportedRelation(OID rel_oid);
 
 			// get type name from the relcache
 			static
-			CMDName *PmdnameType(IMemoryPool *pmp, IMDId *pmdid);
+			CMDName *GetTypeName(IMemoryPool *mp, IMDId *mdid);
 
 			// get function stability property from the GPDB character representation
 			static
-			CMDFunctionGPDB::EFuncStbl EFuncStability(CHAR c);
+			CMDFunctionGPDB::EFuncStbl GetFuncStability(CHAR c);
 
 			// get function data access property from the GPDB character representation
 			static
-			CMDFunctionGPDB::EFuncDataAcc EFuncDataAccess(CHAR c);
+			CMDFunctionGPDB::EFuncDataAcc GetEFuncDataAccess(CHAR c);
 
 			// get type of aggregate's intermediate result from the relcache
 			static
-			IMDId *PmdidAggIntermediateResultType(IMemoryPool *pmp, IMDId *pmdid);
+			IMDId *RetrieveAggIntermediateResultType(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a GPDB metadata object from the relcache
 			static
-			IMDCacheObject *PimdobjGPDB(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			IMDCacheObject *RetrieveObjectGPDB(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// retrieve relstats object from the relcache
 			static
-			IMDCacheObject *PimdobjRelStats(IMemoryPool *pmp, IMDId *pmdid);
+			IMDCacheObject *RetrieveRelStats(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve column stats object from the relcache
 			static
-			IMDCacheObject *PimdobjColStats(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			IMDCacheObject *RetrieveColStats(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// retrieve cast object from the relcache
 			static
-			IMDCacheObject *PimdobjCast(IMemoryPool *pmp, IMDId *pmdid);
+			IMDCacheObject *RetrieveCast(IMemoryPool *mp, IMDId *mdid);
 			
 			// retrieve scalar comparison object from the relcache
 			static
-			IMDCacheObject *PmdobjScCmp(IMemoryPool *pmp, IMDId *pmdid);
+			IMDCacheObject *RetrieveScCmp(IMemoryPool *mp, IMDId *mdid);
 
 			// transform GPDB's MCV information to optimizer's histogram structure
 			static
-			CHistogram *PhistTransformGPDBMCV
+			CHistogram *TransformMcvToOrcaHistogram
 								(
-								IMemoryPool *pmp,
-								const IMDType *pmdtype,
-								const Datum *pdrgdatumMCVValues,
-								const float4 *pdrgfMCVFrequencies,
-								ULONG ulNumMCVValues
+								IMemoryPool *mp,
+								const IMDType *md_type,
+								const Datum *mcv_values,
+								const float4 *mcv_frequencies,
+								ULONG num_mcv_values
 								);
 
 			// transform GPDB's hist information to optimizer's histogram structure
 			static
-			CHistogram *PhistTransformGPDBHist
+			CHistogram *TransformHistToOrcaHistogram
 								(
-								IMemoryPool *pmp,
-								const IMDType *pmdtype,
-								const Datum *pdrgdatumHistValues,
-								ULONG ulNumHistValues,
-								CDouble dDistinctHist,
-								CDouble dFreqHist
+								IMemoryPool *mp,
+								const IMDType *md_type,
+								const Datum *hist_values,
+								ULONG num_hist_values,
+								CDouble num_distinct,
+								CDouble hist_freq
 								);
 
 			// histogram to array of dxl buckets
 			static
-			DrgPdxlbucket *Pdrgpdxlbucket
+			CDXLBucketArray *TransformHistogramToDXLBucketArray
 								(
-								IMemoryPool *pmp,
-								const IMDType *pmdtype,
-								const CHistogram *phist
+								IMemoryPool *mp,
+								const IMDType *md_type,
+								const CHistogram *hist
 								);
 
 			// transform stats from pg_stats form to optimizer's preferred form
 			static
-			DrgPdxlbucket *PdrgpdxlbucketTransformStats
+			CDXLBucketArray *TransformStatsToDXLBucketArray
 								(
-								IMemoryPool *pmp,
-								OID oidAttType,
-								CDouble dDistinct,
-								CDouble dNullFreq,
-								const Datum *pdrgdatumMCVValues,
-								const float4 *pdrgfMCVFrequencies,
-								ULONG ulNumMCVValues,
-								const Datum *pdrgdatumHistValues,
-								ULONG ulNumHistValues
+								IMemoryPool *mp,
+								OID att_type,
+								CDouble num_distinct,
+								CDouble null_freq,
+								const Datum *mcv_values,
+								const float4 *mcv_frequencies,
+								ULONG num_mcv_values,
+								const Datum *hist_values,
+								ULONG num_hist_values
 								);
 
 			// get partition keys and types for a relation
 			static
-			void GetPartKeysAndTypes(IMemoryPool *pmp, Relation rel, OID oid, DrgPul **pdrgpulPartKeys, DrgPsz **pdrgpszPartTypes);
+			void RetrievePartKeysAndTypes(IMemoryPool *mp, Relation rel, OID oid, ULongPtrArray **part_keys, CharPtrArray **part_types);
 
 			// get keysets for relation
 			static
-			DrgPdrgPul *PdrgpdrgpulKeys(IMemoryPool *pmp, OID oid, BOOL fAddDefaultKeys, BOOL fPartitioned, ULONG *pulMapping);
+			ULongPtr2dArray *RetrieveRelKeysets(IMemoryPool *mp, OID oid, BOOL should_add_default_keys, BOOL is_partitioned, ULONG *attno_mapping);
 
 			// storage type for a relation
 			static
-			IMDRelation::Erelstoragetype Erelstorage(CHAR cStorageType);
+			IMDRelation::Erelstoragetype RetrieveRelStorageType(CHAR storage_type);
 
 			// fix frequencies if they add up to more than 1.0
 			static
-			void NormalizeFrequencies(float4 *pdrgf, ULONG ulLength, CDouble *pdNullFrequency);
+			void NormalizeFrequencies(float4 *pdrgf, ULONG length, CDouble *null_freq);
 
 			// get the relation columns
 			static
-			DrgPmdcol *Pdrgpmdcol(IMemoryPool *pmp, CMDAccessor *pmda, Relation rel, IMDRelation::Erelstoragetype erelstorage);
+			CMDColumnArray *RetrieveRelColumns(IMemoryPool *mp, CMDAccessor *md_accessor, Relation rel, IMDRelation::Erelstoragetype rel_storage_type);
 
 			// return the dxl representation of the column's default value
 			static
-			CDXLNode *PdxlnDefaultColumnValue(IMemoryPool *pmp, CMDAccessor *pmda, TupleDesc rd_att, AttrNumber attrno);
+			CDXLNode *GetDefaultColumnValue(IMemoryPool *mp, CMDAccessor *md_accessor, TupleDesc rd_att, AttrNumber attrno);
 
 
 			// get the distribution columns
 			static
-			DrgPul *PdrpulDistrCols(IMemoryPool *pmp, GpPolicy *pgppolicy, DrgPmdcol *pdrgpmdcol, ULONG ulSize);
+			ULongPtrArray *RetrieveRelDistrbutionCols(IMemoryPool *mp, GpPolicy *gp_policy, CMDColumnArray *mdcol_array, ULONG size);
 
 			// construct a mapping GPDB attnos -> position in the column array
 			static
-			ULONG *PulAttnoMapping(IMemoryPool *pmp, DrgPmdcol *pdrgpmdcol, ULONG ulMaxCols);
+			ULONG *ConstructAttnoMapping(IMemoryPool *mp, CMDColumnArray *mdcol_array, ULONG max_cols);
 
 			// check if index is supported
 			static
-			BOOL FIndexSupported(Relation relIndex);
+			BOOL IsIndexSupported(Relation index_rel);
 			
 			// retrieve index info list of partitioned table
 			static
-			List *PlIndexInfoPartTable(Relation rel);
+			List *RetrievePartTableIndexInfo(Relation rel);
 			 
 			// compute the array of included columns
 			static
-			DrgPul *PdrgpulIndexIncludedColumns(IMemoryPool *pmp, const IMDRelation *pmdrel);
+			ULongPtrArray *ComputeIncludedCols(IMemoryPool *mp, const IMDRelation *md_rel);
 			
 			// is given level included in the default partitions
 			static 
-			BOOL FDefaultPartition(List *plDefaultLevels, ULONG ulLevel);
+			BOOL LevelHasDefaultPartition(List *default_levels, ULONG level);
 			
 			// retrieve part constraint for index
 			static
-			CMDPartConstraintGPDB *PmdpartcnstrIndex
+			CMDPartConstraintGPDB *RetrievePartConstraintForIndex
 				(
-				IMemoryPool *pmp, 
-				CMDAccessor *pmda, 
-				const IMDRelation *pmdrel, 
-				Node *pnodePartCnstr,
-				DrgPul *pdrgpulDefaultParts,
-				BOOL fUnbounded
+				IMemoryPool *mp, 
+				CMDAccessor *md_accessor, 
+				const IMDRelation *md_rel, 
+				Node *part_constraint,
+				ULongPtrArray *level_with_default_part_array,
+				BOOL is_unbounded
 				);
 
 			// retrieve part constraint for relation
 			static
-			CMDPartConstraintGPDB *PmdpartcnstrRelation(IMemoryPool *pmp, CMDAccessor *pmda, OID oidRel, DrgPmdcol *pdrgpmdcol, BOOL fhasIndex);
+			CMDPartConstraintGPDB *RetrievePartConstraintForRel(IMemoryPool *mp, CMDAccessor *md_accessor, OID rel_oid, CMDColumnArray *mdcol_array, BOOL has_index);
 
 			// retrieve part constraint from a GPDB node
 			static
-			CMDPartConstraintGPDB *PmdpartcnstrFromNode
+			CMDPartConstraintGPDB *RetrievePartConstraintFromNode
 				(
-				IMemoryPool *pmp, 
-				CMDAccessor *pmda, 
-				DrgPdxlcd *pdrgpdxlcd, 
-				Node *pnodePartCnstr, 
-				DrgPul *pdrgpulDefaultParts,
-				BOOL fUnbounded
+				IMemoryPool *mp, 
+				CMDAccessor *md_accessor,
+				CDXLColDescrArray *dxl_col_descr_array, 
+				Node *part_constraint,
+				ULongPtrArray *level_with_default_part_array,
+				BOOL is_unbounded
 				);
 	
 			// return relation name
 			static
-			CMDName *PmdnameRel(IMemoryPool *pmp, Relation rel);
+			CMDName *GetRelName(IMemoryPool *mp, Relation rel);
 
 			// return the index info list defined on the given relation
 			static
-			DrgPmdIndexInfo *PdrgpmdRelIndexInfo(IMemoryPool *pmp, Relation rel);
+			CMDIndexInfoArray *RetrieveRelIndexInfo(IMemoryPool *mp, Relation rel);
 
 			// return index info list of indexes defined on a partitoned table
 			static
-			DrgPmdIndexInfo *PdrgpmdRelIndexInfoPartTable(IMemoryPool *pmp, Relation relRoot);
+			CMDIndexInfoArray *RetrieveRelIndexInfoForPartTable(IMemoryPool *mp, Relation root_rel);
 
 			// return index info list of indexes defined on regular, external tables or leaf partitions
 			static
-			DrgPmdIndexInfo *PdrgpmdRelIndexInfoNonPartTable(IMemoryPool *pmp, Relation rel);
+			CMDIndexInfoArray *RetrieveRelIndexInfoForNonPartTable(IMemoryPool *mp, Relation rel);
 
 			// retrieve an index over a partitioned table from the relcache
 			static
-			IMDIndex *PmdindexPartTable(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdidIndex, const IMDRelation *pmdrel, LogicalIndexes *plind);
+			IMDIndex *RetrievePartTableIndex(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid_index, const IMDRelation *md_rel, LogicalIndexes *logical_indexes);
 			
 			// lookup an index given its id from the logical indexes structure
 			static
-			LogicalIndexInfo *PidxinfoLookup(LogicalIndexes *plind, OID oid);
+			LogicalIndexInfo *LookupLogicalIndexById(LogicalIndexes *logical_indexes, OID oid);
 			
 			// construct an MD cache index object given its logical index representation
 			static
-			IMDIndex *PmdindexPartTable(IMemoryPool *pmp, CMDAccessor *pmda, LogicalIndexInfo *pidxinfo, IMDId *pmdidIndex, const IMDRelation *pmdrel);
+			IMDIndex *RetrievePartTableIndex(IMemoryPool *mp, CMDAccessor *md_accessor, LogicalIndexInfo *index_info, IMDId *mdid_index, const IMDRelation *md_rel);
 
 			// return the triggers defined on the given relation
 			static
-			DrgPmdid *PdrgpmdidTriggers(IMemoryPool *pmp, Relation rel);
+			IMdIdArray *RetrieveRelTriggers(IMemoryPool *mp, Relation rel);
 
 			// return the check constraints defined on the relation with the given oid
 			static
-			DrgPmdid *PdrgpmdidCheckConstraints(IMemoryPool *pmp, OID oid);
+			IMdIdArray *RetrieveRelCheckConstraints(IMemoryPool *mp, OID oid);
 
 			// does attribute number correspond to a transaction visibility attribute
 			static 
-			BOOL FTransactionVisibilityAttribute(INT iAttNo);
+			BOOL IsTransactionVisibilityAttribute(INT attrnum);
 			
 			// does relation type have system columns
 			static
-			BOOL FHasSystemColumns(char	cRelKind);
+			BOOL RelHasSystemColumns(char	rel_kind);
 			
 			// translate Optimizer comparison types to GPDB
 			static
-			ULONG UlCmpt(IMDType::ECmpType ecmpt);
+			ULONG GetComparisonType(IMDType::ECmpType cmp_type);
 			
 			// retrieve the opfamilies mdids for the given scalar op
 			static
-			DrgPmdid *PdrgpmdidScOpOpFamilies(IMemoryPool *pmp, IMDId *pmdidScOp);
+			IMdIdArray *RetrieveScOpOpFamilies(IMemoryPool *mp, IMDId *mdid_scalar_op);
 			
 			// retrieve the opfamilies mdids for the given index
 			static
-			DrgPmdid *PdrgpmdidIndexOpFamilies(IMemoryPool *pmp, IMDId *pmdidIndex);
+			IMdIdArray *RetrieveIndexOpFamilies(IMemoryPool *mp, IMDId *mdid_index);
 
             // for non-leaf partition tables return the number of child partitions
             // else return 1
             static
-            ULONG UlTableCount(OID oidRelation);
+            ULONG RetrieveNumChildPartitions(OID rel_oid);
 
             // generate statistics for the system level columns
             static
-            CDXLColStats *PdxlcolstatsSystemColumn
+            CDXLColStats *GenerateStatsForSystemCols
                               (
-                              IMemoryPool *pmp,
-                              OID oidRelation,
-                              CMDIdColStats *pmdidColStats,
-                              CMDName *pmdnameCol,
-                              OID oidAttType,
+                              IMemoryPool *mp,
+                              OID rel_oid,
+                              CMDIdColStats *mdid_col_stats,
+                              CMDName *md_colname,
+                              OID att_type,
                               AttrNumber attrnum,
-                              DrgPdxlbucket *pdrgpdxlbucket,
-                              CDouble dRows
+                              CDXLBucketArray *dxl_stats_bucket_array,
+                              CDouble rows
                               );
 		public:
 			// retrieve a metadata object from the relcache
 			static
-			IMDCacheObject *Pimdobj(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			IMDCacheObject *RetrieveObject(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// retrieve a relation from the relcache
 			static
-			IMDRelation *Pmdrel(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			IMDRelation *RetrieveRel(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// add system columns (oid, tid, xmin, etc) in table descriptors
 			static
-			void AddSystemColumns(IMemoryPool *pmp, DrgPmdcol *pdrgpmdcol, Relation rel, BOOL fAOTable);
+			void AddSystemColumns(IMemoryPool *mp, CMDColumnArray *mdcol_array, Relation rel, BOOL is_ao_table);
 
 			// retrieve an index from the relcache
 			static
-			IMDIndex *Pmdindex(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdidIndex);
+			IMDIndex *RetrieveIndex(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid_index);
 
 			// retrieve a check constraint from the relcache
 			static
-			CMDCheckConstraintGPDB *Pmdcheckconstraint(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			CMDCheckConstraintGPDB *RetrieveCheckConstraints(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// populate the attribute number to position mapping
 			static
-			ULONG *PulAttnoPositionMap(IMemoryPool *pmp, const IMDRelation *pmdrel, ULONG ulRgSize);
+			ULONG *PopulateAttnoPositionMap(IMemoryPool *mp, const IMDRelation *md_rel, ULONG size);
 
 			// return the position of a given attribute number
 			static
-			ULONG UlPosition(INT iAttno, ULONG *pul);
+			ULONG GetAttributePosition(INT attno, ULONG *attno_mapping);
 
 			// retrieve a type from the relcache
 			static
-			IMDType *Pmdtype(IMemoryPool *pmp, IMDId *pmdid);
+			IMDType *RetrieveType(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a scalar operator from the relcache
 			static
-			CMDScalarOpGPDB *Pmdscop(IMemoryPool *pmp, IMDId *pmdid);
+			CMDScalarOpGPDB *RetrieveScOp(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a function from the relcache
 			static
-			CMDFunctionGPDB *Pmdfunc(IMemoryPool *pmp, IMDId *pmdid);
+			CMDFunctionGPDB *RetrieveFunc(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve an aggregate from the relcache
 			static
-			CMDAggregateGPDB *Pmdagg(IMemoryPool *pmp, IMDId *pmdid);
+			CMDAggregateGPDB *RetrieveAgg(IMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a trigger from the relcache
 			static
-			CMDTriggerGPDB *Pmdtrigger(IMemoryPool *pmp, IMDId *pmdid);
+			CMDTriggerGPDB *RetrieveTrigger(IMemoryPool *mp, IMDId *mdid);
 			
 			// translate GPDB comparison type
 			static
-			IMDType::ECmpType Ecmpt(ULONG ulCmpt);
+			IMDType::ECmpType ParseCmpType(ULONG cmpt);
 			
 			// get the distribution policy of the relation
 			static
-			IMDRelation::Ereldistrpolicy Ereldistribution(GpPolicy *pgppolicy);
+			IMDRelation::Ereldistrpolicy GetRelDistribution(GpPolicy *gp_policy);
 	};
 }
 

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -61,304 +61,304 @@ namespace gpdxl
 	class CTranslatorScalarToDXL
 	{
 		// shorthand for functions for translating GPDB expressions into DXL nodes
-		typedef CDXLNode * (CTranslatorScalarToDXL::*PfPdxln)(const Expr *pexpr, const CMappingVarColId* pmapvarcolid);
+		typedef CDXLNode * (CTranslatorScalarToDXL::*ExprToDXLFn)(const Expr *expr, const CMappingVarColId* var_colid_mapping);
 
 		// shorthand for functions for translating DXL nodes to GPDB expressions
-		typedef CDXLDatum * (PfPdxldatumFromDatum)(IMemoryPool *pmp, const IMDType *pmdtype, BOOL fNull, ULONG ulLen, Datum datum);
+		typedef CDXLDatum * (DxlDatumFromDatum)(IMemoryPool *mp, const IMDType *md_type, BOOL is_null, ULONG len, Datum datum);
 
 		private:
 
 			// pair of node tag and translator function
 			struct STranslatorElem
 			{
-				NodeTag ent;
-				PfPdxln pf;
+				NodeTag tag;
+				ExprToDXLFn func_ptr;
 			};
 
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// meta data accessor
-			CMDAccessor *m_pmda;
+			CMDAccessor *m_md_accessor;
 
 			// counter for generating unique column ids
-			CIdGenerator *m_pidgtorCol;
+			CIdGenerator *m_colid_generator;
 
 			// counter for generating unique CTE ids
-			CIdGenerator *m_pidgtorCTE;
+			CIdGenerator *m_cte_id_generator;
 
 			// absolute level of query whose vars will be translated
-			ULONG m_ulQueryLevel;
+			ULONG m_query_level;
 
 			// does the currently translated scalar have distributed tables
-			BOOL m_fHasDistributedTables;
+			BOOL m_has_distributed_tables;
 
 			// is scalar being translated in query mode
-			BOOL m_fQuery;
+			BOOL m_is_query_mode;
 
 			// physical operator that created this translator
-			EPlStmtPhysicalOpType m_eplsphoptype;
+			EPlStmtPhysicalOpType m_op_type;
 
 			// hash map that maintains the list of CTEs defined at a particular query level
-			HMUlCTEListEntry *m_phmulCTEEntries;
+			HMUlCTEListEntry *m_cte_entries;
 
 			// list of CTE producers shared among the logical and scalar translators
-			DrgPdxln *m_pdrgpdxlnCTE;
+			CDXLNodeArray *m_cte_producers;
 
 			EdxlBoolExprType EdxlbooltypeFromGPDBBoolType(BoolExprType) const;
 
 			// translate list elements and add them as children of the DXL node
 			void TranslateScalarChildren
 				(
-				CDXLNode *pdxln,
-				List *plist,
-				const CMappingVarColId* pmapvarcolid,
-				BOOL *pfHasDistributedTables = NULL
+				CDXLNode *dxlnode,
+				List *list,
+				const CMappingVarColId* var_colid_mapping,
+				BOOL *has_distributed_tables = NULL
 				);
 
 			// create a DXL scalar distinct comparison node from a GPDB DistinctExpr
-			CDXLNode *PdxlnScDistCmpFromDistExpr
+			CDXLNode *TranslateDistinctExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar boolean expression node from a GPDB qual list
-			CDXLNode *PdxlnScCondFromQual
+			CDXLNode *CreateScalarCondFromQual
 				(
-				List *plQual,
-				const CMappingVarColId* pmapvarcolid,
-				BOOL *pfHasDistributedTables
+				List *quals,
+				const CMappingVarColId* var_colid_mapping,
+				BOOL *has_distributed_tables
 				);
 
 			// create a DXL scalar comparison node from a GPDB op expression
-			CDXLNode *PdxlnScCmpFromOpExpr
+			CDXLNode *CreateScalarCmpFromOpExpr
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar opexpr node from a GPDB expression
-			CDXLNode *PdxlnScOpExprFromExpr
+			CDXLNode *TranslateOpExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// translate an array expression
-			CDXLNode *PdxlnArrayOpExpr
+			CDXLNode *TranslateScalarArrayOpExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar array comparison node from a GPDB expression
-			CDXLNode *PdxlnScArrayCompFromExpr
+			CDXLNode *CreateScalarArrayCompFromExpr
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar Const node from a GPDB expression
-			CDXLNode *PdxlnScConstFromExpr
+			CDXLNode *TranslateConstToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL node for a scalar nullif from a GPDB Expr
-			CDXLNode *PdxlnScNullIfFromExpr
+			CDXLNode *TranslateNullIfExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar boolexpr node from a GPDB expression
-			CDXLNode *PdxlnScBoolExprFromExpr
+			CDXLNode *TranslateBoolExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar boolean test node from a GPDB expression
-			CDXLNode *PdxlnScBooleanTestFromExpr
+			CDXLNode *TranslateBooleanTestToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar nulltest node from a GPDB expression
-			CDXLNode *PdxlnScNullTestFromNullTest
+			CDXLNode *TranslateNullTestToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar case statement node from a GPDB expression
-			CDXLNode *PdxlnScCaseStmtFromExpr
+			CDXLNode *TranslateCaseExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar if statement node from a GPDB case expression
-			CDXLNode *PdxlnScIfStmtFromCaseExpr
+			CDXLNode *CreateScalarIfStmtFromCaseExpr
 				(
-				const CaseExpr *pcaseexpr,
-				const CMappingVarColId* pmapvarcolid
+				const CaseExpr *case_expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar switch node from a GPDB case expression
-			CDXLNode *PdxlnScSwitchFromCaseExpr
+			CDXLNode *CreateScalarSwitchFromCaseExpr
 				(
-				const CaseExpr *pcaseexpr,
-				const CMappingVarColId* pmapvarcolid
+				const CaseExpr *case_expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL node for a case test from a GPDB Expr.
-			CDXLNode *PdxlnScCaseTestFromExpr
+			CDXLNode *TranslateCaseTestExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar coalesce node from a GPDB expression
-			CDXLNode *PdxlnScCoalesceFromExpr
+			CDXLNode *TranslateCoalesceExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar minmax node from a GPDB expression
-			CDXLNode *PdxlnScMinMaxFromExpr
+			CDXLNode *TranslateMinMaxExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar relabeltype node from a GPDB expression
-			CDXLNode *PdxlnScCastFromRelabelType
+			CDXLNode *TranslateRelabelTypeToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar coerce node from a GPDB expression
-			CDXLNode *PdxlnScCoerceFromCoerce
+			CDXLNode *TranslateCoerceToDomainToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar coerceviaio node from a GPDB expression
-			CDXLNode *PdxlnScCoerceFromCoerceViaIO
+			CDXLNode *TranslateCoerceViaIOToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 		
 			// create a DXL scalar array coerce expression node from a GPDB expression
-			CDXLNode *PdxlnScArrayCoerceExprFromExpr
+			CDXLNode *TranslateArrayCoerceExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar funcexpr node from a GPDB expression
-			CDXLNode *PdxlnScFuncExprFromFuncExpr
+			CDXLNode *TranslateFuncExprToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// return the window frame boundary
 			EdxlFrameBoundary Edxlfb(WindowBoundingKind kind, Node *pnode) const;
 
 			// create a DXL scalar Windowref node from a GPDB expression
-			CDXLNode *PdxlnScWindowref
+			CDXLNode *TranslateWindowRefToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// create a DXL scalar Aggref node from a GPDB expression
-			CDXLNode *PdxlnScAggrefFromAggref
+			CDXLNode *TranslateAggrefToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
-			CDXLNode *PdxlnScIdFromVar
+			CDXLNode *TranslateVarToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
-			CDXLNode *PdxlnInitPlanFromParam(const Param *pparam) const;
+			CDXLNode *CreateInitPlanFromParam(const Param *param) const;
 
 			// create a DXL SubPlan node for a from a GPDB SubPlan
-			CDXLNode *PdxlnSubPlanFromSubPlan
+			CDXLNode *TranslateSubplanToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
-			CDXLNode *PdxlnPlanFromParam
+			CDXLNode *CreatePlanFromParam
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
-			CDXLNode *PdxlnFromSublink
+			CDXLNode *TranslateSubLinkToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping
 				);
 
-			CDXLNode *PdxlnScSubqueryFromSublink
+			CDXLNode *CreateScalarSubqueryFromSublink
 				(
-				const SubLink *psublink,
-				const CMappingVarColId* pmapvarcolid
+				const SubLink *sublink,
+				const CMappingVarColId* var_colid_mapping
 				);
 
-			CDXLNode *PdxlnExistSubqueryFromSublink
+			CDXLNode *CreateExistSubqueryFromSublink
 				(
-				const SubLink *psublink,
-				const CMappingVarColId* pmapvarcolid
+				const SubLink *sublink,
+				const CMappingVarColId* var_colid_mapping
 				);
 
-			CDXLNode *PdxlnQuantifiedSubqueryFromSublink
+			CDXLNode *CreateQuantifiedSubqueryFromSublink
 				(
-				const SubLink *psublink,
-				const CMappingVarColId* pmapvarcolid
+				const SubLink *sublink,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// translate an array expression
-			CDXLNode *PdxlnArray(const Expr *pexpr, const CMappingVarColId* pmapvarcolid);
+			CDXLNode *TranslateArrayExprToDXL(const Expr *expr, const CMappingVarColId* var_colid_mapping);
 
 			// translate an arrayref expression
-			CDXLNode *PdxlnArrayRef(const Expr *pexpr, const CMappingVarColId* pmapvarcolid);
+			CDXLNode *TranslateArrayRefToDXL(const Expr *expr, const CMappingVarColId* var_colid_mapping);
 
 			// add an indexlist to the given DXL arrayref node
 			void AddArrayIndexList
 				(
-				CDXLNode *pdxln,
-				List *plist,
-				CDXLScalarArrayRefIndexList::EIndexListBound eilb,
-				const CMappingVarColId* pmapvarcolid
+				CDXLNode *dxlnode,
+				List *list,
+				CDXLScalarArrayRefIndexList::EIndexListBound index_list_bound,
+				const CMappingVarColId* var_colid_mapping
 				);
 
 			// get the operator name
-			const CWStringConst *PstrOpName(IMDId *pmdid) const;
+			const CWStringConst *GetDXLArrayCmpType(IMDId *mdid) const;
 
 			// translate the window frame edge, if the column used in the edge is a
 			// computed column then add it to the project list
-			CDXLNode *PdxlnWindowFrameEdgeVal
+			CDXLNode *TranslateWindowFrameEdgeToDXL
 				(
-				const Node *pnode,
-				const CMappingVarColId* pmapvarcolid,
-				CDXLNode *pdxlnNewChildScPrL,
-				BOOL *pfHasDistributedTables
+				const Node *node,
+				const CMappingVarColId* var_colid_mapping,
+				CDXLNode *new_scalar_proj_list,
+				BOOL *has_distributed_tables
 				);
 
 		public:
@@ -366,192 +366,192 @@ namespace gpdxl
 			// ctor
 			CTranslatorScalarToDXL
 				(
-				IMemoryPool *pmp,
-				CMDAccessor *pmda,
-				CIdGenerator *pulidgtorCol,
-				CIdGenerator *pulidgtorCTE,
-				ULONG ulQueryLevel,
-				BOOL fQuery,
-				HMUlCTEListEntry *phmulCTEEntries,
-				DrgPdxln *pdrgpdxlnCTE
+				IMemoryPool *mp,
+				CMDAccessor *md_accessor,
+				CIdGenerator *colid_generator,
+				CIdGenerator *cte_id_generator,
+				ULONG query_level,
+				BOOL is_query_mode,
+				HMUlCTEListEntry *cte_entries,
+				CDXLNodeArray *cte_dxlnode_array
 				);
 
 			// set the caller type
 			void SetCallingPhysicalOpType
 					(
-					EPlStmtPhysicalOpType eplsphoptype
+					EPlStmtPhysicalOpType plstmt_physical_op_type
 					)
 			{
-				m_eplsphoptype = eplsphoptype;
+				m_op_type = plstmt_physical_op_type;
 			}
 
 			// create a DXL datum from a GPDB const
-			CDXLDatum *Pdxldatum(const Const *pconst) const;
+			CDXLDatum *TranslateConstToDXL(const Const *constant) const;
 
 			// return the current caller type
-			EPlStmtPhysicalOpType Eplsphoptype() const
+			EPlStmtPhysicalOpType GetPhysicalOpType() const
 			{
-				return m_eplsphoptype;
+				return m_op_type;
 			}
 			// create a DXL scalar operator node from a GPDB expression
 			// and a table descriptor for looking up column descriptors
-			CDXLNode *PdxlnScOpFromExpr
+			CDXLNode *TranslateScalarToDXL
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid,
-				BOOL *pfHasDistributedTables = NULL
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping,
+				BOOL *has_distributed_tables = NULL
 				);
 
 			// create a DXL scalar filter node from a GPDB qual list
-			CDXLNode *PdxlnFilterFromQual
+			CDXLNode *CreateFilterFromQual
 				(
-				List *plQual,
-				const CMappingVarColId* pmapvarcolid,
-				Edxlopid edxlopFilterType,
-				BOOL *pfHasDistributedTables = NULL
+				List *quals,
+				const CMappingVarColId* var_colid_mapping,
+				Edxlopid filter_type,
+				BOOL *has_distributed_tables = NULL
 				);
 
 			// create a DXL WindowFrame node from a GPDB expression
-			CDXLWindowFrame *Pdxlwf
+			CDXLWindowFrame *GetWindowFrame
 				(
-				const Expr *pexpr,
-				const CMappingVarColId* pmapvarcolid,
-				CDXLNode *pdxlnNewChildScPrL,
-				BOOL *pfHasDistributedTables = NULL
+				const Expr *expr,
+				const CMappingVarColId* var_colid_mapping,
+				CDXLNode *new_scalar_proj_list,
+				BOOL *has_distributed_tables = NULL
 				);
 
 			// translate GPDB Const to CDXLDatum
 			static
-			CDXLDatum *Pdxldatum
+			CDXLDatum *TranslateConstToDXL
 				(
-				IMemoryPool *pmp,
+				IMemoryPool *mp,
 				CMDAccessor *mda,
-				const Const *pconst
+				const Const *constant
 				);
 
 			// translate GPDB datum to CDXLDatum
 			static
-			CDXLDatum *Pdxldatum
+			CDXLDatum *TranslateDatumToDXL
 				(
-				IMemoryPool *pmp,
-				const IMDType *pmdtype,
-				INT iTypeModifier,
-				BOOL fNull,
-				ULONG ulLen,
+				IMemoryPool *mp,
+				const IMDType *md_type,
+				INT type_modifier,
+				BOOL is_null,
+				ULONG len,
 				Datum datum
 				);
 
 			// translate GPDB datum to IDatum
 			static
-			IDatum *Pdatum
+			IDatum *CreateIDatumFromGpdbDatum
 				(
-				IMemoryPool *pmp,
-				const IMDType *pmdtype,
-				BOOL fNull,
+				IMemoryPool *mp,
+				const IMDType *md_type,
+				BOOL is_null,
 				Datum datum
 				);
 
 			// extract the byte array value of the datum
 			static
-			BYTE *Pba
+			BYTE *ExtractByteArrayFromDatum
 				(
-				IMemoryPool *pmp,
-				const IMDType *pmdtype,
-				BOOL fNull,
-				ULONG ulLen,
+				IMemoryPool *mp,
+				const IMDType *md_type,
+				BOOL is_null,
+				ULONG len,
 				Datum datum
 				);
 
 			static
-			CDouble DValue
+			CDouble ExtractDoubleValueFromDatum
 				(
-				IMDId *pmdid,
-				BOOL fNull,
-				BYTE *pba,
+				IMDId *mdid,
+				BOOL is_null,
+				BYTE *bytes,
 				Datum datum
 				);
 
 			// extract the long int value of a datum
 			static
-			LINT LValue
+			LINT ExtractLintValueFromDatum
 				(
-				IMDId *pmdid,
-				BOOL fNull,
-				BYTE *pba,
-				ULONG ulLen
+				IMDId *mdid,
+				BOOL is_null,
+				BYTE *bytes,
+				ULONG len
 				);
 
 			// pair of DXL datum type and translator function
 			struct SDXLDatumTranslatorElem
 			{
-				IMDType::ETypeInfo eti;
-				PfPdxldatumFromDatum *pf;
+				IMDType::ETypeInfo type_info;
+				DxlDatumFromDatum *func_ptr;
 			};
 
 			// datum to oid CDXLDatum
 			static
-			CDXLDatum *PdxldatumOid
+			CDXLDatum *TranslateOidDatumToDXL
 				(
-				IMemoryPool *pmp,
-				const IMDType *pmdtype,
-				BOOL fNull,
-				ULONG ulLen,
+				IMemoryPool *mp,
+				const IMDType *md_type,
+				BOOL is_null,
+				ULONG len,
 				Datum datum
 				);
 
 			// datum to int2 CDXLDatum
 			static
-			CDXLDatum *PdxldatumInt2
+			CDXLDatum *TranslateInt2DatumToDXL
 				(
-				IMemoryPool *pmp,
-				const IMDType *pmdtype,
-				BOOL fNull,
-				ULONG ulLen,
+				IMemoryPool *mp,
+				const IMDType *md_type,
+				BOOL is_null,
+				ULONG len,
 				Datum datum
 				);
 
 			// datum to int4 CDXLDatum
 			static
-			CDXLDatum *PdxldatumInt4
+			CDXLDatum *TranslateInt4DatumToDXL
 				(
-				IMemoryPool *pmp,
-				const IMDType *pmdtype,
-				BOOL fNull,
-				ULONG ulLen,
+				IMemoryPool *mp,
+				const IMDType *md_type,
+				BOOL is_null,
+				ULONG len,
 				Datum datum
 				);
 
 			// datum to int8 CDXLDatum
 			static
-			CDXLDatum *PdxldatumInt8
+			CDXLDatum *TranslateInt8DatumToDXL
 				(
-				IMemoryPool *pmp,
-				const IMDType *pmdtype,
-				BOOL fNull,
-				ULONG ulLen,
+				IMemoryPool *mp,
+				const IMDType *md_type,
+				BOOL is_null,
+				ULONG len,
 				Datum datum
 				);
 
 			// datum to bool CDXLDatum
 			static
-			CDXLDatum *PdxldatumBool
+			CDXLDatum *TranslateBoolDatumToDXL
 				(
-				IMemoryPool *pmp,
-				const IMDType *pmdtype,
-				BOOL fNull,
-				ULONG ulLen,
+				IMemoryPool *mp,
+				const IMDType *md_type,
+				BOOL is_null,
+				ULONG len,
 				Datum datum
 				);
 
 			// datum to generic CDXLDatum
 			static
-			CDXLDatum *PdxldatumGeneric
+			CDXLDatum *TranslateGenericDatumToDXL
 				(
-				IMemoryPool *pmp,
-				const IMDType *pmdtype,
-				INT iTypeModifier,
-				BOOL fNull,
-				ULONG ulLen,
+				IMemoryPool *mp,
+				const IMDType *md_type,
+				INT type_modifier,
+				BOOL is_null,
+				ULONG len,
 				Datum datum
 				);
 	};

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -40,7 +40,7 @@ namespace gpopt
 	class CMDAccessor;
 
 	// dynamic array of bitsets
-	typedef CDynamicPtrArray<CBitSet, CleanupRelease> DrgPbs;
+	typedef CDynamicPtrArray<CBitSet, CleanupRelease> CBitSetArray;
 }
 
 namespace gpdxl
@@ -67,156 +67,156 @@ namespace gpdxl
 
 			// construct a set of column attnos corresponding to a single grouping set
 			static
-			CBitSet *PbsGroupingSet(IMemoryPool *pmp, List *plGroupElems, ULONG ulCols, HMUlUl *phmululGrpColPos, CBitSet *pbsGrpCols);
+			CBitSet *CreateAttnoSetForGroupingSet(IMemoryPool *mp, List *group_elems, ULONG num_cols, UlongToUlongMap *group_col_pos, CBitSet *group_cols);
 
 			// create a set of grouping sets for a rollup
 			static
-			DrgPbs *PdrgpbsRollup(IMemoryPool *pmp, GroupingClause *pgrcl, ULONG ulCols, HMUlUl *phmululGrpColPos, CBitSet *pbsGrpCols);
+			CBitSetArray *CreateGroupingSetsForRollup(IMemoryPool *mp, GroupingClause *grouping_clause, ULONG num_cols, UlongToUlongMap *grouping_col_to_pos_map, CBitSet *group_cols);
 
 			// check if the given mdid array contains any of the polymorphic
 			// types (ANYELEMENT, ANYARRAY)
 			static
-			BOOL FContainsPolymorphicTypes(DrgPmdid *pdrgpmdidTypes);
+			BOOL ContainsPolymorphicTypes(IMdIdArray *mdid_array);
 
 			// resolve polymorphic types in the given array of type ids, replacing
 			// them with the actual types obtained from the query
 			static
-			DrgPmdid *PdrgpmdidResolvePolymorphicTypes
+			IMdIdArray *ResolvePolymorphicTypes
 						(
-						IMemoryPool *pmp,
-						DrgPmdid *pdrgpmdidTypes,
-						List *plArgTypes,
-						FuncExpr *pfuncexpr
+						IMemoryPool *mp,
+						IMdIdArray *mdid_array,
+						List *arg_types,
+						FuncExpr *func_expr
 						);
 			
 			// update grouping col position mappings
 			static
-			void UpdateGrpColMapping(IMemoryPool *pmp, HMUlUl *phmululGrpColPos, CBitSet *pbsGrpCols, ULONG ulSortGrpRef);
+			void UpdateGrpColMapping(IMemoryPool *mp, UlongToUlongMap *grouping_col_to_pos_map, CBitSet *group_cols, ULONG sort_group_ref);
 
 		public:
 
 			struct SCmptypeStrategy
 			{
-				IMDType::ECmpType ecomptype;
-				StrategyNumber sn;
+				IMDType::ECmpType comptype;
+				StrategyNumber strategy_no;
 
 			};
 
 			// get the GPDB scan direction from its corresponding DXL representation
 			static
-			ScanDirection Scandirection(EdxlIndexScanDirection edxlisd);
+			ScanDirection GetScanDirection(EdxlIndexScanDirection idx_scan_direction);
 
 			// get the oid of comparison operator
 			static
-			OID OidCmpOperator(Expr* pexpr);
+			OID OidCmpOperator(Expr* expr);
 
 			// get the opfamily for index key
 			static
-			OID OidIndexQualOpFamily(INT iAttno, OID oidIndex);
+			OID GetOpFamilyForIndexQual(INT attno, OID oid_index);
 			
 			// return the type for the system column with the given number
 			static
-			CMDIdGPDB *PmdidSystemColType(IMemoryPool *pmp, AttrNumber attno);
+			CMDIdGPDB *GetSystemColType(IMemoryPool *mp, AttrNumber attno);
 
 			// find the n-th column descriptor in the table descriptor
 			static
-			const CDXLColDescr *Pdxlcd(const CDXLTableDescr *pdxltabdesc, ULONG ulPos);
+			const CDXLColDescr *GetColumnDescrAt(const CDXLTableDescr *table_descr, ULONG pos);
 
 			// return the name for the system column with given number
 			static
-			const CWStringConst *PstrSystemColName(AttrNumber attno);
+			const CWStringConst *GetSystemColName(AttrNumber attno);
 
 			// returns the length for the system column with given attno number
 			static
-			const ULONG UlSystemColLength(AttrNumber attno);
+			const ULONG GetSystemColLength(AttrNumber attno);
 
 			// translate the join type from its GPDB representation into the DXL one
 			static
-			EdxlJoinType EdxljtFromJoinType(JoinType jt);
+			EdxlJoinType ConvertToDXLJoinType(JoinType jt);
 
 			// translate the index scan direction from its GPDB representation into the DXL one
 			static
-			EdxlIndexScanDirection EdxlIndexDirection(ScanDirection sd);
+			EdxlIndexScanDirection ConvertToDXLIndexScanDirection(ScanDirection sd);
 
 			// create a DXL index descriptor from an index MD id
 			static
-			CDXLIndexDescr *Pdxlid(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid);
+			CDXLIndexDescr *GetIndexDescr(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// translate a RangeTableEntry into a CDXLTableDescr
 			static
-			CDXLTableDescr *Pdxltabdesc
+			CDXLTableDescr *GetTableDescr
 								(
-								IMemoryPool *pmp,
-								CMDAccessor *pmda,
-								CIdGenerator *pidgtor,
-								const RangeTblEntry *prte,
-								BOOL *pfDistributedTable = NULL
+								IMemoryPool *mp,
+								CMDAccessor *md_accessor,
+								CIdGenerator *id_generator,
+								const RangeTblEntry *rte,
+								BOOL *is_distributed_table = NULL
 								);
 
 			// translate a RangeTableEntry into a CDXLLogicalTVF
 			static
-			CDXLLogicalTVF *Pdxltvf
+			CDXLLogicalTVF *ConvertToCDXLLogicalTVF
 								(
-								IMemoryPool *pmp,
-								CMDAccessor *pmda,
-								CIdGenerator *pidgtor,
-								const RangeTblEntry *prte
+								IMemoryPool *mp,
+								CMDAccessor *md_accessor,
+								CIdGenerator *id_generator,
+								const RangeTblEntry *rte
 								);
 
 			// get column descriptors from a record type
 			static
-			DrgPdxlcd *PdrgdxlcdRecord
+			CDXLColDescrArray *GetColumnDescriptorsFromRecord
 						(
-						IMemoryPool *pmp,
-						CIdGenerator *pidgtor,
-						List *plColNames,
-						List *plColTypes,
-						List *plColTypeModifiers
+						IMemoryPool *mp,
+						CIdGenerator *id_generator,
+						List *col_names,
+						List *col_types,
+						List *col_type_modifiers
 						);
 
 			// get column descriptors from a record type
 			static
-			DrgPdxlcd *PdrgdxlcdRecord
+			CDXLColDescrArray *GetColumnDescriptorsFromRecord
 						(
-						IMemoryPool *pmp,
-						CIdGenerator *pidgtor,
-						List *plColNames,
-						DrgPmdid *pdrgpmdidOutArgTypes
+						IMemoryPool *mp,
+						CIdGenerator *id_generator,
+						List *col_names,
+						IMdIdArray *out_arg_types
 						);
 
 			// get column descriptor from a base type
 			static
-			DrgPdxlcd *PdrgdxlcdBase
+			CDXLColDescrArray *GetColumnDescriptorsFromBase
 						(
-						IMemoryPool *pmp,
-						CIdGenerator *pidgtor,
-						IMDId *pmdidRetType,
-						INT iTypeModifier,
-						CMDName *pmdName
+						IMemoryPool *mp,
+						CIdGenerator *id_generator,
+						IMDId *mdid_return_type,
+						INT type_modifier,
+						CMDName *md_name
 						);
 
 			// get column descriptors from a composite type
 			static
-			DrgPdxlcd *PdrgdxlcdComposite
+			CDXLColDescrArray *GetColumnDescriptorsFromComposite
 						(
-						IMemoryPool *pmp,
-						CMDAccessor *pmda,
-						CIdGenerator *pidgtor,
-						const IMDType *pmdType
+						IMemoryPool *mp,
+						CMDAccessor *md_accessor,
+						CIdGenerator *id_generator,
+						const IMDType *md_type
 						);
 
 			// expand a composite type into an array of IMDColumns
 			static
-			DrgPmdcol *ExpandCompositeType
+			CMDColumnArray *ExpandCompositeType
 						(
-						IMemoryPool *pmp,
-						CMDAccessor *pmda,
-						const IMDType *pmdType
+						IMemoryPool *mp,
+						CMDAccessor *md_accessor,
+						const IMDType *md_type
 						);
 
 			// return the dxl representation of the set operation
 			static
-			EdxlSetOpType Edxlsetop(SetOperation setop, BOOL fAll);
+			EdxlSetOpType GetSetOpType(SetOperation setop, BOOL is_all);
 
 			// return the GPDB frame exclusion strategy from its corresponding DXL representation
 			static
@@ -229,197 +229,196 @@ namespace gpdxl
 			// construct a dynamic array of sets of column attnos corresponding
 			// to the group by clause
 			static
-			DrgPbs *PdrgpbsGroupBy(IMemoryPool *pmp, List *plGroupClause, ULONG ulCols, HMUlUl *phmululGrpColPos, CBitSet *pbsGrpCols);
+			CBitSetArray *GetColumnAttnosForGroupBy(IMemoryPool *mp, List *group_clause, ULONG num_cols, UlongToUlongMap *group_col_pos, CBitSet *group_cold);
 
 			// return a copy of the query with constant of unknown type being coerced
 			// to the common data type of the output target list
 			static
-			Query *PqueryFixUnknownTypeConstant(Query *pquery, List *plTargetList);
+			Query *FixUnknownTypeConstant(Query *query, List *target_list);
 
 			// return the type of the nth non-resjunked target list entry
-			static OID OidTargetListReturnType(List *plTargetList, ULONG ulColPos);
+			static OID GetTargetListReturnTypeOid(List *target_list, ULONG col_pos);
 
 			// construct an array of DXL column identifiers for a target list
 			static
-			DrgPul *PdrgpulGenerateColIds
+			ULongPtrArray *GenerateColIds
 					(
-					IMemoryPool *pmp,
-					List *plTargetList,
-					DrgPmdid *pdrgpmdidInput,
-					DrgPul *pdrgpulInput,
-					BOOL *pfOuterRef,
-					CIdGenerator *pidgtorColId
+					IMemoryPool *mp,
+					List *target_list,
+					IMdIdArray *input_mdids,
+					ULongPtrArray *input_nums,
+					BOOL *is_outer_ref,
+					CIdGenerator *colid_generator
 					);
 
 			// construct an array of DXL column descriptors for a target list
 			// using the column ids in the given array
 			static
-			DrgPdxlcd *Pdrgpdxlcd(IMemoryPool *pmp, List *plTargetList, DrgPul *pdrgpulColIds, BOOL fKeepResjunked);
+			CDXLColDescrArray *GetDXLColumnDescrArray(IMemoryPool *mp, List *target_list, ULongPtrArray *colids, BOOL keep_res_junked);
 
 			// return the positions of the target list entries included in the output
 			static
-			DrgPul *PdrgpulPosInTargetList(IMemoryPool *pmp, List *plTargetList, BOOL fKeepResjunked);
+			ULongPtrArray *GetPosInTargetList(IMemoryPool *mp, List *target_list, BOOL keep_res_junked);
 
 			// construct a column descriptor from the given target entry, column identifier and position in the output
 			static
-			CDXLColDescr *Pdxlcd(IMemoryPool *pmp, TargetEntry *pte, ULONG ulColId, ULONG ulPos);
+			CDXLColDescr *GetColumnDescrAt(IMemoryPool *mp, TargetEntry *target_entry, ULONG colid, ULONG pos);
 
 			// create a dummy project element to rename the input column identifier
 			static
-			CDXLNode *PdxlnDummyPrElem(IMemoryPool *pmp, ULONG ulColIdInput, ULONG ulColIdOutput, CDXLColDescr *pdxlcd);
+			CDXLNode *CreateDummyProjectElem(IMemoryPool *mp, ULONG colid_input, ULONG colid_output, CDXLColDescr *dxl_col_descr);
 
 			// construct a list of colids corresponding to the given target list
 			// using the given attno->colid map
 			static
-			DrgPul *PdrgpulColIds(IMemoryPool *pmp, List *plTargetList, HMIUl *phmiulAttnoColId);
+			ULongPtrArray *GetOutputColIdsArray(IMemoryPool *mp, List *target_list, IntToUlongMap *attno_to_colid_map);
 
 			// construct an array of column ids for the given group by set
 			static
-			DrgPul *PdrgpulGroupingCols(IMemoryPool *pmp, CBitSet *pbsGroupByCols, HMIUl *phmiulSortGrpColsColId);
+			ULongPtrArray *GetGroupingColidArray(IMemoryPool *mp, CBitSet *group_by_cols, IntToUlongMap *sort_group_cols_to_colid_map);
 
 			// return the Colid of column with given index
 			static
-			ULONG UlColId(INT iIndex, HMIUl *phmiul);
+			ULONG GetColId(INT index, IntToUlongMap *index_to_colid_map);
 
 			// return the corresponding ColId for the given varno, varattno and querylevel
 			static
-			ULONG UlColId(ULONG ulQueryLevel, INT iVarno, INT iVarAttno, IMDId *pmdid, CMappingVarColId *pmapvarcolid);
+			ULONG GetColId(ULONG query_level, INT varno, INT var_attno, IMDId *mdid, CMappingVarColId *var_colid_mapping);
 
 			// check to see if the target list entry is a sorting column
 			static
-			BOOL FSortingColumn(const TargetEntry *pte, List *plSortCl);
-
+			BOOL IsSortingColumn(const TargetEntry *target_entry, List *sort_clause_list);
 			// check to see if the target list entry is used in the window reference
 			static
-			BOOL FWindowSpec(const TargetEntry *pte, List *plWindowClause);
+			BOOL IsWindowSpec(const TargetEntry *target_entry, List *window_clause_list);
 
 			// extract a matching target entry that is a window spec
 			static
-			TargetEntry *PteWindowSpec(Node *pnode, List *plWindowClause, List *plTargetList);
+			TargetEntry *GetWindowSpecTargetEntry(Node *node, List *window_clause_list, List *target_list);
 
 			// check if the expression has a matching target entry that is a window spec
 			static
-			BOOL FWindowSpec(Node *pnode, List *plWindowClause, List *plTargetList);
+			BOOL IsWindowSpec(Node *node, List *window_clause_list, List *target_list);
 
 			// create a scalar const value expression for the given int8 value
 			static
-			CDXLNode *PdxlnInt8Const(IMemoryPool *pmp, CMDAccessor *pmda, INT iVal);
+			CDXLNode *CreateDXLProjElemFromInt8Const(IMemoryPool *mp, CMDAccessor *md_accessor, INT val);
 
 			// check to see if the target list entry is a grouping column
 			static
-			BOOL FGroupingColumn(const TargetEntry *pte, List *plGrpCl);
+			BOOL IsGroupingColumn(const TargetEntry *target_entry, List *group_clause_list);
 
 			// check to see if the target list entry is a grouping column
 			static
-			BOOL FGroupingColumn(const TargetEntry *pte, const GroupClause *pgrcl);
+			BOOL IsGroupingColumn(const TargetEntry *target_entry, const GroupClause *sort_group_clause);
 
 			// check to see if the sorting column entry is a grouping column
 			static
-			BOOL FGroupingColumn(const SortClause *psortcl, List *plGrpCl);
+			BOOL IsGroupingColumn(const SortClause *sort_group_clause, List *group_clause_list);
 
 			// check if the expression has a matching target entry that is a grouping column
 			static
-			BOOL FGroupingColumn(Node *pnode, List *plGrpCl, List *plTargetList);
+			BOOL IsGroupingColumn(Node *node, List *group_clause_list, List *target_list);
 
 			// extract a matching target entry that is a grouping column
 			static
-			TargetEntry *PteGroupingColumn(Node *pnode, List *plGrpCl, List *plTargetList);
+			TargetEntry *GetGroupingColumnTargetEntry(Node *node, List *group_clause_list, List *target_list);
 
 			// convert a list of column ids to a list of attribute numbers using
 			// the provided context with mappings
 			static
-			List *PlAttnosFromColids(DrgPul *pdrgpul, CDXLTranslateContext *pdxltrctx);
+			List *ConvertColidToAttnos(ULongPtrArray *pdrgpul, CDXLTranslateContext *dxl_translate_ctxt);
 			
 			// parse string value into a Long Integer
 			static
-			LINT LFromStr(const CWStringBase *pstr);
+			LINT GetLongFromStr(const CWStringBase *wcstr);
 
 			// parse string value into an Integer
 			static
-			INT IFromStr(const CWStringBase *pstr);
+			INT GetIntFromStr(const CWStringBase *wcstr);
 
 			// check whether the given project list has a project element of the given
 			// operator type
 			static
-			BOOL FHasProjElem(CDXLNode *pdxlnPrL, Edxlopid edxlopid);
+			BOOL HasProjElem(CDXLNode *project_list_dxlnode, Edxlopid dxl_op_id);
 
 			// create a multi-byte character string from a wide character string
 			static
-			CHAR *SzFromWsz(const WCHAR *wsz);
+			CHAR *CreateMultiByteCharStringFromWCString(const WCHAR *wcstr);
 			
 			static 
-			HMUlUl *PhmululMap(IMemoryPool *pmp, DrgPul *pdrgpulOld, DrgPul *pdrgpulNew);
+			UlongToUlongMap *MakeNewToOldColMapping(IMemoryPool *mp, ULongPtrArray *old_colids, ULongPtrArray *new_colids);
 
 			// check if the given tree contains a subquery
 			static
-			BOOL FHasSubquery(Node *pnode);
+			BOOL HasSubquery(Node *node);
 
 			// check if the given function is a SIRV (single row volatile) that reads
 			// or modifies SQL data
 			static
-			BOOL FSirvFunc(IMemoryPool *pmp, CMDAccessor *pmda, OID oidFunc);
+			BOOL IsSirvFunc(IMemoryPool *mp, CMDAccessor *md_accessor, OID func_oid);
 			
 			// is this a motion sensitive to duplicates
 			static
-			BOOL FDuplicateSensitiveMotion(CDXLPhysicalMotion *pdxlopMotion);
+			BOOL IsDuplicateSensitiveMotion(CDXLPhysicalMotion *dxl_motion);
 
 			// construct a project element with a const NULL expression
 			static
-			CDXLNode *PdxlnPrElNull(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid, ULONG ulColId, const WCHAR *wszColName);
+			CDXLNode *CreateDXLProjElemConstNULL(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid, ULONG colid, const WCHAR *col_name);
 
 			// construct a project element with a const NULL expression
 			static
-			CDXLNode *PdxlnPrElNull(IMemoryPool *pmp, CMDAccessor *pmda, IMDId *pmdid, ULONG ulColId, CHAR *szAliasName);
+			CDXLNode *CreateDXLProjElemConstNULL(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid, ULONG colid, CHAR *alias_name);
 
 			// create a DXL project element node with a Const NULL of type provided
 			// by the column descriptor
 			static
-			CDXLNode *PdxlnPrElNull(IMemoryPool *pmp, CMDAccessor *pmda, CIdGenerator *pidgtorCol, const IMDColumn *pmdcol);
+			CDXLNode *CreateDXLProjElemConstNULL(IMemoryPool *mp, CMDAccessor *md_accessor, CIdGenerator *colid_generator, const IMDColumn *col);
 
 			// check required permissions for the range table
 			static 
-			void CheckRTEPermissions(List *plRangeTable);
+			void CheckRTEPermissions(List *range_table_list);
 
 			// check if an aggregate window function has either prelim or inverse prelim func
 			static
-			void CheckAggregateWindowFn(Node *pnode);
+			void CheckAggregateWindowFn(Node *node);
 
 			// check if given column ids are outer references in the tree rooted by given node
                         static
-			void MarkOuterRefs(ULONG *pulColId, BOOL *pfOuterRef, ULONG ulColumns, CDXLNode *pdxlnode);
+			void MarkOuterRefs(ULONG *colid, BOOL *is_outer_ref, ULONG num_columns, CDXLNode *node);
 
 			// map DXL Subplan type to GPDB SubLinkType
 			static
-			SubLinkType Slink(EdxlSubPlanType edxlsubplantype);
+			SubLinkType MapDXLSubplanToSublinkType(EdxlSubPlanType dxl_subplan_type);
 
 			// map GPDB SubLinkType to DXL Subplan type
 			static
-			EdxlSubPlanType Edxlsubplantype(SubLinkType slink);
+			EdxlSubPlanType MapSublinkTypeToDXLSubplan(SubLinkType slink);
 
 			// check whether there are triggers for the given operation on
 			// the given relation
 			static
-			BOOL FRelHasTriggers(IMemoryPool *pmp, CMDAccessor *pmda, const IMDRelation *pmdrel, const EdxlDmlType edxldmltype);
+			BOOL RelHasTriggers(IMemoryPool *mp, CMDAccessor *md_accessor, const IMDRelation *mdrel, const EdxlDmlType dml_type_dxl);
 
 			// check whether the given trigger is applicable to the given DML operation
 			static
-			BOOL FApplicableTrigger(CMDAccessor *pmda, IMDId *pmdidTrigger, const EdxlDmlType edxldmltype);
+			BOOL IsApplicableTrigger(CMDAccessor *md_accessor, IMDId *trigger_mdid, const EdxlDmlType dml_type_dxl);
 						
 			// check whether there are NOT NULL or CHECK constraints for the given relation
 			static
-			BOOL FRelHasConstraints(const IMDRelation *pmdrel);
+			BOOL RelHasConstraints(const IMDRelation *rel);
 
 			// translate the list of error messages from an assert constraint list
 			static 
-			List *PlAssertErrorMsgs(CDXLNode *pdxlnAssertConstraintList);
+			List *GetAssertErrorMsgs(CDXLNode *assert_constraint_list);
 
 			// return the count of non-system columns in the relation
 			static
-			ULONG UlNonSystemColumns(const IMDRelation *pmdrel);
+			ULONG GetNumNonSystemColumns(const IMDRelation *mdrel);
 
 			// check if we need to create stats buckets in DXL for the column attribute
 			static
-			BOOL FCreateStatsBucket(OID oidAttType);
+			BOOL ShouldCreateStatsBucket(OID att_type_oid);
 	};
 }
 

--- a/src/include/gpopt/utils/CCatalogUtils.h
+++ b/src/include/gpopt/utils/CCatalogUtils.h
@@ -22,23 +22,23 @@
 class CCatalogUtils {
 
 	private:
-		// return list of relation plOids in catalog
+		// return list of relation oids_list in catalog
 		static
-		List *PlRelationOids();
+		List *GetRelationOids();
 
-		// return list of operator plOids in catalog
+		// return list of operator oids_list in catalog
 		static
-		List *PlOperatorOids();
+		List *GetOperatorOids();
 
-		// return list of function plOids in catalog
+		// return list of function oids_list in catalog
 		static
-		List *PlFunctionOids();
+		List *GetFunctionOids();
 
 	public:
 
-		// return list of all object plOids in catalog
+		// return list of all object oids_list in catalog
 		static
-		List *PlAllOids();
+		List *GetAllOids();
 };
 
 #endif // CCatalogUtils_H

--- a/src/include/gpopt/utils/CConstExprEvaluatorProxy.h
+++ b/src/include/gpopt/utils/CConstExprEvaluatorProxy.h
@@ -57,10 +57,10 @@ namespace gpdxl
 					explicit
 					CEmptyMappingColIdVar
 						(
-						IMemoryPool *pmp
+						IMemoryPool *mp
 						)
 						:
-						CMappingColIdVar(pmp)
+						CMappingColIdVar(mp)
 					{
 					}
 
@@ -70,34 +70,34 @@ namespace gpdxl
 					}
 
 					virtual
-					Var *PvarFromDXLNodeScId(const CDXLScalarIdent *pdxlop);
+					Var *VarFromDXLNodeScId(const CDXLScalarIdent *scalar_ident);
 
 			};
 
 			// memory pool, not owned
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// empty mapping needed for the translator
 			CEmptyMappingColIdVar m_emptymapcidvar;
 
 			// pointer to metadata cache accessor
-			CMDAccessor *m_pmda;
+			CMDAccessor *m_md_accessor;
 
 			// translator for the DXL input -> GPDB Expr
-			CTranslatorDXLToScalar m_trdxl2scalar;
+			CTranslatorDXLToScalar m_dxl2scalar_translator;
 
 		public:
 			// ctor
 			CConstExprEvaluatorProxy
 				(
-				IMemoryPool *pmp,
-				CMDAccessor *pmda
+				IMemoryPool *mp,
+				CMDAccessor *md_accessor
 				)
 				:
-				m_pmp(pmp),
-				m_emptymapcidvar(m_pmp),
-				m_pmda(pmda),
-				m_trdxl2scalar(m_pmp, m_pmda, 0)
+				m_mp(mp),
+				m_emptymapcidvar(m_mp),
+				m_md_accessor(md_accessor),
+				m_dxl2scalar_translator(m_mp, m_md_accessor, 0)
 			{
 			}
 
@@ -109,9 +109,9 @@ namespace gpdxl
 
 			// evaluate given constant expressionand return the DXL representation of the result.
 			// if the expression has variables, an error is thrown.
-			// caller keeps ownership of 'pdxlnExpr' and takes ownership of the returned pointer
+			// caller keeps ownership of 'expr_dxlnode' and takes ownership of the returned pointer
 			virtual
-			CDXLNode *PdxlnEvaluateExpr(const CDXLNode *pdxlnExpr);
+			CDXLNode *EvaluateExpr(const CDXLNode *expr);
 
 			// returns true iff the evaluator can evaluate constant expressions without subqueries
 			virtual

--- a/src/include/gpopt/utils/COptClient.h
+++ b/src/include/gpopt/utils/COptClient.h
@@ -63,47 +63,47 @@ namespace gpoptudfs
 			struct SOptParams
 			{
 				// path where socket is initialized
-				const char *m_szPath;
+				const char *m_path;
 
 				// input query
-				Query *m_pquery;
+				Query *m_query;
 			};
 
 			// input query
-			Query *m_pquery;
+			Query *m_query;
 
 			// path where socket is initialized
-			const char *m_szPath;
+			const char *m_path;
 
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// communicator
-			CCommunicator *m_pcomm;
+			CCommunicator *m_communicator;
 
 			// default id for the source system
 			static
-			const CSystemId m_sysidDefault;
+			const CSystemId m_default_sysid;
 
 			// error severity levels
 
 			// array mapping GPOS to elog() error severity
 			static
-			ULONG m_rgrgulSev[CException::ExsevSentinel][2];
+			ULONG elog_to_severity_map[CException::ExsevSentinel][2];
 
 			// ctor
 			COptClient
 				(
-				SOptParams *pop
+				SOptParams *op
 				)
 				:
-				m_pquery(pop->m_pquery),
-				m_szPath(pop->m_szPath),
-				m_pmp(NULL),
-				m_pcomm(NULL)
+				m_query(op->m_query),
+				m_path(op->m_path),
+				m_mp(NULL),
+				m_communicator(NULL)
 			{
-				GPOS_ASSERT(NULL != m_pquery);
-				GPOS_ASSERT(NULL != m_szPath);
+				GPOS_ASSERT(NULL != m_query);
+				GPOS_ASSERT(NULL != m_path);
 			}
 
 			// dtor
@@ -111,31 +111,31 @@ namespace gpoptudfs
 			{}
 
 			// request optimization from server
-			PlannedStmt *PplstmtOptimize();
+			PlannedStmt *GPOPTOptimizedPlan();
 
 			// set traceflags
 			void SetTraceflags();
 
 			// send query optimization request to server
-			void SendRequest(CMDAccessor *pmda);
+			void SendRequest(CMDAccessor *md_accessor);
 
 			// retrieve DXL plan
-			const CHAR *SzPlanDXL(IMDProvider *pmdp);
+			const CHAR *SzPlanDXL(IMDProvider *md_provider);
 
 			// send MD response
-			void SendMDResponse(CMDProviderCommProxy *pmdpcp, const WCHAR *wszReq);
+			void SendMDResponse(CMDProviderCommProxy *md_provider_proxy, const WCHAR *req);
 
 			// build planned statement from serialized plan
-			PlannedStmt *PplstmtConstruct(CMDAccessor *pmda, const CHAR *szPlan);
+			PlannedStmt *ConstructPlanStmt(CMDAccessor *md_accessor, const CHAR *serialized_plan);
 
 			// elog wrapper
-			void Elog(ULONG ulSev, const WCHAR *wszMsg);
+			void Elog(ULONG severity, const WCHAR *msg);
 
 		public:
 
 			// invoke optimizer instance
 			static
-			void *PvRun(void *pv);
+			void *Run(void *pv);
 
 	}; // class COptClient
 }

--- a/src/include/gpopt/utils/COptServer.h
+++ b/src/include/gpopt/utils/COptServer.h
@@ -63,31 +63,31 @@ namespace gpoptudfs
 			struct SConnectionDescriptor
 			{
 				// ID
-				ULONG_PTR m_ulpId;
+				ULONG_PTR m_id;
 
 				// task
-				CTask *m_ptsk;
+				CTask *m_task;
 
 				// socket
-				CSocket *m_psocket;
+				CSocket *m_socket;
 
 				// link for hashtable
 				SLink m_link;
 
 				// invalid connection id
 				static
-				ULONG_PTR m_ulpInvalid;
+				ULONG_PTR m_invalid_id;
 
 				// ctor
 				SConnectionDescriptor
 					(
-					CTask *ptsk,
-					CSocket *psocket
+					CTask *task,
+					CSocket *socket
 					)
 					:
-					m_ulpId((ULONG_PTR) ptsk),
-					m_ptsk(ptsk),
-					m_psocket(psocket)
+					m_id((ULONG_PTR) task),
+					m_task(task),
+					m_socket(socket)
 				{}
 
 			};
@@ -105,21 +105,21 @@ namespace gpoptudfs
 				ConnectionIterAccessor;
 
 			// path where socket is initialized
-			const CHAR *m_szSocketPath;
+			const CHAR *m_socket_path;
 
 			// memory pool for connections
-			IMemoryPool *m_pmp;
+			IMemoryPool *m_mp;
 
 			// hashtable of connections
-			ConnectionHT *m_pshtConnections;
+			ConnectionHT *m_connections_ht;
 
 			// default id for the source system
 			static
-			const CSystemId m_sysidDefault;
+			const CSystemId m_default_id;
 
 			// ctor
 			explicit
-			COptServer(const CHAR *szPath);
+			COptServer(const CHAR *path);
 
 			// dtor
 			~COptServer();
@@ -131,43 +131,43 @@ namespace gpoptudfs
 			void InitHT();
 
 			// register connection for status checking
-			void TrackConnection(CTask *ptsk, CSocket *psocket);
+			void TrackConnection(CTask *task, CSocket *socket);
 
 			// release connection
-			void ReleaseConnection(CTask *ptsk);
+			void ReleaseConnection(CTask *task);
 
 			// connection check task
 			static
-			void * PvCheckConnections(void *pv);
+			void * CheckConnections(void *ptr);
 
 			// optimization task
 			static
-			void *PvOptimize(void *pv);
+			void *Optimize(void *ptr);
 
 			// receive optimization request and construct query context for it
 			static
-			CQueryContext *PqcRecvQuery(IMemoryPool *pmp, CCommunicator *pcomm, CMDAccessor *pmda);
+			CQueryContext *RecvQuery(IMemoryPool *mp, CCommunicator *communicator, CMDAccessor *md_accessor);
 
 			// extract query plan, serialize it and send it to client
 			static
 			void SendPlan
 				(
-				IMemoryPool *pmp,
-				CCommunicator *pcomm,
-				CMDAccessor *pmda,
-				CQueryContext *pqc,
-				CExpression *pexprPlan
+				IMemoryPool *mp,
+				CCommunicator *communicator,
+				CMDAccessor *md_accessor,
+				CQueryContext *query_ctxt,
+				CExpression *plan_expr
 				);
 
 			// dump collected artifacts to file
 			static
-			void FinalizeMinidump(CMiniDumperDXL *pmdmp);
+			void FinalizeMinidump(CMiniDumperDXL *dump);
 
 		public:
 
 			// invoke optimizer instance
 			static
-			void *PvRun(void *pv);
+			void *Run(void *ptr);
 
 	}; // class COptServer
 }

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -60,53 +60,53 @@ struct SOptContext
 	// when calling Free() function
 	enum EPin
 	{
-		epinQueryDXL, // keep m_szQueryDXL
-		epinQuery, 	 // keep m_pquery
-		epinPlanDXL, // keep m_szPlanDXL
-		epinPlStmt, // keep m_pplstmt
-		epinErrorMsg // keep m_szErrorMsg
+		epinQueryDXL, // keep m_query_dxl
+		epinQuery, 	 // keep m_query
+		epinPlanDXL, // keep m_plan_dxl
+		epinPlStmt, // keep m_plan_stmt
+		epinErrorMsg // keep m_error_msg
 	};
 
 	// query object serialized to DXL
-	CHAR *m_szQueryDXL;
+	CHAR *m_query_dxl;
 
 	// query object
-	Query *m_pquery;
+	Query *m_query;
 
 	// plan object serialized to DXL
-	CHAR *m_szPlanDXL;
+	CHAR *m_plan_dxl;
 
 	// plan object
-	PlannedStmt *m_pplstmt;
+	PlannedStmt *m_plan_stmt;
 
 	// is generating a plan object required ?
-	BOOL m_fGeneratePlStmt;
+	BOOL m_should_generate_plan_stmt;
 
 	// is serializing a plan to DXL required ?
-	BOOL m_fSerializePlanDXL;
+	BOOL m_should_serialize_plan_dxl;
 
 	// did the optimizer fail unexpectedly?
-	BOOL m_fUnexpectedFailure;
+	BOOL m_is_unexpected_failure;
 
 	// buffer for optimizer error messages
-	CHAR *m_szErrorMsg;
+	CHAR *m_error_msg;
 
 	// ctor
 	SOptContext();
 
 	// If there is an error print as warning and throw exception to abort
 	// plan generation
-	void HandleError(BOOL *pfUnexpectedFailure);
+	void HandleError(BOOL *had_unexpected_failure);
 
 	// free all members except input and output pointers
-	void Free(EPin epinInput, EPin epinOutput);
+	void Free(EPin input, EPin epinOutput);
 
 	// Clone the error message in given context.
 	CHAR* CloneErrorMsg(struct MemoryContextData *context);
 
 	// casting function
 	static
-	SOptContext *PoptctxtConvert(void *pv);
+	SOptContext *Cast(void *ptr);
 
 }; // struct SOptContext
 
@@ -118,37 +118,37 @@ class COptTasks
 		struct SContextRelcacheToDXL
 		{
 			// list of object oids to lookup
-			List *m_plistOids;
+			List *m_oid_list;
 
 			// comparison type for tasks retrieving scalar comparisons
-			ULONG m_ulCmpt;
+			ULONG m_cmp_type;
 
 			// if filename is not null, then output will be written to file
-			const char *m_szFilename;
+			const char *m_filename;
 
 			// if filename is null, then output will be stored here
-			char *m_szDXL;
+			char *m_dxl;
 
 			// ctor
-			SContextRelcacheToDXL(List *plistOids, ULONG ulCmpt, const char *szFilename);
+			SContextRelcacheToDXL(List *oid_list, ULONG cmp_type, const char *filename);
 
 			// casting function
 			static
-			SContextRelcacheToDXL *PctxrelcacheConvert(void *pv);
+			SContextRelcacheToDXL *RelcacheConvert(void *ptr);
 		};
 
 		// Structure containing the input and output string for a task that evaluates expressions.
 		struct SEvalExprContext
 		{
 			// Serialized DXL of the expression to be evaluated
-			char *m_szDXL;
+			char *m_dxl;
 
 			// The result of evaluating the expression
-			char *m_szDXLResult;
+			char *m_dxl_result;
 
 			// casting function
 			static
-			SEvalExprContext *PevalctxtConvert(void *pv);
+			SEvalExprContext *PevalctxtConvert(void *ptr);
 		};
 
 		// context of minidump load and execution
@@ -158,68 +158,68 @@ class COptTasks
 			char *m_szFileName;
 
 			// the result of optimizing the minidump
-			char *m_szDXLResult;
+			char *m_dxl_result;
 
 			// casting function
 			static
-			SOptimizeMinidumpContext *PoptmdpConvert(void *pv);
+			SOptimizeMinidumpContext *Cast(void *ptr);
 		};
 
 		// execute a task given the argument
 		static
-		void Execute ( void *(*pfunc) (void *), void *pfuncArg);
+		void Execute ( void *(*func) (void *), void *func_arg);
 
 		// map GPOS log severity level to GPDB, print error and delete the given error buffer
 		static
-		void LogExceptionMessageAndDelete(CHAR* err_buf, ULONG ulSeverityLevel=CException::ExsevInvalid);
+		void LogExceptionMessageAndDelete(CHAR* err_buf, ULONG severity_level=CException::ExsevInvalid);
 
-		// task that does the translation from xml to dxl to pplstmt
+		// task that does the translation from xml to dxl to planned_stmt
 		static
-		void* PvPlstmtFromDXLTask(void *pv);
+		void* ConvertToPlanStmtFromDXLTask(void *ptr);
 
 		// task that does the translation from query to XML
 		static
-		void* PvDXLFromQueryTask(void *pv);
+		void* ConvertToDXLFromQueryTask(void *ptr);
 
 		// dump relcache info for an object into DXL
 		static
-		void* PvDXLFromMDObjsTask(void *pv);
+		void* ConvertToDXLFromMDObjsTask(void *ptr);
 
 		// dump metadata about cast objects from relcache to a string in DXL format
 		static
-		void *PvMDCast(void *pv);
+		void *ConvertToDXLFromMDCast(void *ptr);
 		
 		// dump metadata about scalar comparison objects from relcache to a string in DXL format
 		static
-		void *PvMDScCmp(void *pv);
+		void *ConvertToDXLFromMDScalarCmp(void *ptr);
 		
 		// dump relstats info for an object into DXL
 		static
-		void* PvDXLFromRelStatsTask(void *pv);
+		void* ConvertToDXLFromRelStatsTask(void *ptr);
 
 		// evaluates an expression given as a serialized DXL string and returns the serialized DXL result
 		static
-		void* PvEvalExprFromDXLTask(void *pv);
+		void* EvalExprFromDXLTask(void *ptr);
 
 		// create optimizer configuration object
 		static
-		COptimizerConfig *PoconfCreate(IMemoryPool *pmp, ICostModel *pcm);
+		COptimizerConfig *CreateOptimizerConfig(IMemoryPool *mp, ICostModel *cost_model);
 
 		// optimize a query to a physical DXL
 		static
-		void* PvOptimizeTask(void *pv);
+		void* OptimizeTask(void *ptr);
 
 		// optimize the query in a minidump and return resulting plan in DXL format
 		static
-		void* PvOptimizeMinidumpTask(void *pv);
+		void* OptimizeMinidumpTask(void *ptr);
 
 		// translate a DXL tree into a planned statement
 		static
-		PlannedStmt *Pplstmt(IMemoryPool *pmp, CMDAccessor *pmda, const CDXLNode *pdxln, bool canSetTag);
+		PlannedStmt *ConvertToPlanStmtFromDXL(IMemoryPool *mp, CMDAccessor *md_accessor, const CDXLNode *dxlnode, bool can_set_tag);
 
 		// load search strategy from given path
 		static
-		DrgPss *PdrgPssLoad(IMemoryPool *pmp, char *szPath);
+		CSearchStageArray *LoadSearchStrategy(IMemoryPool *mp, char *path);
 
 		// allocate memory for string
 		static
@@ -227,58 +227,58 @@ class COptTasks
 
 		// helper for converting wide character string to regular string
 		static
-		CHAR *SzFromWsz(const WCHAR *wsz);
+		CHAR *CreateMultiByteCharStringFromWCString(const WCHAR *wcstr);
 
 		// lookup given exception type in the given array
 		static
-		BOOL FExceptionFound(gpos::CException &exc, const ULONG *pulExceptions, ULONG ulSize);
+		BOOL FoundException(gpos::CException &exc, const ULONG *exceptions, ULONG size);
 
 		// check if given exception is an unexpected reason for failing to produce a plan
 		static
-		BOOL FUnexpectedFailure(gpos::CException &exc);
+		BOOL IsUnexpectedFailure(gpos::CException &exc);
 
 		// check if given exception should error out
 		static
-		BOOL FErrorOut(gpos::CException &exc);
+		BOOL ShouldErrorOut(gpos::CException &exc);
 
 		// set cost model parameters
 		static
-		void SetCostModelParams(ICostModel *pcm);
+		void SetCostModelParams(ICostModel *cost_model);
 
 		// generate an instance of optimizer cost model
 		static
-		ICostModel *Pcm(IMemoryPool *pmp, ULONG ulSegments);
+		ICostModel *GetCostModel(IMemoryPool *mp, ULONG num_segments);
 
 		// print warning messages for columns with missing statistics
 		static
-		void PrintMissingStatsWarning(IMemoryPool *pmp, CMDAccessor *pmda, DrgPmdid *pdrgmdidCol, HSMDId *phsmdidRel);
+		void PrintMissingStatsWarning(IMemoryPool *mp, CMDAccessor *md_accessor, IMdIdArray *col_stats, MdidHashSet *phsmdidRel);
 
 	public:
 
 		// convert Query->DXL->LExpr->Optimize->PExpr->DXL
 		static
-		char *SzOptimize(Query *pquery);
+		char *Optimize(Query *query);
 
 		// optimize Query->DXL->LExpr->Optimize->PExpr->DXL->PlannedStmt
 		static
-		PlannedStmt *PplstmtOptimize
+		PlannedStmt *GPOPTOptimizedPlan
 			(
-			Query *pquery,
-			SOptContext* octx,
-			BOOL *pfUnexpectedFailure // output : set to true if optimizer unexpectedly failed to produce plan
+			Query *query,
+			SOptContext* gpopt_context,
+			BOOL *had_unexpected_failure // output : set to true if optimizer unexpectedly failed to produce plan
 			);
 
 		// convert query to DXL to xml string.
 		static
-		char *SzDXL(Query *pquery);
+		char *ConvertQueryToDXL(Query *query);
 
 		// convert xml string to DXL and to PS
 		static
-		PlannedStmt *PplstmtFromXML(char *szXmlString);
+		PlannedStmt *ConvertToiPlanStmtFromXML(char *xml_string);
 
 		// dump metadata objects from relcache to file in DXL format
 		static
-		void DumpMDObjs(List *oids, const char *szFilename);
+		void DumpMDObjs(List *oids, const char *filename);
 
 		// dump metadata objects from relcache to a string in DXL format
 		static
@@ -286,32 +286,32 @@ class COptTasks
 		
 		// dump cast function from relcache to a string in DXL format
 		static
-		char *SzMDCast(List *oids);
+		char *DumpMDCast(List *oids);
 		
 		// dump scalar comparison from relcache to a string in DXL format
 		static
-		char *SzMDScCmp(List *oids, char *szCmpType);
+		char *DumpMDScalarCmp(List *oids, char *cmp_type);
 
 		// dump statistics from relcache to a string in DXL format
 		static
-		char *SzRelStats(List *oids);
+		char *DumpRelStats(List *oids);
 
 		// enable/disable a given xforms
 		static
-		bool FSetXform(char *szXform, bool fDisable);
+		bool SetXform(char *xform_str, bool should_disable);
 		
 		// return comparison type code
 		static
-		ULONG UlCmpt(char *szCmpType);
+		ULONG GetComparisonType(char *cmp_type);
 
 		// converts XML string to DXL and evaluates the expression
 		static
-		char *SzEvalExprFromXML(char *szXmlString);
+		char *EvalExprFromXML(char *xml_string);
 
 		// loads a minidump from the given file path, executes it and returns
 		// the serialized representation of the result as DXL
 		static
-		char *SzOptimizeMinidumpFromFile(char *szFileName);
+		char *OptimizeMinidumpFromFile(char *file_name);
 };
 
 #endif // COptTasks_H

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -68,7 +68,7 @@ extern "C" {
 #include "funcapi.h"
 
 extern
-Query *preprocess_query_optimizer(Query *pquery, ParamListInfo boundParams);
+Query *preprocess_query_optimizer(Query *query, ParamListInfo boundParams);
 
 extern
 List *pg_parse_and_rewrite(const char *query_string, Oid *paramTypes, int iNumParams);

--- a/src/test/tinc/tincrepo/mpp/models/test/sql_related/optimizer/function_owners2.csv
+++ b/src/test/tinc/tincrepo/mpp/models/test/sql_related/optimizer/function_owners2.csv
@@ -3725,7 +3725,7 @@ libgpoptudf/src/CCatalogUtils.cpp,libgpoptudf/src/CCatalogUtils.cpp,CCatalogUtil
 libgpoptudf/src/CCatalogUtils.cpp,libgpoptudf/src/CCatalogUtils.cpp,CCatalogUtils::PlFunctionOids,raghav
 libgpoptudf/src/CCatalogUtils.cpp,libgpoptudf/src/CCatalogUtils.cpp,CCatalogUtils::PlAllOids,raghav
 libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::PvRun,solimm1
-libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::PplstmtOptimize,solimm1
+libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::GPOPTOptimizedPlan,solimm1
 libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::SetTraceflags,solimm1
 libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::SendRequest,solimm1
 libgpoptudf/src/COptClient.cpp,libgpoptudf/src/COptClient.cpp,COptClient::SzPlanDXL,solimm1
@@ -3755,7 +3755,7 @@ libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PvQueryFr
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PvDXLFromMDObjsTask,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PvDXLFromRelStatsTask,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::SzOptimize,raghav
-libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PplstmtOptimize,raghav
+libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::GPOPTOptimizedPlan,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::SzDXL,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::SzDXL,raghav
 libgpoptudf/src/COptTasks.cpp,libgpoptudf/src/COptTasks.cpp,COptTasks::PqueryFromXML,raghav

--- a/src/test/unit/mock/gpopt_mock.c
+++ b/src/test/unit/mock/gpopt_mock.c
@@ -5,16 +5,16 @@
 #include "nodes/plannodes.h"
 
 char *
-SzDXLPlan(Query *pquery)
+SerializeDXLPlan(Query *pquery)
 {
-	elog(ERROR, "mock implementation of SzDXLPlan called");
+	elog(ERROR, "mock implementation of SerializeDXLPlan called");
 	return NULL;
 }
 
 PlannedStmt *
-PplstmtOptimize(Query *pquery, bool pfUnexpectedFailure)
+GPOPTOptimizedPlan(Query *pquery, bool pfUnexpectedFailure)
 {
-	elog(ERROR, "mock implementation of PplStmtOptimize called");
+	elog(ERROR, "mock implementation of GPOPTOptimizedPlan called");
 	return NULL;
 }
 


### PR DESCRIPTION
    Hungarian notation removal specific to GPOS and Naucrates libraries

    As part of moving away from Hungarian notation in the GPORCA codebase,
    the integration points between GPORCA and GPDB in the translator have
    been renamed to the new convention used in GPORCA. The libraries
    currently updated to the new notation in GPORCA are Naucrates and GPOS.
    The new naming convention is a custom version of common C++ naming
    conventions. The style guide for this convention can be found in the
    GPORCA repository.