### PR TITLE
Remove misc unused or otherwise unnecessary code.

### DIFF
--- a/src/backend/cdb/cdbappendonlystorage.c
+++ b/src/backend/cdb/cdbappendonlystorage.c
@@ -12,11 +12,10 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
-#include "storage/gp_compress.h"
+
 #include "cdb/cdbappendonlystorage_int.h"
 #include "cdb/cdbappendonlystorage.h"
 #include "cdb/cdbappendonlyxlog.h"
-#include "utils/guc.h"
 
 #include "cdb/cdbappendonlyam.h"
 

--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -12,6 +12,7 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
+
 #include "cdb/cdbdistributedsnapshot.h"
 #include "cdb/cdblocaldistribxact.h"
 #include "cdb/cdbdtxcontextinfo.h"

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -30,13 +30,6 @@
 static Flow *copyFlow(Flow *model_flow, bool withExprs, bool withSort);
 static List *makeHashExprsFromNonjunkTargets(List *targetList);
 
-#define ARRAYCOPY(to, from, sz) \
-	do { \
-		Size	_size = (sz); \
-		(to) = palloc(_size); \
-		memcpy((to), (from), _size); \
-	} while (0)
-
 /*
  * Function: choose_setop_type
  *

--- a/src/backend/cdb/cdbsrlz.c
+++ b/src/backend/cdb/cdbsrlz.c
@@ -14,14 +14,11 @@
  */
 
 #include "postgres.h"
-#include "cdb/cdbplan.h"
-#include "cdb/cdbsrlz.h"
+
 #include <math.h>
-#include "miscadmin.h"
-#include "nodes/print.h"
-#include "optimizer/clauses.h"
-#include "regex/regex.h"
-#include "utils/guc.h"
+
+#include "cdb/cdbsrlz.h"
+#include "nodes/nodes.h"
 #include "utils/memaccounting.h"
 #include "utils/zlib_wrapper.h"
 

--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -14,7 +14,6 @@
  */
 #include "postgres.h"
 
-#include "catalog/pg_type.h"	/* INT8OID */
 #include "catalog/pg_operator.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/clauses.h"

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -17,8 +17,8 @@
  *
  *-------------------------------------------------------------------------
  */
-
 #include "postgres.h"
+
 #include "miscadmin.h"
 #include "utils/guc.h"
 #include "catalog/gp_segment_config.h"
@@ -31,10 +31,8 @@
 #include "cdb/cdbdisp.h"
 #include "lib/stringinfo.h"
 #include "libpq/libpq-be.h"
-#include "utils/memutils.h"
 #include "utils/resource_manager.h"
 #include "utils/resgroup-ops.h"
-#include "storage/bfz.h"
 #include "storage/proc.h"
 #include "cdb/memquota.h"
 
@@ -241,11 +239,6 @@ bool		gp_selectivity_damping_sigsort = true;
 int			gp_hashjoin_tuples_per_bucket = 5;
 int			gp_hashagg_groups_per_bucket = 5;
 
-
-/* default value to 0, which means we do not try to control number of spill batches */
-int			gp_hashagg_spillbatch_min = 0;
-int			gp_hashagg_spillbatch_max = 0;
-
 /* Analyzing aid */
 int			gp_motion_slice_noop = 0;
 
@@ -259,7 +252,6 @@ bool		gp_enable_motion_deadlock_sanity = FALSE;	/* planning time sanity
 bool		gp_mk_sort_check = false;
 #endif
 int			gp_sort_flags = 0;
-int			gp_dbg_flags = 0;
 int			gp_sort_max_distinct = 20000;
 
 bool		gp_enable_tablespace_auto_mkdir = FALSE;
@@ -379,8 +371,7 @@ int			cdb_max_slices = 0;
 /*
  *	Forward declarations of local function.
  */
-GpRoleValue string_to_role(const char *string);
-const char *role_to_string(GpRoleValue role);
+static GpRoleValue string_to_role(const char *string);
 
 
 /*
@@ -388,7 +379,7 @@ const char *role_to_string(GpRoleValue role);
  * enum value of type GpRoleValue. Return GP_ROLE_UNDEFINED in case the
  * string is unrecognized.
  */
