### PR TITLE
Fix assertion failure trying to build a Motion on a non-hashable column.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1018,6 +1018,18 @@ make_hashed_motion(Plan *lefttree,
 				   List *hashExpr, bool useExecutorVarFormat)
 {
 	Motion	   *motion;
+	ListCell   *lc;
+
+	/*
+	 * The expressions used as the distribution key must be "GPDB-hashable".
+	 * There's also an assertion for this in setrefs.c, but better to catch
+	 * these as early as possible.
+	 */
+	foreach(lc, hashExpr)
+	{
+		if (!isGreenplumDbHashable(exprType((Node *) lfirst(lc))))
+			elog(ERROR, "cannot use expression as distribution key, because it is not hashable");
+	}
 
 	motion = make_motion(NULL, lefttree, NIL, useExecutorVarFormat);
 	add_slice_to_motion(motion, MOTIONTYPE_HASH, hashExpr, 0, NULL);

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -21,6 +21,7 @@
 
 #include "nodes/makefuncs.h"
 
+#include "cdb/cdbhash.h"
 #include "cdb/cdbllize.h"
 #include "cdb/cdbmutate.h"
 #include "cdb/cdbsetop.h"
@@ -28,7 +29,6 @@
 #include "cdb/cdbpullup.h"
 
 static Flow *copyFlow(Flow *model_flow, bool withExprs, bool withSort);
-static List *makeHashExprsFromNonjunkTargets(List *targetList);
 
 /*
  * Function: choose_setop_type
@@ -362,13 +362,44 @@ make_motion_gather(PlannerInfo *root, Plan *subplan, int segindex, List *sortPat
  *		Add a Motion node atop the given subplan to hash collocate
  *      tuples non-distinct on the non-junk attributes.  This motion
  *      should only be applied to a non-replicated, non-root subplan.
+ *
+ * This will align with the sort attributes used as input to a SetOp
+ * or Unique operator. This is used in plans for UNION and other
+ * set-operations that implicitly do a DISTINCT on the whole target
+ * list.
  */
 Motion *
 make_motion_hash_all_targets(PlannerInfo *root, Plan *subplan)
 {
-	List	   *hashexprs = makeHashExprsFromNonjunkTargets(subplan->targetlist);
+	ListCell   *cell;
+	List	   *hashexprs = NIL;
 
-	return make_motion_hash(root, subplan, hashexprs);
+	foreach(cell, subplan->targetlist)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(cell);
+
+		if (tle->resjunk)
+			continue;
+
+		if (!isGreenplumDbHashable(exprType((Node *) tle->expr)))
+			continue;
+
+		hashexprs = lappend(hashexprs, copyObject(tle->expr));
+	}
+
+	if (hashexprs)
+		return make_motion_hash(root, subplan, hashexprs);
+	else
+	{
+		/*
+		 * Degenerate case, where none of the columns are hashable.
+		 *
+		 * (If the caller knew this, it probably would have been better to
+		 * produce a different plan, with Sorts in the segments, and an
+		 * order-preserving gather on the top.)
+		 */
+		return make_motion_gather(root, subplan, -1, NIL);
+	}
 }
 
 /*
@@ -390,34 +421,6 @@ make_motion_hash(PlannerInfo *root __attribute__((unused)), Plan *subplan, List 
 								false /* useExecutorVarFormat */ );
 
 	return motion;
