### PR TITLE
Make planner generate redistribute-motion.

### DIFF
--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -1106,7 +1106,7 @@ select * from ds_4 a1,ds_4 a2 where a1.month_id = a2.month_id and a1.month_id > 
 select count_operator('select * from ds_4 a1,ds_4 a2 where a1.month_id = a2.month_id and a1.month_id > E''200800'';','Partition Selector');
  count_operator 
 ----------------
-              1
+              0
 (1 row)
 
 -- CLEANUP

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -991,10 +991,10 @@ select * from t, pt where tid < ptid;
 -- cascading joins
 --
 explain select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=2.43..22.45 rows=108 width=69)
-   ->  Hash Join  (cost=2.43..22.45 rows=36 width=69)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=4.42..24.44 rows=108 width=69)
+   ->  Hash Join  (cost=4.42..24.44 rows=36 width=69)
          Hash Cond: dpe_single.pt.ptid = t1.tid
          ->  Append  (cost=0.00..18.54 rows=18 width=31)
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
@@ -1015,18 +1015,21 @@ explain select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
                      One-Time Filter: PartSelected
                      ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..3.09 rows=3 width=31)
-         ->  Hash  (cost=2.33..2.33 rows=3 width=38)
-               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=1.13..2.33 rows=3 width=38)
+         ->  Hash  (cost=4.32..4.32 rows=3 width=38)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=2.08..4.32 rows=3 width=38)
                      Filter: t1.tid
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.13..2.33 rows=3 width=38)
-                           ->  Hash Join  (cost=1.13..2.21 rows=2 width=38)
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=2.08..4.32 rows=3 width=38)
+                           ->  Hash Join  (cost=2.08..4.20 rows=2 width=38)
                                  Hash Cond: t.t2 = t1.t2
-                                 ->  Seq Scan on t  (cost=0.00..1.02 rows=1 width=19)
-                                 ->  Hash  (cost=1.08..1.08 rows=2 width=19)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.08 rows=2 width=19)
-                                             ->  Seq Scan on t1  (cost=0.00..1.02 rows=1 width=19)
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.06 rows=1 width=19)
+                                       Hash Key: t.t2
+                                       ->  Seq Scan on t  (cost=0.00..2.02 rows=1 width=19)
+                                 ->  Hash  (cost=2.06..2.06 rows=1 width=19)
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2.06 rows=1 width=19)
+                                             Hash Key: t1.t2
+                                             ->  Seq Scan on t1  (cost=0.00..2.02 rows=1 width=19)
  Optimizer: legacy query optimizer
-(33 rows)
+(36 rows)
 
 select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
  dist | tid |   t1   | t2  | dist | tid |   t1   | t2  | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -1225,14 +1228,17 @@ set enable_hashjoin=off;
 set enable_seqscan=on;
 set enable_nestloop=on;
 explain select * from t, pt where a = b;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..8.02 rows=5 width=16)
-   ->  Nested Loop  (cost=0.00..8.02 rows=2 width=16)
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..8.69 rows=5 width=16)
+   ->  Nested Loop  (cost=0.00..8.69 rows=2 width=16)
          Join Filter: t.a = dpe_single.pt.b
-         ->  Seq Scan on t  (cost=0.00..2.05 rows=2 width=8)
-         ->  Materialize  (cost=0.00..5.25 rows=4 width=8)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..5.20 rows=4 width=8)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.15 rows=2 width=8)
+               Hash Key: t.a
+               ->  Seq Scan on t  (cost=0.00..3.05 rows=2 width=8)
+         ->  Materialize  (cost=0.00..5.17 rows=2 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..5.15 rows=2 width=8)
+                     Hash Key: dpe_single.pt.b
                      ->  Append  (cost=0.00..5.05 rows=2 width=8)
                            ->  Seq Scan on pt_1_prt_1 pt  (cost=0.00..1.01 rows=1 width=8)
                            ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..1.01 rows=1 width=8)
@@ -1240,7 +1246,7 @@ explain select * from t, pt where a = b;
                            ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..1.01 rows=1 width=8)
                            ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..1.01 rows=1 width=8)
  Optimizer: legacy query optimizer
-(13 rows)
+(16 rows)
 
 select * from t, pt where a = b;
  id | a | id | b 

