### PR TITLE
Avoids deadlocks for concurrent index creation on AO tables.

### DIFF
--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -29,8 +29,8 @@ brew install dep
 
 # Installing python libraries
 brew install python2
-pip install -r python-dependencies.txt
-pip install -r python-developer-dependencies.txt
+pip install --user -r python-dependencies.txt
+pip install --user -r python-developer-dependencies.txt
 
 #echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts
 echo 127.0.0.1$'\t'$HOSTNAME | sudo tee -a /etc/hosts

--- a/src/backend/catalog/aoblkdir.c
+++ b/src/backend/catalog/aoblkdir.c
@@ -21,6 +21,7 @@
 #include "catalog/aocatalog.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
+#include "utils/faultinjector.h"
 
 void
 AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child, bool is_part_parent)
@@ -31,6 +32,8 @@ AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child, bool is_part_paren
 	Oid			classObjectId[3];
 	int16		coloptions[3];
 	List	   *indexColNames;
+
+	SIMPLE_FAULT_INJECTOR(BeforeAquireLockDuringCreateAoBlkdirTable);
 
 	/*
 	 * Grab an exclusive lock on the target table, which we will NOT release

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -368,6 +368,7 @@ CheckIndexCompatible(Oid oldId,
 	return ret;
 }
 
+
 /*
  * DefineIndex
  *		Creates a new index.
@@ -487,7 +488,11 @@ DefineIndex(RangeVar *heapRelation,
 	 * index build; but for concurrent builds we allow INSERT/UPDATE/DELETE
 	 * (but not VACUUM).
 	 */
-	heap_lockmode = concurrent ? ShareUpdateExclusiveLock : ShareLock;
+	if (RangeVarIsAppendOptimizedTable(heapRelation))
+		heap_lockmode = ShareRowExclusiveLock;
+	else
+		heap_lockmode = concurrent ? ShareUpdateExclusiveLock : ShareLock;
+
 	rel = heap_openrv(heapRelation, heap_lockmode);
 
 	relationId = RelationGetRelid(rel);

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -52,6 +52,7 @@ typedef void (*RangeVarGetRelidCallback) (const RangeVar *relation, Oid relId,
 #define RangeVarGetRelid(relation, lockmode, missing_ok) \
 	RangeVarGetRelidExtended(relation, lockmode, missing_ok, false, NULL, NULL)
 
+
 extern Oid RangeVarGetRelidExtended(const RangeVar *relation,
 						 LOCKMODE lockmode, bool missing_ok, bool nowait,
 						 RangeVarGetRelidCallback callback,
@@ -61,6 +62,7 @@ extern Oid RangeVarGetAndCheckCreationNamespace(RangeVar *newRelation,
 									 LOCKMODE lockmode,
 									 Oid *existing_relation_id);
 extern void RangeVarAdjustRelationPersistence(RangeVar *newRelation, Oid nspid);
+extern bool RangeVarIsAppendOptimizedTable(RangeVar *relation);
 extern Oid	RelnameGetRelid(const char *relname);
 extern bool RelationIsVisible(Oid relid);
 

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -247,6 +247,8 @@ FI_IDENT(AutoVacWorkerBeforeDoAutovacuum, "auto_vac_worker_before_do_autovacuum"
 FI_IDENT(GetDnsCachedAddress, "get_dns_cached_address")
 /* inject fault before notify fts probe */
 FI_IDENT(BeforeFtsNotify, "before_fts_notify")
+/* inject fault before aquiring lock during AlterTableCreateAoBlkdirTable */
+FI_IDENT(BeforeAquireLockDuringCreateAoBlkdirTable, "before_aquire_lock_during_create_ao_blkdir_table")
 /* inject fault during gang creation, before check for interrupts */
 FI_IDENT(CreateGangInProgress, "create_gang_in_progress")
 #endif

--- a/src/test/isolation2/expected/concurrent_index_creation_should_not_deadlock.out
+++ b/src/test/isolation2/expected/concurrent_index_creation_should_not_deadlock.out
@@ -1,0 +1,34 @@
+CREATE extension if NOT EXISTS gp_inject_fault;
+CREATE
+
+-- Create an append only table, popluated with data
+CREATE TABLE index_deadlocking_test_table (value int) WITH (appendonly=true);
+CREATE
+
+-- Setup a fault to ensure that the first session pauses while creating an index,
+-- ensuring a concurrent index creation.
+SELECT gp_inject_fault('before_aquire_lock_during_create_ao_blkdir_table', 'suspend', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+-- Attempt to concurrently create an index
+1>: CREATE INDEX index_deadlocking_test_table_idx1 ON index_deadlocking_test_table (value);  <waiting ...>
+SELECT gp_wait_until_triggered_fault('before_aquire_lock_during_create_ao_blkdir_table', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
+2>: CREATE INDEX index_deadlocking_test_table_idx2 ON index_deadlocking_test_table (value);  <waiting ...>
+SELECT gp_inject_fault('before_aquire_lock_during_create_ao_blkdir_table', 'reset', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+-- Both index creation attempts should succeed
+1<:  <... completed>
+CREATE
+2<:  <... completed>
+CREATE

--- a/src/test/isolation2/sql/concurrent_index_creation_should_not_deadlock.sql
+++ b/src/test/isolation2/sql/concurrent_index_creation_should_not_deadlock.sql
@@ -1,0 +1,18 @@
+CREATE extension if NOT EXISTS gp_inject_fault;
+
+-- Create an append only table, popluated with data
+CREATE TABLE index_deadlocking_test_table (value int) WITH (appendonly=true);
+
+-- Setup a fault to ensure that the first session pauses while creating an index,
+-- ensuring a concurrent index creation.
+SELECT gp_inject_fault('before_aquire_lock_during_create_ao_blkdir_table', 'suspend', 1);
+
+-- Attempt to concurrently create an index
+1>: CREATE INDEX index_deadlocking_test_table_idx1 ON index_deadlocking_test_table (value);
+SELECT gp_wait_until_triggered_fault('before_aquire_lock_during_create_ao_blkdir_table', 1, 1);
+2>: CREATE INDEX index_deadlocking_test_table_idx2 ON index_deadlocking_test_table (value);
+SELECT gp_inject_fault('before_aquire_lock_during_create_ao_blkdir_table', 'reset', 1);
+
+-- Both index creation attempts should succeed
+1<:
+2<:


### PR DESCRIPTION
Creating the block directory auxiliary table for an append-only table requires
an AccessExclusive lock (we're not sure why). We defer the creation of the
block directory until creation of the first index on an AO table. This leads to
a lock upgrade later, which causes a dead lock when two concurrent sessions
both believe they are creating the first index.

Acquire a ShareRowExclusiveLock on the target table while creating an index.
This allows only one of the concurrent users to have access to the table at a
time, and then allows the winner to aquire an AccessExclusive lock when
creating the AOBlkDir table.