### PR TITLE
Adding GiST Support for ORCA

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.67.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.68.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.67.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.68.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13405,7 +13405,7 @@ int
 main ()
 {
 
-return strncmp("2.67.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.68.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13415,7 +13415,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.67.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.68.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.67.0@gpdb/stable
+orca/v2.68.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.67.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.68.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -496,7 +496,8 @@ typedef Scan TableScan;
 typedef enum LogicalIndexType
 {
 	INDTYPE_BTREE = 0,
-	INDTYPE_BITMAP = 1
+	INDTYPE_BITMAP = 1,
+	INDTYPE_GIST = 2
 } LogicalIndexType;
 
 typedef struct LogicalIndexInfo

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -375,16 +375,19 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM fast_emp4000
     WHERE home_base @ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: ((home_base[0])[0])
-   ->  Sort
-         Sort Key: ((home_base[0])[0])
-         ->  Index Scan using grect2ind on fast_emp4000
-               Index Cond: home_base @ '(2000,1000),(200,200)'::box
- Optimizer: legacy query optimizer
-(7 rows)
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Result
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((home_base[0])[0])
+         ->  Sort
+               Sort Key: ((home_base[0])[0])
+               ->  Result
+                     ->  Index Scan using grect2ind on fast_emp4000
+                           Index Cond: home_base @ '(2000,1000),(200,200)'::box
+                           Filter: home_base @ '(2000,1000),(200,200)'::box
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
 SELECT * FROM fast_emp4000
     WHERE home_base @ '(200,200),(2000,1000)'::box
@@ -404,8 +407,9 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base && '(1000,1000,0,0)'::box;
          ->  Aggregate
                ->  Index Scan using grect2ind on fast_emp4000
                      Index Cond: home_base && '(1000,1000),(0,0)'::box
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: home_base && '(1000,1000),(0,0)'::box
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM fast_emp4000 WHERE home_base && '(1000,1000,0,0)'::box;
  count 
@@ -434,16 +438,19 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base IS NULL;
 EXPLAIN (COSTS OFF)
 SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
-                          QUERY PLAN                           
----------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: ((poly_center(f1))[0])
-   ->  Sort
-         Sort Key: ((poly_center(f1))[0])
-         ->  Index Scan using gpolygonind on polygon_tbl
-               Index Cond: f1 ~ '((1,1),(2,2),(2,1))'::polygon
- Optimizer: legacy query optimizer
-(7 rows)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Result
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((poly_center(f1))[0])
+         ->  Sort
+               Sort Key: ((poly_center(f1))[0])
+               ->  Result
+                     ->  Index Scan using gpolygonind on polygon_tbl
+                           Index Cond: f1 ~ '((1,1),(2,2),(2,1))'::polygon
+                           Filter: f1 ~ '((1,1),(2,2),(2,1))'::polygon
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
 SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
@@ -455,16 +462,18 @@ SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
 EXPLAIN (COSTS OFF)
 SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
     ORDER BY area(f1);
-                      QUERY PLAN                       
--------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (area(f1))
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Result
    ->  Sort
          Sort Key: (area(f1))
-         ->  Index Scan using gcircleind on circle_tbl
-               Index Cond: f1 && '<(1,-2),1>'::circle
- Optimizer: legacy query optimizer
-(7 rows)
+         ->  Result
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Index Scan using gcircleind on circle_tbl
+                           Index Cond: f1 && '<(1,-2),1>'::circle
+                           Filter: f1 && '<(1,-2),1>'::circle
+ Optimizer: PQO version 2.68.0
+(9 rows)
 
 SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
     ORDER BY area(f1);
@@ -485,8 +494,9 @@ SELECT count(*) FROM gpolygon_tbl WHERE f1 && '(1000,1000,0,0)'::polygon;
          ->  Aggregate
                ->  Index Scan using ggpolygonind on gpolygon_tbl
                      Index Cond: f1 && '((1000,1000),(0,0))'::polygon
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 && '((1000,1000),(0,0))'::polygon
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM gpolygon_tbl WHERE f1 && '(1000,1000,0,0)'::polygon;
  count 
@@ -503,8 +513,9 @@ SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
          ->  Aggregate
                ->  Index Scan using ggcircleind on gcircle_tbl
                      Index Cond: f1 && '<(500,500),500>'::circle
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 && '<(500,500),500>'::circle
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
  count 
@@ -521,8 +532,9 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 <@ '(100,100),(0,0)'::box
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 <@ '(100,100),(0,0)'::box
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
  count 
@@ -538,9 +550,10 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: '(100,100),(0,0)'::box @> f1
- Optimizer: legacy query optimizer
-(6 rows)
+                     Index Cond: f1 <@ '(100,100),(0,0)'::box
+                     Filter: f1 <@ '(100,100),(0,0)'::box
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
  count 
@@ -557,8 +570,9 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
  count 
@@ -575,8 +589,9 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 <@ '<(50,50),50>'::circle
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 <@ '<(50,50),50>'::circle
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
  count 
@@ -586,15 +601,16 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using gpointind on point_tbl p
+               ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 << '(0,0)'::point
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 << '(0,0)'::point
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
  count 
@@ -604,15 +620,16 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using gpointind on point_tbl p
+               ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 >> '(0,0)'::point
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 >> '(0,0)'::point
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
  count 
@@ -622,15 +639,16 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using gpointind on point_tbl p
+               ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 <^ '(0,0)'::point
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 <^ '(0,0)'::point
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
  count 
@@ -640,15 +658,16 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using gpointind on point_tbl p
+               ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 >^ '(0,0)'::point
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 >^ '(0,0)'::point
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
  count 
@@ -658,15 +677,16 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using gpointind on point_tbl p
+               ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 ~= '(-5,-12)'::point
- Optimizer: legacy query optimizer
-(6 rows)
+                     Filter: f1 ~= '(-5,-12)'::point
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
  count 
@@ -738,15 +758,18 @@ SELECT * FROM point_tbl WHERE f1 IS NOT NULL ORDER BY f1 <-> '0,1';
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
-                     QUERY PLAN                     
-----------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (f1 <-> '(0,1)'::point)
-   ->  Index Scan using gpointind on point_tbl
-         Index Cond: f1 <@ '(10,10),(-10,-10)'::box
-         Order By: f1 <-> '(0,1)'::point
- Optimizer: legacy query optimizer
-(6 rows)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Result
+   ->  Sort
+         Sort Key: (f1 <-> '(0,1)'::point)
+         ->  Result
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Index Scan using gpointind on point_tbl
+                           Index Cond: f1 <@ '(10,10),(-10,-10)'::box
+                           Filter: f1 <@ '(10,10),(-10,-10)'::box
+ Optimizer: PQO version 2.68.0
+(9 rows)
 
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
    f1    
@@ -1302,17 +1325,17 @@ SET enable_indexscan = OFF;
 SET enable_bitmapscan = ON;
 EXPLAIN (COSTS OFF)
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (f1 <-> '(0,1)'::point)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Result
    ->  Sort
          Sort Key: (f1 <-> '(0,1)'::point)
-         ->  Bitmap Heap Scan on point_tbl
-               Recheck Cond: f1 <@ '(10,10),(-10,-10)'::box
-               ->  Bitmap Index Scan on gpointind
-                     Index Cond: f1 <@ '(10,10),(-10,-10)'::box
- Optimizer: legacy query optimizer
+         ->  Result
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Index Scan using gpointind on point_tbl
+                           Index Cond: f1 <@ '(10,10),(-10,-10)'::box
+                           Filter: f1 <@ '(10,10),(-10,-10)'::box
+ Optimizer: PQO version 2.68.0
 (9 rows)
 
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
@@ -2488,6 +2511,8 @@ ERROR:  hash indexes are not supported
 -- Test functional index
 --
 CREATE TABLE func_index_heap (f1 text, f2 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE INDEX func_index_index on func_index_heap (textcat(f1,f2));
 INSERT INTO func_index_heap VALUES('ABC','DEF');
 INSERT INTO func_index_heap VALUES('AB','CDEFG');
@@ -2501,6 +2526,8 @@ INSERT INTO func_index_heap VALUES('QWERTY');
 --
 DROP TABLE func_index_heap;
 CREATE TABLE func_index_heap (f1 text, f2 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE  INDEX func_index_index on func_index_heap ((f1 || f2) text_ops);
 INSERT INTO func_index_heap VALUES('ABC','DEF');
 INSERT INTO func_index_heap VALUES('AB','CDEFG');
@@ -2952,6 +2979,9 @@ SELECT count(*) FROM tenk1
 --
 CREATE TABLE dupindexcols AS
   SELECT unique1 as id, stringu2::text as f1 FROM tenk1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE INDEX dupindexcols_i ON dupindexcols (f1, id, f1 text_pattern_ops);
 ANALYZE dupindexcols;
 EXPLAIN (COSTS OFF)

--- a/src/test/regress/expected/qp_gist_indexes3.out
+++ b/src/test/regress/expected/qp_gist_indexes3.out
@@ -134,6 +134,7 @@ SELECT id, property AS "ProperTee" FROM GistTable3
 ------------------------------------------------------------------------------
 -- Encourage the optimizer to use indexes rather than sequential table scans.
 SET enable_seqscan=False;
+SET optimizer_enable_tablescan=False;
 -- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
 -- The "~=" operator means that the coordinate values, not just the area,
 -- are the same.
@@ -144,7 +145,6 @@ SELECT id, property AS "Property" FROM GistTable3
  999 | (999,999),(998,998)
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT id, property AS "Property" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
                                     QUERY PLAN                                    
@@ -158,7 +158,6 @@ EXPLAIN SELECT id, property AS "Property" FROM GistTable3
  Optimizer status: legacy query optimizer
 (7 rows)
 
--- end_ignore
 VACUUM ANALYZE GistTable3;
 SELECT id, property AS "ProperTee" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
@@ -167,7 +166,6 @@ SELECT id, property AS "ProperTee" FROM GistTable3
  999 | (999,999),(998,998)
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
                                       QUERY PLAN                                       
@@ -179,7 +177,6 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable3
  Optimizer status: legacy query optimizer
 (5 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test07Reindex.sql
 -- ----------------------------------------------------------------------
@@ -195,6 +192,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable3
 ------------------------------------------------------------------------------
 -- Encourage the optimizer to use indexes rather than sequential table scans.
 SET enable_seqscan=False;
+SET optimizer_enable_tablescan=False;
 REINDEX INDEX GistIndex3a;
 REINDEX TABLE GistTable3;
 -- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
@@ -207,7 +205,6 @@ SELECT id, property AS "Property" FROM GistTable3
  999 | (999,999),(998,998)
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT id, property AS "Property" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
                                       QUERY PLAN                                       
@@ -219,7 +216,6 @@ EXPLAIN SELECT id, property AS "Property" FROM GistTable3
  Optimizer status: legacy query optimizer
 (5 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test08UniqueAndPKey.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_gist_indexes3_optimizer.out
+++ b/src/test/regress/expected/qp_gist_indexes3_optimizer.out
@@ -1,17 +1,13 @@
-
 -- ----------------------------------------------------------------------
 -- Test: setup.sql
 -- ----------------------------------------------------------------------
-
 -- start_ignore
 create schema qp_gist_indexes3;
 set search_path to qp_gist_indexes3;
 -- end_ignore
-
 -- ----------------------------------------------------------------------
 -- Test: test01CreateTable.sql
 -- ----------------------------------------------------------------------
-
 ------------------------------------------------------------------------------
 -- start_ignore
 -- Portions Copyright (c) 2010, Greenplum, Inc.  All rights reserved.
@@ -28,14 +24,16 @@ set search_path to qp_gist_indexes3;
 --         DELETE that can't be executed on AO and CO tables.
 -- end_ignore
 ------------------------------------------------------------------------------
-
 -- start_ignore
 DROP TABLE IF EXISTS GistTable3;
+NOTICE:  table "gisttable3" does not exist, skipping
 DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
 DROP FUNCTION IF EXISTS insertIntoGistTable3(INTEGER);
+NOTICE:  function insertintogisttable3(pg_catalog.int4) does not exist, skipping
 DROP FUNCTION IF EXISTS insertManyIntoGistTable3(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable3(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
 -- end_ignore
-
 CREATE TABLE GistTable3 (
  id INTEGER,
  property BOX,
@@ -43,13 +41,11 @@ CREATE TABLE GistTable3 (
  filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
  )
  DISTRIBUTED BY (id);
-
 -- Register a function that converts TEXT to BOX data type.
 CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
   $$
     SELECT box_in(textout($1))
   $$ LANGUAGE SQL;
-
 CREATE FUNCTION insertIntoGistTable3 (seed INTEGER) RETURNS VOID
 AS
 $$
@@ -66,7 +62,6 @@ END;
 $$
 LANGUAGE PLPGSQL
 ;
-
 CREATE FUNCTION insertManyIntoGistTable3 (startValue INTEGER, endValue INTEGER) RETURNS VOID
 AS
 $$
@@ -82,12 +77,9 @@ END;
 $$
 LANGUAGE PLPGSQL
 ;
-
-
 -- ----------------------------------------------------------------------
 -- Test: test02Insert.sql
 -- ----------------------------------------------------------------------
-
 ------------------------------------------------------------------------------
 -- start_ignore
 -- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
@@ -103,26 +95,33 @@ LANGUAGE PLPGSQL
 --         DELETE that can't be executed on AO and CO tables.
 -- end_ignore
 ------------------------------------------------------------------------------
-
-
 -- Add some rows before we create the index.
 SELECT insertManyIntoGistTable3(1, 2000);
+ insertmanyintogisttable3 
+--------------------------
+ 
+(1 row)
 
 -- Create the index.
 CREATE INDEX GistIndex3a ON GistTable3 USING GiST (property);
 CREATE INDEX GistIndex3b ON GistTable3 USING GiST (poli);
-
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable3(2001, 4000);
+ insertmanyintogisttable3 
+--------------------------
+ 
+(1 row)
 
 SELECT id, property AS "ProperTee" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
-
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
 
 -- ----------------------------------------------------------------------
 -- Test: test06VacuumFull.sql
 -- ----------------------------------------------------------------------
-
 ------------------------------------------------------------------------------
 -- start_ignore
 -- PURPOSE: Help test VACUUM and REINDEX with GiST indexes. 
@@ -133,32 +132,55 @@ SELECT id, property AS "ProperTee" FROM GistTable3
 --        optimizer.
 -- end_ignore
 ------------------------------------------------------------------------------
-
 -- Encourage the optimizer to use indexes rather than sequential table scans.
 SET enable_seqscan=False;
 SET optimizer_enable_tablescan=False;
-
 -- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
 -- The "~=" operator means that the coordinate values, not just the area,
 -- are the same.
 SELECT id, property AS "Property" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
+ id  |      Property       
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
 
 EXPLAIN SELECT id, property AS "Property" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=36)
+   ->  Bitmap Table Scan on gisttable3  (cost=0.00..0.00 rows=1 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex3a  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: PQO version 2.64.0
+(7 rows)
 
 VACUUM ANALYZE GistTable3;
-
 SELECT id, property AS "ProperTee" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3201.22 rows=1600 width=36)
+   ->  Index Scan using gistindex3a on gisttable3  (cost=0.00..3201.01 rows=534 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: PQO version 2.64.0
+(6 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test07Reindex.sql
 -- ----------------------------------------------------------------------
-
 ------------------------------------------------------------------------------
 -- start_ignore
 -- PURPOSE: Help test VACUUM and REINDEX with GiST indexes. 
@@ -169,27 +191,36 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable3
 --        optimizer.
 -- end_ignore
 ------------------------------------------------------------------------------
-
 -- Encourage the optimizer to use indexes rather than sequential table scans.
 SET enable_seqscan=False;
 SET optimizer_enable_tablescan=False;
-
 REINDEX INDEX GistIndex3a;
 REINDEX TABLE GistTable3;
-
 -- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
 -- The "~=" operator means that the coordinate values, not just the area,
 -- are the same.
 SELECT id, property AS "Property" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
+ id  |      Property       
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
 
 EXPLAIN SELECT id, property AS "Property" FROM GistTable3
  WHERE property ~= '( (999,999), (998,998) )';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3201.22 rows=1600 width=36)
+   ->  Index Scan using gistindex3a on gisttable3  (cost=0.00..3201.01 rows=534 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: PQO version 2.64.0
+(6 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test08UniqueAndPKey.sql
 -- ----------------------------------------------------------------------
-
 ------------------------------------------------------------------------------
 -- PURPOSE:
 --     Test UNIQUE indexes and primary keys on geometric data types.
@@ -203,62 +234,68 @@ EXPLAIN SELECT id, property AS "Property" FROM GistTable3
 --     test that verifies that we get reasonable error messages when we try
 --     to create unique GiST indexes or pimary keys on gemoetric data types.
 ------------------------------------------------------------------------------
-
 CREATE TABLE gisttable_pktest (id integer, property box, poli polygon, bullseye point);
-
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE UNIQUE INDEX ShouldNotExist ON gisttable_pktest USING GiST (property);
+ERROR:  access method "gist" does not support unique indexes
 CREATE UNIQUE INDEX ShouldNotExist ON gisttable_pktest USING GiST (poli);
+ERROR:  access method "gist" does not support unique indexes
 CREATE UNIQUE INDEX ShouldNotExist ON gisttable_pktest USING GiST (bullseye);
-
-
+ERROR:  access method "gist" does not support unique indexes
 -- Test whether geometric types can be part of a primary key.
 CREATE TABLE GistTable2 (id INTEGER, property BOX) DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
 CREATE TABLE GistTable2 (id INTEGER, poli POLYGON) DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
 CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE) DISTRIBUTED BY (bullseye);
-
+ERROR:  type "circle" can't be a part of a distribution key
 -- ----------------------------------------------------------------------
 -- Test: test09NegativeTests.sql
 -- ----------------------------------------------------------------------
-
 ------------------------------------------------------------------------------
 -- PURPOSE:
 --     "Negative" tests.  Verify that we get reasonable error messages when
 --     we try to do unreasonable things, such as create indexes on types that
 --     do not support GiST (non-geometric types).
 ------------------------------------------------------------------------------
-
 -- Try to create GiST indexes on non-geometric data types.
 CREATE INDEX ShouldNotExist ON gisttable_pktest USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
 -- Try to create GiST indexes on a mix of geometric and
 -- non-geometric types.
 CREATE INDEX ShouldNotExist ON gisttable_pktest USING GiST (id, property);
-
-
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
 -- ----------------------------------------------------------------------
 -- Test: test14Hash.sql
 -- ----------------------------------------------------------------------
-
 ------------------------------------------------------------------------------
 -- PURPOSE:
 --     Test that you get a reasonable error message when you try to create a
 --     HASH index (we no longer support those).
 ------------------------------------------------------------------------------
-
 CREATE TABLE GistTable14 (
  id INTEGER,
  property BOX
  )
  DISTRIBUTED BY (id);
-
 -- Try to create a hash index.
 CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
 CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
-
-
+ERROR:  hash indexes are not supported
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
-
 -- start_ignore
 drop schema qp_gist_indexes3 cascade;
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to table gisttable3
+drop cascades to function to_box(text)
+drop cascades to function insertintogisttable3(integer)
+drop cascades to function insertmanyintogisttable3(integer,integer)
+drop cascades to table gisttable_pktest
+drop cascades to table gisttable14
 -- end_ignore

--- a/src/test/regress/expected/qp_gist_indexes4.out
+++ b/src/test/regress/expected/qp_gist_indexes4.out
@@ -192,7 +192,6 @@ SELECT * FROM geometricTypes
  10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
                                    QUERY PLAN                                    
@@ -204,7 +203,6 @@ EXPLAIN SELECT * FROM geometricTypes
  Optimizer status: legacy query optimizer
 (5 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
  seed |         c          |            b             |             p              
@@ -212,7 +210,6 @@ SELECT * FROM geometricTypes
  1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
                                    QUERY PLAN                                    
@@ -224,7 +221,6 @@ EXPLAIN SELECT * FROM geometricTypes
  Optimizer status: legacy query optimizer
 (5 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
  seed |         c          |            b             |             p              
@@ -232,7 +228,6 @@ SELECT * FROM geometricTypes
  3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
                                    QUERY PLAN                                    
@@ -244,7 +239,6 @@ EXPLAIN SELECT * FROM geometricTypes
  Optimizer status: legacy query optimizer
 (5 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test06_createIndexes.sql
 -- ----------------------------------------------------------------------
@@ -264,6 +258,7 @@ CREATE INDEX gt_index_p ON geometricTypes USING GIST (p);
 --     statements.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
 SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
  seed  |         c          |            b            |             p             
@@ -271,7 +266,6 @@ SELECT * FROM geometricTypes
  10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
                                         QUERY PLAN                                         
@@ -284,7 +278,6 @@ EXPLAIN SELECT * FROM geometricTypes
  Optimizer status: legacy query optimizer
 (6 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
  seed |         c          |            b             |             p              
@@ -292,7 +285,6 @@ SELECT * FROM geometricTypes
  1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
                                         QUERY PLAN                                         
@@ -304,7 +296,6 @@ EXPLAIN SELECT * FROM geometricTypes
  Optimizer status: legacy query optimizer
 (5 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
  seed |         c          |            b             |             p              
@@ -312,7 +303,6 @@ SELECT * FROM geometricTypes
  3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
                                         QUERY PLAN                                         
@@ -325,7 +315,6 @@ EXPLAIN SELECT * FROM geometricTypes
  Optimizer status: legacy query optimizer
 (6 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test08_reindex.sql
 -- ----------------------------------------------------------------------
@@ -364,6 +353,7 @@ INSERT INTO gone (seed, already_gone, too_far_gone, paragon)
  ;
  
 SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
 -- Create an index; use the index; then roll back.
 BEGIN WORK;
 CREATE INDEX gone_around_the_bend ON gone USING GiST (already_gone);
@@ -388,6 +378,7 @@ EXPLAIN SELECT * FROM gone
 (6 rows)
 
 ROLLBACK WORK;
+SET optimizer_enable_tablescan = True;
 -- Should not use the index, since we rolled back the statement that created 
 -- the index.
 SELECT * FROM gone 
@@ -408,6 +399,7 @@ EXPLAIN SELECT * FROM gone
  Optimizer status: legacy query optimizer
 (5 rows)
 
+SET optimizer_enable_tablescan = False;
 CREATE INDEX polly_gone ON gone USING GiST (paragon);
 BEGIN WORK;
 ALTER INDEX polly_gone RENAME TO polly_wanna_cracker;
@@ -610,6 +602,7 @@ DROP TABLE IF EXISTS gone;
 --     statements.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
 SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
  seed  |         c          |            b            |             p             
@@ -617,7 +610,6 @@ SELECT * FROM geometricTypes
  10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
                                         QUERY PLAN                                         
@@ -630,7 +622,6 @@ EXPLAIN SELECT * FROM geometricTypes
  Optimizer status: legacy query optimizer
 (6 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
  seed |         c          |            b             |             p              
@@ -638,7 +629,6 @@ SELECT * FROM geometricTypes
  1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
                                         QUERY PLAN                                         
@@ -650,7 +640,6 @@ EXPLAIN SELECT * FROM geometricTypes
  Optimizer status: legacy query optimizer
 (5 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
  seed |         c          |            b             |             p              
@@ -658,7 +647,6 @@ SELECT * FROM geometricTypes
  3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
                                         QUERY PLAN                                         
@@ -671,7 +659,232 @@ EXPLAIN SELECT * FROM geometricTypes
  Optimizer status: legacy query optimizer
 (6 rows)
 
--- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test11_multiple_filters.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly when there are multple predicates in the
+--     where clause.  Furthermore, we request EXPLAIN info for each SELECT.  
+--     In this script, we ignore the output of the EXPLAIN commands, but a 
+--     later part of the test checks that we used an index scan rather than 
+--     a sequential scan when executing the SELECT statements.
+-- ----------------------------------------------------------------------------
+SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(19510) AND c << SeedToCircle(100000);
+ seed  |          c          |            b             |             p              
+-------+---------------------+--------------------------+----------------------------
+ 19510 | <(-3197,7903),3150> | (3150,7903),(-3197,7679) | ((-3197,7903),(3150,7679))
+(1 row)
+
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(19510) AND c << SeedToCircle(100000);
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..201.27 rows=1 width=129)
+   ->  Index Scan using gt_index_c on geometrictypes  (cost=0.00..201.27 rows=1 width=129)
+         Index Cond: c ~= '<(-3197,7903),3150>'::circle AND c << '<(7879,8779),7868>'::circle
+ Optimizer: legacy query optimizer
+(4 rows)
+
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001) AND b << SeedToBox(101);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
+(1 row)
+
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001) AND b << SeedToBox(101);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.37 rows=1 width=129)
+   ->  Index Scan using gt_index_b on geometrictypes  (cost=0.00..200.37 rows=1 width=129)
+         Index Cond: b ~= '(7352,7352),(7350,-3128)'::box AND b << '(8479,7579),(8441,-3121)'::box
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(345) AND p << SeedToPolygon(34);
+ seed |         c          |            b            |             p             
+------+--------------------+-------------------------+---------------------------
+  345 | <(1252,8252),1274> | (1274,8252),(1252,7975) | ((1252,8252),(1274,7975))
+(1 row)
+
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(345) AND p << SeedToPolygon(34);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.37 rows=1 width=129)
+   ->  Index Scan using gt_index_p on geometrictypes  (cost=0.00..200.37 rows=1 width=129)
+         Index Cond: p ~= '((1252,8252),(1274,7975))'::polygon AND p << '((8778,6578),(8765,8265))'::polygon
+         Filter: p ~= '((1252,8252),(1274,7975))'::polygon AND p << '((8778,6578),(8765,8265))'::polygon
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test12_partition.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This tests partition tables with GiST indexes as a brief sanity check
+--     that the indexes are working correctly. Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- ----------------------------------------------------------------------------
+CREATE TABLE geometricTypesPartition (seed INTEGER, c CIRCLE, b BOX, p POLYGON) 
+PARTITION BY range(seed) (Start(1) end(3) every(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'seed' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "geometrictypespartition_1_prt_1" for table "geometrictypespartition"
+NOTICE:  CREATE TABLE will create partition "geometrictypespartition_1_prt_2" for table "geometrictypespartition"
+INSERT INTO geometricTypesPartition (seed, c, b, p) 
+ SELECT x%2 + 1, 
+   SeedToCircle(x), 
+   SeedToBox(x), 
+   SeedToPolygon(x)
+  FROM generate_series(1, 3000)x
+ ;
+CREATE INDEX gt_index_c_part ON geometricTypesPartition USING GIST (c);
+NOTICE:  building index for child partition "geometrictypespartition_1_prt_1"
+NOTICE:  building index for child partition "geometrictypespartition_1_prt_2"
+SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
+SELECT * FROM geometricTypesPartition 
+ WHERE c ~= SeedToCircle(101);
+ seed |          c          |            b             |             p              
+------+---------------------+--------------------------+----------------------------
+    2 | <(8479,-3121),8441> | (8479,7579),(8441,-3121) | ((8479,-3121),(8441,7579))
+(1 row)
+
+EXPLAIN SELECT * FROM geometricTypesPartition 
+ WHERE c ~= SeedToCircle(101);
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.56..2673.79 rows=54 width=92)
+   ->  Append  (cost=100.56..2673.79 rows=18 width=92)
+         ->  Bitmap Heap Scan on geometrictypespartition_1_prt_1 geometrictypespartition  (cost=100.56..1336.90 rows=9 width=92)
+               Filter: c ~= '<(8479,-3121),8441>'::circle
+               ->  Bitmap Index Scan on gt_index_c_part_1_prt_1  (cost=0.00..100.55 rows=9 width=0)
+                     Index Cond: c ~= '<(8479,-3121),8441>'::circle
+         ->  Bitmap Heap Scan on geometrictypespartition_1_prt_2 geometrictypespartition  (cost=100.56..1336.90 rows=9 width=92)
+               Filter: c ~= '<(8479,-3121),8441>'::circle
+               ->  Bitmap Index Scan on gt_index_c_part_1_prt_2  (cost=0.00..100.55 rows=9 width=0)
+                     Index Cond: c ~= '<(8479,-3121),8441>'::circle
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+DROP TABLE IF EXISTS geometricTypesPartition;
+-- ----------------------------------------------------------------------
+-- Test: test13_textsearch.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This tests full text search with GiST indexes as a brief sanity check
+--     that the indexes are working correctly. Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- ----------------------------------------------------------------------------
+CREATE TABLE textSearch (seed INTEGER, t tsvector);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'seed' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX text_index ON textSearch USING GIST (t);
+INSERT INTO textSearch VALUES (1, 'test');
+INSERT INTO textSearch VALUES (2, 'test');
+INSERT INTO textSearch VALUES (2, 't');
+INSERT INTO textSearch VALUES (1, 'est');
+INSERT INTO textSearch VALUES (2, 'te');
+INSERT INTO textSearch VALUES (1, 'st');
+INSERT INTO textSearch VALUES (2, 'tt');
+INSERT INTO textSearch VALUES (1, 'hello');
+INSERT INTO textSearch VALUES (3, 'world');
+INSERT INTO textSearch VALUES (4, 'orca');
+INSERT INTO textSearch VALUES (3, 'gpdb');
+INSERT INTO textSearch VALUES (4, 'gist');
+INSERT INTO textSearch VALUES (3, 'cool');
+SELECT * FROM textSearch 
+ WHERE t @@ to_tsquery('test'); 
+ seed |   t    
+------+--------
+    1 | 'test'
+    2 | 'test'
+(2 rows)
+
+EXPLAIN SELECT * FROM textSearch 
+ WHERE t @@ to_tsquery('test'); 
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=17)
+   ->  Index Scan using text_index on textsearch  (cost=0.00..200.27 rows=1 width=17)
+         Index Cond: t @@ '''test'''::tsquery
+         Filter: t @@ '''test'''::tsquery
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+DROP TABLE IF EXISTS textSearch;
+-- ----------------------------------------------------------------------
+-- Test: test14_performance.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This tests performance with GiST indexes as a brief sanity check
+--     that the indexes are working correctly. Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements. This test should not be taking longer than a couple of 
+--     seconds. If it goes for a table scan/seq scan, then this query will take
+--     at least 70x times longer. 
+-- ----------------------------------------------------------------------------
+SET optimizer_enable_tablescan = TRUE;
+CREATE TABLE gist_tbl (a int, p polygon);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE gist_tbl2 (b int, p polygon);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX poly_index ON gist_tbl USING gist(p);
+INSERT INTO gist_tbl SELECT i, polygon(box(point(i, i+2),point(i+4,
+i+6))) FROM generate_series(1,50000)i;
+INSERT INTO gist_tbl2 SELECT i, polygon(box(point(i+1, i+3),point(i+5,
+i+7))) FROM generate_series(1,50000)i;
+ANALYZE gist_tbl;
+ANALYZE gist_tbl2;
+SELECT count(*) FROM gist_tbl, gist_tbl2 
+ WHERE gist_tbl.p <@ gist_tbl2.p;
+ count 
+-------
+ 49999
+(1 row)
+
+EXPLAIN SELECT count(*) FROM gist_tbl, gist_tbl2 
+ WHERE gist_tbl.p <@ gist_tbl2.p;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=398146.51..398146.52 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=398146.44..398146.49 rows=1 width=8)
+         ->  Aggregate  (cost=398146.44..398146.45 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..391855.82 rows=838750 width=0)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2715.85 rows=49997 width=101)
+                           ->  Seq Scan on gist_tbl2  (cost=0.00..715.97 rows=16666 width=101)
+                     ->  Index Scan using poly_index on gist_tbl  (cost=0.00..1.97 rows=17 width=101)
+                           Index Cond: gist_tbl.p <@ gist_tbl2.p
+                           Filter: gist_tbl.p <@ gist_tbl2.p
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_gist_indexes4_optimizer.out
+++ b/src/test/regress/expected/qp_gist_indexes4_optimizer.out
@@ -192,19 +192,16 @@ SELECT * FROM geometricTypes
  10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
-   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..436.30 rows=8013 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..432.44 rows=2671 width=129)
          Filter: c ~= '<(1255,7955),1227>'::circle
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+ Optimizer: PQO version 2.68.0
+(4 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
  seed |         c          |            b             |             p              
@@ -212,19 +209,16 @@ SELECT * FROM geometricTypes
  1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
-   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..436.30 rows=8013 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..432.44 rows=2671 width=129)
          Filter: b ~= '(7352,7352),(7350,-3128)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+ Optimizer status: PQO version 2.64.0
+(4 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
  seed |         c          |            b             |             p              
@@ -232,19 +226,16 @@ SELECT * FROM geometricTypes
  3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
-   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..436.30 rows=8013 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..432.44 rows=2671 width=129)
          Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+ Optimizer: PQO version 2.68.0
+(4 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test06_createIndexes.sql
 -- ----------------------------------------------------------------------
@@ -264,6 +255,7 @@ CREATE INDEX gt_index_p ON geometricTypes USING GIST (p);
 --     statements.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
 SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
  seed  |         c          |            b            |             p             
@@ -271,19 +263,17 @@ SELECT * FROM geometricTypes
  10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
-   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..16031.38 rows=8013 width=129)
+   ->  Index Scan using gt_index_c on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
+         Index Cond: c ~= '<(1255,7955),1227>'::circle
          Filter: c ~= '<(1255,7955),1227>'::circle
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
  seed |         c          |            b             |             p              
@@ -291,19 +281,17 @@ SELECT * FROM geometricTypes
  1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
-   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..16031.38 rows=8013 width=129)
+   ->  Index Scan using gt_index_b on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
+         Index Cond: b ~= '(7352,7352),(7350,-3128)'::box
          Filter: b ~= '(7352,7352),(7350,-3128)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
  seed |         c          |            b             |             p              
@@ -311,19 +299,17 @@ SELECT * FROM geometricTypes
  3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
-   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..16031.38 rows=8013 width=129)
+   ->  Index Scan using gt_index_p on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
+         Index Cond: p ~= '((4679,8579),(4670,-3232))'::polygon
          Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test08_reindex.sql
 -- ----------------------------------------------------------------------
@@ -362,6 +348,7 @@ INSERT INTO gone (seed, already_gone, too_far_gone, paragon)
  ;
  
 SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
 -- Create an index; use the index; then roll back.
 BEGIN WORK;
 CREATE INDEX gone_around_the_bend ON gone USING GiST (already_gone);
@@ -375,16 +362,17 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE already_gone ~= SeedToCircle(857);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using gone_around_the_bend on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: already_gone ~= '<(-3176,7824),3174>'::circle
          Filter: already_gone ~= '<(-3176,7824),3174>'::circle
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
+SET optimizer_enable_tablescan = True;
 -- Should not use the index, since we rolled back the statement that created 
 -- the index.
 SELECT * FROM gone 
@@ -401,10 +389,10 @@ EXPLAIN SELECT * FROM gone
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
    ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
          Filter: already_gone ~= '<(-3176,7824),3174>'::circle
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+ Optimizer: PQO version 2.68.0
+(4 rows)
 
+SET optimizer_enable_tablescan = False;
 CREATE INDEX polly_gone ON gone USING GiST (paragon);
 BEGIN WORK;
 ALTER INDEX polly_gone RENAME TO polly_wanna_cracker;
@@ -418,13 +406,13 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE paragon ~= SeedToPolygon(858);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using polly_wanna_cracker on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: paragon ~= '((7625,8425),(7643,7849))'::polygon
          Filter: paragon ~= '((7625,8425),(7643,7849))'::polygon
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -438,13 +426,13 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE paragon ~= SeedToPolygon(858);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using polly_gone on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: paragon ~= '((7625,8425),(7643,7849))'::polygon
          Filter: paragon ~= '((7625,8425),(7643,7849))'::polygon
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 CREATE INDEX box_of_rain ON gone USING GiST (too_far_gone) 
@@ -462,13 +450,13 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE too_far_gone ~= SeedToBox(859);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -481,13 +469,13 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE too_far_gone ~= SeedToBox(859);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 BEGIN WORK;
@@ -501,13 +489,13 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE too_far_gone ~= SeedToBox(859);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -523,13 +511,13 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE too_far_gone ~= SeedToBox(859);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -544,13 +532,13 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE too_far_gone ~= SeedToBox(859);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 REINDEX TABLE gone;
@@ -563,13 +551,13 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE too_far_gone ~= SeedToBox(859);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -582,13 +570,13 @@ SELECT * FROM gone
 
 EXPLAIN SELECT * FROM gone 
  WHERE too_far_gone ~= SeedToBox(859);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
-   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8003.28 rows=4000 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 DROP TABLE IF EXISTS gone;
@@ -605,6 +593,7 @@ DROP TABLE IF EXISTS gone;
 --     statements.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
 SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
  seed  |         c          |            b            |             p             
@@ -612,19 +601,17 @@ SELECT * FROM geometricTypes
  10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE c ~= SeedToCircle(10001);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
-   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..16031.38 rows=8013 width=129)
+   ->  Index Scan using gt_index_c on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
+         Index Cond: c ~= '<(1255,7955),1227>'::circle
          Filter: c ~= '<(1255,7955),1227>'::circle
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
  seed |         c          |            b             |             p              
@@ -632,19 +619,17 @@ SELECT * FROM geometricTypes
  1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE b ~= SeedToBox(1001);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
-   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..16031.38 rows=8013 width=129)
+   ->  Index Scan using gt_index_b on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
+         Index Cond: b ~= '(7352,7352),(7350,-3128)'::box
          Filter: b ~= '(7352,7352),(7350,-3128)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
--- end_ignore
 SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
  seed |         c          |            b             |             p              
@@ -652,26 +637,258 @@ SELECT * FROM geometricTypes
  3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
 (1 row)
 
--- start_ignore
 EXPLAIN SELECT * FROM geometricTypes 
  WHERE p ~= SeedToPolygon(3456);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
-   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..16031.38 rows=8013 width=129)
+   ->  Index Scan using gt_index_p on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
+         Index Cond: p ~= '((4679,8579),(4670,-3232))'::polygon
          Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
--- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test11_multiple_filters.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly when there are multple predicates in the
+--     where clause.  Furthermore, we request EXPLAIN info for each SELECT.  
+--     In this script, we ignore the output of the EXPLAIN commands, but a 
+--     later part of the test checks that we used an index scan rather than 
+--     a sequential scan when executing the SELECT statements.
+-- ----------------------------------------------------------------------------
+SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(19510) AND c << SeedToCircle(100000);
+ seed  |          c          |            b             |             p              
+-------+---------------------+--------------------------+----------------------------
+ 19510 | <(-3197,7903),3150> | (3150,7903),(-3197,7679) | ((-3197,7903),(3150,7679))
+(1 row)
+
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(19510) AND c << SeedToCircle(100000);
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6412.55 rows=3205 width=129)
+   ->  Index Scan using gt_index_c on geometrictypes  (cost=0.00..6411.01 rows=1069 width=129)
+         Index Cond: c ~= '<(-3197,7903),3150>'::circle AND c << '<(7879,8779),7868>'::circle
+         Filter: c ~= '<(-3197,7903),3150>'::circle AND c << '<(7879,8779),7868>'::circle
+ Optimizer: PQO version 2.68.0
+(5 rows)
+
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001) AND b << SeedToBox(101);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
+(1 row)
+
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001) AND b << SeedToBox(101);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6412.55 rows=3205 width=129)
+   ->  Index Scan using gt_index_b on geometrictypes  (cost=0.00..6411.01 rows=1069 width=129)
+         Index Cond: b ~= '(7352,7352),(7350,-3128)'::box AND b << '(8479,7579),(8441,-3121)'::box
+         Filter: b ~= '(7352,7352),(7350,-3128)'::box AND b << '(8479,7579),(8441,-3121)'::box
+ Optimizer: PQO version 2.68.0
+(5 rows)
+
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(345) AND p << SeedToPolygon(34);
+ seed |         c          |            b            |             p             
+------+--------------------+-------------------------+---------------------------
+  345 | <(1252,8252),1274> | (1274,8252),(1252,7975) | ((1252,8252),(1274,7975))
+(1 row)
+
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(345) AND p << SeedToPolygon(34);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6412.55 rows=3205 width=129)
+   ->  Index Scan using gt_index_p on geometrictypes  (cost=0.00..6411.01 rows=1069 width=129)
+         Index Cond: p ~= '((1252,8252),(1274,7975))'::polygon AND p << '((8778,6578),(8765,8265))'::polygon
+         Filter: p ~= '((1252,8252),(1274,7975))'::polygon AND p << '((8778,6578),(8765,8265))'::polygon
+ Optimizer: PQO version 2.68.0
+(5 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test12_partition.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This tests partition tables with GiST indexes as a brief sanity check
+--     that the indexes are working correctly. Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- ----------------------------------------------------------------------------
+CREATE TABLE geometricTypesPartition (seed INTEGER, c CIRCLE, b BOX, p POLYGON) 
+PARTITION BY range(seed) (Start(1) end(3) every(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'seed' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "geometrictypespartition_1_prt_1" for table "geometrictypespartition"
+NOTICE:  CREATE TABLE will create partition "geometrictypespartition_1_prt_2" for table "geometrictypespartition"
+INSERT INTO geometricTypesPartition (seed, c, b, p) 
+ SELECT x%2 + 1, 
+   SeedToCircle(x), 
+   SeedToBox(x), 
+   SeedToPolygon(x)
+  FROM generate_series(1, 3000)x
+ ;
+CREATE INDEX gt_index_c_part ON geometricTypesPartition USING GIST (c);
+NOTICE:  building index for child partition "geometrictypespartition_1_prt_1"
+NOTICE:  building index for child partition "geometrictypespartition_1_prt_2"
+SET enable_seqscan = False;
+SET optimizer_enable_tablescan = False;
+SELECT * FROM geometricTypesPartition 
+ WHERE c ~= SeedToCircle(101);
+ seed |          c          |            b             |             p              
+------+---------------------+--------------------------+----------------------------
+    2 | <(8479,-3121),8441> | (8479,7579),(8441,-3121) | ((8479,-3121),(8441,7579))
+(1 row)
+
+EXPLAIN SELECT * FROM geometricTypesPartition 
+ WHERE c ~= SeedToCircle(101);
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.01 rows=1 width=68)
+   ->  Sequence  (cost=0.00..0.00 rows=1 width=68)
+         ->  Partition Selector for geometrictypespartition (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 2 (out of 2)
+         ->  Bitmap Table Scan on geometrictypespartition (dynamic scan id: 1)  (cost=0.00..0.00 rows=1 width=68)
+               Recheck Cond: c ~= '<(8479,-3121),8441>'::circle
+               ->  Dynamic Bitmap Index Scan on gt_index_c_part_1_prt_1  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: c ~= '<(8479,-3121),8441>'::circle
+ Optimizer: PQO version 2.68.0
+(9 rows)
+
+DROP TABLE IF EXISTS geometricTypesPartition;
+-- ----------------------------------------------------------------------
+-- Test: test13_textsearch.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This tests full text search with GiST indexes as a brief sanity check
+--     that the indexes are working correctly. Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- ----------------------------------------------------------------------------
+CREATE TABLE textSearch (seed INTEGER, t tsvector);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'seed' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX text_index ON textSearch USING GIST (t);
+INSERT INTO textSearch VALUES (1, 'test');
+INSERT INTO textSearch VALUES (2, 'test');
+INSERT INTO textSearch VALUES (2, 't');
+INSERT INTO textSearch VALUES (1, 'est');
+INSERT INTO textSearch VALUES (2, 'te');
+INSERT INTO textSearch VALUES (1, 'st');
+INSERT INTO textSearch VALUES (2, 'tt');
+INSERT INTO textSearch VALUES (1, 'hello');
+INSERT INTO textSearch VALUES (3, 'world');
+INSERT INTO textSearch VALUES (4, 'orca');
+INSERT INTO textSearch VALUES (3, 'gpdb');
+INSERT INTO textSearch VALUES (4, 'gist');
+INSERT INTO textSearch VALUES (3, 'cool');
+SELECT * FROM textSearch 
+ WHERE t @@ to_tsquery('test'); 
+ seed |   t    
+------+--------
+    1 | 'test'
+    2 | 'test'
+(2 rows)
+
+EXPLAIN SELECT * FROM textSearch 
+ WHERE t @@ to_tsquery('test'); 
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=17)
+   ->  Index Scan using text_index on textsearch  (cost=0.00..2.00 rows=1 width=17)
+         Index Cond: t @@ '''test'''::tsquery
+         Filter: t @@ '''test'''::tsquery
+ Optimizer: PQO version 2.68.0
+(5 rows)
+
+DROP TABLE IF EXISTS textSearch;
+-- ----------------------------------------------------------------------
+-- Test: test14_performance.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This tests performance with GiST indexes as a brief sanity check
+--     that the indexes are working correctly. Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements. This test should not be taking longer than a couple of 
+--     seconds. If it goes for a table scan/seq scan, then this query will take
+--     at least 70x times longer. 
+-- ----------------------------------------------------------------------------
+SET optimizer_enable_tablescan = TRUE;
+CREATE TABLE gist_tbl (a int, p polygon);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE gist_tbl2 (b int, p polygon);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX poly_index ON gist_tbl USING gist(p);
+INSERT INTO gist_tbl SELECT i, polygon(box(point(i, i+2),point(i+4,
+i+6))) FROM generate_series(1,50000)i;
+INSERT INTO gist_tbl2 SELECT i, polygon(box(point(i+1, i+3),point(i+5,
+i+7))) FROM generate_series(1,50000)i;
+ANALYZE gist_tbl;
+ANALYZE gist_tbl2;
+SELECT count(*) FROM gist_tbl, gist_tbl2 
+ WHERE gist_tbl.p <@ gist_tbl2.p;
+ count 
+-------
+ 49999
+(1 row)
+
+EXPLAIN SELECT count(*) FROM gist_tbl, gist_tbl2 
+ WHERE gist_tbl.p <@ gist_tbl2.p;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..21623779.93 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..21623779.93 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..21623779.93 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..21623779.93 rows=333840193 width=1)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..525.84 rows=50038 width=101)
+                           ->  Table Scan on gist_tbl2  (cost=0.00..432.24 rows=16680 width=101)
+                     ->  Bitmap Table Scan on gist_tbl  (cost=0.00..21621461.63 rows=6672 width=1)
+                           Recheck Cond: p <@ gist_tbl2.p
+                           ->  Bitmap Index Scan on poly_index  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: p <@ gist_tbl2.p
+ Optimizer: PQO version 2.68.0
+(12 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore
 drop schema qp_gist_indexes4 cascade;
-NOTICE:  drop cascades to function seedtopolygon(integer)
-NOTICE:  drop cascades to function seedtocircle(integer)
-NOTICE:  drop cascades to function seedtobox(integer)
-NOTICE:  drop cascades to function seedtoboxastext(integer)
+NOTICE:  drop cascades to 14 other objects
+DETAIL:  drop cascades to function seedtomangledinteger(integer,bytea,bytea)
+drop cascades to function f1(integer)
+drop cascades to function f2(integer)
+drop cascades to function f3(integer)
+drop cascades to function f4(integer)
+drop cascades to function seedtopoint1(integer)
+drop cascades to function seedtopoint2(integer)
+drop cascades to function seedtoboxastext(integer)
+drop cascades to function seedtobox(integer)
+drop cascades to function seedtocircle(integer)
+drop cascades to function seedtopolygon(integer)
+drop cascades to table geometrictypes
+drop cascades to table gist_tbl
+drop cascades to table gist_tbl2
 -- end_ignore

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -13,6 +13,7 @@ m/^WARNING:  gpmon:.*Connection refused.*/
 
 m/^ Optimizer status:.*/
 m/^ Optimizer: PQO version .*/
+m/^ Settings:.*/
 
 # There are a number of NOTICE and HINT messages around table distribution,
 # for example to inform the user that the database will pick a particular

--- a/src/test/regress/input/qp_gist_indexes2.source
+++ b/src/test/regress/input/qp_gist_indexes2.source
@@ -6,6 +6,23 @@
 create schema qp_gist_indexes2;
 set search_path to qp_gist_indexes2;
 
+ -- start_ignore
+create language plpythonu;
+-- end_ignore
+
+create or replace function count_index_scans(explain_query text) returns int as
+$$
+rv = plpy.execute(explain_query)
+search_text = 'Index Scan'
+result = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text.lower() in cur_line.lower():
+        result = result+1
+return result
+$$
+language plpythonu;
+
 -- ----------------------------------------------------------------------
 -- Test: test01create_table.sql
 -- ----------------------------------------------------------------------
@@ -37,6 +54,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -51,11 +69,9 @@ SELECT owner, property FROM GistTable1
  WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
 
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
@@ -70,11 +86,9 @@ SELECT owner, property FROM GistTable1
  WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
 EXPLAIN
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
 
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
@@ -104,6 +118,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -115,6 +130,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 
@@ -166,6 +182,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -182,6 +199,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
@@ -233,6 +251,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -241,15 +260,17 @@ SET enable_seqscan = FALSE;
 -- canonical form, as it is for the BOX data type and perhaps some other 
 -- data types), as long as data in all of those formats should be converted 
 -- to the same internal representation.