--- a/src/test/regress/expected/gpdiffcheck.out
+++ b/src/test/regress/expected/gpdiffcheck.out
@@ -138,52 +138,59 @@ set optimizer_segments=4;
 set gp_cost_hashjoin_chainwalk=on;
 set optimizer_nestloop_factor = 1.0;
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=10000000001.20..10000000003.39 rows=4 width=12) (actual time=5.598..5.618 rows=16 loops=1)
-   ->  Hash Semi Join  (cost=10000000001.20..10000000003.39 rows=2 width=12) (actual time=4.114..5.048 rows=8 loops=1)
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000001.14..10000000003.38 rows=4 width=12) (actual time=5.946..5.951 rows=16 loops=1)
+   ->  Hash Semi Join  (cost=10000000001.14..10000000003.38 rows=2 width=12) (actual time=4.100..4.745 rows=16 loops=1)
          Hash Cond: b.c1 = (max((max(gpd1.c1))))
          (seg2)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
-         ->  Nested Loop  (cost=10000000000.00..10000000002.13 rows=2 width=14) (actual time=0.304..0.479 rows=32 loops=1)
-               ->  Seq Scan on gpd1 a  (cost=0.00..1.01 rows=1 width=12) (actual time=0.043..0.046 rows=4 loops=1)
-               ->  Materialize  (cost=0.00..1.08 rows=2 width=2) (actual time=0.059..0.065 rows=8 loops=4)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=2) (actual time=0.020..0.035 rows=8 loops=1)
-                           ->  Seq Scan on gpd1 b  (cost=0.00..1.01 rows=1 width=2) (actual time=0.052..0.058 rows=4 loops=1)
-         ->  Hash  (cost=1.16..1.16 rows=2 width=32) (actual time=1.156..1.156 rows=1 loops=1)
-               ->  Broadcast Motion 1:3  (slice3; segments: 1)  (cost=1.08..1.16 rows=4 width=32) (actual time=1.138..1.139 rows=1 loops=1)
-                     ->  Aggregate  (cost=1.08..1.09 rows=1 width=32) (actual time=1.188..1.189 rows=1 loops=1)
-                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=1.01..1.07 rows=1 width=32) (actual time=0.573..1.129 rows=3 loops=1)
-                                 ->  Aggregate  (cost=1.01..1.02 rows=1 width=32) (actual time=0.101..0.101 rows=1 loops=1)
-                                       ->  Seq Scan on gpd1  (cost=0.00..1.01 rows=1 width=2) (actual time=0.046..0.053 rows=4 loops=1)
-   (slice0)    Executor memory: 386K bytes.
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000000.00..10000000002.20 rows=2 width=14) (actual time=0.021..0.041 rows=16 loops=1)
+               Hash Key: b.c1
+               ->  Nested Loop  (cost=10000000000.00..10000000002.13 rows=2 width=14) (actual time=0.524..1.567 rows=32 loops=1)
+                     ->  Seq Scan on gpd1 a  (cost=0.00..1.01 rows=1 width=12) (actual time=0.123..0.127 rows=4 loops=1)
+                     ->  Materialize  (cost=0.00..1.08 rows=2 width=2) (actual time=0.094..0.261 rows=8 loops=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=2) (actual time=0.055..0.705 rows=8 loops=1)
+                                 ->  Seq Scan on gpd1 b  (cost=0.00..1.01 rows=1 width=2) (actual time=0.108..0.115 rows=4 loops=1)
+         ->  Hash  (cost=1.12..1.12 rows=1 width=32) (actual time=2.871..2.871 rows=1 loops=1)
+               ->  Redistribute Motion 1:3  (slice4; segments: 1)  (cost=1.08..1.12 rows=1 width=32) (actual time=2.852..2.853 rows=1 loops=1)
+                     Hash Key: (max((max(gpd1.c1))))
+                     ->  Aggregate  (cost=1.08..1.09 rows=1 width=32) (actual time=2.667..2.668 rows=1 loops=1)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.01..1.07 rows=1 width=32) (actual time=1.524..2.512 rows=3 loops=1)
+                                 ->  Aggregate  (cost=1.01..1.02 rows=1 width=32) (actual time=0.212..0.212 rows=1 loops=1)
+                                       ->  Seq Scan on gpd1  (cost=0.00..1.01 rows=1 width=2) (actual time=0.108..0.113 rows=4 loops=1)
+   (slice0)    Executor memory: 518K bytes.
    (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 81K bytes avg x 3 workers, 81K bytes max (seg0).
-   (slice3)    Executor memory: 66K bytes (seg2).
-   (slice4)    Executor memory: 1158K bytes avg x 3 workers, 1158K bytes max (seg0).  Work_mem: 1K bytes max.
+   (slice2)    Executor memory: 126K bytes avg x 3 workers, 126K bytes max (seg0).
+   (slice3)    Executor memory: 86K bytes avg x 3 workers, 86K bytes max (seg0).
+   (slice4)    Executor memory: 66K bytes (seg2).
+   (slice5)    Executor memory: 1103K bytes avg x 3 workers, 1114K bytes max (seg2).  Work_mem: 1K bytes max.
  Memory used:  128000kB
  Optimizer: legacy query optimizer
- Total runtime: 34.754 ms
-(23 rows)
+ Total runtime: 4571.552 ms
+(27 rows)
 
 explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=10000000001.20..10000000003.39 rows=4 width=12)
