### PR TITLE
Fix panic in optimizer translater

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -509,12 +509,12 @@ rel_has_appendonly_partition(Oid relid)
 	{
 		Relation	rel = heap_open(lfirst_oid(lc), NoLock);
 
-		heap_close(rel, NoLock);
-
 		if (RelationIsAppendOptimized(rel))
 		{
+			heap_close(rel, NoLock);
 			return true;
 		}
+		heap_close(rel, NoLock);
 	}
 
 	return false;


### PR DESCRIPTION
CTranslatorRelcacheToDXL::RetrieveIndex() access 'rd_index' after the relation
is closed, it would panic when compiled with '-DRELCACHE_FORCE_RELEASE' flag.

Co-authored-by: Alexandra Wang <lewang@pivotal.io>
Co-authored-by: Gang Xiong <gxiong@pivotal.io>