-}
-
-/*
- * makeHashExprsFromNonjunkTargets
- *		Make a list of hash expressions over all non-resjunk targets in
- *		the targetlist are in the given target list.  This will align
- *		with the sort attributes used as input to a SetOp or Unique
- *		operator.
- *
- * Returns the newly allocate expression list for a Motion node.
- */
-static List *
-makeHashExprsFromNonjunkTargets(List *targetlist)
-{
-	ListCell   *cell;
-	List	   *hashlist = NIL;
-
-	foreach(cell, targetlist)
-	{
-		TargetEntry *tle = (TargetEntry *) lfirst(cell);
-
-		if (!tle->resjunk)
-		{
-			hashlist = lappend(hashlist, copyObject(tle->expr));
-		}
-	}
-	return hashlist;
-
 }
 
 /*

--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -20,6 +20,7 @@
 #include "postgres.h"
 
 #include "access/skey.h"
+#include "cdb/cdbhash.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/plannodes.h"
@@ -1360,6 +1361,57 @@ make_pathkeys_for_sortclauses(PlannerInfo *root,
 			pathkeys = lappend(pathkeys, pathkey);
 	}
 	return pathkeys;
+}
+
+/****************************************************************************
+ *		DISTRIBUTION KEYS
+ ****************************************************************************/
+
+/*
+ * Make a list of PathKeys, and a list of plain expressions, to represent a
+ * distribution key that is suitable for implementing grouping on the given
+ * grouping clause. Only expressions that are GPDB-hashable are included,
+ * so the resulting lists can be shorter than 'groupclause', or even empty.
+ *
+ * The result is stored in *partition_dist_keys and *partition_dist_exprs.
+ * *partition_dist_keys is set to a list of PathKeys, and
+ * *partition_dist_exprs to a corresponding list of plain expressions.
+ */
+void
+make_distribution_keys_for_groupclause(PlannerInfo *root, List *groupclause, List *tlist,
+									   List **partition_dist_keys,
+									   List **partition_dist_exprs)
+{
+	List	   *pathkeys = NIL;
+	List	   *exprs = NIL;
+	ListCell   *l;
+
+	foreach(l, groupclause)
+	{
+		SortGroupClause *sortcl = (SortGroupClause *) lfirst(l);
+		Expr	   *expr;
+		PathKey    *pathkey;
+
+		expr = (Expr *) get_sortgroupclause_expr(sortcl, tlist);
+
+		if (!isGreenplumDbHashable(exprType((Node *) expr)))
+			continue;
+
+		Assert(OidIsValid(sortcl->sortop));
+		pathkey = make_pathkey_from_sortop(root,
+										   expr,
+										   sortcl->sortop,
+										   sortcl->nulls_first,
+										   sortcl->tleSortGroupRef,
+										   true,
+										   false);
+
+		pathkeys = lappend(pathkeys, pathkey);
+		exprs = lappend(exprs, expr);
+	}
+
+	*partition_dist_keys = pathkeys;
+	*partition_dist_exprs = exprs;
 }
 
 /****************************************************************************

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1436,6 +1436,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	bool		tested_hashed_distinct = false;
 	double		numDistinct = 1;
 	List	   *distinctExprs = NIL;
+	List	   *distinct_dist_keys = NIL;
+	List	   *distinct_dist_exprs = NIL;
 	bool		must_gather;
 
 	double		motion_cost_per_row =
@@ -2265,6 +2267,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				int			firstOrderCol = 0;
 				Oid			firstOrderCmpOperator = InvalidOid;
 				bool		firstOrderNullsFirst = false;
+				bool		need_gather_for_partitioning;
 
 				/*
 				 * Unless the PARTITION BY in the window happens to match the
@@ -2276,28 +2279,35 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				 * node. But we'll do that after the Sort, so that the Sort
 				 * is parallelized.
 				 */
