### PR TITLE
Should use op_righttype in ExecIndexBuildScanKeys().

### DIFF
--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -979,8 +979,7 @@ ExecIndexBuildScanKeys(PlanState *planstate, Relation index,
 									   flags,
 									   varattno,		/* attribute number */
 									   op_strategy,		/* op's strategy */
-									   /* GPDB_91_MERGE_FIXME: why do we use op_lefttype here, when upstream uses op_righttype? */
-									   op_lefttype,		/* strategy subtype */
+									   op_righttype,	/* strategy subtype */
 									   inputcollation,	/* collation */
 									   opfuncid,		/* reg proc to use */
 									   scanvalue);		/* constant */


### PR DESCRIPTION
This removes a GPDB_91_MERGE_FIXME. The delivered value/argument
is from the right-hand so type should be also right-hand.