### PR TITLE
docs - add pseudo-type anytable to datatypes topic

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/defining-queries.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/defining-queries.xml
@@ -518,31 +518,6 @@ WHERE x &lt; (SELECT count(*) FROM t3 WHERE t1.y = t3.y)
                         href="query-profiling.xml#topic39"/>.</p>
             </body>
         </topic>
-        <topic id="topic22" xml:lang="en">
-            <title>Advanced Table Functions</title>
-            <body>
-                <p>Greenplum Database supports table functions with <codeph>TABLE</codeph> value
-                    expressions. You can sort input rows for advanced table functions with an
-                        <codeph>ORDER BY</codeph> clause. You can redistribute them with a
-                        <codeph>SCATTER BY</codeph> clause to specify one or more columns or an
-                    expression for which rows with the specified characteristics are available to
-                    the same process. This usage is similar to using a <codeph>DISTRIBUTED
-                        BY</codeph> clause when creating a table, but the redistribution occurs when
-                    the query runs.</p>
-                <note type="note">Based on the distribution of data, Greenplum Database
-                    automatically parallelizes table functions with <codeph>TABLE</codeph> value
-                    parameters over the nodes of the cluster.</note>
-                <p otherprops="pivotal">The following command uses the <codeph>TABLE</codeph>
-                    function with the <codeph>SCATTER BY</codeph> clause in the the GPText function
-                        <codeph>gptext.index()</codeph> to populate the index
-                        <codeph>mytest.articles</codeph> with data from the messages
-                    table:<codeblock>SELECT * FROM gptext.index(TABLE(SELECT * FROM messages 
-SCATTER BY distrib_id), 'mytest.articles');
-</codeblock></p>
-                <p otherprops="pivotal">For information about the function
-                        <codeph>gptext.index()</codeph>, see the Pivotal GPText documentation.</p>
-            </body>
-        </topic>
         <topic id="topic23" xml:lang="en">
             <title>Array Constructors</title>
             <body>

--- a/gpdb-doc/dita/ref_guide/data_types.xml
+++ b/gpdb-doc/dita/ref_guide/data_types.xml
@@ -405,12 +405,12 @@
       <p>The <codeph>SELECT</codeph> statement may include joins on multiple base tables,
           <codeph>WHERE</codeph> clauses, aggregates, and any other valid query syntax.</p>
       <p>The <i>anytable</i> type is only permitted in functions implemented in the C or C++
-        languages. The body of the function can access the table using  Greenplum Database Server
-        Programming Interface (SPI) functions. </p>
-      <p otherprops="pivotal">The <i>anytable</i> type is used with the Pivotal GPText API and the
-        Greenplum Partner Connector (GPPC) API. The following GPText example uses the
-          <codeph>TABLE</codeph> function with the <codeph>SCATTER BY</codeph> clause in the GPText
-        function <codeph>gptext.index()</codeph> to populate the index
+        languages. The body of the function can access the table using the Greenplum Database Server
+        Programming Interface (SPI) or the Greenplum Partner Connector (GPPC) API. </p>
+      <p otherprops="pivotal">The <i>anytable</i> type is used in some user-defined functions in the
+        Pivotal GPText API. The following GPText example uses the <codeph>TABLE</codeph> function
+        with the <codeph>SCATTER BY</codeph> clause in the GPText function
+          <codeph>gptext.index()</codeph> to populate the index
           <codeph>mydb.mytest.articles</codeph> with data from the messages
         table:<codeblock>SELECT * FROM gptext.index(TABLE(SELECT * FROM mytest.messages 
           SCATTER BY distrib_id), 'mydb.mytest.messages');

--- a/gpdb-doc/dita/ref_guide/data_types.xml
+++ b/gpdb-doc/dita/ref_guide/data_types.xml
@@ -335,13 +335,17 @@
         pseudo-types called polymorphic types. Some procedural languages also support polymorphic
         functions using the types <i>anyarray</i>, <i>anyelement</i>, <i>anyenum</i>, and
           <i>anynonarray</i>.</p>
