### PR TITLE
For 5X_STABLE: Silence DNS errors completely when DNSLookupAsError == false

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -366,6 +366,14 @@ probeGetIpAddr(ProbeConnectionInfo *probeInfo)
 	probeInfo->addrs = NULL;
 
 	/*
+	 * cdbcomponentdatabases get a DNS error to resolve the hostname,
+	 * return false otherwise following pg_getaddrinfo_all will treat
+	 * it as a local host.
+	 */
+	if (probeInfo->hostIp == NULL)
+		return false;
+
+	/*
 	 * Get an sockaddr that has the right address and port in it.
 	 * We get passed in the IP address (IPv4 or IPv6), not the name, so
 	 * we don't need to worry about name resolution.


### PR DESCRIPTION
This is a modified version of https://github.com/greenplum-db/gpdb/pull/5424 for 5X_STABLE.

the test case is removed because current fault injection framework in 5x_STABLE can not make the test case stable. 

Beside, Fts probe in 5x_STABLE didn't check if the probe info's host ip is NULL which is not right.