### PR TITLE
Resolve a FIXME of copying intoPolicy to query.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2103,7 +2103,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	Assert(leftmostQuery != NULL);
 
 	/* Copy transformed distribution policy to query */
-//	if (qry->intoClause) /* GPDB_92_MERGE_FIXME */
+	if (qry->isCTAS)
 		qry->intoPolicy = leftmostQuery->intoPolicy;
 
 	/*

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2103,8 +2103,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	Assert(leftmostQuery != NULL);
 
 	/* Copy transformed distribution policy to query */
-	if (qry->isCTAS)
-		qry->intoPolicy = leftmostQuery->intoPolicy;
+	qry->intoPolicy = leftmostQuery->intoPolicy;
 
 	/*
 	 * Generate dummy targetlist for outer query using column names of


### PR DESCRIPTION
As with upstream, intoClause has been removed from Query.
We can skip the intoClause check and just let it copy NULL if
not a CTAS query.