+set optimizer_trace_fallback = TRUE;
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL;
--- start_ignore
+SELECT count_index_scans('EXPLAIN SELECT owner, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
+--start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
--- end_ignore
+--end_ignore
 
 -- Alter the table and see if we get the same results.
 ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
@@ -258,13 +279,15 @@ SELECT id, property FROM GistTable1
  WHERE property IS NULL 
  ORDER BY id
  ;
--- start_ignore
+SELECT count_index_scans('EXPLAIN SELECT id, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
+--start_ignore
 EXPLAIN
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id
  ;
--- end_ignore
+--end_ignore
+reset optimizer_trace_fallback;
 
 
 -- ----------------------------------------------------------------------
@@ -334,6 +357,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
@@ -388,38 +412,35 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 REINDEX INDEX propertyBoxIndex;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 DROP INDEX propertyBoxIndex;
-
 -- Obviously, this shouldn't use the index now that the index is gone.
+
+set optimizer_enable_tablescan = TRUE;
+
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 
 -- ----------------------------------------------------------------------
@@ -472,6 +493,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -486,11 +508,9 @@ SELECT owner, property FROM GistTable1
  WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
 
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
@@ -519,6 +539,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -530,6 +551,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 
@@ -579,6 +601,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -595,6 +618,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
@@ -646,6 +670,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -656,13 +681,11 @@ SET enable_seqscan = FALSE;
 -- to the same internal representation.
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL;
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
--- end_ignore
 
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
@@ -732,6 +755,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
@@ -786,38 +810,35 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 REINDEX INDEX propertyBoxIndex;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 DROP INDEX propertyBoxIndex;
-
 -- Obviously, this shouldn't use the index now that the index is gone.
+
+SET optimizer_enable_tablescan = TRUE; 
+
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 
 -- ----------------------------------------------------------------------
@@ -871,6 +892,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -885,11 +907,9 @@ SELECT owner, property FROM GistTable1
  WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
 
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
@@ -919,6 +939,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -930,6 +951,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 
@@ -979,6 +1001,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -995,6 +1018,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
@@ -1046,6 +1070,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -1056,13 +1081,11 @@ SET enable_seqscan = FALSE;
 -- to the same internal representation.
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL;
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
--- end_ignore
 
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
@@ -1132,6 +1155,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
@@ -1186,38 +1210,35 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 REINDEX INDEX propertyBoxIndex;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 DROP INDEX propertyBoxIndex;
-
 -- Obviously, this shouldn't use the index now that the index is gone.
+
+set optimizer_enable_tablescan = TRUE;
+
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 
 -- ----------------------------------------------------------------------
@@ -1271,6 +1292,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -1285,11 +1307,9 @@ SELECT owner, property FROM GistTable1
  WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
 
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
@@ -1319,6 +1339,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -1330,6 +1351,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 
@@ -1379,6 +1401,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -1395,6 +1418,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
@@ -1446,6 +1470,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -1456,13 +1481,11 @@ SET enable_seqscan = FALSE;
 -- to the same internal representation.
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL;
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
--- end_ignore
 
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
@@ -1532,6 +1555,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
@@ -1586,38 +1610,35 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 REINDEX INDEX propertyBoxIndex;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 DROP INDEX propertyBoxIndex;
-
 -- Obviously, this shouldn't use the index now that the index is gone.
+
+set optimizer_enable_tablescan = TRUE;
+
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 
 -- ----------------------------------------------------------------------
@@ -1672,6 +1693,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -1686,11 +1708,9 @@ SELECT owner, property FROM GistTable1
  WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
 
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
@@ -1720,6 +1740,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -1731,6 +1752,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 
@@ -1780,6 +1802,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
@@ -1796,6 +1819,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
@@ -1847,6 +1871,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
@@ -1857,13 +1882,11 @@ SET enable_seqscan = FALSE;
 -- to the same internal representation.
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL;
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
--- end_ignore
 
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
@@ -1933,6 +1956,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
@@ -1987,38 +2011,35 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 -- ----------------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 REINDEX INDEX propertyBoxIndex;
 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 DROP INDEX propertyBoxIndex;
-
 -- Obviously, this shouldn't use the index now that the index is gone.
+
+set optimizer_enable_tablescan = TRUE;
+
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
--- end_ignore
 
 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/output/qp_gist_indexes2.source
+++ b/src/test/regress/output/qp_gist_indexes2.source
@@ -3,6 +3,21 @@
 -- ----------------------------------------------------------------------
 create schema qp_gist_indexes2;
 set search_path to qp_gist_indexes2;
+ -- start_ignore
+create language plpythonu;
+-- end_ignore
+create or replace function count_index_scans(explain_query text) returns int as
+$$
+rv = plpy.execute(explain_query)
+search_text = 'Index Scan'
+result = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text.lower() in cur_line.lower():
+        result = result+1
+return result
+$$
+language plpythonu;
 -- ----------------------------------------------------------------------
 -- Test: test01create_table.sql
 -- ----------------------------------------------------------------------
@@ -28,6 +43,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -59,20 +75,17 @@ SELECT owner, property FROM GistTable1
  Hypatia | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=47)
-   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..200.27 rows=1 width=47)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..701.27 rows=1 width=47)
+   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..701.27 rows=1 width=47)
          Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(5 rows)