-				if (wc->partitionClause && !CdbPathLocus_IsGeneral(current_locus))
+				if (CdbPathLocus_IsGeneral(current_locus))
+					need_gather_for_partitioning = false;
+				else
 				{
-					List	   *dist_pathkeys;
+					List	   *partition_dist_keys;
+					List	   *partition_dist_exprs;
 
-					dist_pathkeys =
-						make_pathkeys_for_sortclauses(root, wc->partitionClause,
-													  tlist, false);
-
-					if (!cdbpathlocus_collocates(root, current_locus, dist_pathkeys, false))
+					make_distribution_keys_for_groupclause(root,
+														   wc->partitionClause,
+														   tlist,
+														   &partition_dist_keys,
+														   &partition_dist_exprs);
+					if (!partition_dist_keys)
 					{
-						List	   *dist_exprs = NIL;
-						ListCell   *lc;
-
-						foreach (lc, wc->partitionClause)
-						{
-							SortGroupClause *sc = (SortGroupClause *) lfirst(lc);
-							TargetEntry *tle = get_sortgroupclause_tle(sc, tlist);
-
-							dist_exprs = lappend(dist_exprs, tle->expr);
-						}
-
-						result_plan = (Plan *) make_motion_hash(root, result_plan, dist_exprs);
+						/*
+						 * There is no PARTITION BY, or none of the PARTITION BY
+						 * expressions can be used as a distribution key. Have to
+						 * gather everything to a single node.
+						 */
+						need_gather_for_partitioning = true;
+					}
+					else if (cdbpathlocus_collocates(root, current_locus, partition_dist_keys, false))
+					{
+						need_gather_for_partitioning = false;
+					}
+					else
+					{
+						result_plan = (Plan *) make_motion_hash(root, result_plan,
+																partition_dist_exprs);
 						result_plan->total_cost += motion_cost_per_row * result_plan->plan_rows;
 						current_pathkeys = NIL; /* no longer sorted */
 						Assert(result_plan->flow);
@@ -2306,7 +2316,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 						 * Change current_locus based on the new distribution
 						 * pathkeys.
 						 */
-						CdbPathLocus_MakeHashed(&current_locus, dist_pathkeys);
+						CdbPathLocus_MakeHashed(&current_locus, partition_dist_keys);
+						need_gather_for_partitioning = false;
 					}
 				}
 
@@ -2389,9 +2400,9 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				}
 
 				/*
-				 * If there was no PARTITION BY, gather the result.
+				 * If the input's locus doesn't match the PARTITION BY, gather the result.
 				 */
-				if (!wc->partitionClause &&
+				if (need_gather_for_partitioning &&
 					!CdbPathLocus_IsGeneral(current_locus) &&
 					result_plan->flow->flotype != FLOW_SINGLETON)
 				{
@@ -2523,6 +2534,9 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 									   dNumDistinctRows);
 		}
 
+		if (CdbPathLocus_IsNull(current_locus))
+			current_locus = cdbpathlocus_from_flow(result_plan->flow);
+
 		/*
 		 * MPP: If there's a DISTINCT clause and we're not collocated on the
 		 * distinct key, we need to redistribute on that key.  In addition, we
@@ -2533,20 +2547,23 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		 * the cost of an extra Redistribute-Sort-Unique on the pre-uniqued
 		 * (reduced) input.
 		 */
+		make_distribution_keys_for_groupclause(root,
+											   parse->distinctClause,
+											   result_plan->targetlist,
+											   &distinct_dist_keys,
+											   &distinct_dist_exprs);
+
 		distinctExprs = get_sortgrouplist_exprs(parse->distinctClause,
 												result_plan->targetlist);
 		numDistinct = estimate_num_groups(root, distinctExprs,
 										  result_plan->plan_rows);
 
-		if (CdbPathLocus_IsNull(current_locus))
-		{
-			current_locus = cdbpathlocus_from_flow(result_plan->flow);
-		}
-
 		if (Gp_role == GP_ROLE_DISPATCH && CdbPathLocus_IsPartitioned(current_locus))
 		{
-			bool		needMotion = !cdbpathlocus_collocates(root, current_locus,
-															  root->distinct_pathkeys, false /* exact_match */ );
+			bool		needMotion;
+
+			needMotion = !cdbpathlocus_collocates(root, current_locus,
+												  distinct_dist_keys, false /* exact_match */ );
 
 			/* Apply the preunique optimization, if enabled and worthwhile. */
 			/* GPDB_84_MERGE_FIXME: pre-unique for hash distinct not implemented. */
@@ -2613,9 +2630,16 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 
 			if (needMotion)
 			{
-				result_plan = (Plan *) make_motion_hash(root, result_plan, distinctExprs);
+				if (distinct_dist_exprs)
+				{
+					result_plan = (Plan *) make_motion_hash(root, result_plan, distinct_dist_exprs);
+					current_pathkeys = NIL;		/* Any pre-existing order now lost. */
+				}
+				else
+				{
+					result_plan = (Plan *) make_motion_gather(root, result_plan, -1, current_pathkeys);
+				}
 				result_plan->total_cost += motion_cost_per_row * result_plan->plan_rows;
-				current_pathkeys = NIL;		/* Any pre-existing order now lost. */
 			}
 		}
 		else if ( result_plan->flow->flotype == FLOW_SINGLETON )

