### PR TITLE
Don't PANIC, if inserting entry in bitmap index's aux LOV table fails.

### DIFF
--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -493,7 +493,7 @@ DETAIL:  Key (i, j)=(1, 3) is duplicated.
 create unique index ijk_ijk on ijk(i,j,k);
 set gp_enable_mk_sort=off;
 drop table ijk;
----------
+--
 -- test bitmaps with NULL and non-NULL values (MPP-8461)
 --
 create table bmap_test (x int, y int, z int);
@@ -521,3 +521,31 @@ select * from bmap_test where x = 1 order by x,y,z;
 (4 rows)
 
 drop table bmap_test;
+--
+-- Test over-sized values
+--
+create table oversize_test (c1 text);
+CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
+insert into oversize_test values ('a');
+select * from oversize_test;
+ c1 
+----
+ a
+(1 row)
+
+-- this fails, because the value is too large
+insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)
+set enable_seqscan=off;
+select * from oversize_test where c1 < 'z';
+ c1 
+----
+ a
+(1 row)
+
+-- Drop the index, insert the row, and then try creating the index again. This is essentially
+-- the same test, but now the failure happens during CREATE INDEX rather than INSERT.
+drop index oversize_test_idx;
+insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
+CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -493,7 +493,7 @@ DETAIL:  Key (i, j)=(1, 3) is duplicated.
 create unique index ijk_ijk on ijk(i,j,k);
 set gp_enable_mk_sort=off;
 drop table ijk;
----------
+--
 -- test bitmaps with NULL and non-NULL values (MPP-8461)
 --
 create table bmap_test (x int, y int, z int);
@@ -521,3 +521,31 @@ select * from bmap_test where x = 1 order by x,y,z;
 (4 rows)
 
 drop table bmap_test;
+--
+-- Test over-sized values
+--
+create table oversize_test (c1 text);
+CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
+insert into oversize_test values ('a');
+select * from oversize_test;
+ c1 
+----
+ a
+(1 row)
+
+-- this fails, because the value is too large
+insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)
+set enable_seqscan=off;
+select * from oversize_test where c1 < 'z';
+ c1 
+----
+ a
+(1 row)
+
+-- Drop the index, insert the row, and then try creating the index again. This is essentially
+-- the same test, but now the failure happens during CREATE INDEX rather than INSERT.
+drop index oversize_test_idx;
+insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
+CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)


### PR DESCRIPTION
Fixes #1015, in github issues.