+ Optimizer: legacy query optimizer
+(4 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -107,20 +120,17 @@ SELECT owner, property FROM GistTable1
  Hypatia | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=47)
-   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..200.27 rows=1 width=47)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..701.27 rows=1 width=47)
+   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..701.27 rows=1 width=47)
          Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(5 rows)
+ Optimizer: legacy query optimizer
+(4 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -146,6 +156,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -176,6 +187,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
@@ -292,6 +304,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -325,6 +338,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -374,6 +388,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -381,6 +396,7 @@ SET enable_seqscan = FALSE;
 -- canonical form, as it is for the BOX data type and perhaps some other 
 -- data types), as long as data in all of those formats should be converted 
 -- to the same internal representation.
+set optimizer_trace_fallback = TRUE;
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL;
             owner            | property 
@@ -391,7 +407,13 @@ SELECT owner, property FROM GistTable1
  S. T. "Rip" Sunset          | 
 (4 rows)
 
--- start_ignore
+SELECT count_index_scans('EXPLAIN SELECT owner, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
+ count_index_scans 
+-------------------
+                 1
+(1 row)
+
+--start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
@@ -399,16 +421,17 @@ SELECT owner, property FROM GistTable1
  ;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
-   Merge Key: "?column3?"
-   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=700.38..700.38 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=700.38..700.38 rows=1 width=51)
          Sort Key: id