-   ->  Hash Semi Join  (cost=10000000001.20..10000000003.39 rows=2 width=12)
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000001.14..10000000003.38 rows=4 width=12)
+   ->  Hash Semi Join  (cost=10000000001.14..10000000003.38 rows=2 width=12)
          Hash Cond: b.c1 = (max((max(gpd1.c1))))
-         ->  Nested Loop  (cost=10000000000.00..10000000002.13 rows=2 width=14)
-               ->  Seq Scan on gpd1 a  (cost=0.00..1.01 rows=1 width=12)
-               ->  Materialize  (cost=0.00..1.08 rows=2 width=2)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=2)
-                           ->  Seq Scan on gpd1 b  (cost=0.00..1.01 rows=1 width=2)
-         ->  Hash  (cost=1.16..1.16 rows=2 width=32)
-               ->  Broadcast Motion 1:3  (slice3; segments: 1)  (cost=1.08..1.16 rows=4 width=32)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000000.00..10000000002.20 rows=2 width=14)
+               Hash Key: b.c1
+               ->  Nested Loop  (cost=10000000000.00..10000000002.13 rows=2 width=14)
+                     ->  Seq Scan on gpd1 a  (cost=0.00..1.01 rows=1 width=12)
+                     ->  Materialize  (cost=0.00..1.08 rows=2 width=2)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=2)
+                                 ->  Seq Scan on gpd1 b  (cost=0.00..1.01 rows=1 width=2)
+         ->  Hash  (cost=1.12..1.12 rows=1 width=32)
+               ->  Redistribute Motion 1:3  (slice4; segments: 1)  (cost=1.08..1.12 rows=1 width=32)
+                     Hash Key: (max((max(gpd1.c1))))
                      ->  Aggregate  (cost=1.08..1.09 rows=1 width=32)
-                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=1.01..1.07 rows=1 width=32)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.01..1.07 rows=1 width=32)
                                  ->  Aggregate  (cost=1.01..1.02 rows=1 width=32)
                                        ->  Seq Scan on gpd1  (cost=0.00..1.01 rows=1 width=2)
  Optimizer: legacy query optimizer
-(15 rows)
+(18 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
  c1 | c2 | c3 
@@ -210,24 +217,27 @@ set gp_segments_for_planner=40;
 set optimizer_segments=40;
 set optimizer_nestloop_factor = 1.0;
 explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=10000000001.50..10000000004.57 rows=4 width=12)
-   ->  Hash Join  (cost=10000000001.50..10000000004.57 rows=2 width=12)
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000001.50..10000000004.64 rows=4 width=12)
+   ->  Hash Semi Join  (cost=10000000001.50..10000000004.64 rows=2 width=12)
          Hash Cond: b.c1 = (max((max(gpd1.c1))))
