### PR TITLE
Remove cdbpath_rows function

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -52,11 +52,20 @@ cdbpath_cost_motion(PlannerInfo *root, CdbMotionPath *motionpath)
 	double		recvrows;
 	double		sendrows;
 
+	if (! IsA(subpath, BitmapHeapPath) &&
+		! IsA(subpath, BitmapAppendOnlyPath) && 
+		! IsA(subpath, IndexPath) && 
+		! IsA(subpath, UniquePath) &&
+		CdbPathLocus_IsReplicated(motionpath->path.locus))
+		motionpath->path.rows = subpath->rows * root->config->cdbpath_segments;
+	else
+		motionpath->path.rows = subpath->rows;
+
 	cost_per_row = (gp_motion_cost_per_row > 0.0)
 		? gp_motion_cost_per_row
 		: 2.0 * cpu_tuple_cost;
-	sendrows = cdbpath_rows(root, subpath);
-	recvrows = cdbpath_rows(root, (Path *) motionpath);
+	sendrows = subpath->rows;
+	recvrows = motionpath->path.rows;
 	motioncost = cost_per_row * 0.5 * (sendrows + recvrows);
 
 	motionpath->path.total_cost = motioncost + subpath->total_cost;
@@ -891,8 +900,8 @@ cdbpath_motion_for_join(PlannerInfo *root,
 	}
 
 	/* Get rel sizes. */
-	outer.bytes = cdbpath_rows(root, outer.path) * outer.path->parent->width;
-	inner.bytes = cdbpath_rows(root, inner.path) * inner.path->parent->width;
+	outer.bytes = outer.path->rows * outer.path->parent->width;
+	inner.bytes = inner.path->rows * inner.path->parent->width;
 
 	/*
 	 * Motion not needed if either source is everywhere (e.g. a constant).
@@ -1519,7 +1528,7 @@ cdbpath_dedup_fixup_joinrel(JoinPath *joinpath, CdbpathDedupFixupContext *ctx)
 		/* Which rel has more rows?  Put its row id vars in front. */
 		if (outer_rowid_vars &&
 			ctx->rowid_vars &&
-			cdbpath_rows(ctx->root, joinpath->outerjoinpath) >= cdbpath_rows(ctx->root, joinpath->innerjoinpath))
+			joinpath->outerjoinpath->rows >= joinpath->innerjoinpath->rows)
 			ctx->rowid_vars = list_concat(outer_rowid_vars, ctx->rowid_vars);
 		else
 			ctx->rowid_vars = list_concat(ctx->rowid_vars, outer_rowid_vars);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1246,7 +1246,7 @@ create_unique_plan(PlannerInfo *root, UniquePath *best_path)
 	}
 
 	/* Adjust output size estimate (other fields should be OK already) */
-	plan->plan_rows = cdbpath_rows(root, &best_path->path);
+	plan->plan_rows = best_path->path.rows;
 
 	return plan;
 }
@@ -4391,7 +4391,7 @@ copy_path_costsize(PlannerInfo *root, Plan *dest, Path *src)
 	{
 		dest->startup_cost = src->startup_cost;
 		dest->total_cost = src->total_cost;
-		dest->plan_rows = cdbpath_rows(root, src);
+		dest->plan_rows = src->rows;
 		dest->plan_width = src->parent->width;
 	}
 	else

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -432,7 +432,7 @@ query_planner(PlannerInfo *root, List *tlist,
 			/* Figure cost for sorting */
 			cost_sort(&sort_path, root, root->query_pathkeys,
 					  cheapestpath->total_cost,
-					  cdbpath_rows(root, cheapestpath), final_rel->width,
+					  cheapestpath->rows, final_rel->width,
 					  0.0, work_mem, limit_tuples);
 		}
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1677,7 +1677,7 @@ create_material_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath)
 				  root,
 				  subpath->startup_cost,
 				  subpath->total_cost,
-				  cdbpath_rows(root, subpath),
+				  subpath->rows,
 				  rel->width);
 
 	return pathnode;
@@ -3262,9 +3262,9 @@ create_hashjoin_path(PlannerInfo *root,
 		double		innersize;
 
 		outersize = ExecHashRowSize(outer_path->parent->width) *
-			cdbpath_rows(root, outer_path);
+			outer_path->rows;
 		innersize = ExecHashRowSize(inner_path->parent->width) *
-			cdbpath_rows(root, inner_path);
+			inner_path->rows;
 
 		if (innersize > outersize)
 			return NULL;

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -44,33 +44,4 @@ cdbpath_dedup_fixup(PlannerInfo *root, Path *path);
 bool
 cdbpath_contains_wts(Path *path);
 
-/*
- * cdbpath_rows
- *
- * Returns a Path's estimated number of result rows.
- */
-static inline double
-cdbpath_rows(PlannerInfo *root, Path *path)
-{
-	/* GPDB_92_MERGE_FIXME: Maybe we should think about removing this function.
-	 * That will eliminate merge risk since pg upstream (since 9.2) uses
-	 * path->rows directly.
-	 */
-	Path  *p;
-
-	p = (IsA(path, CdbMotionPath))  ? ((CdbMotionPath *)path)->subpath
-		: path;
-
-	if (IsA(p, BitmapHeapPath) ||
-			IsA(p, BitmapAppendOnlyPath) ||
-			IsA(p, IndexPath) ||
-			IsA(p, UniquePath))
-		return p->rows;
-
-	if (CdbPathLocus_IsReplicated(path->locus))
-		return  (path->parent->rows * root->config->cdbpath_segments);
-
-	return  path->parent->rows;
-}                               /* cdbpath_rows */
-
 #endif   /* CDBPATH_H */


### PR DESCRIPTION
Replace function `cdbpath_rows(root, path)` with path->rows, this is in line
with upstream 9.2. By doing this we removed a GPDB_92_MERGE_FIXME

Co-authored-by: Alexandra Wang<lewang@pivotal.io>
Co-authored-by: Gang Xiong<gxiong@pivotal.io>