-         ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..200.27 rows=1 width=51)
- Settings:  enable_seqscan=off
+         ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..700.37 rows=1 width=51)
+               Index Cond: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
-(7 rows)
+(8 rows)
 
--- end_ignore
+--end_ignore
 -- Alter the table and see if we get the same results.
 ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 SELECT id, property FROM GistTable1 
@@ -423,7 +446,13 @@ SELECT id, property FROM GistTable1
  99 | 
 (4 rows)
 
--- start_ignore
+SELECT count_index_scans('EXPLAIN SELECT id, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
+ count_index_scans 
+-------------------
+                 1
+(1 row)
+
+--start_ignore
 EXPLAIN
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
@@ -431,16 +460,17 @@ SELECT id, property FROM GistTable1
  ;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=36)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
+   ->  Sort  (cost=701.28..701.28 rows=1 width=36)
          Sort Key: id
-         ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..200.27 rows=1 width=36)
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
+         ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..701.27 rows=1 width=36)
+               Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
 (7 rows)
 
--- end_ignore
+--end_ignore
+reset optimizer_trace_fallback;
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -506,6 +536,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -531,7 +562,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
    ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
          Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
+ Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
 (5 rows)
 
@@ -551,7 +582,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
    ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
          Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
+ Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
 (5 rows)
 
@@ -581,7 +612,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
    ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
          Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
+ Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
 (5 rows)
 
@@ -598,6 +629,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -608,23 +640,20 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.28 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.28 rows=1 width=4)
          Sort Key: id
-         ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..200.27 rows=1 width=4)
+         ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..701.27 rows=1 width=4)
                Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(8 rows)
+ Optimizer: legacy query optimizer
+(7 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -636,25 +665,23 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.28 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.28 rows=1 width=4)
          Sort Key: id
-         ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..200.27 rows=1 width=4)
+         ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..701.27 rows=1 width=4)
                Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(8 rows)
+ Optimizer: legacy query optimizer
+(7 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+set optimizer_enable_tablescan = TRUE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -665,7 +692,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -677,11 +703,10 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Seq Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
+ Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
 (8 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
@@ -725,6 +750,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -756,22 +782,19 @@ SELECT owner, property FROM GistTable1
   Patty  | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
-   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=601.26..701.27 rows=1 width=47)
+   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=47)
          Recheck Cond: property ~= '(7052,250),(6050,20)'::box
-         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(7 rows)
+ Optimizer: legacy query optimizer
+(6 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -797,6 +820,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -827,6 +851,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -942,6 +967,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -975,6 +1001,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -1024,6 +1051,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -1041,7 +1069,6 @@ SELECT owner, property FROM GistTable1
  FelDon Adams                | 
 (4 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
@@ -1049,18 +1076,17 @@ SELECT owner, property FROM GistTable1
  ;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
-   Merge Key: "?column3?"
-   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=701.28..701.28 rows=1 width=51)
          Sort Key: id
-         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=51)
                Recheck Cond: property IS NULL
