### PR TITLE
Support bitmap index for 'unlogged' table

### DIFF
--- a/contrib/xlogdump/xlogdump_rmgr.c
+++ b/contrib/xlogdump/xlogdump_rmgr.c
@@ -1449,8 +1449,8 @@ print_rmgr_bitmap(XLogRecPtr cur, XLogRecord *record, uint8 info)
 		{
 			xl_bm_lovitem	*xlrec = (xl_bm_lovitem *) XLogRecGetData(record);
 			snprintf(buf, sizeof(buf),
-				"bitmap insert lov item: s/d/r:%u/%u/%u lov_block:%u, lov_off:%u, lov_isnew:%u",
-				xlrec->bm_node.spcNode, xlrec->bm_node.dbNode, xlrec->bm_node.relNode,
+				"bitmap insert lov item: s/d/r:%u/%u/%u fork:%u, lov_block:%u, lov_off:%u, lov_isnew:%u",
+				xlrec->bm_node.spcNode, xlrec->bm_node.dbNode, xlrec->bm_node.relNode, xlrec->bm_fork,
 				xlrec->bm_lov_blkno, xlrec->bm_lov_offset, xlrec->bm_is_new_lov_blkno);
 			break;
 		}
@@ -1459,8 +1459,8 @@ print_rmgr_bitmap(XLogRecPtr cur, XLogRecord *record, uint8 info)
 		{
 			xl_bm_metapage	*xlrec = (xl_bm_metapage *) XLogRecGetData(record);
 			snprintf(buf, sizeof(buf),
-				"bitmap insert meta: s/d/r:%u/%u/%u heap:%u, index:%u, last_lov:%u",
-				xlrec->bm_node.spcNode, xlrec->bm_node.dbNode, xlrec->bm_node.relNode,
+				"bitmap insert meta: s/d/r:%u/%u/%u fork: %u, heap:%u, index:%u, last_lov:%u",
+				xlrec->bm_node.spcNode, xlrec->bm_node.dbNode, xlrec->bm_node.relNode, xlrec->bm_fork,
 				xlrec->bm_lov_heapId, xlrec->bm_lov_indexId, xlrec->bm_lov_lastpage);
 			break;
 		}

--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -81,8 +81,8 @@ bmbuild(PG_FUNCTION_ARGS)
 
 	tupDesc = RelationGetDescr(index);
 
-	/* initialize the bitmap index. */
-	_bitmap_init(index, RelationNeedsWAL(index));
+	/* initialize the bitmap index for MAIN_FORKNUM. */
+	_bitmap_init(index, RelationNeedsWAL(index), false);
 
 	/* initialize the build state. */
 	_bitmap_init_buildstate(index, &bmstate);
@@ -108,7 +108,10 @@ bmbuild(PG_FUNCTION_ARGS)
 Datum
 bmbuildempty(PG_FUNCTION_ARGS)
 {
-	elog(ERROR, "GPDB_91_MERGE_FIXME: bmbuildempty not implemented");
+	Relation indexrel = (Relation) PG_GETARG_POINTER(0);
+	/* initialize meta page and first LOV page for INIT_FORKNUM */
+	_bitmap_init(indexrel, true, true);
+	PG_RETURN_VOID();
 }
 
 /*

--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -1603,7 +1603,7 @@ create_lovitem(Relation rel, Buffer metabuf, uint64 tidnum,
 				RelationGetRelationName(rel))));
 
 	if(use_wal)
-		_bitmap_log_lovitem(rel, currLovBuffer, *lovOffsetP, lovitem,
+		_bitmap_log_lovitem(rel, MAIN_FORKNUM, currLovBuffer, *lovOffsetP, lovitem,
 							metabuf, is_new_lov_blkno);
 
 	END_CRIT_SECTION();

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -829,7 +829,7 @@ _bitmap_log_newpage(Relation rel, uint8 info, Buffer buf)
  * _bitmap_log_metapage() -- log the changes to the metapage
  */
 void
