### PR TITLE
Introduce MRPOTECT_BUFFER flag to control shared buffer protection

### DIFF
--- a/src/backend/access/heap/visibilitymap.c
+++ b/src/backend/access/heap/visibilitymap.c
@@ -529,11 +529,30 @@ vm_readbuf(Relation rel, BlockNumber blkno, bool extend)
 	 * Use ZERO_ON_ERROR mode, and initialize the page if necessary. It's
 	 * always safe to clear bits, so it's better to clear corrupt pages than
 	 * error out.
+	 *
+	 * The initialize-the-page part is trickier than it looks, because of the
+	 * possibility of multiple backends doing this concurrently, and our
+	 * desire to not uselessly take the buffer lock in the normal path where
+	 * the page is OK.  We must take the lock to initialize the page, so
+	 * recheck page newness after we have the lock, in case someone else
+	 * already did it.  Also, because we initially check PageIsNew with no
+	 * lock, it's possible to fall through and return the buffer while someone
+	 * else is still initializing the page (i.e., we might see pd_upper as set
+	 * but other page header fields are still zeroes).  This is harmless for
+	 * callers that will take a buffer lock themselves, but some callers
+	 * inspect the page without any lock at all.  The latter is OK only so
+	 * long as it doesn't depend on the page header having correct contents.
+	 * Current usage is safe because PageGetContents() does not require that.
 	 */
 	buf = ReadBufferExtended(rel, VISIBILITYMAP_FORKNUM, blkno,
 							 RBM_ZERO_ON_ERROR, NULL);
 	if (PageIsNew(BufferGetPage(buf)))
-		PageInit(BufferGetPage(buf), BLCKSZ, 0);
+	{
+		LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
+		if (PageIsNew(BufferGetPage(buf)))
+			PageInit(BufferGetPage(buf), BLCKSZ, 0);
+		LockBuffer(buf, BUFFER_LOCK_UNLOCK);
+	}
 	return buf;
 }
 

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -33,7 +33,9 @@
 #include "postgres.h"
 
 #include <sys/file.h>
+#ifdef MPROTECT_BUFFERS
 #include <sys/mman.h>
+#endif
 #include <unistd.h>
 
 #include "catalog/catalog.h"
@@ -74,7 +76,6 @@
 
 
 /* GUC variables */
-bool        memory_protect_buffer_pool = true;
 bool		zero_damaged_pages = false;
 int			bgwriter_lru_maxpages = 100;
 double		bgwriter_lru_multiplier = 2.0;
@@ -120,69 +121,73 @@ static volatile BufferDesc *BufferAlloc(SMgrRelation smgr,
 static void FlushBuffer(volatile BufferDesc *buf, SMgrRelation reln);
 static void AtProcExit_Buffers(int code, Datum arg);
 
-
-#define ShouldMemoryProtect(buf) (ShouldMemoryProtectBufferPool() && ! BufferIsLocal(buf->buf_id+1) && ! BufferIsInvalid(buf->buf_id+1))
+#ifdef MPROTECT_BUFFERS
+#define ShouldMemoryProtect(buf) (IsUnderPostmaster &&		  \
+								  IsNormalProcessingMode() && \
+								  !BufferIsLocal(buf->buf_id+1) && \
+								  !BufferIsInvalid(buf->buf_id+1))
 
 static inline void BufferMProtect(volatile BufferDesc *bufHdr, int protectionLevel)
 {
-    if ( ShouldMemoryProtect(bufHdr))
-    {
-        if ( mprotect(BufHdrGetBlock(bufHdr), BLCKSZ, protectionLevel))
-        {
-            ereport(ERROR,
-                    (errmsg("Unable to set memory level to %d, error %d, block size %d, ptr %ld", protectionLevel,
-                    errno, BLCKSZ, (long int) BufHdrGetBlock(bufHdr))));
-        }
-    }
+	if (ShouldMemoryProtect(bufHdr))
+	{
+		if (mprotect(BufHdrGetBlock(bufHdr), BLCKSZ, protectionLevel))
+		{
+			ereport(ERROR,
+					(errmsg("unable to set memory level to %d, error %d, "
+							"block size %d, ptr %ld", protectionLevel,
+							errno, BLCKSZ, (long int) BufHdrGetBlock(bufHdr))));
+		}
+	}
+}
+#endif
+
+static inline void ReleaseContentLock(volatile BufferDesc *buf)
+{
+	LWLockRelease(buf->content_lock);
+
+#ifdef MPROTECT_BUFFERS
+	/* make the buffer read-only after releasing content lock */
+	if (!LWLockHeldByMe(buf->content_lock))
+		BufferMProtect(buf, PROT_READ);
+#endif
 }
 
