### PR TITLE
Remove unused function 'isPrimaryWriterGangAlive'

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1256,39 +1256,3 @@ getgpsegmentCount(void)
 	Assert(GpIdentity.numsegments > 0);
 	return GpIdentity.numsegments;
 }
-
-bool
-isSockAlive(int sock)
-{
-	int			ret;
-	char		buf;
-	int			i = 0;
-
-	for (i = 0; i < 10; i++)
-	{
-#ifndef WIN32
-		ret = recv(sock, &buf, 1, MSG_PEEK | MSG_DONTWAIT);
-#else
-		ret = recv(sock, &buf, 1, MSG_PEEK | MSG_PARTIAL);
-#endif
-
-		if (ret == 0)			/* socket has been closed. EOF */
-			return false;
-
-		if (ret > 0)			/* data waiting on socket, it must be OK. */
-			return true;
-
-		if (ret == -1)			/* error, or would be block. */
-		{
-			if (errno == EAGAIN || errno == EINPROGRESS)
-				return true;	/* connection intact, no data available */
-			else if (errno == EINTR)
-				continue;		/* interrupted by signal, retry at most 10
-								 * times */
-			else
-				return false;
-		}
-	}
-
-	return true;
-}

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -294,31 +294,6 @@ createGang(GangType type, int gang_id, int size, int content)
 }
 
 /*
- * Test if the connections of the primary writer gang are alive.
- */
-bool
-isPrimaryWriterGangAlive(void)
-{
-	if (primaryWriterGang == NULL)
-		return false;
-
-	int			size = primaryWriterGang->size;
-	int			i = 0;
-
-	Assert(size == getgpsegmentCount());
-
-	for (i = 0; i < size; i++)
-	{
-		SegmentDatabaseDescriptor *segdb = &primaryWriterGang->db_descriptors[i];
-
-		if (!isSockAlive(segdb->conn->sock))
-			return false;
-	}
-
-	return true;
-}
-
-/*
  * Check the segment failure reason by comparing connection error message.
  */
 bool

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -100,8 +100,6 @@ extern bool GangsExist(void);
 
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);
 
-bool isPrimaryWriterGangAlive(void);
-
 Gang *buildGangDefinition(GangType type, int gang_id, int size, int content);
 bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int gangId, int hostSegs);
 char *makeOptions(void);

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -179,8 +179,6 @@ extern int16 contentid_get_dbid(int16 contentid, char role, bool getPreferredRol
  */
 extern int	getgpsegmentCount(void);
 
-extern bool isSockAlive(int sock);
-
 #define ELOG_DISPATCHER_DEBUG(...) do { \
        if (gp_log_gang >= GPVARS_VERBOSITY_DEBUG) elog(LOG, __VA_ARGS__); \
     } while(false);


### PR DESCRIPTION
It's originally added to test if the writer gang is alive
(like segment be killed by 9) by calling an actual recv()
syscall. It's removed because of calling syscall for each
segments is heavy, there is no need to do the optimization
for such a rare case, the error can bump up when the command
is actually sent.