### PR TITLE
Fix ALTER EXTERNAL TABLE ... ALTER TYPE to not require USING.

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_EXTERNAL_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_EXTERNAL_TABLE.xml
@@ -11,7 +11,7 @@
         <p>where <varname>action</varname> is one of:</p>
         <codeblock>  ADD [COLUMN] <varname>new_column</varname> <varname>type</varname>
   DROP [COLUMN] <varname>column</varname> [RESTRICT|CASCADE]
-  ALTER [COLUMN] <varname>column</varname> TYPE <varname>type</varname> [USING <varname>expression</varname>]
+  ALTER [COLUMN] <varname>column</varname> TYPE <varname>type</varname>
   OWNER TO <varname>new_owner</varname></codeblock>
       </sectiondiv></section>
     <section id="section3">
@@ -62,12 +62,6 @@
           <pd>Name of a new column.</pd>
         </plentry>
         <plentry>
-          <pt>USING <varname>expression</varname></pt>
-          <pd>Optional if an implicit or assignment cast exists from the old column data type to new
-            data type. The clause is required if there is no implicit or assignment cast. </pd>
-          <pd>The <codeph>USING</codeph> clause does not affect the external data.</pd>
-        </plentry>
-        <plentry>
           <pt><varname>type</varname></pt>
           <pd>Data type of the new column, or new data type for an existing column.</pd>
         </plentry>
@@ -90,10 +84,8 @@
         definition:</p><codeblock>ALTER EXTERNAL TABLE ext_expenses ADD COLUMN manager text;</codeblock><p>Change
         the owner of an external
         table:</p><codeblock>ALTER EXTERNAL TABLE ext_data OWNER TO jojo;</codeblock><p>Change the
-        data type of an external table:</p><codeblock>ALTER EXTERNAL TABLE ext_leads ALTER COLUMN acct_code TYPE integer USING acct_code::integer</codeblock>
-      <p>When altering the column data type from <codeph>text</codeph> to <codeph>integer</codeph>,
-        the <codeph>USING</codeph> clause is required but does not affect the external data.
-      </p></section>
+        data type of an external table:</p><codeblock>ALTER EXTERNAL TABLE ext_leads ALTER COLUMN acct_code TYPE integer</codeblock>
+      </section>
     <section id="section6"><title>Compatibility</title><p><codeph>ALTER EXTERNAL TABLE</codeph> is a
         Greenplum Database extension. There is no <codeph>ALTER EXTERNAL TABLE</codeph> statement in
         the SQL standard or regular PostgreSQL. </p></section>

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -159,6 +159,9 @@ alter external table ext add column extnewcol int not null; -- should fail (cons
 alter external table ext add column extnewcol int; -- pass
 alter external table ext alter column extnewcol set default 1; -- should fail (unsupported alter type)
 
+alter external table ext alter column x type integer using 123; -- should fail (USING doesn't make sense on external table)
+alter external table ext alter column x type integer; -- pass
+
 --
 -- TRUNCATE/UPDATE/DELETE/INSERT (INTO RET)
 --

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -193,6 +193,9 @@ ERROR:  Unsupported ALTER command for table type external. No constraints allowe
 alter external table ext add column extnewcol int; -- pass
 alter external table ext alter column extnewcol set default 1; -- should fail (unsupported alter type)
 ERROR:  Unsupported ALTER command for table type external
+alter external table ext alter column x type integer using 123; -- should fail (USING doesn't make sense on external table)
+ERROR:  cannot specify a USING expression when altering an external table
+alter external table ext alter column x type integer; -- pass
 --
 -- TRUNCATE/UPDATE/DELETE/INSERT (INTO RET)
 --


### PR DESCRIPTION
Don't require a USING clause, when there is no cast between the old and
new datatype are not compatible, when altering an external table. It'll
just be ignored, we're not going to rewrite any data in an external
source. And conversely, don't allow USING, because it'll just be ignored.

Fixes https://github.com/greenplum-db/gpdb/issues/3356