### PR TITLE
Adds support for GPHDFS Regression tests in Oracle Linux

### DIFF
--- a/concourse/scripts/regression_tests_gphdfs.bash
+++ b/concourse/scripts/regression_tests_gphdfs.bash
@@ -124,7 +124,7 @@ function _main() {
 	time setup_gpadmin_user
 	time install_mapr_client
 	time configure
-	sed -i s/1024/unlimited/ /etc/security/limits.d/90-nproc.conf
+	sed -i s/\(1024\|4096\)/unlimited/ /etc/security/limits.d/*-nproc.conf
 	time install_gpdb
 	time make_cluster
 	time copy_jar_to_mapr_host

--- a/concourse/scripts/regression_tests_gphdfs.bash
+++ b/concourse/scripts/regression_tests_gphdfs.bash
@@ -124,7 +124,7 @@ function _main() {
 	time setup_gpadmin_user
 	time install_mapr_client
 	time configure
-	sed -i s/\(1024\|4096\)/unlimited/ /etc/security/limits.d/*-nproc.conf
+	echo "*          soft    nproc     unlimited" >> /etc/security/limits.d/99-nproc.conf
 	time install_gpdb
 	time make_cluster
 	time copy_jar_to_mapr_host


### PR DESCRIPTION
This commit adds supports for Oracle linux tests to run GPHDFS regression tests. These changes were originally added to support the Oracle pipeline. Although, it was decided the GPHDFS regression tests were not going to be included in Oracle linux, we decided to keep this change in case we decide to support it in the future.

Authored-by: Francisco Guerrero <aguerrero@pivotal.io>