-               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..601.26 rows=1 width=0)
+                     Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
 (9 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -1127,6 +1153,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -1154,8 +1181,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 VACUUM GistTable13;
 ANALYZE GistTable13;
@@ -1175,8 +1203,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 TRUNCATE TABLE GistTable13;
 -- Add some rows.
@@ -1206,8 +1235,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test15ReindexDropIndex.sql
@@ -1222,6 +1252,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1232,25 +1263,22 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.29 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.29 rows=1 width=4)
          Sort Key: id
-         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=4)
                Recheck Cond: property ~= '(3,4),(1,2)'::box
-               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                      Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(10 rows)
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -1262,27 +1290,25 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.29 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.29 rows=1 width=4)
          Sort Key: id
-         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=4)
                Recheck Cond: property ~= '(3,4),(1,2)'::box
-               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                      Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(10 rows)
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+SET optimizer_enable_tablescan = TRUE; 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1293,7 +1319,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1305,11 +1330,10 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Append-only Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
+ Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
 (8 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
@@ -1353,6 +1377,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -1384,22 +1409,19 @@ SELECT owner, property FROM GistTable1
  Hypatia | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
-   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=601.26..701.27 rows=1 width=47)
+   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=47)
          Recheck Cond: property ~= '(7052,250),(6050,20)'::box
-         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(7 rows)
+ Optimizer: legacy query optimizer
+(6 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -1425,6 +1447,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -1455,6 +1478,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -1570,6 +1594,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -1603,6 +1628,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -1652,6 +1678,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -1669,7 +1696,6 @@ SELECT owner, property FROM GistTable1
  FelDon Adams                | 
 (4 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
@@ -1677,18 +1703,17 @@ SELECT owner, property FROM GistTable1
  ;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
-   Merge Key: "?column3?"
-   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=701.28..701.28 rows=1 width=51)
          Sort Key: id
-         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=51)
                Recheck Cond: property IS NULL
-               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..601.26 rows=1 width=0)
+                     Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
 (9 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -1755,6 +1780,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -1782,8 +1808,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 VACUUM GistTable13;
 ANALYZE GistTable13;
@@ -1803,8 +1830,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 TRUNCATE TABLE GistTable13;
 -- Add some rows.
@@ -1834,8 +1862,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test15ReindexDropIndex.sql
@@ -1850,6 +1879,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1860,25 +1890,22 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.29 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.29 rows=1 width=4)
          Sort Key: id
-         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=4)
                Recheck Cond: property ~= '(3,4),(1,2)'::box
-               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                      Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(10 rows)
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -1890,27 +1917,25 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.29 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.29 rows=1 width=4)
          Sort Key: id
-         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=4)
                Recheck Cond: property ~= '(3,4),(1,2)'::box
-               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                      Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(10 rows)
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+set optimizer_enable_tablescan = TRUE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1921,7 +1946,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1933,11 +1957,10 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Append-only Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
+ Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
 (8 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
@@ -1981,6 +2004,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -2012,22 +2036,19 @@ SELECT owner, property FROM GistTable1
  Hypatia | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
-   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=601.26..701.27 rows=1 width=47)
+   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=47)
          Recheck Cond: property ~= '(7052,250),(6050,20)'::box
-         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(7 rows)
+ Optimizer: legacy query optimizer
+(6 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -2053,6 +2074,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -2083,6 +2105,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -2198,6 +2221,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -2231,6 +2255,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -2280,6 +2305,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -2297,7 +2323,6 @@ SELECT owner, property FROM GistTable1
  FelDon Adams                | 
 (4 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
@@ -2305,18 +2330,17 @@ SELECT owner, property FROM GistTable1
  ;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
-   Merge Key: "?column3?"
-   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=701.28..701.28 rows=1 width=51)
          Sort Key: id
-         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=51)
                Recheck Cond: property IS NULL
-               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..601.26 rows=1 width=0)
+                     Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
 (9 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -2383,6 +2407,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -2410,8 +2435,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 VACUUM GistTable13;
 ANALYZE GistTable13;
@@ -2431,8 +2457,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 TRUNCATE TABLE GistTable13;
 -- Add some rows.
@@ -2462,8 +2489,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test15ReindexDropIndex.sql
@@ -2478,6 +2506,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -2488,25 +2517,22 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.29 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.29 rows=1 width=4)
          Sort Key: id
-         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=4)
                Recheck Cond: property ~= '(3,4),(1,2)'::box
-               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                      Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(10 rows)
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -2518,27 +2544,25 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.29 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.29 rows=1 width=4)
          Sort Key: id
-         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=4)
                Recheck Cond: property ~= '(3,4),(1,2)'::box
-               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                      Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(10 rows)
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+set optimizer_enable_tablescan = TRUE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -2549,7 +2573,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -2561,11 +2584,10 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Append-only Columnar Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
+ Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
 (8 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
@@ -2609,6 +2631,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -2640,22 +2663,19 @@ SELECT owner, property FROM GistTable1
  Hypatia | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
-   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=601.26..701.27 rows=1 width=47)
+   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=47)
          Recheck Cond: property ~= '(7052,250),(6050,20)'::box
-         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(7 rows)
+ Optimizer: legacy query optimizer
+(6 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -2681,6 +2701,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -2711,6 +2732,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -2826,6 +2848,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -2859,6 +2882,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -2908,6 +2932,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -2925,7 +2950,6 @@ SELECT owner, property FROM GistTable1
  FelDon Adams                | 
 (4 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
@@ -2933,18 +2957,17 @@ SELECT owner, property FROM GistTable1
  ;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
-   Merge Key: "?column3?"
-   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=701.28..701.28 rows=1 width=51)
          Sort Key: id
-         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=51)
                Recheck Cond: property IS NULL
