### PR TITLE
Fix cost of BTree Index scan in ORCA

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.69.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.70.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.69.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.70.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12402,7 +12402,7 @@ int
 main ()
 {
 
-return strncmp("2.69.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.70.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12412,7 +12412,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.69.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.70.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.69.0@gpdb/stable
+orca/v2.70.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.69.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.70.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/qp_gist_indexes4_optimizer.out
+++ b/src/test/regress/expected/qp_gist_indexes4_optimizer.out
@@ -834,8 +834,8 @@ EXPLAIN SELECT * FROM textSearch
  WHERE t @@ to_tsquery('test'); 
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=17)
-   ->  Index Scan using text_index on textsearch  (cost=0.00..2.00 rows=1 width=17)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=17)
+   ->  Index Scan using text_index on textsearch  (cost=0.00..6.00 rows=1 width=17)
          Index Cond: t @@ '''test'''::tsquery
          Filter: t @@ '''test'''::tsquery
  Settings:  enable_seqscan=off
@@ -882,20 +882,18 @@ EXPLAIN SELECT count(*) FROM gist_tbl, gist_tbl2
  WHERE gist_tbl.p <@ gist_tbl2.p;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..21341547.46 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..21341547.46 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..21341547.46 rows=1 width=8)
-               ->  Nested Loop  (cost=0.00..21341547.46 rows=329213580 width=1)
+ Aggregate  (cost=0.00..570099.74 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..570099.74 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..570099.74 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..570099.74 rows=335499869 width=1)
                      Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..524.60 rows=49385 width=101)
-                           ->  Table Scan on gist_tbl2  (cost=0.00..432.22 rows=16462 width=101)
-                     ->  Bitmap Table Scan on gist_tbl  (cost=0.00..21339255.24 rows=6667 width=1)
-                           Recheck Cond: gist_tbl.p <@ gist_tbl2.p
-                           ->  Bitmap Index Scan on poly_index  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: gist_tbl.p <@ gist_tbl2.p
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.68.0
-(13 rows)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..525.76 rows=49997 width=101)
+                           ->  Table Scan on gist_tbl2  (cost=0.00..432.24 rows=16666 width=101)
+                     ->  Index Scan using poly_index on gist_tbl  (cost=0.00..568396.66 rows=2685 width=1)
+                           Index Cond: p <@ gist_tbl2.p
+                           Filter: p <@ gist_tbl2.p
+ Optimizer: PQO version 2.69.0
+(11 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1601,120 +1601,116 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..631.98 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..631.98 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..631.98 rows=1 width=8)
-               ->  Nested Loop  (cost=0.00..631.98 rows=34 width=1)
-                     Join Filter: true
-                     ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                           Group By: public.tenk1.hundred
-                           ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                 Sort Key: public.tenk1.hundred
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                       Hash Key: public.tenk1.hundred
-                                       ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                             Group By: public.tenk1.hundred
-                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
-                     ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=1)
-                           Index Cond: public.tenk1.unique1 = public.tenk1.hundred
- Settings:  optimizer=on
- Optimizer status: PQO version 2.34.1
-(18 rows)
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.06 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..864.06 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.06 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..864.06 rows=34 width=1)
+                     Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
+                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                     ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                           ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                 Group By: public.tenk1.hundred
+                                 ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                       Sort Key: public.tenk1.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                             Hash Key: public.tenk1.hundred
+                                             ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                   Group By: public.tenk1.hundred
+                                                   ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+ Optimizer status: PQO version 2.70.0
+(17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..631.98 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..631.98 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.10 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
                Group By: public.tenk1.ten
-               ->  Sort  (cost=0.00..631.98 rows=4 width=4)
+               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
                      Sort Key: public.tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..631.98 rows=4 width=4)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
                            Hash Key: public.tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
+                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
                                  Group By: public.tenk1.ten
-                                 ->  Sort  (cost=0.00..631.98 rows=34 width=4)
+                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
                                        Sort Key: public.tenk1.ten
-                                       ->  Nested Loop  (cost=0.00..631.98 rows=34 width=4)
-                                             Join Filter: true
-                                             ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                   Group By: public.tenk1.hundred
-                                                   ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                         Sort Key: public.tenk1.hundred
-                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                               Hash Key: public.tenk1.hundred
-                                                               ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                                     Group By: public.tenk1.hundred
-                                                                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
-                                             ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=4)
-                                                   Index Cond: public.tenk1.unique1 = public.tenk1.hundred
- Settings:  optimizer=on
- Optimizer status: PQO version 2.34.1
-(27 rows)
+                                       ->  Hash Join  (cost=0.00..864.10 rows=34 width=4)
+                                             Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
+                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=8)
+                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                         Group By: public.tenk1.hundred
+                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                                               Sort Key: public.tenk1.hundred
+                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                                     Hash Key: public.tenk1.hundred
+                                                                     ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                                           Group By: public.tenk1.hundred
+                                                                           ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+ Optimizer status: PQO version 2.70.0
+(26 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..631.98 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..631.98 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..631.98 rows=1 width=8)
-               ->  Nested Loop  (cost=0.00..631.98 rows=34 width=1)
-                     Join Filter: true
-                     ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                           Group By: public.tenk1.hundred
-                           ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                 Sort Key: public.tenk1.hundred
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                       Hash Key: public.tenk1.hundred
-                                       ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                             Group By: public.tenk1.hundred
-                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
-                     ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=1)
-                           Index Cond: public.tenk1.unique1 = public.tenk1.hundred
- Settings:  optimizer=on
- Optimizer status: PQO version 2.34.1
-(18 rows)
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.06 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..864.06 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.06 rows=1 width=8)
+               ->  Hash EXISTS Join  (cost=0.00..864.06 rows=34 width=1)
+                     Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
+                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+                     ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                           ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                 Group By: public.tenk1.hundred
+                                 ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                       Sort Key: public.tenk1.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                             Hash Key: public.tenk1.hundred
+                                             ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                   Group By: public.tenk1.hundred
+                                                   ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+ Optimizer status: PQO version 2.70.0
+(17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..631.98 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..631.98 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.10 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
                Group By: public.tenk1.ten
-               ->  Sort  (cost=0.00..631.98 rows=4 width=4)
+               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
                      Sort Key: public.tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..631.98 rows=4 width=4)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
                            Hash Key: public.tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..631.98 rows=4 width=4)
