### PR TITLE
Faithfully parse inheritance-recursion for external tables

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4371,7 +4371,7 @@
           <tbody>
             <row>
               <entry colname="col1">number of bytes</entry>
-              <entry colname="col2">4194304</entry>
+              <entry colname="col2">1048576</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4353,7 +4353,7 @@
     <title>gp_max_csv_line_length</title>
     <body>
       <p>The maximum length of a line in a CSV formatted file that will be imported into the system.
-        The default is 1MB (1048576 bytes). Maximum allowed is 4MB (4194184 bytes). The default may
+        The default is 1MB (1048576 bytes). Maximum allowed is 4MB (4194304 bytes). The default may
         need to be increased if using the <i>gp_toolkit</i> administrative schema to read Greenplum
         Database log files.</p>
       <table id="gp_max_csv_line_length_table">
@@ -4371,7 +4371,7 @@
           <tbody>
             <row>
               <entry colname="col1">number of bytes</entry>
-              <entry colname="col2">1048576</entry>
+              <entry colname="col2">4194304</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3024,21 +3024,19 @@ CTranslatorQueryToDXL::PdxlnFromRelation
 	ULONG //ulCurrQueryLevel 
 	)
 {
+	if (false == prte->inh)
+	{
+		GPOS_ASSERT(RTE_RELATION == prte->rtekind);
+		// RangeTblEntry::inh is set to false iff there is ONLY in the FROM
+		// clause. c.f. transformTableEntry, called from transformFromClauseItem
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("ONLY in the FROM clause"));
+	}
+
 	// construct table descriptor for the scan node from the range table entry
 	CDXLTableDescr *pdxltabdesc = CTranslatorUtils::Pdxltabdesc(m_pmp, m_pmda, m_pidgtorCol, prte, &m_fHasDistributedTables);
 
 	CDXLLogicalGet *pdxlop = NULL;
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-
-	if (false == prte->inh && IMDRelation::ErelstorageExternal != pmdrel->Erelstorage())
-	{
-		GPOS_ASSERT(RTE_RELATION == prte->rtekind);
-		// RangeTblEntry::inh is set to false if there is ONLY in the FROM clause.
-		// c.f. transformTableEntry, called from transformFromClauseItem.  Ignore
-		// external tables, however, since inh is always false for external tables.
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("ONLY in the FROM clause"));
-	}
-
 	if (IMDRelation::ErelstorageExternal == pmdrel->Erelstorage())
 	{
 		pdxlop = GPOS_NEW(m_pmp) CDXLLogicalExternalGet(m_pmp, pdxltabdesc);

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -955,9 +955,6 @@ addRangeTableEntry(ParseState *pstate,
 	rte->relid = RelationGetRelid(rel);
 	rte->relkind = rel->rd_rel->relkind;
 
-	/* external tables don't allow inheritance */
-	if (RelationIsExternal(rel))
-		inh = false;
 
 	/*
 	 * Build the list of effective column names using user-supplied aliases

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -493,7 +493,7 @@ DETAIL:  Key (i, j)=(1, 3) is duplicated.
 create unique index ijk_ijk on ijk(i,j,k);
 set gp_enable_mk_sort=off;
 drop table ijk;
----------
+--
 -- test bitmaps with NULL and non-NULL values (MPP-8461)
 --
 create table bmap_test (x int, y int, z int);
@@ -521,3 +521,31 @@ select * from bmap_test where x = 1 order by x,y,z;
 (4 rows)
 
 drop table bmap_test;
+--
+-- Test over-sized values
+--
+create table oversize_test (c1 text);
+CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
+insert into oversize_test values ('a');
+select * from oversize_test;
+ c1 
+----
+ a
+(1 row)
+
+-- this fails, because the value is too large
+insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)
+set enable_seqscan=off;
+select * from oversize_test where c1 < 'z';
+ c1 
+----
+ a
+(1 row)
+
+-- Drop the index, insert the row, and then try creating the index again. This is essentially
+-- the same test, but now the failure happens during CREATE INDEX rather than INSERT.
+drop index oversize_test_idx;
+insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
+CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -493,7 +493,7 @@ DETAIL:  Key (i, j)=(1, 3) is duplicated.
 create unique index ijk_ijk on ijk(i,j,k);
 set gp_enable_mk_sort=off;
 drop table ijk;
----------
+--
 -- test bitmaps with NULL and non-NULL values (MPP-8461)
 --
 create table bmap_test (x int, y int, z int);
@@ -521,3 +521,31 @@ select * from bmap_test where x = 1 order by x,y,z;
 (4 rows)
 
 drop table bmap_test;
+--
+-- Test over-sized values
+--
+create table oversize_test (c1 text);
+CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
+insert into oversize_test values ('a');
+select * from oversize_test;
+ c1 
+----
+ a
+(1 row)
+
+-- this fails, because the value is too large
+insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)
+set enable_seqscan=off;
+select * from oversize_test where c1 < 'z';
+ c1 
+----
+ a
+(1 row)
+
+-- Drop the index, insert the row, and then try creating the index again. This is essentially
+-- the same test, but now the failure happens during CREATE INDEX rather than INSERT.
+drop index oversize_test_idx;
+insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
+CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -141,12 +141,8 @@ SELECT * FROM homer;
  4 | 3 | 44
 (4 rows)
 
--- ORCA should not fallback when ONLY clause is used on external tables
+-- ORCA should not fallback just because external tables are in FROM clause
 -- start_ignore
-DROP TABLE IF EXISTS t1;
-NOTICE:  table "t1" does not exist, skipping
-DROP TABLE IF EXISTS ext_table_no_fallback;
-NOTICE:  table "ext_table_no_fallback" does not exist, skipping
 CREATE TABLE heap_t1 (a int, b int) DISTRIBUTED BY (b);
 CREATE EXTERNAL TABLE ext_table_no_fallback (a int, b int) LOCATION ('gpfdist://myhost:8080/test.csv') FORMAT 'CSV';
 -- end_ignore

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -170,12 +170,8 @@ SELECT * FROM homer;
  4 | 3 | 44
 (4 rows)
 
--- ORCA should not fallback when ONLY clause is used on external tables
+-- ORCA should not fallback just because external tables are in FROM clause
 -- start_ignore
-DROP TABLE IF EXISTS t1;
-NOTICE:  table "t1" does not exist, skipping
-DROP TABLE IF EXISTS ext_table_no_fallback;
-NOTICE:  table "ext_table_no_fallback" does not exist, skipping
 CREATE TABLE heap_t1 (a int, b int) DISTRIBUTED BY (b);
 CREATE EXTERNAL TABLE ext_table_no_fallback (a int, b int) LOCATION ('gpfdist://myhost:8080/test.csv') FORMAT 'CSV';
 -- end_ignore
@@ -188,21 +184,22 @@ EXPLAIN SELECT * FROM ext_table_no_fallback;
 (3 rows)
 
 EXPLAIN SELECT * FROM ONLY ext_table_no_fallback;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..472.74 rows=1000000 width=8)
-   ->  External Scan on ext_table_no_fallback  (cost=0.00..437.97 rows=333334 width=8)
- Optimizer: PQO version 2.67.0
+INFO:  GPORCA failed to produce a plan, falling back to planner
+                                       QUERY PLAN
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..11000.00 rows=1000000 width=8)
+   ->  External Scan on ext_table_no_fallback  (cost=0.00..11000.00 rows=333334 width=8)
+ Optimizer: legacy query optimizer
 (3 rows)
 
 EXPLAIN INSERT INTO heap_t1 SELECT * FROM ONLY ext_table_no_fallback;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
- Insert  (cost=0.00..16080.27 rows=333334 width=8)
-   ->  Result  (cost=0.00..455.27 rows=333334 width=12)
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..451.27 rows=333334 width=8)
-               Hash Key: ext_table_no_fallback.b
-               ->  External Scan on ext_table_no_fallback  (cost=0.00..437.97 rows=333334 width=8)
- Optimizer: PQO version 2.67.0
-(6 rows)
+INFO:  GPORCA failed to produce a plan, falling back to planner
+                                           QUERY PLAN
+-------------------------------------------------------------------------------------------------
+ Insert on heap_t1  (cost=0.00..11000.00 rows=333334 width=8)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..11000.00 rows=333334 width=8)
+         Hash Key: ext_table_no_fallback.b
+         ->  External Scan on ext_table_no_fallback  (cost=0.00..11000.00 rows=333334 width=8)
+ Optimizer: legacy query optimizer
+(5 rows)
 

--- a/src/test/regress/sql/qp_orca_fallback.sql
+++ b/src/test/regress/sql/qp_orca_fallback.sql
@@ -75,10 +75,8 @@ SELECT * FROM homer;
 DELETE FROM ONLY homer WHERE a = 3;
 SELECT * FROM homer;
 
--- ORCA should not fallback when ONLY clause is used on external tables
+-- ORCA should not fallback just because external tables are in FROM clause
 -- start_ignore
-DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS ext_table_no_fallback;
 CREATE TABLE heap_t1 (a int, b int) DISTRIBUTED BY (b);
 CREATE EXTERNAL TABLE ext_table_no_fallback (a int, b int) LOCATION ('gpfdist://myhost:8080/test.csv') FORMAT 'CSV';
 -- end_ignore


### PR DESCRIPTION
When table inheritance was added in Postgres, mentioning a table in the FROM clause of a query would necessarily mean traversing through the inheritance hierarchy. The need to distinguish between the (legacy, less common, but legitimate nonetheless) intent of not recursing into child tables gave rise to two things: the guc `sql_inheritance` which toggles the default semantics of parent tables, and the `ONLY` keyword used in front of parent table names to explicitly skip descendant tables.

ORCA doesn't like queries that skip descendant tables: it falls back to the legacy planner as soon as it detects that intent.

Way way back in Greenplum-land, when external tables were given a separate designation in relstorage (RELSTORAGE_EXTERNAL), we seemed to have added code in parser (parse analysis) so that queries on external tables *never* recurse into their child tables, regardless of what the user specifies -- either via `ONLY` and `*` in the query, or via guc `sql_inheritance`. Technically, that process scrubs the range table entries to hard-code "do not recurse".

The combination of those two things -- hardcoding "do not recurse" in the RTE for the analyzed parse tree and ORCA detecting intent of `ONLY` through RTE -- led ORCA to *always* fall back to planner when an external table is mentioned in the FROM clause. commit 013a6e9dfb tried fixing this by *detecting harder* whether there's an external table.

The behavior of the parse-analyzer hard coding a "do not recurse" in the RTE for an external table seems wrong for several reasons:

  1. It seems unnecessarily defensive

  2. It doesn't seem to belong in the parser.

     a. While changing "recurse" back to "do not recurse" abounds, all other occurrences happen in the planner as an optimization for childless tables.

     b. It deprives an optimizer of the actual intent expressed by the user: because of this hardcoding, neither ORCA nor planner would have a way of knowing whether the user specified `ONLY` in the query.

     c. It deprives the user of the ability to use child tables with an external table, either deliberately or coincidentally.

This commit reinstated the simpler RTE check before commit 013a6e9dfb.

Open questions:
- [ ] Do we want to add a test for external tables with child tables? This patch introduces a (not necessarily bad) breaking change: an external table with child tables previously would *never* recurse into child tables, after this patch you need to use `ONLY` to exclude descendant tables.