-               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..601.26 rows=1 width=0)
+                     Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
 (9 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -3011,6 +3034,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -3038,8 +3062,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 VACUUM GistTable13;
 ANALYZE GistTable13;
@@ -3059,8 +3084,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 TRUNCATE TABLE GistTable13;
 -- Add some rows.
@@ -3090,8 +3116,9 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: property ~= '(999,999),(998,998)'::box
          ->  Bitmap Index Scan on gistindex13  (cost=0.00..100.26 rows=1 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off
-(6 rows)
+ Settings:  enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test15ReindexDropIndex.sql
@@ -3106,6 +3133,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -3116,25 +3144,22 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.29 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.29 rows=1 width=4)
          Sort Key: id
-         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=4)
                Recheck Cond: property ~= '(3,4),(1,2)'::box
-               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                      Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(10 rows)
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -3146,27 +3171,25 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.29 rows=1 width=4)
    Merge Key: id
-   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+   ->  Sort  (cost=701.28..701.29 rows=1 width=4)
          Sort Key: id
-         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=4)
                Recheck Cond: property ~= '(3,4),(1,2)'::box
-               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..601.26 rows=1 width=0)
                      Index Cond: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(10 rows)
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+set optimizer_enable_tablescan = TRUE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -3177,7 +3200,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -3189,11 +3211,10 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Append-only Columnar Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off
+ Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
 (8 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -3,6 +3,21 @@
 -- ----------------------------------------------------------------------
 create schema qp_gist_indexes2;
 set search_path to qp_gist_indexes2;
+ -- start_ignore
+create language plpythonu;
+-- end_ignore
+create or replace function count_index_scans(explain_query text) returns int as
+$$
+rv = plpy.execute(explain_query)
+search_text = 'Index Scan'
+result = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text.lower() in cur_line.lower():
+        result = result+1
+return result
+$$
+language plpythonu;
 -- ----------------------------------------------------------------------
 -- Test: test01create_table.sql
 -- ----------------------------------------------------------------------
@@ -28,6 +43,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -59,20 +75,18 @@ SELECT owner, property FROM GistTable1
   Patty  | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..14.40 rows=8 width=47)
+   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..14.40 rows=3 width=47)
+         Index Cond: property ~= '(7052,250),(6050,20)'::box
          Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -107,20 +121,18 @@ SELECT owner, property FROM GistTable1
   Patty  | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..14.40 rows=8 width=47)
+   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..14.40 rows=3 width=47)
+         Index Cond: property ~= '(7052,250),(6050,20)'::box
          Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -146,6 +158,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -176,6 +189,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
@@ -292,6 +306,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -325,6 +340,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -374,6 +390,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -381,8 +398,10 @@ SET enable_seqscan = FALSE;
 -- canonical form, as it is for the BOX data type and perhaps some other 
 -- data types), as long as data in all of those formats should be converted 
 -- to the same internal representation.
+set optimizer_trace_fallback = TRUE;
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL;
+INFO:  GPORCA failed to produce a plan, falling back to planner
             owner            | property 
 -----------------------------+----------
  A. Gent                     | 
@@ -391,33 +410,42 @@ SELECT owner, property FROM GistTable1
  S. T. "Rip" Sunset          | 
 (4 rows)
 
--- start_ignore
+SELECT count_index_scans('EXPLAIN SELECT owner, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
+INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to planner
+CONTEXT:  SQL statement "EXPLAIN SELECT owner, property FROM GistTable1 WHERE property IS NULL ORDER BY id;"
+PL/Python function "count_index_scans"
+ count_index_scans 
+-------------------
+                 1
+(1 row)
+
+--start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Result  (cost=0.00..431.00 rows=3 width=47)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-         Merge Key: id
-         ->  Result  (cost=0.00..431.00 rows=3 width=51)
-               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
-                     Sort Key: id
-                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
-                           Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(10 rows)
+INFO:  GPORCA failed to produce a plan, falling back to planner
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=701.28..701.28 rows=1 width=51)
+         Sort Key: id
+         ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..701.27 rows=1 width=51)
+               Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
+(7 rows)
 
--- end_ignore
+--end_ignore
 -- Alter the table and see if we get the same results.
 ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id
  ;
+INFO:  GPORCA failed to produce a plan, falling back to planner
  id | property 
 ----+----------
   8 | 
@@ -426,25 +454,36 @@ SELECT id, property FROM GistTable1
  99 | 
 (4 rows)
 
--- start_ignore
+SELECT count_index_scans('EXPLAIN SELECT id, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
+INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to planner
+CONTEXT:  SQL statement "EXPLAIN SELECT id, property FROM GistTable1 WHERE property IS NULL ORDER BY id;"
+PL/Python function "count_index_scans"
+ count_index_scans 
+-------------------
+                 1
+(1 row)
+
+--start_ignore
 EXPLAIN
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id
  ;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
+INFO:  GPORCA failed to produce a plan, falling back to planner
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=36)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
+   ->  Sort  (cost=701.28..701.28 rows=1 width=36)
          Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
-               Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+         ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..701.27 rows=1 width=36)
+               Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
+(7 rows)
 
--- end_ignore
+--end_ignore
+reset optimizer_trace_fallback;
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -510,6 +549,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -530,13 +570,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1600.61 rows=800 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..1600.50 rows=267 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
          Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 VACUUM GistTable13;
@@ -550,13 +590,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1600.61 rows=800 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..1600.50 rows=267 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
          Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 TRUNCATE TABLE GistTable13;
@@ -580,13 +620,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..800.31 rows=400 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..800.25 rows=134 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
          Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer: PQO version 2.68.0
 (5 rows)
 
 -- ----------------------------------------------------------------------
@@ -602,6 +642,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -612,23 +653,22 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..14.40 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..14.40 rows=3 width=4)
+         ->  Sort  (cost=0.00..14.40 rows=3 width=4)
+               Sort Key: id
+               ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..14.40 rows=3 width=4)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Filter: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(9 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -640,25 +680,25 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..14.40 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..14.40 rows=3 width=4)
+         ->  Sort  (cost=0.00..14.40 rows=3 width=4)
+               Sort Key: id
+               ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..14.40 rows=3 width=4)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Filter: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(9 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+set optimizer_enable_tablescan = TRUE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -669,7 +709,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -681,11 +720,9 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
@@ -694,6 +731,7 @@ drop schema qp_gist_indexes2 cascade;
 NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
 NOTICE:  drop cascades to function insertintogisttable13(integer)
 NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to table gisttable13
 NOTICE:  drop cascades to table gisttable1
 -- end_ignore
 -- ----------------------------------------------------------------------
@@ -729,6 +767,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -760,20 +799,19 @@ SELECT owner, property FROM GistTable1
  Hypatia | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
-         Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.57 rows=8 width=47)
+   ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.57 rows=3 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -799,6 +837,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -829,6 +868,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -944,6 +984,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -977,6 +1018,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -1026,6 +1068,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -1043,27 +1086,24 @@ SELECT owner, property FROM GistTable1
  A. Gent                     | 
 (4 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Result  (cost=0.00..431.00 rows=3 width=47)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-         Merge Key: id
-         ->  Result  (cost=0.00..431.00 rows=3 width=51)
-               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
-                     Sort Key: id
-                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
-                           Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(10 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=701.28..701.28 rows=1 width=51)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=51)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..601.26 rows=1 width=0)
+                     Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -1130,6 +1170,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -1150,14 +1191,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..66595.18 rows=800 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..66595.06 rows=267 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 VACUUM GistTable13;
 ANALYZE GistTable13;
@@ -1170,14 +1212,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..66595.18 rows=800 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..66595.06 rows=267 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 TRUNCATE TABLE GistTable13;
 -- Add some rows.
@@ -1200,14 +1243,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..33281.85 rows=400 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..33281.78 rows=134 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test15ReindexDropIndex.sql
@@ -1222,6 +1266,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1232,23 +1277,23 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.55 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..1471.55 rows=3 width=4)
+         ->  Sort  (cost=0.00..1471.55 rows=3 width=4)
+               Sort Key: id
+               ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.55 rows=3 width=4)
+                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -1260,25 +1305,26 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.55 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..1471.55 rows=3 width=4)
+         ->  Sort  (cost=0.00..1471.55 rows=3 width=4)
+               Sort Key: id
+               ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.55 rows=3 width=4)
+                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+SET optimizer_enable_tablescan = TRUE; 
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1289,7 +1335,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1301,11 +1346,9 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
@@ -1314,6 +1357,7 @@ drop schema qp_gist_indexes2 cascade;
 NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
 NOTICE:  drop cascades to function insertintogisttable13(integer)
 NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only table gisttable13
 NOTICE:  drop cascades to append only table gisttable1
 -- end_ignore
 -- ----------------------------------------------------------------------
@@ -1349,6 +1393,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -1380,20 +1425,19 @@ SELECT owner, property FROM GistTable1
   Patty  | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
-         Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.57 rows=8 width=47)
+   ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.57 rows=3 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -1419,6 +1463,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -1449,6 +1494,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -1564,6 +1610,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -1597,6 +1644,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -1646,6 +1694,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -1663,27 +1712,24 @@ SELECT owner, property FROM GistTable1
  FelDon Adams                | 
 (4 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Result  (cost=0.00..431.00 rows=3 width=47)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-         Merge Key: id
-         ->  Result  (cost=0.00..431.00 rows=3 width=51)
-               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
-                     Sort Key: id
-                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
-                           Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(10 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=701.28..701.28 rows=1 width=51)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=51)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..601.26 rows=1 width=0)
+                     Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -1750,6 +1796,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -1770,14 +1817,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..66595.18 rows=800 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..66595.06 rows=267 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 VACUUM GistTable13;
 ANALYZE GistTable13;
@@ -1790,14 +1838,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..66595.18 rows=800 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..66595.06 rows=267 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 TRUNCATE TABLE GistTable13;
 -- Add some rows.
@@ -1820,14 +1869,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..33281.85 rows=400 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..33281.78 rows=134 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test15ReindexDropIndex.sql
@@ -1842,6 +1892,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1852,23 +1903,23 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.55 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..1471.55 rows=3 width=4)
+         ->  Sort  (cost=0.00..1471.55 rows=3 width=4)
+               Sort Key: id
+               ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.55 rows=3 width=4)
+                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -1880,25 +1931,26 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.55 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..1471.55 rows=3 width=4)
+         ->  Sort  (cost=0.00..1471.55 rows=3 width=4)
+               Sort Key: id
+               ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.55 rows=3 width=4)
+                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+set optimizer_enable_tablescan = TRUE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1909,7 +1961,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -1921,11 +1972,9 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
@@ -1934,6 +1983,7 @@ drop schema qp_gist_indexes2 cascade;
 NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
 NOTICE:  drop cascades to function insertintogisttable13(integer)
 NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only table gisttable13
 NOTICE:  drop cascades to append only table gisttable1
 -- end_ignore
 -- ----------------------------------------------------------------------
@@ -1969,6 +2019,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -2000,20 +2051,19 @@ SELECT owner, property FROM GistTable1
   Patty  | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