+                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
                                  Group By: public.tenk1.ten
-                                 ->  Sort  (cost=0.00..631.98 rows=34 width=4)
+                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
                                        Sort Key: public.tenk1.ten
-                                       ->  Nested Loop  (cost=0.00..631.98 rows=34 width=4)
-                                             Join Filter: true
-                                             ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                   Group By: public.tenk1.hundred
-                                                   ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                         Sort Key: public.tenk1.hundred
-                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                               Hash Key: public.tenk1.hundred
-                                                               ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                                     Group By: public.tenk1.hundred
-                                                                     ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
-                                             ->  Index Scan using tenk1_unique1 on tenk1  (cost=0.00..200.04 rows=1 width=4)
-                                                   Index Cond: public.tenk1.unique1 = public.tenk1.hundred
- Settings:  optimizer=on
- Optimizer status: PQO version 2.34.1
-(27 rows)
+                                       ->  Hash EXISTS Join  (cost=0.00..864.10 rows=34 width=4)
+                                             Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
+                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=8)
+                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                         Group By: public.tenk1.hundred
+                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                                               Sort Key: public.tenk1.hundred
+                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                                     Hash Key: public.tenk1.hundred
+                                                                     ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                                           Group By: public.tenk1.hundred
+                                                                           ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
+ Optimizer status: PQO version 2.70.0
+(26 rows)
 
 --
 -- Test planner to catch dedup information for semi join queries is calculated

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -78,10 +78,10 @@ SELECT owner, property FROM GistTable1
 EXPLAIN 
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..14.40 rows=8 width=47)
-   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..14.40 rows=3 width=47)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=8 width=47)
+   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..6.00 rows=3 width=47)
          Index Cond: property ~= '(7052,250),(6050,20)'::box
          Filter: property ~= '(7052,250),(6050,20)'::box
  Settings:  enable_seqscan=off
@@ -125,10 +125,10 @@ SELECT owner, property FROM GistTable1
 EXPLAIN
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..14.40 rows=8 width=47)
-   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..14.40 rows=3 width=47)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=8 width=47)
+   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..6.00 rows=3 width=47)
          Index Cond: property ~= '(7052,250),(6050,20)'::box
          Filter: property ~= '(7052,250),(6050,20)'::box
  Settings:  enable_seqscan=off
@@ -663,14 +663,14 @@ SELECT id FROM GistTable1
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..14.40 rows=8 width=4)
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=8 width=4)
    Merge Key: id
-   ->  Result  (cost=0.00..14.40 rows=3 width=4)
-         ->  Sort  (cost=0.00..14.40 rows=3 width=4)
+   ->  Result  (cost=0.00..6.00 rows=3 width=4)
+         ->  Sort  (cost=0.00..6.00 rows=3 width=4)
                Sort Key: id
-               ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..14.40 rows=3 width=4)
+               ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..6.00 rows=3 width=4)
                      Index Cond: property ~= '(3,4),(1,2)'::box
                      Filter: property ~= '(3,4),(1,2)'::box
  Settings:  enable_seqscan=off
@@ -691,14 +691,14 @@ SELECT id FROM GistTable1
 EXPLAIN SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..14.40 rows=8 width=4)
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=8 width=4)
    Merge Key: id
-   ->  Result  (cost=0.00..14.40 rows=3 width=4)
-         ->  Sort  (cost=0.00..14.40 rows=3 width=4)
+   ->  Result  (cost=0.00..6.00 rows=3 width=4)
+         ->  Sort  (cost=0.00..6.00 rows=3 width=4)
                Sort Key: id
-               ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..14.40 rows=3 width=4)
+               ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..6.00 rows=3 width=4)
                      Index Cond: property ~= '(3,4),(1,2)'::box
                      Filter: property ~= '(3,4),(1,2)'::box
  Settings:  enable_seqscan=off


### PR DESCRIPTION
This is the GPDB side commit for the ORCA commit.

A note on test case changes :

In `subselect_gp` the plans becomes similar to Planner generated plans.

In `qp_gist_indexes4`, we started picking Index Scan over Bitmap Scan.

Bumped the ORCA version to v2.70.0