### PR TITLE
Inferring quals on left outer joins incorrectly

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -123,7 +123,6 @@ gen_implied_qual(PlannerInfo *root,
 	Relids		new_qualscope;
 	ListCell   *lc;
 	RestrictInfo *new_rinfo;
-	Relids		required_relids;
 
 	/* Expression types must match */
 	Assert(exprType(old_expr) == exprType(new_expr)
@@ -172,13 +171,11 @@ gen_implied_qual(PlannerInfo *root,
 	 * equivalence class machinery, because it's derived from a clause that
 	 * wasn't either.
 	 */
-	required_relids = bms_union(new_qualscope, old_rinfo->ojscope_relids);
-
 	new_rinfo = make_restrictinfo((Expr *) new_clause,
 								  old_rinfo->is_pushed_down,
 								  old_rinfo->outerjoin_delayed,
 								  old_rinfo->pseudoconstant,
-								  required_relids,
+								  new_qualscope,
 								  old_rinfo->outer_relids, /* GPDB_92_MERGE_FIXME */
 								  old_rinfo->nullable_relids,
 								  old_rinfo->ojscope_relids);
@@ -197,7 +194,7 @@ gen_implied_qual(PlannerInfo *root,
 										   PVC_RECURSE_AGGREGATES,
 										   PVC_INCLUDE_PLACEHOLDERS);
 
-		add_vars_to_targetlist(root, vars, required_relids, false);
+		add_vars_to_targetlist(root, vars, new_qualscope, false);
 		list_free(vars);
 	}
 

--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -150,7 +150,7 @@ gen_implied_qual(PlannerInfo *root,
 		return;
 
 	/* No inferences may be performed across an outer join */
-	if (old_rinfo->ojscope_relids && !bms_is_subset(new_qualscope, old_rinfo->ojscope_relids))
+	if (old_rinfo->ojscope_relids)
 		return;
 
 	/*

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3066,3 +3066,60 @@ full outer join fjtest_c on (s.aid = cid);
      |     |   4
 (4 rows)
 
+-- Do not push down any implied predicates to the Left Outer Join
+DROP TABLE IF EXISTS member;
+DROP TABLE IF EXISTS member_group;
+DROP TABLE IF EXISTS member_subgroup;
+DROP TABLE IF EXISTS region;
+CREATE TABLE member(member_id int NOT NULL, group_id int NOT NULL) DISTRIBUTED BY(member_id);
+CREATE TABLE member_group(group_id int NOT NULL) DISTRIBUTED BY(group_id);
+CREATE TABLE region(region_id char(4), county_name varchar(25)) DISTRIBUTED BY(region_id);
+CREATE TABLE member_subgroup(subgroup_id int NOT NULL, group_id int NOT NULL, subgroup_name text) DISTRIBUTED RANDOMLY;
+INSERT INTO region SELECT i, i FROM generate_series(1, 200) i;
+INSERT INTO member_group SELECT i FROM generate_series(1, 15) i;
+INSERT INTO member SELECT i, i%15 FROM generate_series(1, 10000) i;
+--start_ignore
+ANALYZE member;
+ANALYZE member_group;
+ANALYZE region;
+ANALYZE member_subgroup;
+--end_ignore
+EXPLAIN SELECT member.member_id
+FROM member
+INNER JOIN member_group
+ON member.group_id = member_group.group_id
+INNER JOIN member_subgroup
+ON member_group.group_id = member_subgroup.group_id
+LEFT OUTER JOIN region
+ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=16.08..166.18 rows=14 width=4)
+   ->  Hash Left Join  (cost=16.08..166.18 rows=5 width=4)
+         Hash Cond: member_subgroup.subgroup_name = region.county_name::text
+         Join Filter: member_group."group_id" = ANY ('{12,13,14,15}'::integer[])
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=4.58..154.48 rows=5 width=40)
+               Hash Key: member_subgroup.subgroup_name
+               ->  Hash Join  (cost=4.58..154.21 rows=5 width=40)
+                     Hash Cond: member."group_id" = member_group."group_id"
+                     ->  Seq Scan on member  (cost=0.00..112.00 rows=3334 width=8)
+                     ->  Hash  (cost=4.43..4.43 rows=4 width=40)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.03..4.43 rows=4 width=40)
+                                 ->  Hash Join  (cost=1.03..4.28 rows=2 width=40)
+                                       Hash Cond: member_group."group_id" = member_subgroup."group_id"
+                                       ->  Seq Scan on member_group  (cost=0.00..3.15 rows=5 width=4)
+                                       ->  Hash  (cost=1.02..1.02 rows=1 width=36)
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=36)
+                                                   Hash Key: member_subgroup."group_id"
+                                                   ->  Seq Scan on member_subgroup  (cost=0.00..1.00 rows=1 width=36)
+         ->  Hash  (cost=9.00..9.00 rows=67 width=3)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..9.00 rows=67 width=3)
+                     Hash Key: region.county_name
+                     ->  Seq Scan on region  (cost=0.00..5.00 rows=67 width=3)
+ Optimizer: legacy query optimizer
+(23 rows)
+
+DROP TABLE member;
+DROP TABLE member_group;
+DROP TABLE member_subgroup;
+DROP TABLE region;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3084,7 +3084,7 @@ ANALYZE member_group;
 ANALYZE region;
 ANALYZE member_subgroup;
 --end_ignore
-EXPLAIN SELECT member.member_id
+EXPLAIN(COSTS OFF) SELECT member.member_id
 FROM member
 INNER JOIN member_group
 ON member.group_id = member_group.group_id
@@ -3094,28 +3094,28 @@ LEFT OUTER JOIN region
 ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=16.08..166.18 rows=14 width=4)
-   ->  Hash Left Join  (cost=16.08..166.18 rows=5 width=4)
+ Gather Motion 3:1  (slice5; segments: 3)
+   ->  Hash Left Join
          Hash Cond: member_subgroup.subgroup_name = region.county_name::text
          Join Filter: member_group."group_id" = ANY ('{12,13,14,15}'::integer[])
-         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=4.58..154.48 rows=5 width=40)
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)
                Hash Key: member_subgroup.subgroup_name
-               ->  Hash Join  (cost=4.58..154.21 rows=5 width=40)
+               ->  Hash Join
                      Hash Cond: member."group_id" = member_group."group_id"
-                     ->  Seq Scan on member  (cost=0.00..112.00 rows=3334 width=8)
-                     ->  Hash  (cost=4.43..4.43 rows=4 width=40)
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.03..4.43 rows=4 width=40)
-                                 ->  Hash Join  (cost=1.03..4.28 rows=2 width=40)
+                     ->  Seq Scan on member
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  Hash Join
                                        Hash Cond: member_group."group_id" = member_subgroup."group_id"
-                                       ->  Seq Scan on member_group  (cost=0.00..3.15 rows=5 width=4)
-                                       ->  Hash  (cost=1.02..1.02 rows=1 width=36)
-                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=36)
+                                       ->  Seq Scan on member_group
+                                       ->  Hash
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                                    Hash Key: member_subgroup."group_id"
-                                                   ->  Seq Scan on member_subgroup  (cost=0.00..1.00 rows=1 width=36)
-         ->  Hash  (cost=9.00..9.00 rows=67 width=3)
-               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..9.00 rows=67 width=3)
+                                                   ->  Seq Scan on member_subgroup
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)
                      Hash Key: region.county_name
-                     ->  Seq Scan on region  (cost=0.00..5.00 rows=67 width=3)
+                     ->  Seq Scan on region
  Optimizer: legacy query optimizer
 (23 rows)
 

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3084,7 +3084,7 @@ ANALYZE member_group;
 ANALYZE region;
 ANALYZE member_subgroup;
 --end_ignore
-EXPLAIN SELECT member.member_id
+EXPLAIN(COSTS OFF) SELECT member.member_id
 FROM member
 INNER JOIN member_group
 ON member.group_id = member_group.group_id
@@ -3094,28 +3094,28 @@ LEFT OUTER JOIN region
 ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1724.73 rows=1 width=4)
-   ->  Hash Left Join  (cost=0.00..1724.73 rows=1 width=4)
+ Gather Motion 3:1  (slice5; segments: 3)
+   ->  Hash Left Join
          Hash Cond: member_subgroup.subgroup_name = region.county_name::text
          Join Filter: member_group."group_id" = ANY ('{12,13,14,15}'::integer[])
-         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1293.72 rows=1 width=16)
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)
                Hash Key: member_subgroup.subgroup_name
-               ->  Hash Join  (cost=0.00..1293.72 rows=1 width=16)
+               ->  Hash Join
                      Hash Cond: member."group_id" = member_group."group_id" AND member_subgroup."group_id" = member_group."group_id"
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.72 rows=1 width=20)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: member."group_id"
-                           ->  Hash Join  (cost=0.00..862.72 rows=1 width=20)
+                           ->  Hash Join
                                  Hash Cond: member."group_id" = member_subgroup."group_id"
-                                 ->  Table Scan on member  (cost=0.00..431.07 rows=3334 width=8)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-                                             ->  Table Scan on member_subgroup  (cost=0.00..431.00 rows=1 width=12)
-                     ->  Hash  (cost=431.00..431.00 rows=5 width=4)
-                           ->  Table Scan on member_group  (cost=0.00..431.00 rows=5 width=4)
-         ->  Hash  (cost=431.00..431.00 rows=67 width=3)
-               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=67 width=3)
+                                 ->  Table Scan on member
+                                 ->  Hash
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                             ->  Table Scan on member_subgroup
+                     ->  Hash
+                           ->  Table Scan on member_group
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)
                      Hash Key: region.county_name::text
-                     ->  Table Scan on region  (cost=0.00..431.00 rows=67 width=3)
+                     ->  Table Scan on region
  Optimizer: PQO version 2.69.0
 (23 rows)
 

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3066,3 +3066,60 @@ full outer join fjtest_c on (s.aid = cid);
      |     |   4
 (4 rows)
 
+-- Do not push down any implied predicates to the Left Outer Join
+DROP TABLE IF EXISTS member;
+DROP TABLE IF EXISTS member_group;
+DROP TABLE IF EXISTS member_subgroup;
+DROP TABLE IF EXISTS region;
+CREATE TABLE member(member_id int NOT NULL, group_id int NOT NULL) DISTRIBUTED BY(member_id);
+CREATE TABLE member_group(group_id int NOT NULL) DISTRIBUTED BY(group_id);
+CREATE TABLE region(region_id char(4), county_name varchar(25)) DISTRIBUTED BY(region_id);
+CREATE TABLE member_subgroup(subgroup_id int NOT NULL, group_id int NOT NULL, subgroup_name text) DISTRIBUTED RANDOMLY;
+INSERT INTO region SELECT i, i FROM generate_series(1, 200) i;
+INSERT INTO member_group SELECT i FROM generate_series(1, 15) i;
+INSERT INTO member SELECT i, i%15 FROM generate_series(1, 10000) i;
+--start_ignore
+ANALYZE member;
+ANALYZE member_group;
+ANALYZE region;
+ANALYZE member_subgroup;
+--end_ignore
+EXPLAIN SELECT member.member_id
+FROM member
+INNER JOIN member_group
+ON member.group_id = member_group.group_id
+INNER JOIN member_subgroup
+ON member_group.group_id = member_subgroup.group_id
+LEFT OUTER JOIN region
+ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1724.73 rows=1 width=4)
+   ->  Hash Left Join  (cost=0.00..1724.73 rows=1 width=4)
+         Hash Cond: member_subgroup.subgroup_name = region.county_name::text
+         Join Filter: member_group."group_id" = ANY ('{12,13,14,15}'::integer[])
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1293.72 rows=1 width=16)
+               Hash Key: member_subgroup.subgroup_name
+               ->  Hash Join  (cost=0.00..1293.72 rows=1 width=16)
+                     Hash Cond: member."group_id" = member_group."group_id" AND member_subgroup."group_id" = member_group."group_id"
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.72 rows=1 width=20)
+                           Hash Key: member."group_id"
+                           ->  Hash Join  (cost=0.00..862.72 rows=1 width=20)
+                                 Hash Cond: member."group_id" = member_subgroup."group_id"
+                                 ->  Table Scan on member  (cost=0.00..431.07 rows=3334 width=8)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                             ->  Table Scan on member_subgroup  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Hash  (cost=431.00..431.00 rows=5 width=4)
+                           ->  Table Scan on member_group  (cost=0.00..431.00 rows=5 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=67 width=3)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=67 width=3)
+                     Hash Key: region.county_name::text
+                     ->  Table Scan on region  (cost=0.00..431.00 rows=67 width=3)
+ Optimizer: PQO version 2.69.0
+(23 rows)
+
+DROP TABLE member;
+DROP TABLE member_group;
+DROP TABLE member_subgroup;
+DROP TABLE region;

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -213,7 +213,7 @@ ANALYZE member_group;
 ANALYZE region;
 ANALYZE member_subgroup;
 --end_ignore
-EXPLAIN SELECT member.member_id
+EXPLAIN(COSTS OFF) SELECT member.member_id
 FROM member
 INNER JOIN member_group
 ON member.group_id = member_group.group_id


### PR DESCRIPTION
The function `generate_implied_quals` was inferring quals and trying
to push them down inside the non Nullable side of the LEFT OUTER JOIN
and that behavior was incorrect. This was bubbling up in the following
error while trying to set join references(`set_join_references`):
`ERROR: variable not found in subplan target lists (setrefs.c:2085)`

This commit check if it is an outer join and if so will not try to infer
any predicates