### PR TITLE
Remove a GPDB_91_MERGE_FIXME for IS NOT DISTINCT FROM in hash join

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -188,7 +188,10 @@ ExecHashJoin(HashJoinState *node)
 				hashtable = ExecHashTableCreate(hashNode,
 												node,
 												node->hj_HashOperators,
-				/* GPDB_91_MERGE_FIXME: do we need to get rid of hs_keepnull? */
+				/*
+				 * hashNode->hs_keepnull is required to support using IS NOT DISTINCT FROM as hash condition
+				 * For example, in ORCA, `explain SELECT t2.a FROM t2 INTERSECT (SELECT t1.a FROM t1);`
+				 */
 												HJ_FILL_INNER(node) || hashNode->hs_keepnull,
 												PlanStateOperatorMemKB((PlanState *) hashNode));
 				node->hj_HashTable = hashtable;


### PR DESCRIPTION
ORCA is able to treat `IS NOT DISTINCT FROM` as hash condition whereas planner
and upstream seems treat it as a filter. In the future we may want to consider
implementing `IS NOT DISTINCT FROM` as a hash condition as well in planner.

Co-authored-by: Alexandra Wang <leiwangcheme@gmail.com>
Co-authored-by: Paul Guo <paulguo@gmail.com>