### PR TITLE
Prevent concurrent DROP SCHEMA when objects are being created

### DIFF
--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -1010,6 +1010,9 @@ CreateFunction(CreateFunctionStmt *stmt, const char *queryString)
 	namespaceId = QualifiedNameGetCreationNamespace(stmt->funcname,
 													&funcname);
 
+	/* Lock the creation namespace to protect against concurrent namespace drop */
+	LockDatabaseObject(NamespaceRelationId, namespaceId, 0, AccessShareLock);
+
 	/* Check we have creation rights in target namespace */
 	aclresult = pg_namespace_aclcheck(namespaceId, GetUserId(), ACL_CREATE);
 	if (aclresult != ACLCHECK_OK)

--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -272,6 +272,9 @@ RemoveSchema(List *names, DropBehavior behavior, bool missing_ok)
 						namespaceName)));
 	}
 
+	/* Lock namespace to prevent concurrent object creation inside the namespace */
+	LockDatabaseObject(NamespaceRelationId, namespaceId, 0, AccessExclusiveLock);
+
 	/*
 	 * Do the deletion.  Objects contained in the schema are removed by means
 	 * of their dependency links to the schema.

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -426,6 +426,9 @@ DefineRelation(CreateStmt *stmt, char relkind, char relstorage, bool dispatch)
 	 */
 	namespaceId = RangeVarGetCreationNamespace(stmt->relation);
 
