### PR TITLE
Fix a FIXME in PG9.1 merge which does not use DistributedBy type expl…

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -6613,7 +6613,7 @@ atpxPartAddList(Relation rel,
 	ct->ownerid = ownerid;
 
 	if (!ct->distributedBy)
-		ct->distributedBy = (Node *)make_dist_clause(rel);
+		ct->distributedBy = make_dist_clause(rel);
 
 	/* this function does transformExpr on the boundary specs */
 	(void) atpxPart_validate_spec(pBy, rel, ct, pelem, pNode, partName,

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -403,7 +403,7 @@ intorel_initplan(struct QueryDesc *queryDesc, int eflags)
 	else
 		relstorage = RELSTORAGE_HEAP;
 
-	create->distributedBy = into->distributedBy; /* Seems to be not needed? */
+	create->distributedBy = (DistributedBy *) into->distributedBy; /* Seems to be not needed? */
 	create->partitionBy = NULL; /* CTAS does not not support partition. */
 
     create->policy = queryDesc->plannedstmt->intoPolicy;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13730,7 +13730,7 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 		List **col_encs = NULL;
 
 		cs->relKind = RELKIND_RELATION;
-		cs->distributedBy = (Node *)distro;
+		cs->distributedBy = distro;
 		cs->relation = tmpname;
 		cs->ownerid = rel->rd_rel->relowner;
 		cs->tablespacename = get_tablespace_name(rel->rd_rel->reltablespace);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3821,7 +3821,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $10;
 					n->tablespacename = $11;
 					n->if_not_exists = false;
-					n->distributedBy = $12;
+					n->distributedBy = (DistributedBy *) $12;
 					n->partitionBy = $13;
 					n->relKind = RELKIND_RELATION;
 					n->policy = 0;
@@ -3843,7 +3843,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $13;
 					n->tablespacename = $14;
 					n->if_not_exists = true;
-					n->distributedBy = $15;
+					n->distributedBy = (DistributedBy *) $15;
 					n->partitionBy = $16;
 					n->relKind = RELKIND_RELATION;
 					n->policy = 0;
@@ -3865,7 +3865,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $9;
 					n->tablespacename = $10;
 					n->if_not_exists = false;
-					n->distributedBy = $11;
+					n->distributedBy = (DistributedBy *) $11;
 					n->partitionBy = $12;
 					n->relKind = RELKIND_RELATION;
 					n->policy = 0;
@@ -3887,7 +3887,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $12;
 					n->tablespacename = $13;
 					n->if_not_exists = true;
-					n->distributedBy = $14;
+					n->distributedBy = (DistributedBy *) $14;
 					n->partitionBy = $15;
 					n->relKind = RELKIND_RELATION;
 					n->policy = 0;
@@ -5116,7 +5116,7 @@ CreateExternalStmt:	CREATE OptWritable EXTERNAL OptWeb OptTemp TABLE qualified_n
 							n->extOptions = $15;
 							n->encoding = $16;
 							n->sreh = $17;
-							n->distributedBy = $18;
+							n->distributedBy = (DistributedBy *) $18;
 							n->policy = 0;
 							
 							/* various syntax checks for EXECUTE external table */

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -413,8 +413,8 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString, bool createPartit
 	 *  explicitly). Not for foreign tables, though.
 	 */
 	if (stmt->relKind == RELKIND_RELATION)
-		stmt->policy = transformDistributedBy(&cxt, (DistributedBy *)stmt->distributedBy,
-							   (DistributedBy *)likeDistributedBy, bQuiet);
+		stmt->policy = transformDistributedBy(&cxt, stmt->distributedBy,
+							   likeDistributedBy, bQuiet);
 
 	if ((stmt->partitionBy != NULL) &&
 		GpPolicyIsReplicated(stmt->policy))

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1682,8 +1682,7 @@ typedef struct CreateStmt
 	char	   *tablespacename; /* table space to use, or NULL */
 	bool		if_not_exists;	/* just do nothing if it already exists? */
 
-	/* GPDB_91_MERGE_FIXME: why is this not a DistributedBy*? */
-	Node       *distributedBy;   /* what columns we distribute the data by */
+	DistributedBy *distributedBy;   /* what columns we distribute the data by */
 	Node       *partitionBy;     /* what columns we partition the data by */
 	char	    relKind;         /* CDB: force relkind to this */
 	char		relStorage;
@@ -1739,7 +1738,7 @@ typedef struct CreateExternalStmt
 	List       *extOptions;		/* generic options to external table */
 	List	   *encoding;		/* List (size 1 max) of DefElem nodes for
 								   data encoding */
-	Node       *distributedBy;   /* what columns we distribute the data by */
+	DistributedBy *distributedBy;   /* what columns we distribute the data by */
 	struct GpPolicy  *policy;	/* used for writable tables */
 
 } CreateExternalStmt;


### PR DESCRIPTION
…icitly.

distributedBy is still a Node* in IntoClause since I do not want to
include header file in primnodes.h which is for 'primitive' node types.

Previously using Node* has no special meaning so we change
to use DistributedBy explicitly to benefit debug.