### PR TITLE
Backport a PG upstream patch to fix a panic related to that.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -344,16 +344,12 @@ transformStmt(ParseState *pstate, Node *parseTree)
  *		Returns true if a snapshot must be set before doing parse analysis
  *		on the given raw parse tree.
  *
- * Classification here should match transformStmt(); but we also have to
- * allow a NULL input (for Parse/Bind of an empty query string).
+ * Classification here should match transformStmt().
  */
 bool
 analyze_requires_snapshot(Node *parseTree)
 {
 	bool		result;
-
-	if (parseTree == NULL)
-		return false;
 
 	switch (nodeTag(parseTree))
 	{

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -2319,7 +2319,9 @@ exec_bind_message(StringInfo input_message)
 	 * functions might need it) or the query isn't a utility command (and
 	 * hence could require redoing parse analysis and planning).
 	 */
-	if (numParams > 0 || analyze_requires_snapshot(psrc->raw_parse_tree))
+	if (numParams > 0 ||
+		(psrc->raw_parse_tree &&
+		 analyze_requires_snapshot(psrc->raw_parse_tree)))
 	{
 		mySnapshot = CopySnapshot(GetTransactionSnapshot());
 		ActiveSnapshot = mySnapshot;

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -3146,7 +3146,7 @@ GetCommandLogLevel(Node *parsetree)
 
 				/* Look through an EXECUTE to the referenced stmt */
 				ps = FetchPreparedStatement(stmt->name, false);
-				if (ps)
+				if (ps && ps->plansource->raw_parse_tree)
 					lev = GetCommandLogLevel(ps->plansource->raw_parse_tree);
 				else
 					lev = LOGSTMT_ALL;

--- a/src/include/utils/plancache.h
+++ b/src/include/utils/plancache.h
@@ -48,7 +48,7 @@
  */
 typedef struct CachedPlanSource
 {
-	Node	   *raw_parse_tree; /* output of raw_parser() */
+	Node	   *raw_parse_tree; /* output of raw_parser(), or NULL */
 	char	   *query_string;	/* text of query, or NULL */
 	const char *commandTag;		/* command tag (a constant!), or NULL */
 	NodeTag		sourceTag;		/* GPDB: Original statement NodeTag */


### PR DESCRIPTION
One user encountered panic recently with stack backtrace as below,

\#2  <signal handler called>
\#3  transformStmt (pstate=pstate@entry=0x1464200, parseTree=parseTree@entry=0x0) at analyze.c:269
\#4  0x00000000005b5852 in parse_analyze (parseTree=parseTree@entry=0x0, sourceText=sourceText@entry=0x207c8c0 "",
    paramTypes=0x0, numParams=0) at analyze.c:166
\#5  0x000000000082cbc9 in pg_analyze_and_rewrite (parsetree=0x0, query_string=0x207c8c0 "",
    paramTypes=<optimized out>, numParams=<optimized out>) at postgres.c:811
\#6  0x000000000092a232 in RevalidateCachedPlanWithParams (plansource=plansource@entry=0x207c830,
    useResOwner=useResOwner@entry=0 '\000', boundParams=boundParams@entry=0x0, intoClause=intoClause@entry=0x0)
    at plancache.c:556
\#7  0x000000000092a462 in RevalidateCachedPlan (plansource=plansource@entry=0x207c830,
    useResOwner=useResOwner@entry=0 '\000') at plancache.c:665
\#8  0x0000000000828b1a in exec_bind_message (input_message=input_message@entry=0x7fff0c00a300) at postgres.c:2521
\#9  0x000000000082b935 in PostgresMain (argc=<optimized out>, argv=argv@entry=0x12e1bb0, dbname=<optimized out>,
    username=<optimized out>) at postgres.c:5309

While this issue is not reproducible so far but according to analysis
of code and core file, the root cause should be related to PG upstream patch
as below.

commit 677708032c4a4d37cdb2a4bd45726fc260308db7
Author: Tom Lane <tgl AT sss.pgh.pa.us>
Date:   Wed Nov 12 15:58:37 2014 -0500

    Explicitly support the case that a plancache's raw_parse_tree is NULL.

    This only happens if a client issues a Parse message with an empty query
    string, which is a bit odd; but since it is explicitly called out as legal
    by our FE/BE protocol spec, we'd probably better continue to allow it.

    Fix by adding tests everywhere that the raw_parse_tree field is passed to
    functions that don't or shouldn't accept NULL.  Also make it clear in the
    relevant comments that NULL is an expected case.

    This reverts commits a73c9dbab0165b3395dfe8a44a7dfd16166963c4 and
    2e9650cbcff8c8fb0d9ef807c73a44f241822eee, which fixed specific crash
    symptoms by hacking things at what now seems to be the wrong end, ie the
    callee functions.  Making the callees allow NULL is superficially more
    robust, but it's not always true that there is a defensible thing for the
    callee to do in such cases.  The caller has more context and is better
    able to decide what the empty-query case ought to do.

    Per followup discussion of bug #11335.  Back-patch to 9.2.  The code
    before that is sufficiently different that it would require development
    of a separate patch, which doesn't seem worthwhile for what is believed
    to be an essentially cosmetic change.