### PR TITLE
Fix copy-pasto in 'rpt' test.

### DIFF
--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -110,7 +110,8 @@ create table bar (x int, y int) distributed randomly;
 -- success
 create unique index foo_idx on foo (y);
 -- should fail
-create unique index bar_idx on foo (y);
+create unique index bar_idx on bar (y);
+ERROR:  UNIQUE and DISTRIBUTED RANDOMLY are incompatible
 drop table if exists foo;
 drop table if exists bar;
 --

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -59,7 +59,7 @@ create table bar (x int, y int) distributed randomly;
 -- success
 create unique index foo_idx on foo (y);
 -- should fail
-create unique index bar_idx on foo (y);
+create unique index bar_idx on bar (y);
 
 drop table if exists foo;
 drop table if exists bar;


### PR DESCRIPTION
Surely the intention here was to create an index on 'foo' and 'bar' table,
not two indexes on 'foo'. Now the second CREATE UNIQUE INDEX fails, like
the comment says it should.