--- a/src/include/optimizer/paths.h
+++ b/src/include/optimizer/paths.h
@@ -205,6 +205,9 @@ extern List *make_pathkeys_for_sortclauses(PlannerInfo *root,
 							  List *sortclauses,
 							  List *tlist,
 							  bool canonicalize);
+extern void make_distribution_keys_for_groupclause(PlannerInfo *root, List *groupclause, List *tlist,
+									   List **partition_dist_keys,
+									   List **partition_dist_exprs);
 extern void initialize_mergeclause_eclasses(PlannerInfo *root,
 								RestrictInfo *restrictinfo);
 extern void update_mergeclause_eclasses(PlannerInfo *root,

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1613,6 +1613,46 @@ select avg('1000000000000000000'::int8) from generate_series(1, 100000);
  1000000000000000000
 (1 row)
 
+-- Test cases where the planner would like to distribute on a column, to implement
+-- grouping or distinct, but can't because the datatype isn't GPDB-hashable.
+-- These are all variants of the the same issue; all of these used to miss the
+-- check on whether the column is GPDB_hashble, producing an assertion failure.
+create table int2vectortab (distkey int, t int2vector) distributed by (distkey);
+insert into int2vectortab values
+  (1, '1'),
+  (2, '1 2'),
+  (3, '1 2 3'),
+  (22,'22'),
+  (22,'1 2');
+select distinct t from int2vectortab group by distkey, t;
+   t   
+-------
+ 1
+ 1 2
+ 1 2 3
+ 22
+(4 rows)
+
+select * from int2vectortab union select * from int2vectortab;
+ distkey |   t   
+---------+-------
+       1 | 1
+       2 | 1 2
+       3 | 1 2 3
+      22 | 1 2
+      22 | 22
+(5 rows)
+
+select count(*) over (partition by t) from int2vectortab;
+ count 
+-------
+     1
+     1
+     1
+     2
+     2
+(5 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1613,6 +1613,46 @@ select avg('1000000000000000000'::int8) from generate_series(1, 100000);
  1000000000000000000
 (1 row)
 
+-- Test cases where the planner would like to distribute on a column, to implement
+-- grouping or distinct, but can't because the datatype isn't GPDB-hashable.
+-- These are all variants of the the same issue; all of these used to miss the
+-- check on whether the column is GPDB_hashble, producing an assertion failure.
+create table int2vectortab (distkey int, t int2vector) distributed by (distkey);
+insert into int2vectortab values
+  (1, '1'),
+  (2, '1 2'),
+  (3, '1 2 3'),
+  (22,'22'),
+  (22,'1 2');
+select distinct t from int2vectortab group by distkey, t;
+   t   
+-------
+ 1
+ 1 2
+ 1 2 3
+ 22
+(4 rows)
+
+select * from int2vectortab union select * from int2vectortab;
+ distkey |   t   
+---------+-------
+       1 | 1
+       2 | 1 2
+       3 | 1 2 3
+      22 | 1 2
+      22 | 22
+(5 rows)
+
+select count(*) over (partition by t) from int2vectortab;
+ count 
+-------
+     1
+     1
+     1
+     2
+     2
+(5 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;


### PR DESCRIPTION
Be more careful to not build a Redistribute Motion on an expression that's
not GPDB-hashable.

Fixes github issue #4868, as well as a couple of other similar cases that
were found while investigating this.