-         ->  Nested Loop  (cost=10000000000.00..10000000003.03 rows=2 width=14)
-               ->  Seq Scan on gpd1 a  (cost=0.00..1.01 rows=1 width=12)
-               ->  Materialize  (cost=0.00..1.62 rows=14 width=2)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.42 rows=14 width=2)
-                           ->  Seq Scan on gpd1 b  (cost=0.00..1.01 rows=1 width=2)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000000.00..10000000003.10 rows=2 width=14)
+               Hash Key: b.c1
+               ->  Nested Loop  (cost=10000000000.00..10000000003.03 rows=2 width=14)
+                     ->  Seq Scan on gpd1 a  (cost=0.00..1.01 rows=1 width=12)
+                     ->  Materialize  (cost=0.00..1.62 rows=14 width=2)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.42 rows=14 width=2)
+                                 ->  Seq Scan on gpd1 b  (cost=0.00..1.01 rows=1 width=2)
          ->  Hash  (cost=1.49..1.49 rows=1 width=32)
-               ->  Broadcast Motion 1:3  (slice3; segments: 1)  (cost=1.45..1.49 rows=1 width=32)
+               ->  Redistribute Motion 1:3  (slice4; segments: 1)  (cost=1.45..1.49 rows=1 width=32)
+                     Hash Key: (max((max(gpd1.c1))))
                      ->  Aggregate  (cost=1.45..1.46 rows=1 width=32)
-                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=1.01..1.43 rows=1 width=32)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.01..1.43 rows=1 width=32)
                                  ->  Aggregate  (cost=1.01..1.02 rows=1 width=32)
                                        ->  Seq Scan on gpd1  (cost=0.00..1.01 rows=1 width=2)
  Optimizer: legacy query optimizer
-(15 rows)
+(18 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
  c1 | c2 | c3 
@@ -251,32 +261,36 @@ select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
 (16 rows)
 
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=10000000001.50..10000000004.57 rows=4 width=12) (actual time=3.541..5.075 rows=16 loops=1)
-   ->  Hash Join  (cost=10000000001.50..10000000004.57 rows=2 width=12) (actual time=3.400..4.445 rows=8 loops=1)
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000001.50..10000000004.64 rows=4 width=12) (actual time=1505.871..1505.879 rows=16 loops=1)
+   ->  Hash Semi Join  (cost=10000000001.50..10000000004.64 rows=2 width=12) (actual time=1504.363..1505.028 rows=16 loops=1)
          Hash Cond: b.c1 = (max((max(gpd1.c1))))
          (seg2)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
