### PR TITLE
Remove fixme and a copy of group clause

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4579,13 +4579,8 @@ add_second_stage_agg(PlannerInfo *root,
 
 	/*
 	 * Since the rtable has changed, we had better recreate a RelOptInfo entry
-	 * for it. Make a copy of the groupClause since freeing the arrays can
-	 * pull out references still in use from underneath it.
-	 * We do not free root->simple_rel_array and root->simple_rte_array since
-	 * they are used by subroot.
-	 * GPDB_92_MERGE_FIXME: Do we still need to copy groupClause?
+	 * for it.
 	 */
-	root->parse->groupClause = copyObject(root->parse->groupClause);
 	rebuild_simple_rel_and_rte(root);
 
 	/*

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4578,7 +4578,7 @@ add_second_stage_agg(PlannerInfo *root,
 		*p_current_pathkeys = NIL;
 
 	/*
-	 * Since the rtable has changed, we had better recreate RelOptInfo entry
+	 * Since the rtable has changed, we had better recreate RelOptInfo entrys
 	 * for it.
 	 */
 	rebuild_simple_rel_and_rte(root);

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4578,7 +4578,7 @@ add_second_stage_agg(PlannerInfo *root,
 		*p_current_pathkeys = NIL;
 
 	/*
-	 * Since the rtable has changed, we had better recreate a RelOptInfo entry
+	 * Since the rtable has changed, we had better recreate RelOptInfo entry
 	 * for it.
 	 */
 	rebuild_simple_rel_and_rte(root);


### PR DESCRIPTION
A parse object has been copyed to subroot, and We do not free
root->simple_rel_array and root->simple_rte_array. So We do not
need to copy group clause.