-_bitmap_log_metapage(Relation rel, Page page)
+_bitmap_log_metapage(Relation rel, ForkNumber fork, Page page)
 {
 	BMMetaPage metapage = (BMMetaPage) PageGetContents(page);
 
@@ -840,6 +840,7 @@ _bitmap_log_metapage(Relation rel, Page page)
 	xlMeta = (xl_bm_metapage *)
 		palloc(MAXALIGN(sizeof(xl_bm_metapage)));
 	xlMeta->bm_node = rel->rd_node;
+	xlMeta->bm_fork = fork;
 	xlMeta->bm_lov_heapId = metapage->bm_lov_heapId;
 	xlMeta->bm_lov_indexId = metapage->bm_lov_indexId;
 	xlMeta->bm_lov_lastpage = metapage->bm_lov_lastpage;
@@ -890,7 +891,7 @@ _bitmap_log_bitmap_lastwords(Relation rel, Buffer lovBuffer,
  * _bitmap_log_lovitem() -- log adding a new lov item to a lov page.
  */
 void
-_bitmap_log_lovitem(Relation rel, Buffer lovBuffer, OffsetNumber offset,
+_bitmap_log_lovitem(Relation rel, ForkNumber fork, Buffer lovBuffer, OffsetNumber offset,
 					BMLOVItem lovItem, Buffer metabuf, bool is_new_lov_blkno)
 {
 	Page lovPage = BufferGetPage(lovBuffer);
@@ -902,6 +903,7 @@ _bitmap_log_lovitem(Relation rel, Buffer lovBuffer, OffsetNumber offset,
 	Assert(BufferGetBlockNumber(lovBuffer) > 0);
 
 	xlLovItem.bm_node = rel->rd_node;
+	xlLovItem.bm_fork = fork;
 	xlLovItem.bm_lov_blkno = BufferGetBlockNumber(lovBuffer);
 	xlLovItem.bm_lov_offset = offset;
 	memcpy(&(xlLovItem.bm_lovItem), lovItem, sizeof(BMLOVItemData));

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -220,6 +220,7 @@ btbuildempty(PG_FUNCTION_ARGS)
 	_bt_initmetapage(metapage, P_NONE, 0);
 
 	/* Write the page.	If archiving/streaming, XLOG it. */
+	PageSetChecksumInplace(metapage, BTREE_METAPAGE);
 	smgrwrite(index->rd_smgr, INIT_FORKNUM, BTREE_METAPAGE,
 			  (char *) metapage, true);
 	if (XLogIsNeeded())

--- a/src/backend/access/spgist/spginsert.c
+++ b/src/backend/access/spgist/spginsert.c
@@ -152,6 +152,7 @@ spgbuildempty(PG_FUNCTION_ARGS)
 	SpGistInitMetapage(page);
 
 	/* Write the page.	If archiving/streaming, XLOG it. */
+	PageSetChecksumInplace(page, SPGIST_METAPAGE_BLKNO);
 	smgrwrite(index->rd_smgr, INIT_FORKNUM, SPGIST_METAPAGE_BLKNO,
 			  (char *) page, true);
 	if (XLogIsNeeded())
@@ -161,6 +162,7 @@ spgbuildempty(PG_FUNCTION_ARGS)
 	/* Likewise for the root page. */
 	SpGistInitPage(page, SPGIST_LEAF);
 
+	PageSetChecksumInplace(page, SPGIST_ROOT_BLKNO);
 	smgrwrite(index->rd_smgr, INIT_FORKNUM, SPGIST_ROOT_BLKNO,
 			  (char *) page, true);
 	if (XLogIsNeeded())
@@ -170,6 +172,7 @@ spgbuildempty(PG_FUNCTION_ARGS)
 	/* Likewise for the null-tuples root page. */
 	SpGistInitPage(page, SPGIST_LEAF | SPGIST_NULLS);
 
+	PageSetChecksumInplace(page, SPGIST_NULL_BLKNO);
 	smgrwrite(index->rd_smgr, INIT_FORKNUM, SPGIST_NULL_BLKNO,
 			  (char *) page, true);
 	if (XLogIsNeeded())

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -916,10 +916,15 @@ BufferAlloc(SMgrRelation smgr, char relpersistence, ForkNumber forkNum,
 	 * paranoia.  We also reset the usage_count since any recency of use of
 	 * the old content is no longer relevant.  (The usage_count starts out at
 	 * 1 so that the buffer can survive one clock-sweep pass.)
+	 *
+	 * Make sure BM_PERMANENT is set for buffers that must be written at every
+	 * checkpoint.  Unlogged buffers only need to be written at shutdown
+	 * checkpoints, except for their "init" forks, which need to be treated
+	 * just like permanent relations.
 	 */
 	buf->tag = newTag;
 	buf->flags &= ~(BM_VALID | BM_DIRTY | BM_JUST_DIRTIED | BM_CHECKPOINT_NEEDED | BM_IO_ERROR | BM_PERMANENT | BM_TEMP);
-	if (relpersistence == RELPERSISTENCE_PERMANENT)
+	if (relpersistence == RELPERSISTENCE_PERMANENT || forkNum == INIT_FORKNUM)
 		buf->flags |= BM_TAG_VALID | BM_PERMANENT;
 	else if (relpersistence == RELPERSISTENCE_TEMP)
 		buf->flags |= BM_TAG_VALID | BM_TEMP;

--- a/src/include/access/bitmap.h
+++ b/src/include/access/bitmap.h
@@ -673,6 +673,7 @@ typedef struct xl_bm_updateword
 typedef struct xl_bm_lovitem
 {
 	RelFileNode 	bm_node;
+	ForkNumber		bm_fork;
 
 	BlockNumber		bm_lov_blkno;
 	OffsetNumber	bm_lov_offset;
@@ -727,6 +728,7 @@ typedef struct xl_bm_bitmap_lastwords
 typedef struct xl_bm_metapage
 {
 	RelFileNode 	bm_node;
+	ForkNumber		bm_fork;
 	Oid				bm_lov_heapId;		/* the relation id for the heap */
 	Oid				bm_lov_indexId;		/* the relation id for the index */
 	/* the block number for the last LOV pages. */
@@ -758,7 +760,7 @@ extern void _bitmap_init_lovpage(Relation rel, Buffer buf);
 extern void _bitmap_init_bitmappage(Relation rel, Buffer buf);
 extern void _bitmap_init_buildstate(Relation index, BMBuildState* bmstate);
 extern void _bitmap_cleanup_buildstate(Relation index, BMBuildState* bmstate);
-extern void _bitmap_init(Relation indexrel, bool use_wal);
+extern void _bitmap_init(Relation indexrel, bool use_wal, bool for_empty);
 
 /* bitmapinsert.c */
 extern void _bitmap_buildinsert(Relation rel, ItemPointerData ht_ctid, 
@@ -799,10 +801,10 @@ extern void _bitmap_union(BMBatchWords **batches, uint32 numBatches,
 					   BMBatchWords *result);
 extern void _bitmap_begin_iterate(BMBatchWords *words, BMIterateResult *result);
 extern void _bitmap_log_newpage(Relation rel, uint8 info, Buffer buf);
-extern void _bitmap_log_metapage(Relation rel, Page page);
+extern void _bitmap_log_metapage(Relation rel, ForkNumber fork, Page page);
 extern void _bitmap_log_bitmap_lastwords(Relation rel, Buffer lovBuffer,
 									 OffsetNumber lovOffset, BMLOVItem lovItem);
-extern void _bitmap_log_lovitem	(Relation rel, Buffer lovBuffer,
+extern void _bitmap_log_lovitem	(Relation rel, ForkNumber fork, Buffer lovBuffer,
 								 OffsetNumber offset, BMLOVItem lovItem,
 								 Buffer metabuf,  bool is_new_lov_blkno);
 extern void _bitmap_log_bitmapwords(Relation rel, Buffer bitmapBuffer, Buffer lovBuffer,

--- a/src/include/storage/buf_internals.h
+++ b/src/include/storage/buf_internals.h
@@ -39,7 +39,7 @@
 #define BM_PIN_COUNT_WAITER		(1 << 6)		/* have waiter for sole pin */
 #define BM_CHECKPOINT_NEEDED	(1 << 7)		/* must write for checkpoint */
 #define BM_PERMANENT			(1 << 8)		/* permanent relation (neither
-												 * unlogged or temporary) */
+												 * unlogged, or init fork) */
 #define BM_TEMP					(1 << 9)		/* temporary relation */
 
 typedef bits16 BufFlags;

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -548,4 +548,32 @@ select * from oversize_test where c1 < 'z';
 drop index oversize_test_idx;
 insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
 CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
-ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 172.17.0.2:25434 pid=390371)
+--
+-- Test unlogged table
+--
+set enable_seqscan=off;
+set enable_indexscan=on;
+set optimizer_enable_bitmapscan=on;
+create unlogged table unlogged_test(c1 int); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into unlogged_test select * from generate_series(1,1000);
+CREATE INDEX unlogged_test_idx ON unlogged_test USING BITMAP (c1);
+analyze unlogged_test;
+explain select * from unlogged_test where c1 = 100;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..200.45 rows=1 width=4)
+   ->  Index Scan using unlogged_test_idx on unlogged_test  (cost=0.00..200.45 rows=1 width=4)
+         Index Cond: c1 = 100
+ Optimizer: legacy query optimizer
+(4 rows)
+
+select * from unlogged_test where c1 = 100;
+ c1  
+-----
+ 100
+(1 row)
+
+drop table unlogged_test;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -548,4 +548,34 @@ select * from oversize_test where c1 < 'z';
 drop index oversize_test_idx;
 insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
 CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
-ERROR:  row is too big: size 33256, maximum size 32736  (seg2 127.0.0.1:40002 pid=5270)
+ERROR:  row is too big: size 33256, maximum size 32736  (seg2 172.17.0.2:25434 pid=391078)
+--
+-- Test unlogged table
+--
+set enable_seqscan=off;
+set enable_indexscan=on;
+set optimizer_enable_bitmapscan=on;
+create unlogged table unlogged_test(c1 int); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into unlogged_test select * from generate_series(1,1000);
+CREATE INDEX unlogged_test_idx ON unlogged_test USING BITMAP (c1);
+analyze unlogged_test;
+explain select * from unlogged_test where c1 = 100;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..204.38 rows=1 width=4)
+   ->  Bitmap Table Scan on unlogged_test  (cost=0.00..204.38 rows=1 width=4)
+         Recheck Cond: c1 = 100
+         ->  Bitmap Index Scan on unlogged_test_idx  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: c1 = 100
+ Optimizer: PQO version 2.70.0
+(6 rows)
+
+select * from unlogged_test where c1 = 100;
+ c1  
+-----
+ 100
+(1 row)
+
+drop table unlogged_test;

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -235,3 +235,18 @@ select * from oversize_test where c1 < 'z';
 drop index oversize_test_idx;
 insert into oversize_test values (array_to_string(array(select generate_series(1, 10000)), '123456789'));
 CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
+
+
+--
+-- Test unlogged table
+--
+set enable_seqscan=off;
+set enable_indexscan=on;
+set optimizer_enable_bitmapscan=on;
+create unlogged table unlogged_test(c1 int); 
+insert into unlogged_test select * from generate_series(1,1000);
+CREATE INDEX unlogged_test_idx ON unlogged_test USING BITMAP (c1);
+analyze unlogged_test;
+explain select * from unlogged_test where c1 = 100;
+select * from unlogged_test where c1 = 100;
+drop table unlogged_test;


### PR DESCRIPTION
- Implement bmbuildempty() to support bitmap index for 'unlogged' table
- Cherry-pick 6bd781 
- Fix checksum issue for btree and spg index on 'unlogged' table

Co-authored-by: Alexandra Wang <lewang@pivotal.io>
Co-authored-by: Gang Xiong <gxiong@pivotal.io>