-static inline void ReleaseContentLock( volatile BufferDesc *buf )
-{
-    LWLockRelease(buf->content_lock);
 
-    /**
-     * if last content lock released then reduce memory access level
-     */
-    if ( ShouldMemoryProtect(buf))
-    {
-        if ( ! LWLockHeldByMe(buf->content_lock))
-        {
-            BufferMProtect( buf, PROT_READ );
-        }
-    }
+static inline void AcquireContentLock(volatile BufferDesc *buf, LWLockMode mode)
+{
+#ifdef MPROTECT_BUFFERS
+	const bool newAcquisition =
+		!LWLockHeldByMe(buf->content_lock);
+
+	LWLockAcquire(buf->content_lock, mode);
+
+	/* new acquisition of content lock, allow read/write memory access */
+	if (newAcquisition)
+		BufferMProtect(buf, PROT_READ|PROT_WRITE);
+#else
+	LWLockAcquire(buf->content_lock, mode);
+#endif
 }
 
-static inline void AcquireContentLock( volatile BufferDesc *buf, LWLockMode mode)
+static inline bool ConditionalAcquireContentLock(volatile BufferDesc *buf,
+												 LWLockMode mode)
 {
-    const bool shouldChangeMemoryProtection = ShouldMemoryProtect(buf) && ! LWLockHeldByMe( buf->content_lock );
+#ifdef MPROTECT_BUFFERS
+	const bool newAcquisition =
+		!LWLockHeldByMe(buf->content_lock);
 
-    LWLockAcquire(buf->content_lock, mode);
-
-    if ( shouldChangeMemoryProtection )
-    {
-        /*
-         * first acquisition of lock...allow read/write memory access
-         */
-        BufferMProtect( buf, PROT_READ | PROT_WRITE );
-    }
-}
-
-static inline bool ConditionalAcquireContentLock( volatile BufferDesc *buf, LWLockMode mode)
-{
-    const bool shouldChangeMemoryProtection = ShouldMemoryProtect(buf) && ! LWLockHeldByMe( buf->content_lock );
-
-    if ( LWLockConditionalAcquire(buf->content_lock, mode))
-    {
-        if ( shouldChangeMemoryProtection )
-        {
-            /*
-             * first acquisition of lock...allow read/write memory access
-             */
-            BufferMProtect( buf, PROT_READ | PROT_WRITE );
-        }
-        return true;
-    }
-    else return false;
+	if (LWLockConditionalAcquire(buf->content_lock, mode))
+	{
+		/* new acquisition of lock, allow read/write memory access */
+		if (newAcquisition)
+			BufferMProtect( buf, PROT_READ | PROT_WRITE );
+		return true;
+	}
+	return false;
+#else
+	return LWLockConditionalAcquire(buf->content_lock, mode);
+#endif
 }
 
 /*
@@ -507,7 +512,9 @@ ReadBuffer_common(SMgrRelation smgr, char relpersistence, ForkNumber forkNum,
 
 	bufBlock = isLocalBuf ? LocalBufHdrGetBlock(bufHdr) : BufHdrGetBlock(bufHdr);
 
-    BufferMProtect( bufHdr, PROT_WRITE | PROT_READ );
+#ifdef MPROTECT_BUFFERS
+    BufferMProtect(bufHdr, PROT_WRITE | PROT_READ);
+#endif
 
 	if (isExtend)
 	{
@@ -564,7 +571,9 @@ ReadBuffer_common(SMgrRelation smgr, char relpersistence, ForkNumber forkNum,
 		}
 	}
 
+#ifdef MPROTECT_BUFFERS
     BufferMProtect( bufHdr, PROT_READ );
+#endif
 
 	if (isLocalBuf)
 	{
@@ -1195,7 +1204,9 @@ PinBuffer(volatile BufferDesc *buf, BufferAccessStrategy strategy)
 				buf->usage_count = 1;
 		}
 		result = (buf->flags & BM_VALID) != 0;
+#ifdef MPROTECT_BUFFERS
 		BufferMProtect(buf, PROT_READ);
+#endif
 		UnlockBufHdr(buf);
 	}
 	else
@@ -1231,7 +1242,9 @@ PinBuffer_Locked(volatile BufferDesc *buf)
 	if (PrivateRefCount[b] == 0)
     {
 		buf->refcount++;
+#ifdef MPROTECT_BUFFERS
 		BufferMProtect(buf, PROT_READ);
+#endif
     }
 	UnlockBufHdr(buf);
 	PrivateRefCount[b]++;
@@ -1270,7 +1283,9 @@ UnpinBuffer(volatile BufferDesc *buf, bool fixOwner)
 		/* Decrement the shared reference count */
 		Assert(buf->refcount > 0);
 		buf->refcount--;
+#ifdef MPROTECT_BUFFERS
 		BufferMProtect(buf, PROT_NONE);
+#endif
 
 		/* Support LockBufferForCleanup() */
 		if ((buf->flags & BM_PIN_COUNT_WAITER) &&
@@ -3130,7 +3145,9 @@ StartBufferIO(volatile BufferDesc *buf, bool forInput)
 	}
 
 	buf->flags |= BM_IO_IN_PROGRESS;
-
+#ifdef MPROTECT_BUFFERS
+    BufferMProtect(buf, forInput ? PROT_WRITE|PROT_READ : PROT_READ);
+#endif
 	UnlockBufHdr(buf);
 
 	InProgressBuf = buf;
@@ -3174,6 +3191,11 @@ TerminateBufferIO(volatile BufferDesc *buf, bool clear_dirty,
 
 	InProgressBuf = NULL;
 
+#ifdef MPROTECT_BUFFERS
+	/* XXX: should this be PROT_NONE if called from AbortBufferIO? */
+	if (!LWLockHeldByMe(buf->content_lock))
+		BufferMProtect(buf, PROT_READ);
+#endif
 	LWLockRelease(buf->io_in_progress_lock);
 }
 

--- a/src/backend/storage/freespace/freespace.c
+++ b/src/backend/storage/freespace/freespace.c
@@ -791,8 +791,17 @@ fsm_vacuum_page(Relation rel, FSMAddress addr, bool *eof_p)
 	 * pages, increasing the chances that a later vacuum can truncate the
 	 * relation.
 	 */
+#ifdef MPROTECT_BUFFERS
+	/*
+	 * When mprotect() is used to detect shared buffer access violations, lock
+	 * must be acquired so that write access is allowed on this buffer.
+	 */
+	LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
+#endif
 	((FSMPage) PageGetContents(page))->fp_next_slot = 0;
-
+#ifdef MPROTECT_BUFFERS
+	LockBuffer(buf, BUFFER_LOCK_UNLOCK);
+#endif
 	ReleaseBuffer(buf);
 
 	return max_avail;

--- a/src/backend/storage/freespace/freespace.c
+++ b/src/backend/storage/freespace/freespace.c
@@ -538,10 +538,29 @@ fsm_readbuf(Relation rel, FSMAddress addr, bool extend)
 	 * pages than error out. Since the FSM changes are not WAL-logged, the
 	 * so-called torn page problem on crash can lead to pages with corrupt
 	 * headers, for example.
+	 *
+	 * The initialize-the-page part is trickier than it looks, because of the
+	 * possibility of multiple backends doing this concurrently, and our
+	 * desire to not uselessly take the buffer lock in the normal path where
+	 * the page is OK.  We must take the lock to initialize the page, so
+	 * recheck page newness after we have the lock, in case someone else
+	 * already did it.  Also, because we initially check PageIsNew with no
+	 * lock, it's possible to fall through and return the buffer while someone
+	 * else is still initializing the page (i.e., we might see pd_upper as set
+	 * but other page header fields are still zeroes).  This is harmless for
+	 * callers that will take a buffer lock themselves, but some callers
+	 * inspect the page without any lock at all.  The latter is OK only so
+	 * long as it doesn't depend on the page header having correct contents.
+	 * Current usage is safe because PageGetContents() does not require that.
 	 */
 	buf = ReadBufferExtended(rel, FSM_FORKNUM, blkno, RBM_ZERO_ON_ERROR, NULL);
 	if (PageIsNew(BufferGetPage(buf)))
-		PageInit(BufferGetPage(buf), BLCKSZ, 0);
+	{
+		LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
+		if (PageIsNew(BufferGetPage(buf)))
+			PageInit(BufferGetPage(buf), BLCKSZ, 0);
+		LockBuffer(buf, BUFFER_LOCK_UNLOCK);
+	}
 	return buf;
 }
 