+	/* Lock the creation namespace to protect against concurrent namespace drop */
+	LockDatabaseObject(NamespaceRelationId, namespaceId, 0, AccessShareLock);
+
 	if (!IsBootstrapProcessingMode())
 	{
 		AclResult	aclresult;
@@ -15546,6 +15549,9 @@ AlterTableNamespace(RangeVar *relation, const char *newschema)
 
 	/* get schema OID and check its permissions */
 	nspOid = LookupCreationNamespace(newschema);
+
+	/* Lock the creation namespace to protect against concurrent namespace drop */
+	LockDatabaseObject(NamespaceRelationId, nspOid, 0, AccessShareLock);
 
 	/* common checks on switching namespaces */
 	CheckSetNamespace(oldNspOid, nspOid, RelationRelationId, relid);

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -139,6 +139,9 @@ DefineType(List *names, List *parameters)
 	/* Convert list of names to a name and namespace */
 	typeNamespace = QualifiedNameGetCreationNamespace(names, &typeName);
 
+	/* Lock the creation namespace to protect against concurrent namespace drop */
+	LockDatabaseObject(NamespaceRelationId, typeNamespace, 0, AccessShareLock);
+
 	/* Check we have creation rights in target namespace */
 	aclresult = pg_namespace_aclcheck(typeNamespace, GetUserId(), ACL_CREATE);
 	if (aclresult != ACLCHECK_OK)

--- a/src/test/isolation2/expected/concurrent_schema_drop.out
+++ b/src/test/isolation2/expected/concurrent_schema_drop.out
@@ -1,0 +1,118 @@
+-- Test that dropping a new empty schema while concurrently creating
+-- objects in that schema blocks the DROP SCHEMA. Each DROP SCHEMA in
+-- this test should block trying to obtain AccessExclusiveLock on its
+-- corresponding pg_namespace entry.
+
+CREATE SCHEMA concurrent_schema_drop1;
+CREATE
+CREATE SCHEMA concurrent_schema_drop2;
+CREATE
+CREATE SCHEMA concurrent_schema_drop3;
+CREATE
+CREATE SCHEMA concurrent_schema_drop4;
+CREATE
+CREATE SCHEMA concurrent_schema_drop5;
+CREATE
+CREATE SCHEMA concurrent_schema_drop6;
+CREATE
+
+-- Test on CREATE TABLE
+1: BEGIN;
+BEGIN
+1: CREATE TABLE concurrent_schema_drop1.concurrent_schema_drop1_table(a int);
+CREATE
+2&: DROP SCHEMA concurrent_schema_drop1;  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ERROR:  cannot drop schema concurrent_schema_drop1 because other objects depend on it
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+1: SELECT * FROM concurrent_schema_drop1.concurrent_schema_drop1_table;
+a
+-
+(0 rows)
+
+-- Test on CREATE TYPE
+1: BEGIN;
+BEGIN
+1: CREATE TYPE concurrent_schema_drop2.concurrent_schema_drop2_type;
+CREATE
+2&: DROP SCHEMA concurrent_schema_drop2;  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ERROR:  cannot drop schema concurrent_schema_drop2 because other objects depend on it
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+1: SELECT typname FROM pg_type WHERE typname = 'concurrent_schema_drop2_type';
+typname                     
+----------------------------
+concurrent_schema_drop2_type
+(1 row)
+
+1: BEGIN;
+BEGIN
+1: CREATE TYPE concurrent_schema_drop3.concurrent_schema_drop3_composite_type AS (r double precision, i double precision);
+CREATE
+2&: DROP SCHEMA concurrent_schema_drop3;  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ERROR:  cannot drop schema concurrent_schema_drop3 because other objects depend on it
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+1: SELECT typname FROM pg_type WHERE typname = 'concurrent_schema_drop3_composite_type';
+typname                               
+--------------------------------------
+concurrent_schema_drop3_composite_type
+(1 row)
+
+-- Test on CREATE VIEW
+1: BEGIN;
+BEGIN
+1: CREATE VIEW concurrent_schema_drop4.concurrent_schema_drop4_view AS SELECT 1;
+CREATE
+2&: DROP SCHEMA concurrent_schema_drop4;  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ERROR:  cannot drop schema concurrent_schema_drop4 because other objects depend on it
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+1: SELECT * FROM concurrent_schema_drop4.concurrent_schema_drop4_view;
+?column?
+--------
+1       
+(1 row)
+
+-- Test on CREATE FUNCTION
+1: BEGIN;
+BEGIN
+1: CREATE FUNCTION concurrent_schema_drop5.concurrent_schema_drop5_func() RETURNS bool LANGUAGE SQL AS 'SELECT true';
+CREATE
+2&: DROP SCHEMA concurrent_schema_drop5;  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ERROR:  cannot drop schema concurrent_schema_drop5 because other objects depend on it
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+1: SELECT concurrent_schema_drop5.concurrent_schema_drop5_func();
+concurrent_schema_drop5_func
+----------------------------
+t                           
+(1 row)
+
+-- Test on ALTER TABLE .. SET SCHEMA
+1: CREATE TABLE concurrent_schema_drop6_table(a int);
+CREATE
+1: BEGIN;
+BEGIN
+1: ALTER TABLE concurrent_schema_drop6_table SET SCHEMA concurrent_schema_drop6;
+ALTER
+2&: DROP SCHEMA concurrent_schema_drop6;  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ERROR:  cannot drop schema concurrent_schema_drop6 because other objects depend on it
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+1: SELECT * FROM concurrent_schema_drop6.concurrent_schema_drop6_table;
+a
+-
+(0 rows)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -7,7 +7,7 @@ test: pg_views_concurrent_drop
 test: resource_queue
 test: alter_blocks_for_update_and_viceversa
 test: reader_waits_for_lock
-test: drop_rename
+test: drop_rename concurrent_schema_drop
 test: instr_in_shmem_setup
 test: instr_in_shmem_terminate
 test: instr_in_shmem_cleanup

--- a/src/test/isolation2/sql/concurrent_schema_drop.sql
+++ b/src/test/isolation2/sql/concurrent_schema_drop.sql
@@ -1,0 +1,60 @@
+-- Test that dropping a new empty schema while concurrently creating
+-- objects in that schema blocks the DROP SCHEMA. Each DROP SCHEMA in
+-- this test should block trying to obtain AccessExclusiveLock on its
+-- corresponding pg_namespace entry.
+
+CREATE SCHEMA concurrent_schema_drop1;
+CREATE SCHEMA concurrent_schema_drop2;
+CREATE SCHEMA concurrent_schema_drop3;
+CREATE SCHEMA concurrent_schema_drop4;
+CREATE SCHEMA concurrent_schema_drop5;
+CREATE SCHEMA concurrent_schema_drop6;
+
+-- Test on CREATE TABLE
+1: BEGIN;
+1: CREATE TABLE concurrent_schema_drop1.concurrent_schema_drop1_table(a int);
+2&: DROP SCHEMA concurrent_schema_drop1;
+1: COMMIT;
+2<:
+1: SELECT * FROM concurrent_schema_drop1.concurrent_schema_drop1_table;
+
+-- Test on CREATE TYPE
+1: BEGIN;
+1: CREATE TYPE concurrent_schema_drop2.concurrent_schema_drop2_type;
+2&: DROP SCHEMA concurrent_schema_drop2;
+1: COMMIT;
+2<:
+1: SELECT typname FROM pg_type WHERE typname = 'concurrent_schema_drop2_type';
+
+1: BEGIN;
+1: CREATE TYPE concurrent_schema_drop3.concurrent_schema_drop3_composite_type
+       AS (r double precision, i double precision);
+2&: DROP SCHEMA concurrent_schema_drop3;
+1: COMMIT;
+2<:
+1: SELECT typname FROM pg_type WHERE typname = 'concurrent_schema_drop3_composite_type';
+
+-- Test on CREATE VIEW
+1: BEGIN;
+1: CREATE VIEW concurrent_schema_drop4.concurrent_schema_drop4_view AS SELECT 1;
+2&: DROP SCHEMA concurrent_schema_drop4;
+1: COMMIT;
+2<:
+1: SELECT * FROM concurrent_schema_drop4.concurrent_schema_drop4_view;
+
+-- Test on CREATE FUNCTION
+1: BEGIN;
+1: CREATE FUNCTION concurrent_schema_drop5.concurrent_schema_drop5_func() RETURNS bool LANGUAGE SQL AS 'SELECT true';
+2&: DROP SCHEMA concurrent_schema_drop5;
+1: COMMIT;
+2<:
+1: SELECT concurrent_schema_drop5.concurrent_schema_drop5_func();
+
+-- Test on ALTER TABLE .. SET SCHEMA
+1: CREATE TABLE concurrent_schema_drop6_table(a int);
+1: BEGIN;
+1: ALTER TABLE concurrent_schema_drop6_table SET SCHEMA concurrent_schema_drop6;
+2&: DROP SCHEMA concurrent_schema_drop6;
+1: COMMIT;
+2<:
+1: SELECT * FROM concurrent_schema_drop6.concurrent_schema_drop6_table;


### PR DESCRIPTION
When an empty namespace is being populated with objects, it was
possible for a DROP SCHEMA operation to come in and delete the
namespace without using CASCADE. This was capable of creating pg_class
and pg_type entries with invalid namespace values. To prevent this
from happening, we take an AccessShareLock on the schema to which the
relation/type is being added to and add an AccessExclusiveLock acquire
to DROP SCHEMA.

This patch was inspired from upstream Postgres 9.2 commit:
https://github.com/postgres/postgres/commit/1575fbcb795fc331f46588b4520c4bca7e854d5c

We do not backport the commit fully because of drastic differences
between the Greenplum 5X_STABLE (based off Postgres 8.3) and upstream
Postgres 9.2.