### PR TITLE
Fix redistribute bug on some types which need to convert

### DIFF
--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -833,44 +833,6 @@ bool isGreenplumDbOprHashable(Oid oprid)
 }
 
 /*
- * is_restrictinfo_hashjoinable
- *	  If the restrictinfo's clause is hashjoinable, return true.
- */
-bool
-is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo)
-{
-	Expr	   *clause = restrictinfo->clause;
-	Oid			opno;
-
-	/**
-	 * If this is a IS NOT FALSE boolean test, we can peek underneath.
-	 */
-	if (IsA(clause, BooleanTest))
-	{
-		BooleanTest *bt = (BooleanTest *) clause;
-
-		if (bt->booltesttype == IS_NOT_FALSE)
-		{
-			clause = bt->arg;
-		}
-	}
-
-	if (restrictinfo->pseudoconstant)
-		return false;
-	if (!is_opclause(clause))
-		return false;
-	if (list_length(((OpExpr *) clause)->args) != 2)
-		return false;
-
-	opno = ((OpExpr *) clause)->opno;
-
-	if (isGreenplumDbOprHashable(opno))
-		return true;
-	else
-		return false;
-}
-
-/*
  * fnv1_32_buf - perform a 32 bit FNV 1 hash on a buffer
  *
  * input:

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -715,6 +715,10 @@ typeIsEnumType(Oid typeoid)
 	return res;
 }
 
+/*
+ * isGreenplumDbHashable
+ * return true if a type is hashable in cdb hash
+ */
 bool
 isGreenplumDbHashable(Oid typid)
 {
@@ -784,7 +788,11 @@ isGreenplumDbHashable(Oid typid)
 	}
 }
 
-bool isGreenplumDbOprHashable(Oid oprid)
+/*
+ * isGreenplumDbOprHashable
+ * return true if a operator is redistributable
+ */
+bool isGreenplumDbOprRedistributable(Oid oprid)
 {
 	switch(oprid)
 	{
@@ -821,12 +829,15 @@ bool isGreenplumDbOprHashable(Oid oprid)
 		case BitEqualOperator:
 		case VarbitEqualOperator:
 		case BooleanEqualOperator:
-		case ARRAY_EQ_OP:
 		case OidVectEqualOperator:
 		case CashEqualOperator:
 		case UuidEqualOperator:
 		case ComplexEqualOperator:
 			return true;
+		case ARRAY_EQ_OP:
+		case Float48EqualOperator:
+		case Float84EqualOperator:
+			return false;
 		default:
 			return false;
 	}

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -1606,11 +1606,11 @@ cdbpath_contains_wts(Path *path)
 
 
 /*
- * is_restrictinfo_hashjoinable
- *	  If the restrictinfo's clause is hashjoinable, return true.
+ * has_redistributable_clause
+ *	  If the restrictinfo's clause is redistributable, return true.
  */
 bool
-is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo)
+has_redistributable_clause(RestrictInfo *restrictinfo)
 {
 	Expr	   *clause = restrictinfo->clause;
 	Oid			opno;
@@ -1637,7 +1637,7 @@ is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo)
 
 	opno = ((OpExpr *) clause)->opno;
 
