### PR TITLE
resgroup: gpconfig should check for cpuset cgroup dir on master.

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupimpl
+++ b/gpMgmt/bin/gpcheckresgroupimpl
@@ -67,6 +67,11 @@ class cgroup(object):
             self.validate_permission("memory/gpdb/memory.limit_in_bytes", "rw")
             self.validate_permission("memory/gpdb/memory.usage_in_bytes", "r")
 
+            self.validate_permission("cpuset/gpdb/", "rwx")
+            self.validate_permission("cpuset/gpdb/cgroup.procs", "rw")
+            self.validate_permission("cpuset/gpdb/cpuset.cpus", "rw")
+            self.validate_permission("cpuset/gpdb/cpuset.mems", "rw")
+
     def die(self, msg):
         exit(self.impl + self.error_prefix + msg)
 


### PR DESCRIPTION
On 5X the resgroup cpuset feature is optional, gpconfig will not detect
for it.  However on master branch the feature and the dir is mandatory,
gpconfig must check for it.

Added the check, as well as the unit test for it.

Co-authored-by: Jialun Du <jdu@pivotal.io>
Co-authored-by: Ning Yu <nyu@pivotal.io>