-         ->  Nested Loop  (cost=10000000000.00..10000000003.03 rows=2 width=14) (actual time=1.794..2.100 rows=32 loops=1)
-               ->  Seq Scan on gpd1 a  (cost=0.00..1.01 rows=1 width=12) (actual time=0.043..0.050 rows=4 loops=1)
-               ->  Materialize  (cost=0.00..1.62 rows=14 width=2) (actual time=0.436..0.450 rows=8 loops=4)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.42 rows=14 width=2) (actual time=0.019..0.040 rows=8 loops=1)
-                           ->  Seq Scan on gpd1 b  (cost=0.00..1.01 rows=1 width=2) (actual time=0.026..0.032 rows=4 loops=1)
-         ->  Hash  (cost=1.49..1.49 rows=1 width=32) (actual time=1.422..1.422 rows=1 loops=1)
-               ->  Broadcast Motion 1:3  (slice3; segments: 1)  (cost=1.45..1.49 rows=1 width=32) (actual time=1.413..1.414 rows=1 loops=1)
-                     ->  Aggregate  (cost=1.45..1.46 rows=1 width=32) (actual time=0.516..0.516 rows=1 loops=1)
-                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=1.01..1.43 rows=1 width=32) (actual time=0.031..0.475 rows=3 loops=1)
-                                 ->  Aggregate  (cost=1.01..1.02 rows=1 width=32) (actual time=0.061..0.061 rows=1 loops=1)
-                                       ->  Seq Scan on gpd1  (cost=0.00..1.01 rows=1 width=2) (actual time=0.027..0.032 rows=4 loops=1)
-   (slice0)    Executor memory: 386K bytes.
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000000.00..10000000003.10 rows=2 width=14) (actual time=1502.824..1502.867 rows=16 loops=1)
+               Hash Key: b.c1
+               ->  Nested Loop  (cost=10000000000.00..10000000003.03 rows=2 width=14) (actual time=0.345..0.677 rows=32 loops=1)
+                     ->  Seq Scan on gpd1 a  (cost=0.00..1.01 rows=1 width=12) (actual time=0.076..0.081 rows=4 loops=1)
+                     ->  Materialize  (cost=0.00..1.62 rows=14 width=2) (actual time=0.066..0.072 rows=8 loops=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.42 rows=14 width=2) (actual time=0.030..0.042 rows=8 loops=1)
+                                 ->  Seq Scan on gpd1 b  (cost=0.00..1.01 rows=1 width=2) (actual time=0.078..0.084 rows=4 loops=1)
+         ->  Hash  (cost=1.49..1.49 rows=1 width=32) (actual time=1.442..1.442 rows=1 loops=1)
+               ->  Redistribute Motion 1:3  (slice4; segments: 1)  (cost=1.45..1.49 rows=1 width=32) (actual time=1.436..1.436 rows=1 loops=1)
+                     Hash Key: (max((max(gpd1.c1))))
+                     ->  Aggregate  (cost=1.45..1.46 rows=1 width=32) (actual time=0.036..0.036 rows=1 loops=1)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.01..1.43 rows=1 width=32) (actual time=0.017..0.023 rows=3 loops=1)
+                                 ->  Aggregate  (cost=1.01..1.02 rows=1 width=32) (actual time=0.093..0.093 rows=1 loops=1)
+                                       ->  Seq Scan on gpd1  (cost=0.00..1.01 rows=1 width=2) (actual time=0.055..0.061 rows=4 loops=1)
+   (slice0)    Executor memory: 518K bytes.
    (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 81K bytes avg x 3 workers, 81K bytes max (seg0).
-   (slice3)    Executor memory: 65K bytes (seg2).
-   (slice4)    Executor memory: 1158K bytes avg x 3 workers, 1158K bytes max (seg0).  Work_mem: 1K bytes max.
+   (slice2)    Executor memory: 126K bytes avg x 3 workers, 126K bytes max (seg0).
+   (slice3)    Executor memory: 86K bytes avg x 3 workers, 86K bytes max (seg0).
+   (slice4)    Executor memory: 65K bytes (seg2).
+   (slice5)    Executor memory: 1103K bytes avg x 3 workers, 1114K bytes max (seg2).  Work_mem: 1K bytes max.
  Memory used:  128000kB
  Optimizer: legacy query optimizer
- Total runtime: 7.382 ms
-(23 rows)
+ Total runtime: 1507.339 ms
+(27 rows)
 
 --
 -- Clean up

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3107,3 +3107,31 @@ SELECT * FROM
 (5 rows)
 
 rollback;
+-- github issue 5370 cases
+drop table if exists t5370;
+NOTICE:  table "t5370" does not exist, skipping
+drop table if exists t5370_2;
+NOTICE:  table "t5370_2" does not exist, skipping
+create table t5370(id int,name text) distributed by(id);
+insert into t5370 select i,i from  generate_series(1,1000) i;
+create table t5370_2 as select * from t5370 distributed by (id);
+analyze t5370_2;
+analyze t5370;
+explain select * from t5370 a , t5370_2 b where a.name=b.name;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=45.50..92.25 rows=1000 width=14)
+   ->  Hash Join  (cost=45.50..92.25 rows=334 width=14)
+         Hash Cond: a.name = b.name
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..33.00 rows=334 width=7)
+               Hash Key: a.name
+               ->  Seq Scan on t5370 a  (cost=0.00..13.00 rows=334 width=7)
+         ->  Hash  (cost=33.00..33.00 rows=334 width=7)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..33.00 rows=334 width=7)
+                     Hash Key: b.name
+                     ->  Seq Scan on t5370_2 b  (cost=0.00..13.00 rows=334 width=7)
+ Optimizer: legacy query optimizer
+(11 rows)
+
+drop table t5370;
+drop table t5370_2;

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -2770,49 +2770,55 @@ select * from tenk1 t1 left join
   (tenk1 t2 join tenk1 t3 on t2.thousand = t3.unique2)
   on t1.hundred = t2.hundred and t1.ten = t3.ten
 where t1.unique1 = 1;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
    ->  Hash Right Join
          Hash Cond: t2.hundred = t1.hundred AND t3.ten = t1.ten
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)
                Hash Key: 1
                ->  Hash Join
                      Hash Cond: t2.thousand = t3.unique2
