### PR TITLE
resgroup: treat cpuset as -1 when it is missing in catalog.

### DIFF
--- a/concourse/scripts/ic_gpdb_resgroup.bash
+++ b/concourse/scripts/ic_gpdb_resgroup.bash
@@ -97,6 +97,8 @@ keep_minimal_cgroup_dirs() {
     ssh -t $gpdb_master_alias sudo bash -ex <<EOF
         rmdir $basedir/memory/gpdb/*/ || :
         rmdir $basedir/memory/gpdb
+        rmdir $basedir/cpuset/gpdb/*/ || :
+        rmdir $basedir/cpuset/gpdb
 EOF
 }
 

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -547,6 +547,9 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 
 	MemSet(resgroupCaps, 0, sizeof(ResGroupCaps));
 
+	/* Init cpuset with proper value */
+	strcpy(resgroupCaps->cpuset, DefaultCpuset);
+
 	ScanKeyInit(&key,
 				Anum_pg_resgroupcapability_resgroupid,
 				BTEqualStrategyNumber, F_OIDEQ,


### PR DESCRIPTION
When a resgroup rg1 is created on version 5.8 it has no cpuset setting
in pg_resgroupcapability.  If the cluster is then upgraded to a version
that supports the resgroup cpuset feature (5.9 for example), we will
notice that rg1's cpuset is "" instead of "-1", which stands for a empty
cpuset, thus we accidentally treat rg1's cpuset as non-empty, this will
cause rg1 can not be altered if the cpuset cgroup dir does not exist.

To fix the issue we should set rg1's cpuset to "-1" when it's missing in
pg_resgroupcapability.

Also changed the binary swap tests to remove the cpuset cgroup dir
before running the tests, so this issue could be triggered.

Co-Author: Jialun Du <jdu@pivotal.io>
Co-Author: Ning Yu <nyu@pivotal.io>