### PR TITLE
Fix gpperfmon bug that ATExecSetDistributedBy statement produce wrong tsubmit

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -12019,6 +12019,12 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 						untransformRelOptions(newOptions),
 						&tmprv,
 						useExistingColumnAttributes);
+
+		/*
+		 * bypass gpmon info collecting in following ExecutorStart
+		 * to be consistent with other alter table commands,
+		 * ALTER TABLE SET DISTRIBUTED BY should not be logged in gpperfmon.
+		 */
 		queryDesc->gpmon_pkt = NULL;
 
 		PG_TRY();

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -12019,6 +12019,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 						untransformRelOptions(newOptions),
 						&tmprv,
 						useExistingColumnAttributes);
+		queryDesc->gpmon_pkt = NULL;
 
 		PG_TRY();
 		{


### PR DESCRIPTION
Bypass gpmon start packet for ExecutorStart from ATExecSetDistributedBy,
make such kind of query no more record in gpperfmon.

Co-authored-by: Hao Wang <haowang@pivotal.io>
Co-authored-by: Wenlin Zhang <wzhang@pivotal.io>
Co-authored-by: Ru Yang <ruyang@pivotal.io>