### PR TITLE
Ensure that subpartition template only appears after subpartition by

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4589,6 +4589,8 @@ opt_comma: ',' { $$ = true; }
 list_subparts: TabSubPartitionBy { $$ = $1; }
 			| list_subparts opt_comma TabSubPartitionBy
 				{
+					if (!IsA($1, PartitionBy))
+						yyerror("SUBPARTITION TEMPLATE need to be nested under a SUBPARTITION BY");
 					PartitionBy *pby = (PartitionBy *)$1;
 					$$ = $1;
 

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -7907,3 +7907,19 @@ select array_agg(test_split_part) from test_split_part where log_id = 500;
 
 select array_agg(test_split_part_1_prt_other_log_ids) from test_split_part_1_prt_other_log_ids where log_id = 500;
 ERROR:  could not find array type for data type test_split_part_1_prt_other_log_ids
+-- MPP-26829
+-- This should fail
+CREATE TABLE MPP_26829
+(a integer, b integer NOT NULL, c integer)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+SUBPARTITION TEMPLATE (START (1) END (12) EVERY (1), DEFAULT SUBPARTITION other_months )
+SUBPARTITION BY LIST (c)
+SUBPARTITION TEMPLATE (
+SUBPARTITION p027 VALUES ('027'),
+SUBPARTITION p141 VALUES ('141'),
+SUBPARTITION p037 VALUES ('037'));
+ERROR:  SUBPARTITION TEMPLATE need to be nested under a SUBPARTITION BY at or near "SUBPARTITION"
+LINE 7: SUBPARTITION TEMPLATE ( 
+        ^
+-- MPP-26829

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -7901,3 +7901,19 @@ select array_agg(test_split_part) from test_split_part where log_id = 500;
 
 select array_agg(test_split_part_1_prt_other_log_ids) from test_split_part_1_prt_other_log_ids where log_id = 500;
 ERROR:  could not find array type for data type test_split_part_1_prt_other_log_ids
+-- MPP-26829
+-- This should fail
+CREATE TABLE MPP_26829
+(a integer, b integer NOT NULL, c integer)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+SUBPARTITION TEMPLATE (START (1) END (12) EVERY (1), DEFAULT SUBPARTITION other_months )
+SUBPARTITION BY LIST (c)
+SUBPARTITION TEMPLATE ( 
+SUBPARTITION p027 VALUES ('027'),
+SUBPARTITION p141 VALUES ('141'),
+SUBPARTITION p037 VALUES ('037'));
+ERROR:  SUBPARTITION TEMPLATE need to be nested under a SUBPARTITION BY at or near "SUBPARTITION"
+LINE 7: SUBPARTITION TEMPLATE ( 
+        ^
+-- MPP-26829

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3791,3 +3791,17 @@ ALTER TABLE test_split_part SPLIT DEFAULT PARTITION START (201) INCLUSIVE END (3
 select typname, typtype from pg_type where typname like '%test_split_part%' and typtype = 'b';
 select array_agg(test_split_part) from test_split_part where log_id = 500;
 select array_agg(test_split_part_1_prt_other_log_ids) from test_split_part_1_prt_other_log_ids where log_id = 500;
+
+-- MPP-26829
+-- This should fail
+CREATE TABLE MPP_26829
+(a integer, b integer NOT NULL, c integer)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+SUBPARTITION TEMPLATE (START (1) END (12) EVERY (1), DEFAULT SUBPARTITION other_months )
+SUBPARTITION BY LIST (c)
+SUBPARTITION TEMPLATE (
+SUBPARTITION p027 VALUES ('027'),
+SUBPARTITION p141 VALUES ('141'),
+SUBPARTITION p037 VALUES ('037'));
+-- MPP-26829


### PR DESCRIPTION
This commit changed the way the grammar was parsing the subpartition
information to ensure that the templates could not exist without a
SUBPARTITION BY.
Testing coverage for the case where the Template should up first was
added.

The error displayed when the template appeared after a Partition was
changed to point to the TEMPLATE

---

We will be working on a solution for master in the meanwhile. We decided to go this route because it does not crash on master, the only issue is that the error message is pointing to the incorrect place