-                     ->  Seq Scan on tenk1 t2
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: t2.thousand
+                           ->  Seq Scan on tenk1 t2
                      ->  Hash
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: t3.unique2
                                  ->  Seq Scan on tenk1 t3
          ->  Hash
                ->  Index Scan using tenk1_unique1 on tenk1 t1
                      Index Cond: unique1 = 1
  Optimizer: legacy query optimizer
-(15 rows)
+(18 rows)
 
 explain (costs off)
 select * from tenk1 t1 left join
   (tenk1 t2 join tenk1 t3 on t2.thousand = t3.unique2)
   on t1.hundred = t2.hundred and t1.ten + t2.ten = t3.ten
 where t1.unique1 = 1;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
    ->  Hash Right Join
          Hash Cond: t2.hundred = t1.hundred
          Join Filter: (t1.ten + t2.ten) = t3.ten
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)
                Hash Key: 1
                ->  Hash Join
                      Hash Cond: t2.thousand = t3.unique2
-                     ->  Seq Scan on tenk1 t2
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: t2.thousand
+                           ->  Seq Scan on tenk1 t2
                      ->  Hash
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: t3.unique2
                                  ->  Seq Scan on tenk1 t3
          ->  Hash
                ->  Index Scan using tenk1_unique1 on tenk1 t1
                      Index Cond: unique1 = 1
  Optimizer: legacy query optimizer
-(16 rows)
+(19 rows)
 
 explain (costs off)
 select count(*) from

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3179,3 +3179,31 @@ SELECT * FROM
 (5 rows)
 
 rollback;
+-- github issue 5370 cases
+drop table if exists t5370;
+NOTICE:  table "t5370" does not exist, skipping
+drop table if exists t5370_2;
+NOTICE:  table "t5370_2" does not exist, skipping
+create table t5370(id int,name text) distributed by(id);
+insert into t5370 select i,i from  generate_series(1,1000) i;
+create table t5370_2 as select * from t5370 distributed by (id);
+analyze t5370_2;
+analyze t5370;
+explain select * from t5370 a , t5370_2 b where a.name=b.name;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.25 rows=1000 width=14)
+   ->  Hash Join  (cost=0.00..862.20 rows=334 width=14)
+         Hash Cond: t5370.name = t5370_2.name
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.02 rows=334 width=7)
+               Hash Key: t5370.name
+               ->  Table Scan on t5370  (cost=0.00..431.01 rows=334 width=7)
+         ->  Hash  (cost=431.02..431.02 rows=334 width=7)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=334 width=7)
+                     Hash Key: t5370_2.name
+                     ->  Table Scan on t5370_2  (cost=0.00..431.01 rows=334 width=7)
+ Optimizer: PQO version 2.70.2
+(11 rows)
+
+drop table t5370;
+drop table t5370_2;

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -583,7 +583,7 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=30000000025.29..30000000025.51 rows=10 width=12)
+ Limit  (cost=30000000030.52..30000000030.75 rows=10 width=12)
    InitPlan 1 (returns $0)  (slice6)
      ->  Limit  (cost=10000000000.00..10000000001.58 rows=1 width=0)
            ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000000.00..10000000001.58 rows=1 width=0)
@@ -593,31 +593,29 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C wh
                                    Filter: i = 10
                              ->  Seq Scan on a  (cost=0.00..2.06 rows=1 width=4)
                                    Filter: i = 10
-   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=20000000023.70..20000000023.93 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=20000000028.94..20000000029.17 rows=10 width=12)
          Merge Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
-         ->  Limit  (cost=20000000023.70..20000000023.73 rows=4 width=12)
-               ->  Sort  (cost=20000000023.70..20000000024.38 rows=90 width=12)
+         ->  Limit  (cost=20000000028.94..20000000028.97 rows=4 width=12)
+               ->  Sort  (cost=20000000028.94..20000000029.62 rows=90 width=12)
                      Sort Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
-                     ->  Result  (cost=20000000005.77..20000000017.87 rows=90 width=12)
+                     ->  Result  (cost=20000000003.79..20000000023.11 rows=90 width=12)
                            One-Time Filter: NOT $0
