### PR TITLE
Backport upstream fix for bug in tuplesort_skiptuples().

### DIFF
--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -1797,6 +1797,8 @@ tuplesort_getdatum(Tuplesortstate *state, bool forward,
 bool
 tuplesort_skiptuples(Tuplesortstate *state, int64 ntuples, bool forward)
 {
+	MemoryContext oldcontext;
+
 	/*
 	 * We don't actually support backwards skip yet, because no callers need
 	 * it.	The API is designed to allow for that later, though.
@@ -1832,6 +1834,7 @@ tuplesort_skiptuples(Tuplesortstate *state, int64 ntuples, bool forward)
 			 * We could probably optimize these cases better, but for now it's
 			 * not worth the trouble.
 			 */
+			oldcontext = MemoryContextSwitchTo(state->sortcontext);
 			while (ntuples-- > 0)
 			{
 				SortTuple	stup;
@@ -1839,11 +1842,15 @@ tuplesort_skiptuples(Tuplesortstate *state, int64 ntuples, bool forward)
 
 				if (!tuplesort_gettuple_common_pos(state, &state->pos, forward,
 											   &stup, &should_free))
+				{
+					MemoryContextSwitchTo(oldcontext);
 					return false;
-				if (should_free)
+				}
+				if (should_free && stup.tuple)
 					pfree(stup.tuple);
 				CHECK_FOR_INTERRUPTS();
 			}
+			MemoryContextSwitchTo(oldcontext);
 			return true;
 
 		default:

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -1811,7 +1811,7 @@ tuplesort_skiptuples_mk(Tuplesortstate_mk *state, int64 ntuples, bool forward)
 				fOK = false;
 				break;
 			}
-			if (should_free)
+			if (should_free && e.ptr)
 				pfree(e.ptr);
 			CHECK_FOR_INTERRUPTS();
 		}


### PR DESCRIPTION
We had backported the tuplesort_skiptuples() function, as part of commit
fd6212ce130 which backported upstream support for ordered-set aggregates.
Since we backported the feature, we also need to keep backporting all
bugfixes that follow, until we catch up to that in the merge.

In GPDB, the same fix needs to also be applied to the "mk sort" variant.

Fixes github issue #5334.

Upstream commit:

commit 1def747db68b234b54b784c74dfbe329f5478b79
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Tue Dec 24 17:13:02 2013 -0500

    Fix inadequately-tested code path in tuplesort_skiptuples().

    Per report from Jeff Davis.