### PR TITLE
Move TMGXACT out of PGPROC into a separate array.

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2222,7 +2222,7 @@ StartTransaction(void)
 			 * master database.
 			 */
 			setCurrentGxact();
-			currentDistribXid = MyProc->gxact.gxid;
+			currentDistribXid = MyTmGxact->gxid;
 
 			if (SharedLocalSnapshotSlot != NULL)
 			{

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2180,7 +2180,7 @@ setCurrentGxact(void)
 	DistributedTransactionId gxid = generateGID();
 	Assert(gxid != InvalidDistributedTransactionId);
 
-	currentGxact = &MyProc->gxact;
+	currentGxact = MyTmGxact;
 
 	Assert(*shmDistribTimeStamp != 0);
 	sprintf(currentGxact->gid, "%u-%.10u", *shmDistribTimeStamp, gxid);

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1610,7 +1610,7 @@ getAllDistributedXactStatus(TMGALLXACTSTATUS **allDistributedXactStatus)
 			palloc(MAXALIGN(count * sizeof(TMGXACTSTATUS)));
 		for (i = 0; i < count; i++)
 		{
-			TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
+			volatile TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
 
 			all->statusArray[i].gxid = gxact->gxid;
 			if (strlen(gxact->gid) >= TMGIDSIZE)
@@ -1688,7 +1688,7 @@ getDtxCheckPointInfo(char **result, int *result_size)
 	for (i = 0; i < arrayP->numProcs; i++)
 	{
 		TMGXACT_LOG *gxact_log;
-		TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
+		volatile TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
 
 		if (!includeInCheckpointIsNeeded(gxact))
 			continue;

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -104,6 +104,7 @@ static ProcArrayStruct *procArray;
 
 static PGPROC *allProcs;
 static PGXACT *allPgXact;
+static TMGXACT *allTmGxact;
 
 /*
  * Bookkeeping for tracking emulated transactions in recovery
@@ -249,6 +250,7 @@ CreateSharedProcArray(void)
 
 	allProcs = ProcGlobal->allProcs;
 	allPgXact = ProcGlobal->allPgXact;
+	allTmGxact = ProcGlobal->allTmGxact;
 
 	/* Create or attach to the KnownAssignedXids arrays too, if needed */
 	if (EnableHotStandby)
@@ -382,7 +384,7 @@ void
 ProcArrayEndGxact(void)
 {
 	Assert(LWLockHeldByMe(ProcArrayLock));
-	initGxact(&MyProc->gxact);
+	initGxact(MyTmGxact);
 }
 
 /*
@@ -1608,8 +1610,7 @@ getAllDistributedXactStatus(TMGALLXACTSTATUS **allDistributedXactStatus)
 			palloc(MAXALIGN(count * sizeof(TMGXACTSTATUS)));
 		for (i = 0; i < count; i++)
 		{
-			PGPROC *proc = &allProcs[arrayP->pgprocnos[i]];
-			TMGXACT *gxact = &proc->gxact;
+			TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
 
 			all->statusArray[i].gxid = gxact->gxid;
 			if (strlen(gxact->gid) >= TMGIDSIZE)
@@ -1687,8 +1688,7 @@ getDtxCheckPointInfo(char **result, int *result_size)
 	for (i = 0; i < arrayP->numProcs; i++)
 	{
 		TMGXACT_LOG *gxact_log;
-		PGPROC  *proc = &allProcs[arrayP->pgprocnos[i]];
-		TMGXACT *gxact = &proc->gxact;
+		TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
 
 		if (!includeInCheckpointIsNeeded(gxact))
 			continue;
@@ -1777,9 +1777,9 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	 */
 	for (i = 0; i < arrayP->numProcs; i++)
 	{
-		PGPROC  *proc = &allProcs[arrayP->pgprocnos[i]];
-		TMGXACT	*gxact_candidate = &proc->gxact;
-		volatile DistributedTransactionId gxid;
+		int         pgprocno = arrayP->pgprocnos[i];
+		volatile TMGXACT	*gxact_candidate = &allTmGxact[pgprocno];
+		DistributedTransactionId gxid;
 		DistributedTransactionId dxid;
 
 		/* just fetch once */
@@ -1816,7 +1816,7 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 			xmax = gxid;
 		}
 
-		if (proc == MyProc)
+		if (gxact_candidate == MyTmGxact)
 			continue;
 
 		if (count >= ds->maxCount)
@@ -1860,8 +1860,8 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	ds->xmax = xmax;
 	ds->count = count;
 
-	if (xmin < MyProc->gxact.xminDistributedSnapshot)
-		MyProc->gxact.xminDistributedSnapshot = xmin;
+	if (xmin < MyTmGxact->xminDistributedSnapshot)
+		MyTmGxact->xminDistributedSnapshot = xmin;
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
 		 "CreateDistributedSnapshot distributed snapshot has xmin = %u, count = %u, xmax = %u.",
@@ -1869,7 +1869,7 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
 		 "[Distributed Snapshot #%u] *Create* (gxid = %u, '%s')",
 		 distribSnapshotId,
-		 MyProc->gxact.gxid,
+		 MyTmGxact->gxid,
 		 DtxContextToString(DistributedTransactionContext));
 
 	return true;
@@ -4570,9 +4570,9 @@ ListAllGxid(void)
 
 	for (index = 0; index < arrayP->numProcs; index++)
 	{
-		volatile PGPROC *proc = &allProcs[arrayP->pgprocnos[index]];
+		volatile TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[index]];
 
-		gxid = proc->gxact.gxid;
+		gxid = gxact->gxid;
 		if (gxid == InvalidDistributedTransactionId)
 			continue;
 		gxids = lappend_int(gxids, gxid);
@@ -4599,7 +4599,8 @@ GetPidByGxid(DistributedTransactionId gxid)
 	for (i = 0; i < arrayP->numProcs; i++)
 	{
 		volatile PGPROC *proc = &allProcs[arrayP->pgprocnos[i]];
-		if (proc->gxact.gxid == gxid)
+		volatile TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
+		if (gxact->gxid == gxid)
 		{
 			pid = proc->pid;
 			break;

--- a/src/backend/storage/ipc/test/procarray_test.c
+++ b/src/backend/storage/ipc/test/procarray_test.c
@@ -59,9 +59,9 @@ test__CreateDistributedSnapshot(void **state)
 	will_return_count(getMaxDistributedXid, 25, -1);
 
 	/* This is going to act as our gxact */
-	allProcs[procArray->pgprocnos[0]].gxact.gxid = 20;
-	allProcs[procArray->pgprocnos[0]].gxact.state = DTX_STATE_ACTIVE_DISTRIBUTED;
-	allProcs[procArray->pgprocnos[0]].gxact.xminDistributedSnapshot = 20;
+	allTmGxact[procArray->pgprocnos[0]].gxid = 20;
+	allTmGxact[procArray->pgprocnos[0]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	allTmGxact[procArray->pgprocnos[0]].xminDistributedSnapshot = 20;
 
 	procArray->numProcs = 1;
 
@@ -78,7 +78,7 @@ test__CreateDistributedSnapshot(void **state)
 	assert_true(ds->xmin == 20);
 	assert_true(ds->xmax == 25);
 	assert_true(ds->count == 0);
-	assert_true(MyProc->gxact.xminDistributedSnapshot == 20);
+	assert_true(MyTmGxact->xminDistributedSnapshot == 20);
 
 	/*************************************************************************
 	 * Case where there exist in-progress having taken snpashot with lower
@@ -86,13 +86,13 @@ test__CreateDistributedSnapshot(void **state)
 	 * differ from xminAllDistributedSnapshots. Also, validates xmin and xmax
 	 * get adjusted correctly based on in-progress.
 	 */
-	allProcs[procArray->pgprocnos[1]].gxact.gxid = 10;
-	allProcs[procArray->pgprocnos[1]].gxact.state = DTX_STATE_ACTIVE_DISTRIBUTED;
-	allProcs[procArray->pgprocnos[1]].gxact.xminDistributedSnapshot = 5;
+	allTmGxact[procArray->pgprocnos[1]].gxid = 10;
+	allTmGxact[procArray->pgprocnos[1]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	allTmGxact[procArray->pgprocnos[1]].xminDistributedSnapshot = 5;
 
-	allProcs[procArray->pgprocnos[2]].gxact.gxid = 30;
-	allProcs[procArray->pgprocnos[2]].gxact.state = DTX_STATE_ACTIVE_DISTRIBUTED;
-	allProcs[procArray->pgprocnos[2]].gxact.xminDistributedSnapshot = 20;
+	allTmGxact[procArray->pgprocnos[2]].gxid = 30;
+	allTmGxact[procArray->pgprocnos[2]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	allTmGxact[procArray->pgprocnos[2]].xminDistributedSnapshot = 20;
 
 	procArray->numProcs = 3;
 
@@ -104,19 +104,19 @@ test__CreateDistributedSnapshot(void **state)
 	assert_true(ds->xmin == 10);
 	assert_true(ds->xmax == 30);
 	assert_true(ds->count == 2);
-	assert_true(MyProc->gxact.xminDistributedSnapshot == 10);
+	assert_true(MyTmGxact->xminDistributedSnapshot == 10);
 
 	/*************************************************************************
 	 * Add more elemnets, just to have validation that in-progress array is in
 	 * ascending sorted order with distributed transactions.
 	 */
-	allProcs[procArray->pgprocnos[3]].gxact.gxid = 15;
-	allProcs[procArray->pgprocnos[3]].gxact.state = DTX_STATE_ACTIVE_DISTRIBUTED;
-	allProcs[procArray->pgprocnos[3]].gxact.xminDistributedSnapshot = 12;
+	allTmGxact[procArray->pgprocnos[3]].gxid = 15;
+	allTmGxact[procArray->pgprocnos[3]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	allTmGxact[procArray->pgprocnos[3]].xminDistributedSnapshot = 12;
 
-	allProcs[procArray->pgprocnos[4]].gxact.gxid = 7;
-	allProcs[procArray->pgprocnos[4]].gxact.state = DTX_STATE_ACTIVE_DISTRIBUTED;
-	allProcs[procArray->pgprocnos[4]].gxact.xminDistributedSnapshot = 7;
+	allTmGxact[procArray->pgprocnos[4]].gxid = 7;
+	allTmGxact[procArray->pgprocnos[4]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
+	allTmGxact[procArray->pgprocnos[4]].xminDistributedSnapshot = 7;
 
 	procArray->numProcs = 5;
 
@@ -128,7 +128,7 @@ test__CreateDistributedSnapshot(void **state)
 	assert_true(ds->xmin == 7);
 	assert_true(ds->xmax == 30);
 	assert_true(ds->count == 4);
-	assert_true(MyProc->gxact.xminDistributedSnapshot == 7);
+	assert_true(MyTmGxact->xminDistributedSnapshot == 7);
 	assert_true(ds->inProgressXidArray[0] == 7);
 	assert_true(ds->inProgressXidArray[1] == 10);
 	assert_true(ds->inProgressXidArray[2] == 15);

--- a/src/backend/storage/ipc/test/procarray_test.c
+++ b/src/backend/storage/ipc/test/procarray_test.c
@@ -21,7 +21,7 @@ void setup(TmControlBlock *controlBlock)
 	*shmDistribTimeStamp = time(NULL);
 	*shmNumCommittedGxacts = 0;
 
-	allProcs = malloc(sizeof(PGPROC)*MAX_PROCS);
+	allTmGxact = malloc(sizeof(TMGXACT)*MAX_PROCS);
 
 
 	procArray = malloc(sizeof(ProcArrayStruct) + sizeof(int) * (MAX_PROCS - 1));
@@ -65,7 +65,7 @@ test__CreateDistributedSnapshot(void **state)
 
 	procArray->numProcs = 1;
 
-	MyProc = &allProcs[procArray->pgprocnos[0]];
+	MyTmGxact = &allTmGxact[procArray->pgprocnos[0]];
 
 	/********************************************************
 	 * Basic case, no other in progress transaction in system
@@ -136,7 +136,7 @@ test__CreateDistributedSnapshot(void **state)
 
 	free(distribSnapshotWithLocalMapping.inProgressMappedLocalXids);
 	free(ds->inProgressXidArray);
-	free(allProcs);
+	free(allTmGxact);
 	free(procArray);
 }
 

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -3527,6 +3527,7 @@ GetLockStatusData(void)
 	for (i = 0; i < ProcGlobal->allProcCount; ++i)
 	{
 		PGPROC	   *proc = &ProcGlobal->allProcs[i];
+		TMGXACT	   *gxact = &ProcGlobal->allTmGxact[i];
 		uint32		f;
 
 		LWLockAcquire(proc->backendLock, LW_SHARED);
@@ -3561,7 +3562,7 @@ GetLockStatusData(void)
 			instance->mppSessionId = proc->mppSessionId;
 			instance->mppIsWriter = proc->mppIsWriter;
 			instance->distribXid = (Gp_role == GP_ROLE_DISPATCH)?
-								   proc->gxact.gxid :
+								   gxact->gxid :
 								   proc->localDistribXactData.distribXid;
 			instance->holdTillEndXact = (holdTillEndXactBits > 0);
 			el++;
@@ -3594,7 +3595,7 @@ GetLockStatusData(void)
 			instance->mppSessionId = proc->mppSessionId;
 			instance->mppIsWriter = proc->mppIsWriter;
 			instance->distribXid = (Gp_role == GP_ROLE_DISPATCH)?
-								   proc->gxact.gxid :
+								   gxact->gxid :
 								   proc->localDistribXactData.distribXid;
 			instance->holdTillEndXact = false;
 			el++;
@@ -3636,6 +3637,7 @@ GetLockStatusData(void)
 		PGPROC	   *proc = proclock->tag.myProc;
 		LOCK	   *lock = proclock->tag.myLock;
 		LockInstanceData *instance = &data->locks[el];
+		TMGXACT	   *gxact = &ProcGlobal->allTmGxact[proc->pgprocno];
 
 		memcpy(&instance->locktag, &lock->tag, sizeof(LOCKTAG));
 		instance->holdMask = proclock->holdMask;
@@ -3651,7 +3653,7 @@ GetLockStatusData(void)
 		instance->mppSessionId = proc->mppSessionId;
 		instance->mppIsWriter = proc->mppIsWriter;
 		instance->distribXid = (Gp_role == GP_ROLE_DISPATCH)?
-							   proc->gxact.gxid :
+							   gxact->gxid :
 							   proc->localDistribXactData.distribXid;
 		instance->holdTillEndXact = proclock->tag.myLock->holdTillEndXact;
 		el++;

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -230,8 +230,6 @@ typedef struct TMGXACT
 
 	bool						badPrepareGangs;
 
-	int							debugIndex;
-
 	bool						directTransaction;
 	uint16						directTransactionContentId;
 }	TMGXACT;

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -176,7 +176,6 @@ struct PGPROC
 	void		*resSlot;	/* the resource group slot granted.
    							 * NULL indicates the resource group is
 							 * locked for drop. */
-	TMGXACT		gxact;
 
 	/* Per-backend LWLock.	Protects fields below. */
 	LWLockId	backendLock;	/* protects the fields below */
@@ -194,6 +193,7 @@ struct PGPROC
 
 extern PGDLLIMPORT PGPROC *MyProc;
 extern PGDLLIMPORT struct PGXACT *MyPgXact;
+extern PGDLLIMPORT struct TMGXACT *MyTmGxact;
 
 /* Special for MPP reader gangs */
 extern PGDLLIMPORT PGPROC *lockHolderProcPtr;
@@ -233,6 +233,8 @@ typedef struct PROC_HDR
 	PGPROC	   *allProcs;
 	/* Array of PGXACT structures (not including dummies for prepared txns) */
 	PGXACT	   *allPgXact;
+	/* Array of TMGXACT structures (not including dummies for prepared txns) */
+	TMGXACT	   *allTmGxact;
 	/* Length of allProcs array */
 	uint32		allProcCount;
 	/* Head of list of free PGPROC structures */


### PR DESCRIPTION
Based on the same consideration as in commit ed0b40, this
is supposed to speed up CreateDistributedSnapshot by reducing
the number of cache lines needing to be fetched.