-         Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.57 rows=8 width=47)
+   ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.57 rows=3 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -2039,6 +2089,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -2069,6 +2120,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -2184,6 +2236,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -2217,6 +2270,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -2266,6 +2320,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -2283,27 +2338,24 @@ SELECT owner, property FROM GistTable1
  FelDon Adams                | 
 (4 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Result  (cost=0.00..431.00 rows=3 width=47)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-         Merge Key: id
-         ->  Result  (cost=0.00..431.00 rows=3 width=51)
-               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
-                     Sort Key: id
-                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
-                           Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(10 rows)
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=701.28..701.28 rows=1 width=51)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=51)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..601.26 rows=1 width=0)
+                     Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -2370,6 +2422,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -2390,14 +2443,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..66595.18 rows=800 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..66595.06 rows=267 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 VACUUM GistTable13;
 ANALYZE GistTable13;
@@ -2410,14 +2464,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..66595.18 rows=800 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..66595.06 rows=267 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 TRUNCATE TABLE GistTable13;
 -- Add some rows.
@@ -2440,14 +2495,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..33281.85 rows=400 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..33281.78 rows=134 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test15ReindexDropIndex.sql
@@ -2462,6 +2518,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -2472,23 +2529,23 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.55 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..1471.55 rows=3 width=4)
+         ->  Sort  (cost=0.00..1471.55 rows=3 width=4)
+               Sort Key: id
+               ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.55 rows=3 width=4)
+                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -2500,25 +2557,26 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.55 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..1471.55 rows=3 width=4)
+         ->  Sort  (cost=0.00..1471.55 rows=3 width=4)
+               Sort Key: id
+               ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.55 rows=3 width=4)
+                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+set optimizer_enable_tablescan = TRUE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -2529,7 +2587,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -2541,11 +2598,9 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
@@ -2554,6 +2609,7 @@ drop schema qp_gist_indexes2 cascade;
 NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
 NOTICE:  drop cascades to function insertintogisttable13(integer)
 NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only columnar table gisttable13
 NOTICE:  drop cascades to append only columnar table gisttable1
 -- end_ignore
 -- ----------------------------------------------------------------------
@@ -2589,6 +2645,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
    '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -2620,20 +2677,19 @@ SELECT owner, property FROM GistTable1
   Patty  | (7052,250),(6050,20)
 (2 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
-         Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.57 rows=8 width=47)
+   ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.57 rows=3 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
--- end_ignore
 SELECT id, property FROM GistTable1 
  WHERE property IS NULL 
  ORDER BY id;
@@ -2659,6 +2715,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
 -- PURPOSE: Sanity test GiST indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -2689,6 +2746,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -2804,6 +2862,7 @@ DELETE FROM GistTable1 WHERE bullseye = '( (76, 76), 76)';
 -- Test: test07select.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id, owner, description, property, poli, bullseye FROM GistTable1
  WHERE property IS NOT NULL
  ORDER BY id;
@@ -2837,6 +2896,7 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 --     Test multi-column indexes.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Insert 2 more records, but insert them with the same value for BULLSEYE.
 INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
  VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
@@ -2886,6 +2946,7 @@ INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
  VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
    '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- We should be able to search the column that uses a geometric data type, 
 -- and of course we should find the right rows.  We should be able to search 
 -- using different "formats" (e.g. spacing) of the data, and in some cases 
@@ -2903,27 +2964,24 @@ SELECT owner, property FROM GistTable1
  FelDon Adams                | 
 (4 rows)
 
--- start_ignore
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
  ORDER BY id
  ;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Result  (cost=0.00..431.00 rows=3 width=47)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-         Merge Key: id
-         ->  Result  (cost=0.00..431.00 rows=3 width=51)
-               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
-                     Sort Key: id
-                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
-                           Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(10 rows)
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
+   Merge Key: id
+   ->  Sort  (cost=701.28..701.28 rows=1 width=51)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=601.26..701.27 rows=1 width=51)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..601.26 rows=1 width=0)
+                     Index Cond: property IS NULL
+ Optimizer: legacy query optimizer
+(9 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
 -- ----------------------------------------------------------------------
@@ -2990,6 +3048,7 @@ SELECT insertManyIntoGistTable13(1, 1000);
 -- Create the index.
 CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 -- Add more rows after we create the index.
 SELECT insertManyIntoGistTable13(1001, 2000);
  insertmanyintogisttable13 
@@ -3010,14 +3069,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..66595.18 rows=800 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..66595.06 rows=267 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 VACUUM GistTable13;
 ANALYZE GistTable13;
@@ -3030,14 +3090,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..66595.18 rows=800 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..66595.06 rows=267 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 TRUNCATE TABLE GistTable13;
 -- Add some rows.
@@ -3060,14 +3121,15 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
-   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
-         Filter: property ~= '(999,999),(998,998)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..33281.85 rows=400 width=36)
+   ->  Bitmap Table Scan on gisttable13  (cost=0.00..33281.78 rows=134 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex13  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Optimizer: PQO version 2.68.0
+(6 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: test15ReindexDropIndex.sql
@@ -3082,6 +3144,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13
 --     or something similar in order to verify that the index was used.
 -- ----------------------------------------------------------------------------
 SET enable_seqscan = FALSE;
+set optimizer_enable_tablescan = FALSE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -3092,23 +3155,23 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.55 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..1471.55 rows=3 width=4)
+         ->  Sort  (cost=0.00..1471.55 rows=3 width=4)
+               Sort Key: id
+               ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.55 rows=3 width=4)
+                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
--- end_ignore
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
@@ -3120,25 +3183,26 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1471.55 rows=8 width=4)
    Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
-               Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+   ->  Result  (cost=0.00..1471.55 rows=3 width=4)
+         ->  Sort  (cost=0.00..1471.55 rows=3 width=4)
+               Sort Key: id
+               ->  Bitmap Table Scan on gisttable1  (cost=0.00..1471.55 rows=3 width=4)
+                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: property ~= '(3,4),(1,2)'::box
+ Optimizer: PQO version 2.68.0
+(10 rows)
 
--- end_ignore
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
+set optimizer_enable_tablescan = TRUE;
 SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -3149,7 +3213,6 @@ SELECT id FROM GistTable1
  82
 (3 rows)
 
--- start_ignore
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
@@ -3161,11 +3224,9 @@ EXPLAIN SELECT id FROM GistTable1
          Sort Key: id
          ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
                Filter: property ~= '(3,4),(1,2)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
+ Optimizer: PQO version 2.68.0
+(7 rows)
 
--- end_ignore
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
@@ -3174,5 +3235,6 @@ drop schema qp_gist_indexes2 cascade;
 NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
 NOTICE:  drop cascades to function insertintogisttable13(integer)
 NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only columnar table gisttable13
 NOTICE:  drop cascades to append only columnar table gisttable1
 -- end_ignore


### PR DESCRIPTION
Prior to this PR, there was no support for GiST indexes in GPORCA.
For queries involving GiST indexes, ORCA was selecting Table Scan paths
as the optimal plan. These plans could take up to 300+ times longer than
Planner, which generated a index scan plan using the GiST index.

Example:
```
CREATE TABLE gist_tbl (a int, p polygon);
CREATE TABLE gist_tbl2 (b int, p polygon);
CREATE INDEX poly_index ON gist_tbl USING gist(p);

INSERT INTO gist_tbl SELECT i, polygon(box(point(i, i+2),point(i+4,
i+6))) FROM generate_series(1,50000)i;
INSERT INTO gist_tbl2 SELECT i, polygon(box(point(i+1, i+3),point(i+5,
i+7))) FROM generate_series(1,50000)i;

ANALYZE;
```
With the query `SELECT count(*) FROM gist_tbl, gist_tbl2 WHERE
gist_tbl.p <@ gist_tbl2.p;`, we see a performance increase with the
support of GiST.

Before:
```
EXPLAIN SELECT count(*) FROM gist_tbl, gist_tbl2 WHERE gist_tbl.p <@ gist_tbl2.p;
                                                     QUERY PLAN
---------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=0.00..171401912.12 rows=1 width=8)
   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..171401912.12 rows=1 width=8)
         ->  Aggregate  (cost=0.00..171401912.12 rows=1 width=8)
               ->  Nested Loop  (cost=0.00..171401912.12 rows=335499869 width=1)
                     Join Filter: gist_tbl.p <@ gist_tbl2.p
                     ->  Table Scan on gist_tbl2  (cost=0.00..432.25 rows=16776 width=101)
                     ->  Materialize  (cost=0.00..530.81 rows=49997 width=101)
                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..525.76 rows=49997 width=101)
                                 ->  Table Scan on gist_tbl  (cost=0.00..432.24 rows=16666 width=101)
 Optimizer status: PQO version 2.65.1
(10 rows)

Time: 170.172 ms
SELECT count(*) FROM gist_tbl, gist_tbl2 WHERE gist_tbl.p <@ gist_tbl2.p;
 count
-------
 49999
(1 row)

Time: 546028.227 ms
```

After:
```
EXPLAIN SELECT count(*) FROM gist_tbl, gist_tbl2 WHERE gist_tbl.p <@ gist_tbl2.p;
                                                  QUERY PLAN
---------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=0.00..21749053.24 rows=1 width=8)
   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..21749053.24 rows=1 width=8)
         ->  Aggregate  (cost=0.00..21749053.24 rows=1 width=8)
               ->  Nested Loop  (cost=0.00..21749053.24 rows=335499869 width=1)
                     Join Filter: true
                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..526.39 rows=50328 width=101)
                           ->  Table Scan on gist_tbl2  (cost=0.00..432.25 rows=16776 width=101)
                     ->  Bitmap Table Scan on gist_tbl  (cost=0.00..21746725.48 rows=6667 width=1)
                           Recheck Cond: gist_tbl.p <@ gist_tbl2.p
                           ->  Bitmap Index Scan on poly_index  (cost=0.00..0.00 rows=0 width=0)
                                 Index Cond: gist_tbl.p <@ gist_tbl2.p
 Optimizer status: PQO version 2.65.1
(12 rows)

Time: 617.489 ms

SELECT count(*) FROM gist_tbl, gist_tbl2 WHERE gist_tbl.p <@ gist_tbl2.p;
 count
-------
 49999
(1 row)

Time: 7779.198 ms
```

GiST support was implemented by sending over GiST index information to
GPORCA in the metadata using a new index enum specifically for GiST. 
GPORCA then allows GiST indexes to take both the Bitmap or B-Tree path
when creating alternatives. GPORCA also supports GiST for AOCO tables, 
but will only allow the Bitmap path for them due to the fact that B-Trees
themselves are not supported for AOCO tables by the Executor. 

Corresponding GPORCA PR: https://github.com/greenplum-db/gporca/pull/386

Signed-off-by: Bhuvnesh Chaudhary <bchaudhary@pivotal.io>
Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>