--- a/src/backend/storage/ipc/shmem.c
+++ b/src/backend/storage/ipc/shmem.c
@@ -65,6 +65,10 @@
 
 #include "postgres.h"
 
+#ifdef MPROTECT_BUFFERS
+#include <unistd.h>
+#endif
+
 #include "access/transam.h"
 #include "miscadmin.h"
 #include "storage/lwlock.h"
@@ -183,7 +187,11 @@ ShmemAlloc(Size size)
 
 	newStart = shmemseghdr->freeoffset;
 
-	/* extra alignment for large requests, since they are probably buffers */
+	/*
+	 * Extra alignment for large requests, since they are probably buffers.
+	 * This is also needed for mprotect based shared buffer debugging
+	 * (-DMPROTECT_BUFFERS).
+	 */
 	if (size >= BLCKSZ)
 	{
 		newStart =  TYPEALIGN(ShmemSystemPageSize, newStart);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -731,17 +731,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		NULL, NULL, NULL
 	},
 	{
-		{"memory_protect_buffer_pool", PGC_POSTMASTER, DEVELOPER_OPTIONS,
-			gettext_noop("Enables memory protection of the buffer pool"),
-			gettext_noop("Turn on memory protection of the buffer pool "
-					"to detect invalid accesses to the buffer pool memory."),
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&memory_protect_buffer_pool,
-		false,
-		NULL, NULL, NULL
-	},
-	{
 		{"debug_print_prelim_plan", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Prints the preliminary execution plan to server log."),
 			NULL

--- a/src/include/storage/bufmgr.h
+++ b/src/include/storage/bufmgr.h
@@ -49,8 +49,6 @@ extern PGDLLIMPORT int NBuffers;
 
 /* in bufmgr.c */
 
-/* should not be accessed directly.  Use ShouldMemoryProtectBufferPool() instead */
-extern bool memory_protect_buffer_pool;
 extern bool zero_damaged_pages;
 extern int	bgwriter_lru_maxpages;
 extern double bgwriter_lru_multiplier;
@@ -59,7 +57,6 @@ extern int	target_prefetch_pages;
 extern bool bgwriter_flush_all_buffers;
 
 extern PGDLLIMPORT bool IsUnderPostmaster; /* from utils/init/globals.c */
-#define ShouldMemoryProtectBufferPool() (memory_protect_buffer_pool && IsUnderPostmaster)
 
 /* in buf_init.c */
 extern PGDLLIMPORT char *BufferBlocks;


### PR DESCRIPTION
The shared buffers protection using `mprotect()` existed in Greenplum since long.  It was useful in finding shared buffer access violations in upstream and is submitted upstream in Sept commitfest: https://commitfest.postgresql.org/19/1765/ with a minor refactor.  A compile time flag  controls the feature so that performance overhead can be compiled out.  This patch applies the same change to Greenplum.  Also back ported is the shared buffer access violation fix from upstream.

Running installcheck-good took 34 mins when compiled with `-DMPROTECT_BUFFERS`.  Without the flag, the runtime is ~ 20 mins on the same workstation.
