### PR TITLE
Fix SIRV transformation of function returning composite types.

### DIFF
--- a/src/test/regress/expected/sirv_functions.out
+++ b/src/test/regress/expected/sirv_functions.out
@@ -1875,6 +1875,40 @@ $$
     LANGUAGE plpgsql volatile;
 --ctas with a function returning record
 DROP TABLE countries_results;
+--
+-- SIRV that returns a composite type. Test referencing the individual
+-- fields in WHERE clause.
+--
+CREATE TYPE address AS (street text, name text);
+CREATE TABLE inserted_addresses OF address;
+CREATE TABLE testfunc_seen_streets (street text);
+CREATE OR REPLACE FUNCTION testfunc(street text) RETURNS address AS
+$$
+declare
+  r address;
+begin
+  INSERT INTO testfunc_seen_streets VALUES (street);
+
+  r.street = street;
+  r.name = NULL;
+  return r;
+end;
+$$ LANGUAGE plpgsql VOLATILE;
+INSERT INTO inserted_addresses SELECT street, name FROM testfunc('Wall Street') WHERE name IS NOT NULL;
+INSERT INTO inserted_addresses SELECT street, name FROM testfunc('Abbey Road') WHERE street IS NOT NULL;
+SELECT * FROM inserted_addresses;
+   street   | name 
+------------+------
+ Abbey Road | 
+(1 row)
+
+SELECT * FROM testfunc_seen_streets;
+   street    
+-------------
+ Abbey Road
+ Wall Street
+(2 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
For example, imagine that you had a query like this:

SELECT address, name FROM test()

Previously, this was transformed into:

SELECT sirvf_sq.address, sirvf_sq.name FROM (SELECT test()) AS sirvf_sq

I.e. the Vars referencing the columns returned by test() function were
replaced with FieldSelect expressions, to pick the columns from the
single composite datum returned by the sirvf_sq subquery. However, that
transformation was not done correctly for possible WHERE clause in the
query, only for the target list. So if the query had a WHERE clause:

SELECT address, name, FROM test() WHERE name = 'foo'

You got an error:

ERROR:  subquery testfunc does not have attribute 2

The most straightforward fix would have been to also transform Vars in the
WHERE clause. However, I'm a bit worried that we'll have more bugs like
this in other clauses, even if we fix the WHERE case. We could perhaps call
query_tree_mutator() to find and replace all the Vars everywhere in the
query, but because these functions are modifying the query in place, that'd
also require some restructuring of the code.

So instead, I changed the approach so that we add yet another subquery, to
contain the FieldSelects, and leave the original Vars unmodified. The above
query is now turned into:

SELECT address, name FROM (
  SELECT (sirvf_sq.test).address, (sirvf_sq.test).name
  FROM (SELECT test()) AS sirvf_sq
) as test;

Fixes github issue #2865. A modified version of the repro from that issue
is added to the regression test suite.