+      <p>The pseudo-type <i>anytable</i> is a Greenplum Database type that specifies a table
+        expression—an expression that computes a table. Greenplum Database allows this type only as
+        an argument to a user-defined function. See <xref href="#topic1/topic22" format="dita"/> for
+        more about the <i>anytable</i> pseudo-type.</p>
       <p>For more information about pseudo-types, see the Postgres documentation about <xref
           href="https://www.postgresql.org/docs/8.3/static/datatype-pseudo.html" format="html"
           scope="external">Pseudo-Types</xref>.</p>
     </section>
     <section>
       <title>Polymorphic Types</title>
-      <p>Four pseudo-types types of special interest are <i>anyelement</i>, <i>anyarray</i>,
+      <p>Four pseudo-types of special interest are <i>anyelement</i>, <i>anyarray</i>,
           <i>anynonarray</i>, and <i>anyenum</i>, which are collectively called <i>polymorphic</i>
         types. Any function declared using these types is said to be a polymorphic function. A
         polymorphic function can operate on many different data types, with the specific data types
@@ -357,7 +361,7 @@
           <i>anynonarray</i> is treated exactly the same as <i>anyelement</i>, but adds the
         additional constraint that the actual type must not be an array type. <i>anyenum</i> is
         treated exactly the same as <i>anyelement</i>, but adds the additional constraint that the
-        actual type must be an <codeph>enum</codeph> type.</p>
+        actual type must be an <codeph>enum</codeph> type. </p>
       <p>When more than one argument position is declared with a polymorphic type, the net effect is
         that only certain combinations of actual argument types are allowed. For example, a function
         declared as <codeph>equal(<i>anyelement</i>, <i>anyelement</i>)</codeph> takes any two input
@@ -385,5 +389,34 @@
           href="https://www.postgresql.org/docs/8.3/static/xfunc-c.html#AEN41553" format="html"
           scope="external">Polymorphic Arguments and Return Types</xref>.</p>
     </section>
-  </body>
+    <section id="topic22" xml:lang="en">
+      <title>Table Value Expressions</title>
+      <p>The <i>anytable</i> pseudo-type declares a function argument that is a table value
+        expression. The notation for a table value expression is a <codeph>SELECT</codeph> statement
+        enclosed in a <codeph>TABLE()</codeph> function. You can specify a distribution policy for
+        the table by adding <codeph>SCATTER RANDOMLY</codeph>, or a <codeph>SCATTER BY</codeph>
+        clause with a column list to specify the distribution key. </p>
+      <p>The <codeph>SELECT</codeph> statement is executed when the function is called and the
+        result rows are distributed to segments so that each segment executes the function with a
+        subset of the result table.</p>
+      <p>For example, this table expression selects three columns from a table named
+          <codeph>customer</codeph> and sets the distribution key to the first column:</p>
+      <codeblock>TABLE(SELECT cust_key, name, address FROM customer SCATTER BY 1)</codeblock>
+      <p>The <codeph>SELECT</codeph> statement may include joins on multiple base tables,
+          <codeph>WHERE</codeph> clauses, aggregates, and any other valid query syntax.</p>
+      <p>The <i>anytable</i> type is only permitted in functions implemented in the C or C++
+        languages. The body of the function can access the table using  Greenplum Database Server
+        Programming Interface (SPI) functions. </p>
+      <p otherprops="pivotal">The <i>anytable</i> type is used with the Pivotal GPText API and the
+        Greenplum Partner Connector (GPPC) API. The following GPText example uses the
+          <codeph>TABLE</codeph> function with the <codeph>SCATTER BY</codeph> clause in the GPText
+        function <codeph>gptext.index()</codeph> to populate the index
+          <codeph>mydb.mytest.articles</codeph> with data from the messages
+        table:<codeblock>SELECT * FROM gptext.index(TABLE(SELECT * FROM mytest.messages 
+          SCATTER BY distrib_id), 'mydb.mytest.messages');
+        </codeblock></p>
+      <p otherprops="pivotal">For information about the function <codeph>gptext.index()</codeph>,
+        see the Pivotal GPText documentation.</p>
+    </section>
+  </body> 
 </topic>


### PR DESCRIPTION
- Removes section about TABLE() function from Defining Queries section of Admin Guide

- Adds anytable pseudo-type to the Datatypes topic in the reference guide alongside existing pseudo-types and adds a section to describe how TABLE() is used to specify an anytable type. 

Staged for review at http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/data_types.html