### PR TITLE
Fix crashes when optimizer and '-DRELCACHE_FORCE_RELEASE' are set

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -516,12 +516,13 @@ rel_has_appendonly_partition(Oid relid)
 	foreach(lc, leaf_oid_list)
 	{
 		Relation rel = heap_open(lfirst_oid(lc), NoLock);
-		heap_close(rel, NoLock);
 
 		if (RelationIsAoRows(rel) || RelationIsAoCols(rel))
 		{
+			heap_close(rel, NoLock);
 			return true;
 		}
+		heap_close(rel, NoLock);
 	}
 
 	return false;

--- a/src/backend/executor/nodeDynamicTableScan.c
+++ b/src/backend/executor/nodeDynamicTableScan.c
@@ -91,6 +91,10 @@ initNextTableToScan(DynamicTableScanState *node)
 	if (scanState->scan_state == SCAN_INIT ||
 		scanState->scan_state == SCAN_DONE)
 	{
+		Relation lastScannedRel;
+		TupleDesc partTupDesc;
+		TupleDesc lastTupDesc;
+		AttrNumber *attMap;
 		Oid *pid = hash_seq_search(&node->pidStatus);
 		if (pid == NULL)
 		{
@@ -117,17 +121,12 @@ initNextTableToScan(DynamicTableScanState *node)
 		scanState->ss_ScanTupleSlot->tts_tableOid = *pid;
 
 		scanState->ss_currentRelation = OpenScanRelationByOid(*pid);
-		Relation lastScannedRel = OpenScanRelationByOid(node->lastRelOid);
-		TupleDesc lastTupDesc = RelationGetDescr(lastScannedRel);
-		CloseScanRelation(lastScannedRel);
-
-		TupleDesc partTupDesc = RelationGetDescr(scanState->ss_currentRelation);
-
+		lastScannedRel = OpenScanRelationByOid(node->lastRelOid);
+		lastTupDesc = RelationGetDescr(lastScannedRel);
+		partTupDesc = RelationGetDescr(scanState->ss_currentRelation);
 		ExecAssignScanType(scanState, partTupDesc);
-
-		AttrNumber	*attMap;
-
 		attMap = varattnos_map(lastTupDesc, partTupDesc);
+		CloseScanRelation(lastScannedRel);
 
 		/* If attribute remapping is not necessary, then do not change the varattno */
 		if (attMap)

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1071,6 +1071,9 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 	CMDName *mdname = NULL;
 	IMDIndex::EmdindexType index_type = IMDIndex::EmdindSentinel;
 	IMDId *mdid_item_type = NULL;
+	bool index_clustered = false;
+	ULongPtrArray *index_key_cols_array = NULL;
+	ULONG *attno_mapping = NULL;
 
 	GPOS_TRY
 	{
@@ -1081,6 +1084,7 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 
 		form_pg_index = index_rel->rd_index;
 		GPOS_ASSERT (NULL != form_pg_index);
+		index_clustered = form_pg_index->indisclustered;
 
 		OID rel_oid = form_pg_index->indrelid;
 
@@ -1129,6 +1133,23 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 		CWStringDynamic *str_name = CDXLUtils::CreateDynamicStringFromCharArray(mp, index_name);
 		mdname = GPOS_NEW(mp) CMDName(mp, str_name);
 		GPOS_DELETE(str_name);
+
+		Relation table = gpdb::GetRelation(CMDIdGPDB::CastMdid(md_rel->MDId())->Oid());
+		ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) table->rd_att->natts + 1;
+		gpdb::CloseRelation(table); // close relation as early as possible
+
+		attno_mapping = PopulateAttnoPositionMap(mp, md_rel, size);
+
+		// extract the position of the key columns
+		index_key_cols_array = GPOS_NEW(mp) ULongPtrArray(mp);
+
+		for (ULONG ul = 0; ul < form_pg_index->indnatts; ul++)
+		{
+			INT attno = form_pg_index->indkey.values[ul];
+			GPOS_ASSERT(0 != attno && "Index expressions not supported");
+
+			index_key_cols_array->Append(GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
+		}
 		mdid_rel->Release();
 		gpdb::CloseRelation(index_rel);
 	}
@@ -1138,45 +1159,26 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
-	
-	Relation table = gpdb::GetRelation(CMDIdGPDB::CastMdid(md_rel->MDId())->Oid());
-	ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) table->rd_att->natts + 1;
-	gpdb::CloseRelation(table); // close relation as early as possible
-
-	ULONG *attno_mapping = PopulateAttnoPositionMap(mp, md_rel, size);
 
 	ULongPtrArray *included_cols = ComputeIncludedCols(mp, md_rel);
-
-	// extract the position of the key columns
-	ULongPtrArray *index_key_cols_array = GPOS_NEW(mp) ULongPtrArray(mp);
-
-	for (ULONG ul = 0; ul < form_pg_index->indnatts; ul++)
-	{
-		INT attno = form_pg_index->indkey.values[ul];
-		GPOS_ASSERT(0 != attno && "Index expressions not supported");
-
-		index_key_cols_array->Append(GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
-	}
-
 	mdid_index->AddRef();
 	IMdIdArray *op_families_mdids = RetrieveIndexOpFamilies(mp, mdid_index);
-	
+
 	CMDIndexGPDB *index = GPOS_NEW(mp) CMDIndexGPDB
-										(
-										mp,
-										mdid_index,
-										mdname,
-										form_pg_index->indisclustered,
-										index_type,
-										mdid_item_type,
-										index_key_cols_array,
-										included_cols,
-										op_families_mdids,
-										NULL // mdpart_constraint
-										);
+		(
+		 mp,
+		 mdid_index,
+		 mdname,
+		 index_clustered,
+		 index_type,
+		 mdid_item_type,
+		 index_key_cols_array,
+		 included_cols,
+		 op_families_mdids,
+		 NULL // mdpart_constraint
+		);
 
 	GPOS_DELETE_ARRAY(attno_mapping);
-
 	return index;
 }
 


### PR DESCRIPTION
The access to the members of 'Relation' struct after heap_close() will
cause crash when '-DRELCACHE_FORCE_RELEASE' is set.

Co-authored-by: Alexandra Wang <lewang@pivotal.io>
Co-authored-by: Gang Xiong <gxiong@pivotal.io>