-GpRoleValue
+static GpRoleValue
 string_to_role(const char *string)
 {
 	GpRoleValue role = GP_ROLE_UNDEFINED;
@@ -608,27 +599,6 @@ const char *
 show_gp_role(void)
 {
 	return role_to_string(Gp_role);
-}
-
-/*
- * Show hook routine for "gp_connections_per_thread" option.
- *
- * See src/backend/util/misc/guc.c for option definition.
- */
-const char *
-show_gp_connections_per_thread(void)
-{
-	/*
-	 * We rely on the fact that the memory context will clean up the memory
-	 * for the buffer.data.
-	 */
-	StringInfoData buffer;
-
-	initStringInfo(&buffer);
-
-	appendStringInfo(&buffer, "%d", gp_connections_per_thread);
-
-	return buffer.data;
 }
 
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -104,9 +104,6 @@ static void subquery_push_qual(Query *subquery,
 				   RangeTblEntry *rte, Index rti, Node *qual);
 static void recurse_push_qual(Node *setOp, Query *topquery,
 				  RangeTblEntry *rte, Index rti, Node *qual);
-#ifdef _MSC_VER
-__declspec(noreturn)
-#endif
 
 
 /*

--- a/src/backend/optimizer/util/var.c
+++ b/src/backend/optimizer/util/var.c
@@ -32,6 +32,7 @@
 #include "rewrite/rewriteManip.h"
 #include "utils/lsyscache.h"
 
+
 typedef struct
 {
 	Relids		varnos;

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -18,7 +18,6 @@
  */
 
 #include "postgres.h"
-#include "gpmon/gpmon.h"
 
 #include <fcntl.h>
 #include <limits.h>
@@ -498,7 +497,7 @@ SocketBackend(StringInfo inBuf)
 					{
 						/*
 						 * Can't send DEBUG log messages to client at this
-						 * point.Since we're disconnecting right away, we
+						 * point. Since we're disconnecting right away, we
 						 * don't need to restore whereToSendOutput.
 						 */
 						whereToSendOutput = DestNone;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3644,7 +3644,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_connections_per_thread,
 		0, 0, INT_MAX,
-		NULL, assign_gp_connections_per_thread, show_gp_connections_per_thread
+		NULL, assign_gp_connections_per_thread, NULL
 	},
 
 	{

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -26,8 +26,6 @@
 /*
  * Defines for gp_policy
  */
-#define GpPolicyRelationName		"gp_distribution_policy"
-
 #define GpPolicyRelationId  5002
 
 CATALOG(gp_distribution_policy,5002) BKI_WITHOUT_OIDS

--- a/src/include/catalog/pg_stat_last_operation.h
+++ b/src/include/catalog/pg_stat_last_operation.h
@@ -21,8 +21,6 @@
 #include "catalog/genbki.h"
 
 /* MPP-6929: metadata tracking */
-#define StatLastOpRelationName		"pg_stat_last_operation"
-
 #define StatLastOpRelationId 6052
 
 /*

--- a/src/include/cdb/cdbappendonlystorage_int.h
+++ b/src/include/cdb/cdbappendonlystorage_int.h
@@ -497,6 +497,3 @@ typedef struct AOBulkDenseContentHeaderExt
 #define AOBulkDenseContentHeaderExtInit_largeRowCount(h,e)  {(h)->bulkdensecontent_ext_bytes_4_7|=(0x3FFFFFFF&(e));}
 
 #endif   /* CDBAPPENDONLYSTORAGE_INT_H */
-
-
-

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -763,7 +763,6 @@ extern bool check_gp_role(char **newval, void **extra, GucSource source);
 extern void assign_gp_role(const char *newval, void *extra);
 extern const char *show_gp_role(void);
 extern void assign_gp_connections_per_thread(int newval, void *extra);
-extern const char *show_gp_connections_per_thread(void);
 extern void assign_gp_write_shared_snapshot(bool newval, void *extra);
 extern bool gpvars_check_gp_resource_manager_policy(char **newval, void **extra, GucSource source);
 extern void gpvars_assign_gp_resource_manager_policy(const char *newval, void *extra);


### PR DESCRIPTION
The show_gp_connections_per_thread function is not needed, because the
default "show" functinality for an integer GUC does the same.