### PR TITLE
Add missing out/read funcs for CreateOpClassItem.order_family field.

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3224,6 +3224,7 @@ _outCreateOpClassItem(StringInfo str, const CreateOpClassItem *node)
 	WRITE_NODE_FIELD(name);
 	WRITE_NODE_FIELD(args);
 	WRITE_INT_FIELD(number);
+	WRITE_NODE_FIELD(order_family);
 	WRITE_NODE_FIELD(class_args);
 	WRITE_NODE_FIELD(storedtype);
 }

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2608,6 +2608,7 @@ _readCreateOpClassItem(void)
 	READ_NODE_FIELD(name);
 	READ_NODE_FIELD(args);
 	READ_INT_FIELD(number);
+	READ_NODE_FIELD(order_family);
 	READ_NODE_FIELD(class_args);
 	READ_NODE_FIELD(storedtype);
 

--- a/src/test/regress/expected/opclass_ddl.out
+++ b/src/test/regress/expected/opclass_ddl.out
@@ -84,3 +84,17 @@ ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
   FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 requested again in separate statement
 ERROR:  operator 1(integer,smallint) already exists in operator family "alt_opf17"
 DROP OPERATOR FAMILY alt_opf17 USING btree;
+-- GPDB: Test a GiST ordering operator.
+CREATE TYPE my_gisttest_type AS (f1 int, f2 text);
+CREATE FUNCTION my_gisttest_function(geom1 my_gisttest_type, geom2 my_gisttest_type)
+    RETURNS float8
+    AS $$
+        select 1.0::float8
+    $$ language SQL;
+CREATE OPERATOR <-> (
+    LEFTARG = my_gisttest_type, RIGHTARG = my_gisttest_type, PROCEDURE = my_gisttest_function,
+    COMMUTATOR = '<->'
+);
+CREATE OPERATOR CLASS my_gisttest_op_class
+DEFAULT FOR TYPE my_gisttest_type USING GIST AS
+OPERATOR        13       <-> FOR ORDER BY pg_catalog.float_ops;

--- a/src/test/regress/sql/opclass_ddl.sql
+++ b/src/test/regress/sql/opclass_ddl.sql
@@ -92,3 +92,23 @@ ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
   OPERATOR 5 > (int4, int2) ,
   FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 requested again in separate statement
 DROP OPERATOR FAMILY alt_opf17 USING btree;
+
+
+-- GPDB: Test a GiST ordering operator.
+
+CREATE TYPE my_gisttest_type AS (f1 int, f2 text);
+
+CREATE FUNCTION my_gisttest_function(geom1 my_gisttest_type, geom2 my_gisttest_type)
+    RETURNS float8
+    AS $$
+        select 1.0::float8
+    $$ language SQL;
+
+CREATE OPERATOR <-> (
+    LEFTARG = my_gisttest_type, RIGHTARG = my_gisttest_type, PROCEDURE = my_gisttest_function,
+    COMMUTATOR = '<->'
+);
+
+CREATE OPERATOR CLASS my_gisttest_op_class
+DEFAULT FOR TYPE my_gisttest_type USING GIST AS
+OPERATOR        13       <-> FOR ORDER BY pg_catalog.float_ops;


### PR DESCRIPTION
Fixes https://github.com/greenplum-db/gpdb/issues/5511