### PR TITLE
Give proper error on DELETE RETURNING on AO table.

### DIFF
--- a/src/test/regress/expected/returning_gp.out
+++ b/src/test/regress/expected/returning_gp.out
@@ -91,3 +91,10 @@ select * from returning_parttab;
        2 |      19 | multi2 3
 (11 rows)
 
+--
+-- DELETE RETURNING is currently not supported on AO tables.
+--
+CREATE TEMP TABLE returning_aotab (id int4) WITH (appendonly=true);
+INSERT INTO returning_aotab VALUES (1);
+DELETE FROM returning_aotab RETURNING *;
+ERROR:  DELETE RETURNING is not supported on appendonly tables

--- a/src/test/regress/sql/returning_gp.sql
+++ b/src/test/regress/sql/returning_gp.sql
@@ -40,3 +40,10 @@ delete from returning_parttab where partkey = 14 returning *;
 
 -- Check table contents, to be sure that all the commands did what they claimed.
 select * from returning_parttab;
+
+--
+-- DELETE RETURNING is currently not supported on AO tables.
+--
+CREATE TEMP TABLE returning_aotab (id int4) WITH (appendonly=true);
+INSERT INTO returning_aotab VALUES (1);
+DELETE FROM returning_aotab RETURNING *;


### PR DESCRIPTION
We don't support this at the moment. Would be nice to make it work, but
in the meanwhile, let's at least give a proper error message, instead of
attempting to read the AO table as if it was a heap table.

There was a FIXME comment about this, and it was also reported in github
issue #4735.