### PR TITLE
Remove numFreeProcs from ProcGlobal.

### DIFF
--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -254,9 +254,6 @@ typedef struct PROC_HDR
 
     /* Counter for assigning serial numbers to processes */
     int         mppLocalProcessCounter;
-
-	/* Number of free PGPROC entries in freeProcs list. */
-	int			numFreeProcs;
 } PROC_HDR;
 
 extern PROC_HDR *ProcGlobal;


### PR DESCRIPTION
Variable numFreeProcs is added by GPDB to accelerate HaveNFreeProcs(),
but considering the argument size of calls to HaveNFreeProcs(), this
optimization may be not worth it.
In addition, the current codes calculate numFreeProcs wrong.

So remove numFreeProcs to keep the same as PostgreSQL.