### PR TITLE
Move distributed_transactions regression test in greenplum_schedule

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -25,7 +25,7 @@ test: spi_processed64bit
 test: python_processed64bit
 
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table gp_create_view window_views
-test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain
+test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions
 
 test: bitmap_index gp_dump_query_oids analyze gp_owner_permission incremental_analyze
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules
@@ -61,7 +61,9 @@ test: gpdiffcheck gptokencheck gp_hashagg sequence_gp tidscan co_nestloop_idxsca
 # at the 2nd phase of 2PC.
 test: dtm_retry
 
-test: rangefuncs_cdb gp_aggregates gp_dqa subselect_gp subselect_gp2 gp_transactions distributed_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish
+# The appendonly test cannot be run concurrently with tests that have
+# serializable transactions (may conflict with AO vacuum operations).
+test: rangefuncs_cdb gp_aggregates gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.


### PR DESCRIPTION
The distributed_transactions test contains a serializable
transaction. This serializable transaction may intermittently cause
the appendonly test to fail when run in the same test group. The
appendonly test runs VACUUM on some appendonly tables and checks that
last_sequence is nonzero in gp_fastsequence. Serializable transactions
make concurrent VACUUM operations on appendonly tables exit early.

To fix the contention, let's move the distributed_transactions test to
another test group.

appendonly test failure diff:
```
*** 632,640 ****
   NormalXid |      0 | t        |             0
   NormalXid |      0 | t        |             1
   NormalXid |      0 | t        |             2
!  NormalXid |      1 | t        |             0
!  NormalXid |      1 | t        |             1
!  NormalXid |      1 | t        |             2
  (6 rows)

--- 630,638 ----
   NormalXid |      0 | t        |             0
   NormalXid |      0 | t        |             1
   NormalXid |      0 | t        |             2
!  NormalXid |      1 | f        |             0
!  NormalXid |      1 | f        |             1
!  NormalXid |      1 | f        |             2
  (6 rows)
```

Repro:
```
1: CREATE TABLE heap_table (a int, b int);
1: INSERT INTO heap_table SELECT i, i FROM generate_series(1,100)i;
1: CREATE TABLE ao_table WITH (appendonly=true) AS SELECT * FROM heap_table;
1: SELECT gp_segment_id, * FROM gp_dist_random('gp_fastsequence') WHERE gp_segment_id = 0;
2: BEGIN ISOLATION LEVEL SERIALIZABLE;
2: SELECT 1;
1: VACUUM ao_table; -- VACUUM exits early
1: SELECT gp_segment_id, * FROM gp_dist_random('gp_fastsequence') WHERE gp_segment_id = 0;
2: END;
1: VACUUM ao_table; -- VACUUM completes
1: SELECT gp_segment_id, * FROM gp_dist_random('gp_fastsequence') WHERE gp_segment_id = 0;
```