-	if (isGreenplumDbOprHashable(opno))
+	if (isGreenplumDbOprRedistributable(opno))
 		return true;
 	else
 		return false;

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -769,7 +769,7 @@ cdbpath_motion_for_join(PlannerInfo    *root,
                         JoinType        jointype,           /* JOIN_INNER/FULL/LEFT/RIGHT/IN */
                         Path          **p_outer_path,       /* INOUT */
                         Path          **p_inner_path,       /* INOUT */
-                        List           *mergeclause_list,   /* equijoin RestrictInfo list */
+                        List           *redistribution_clauses,   /* equijoin RestrictInfo list */
                         List           *outer_pathkeys,
                         List           *inner_pathkeys,
                         bool            outer_require_existing_order,
@@ -917,7 +917,7 @@ cdbpath_motion_for_join(PlannerInfo    *root,
 
         /* Redistribute single rel if joining on other rel's partitioning key */
         else if (cdbpath_match_preds_to_partkey(root,
-                                                mergeclause_list,
+                                                redistribution_clauses,
                                                 other->locus,
                                                 &single->move_to))  /* OUT */
         {}
@@ -930,7 +930,7 @@ cdbpath_motion_for_join(PlannerInfo    *root,
         /* Redistribute both rels on equijoin cols. */
         else if (!other->require_existing_order &&
                  cdbpath_partkeys_from_preds(root,
-                                             mergeclause_list,
+                                             redistribution_clauses,
                                              single->path,
                                              &single->move_to,  /* OUT */
                                              &other->move_to))  /* OUT */
@@ -965,7 +965,7 @@ cdbpath_motion_for_join(PlannerInfo    *root,
     /*
      * No motion if partitioned alike and joining on the partitioning keys.
      */
-    else if (cdbpath_match_preds_to_both_partkeys(root, mergeclause_list,
+    else if (cdbpath_match_preds_to_both_partkeys(root, redistribution_clauses,
                                                   outer.locus, inner.locus))
         return cdbpathlocus_join(outer.locus, inner.locus);
 
@@ -994,7 +994,7 @@ cdbpath_motion_for_join(PlannerInfo    *root,
         /* If joining on larger rel's partitioning key, redistribute smaller. */
         if (!small->require_existing_order &&
             cdbpath_match_preds_to_partkey(root,
-                                           mergeclause_list,
+                                           redistribution_clauses,
                                            large->locus,
                                            &small->move_to))    /* OUT */
         {}
@@ -1010,7 +1010,7 @@ cdbpath_motion_for_join(PlannerInfo    *root,
         /* If joining on smaller rel's partitioning key, redistribute larger. */
         else if (!large->require_existing_order &&
                  cdbpath_match_preds_to_partkey(root,
-                                                mergeclause_list,
+                                                redistribution_clauses,
                                                 small->locus,
                                                 &large->move_to))   /* OUT */
         {}
@@ -1025,7 +1025,7 @@ cdbpath_motion_for_join(PlannerInfo    *root,
         else if (!small->require_existing_order &&
                  !large->require_existing_order &&
                  cdbpath_partkeys_from_preds(root,
-                                             mergeclause_list,
+                                             redistribution_clauses,
                                              large->path,
                                              &large->move_to,
                                              &small->move_to))

--- a/src/backend/optimizer/path/joinpath.c
+++ b/src/backend/optimizer/path/joinpath.c
@@ -118,9 +118,6 @@ add_paths_to_joinrel(PlannerInfo *root,
 												restrictlist,
 												jointype);
 
-
-
-
 	/*
 	 * 1. Consider mergejoin paths where both relations must be explicitly
 	 * sorted.

--- a/src/backend/optimizer/path/joinpath.c
+++ b/src/backend/optimizer/path/joinpath.c
@@ -1128,7 +1128,7 @@ select_cdb_redistribute_clauses(PlannerInfo *root,
 		if (isouterjoin && restrictinfo->is_pushed_down)
 			continue;
 
-		if (!is_restrictinfo_hashjoinable(restrictinfo))
+		if (!has_redistributable_clause(restrictinfo))
 			continue;
 
 		if (!restrictinfo->can_join ||

--- a/src/backend/optimizer/path/joinpath.c
+++ b/src/backend/optimizer/path/joinpath.c
@@ -21,6 +21,7 @@
 #include "optimizer/cost.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/paths.h"
+#include "optimizer/planmain.h"
 
 #include "executor/nodeHash.h"                  /* ExecHashRowSize() */
 #include "cdb/cdbpath.h"                        /* cdbpath_rows() */
@@ -28,12 +29,12 @@
 
 static void sort_inner_and_outer(PlannerInfo *root, RelOptInfo *joinrel,
 					 RelOptInfo *outerrel, RelOptInfo *innerrel,
-					 List *restrictlist, List *mergeclause_list,
-					 JoinType jointype);
+					 List *restrictlist, List *cdbclause_list,
+					 List *mergeclause_list, JoinType jointype);
 static void match_unsorted_outer(PlannerInfo *root, RelOptInfo *joinrel,
 					 RelOptInfo *outerrel, RelOptInfo *innerrel,
-					 List *restrictlist, List *mergeclause_list,
-					 JoinType jointype);
+					 List *restrictlist, List *cdbclause_list,
+					 List *mergeclause_list, JoinType jointype);
 static void hash_inner_and_outer(PlannerInfo *root, RelOptInfo *joinrel,
 					 Path *outerpath, Path *innerpath,
 					 List *restrictlist,
@@ -48,6 +49,13 @@ static List *select_mergejoin_clauses(PlannerInfo *root,
 						 RelOptInfo *innerrel,
 						 List *restrictlist,
 						 JoinType jointype);
+
+static List *select_cdb_redistribute_clauses(PlannerInfo *root,
+									  RelOptInfo *joinrel,
+									  RelOptInfo *outerrel,
+									  RelOptInfo *innerrel,
+									  List *restrictlist,
+									  JoinType jointype);
 
 static List *hashclauses_for_join(List *restrictlist,
 					 RelOptInfo *outerrel,
@@ -74,6 +82,7 @@ add_paths_to_joinrel(PlannerInfo *root,
 					 List *restrictlist)
 {
 	List	   *mergeclause_list = NIL;
+	List	   *cdbclause_list = NIL;
     List       *hashclause_list;
 
     Assert(outerrel->pathlist &&
@@ -96,12 +105,21 @@ add_paths_to_joinrel(PlannerInfo *root,
      *
      * CDB: Always build mergeclause_list.  We need it for motion planning.
 	 */
+	cdbclause_list = select_cdb_redistribute_clauses(root,
+													 joinrel,
+													 outerrel,
+													 innerrel,
+													 restrictlist,
+													 jointype);
 	mergeclause_list = select_mergejoin_clauses(root,
 												joinrel,
 												outerrel,
 												innerrel,
 												restrictlist,
 												jointype);
+
+
+
 
 	/*
 	 * 1. Consider mergejoin paths where both relations must be explicitly
@@ -112,7 +130,8 @@ add_paths_to_joinrel(PlannerInfo *root,
 		jointype == JOIN_FULL) &&
 		jointype != JOIN_LASJ_NOTIN)
 	    sort_inner_and_outer(root, joinrel, outerrel, innerrel,
-						     restrictlist, mergeclause_list, jointype);
+						     restrictlist, cdbclause_list,
+							 mergeclause_list, jointype);
 
 	/*
 	 * 2. Consider paths where the outer relation need not be explicitly
@@ -120,7 +139,8 @@ add_paths_to_joinrel(PlannerInfo *root,
 	 * path is already ordered.
 	 */
 	match_unsorted_outer(root, joinrel, outerrel, innerrel,
-						 restrictlist, mergeclause_list, jointype);
+						 restrictlist, cdbclause_list,
+						 mergeclause_list, jointype);
 
 #ifdef NOT_USED
 
@@ -154,6 +174,7 @@ add_paths_to_joinrel(PlannerInfo *root,
                                                outerrel,
                                                innerrel,
                                                jointype);
+
 		if (hashclause_list)
         {
             hash_inner_and_outer(root,
@@ -161,7 +182,7 @@ add_paths_to_joinrel(PlannerInfo *root,
                                  outerrel->cheapest_total_path,
                                  innerrel->cheapest_total_path,
 							     restrictlist,
-                                 mergeclause_list,
+                                 cdbclause_list,
                                  hashclause_list,
                                  jointype);
             if (outerrel->cheapest_startup_path != outerrel->cheapest_total_path)
@@ -197,6 +218,7 @@ sort_inner_and_outer(PlannerInfo *root,
 					 RelOptInfo *outerrel,
 					 RelOptInfo *innerrel,
 					 List *restrictlist,
+					 List *cdbclause_list,
 					 List *mergeclause_list,
 					 JoinType jointype)
 {
@@ -320,7 +342,7 @@ sort_inner_and_outer(PlannerInfo *root,
 									   restrictlist,
 									   merge_pathkeys,
 									   cur_mergeclauses,
-                                       mergeclause_list,
+									   cdbclause_list,
 									   outerkeys,
 									   innerkeys));
 	}
@@ -365,6 +387,7 @@ match_unsorted_outer(PlannerInfo *root,
 					 RelOptInfo *outerrel,
 					 RelOptInfo *innerrel,
 					 List *restrictlist,
+					 List *cdbclause_list,
 					 List *mergeclause_list,
 					 JoinType jointype)
 {
@@ -493,7 +516,7 @@ match_unsorted_outer(PlannerInfo *root,
 										  outerpath,
 										  inner_cheapest_total,
 										  restrictlist,
-                                          mergeclause_list,         /*CDB*/
+										  cdbclause_list,         /*CDB*/
 										  merge_pathkeys));
 			if (matpath != NULL)
 				add_path(root, joinrel, (Path *)
@@ -503,7 +526,7 @@ match_unsorted_outer(PlannerInfo *root,
 											  outerpath,
 											  matpath,
 											  restrictlist,
-                                              mergeclause_list,     /*CDB*/
+											  cdbclause_list,     /*CDB*/
 											  merge_pathkeys));
 			if (inner_cheapest_startup != inner_cheapest_total)
 				add_path(root, joinrel, (Path *)
@@ -513,7 +536,7 @@ match_unsorted_outer(PlannerInfo *root,
 											  outerpath,
 											  inner_cheapest_startup,
 											  restrictlist,
-                                              mergeclause_list,     /*CDB*/
+											  cdbclause_list,     /*CDB*/
 											  merge_pathkeys));
 			if (index_cheapest_total != NULL)
 				add_path(root, joinrel, (Path *)
@@ -523,7 +546,7 @@ match_unsorted_outer(PlannerInfo *root,
 											  outerpath,
 											  index_cheapest_total,
 											  restrictlist,
-                                              mergeclause_list,     /*CDB*/
+											  cdbclause_list,     /*CDB*/
 											  merge_pathkeys));
 			if (index_cheapest_startup != NULL &&
 				index_cheapest_startup != index_cheapest_total)
@@ -534,7 +557,7 @@ match_unsorted_outer(PlannerInfo *root,
 											  outerpath,
 											  index_cheapest_startup,
 											  restrictlist,
-                                              mergeclause_list,
+											  cdbclause_list,
 											  merge_pathkeys));
 		}
 
@@ -594,7 +617,7 @@ match_unsorted_outer(PlannerInfo *root,
 									   restrictlist,
 									   merge_pathkeys,
 									   mergeclauses,
-                                       mergeclause_list,    /*CDB*/
+									   cdbclause_list,    /*CDB*/
 									   NIL,
 									   innersortkeys));
 
@@ -664,7 +687,7 @@ match_unsorted_outer(PlannerInfo *root,
 											   restrictlist,
 											   merge_pathkeys,
 											   newclauses,
-                                               mergeclause_list,    /*CDB*/
+											   cdbclause_list,    /*CDB*/
 											   NIL,
 											   NIL));
 				cheapest_total_inner = innerpath;
@@ -711,7 +734,7 @@ match_unsorted_outer(PlannerInfo *root,
 												   restrictlist,
 												   merge_pathkeys,
 												   newclauses,
-                                                   mergeclause_list,    /*CDB*/
+												   cdbclause_list,    /*CDB*/
 												   NIL,
 												   NIL));
 				}
@@ -1062,6 +1085,125 @@ select_mergejoin_clauses(PlannerInfo *root,
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("FULL JOIN is only supported with merge-joinable join conditions")));
+				break;
+			default:
+				/* otherwise, it's OK to have nonmergeable join quals */
+				break;
+		}
+	}
+
+	return result_list;
+}
+
+
+static List *
+select_cdb_redistribute_clauses(PlannerInfo *root,
+								RelOptInfo *joinrel,
+								RelOptInfo *outerrel,
+								RelOptInfo *innerrel,
+								List *restrictlist,
+								JoinType jointype)
+{
+	List	   *result_list = NIL;
+	bool		isouterjoin = IS_OUTER_JOIN(jointype);
+	bool		have_nonmergeable_joinclause = false;
+	ListCell   *l;
+
+	foreach(l, restrictlist)
+	{
+		RestrictInfo *restrictinfo = (RestrictInfo *) lfirst(l);
+
+		/*
+		 * If processing an outer join, only use its own join clauses in the
+		 * merge.  For inner joins we can use pushed-down clauses too. (Note:
+		 * we don't set have_nonmergeable_joinclause here because pushed-down
+		 * clauses will become otherquals not joinquals.)
+		 */
+		if (isouterjoin && restrictinfo->is_pushed_down)
+			continue;
+
+		if (!is_restrictinfo_hashjoinable(restrictinfo))
+			continue;
+
+		if (!restrictinfo->can_join ||
+			restrictinfo->mergeopfamilies == NIL)
+		{
+			have_nonmergeable_joinclause = true;
+			continue;			/* not mergejoinable */
+		}
+
+		/*
+		 * Check if clause is usable with these input rels.  All the vars
+		 * needed on each side of the clause must be available from one or the
+		 * other of the input rels.
+		 */
+		if (bms_is_subset(restrictinfo->left_relids, outerrel->relids) &&
+			bms_is_subset(restrictinfo->right_relids, innerrel->relids))
+		{
+			/* righthand side is inner */
+			restrictinfo->outer_is_left = true;
+		}
+		else if (bms_is_subset(restrictinfo->left_relids, innerrel->relids) &&
+				 bms_is_subset(restrictinfo->right_relids, outerrel->relids))
+		{
+			/* lefthand side is inner */
+			restrictinfo->outer_is_left = false;
+		}
+		else
+		{
+			have_nonmergeable_joinclause = true;
+			continue;			/* no good for these input relations */
+		}
+
+		/*
+		 * Insist that each side have a non-redundant eclass.  This
+		 * restriction is needed because various bits of the planner expect
+		 * that each clause in a merge be associatable with some pathkey in a
+		 * canonical pathkey list, but redundant eclasses can't appear in
+		 * canonical sort orderings.  (XXX it might be worth relaxing this,
+		 * but not enough time to address it for 8.3.)
+		 *
+		 * Note: it would be bad if this condition failed for an otherwise
+		 * mergejoinable FULL JOIN clause, since that would result in
+		 * undesirable planner failure.  I believe that is not possible
+		 * however; a variable involved in a full join could only appear
+		 * in below_outer_join eclasses, which aren't considered redundant.
+		 *
+		 * This case *can* happen for left/right join clauses: the
+		 * outer-side variable could be equated to a constant.  Because we
+		 * will propagate that constant across the join clause, the loss of
+		 * ability to do a mergejoin is not really all that big a deal, and
+		 * so it's not clear that improving this is important.
+		 */
+		cache_mergeclause_eclasses(root, restrictinfo);
+
+		if (EC_MUST_BE_REDUNDANT(restrictinfo->left_ec) ||
+			EC_MUST_BE_REDUNDANT(restrictinfo->right_ec))
+		{
+			have_nonmergeable_joinclause = true;
+			continue;			/* can't handle redundant eclasses */
+		}
+
+		result_list = lappend(result_list, restrictinfo);
+	}
+
+	/*
+	 * If it is a right/full join then *all* the explicit join clauses must be
+	 * mergejoinable, else the executor will fail. If we are asked for a right
+	 * join then just return NIL to indicate no mergejoin is possible (we can
+	 * handle it as a left join instead). If we are asked for a full join then
+	 * emit an error, because there is no fallback.
+	 */
+	if (have_nonmergeable_joinclause)
+	{
+		switch (jointype)
+		{
+			case JOIN_RIGHT:
+				return NIL;		/* not mergejoinable */
+			case JOIN_FULL:
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								errmsg("FULL JOIN is only supported with merge-joinable join conditions")));
 				break;
 			default:
 				/* otherwise, it's OK to have nonmergeable join quals */

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -1606,7 +1606,10 @@ check_mergejoinable(RestrictInfo *restrictinfo)
 	 */
 }
 
-
+/*
+ * is_restrictinfo_hashjoinable
+ *	  If the restrictinfo's clause is hashjoinable, return true.
+ */
 bool
 is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo)
 {

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -1607,45 +1607,6 @@ check_mergejoinable(RestrictInfo *restrictinfo)
 }
 
 /*
- * is_restrictinfo_hashjoinable
- *	  If the restrictinfo's clause is hashjoinable, return true.
- */
-bool
-is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo)
-{
-	Expr	   *clause = restrictinfo->clause;
-	Oid			opno;
-
-	/**
-	 * If this is a IS NOT FALSE boolean test, we can peek underneath.
-	 */
-	if (IsA(clause, BooleanTest))
-	{
-		BooleanTest *bt = (BooleanTest *) clause;
-
-		if (bt->booltesttype == IS_NOT_FALSE)
-		{
-			clause = bt->arg;
-		}
-	}
-
-	if (restrictinfo->pseudoconstant)
-		return false;
-	if (!is_opclause(clause))
-		return false;
-	if (list_length(((OpExpr *) clause)->args) != 2)
-		return false;
-
-	opno = ((OpExpr *) clause)->opno;
-
-	if (op_hashjoinable(opno) &&
-		!contain_volatile_functions((Node *) clause))
-		return true;
-	else
-		return false;
-}
-
-/*
  * check_hashjoinable
  *	  If the restrictinfo's clause is hashjoinable, set the hashjoin
  *	  info fields in the restrictinfo.

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2563,7 +2563,7 @@ create_nestloop_path(PlannerInfo *root,
 					 Path *outer_path,
 					 Path *inner_path,
 					 List *restrict_clauses,
-                     List *mergeclause_list,    /*CDB*/
+                     List *cdbclause_list,    /*CDB*/
 					 List *pathkeys)
 {
 	NestPath       *pathnode;
@@ -2584,7 +2584,7 @@ create_nestloop_path(PlannerInfo *root,
                                          jointype,
                                          &outer_path,       /* INOUT */
                                          &inner_path,       /* INOUT */
-                                         mergeclause_list,
+                                         cdbclause_list,
                                          pathkeys,
                                          NIL,
                                          false,
@@ -2676,7 +2676,7 @@ create_mergejoin_path(PlannerInfo *root,
 					  List *restrict_clauses,
 					  List *pathkeys,
 					  List *mergeclauses,
-                      List *allmergeclauses,    /*CDB*/
+                      List *cdbclauses,    /*CDB*/
 					  List *outersortkeys,
 					  List *innersortkeys)
 {
@@ -2713,7 +2713,7 @@ create_mergejoin_path(PlannerInfo *root,
                                          jointype,
                                          &outer_path,       /* INOUT */
                                          &inner_path,       /* INOUT */
-                                         allmergeclauses,
+										 cdbclauses,
                                          outermotionkeys,
                                          innermotionkeys,
                                          outersortkeys == NIL,
@@ -2834,7 +2834,7 @@ create_hashjoin_path(PlannerInfo *root,
 					 Path *outer_path,
 					 Path *inner_path,
 					 List *restrict_clauses,
-                     List *mergeclause_list,    /*CDB*/
+                     List *cdbclause_list,    /*CDB*/
 					 List *hashclauses)
 {
 	HashPath       *pathnode;
@@ -2849,7 +2849,7 @@ create_hashjoin_path(PlannerInfo *root,
 										 jointype,
 										 &outer_path,       /* INOUT */
 										 &inner_path,       /* INOUT */
-										 mergeclause_list,
+										 cdbclause_list,
 										 NIL,   /* don't care about ordering */
 										 NIL,
 										 false,

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2563,7 +2563,7 @@ create_nestloop_path(PlannerInfo *root,
 					 Path *outer_path,
 					 Path *inner_path,
 					 List *restrict_clauses,
-                     List *cdbclause_list,    /*CDB*/
+                     List *redistribution_clauses,    /*CDB*/
 					 List *pathkeys)
 {
 	NestPath       *pathnode;
@@ -2584,7 +2584,7 @@ create_nestloop_path(PlannerInfo *root,
                                          jointype,
                                          &outer_path,       /* INOUT */
                                          &inner_path,       /* INOUT */
-                                         cdbclause_list,
+                                         redistribution_clauses,
                                          pathkeys,
                                          NIL,
                                          false,
@@ -2676,7 +2676,7 @@ create_mergejoin_path(PlannerInfo *root,
 					  List *restrict_clauses,
 					  List *pathkeys,
 					  List *mergeclauses,
-                      List *cdbclauses,    /*CDB*/
+                      List *redistribution_clauses,    /*CDB*/
 					  List *outersortkeys,
 					  List *innersortkeys)
 {
@@ -2713,7 +2713,7 @@ create_mergejoin_path(PlannerInfo *root,
                                          jointype,
                                          &outer_path,       /* INOUT */
                                          &inner_path,       /* INOUT */
-										 cdbclauses,
+										 redistribution_clauses,
                                          outermotionkeys,
                                          innermotionkeys,
                                          outersortkeys == NIL,
@@ -2834,7 +2834,7 @@ create_hashjoin_path(PlannerInfo *root,
 					 Path *outer_path,
 					 Path *inner_path,
 					 List *restrict_clauses,
-                     List *cdbclause_list,    /*CDB*/
+                     List *hash_inner_and_outer,    /*CDB*/
 					 List *hashclauses)
 {
 	HashPath       *pathnode;
@@ -2849,7 +2849,7 @@ create_hashjoin_path(PlannerInfo *root,
 										 jointype,
 										 &outer_path,       /* INOUT */
 										 &inner_path,       /* INOUT */
-										 cdbclause_list,
+										 hash_inner_and_outer,
 										 NIL,   /* don't care about ordering */
 										 NIL,
 										 false,

--- a/src/include/catalog/pg_operator.h
+++ b/src/include/catalog/pg_operator.h
@@ -516,6 +516,7 @@ DATA(insert OID = 1117 (  "-"		PGNSP PGUID b f f 700 701 701  0	 0 float48mi - -
 DATA(insert OID = 1118 (  "/"		PGNSP PGUID b f f 700 701 701  0	 0 float48div - - ));
 DATA(insert OID = 1119 (  "*"		PGNSP PGUID b f f 700 701 701 1129	 0 float48mul - - ));
 DATA(insert OID = 1120 (  "="		PGNSP PGUID b t t  700	701  16 1130 1121 float48eq eqsel eqjoinsel ));
+#define Float48EqualOperator 1120
 DATA(insert OID = 1121 (  "<>"		PGNSP PGUID b f f  700	701  16 1131 1120 float48ne neqsel neqjoinsel ));
 DATA(insert OID = 1122 (  "<"		PGNSP PGUID b f f  700	701  16 1133 1125 float48lt scalarltsel scalarltjoinsel ));
 DATA(insert OID = 1123 (  ">"		PGNSP PGUID b f f  700	701  16 1132 1124 float48gt scalargtsel scalargtjoinsel ));
@@ -528,6 +529,7 @@ DATA(insert OID = 1127 (  "-"		PGNSP PGUID b f f 701 700 701  0	 0 float84mi - -
 DATA(insert OID = 1128 (  "/"		PGNSP PGUID b f f 701 700 701  0	 0 float84div - - ));
 DATA(insert OID = 1129 (  "*"		PGNSP PGUID b f f 701 700 701 1119	 0 float84mul - - ));
 DATA(insert OID = 1130 (  "="		PGNSP PGUID b t t  701	700  16 1120 1131 float84eq eqsel eqjoinsel ));
+#define Float84EqualOperator 1130
 DATA(insert OID = 1131 (  "<>"		PGNSP PGUID b f f  701	700  16 1121 1130 float84ne neqsel neqjoinsel ));
 DATA(insert OID = 1132 (  "<"		PGNSP PGUID b f f  701	700  16 1123 1135 float84lt scalarltsel scalarltjoinsel ));
 DATA(insert OID = 1133 (  ">"		PGNSP PGUID b f f  701	700  16 1122 1134 float84gt scalargtsel scalargtjoinsel ));

--- a/src/include/catalog/pg_operator.h
+++ b/src/include/catalog/pg_operator.h
@@ -305,6 +305,7 @@ DATA(insert OID = 646 (  ">"	   PGNSP PGUID b f f	30	30	16 645 647 oidvectorgt s
 DATA(insert OID = 647 (  "<="	   PGNSP PGUID b f f	30	30	16 648 646 oidvectorle scalarltsel scalarltjoinsel ));
 DATA(insert OID = 648 (  ">="	   PGNSP PGUID b f f	30	30	16 647 645 oidvectorge scalargtsel scalargtjoinsel ));
 DATA(insert OID = 649 (  "="	   PGNSP PGUID b t t	30	30	16 649 644 oidvectoreq eqsel eqjoinsel ));
+#define OidVectEqualOperator 649
 
 DATA(insert OID = 613 (  "<->"	   PGNSP PGUID b f f 600 628 701	 0	 0 dist_pl - - ));
 DATA(insert OID = 614 (  "<->"	   PGNSP PGUID b f f 600 601 701	 0	 0 dist_ps - - ));
@@ -947,6 +948,7 @@ DATA(insert OID = 2877 (  "~"	   PGNSP PGUID b f f 1034 1033	 16 0 0 aclcontains
 
 /* uuid operators */
 DATA(insert OID = 2972 (  "="	   PGNSP PGUID b t t 2950 2950 16 2972 2973 uuid_eq eqsel eqjoinsel ));
+#define UuidEqualOperator 2972
 DATA(insert OID = 2973 (  "<>"	   PGNSP PGUID b f f 2950 2950 16 2973 2972 uuid_ne neqsel neqjoinsel ));
 DATA(insert OID = 2974 (  "<"	   PGNSP PGUID b f f 2950 2950 16 2975 2977 uuid_lt scalarltsel scalarltjoinsel ));
 DATA(insert OID = 2975 (  ">"	   PGNSP PGUID b f f 2950 2950 16 2974 2976 uuid_gt scalargtsel scalargtjoinsel ));
@@ -1012,7 +1014,8 @@ DATA(insert OID = 3329 (  "<="    PGNSP PGUID b f f 3310 3310	16 3330 3328 gpxlo
 DATA(insert OID = 3330 (  ">="    PGNSP PGUID b f f 3310 3310	16 3329 3327 gpxloglocge scalargtsel scalargtjoinsel ));
 
 /* operators for complex data type */
-DATA(insert OID = 3469 (  "="	   PGNSP PGUID b t f 195 195 16 3469 3470 complex_eq eqsel eqjoinsel)); 
+DATA(insert OID = 3469 (  "="	   PGNSP PGUID b t f 195 195 16 3469 3470 complex_eq eqsel eqjoinsel));
+#define ComplexEqualOperator 3469
 DATA(insert OID = 3470 (  "<>"	   PGNSP PGUID b f f 195 195 16 3470 3469 complex_ne  neqsel neqjoinsel)); 
 DATA(insert OID = 3471 (  "@"	   PGNSP PGUID l f f 0   195 701 0	0	 complexabs  - -)); 
 DATA(insert OID = 3472 (  "+"	   PGNSP PGUID b f f 195 195 195 0	0	complex_pl  - -));

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -91,7 +91,7 @@ extern bool isGreenplumDbHashable(Oid typide);
 /*
  * Return true if the operator Oid is hashable internally in Greenplum Database.
  */
-extern bool isGreenplumDbOprHashable(Oid oprid);
+extern bool isGreenplumDbOprRedistributable(Oid oprid);
 
 /*
  * Return true if the Oid is an array type.  This can be used prior

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -94,10 +94,6 @@ extern bool isGreenplumDbHashable(Oid typide);
 extern bool isGreenplumDbOprHashable(Oid oprid);
 
 /*
- * Return true if the RestrictInfo is hashable internally in Greenplum Database.
- */
-extern bool is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo);
-/*
  * Return true if the Oid is an array type.  This can be used prior
  *   to hashing the datum because array typeoids are expected to
  *   have been converted to any array oid.

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -86,8 +86,17 @@ extern unsigned int cdbhashreduce(CdbHash *h);
 /*
  * Return true if Oid is hashable internally in Greenplum Database.
  */
-extern bool isGreenplumDbHashable(Oid typid);
+extern bool isGreenplumDbHashable(Oid typide);
 
+/*
+ * Return true if the operator Oid is hashable internally in Greenplum Database.
+ */
+extern bool isGreenplumDbOprHashable(Oid oprid);
+
+/*
+ * Return true if the RestrictInfo is hashable internally in Greenplum Database.
+ */
+extern bool is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo);
 /*
  * Return true if the Oid is an array type.  This can be used prior
  *   to hashing the datum because array typeoids are expected to

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -32,7 +32,7 @@ cdbpath_motion_for_join(PlannerInfo    *root,
                         JoinType        jointype,           /* JOIN_INNER/FULL/LEFT/RIGHT/IN */
                         Path          **p_outer_path,       /* INOUT */
                         Path          **p_inner_path,       /* INOUT */
-                        List           *mergeclause_list,   /* equijoin RestrictInfo list */
+                        List           *redistribution_clauses,   /* equijoin RestrictInfo list */
                         List           *outer_pathkeys,
                         List           *inner_pathkeys,
                         bool            outer_require_existing_order,

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -69,4 +69,9 @@ cdbpath_rows(PlannerInfo *root, Path *path)
     return rows;
 }                               /* cdbpath_rows */
 
+/*
+ * Return true if the RestrictInfo is hashable internally in Greenplum Database.
+ */
+extern bool is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo);
+
 #endif   /* CDBPATH_H */

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -72,6 +72,6 @@ cdbpath_rows(PlannerInfo *root, Path *path)
 /*
  * Return true if the RestrictInfo is hashable internally in Greenplum Database.
  */
-extern bool is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo);
+extern bool has_redistributable_clause(RestrictInfo *restrictinfo);
 
 #endif   /* CDBPATH_H */

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -89,7 +89,7 @@ extern NestPath *create_nestloop_path(PlannerInfo *root,
 					 Path *outer_path,
 					 Path *inner_path,
 					 List *restrict_clauses,
-					 List *cdbclause_list,    /*CDB*/
+					 List *redistribution_clauses,    /*CDB*/
 					 List *pathkeys);
 
 extern MergePath *create_mergejoin_path(PlannerInfo *root,
@@ -100,7 +100,7 @@ extern MergePath *create_mergejoin_path(PlannerInfo *root,
 					  List *restrict_clauses,
 					  List *pathkeys,
 					  List *mergeclauses,
-                      List *cdbclauses,    /*CDB*/
+                      List *redistribution_clauses,    /*CDB*/
 					  List *outersortkeys,
 					  List *innersortkeys);
 
@@ -110,7 +110,7 @@ extern HashPath *create_hashjoin_path(PlannerInfo *root,
 					 Path *outer_path,
 					 Path *inner_path,
 					 List *restrict_clauses,
-                     List *cdbclause_list,    /*CDB*/
+                     List *hash_inner_and_outer,    /*CDB*/
 					 List *hashclauses);
 
 /*

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -89,7 +89,7 @@ extern NestPath *create_nestloop_path(PlannerInfo *root,
 					 Path *outer_path,
 					 Path *inner_path,
 					 List *restrict_clauses,
-					 List *mergeclause_list,    /*CDB*/
+					 List *cdbclause_list,    /*CDB*/
 					 List *pathkeys);
 
 extern MergePath *create_mergejoin_path(PlannerInfo *root,
@@ -100,7 +100,7 @@ extern MergePath *create_mergejoin_path(PlannerInfo *root,
 					  List *restrict_clauses,
 					  List *pathkeys,
 					  List *mergeclauses,
-                      List *allmergeclauses,    /*CDB*/
+                      List *cdbclauses,    /*CDB*/
 					  List *outersortkeys,
 					  List *innersortkeys);
 
@@ -110,7 +110,7 @@ extern HashPath *create_hashjoin_path(PlannerInfo *root,
 					 Path *outer_path,
 					 Path *inner_path,
 					 List *restrict_clauses,
-                     List *mergeclause_list,    /*CDB*/
+                     List *cdbclause_list,    /*CDB*/
 					 List *hashclauses);
 
 /*

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -237,6 +237,7 @@ extern RestrictInfo *build_implied_join_equality(Oid opno,
 							Expr *item2,
 							Relids qualscope,
 							Relids nullable_relids);
+extern bool is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo);
 
 /*
  * prototypes for plan/setrefs.c

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -237,7 +237,7 @@ extern RestrictInfo *build_implied_join_equality(Oid opno,
 							Expr *item2,
 							Relids qualscope,
 							Relids nullable_relids);
-extern bool is_restrictinfo_hashjoinable(RestrictInfo *restrictinfo);
+extern bool has_redistributable_clause(RestrictInfo *restrictinfo);
 
 /*
  * prototypes for plan/setrefs.c

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -447,8 +447,35 @@ insert into SECO_t2 values(11 ,'2018-1-11'::timestamp);
 select * from SECO_t1 t1 full outer join SECO_t2 t2 on T1.id = T2.id and T1.field_dt = t2.field_tms;
  id |  field_dt  | id |        field_tms         
 ----+------------+----+--------------------------
- 10 | 01-10-2018 | 10 | Wed Jan 10 00:00:00 2018
  11 | 01-11-2018 | 11 | Thu Jan 11 00:00:00 2018
+ 10 | 01-10-2018 | 10 | Wed Jan 10 00:00:00 2018
+(2 rows)
+
+-- test float type
+set enable_nestloop to off;
+set enable_hashjoin to on;
+set enable_mergejoin to on;
+create table test_float1(id int, data float4)  DISTRIBUTED BY (data);
+create table test_float2(id int, data float8)  DISTRIBUTED BY (data);
+insert into test_float1 values(1, 10), (2, 20);
+insert into test_float2 values(3, 10), (4, 20);
+select t1.id, t1.data, t2.id, t2.data from test_float1 t1, test_float2 t2 where t1.data = t2.data;
+ id | data | id | data 
+----+------+----+------
+  1 |   10 |  3 |   10
+  2 |   20 |  4 |   20
+(2 rows)
+
+-- test int type
+create table test_int1(id int, data int4)  DISTRIBUTED BY (data);
+create table test_int2(id int, data int8)  DISTRIBUTED BY (data);
+insert into test_int1 values(1, 10), (2, 20);
+insert into test_int2 values(3, 10), (4, 20);
+select t1.id, t1.data, t2.id, t2.data from test_int1 t1, test_int2 t2 where t1.data = t2.data;
+ id | data | id | data 
+----+------+----+------
+  1 |   10 |  3 |   10
+  2 |   20 |  4 |   20
 (2 rows)
 
 -- Cleanup

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -408,6 +408,49 @@ SELECT count(*) FROM subdept;
     48
 (1 row)
 
+-- MPP-29458
+create table SECO_t1 (id  numeric(10,0) ,field_dt date) distributed by (id);
+create table SECO_t2 (id numeric(10,0),field_tms timestamp without time zone) distributed by (id,field_tms);
+insert into seco_t1 values(10 ,'2018-1-10');
+insert into seco_t1 values(11 ,'2018-1-11');
+insert into seco_t2 values(10 ,'2018-1-10'::timestamp);
+insert into seco_t2 values(11 ,'2018-1-11'::timestamp);
+-- Test nest loop redistribute keys
+set enable_nestloop to on;
+set enable_hashjoin to on;
+set enable_mergejoin to on;
+select count(*) from seco_t1 t1 ,seco_t2 t2 where T1.id = T2.id and T1.field_dt = t2.field_tms;
+ count 
+-------
+     2
+(1 row)
+
+-- Test hash join redistribute keys
+set enable_nestloop to off;
+set enable_hashjoin to on;
+set enable_mergejoin to on;
+select count(*) from seco_t1 t1 ,seco_t2 t2 where T1.id = T2.id and T1.field_dt = t2.field_tms;
+ count 
+-------
+     2
+(1 row)
+
+drop table SECO_t1;
+drop table SECO_t2;
+-- Test merge join redistribute keys
+create table SECO_t1 (id  numeric(10,0) ,field_dt date) distributed randomly;
+create table SECO_t2 (id numeric(10,0),field_tms timestamp without time zone) distributed by (field_tms);
+insert into SECO_t1 values(10 ,'2018-1-10');
+insert into SECO_t1 values(11 ,'2018-1-11');
+insert into SECO_t2 values(10 ,'2018-1-10'::timestamp);
+insert into SECO_t2 values(11 ,'2018-1-11'::timestamp);
+select * from SECO_t1 t1 full outer join SECO_t2 t2 on T1.id = T2.id and T1.field_dt = t2.field_tms;
+ id |  field_dt  | id |        field_tms         
+----+------------+----+--------------------------
+ 10 | 01-10-2018 | 10 | Wed Jan 10 00:00:00 2018
+ 11 | 01-11-2018 | 11 | Thu Jan 11 00:00:00 2018
+(2 rows)
+
 -- Cleanup
 set client_min_messages='warning'; -- silence drop-cascade NOTICEs
 drop schema pred cascade;

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -409,6 +409,9 @@ SELECT count(*) FROM subdept;
 (1 row)
 
 -- MPP-29458
+-- When we join on a clause with two different types. If one table distribute by one type, the query plan
+-- will redistribute data on another type. But the has values of two types would not be equal. The data will
+-- redistribute to wrong segments.
 create table SECO_t1 (id  numeric(10,0) ,field_dt date) distributed by (id);
 create table SECO_t2 (id numeric(10,0),field_tms timestamp without time zone) distributed by (id,field_tms);
 insert into seco_t1 values(10 ,'2018-1-10');

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -463,6 +463,33 @@ select * from SECO_t1 t1 full outer join SECO_t2 t2 on T1.id = T2.id and T1.fiel
  10 | 01-10-2018 | 10 | Wed Jan 10 00:00:00 2018
 (2 rows)
 
+-- test float type
+set enable_nestloop to off;
+set enable_hashjoin to on;
+set enable_mergejoin to on;
+create table test_float1(id int, data float4)  DISTRIBUTED BY (data);
+create table test_float2(id int, data float8)  DISTRIBUTED BY (data);
+insert into test_float1 values(1, 10), (2, 20);
+insert into test_float2 values(3, 10), (4, 20);
+select t1.id, t1.data, t2.id, t2.data from test_float1 t1, test_float2 t2 where t1.data = t2.data;
+ id | data | id | data 
+----+------+----+------
+  1 |   10 |  3 |   10
+  2 |   20 |  4 |   20
+(2 rows)
+
+-- test int type
+create table test_int1(id int, data int4)  DISTRIBUTED BY (data);
+create table test_int2(id int, data int8)  DISTRIBUTED BY (data);
+insert into test_int1 values(1, 10), (2, 20);
+insert into test_int2 values(3, 10), (4, 20);
+select t1.id, t1.data, t2.id, t2.data from test_int1 t1, test_int2 t2 where t1.data = t2.data;
+ id | data | id | data 
+----+------+----+------
+  1 |   10 |  3 |   10
+  2 |   20 |  4 |   20
+(2 rows)
+
 -- Cleanup
 set client_min_messages='warning'; -- silence drop-cascade NOTICEs
 drop schema pred cascade;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -420,6 +420,49 @@ SELECT count(*) FROM subdept;
     48
 (1 row)
 
+-- MPP-29458
+create table SECO_t1 (id  numeric(10,0) ,field_dt date) distributed by (id);
+create table SECO_t2 (id numeric(10,0),field_tms timestamp without time zone) distributed by (id,field_tms);
+insert into seco_t1 values(10 ,'2018-1-10');
+insert into seco_t1 values(11 ,'2018-1-11');
+insert into seco_t2 values(10 ,'2018-1-10'::timestamp);
+insert into seco_t2 values(11 ,'2018-1-11'::timestamp);
+-- Test nest loop redistribute keys
+set enable_nestloop to on;
+set enable_hashjoin to on;
+set enable_mergejoin to on;
+select count(*) from seco_t1 t1 ,seco_t2 t2 where T1.id = T2.id and T1.field_dt = t2.field_tms;
+ count 
+-------
+     2
+(1 row)
+
+-- Test hash join redistribute keys
+set enable_nestloop to off;
+set enable_hashjoin to on;
+set enable_mergejoin to on;
+select count(*) from seco_t1 t1 ,seco_t2 t2 where T1.id = T2.id and T1.field_dt = t2.field_tms;
+ count 
+-------
+     2
+(1 row)
+
+drop table SECO_t1;
+drop table SECO_t2;
+-- Test merge join redistribute keys
+create table SECO_t1 (id  numeric(10,0) ,field_dt date) distributed randomly;
+create table SECO_t2 (id numeric(10,0),field_tms timestamp without time zone) distributed by (field_tms);
+insert into SECO_t1 values(10 ,'2018-1-10');
+insert into SECO_t1 values(11 ,'2018-1-11');
+insert into SECO_t2 values(10 ,'2018-1-10'::timestamp);
+insert into SECO_t2 values(11 ,'2018-1-11'::timestamp);
+select * from SECO_t1 t1 full outer join SECO_t2 t2 on T1.id = T2.id and T1.field_dt = t2.field_tms;
+ id |  field_dt  | id |        field_tms         
+----+------------+----+--------------------------
+ 11 | 01-11-2018 | 11 | Thu Jan 11 00:00:00 2018
+ 10 | 01-10-2018 | 10 | Wed Jan 10 00:00:00 2018
+(2 rows)
+
 -- Cleanup
 set client_min_messages='warning'; -- silence drop-cascade NOTICEs
 drop schema pred cascade;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -421,6 +421,9 @@ SELECT count(*) FROM subdept;
 (1 row)
 
 -- MPP-29458
+-- When we join on a clause with two different types. If one table distribute by one type, the query plan
+-- will redistribute data on another type. But the has values of two types would not be equal. The data will
+-- redistribute to wrong segments.
 create table SECO_t1 (id  numeric(10,0) ,field_dt date) distributed by (id);
 create table SECO_t2 (id numeric(10,0),field_tms timestamp without time zone) distributed by (id,field_tms);
 insert into seco_t1 values(10 ,'2018-1-10');

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -269,6 +269,23 @@ insert into SECO_t2 values(11 ,'2018-1-11'::timestamp);
 
 select * from SECO_t1 t1 full outer join SECO_t2 t2 on T1.id = T2.id and T1.field_dt = t2.field_tms;
 
+-- test float type
+set enable_nestloop to off;
+set enable_hashjoin to on;
+set enable_mergejoin to on;
+create table test_float1(id int, data float4)  DISTRIBUTED BY (data);
+create table test_float2(id int, data float8)  DISTRIBUTED BY (data);
+insert into test_float1 values(1, 10), (2, 20);
+insert into test_float2 values(3, 10), (4, 20);
+select t1.id, t1.data, t2.id, t2.data from test_float1 t1, test_float2 t2 where t1.data = t2.data;
+
+-- test int type
+create table test_int1(id int, data int4)  DISTRIBUTED BY (data);
+create table test_int2(id int, data int8)  DISTRIBUTED BY (data);
+insert into test_int1 values(1, 10), (2, 20);
+insert into test_int2 values(3, 10), (4, 20);
+select t1.id, t1.data, t2.id, t2.data from test_int1 t1, test_int2 t2 where t1.data = t2.data;
+
 -- Cleanup
 set client_min_messages='warning'; -- silence drop-cascade NOTICEs
 drop schema pred cascade;

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -234,6 +234,9 @@ WITH RECURSIVE subdept(id, parent_department, name) AS
 SELECT count(*) FROM subdept;
 
 -- MPP-29458
+-- When we join on a clause with two different types. If one table distribute by one type, the query plan
+-- will redistribute data on another type. But the has values of two types would not be equal. The data will
+-- redistribute to wrong segments.
 create table SECO_t1 (id  numeric(10,0) ,field_dt date) distributed by (id);
 create table SECO_t2 (id numeric(10,0),field_tms timestamp without time zone) distributed by (id,field_tms);
 


### PR DESCRIPTION
After 8.4 merge, we have two restrictlist 'mergeclause_list'
and 'hashclause_list' in function 'add_paths_to_joinrel'. We
use mergeclause_list in cdb motion in hashjoin. But some of
keys should not been used as distribution keys.

We can use restrictinfo->hashjoinoperator to determine if
a RestrictInfo in mergeclause_list can be a redistribute
key. Considered there are different requirements for
RestrictInfo for redistribution and merge, We can make a
new function to make a cdbclause_list,rather than use
mergeclause_list as redistribute keys in merge and hash join.