-                           ->  Nested Loop  (cost=20000000005.77..20000000017.87 rows=90 width=12)
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=5.77..5.92 rows=2 width=10)
-                                       ->  HashAggregate  (cost=5.76..5.81 rows=2 width=10)
-                                             Group Key: qp_correlated_query.a.ctid::bigint
-                                             ->  Hash Join  (cost=2.11..5.75 rows=2 width=10)
-                                                   Hash Cond: qp_correlated_query.c.j = qp_correlated_query.a.j
-                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
-                                                         ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
-                                                   ->  Hash  (cost=2.05..2.05 rows=2 width=14)
-                                                         ->  Seq Scan on a  (cost=0.00..2.05 rows=2 width=14)
-                                 ->  Materialize  (cost=10000000000.00..10000000008.71 rows=18 width=8)
-                                       ->  Nested Loop  (cost=10000000000.00..10000000008.44 rows=18 width=8)
-                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
-                                                   ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
-                                             ->  Materialize  (cost=0.00..3.13 rows=3 width=4)
+                           ->  Nested Loop  (cost=20000000003.79..20000000023.11 rows=90 width=12)
+                                 ->  Hash Semi Join  (cost=10000000003.79..10000000010.77 rows=10 width=8)
+                                       Hash Cond: qp_correlated_query.a.j = qp_correlated_query.c.j
+                                       ->  Nested Loop  (cost=10000000000.00..10000000006.40 rows=10 width=12)
+                                             ->  Seq Scan on a  (cost=0.00..2.05 rows=2 width=8)
+                                             ->  Materialize  (cost=0.00..3.39 rows=6 width=4)
+                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
+                                                         ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                                       ->  Hash  (cost=3.45..3.45 rows=9 width=4)
+                                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
                                                    ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                 ->  Materialize  (cost=0.00..3.58 rows=9 width=4)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
+                                             ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
  Optimizer: legacy query optimizer
-(34 rows)
+(32 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -3044,25 +3044,24 @@ reset gp_enable_agg_distinct_pruning;
 set enable_groupagg=off;
 -- both queries should use hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=2918557.42..2918567.42 rows=1000 width=12)
-   ->  HashAggregate  (cost=2918557.42..2918567.42 rows=334 width=12)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2226209.90..2281818.97 rows=1000 width=12)
+   ->  GroupAggregate  (cost=2226209.90..2281818.97 rows=334 width=12)
          Group Key: t1.j
-         ->  HashAggregate  (cost=2918532.42..2918542.42 rows=334 width=8)
-               Group Key: t1.j, t1.j
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2918494.92..2918514.92 rows=334 width=8)
-                     Hash Key: t1.j
-                     ->  HashAggregate  (cost=2918494.92..2918494.92 rows=334 width=8)
-                           Group Key: t1.j, t1.j
-                           ->  Hash Join  (cost=7633.75..2862895.85 rows=2471070 width=4)
-                                 Hash Cond: t1.j = t2.j
-                                 ->  Seq Scan on tbl5994_test t1  (cost=0.00..961.00 rows=28700 width=4)
-                                 ->  Hash  (cost=4405.00..4405.00 rows=86100 width=4)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4405.00 rows=86100 width=4)
-                                             ->  Seq Scan on tbl5994_test t2  (cost=0.00..961.00 rows=28700 width=4)
+         ->  Sort  (cost=2226209.90..2244742.92 rows=2471070 width=4)
+               Sort Key: t1.j
+               ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=4)
+                     Hash Cond: t1.j = t2.j
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                           Hash Key: t1.j
+                           ->  Seq Scan on tbl5994_test t1  (cost=0.00..961.00 rows=28700 width=4)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                 Hash Key: t2.j
+                                 ->  Seq Scan on tbl5994_test t2  (cost=0.00..961.00 rows=28700 width=4)
  Optimizer: legacy query optimizer
-(16 rows)
+(15 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
                                                     QUERY PLAN                                                    
@@ -3087,29 +3086,24 @@ explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_te
 set enable_groupagg=on;
 -- first query should use groupagg, and second one - hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=4285608.00..4285635.50 rows=1000 width=12)
-   ->  GroupAggregate  (cost=4285608.00..4285635.50 rows=334 width=12)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2226209.90..2281818.97 rows=1000 width=12)
+   ->  GroupAggregate  (cost=2226209.90..2281818.97 rows=334 width=12)
          Group Key: t1.j
