### PR TITLE
Add error parsing for Alien warnings.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -523,6 +523,8 @@ class ValidateInstallPackage(Operation):
                     package_name = line.split()[1]
                     rpm_name = "%s.rpm" % package_name
                     rpm_set.remove(rpm_name)
+                # skip extra warnings given by alien--until gppkg supports installing .deb packages, we
+                # need this to be able to install Greenplum rpms on Ubuntu
                 elif 'rpm should not be used directly install rpm packages, use alien instead!' in line.lower():
                     pass
                 elif 'however assuming you know what you are doing' in line.lower():

--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -523,6 +523,10 @@ class ValidateInstallPackage(Operation):
                     package_name = line.split()[1]
                     rpm_name = "%s.rpm" % package_name
                     rpm_set.remove(rpm_name)
+                elif 'RPM should not be used directly install RPM packages, use Alien instead!' in line.lower():
+                    pass
+                elif 'However assuming you know what you are doing' in line.lower():
+                    pass
                 else:
                     # This is unexpected, so bubble up the ExecutionError.
                     raise

--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -523,9 +523,9 @@ class ValidateInstallPackage(Operation):
                     package_name = line.split()[1]
                     rpm_name = "%s.rpm" % package_name
                     rpm_set.remove(rpm_name)
-                elif 'RPM should not be used directly install RPM packages, use Alien instead!' in line.lower():
+                elif 'rpm should not be used directly install rpm packages, use alien instead!' in line.lower():
                     pass
-                elif 'However assuming you know what you are doing' in line.lower():
+                elif 'however assuming you know what you are doing' in line.lower():
                     pass
                 else:
                     # This is unexpected, so bubble up the ExecutionError.


### PR DESCRIPTION
When we use alien to install gppkg files on Ubuntu, we see two
additional lines in the error log even though the operation seems to be
successful. This PR skips those lines (similar to the case for 'already
installed' lines).

This change is needed to support installing any gppkg on Ubuntu.

Co-authored-by: Orhan Kislal <okislal@pivotal.io>