-         ->  Sort  (cost=4285608.00..4285610.50 rows=334 width=12)
+         ->  Sort  (cost=2226209.90..2244742.92 rows=2471070 width=4)
                Sort Key: t1.j
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=4229929.10..4285558.17 rows=334 width=12)
-                     Hash Key: t1.j
-                     ->  GroupAggregate  (cost=4229929.10..4285538.17 rows=334 width=12)
-                           Group Key: t1.j
-                           ->  Sort  (cost=4229929.10..4248462.12 rows=2471070 width=4)
-                                 Sort Key: t1.j
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=7633.75..3011160.05 rows=2471070 width=4)
-                                       Hash Key: t1.j
-                                       ->  Hash Join  (cost=7633.75..2862895.85 rows=2471070 width=4)
-                                             Hash Cond: t1.j = t2.j
-                                             ->  Seq Scan on tbl5994_test t1  (cost=0.00..961.00 rows=28700 width=4)
-                                             ->  Hash  (cost=4405.00..4405.00 rows=86100 width=4)
-                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4405.00 rows=86100 width=4)
-                                                         ->  Seq Scan on tbl5994_test t2  (cost=0.00..961.00 rows=28700 width=4)
+               ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=4)
+                     Hash Cond: t1.j = t2.j
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                           Hash Key: t1.j
+                           ->  Seq Scan on tbl5994_test t1  (cost=0.00..961.00 rows=28700 width=4)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                 Hash Key: t2.j
+                                 ->  Seq Scan on tbl5994_test t2  (cost=0.00..961.00 rows=28700 width=4)
  Optimizer: legacy query optimizer
-(20 rows)
+(15 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
                                                     QUERY PLAN                                                    

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -272,15 +272,13 @@ INSERT INTO foorescan values(5009,5,'abc.5009.5');
 CREATE FUNCTION foorescan(int,int) RETURNS setof foorescan AS 'SELECT * FROM foorescan WHERE fooid >= $1 and fooid < $2 ;' LANGUAGE SQL;
 --invokes ExecReScanFunctionScan
 SELECT * FROM foorescan f WHERE f.fooid IN (SELECT fooid FROM foorescan(5002,5004)) ORDER BY 1,2;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  SQL function "foorescan" statement 1
+ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"  (entry db 127.0.0.1:15432 pid=29701)
+CONTEXT:  SQL function "foorescan" during startup
 CREATE VIEW vw_foorescan AS SELECT * FROM foorescan(5002,5004);
 --invokes ExecReScanFunctionScan
 SELECT * FROM foorescan f WHERE f.fooid IN (SELECT fooid FROM vw_foorescan) ORDER BY 1,2;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  SQL function "foorescan" statement 1
+ERROR:  function cannot execute on a QE slice because it accesses relation "public.foorescan"  (entry db 127.0.0.1:15432 pid=29701)
+CONTEXT:  SQL function "foorescan" during startup
 CREATE TABLE barrescan (fooid int primary key);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "barrescan_pkey" for table "barrescan"
 INSERT INTO barrescan values(5003);

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -857,3 +857,16 @@ SELECT * FROM
   ON true;
 
 rollback;
+
+-- github issue 5370 cases
+drop table if exists t5370;
+drop table if exists t5370_2;
+create table t5370(id int,name text) distributed by(id);
+insert into t5370 select i,i from  generate_series(1,1000) i;
+create table t5370_2 as select * from t5370 distributed by (id);
+analyze t5370_2;
+analyze t5370;
+explain select * from t5370 a , t5370_2 b where a.name=b.name;
+
+drop table t5370;
+drop table t5370_2;


### PR DESCRIPTION
This commit tries to fix the issue https://github.com/greenplum-db/gpdb/issues/5370.

When doing inner join, we will test that if we can use redistributie motion by the function `cdbpath_partkeys_from_preds`.  But if `a_partkey ` is NIL(it is NIL at the beginning 
of the function), we append nothing into it.  Thus this function will only return false. This leads to
the planner can only generate a broadcast motion for the inner relation.

We fix this by the same logic as outer join.

WTS node is immovable, this commit adds some code to handle it.

-----

Co-authored-by: Shujie Zhang <shzhang@pivotal.io>  
Co-authored-by: Zhenghua Lyu <zlv@pivotal.io>
