### PR TITLE
Ensure that subpartition template only appears after subpartition by

### DIFF
--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -3300,7 +3300,7 @@ CREATE TABLE LINEITEM (
                 )
 partition by range (l_discount) 
 subpartition by range (l_quantity) 
-,subpartition by range (l_tax) subpartition template (start('0') end('1.08') every 6 (1))
+subpartition by range (l_tax) subpartition template (start('0') end('1.08') every 6 (1))
 ,subpartition by range (l_receiptdate) subpartition template (subpartition sp1 start('1992-01-03') end('1999-01-01'), subpartition sp2 start('1993-01-03') end ('1997-01-01'))
 (
 partition p1 start('0') end('1.1') 

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -1339,7 +1339,7 @@ PS_COMMENT VARCHAR(199)
 )
 partition by range (ps_suppkey)
 subpartition by range (ps_partkey)
-,subpartition by range (ps_supplycost) subpartition template (start('1')
+subpartition by range (ps_supplycost) subpartition template (start('1')
 end('1001') every(500))
 (
 partition p1 start('1') end('10001') every(5000)
@@ -1480,7 +1480,7 @@ PS_COMMENT VARCHAR(199)
 )
 partition by range (ps_suppkey)
 subpartition by range (ps_partkey)
-,subpartition by range (ps_supplycost) subpartition template (start('1')
+subpartition by range (ps_supplycost) subpartition template (start('1')
 end('1001') every(500))
 (
 partition p1 start('1') end('10001') every(5000)
@@ -1579,7 +1579,7 @@ subpartition jan02 start (date '2002-01-01'),
 subpartition jan03 start (date '2003-01-01'),
 subpartition jan04 start (date '2004-01-01'),
 subpartition jan05 start (date '2005-01-01')
-),
+)
 subpartition by list (usstate)
 subpartition template (
 subpartition mass values ('MA'),
@@ -1638,7 +1638,7 @@ year date, gender char(1),
 usstate char(2))
 DISTRIBUTED BY (id, gender, year, usstate)
 partition by list (gender)
-subpartition by range (year),
+subpartition by range (year)
 subpartition by list (usstate)
 (
   partition boys values ('M') 
@@ -1673,8 +1673,7 @@ subpartition mass values ('MA'),
 subpartition cali values ('CA'),
 subpartition ohio values ('OH')
 )
-)
-,
+),
   partition girls values ('F')
 (
 subpartition jan01 start (date '2001-01-01')
@@ -3313,7 +3312,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 ERROR:  starting value of partition "b" overlaps previous range
 LINE 3: partition b start('e') end('g')
                     ^
--- MPP-5159
+-- MPP-5159 MPP-26829
 -- Should fail -- missing partition spec and subpartition template follows the
 -- partition declaration.
 CREATE TABLE list_sales (trans_id int, date date, amount
@@ -3325,10 +3324,10 @@ SUBPARTITION TEMPLATE
   SUBPARTITION asia VALUES ('asia'),
   SUBPARTITION europe VALUES ('europe')
 );
-ERROR:  syntax error at or near ";"
-LINE 9: );
-         ^
--- MPP-5185
+ERROR:  syntax error at or near "TEMPLATE"
+LINE 5: SUBPARTITION TEMPLATE
+                     ^
+-- MPP-5185 MPP-26829
 -- Should work
 CREATE TABLE rank_settemp (id int, rank int, year date, gender
 char(1)) DISTRIBUTED BY (id, gender, year)
@@ -3647,11 +3646,11 @@ partition by range (b)
 subpartition by list (a) 
 subpartition template ( 
 subpartition l1 values (1,2,3,4,5), 
-subpartition l2 values (6,7,8,9,10) ),
+subpartition l2 values (6,7,8,9,10) )
 subpartition by list (e) 
 subpartition template ( 
 subpartition ll1 values ('Engineering'), 
-subpartition ll2 values ('QA') ),
+subpartition ll2 values ('QA') )
 subpartition by list (c) 
 subpartition template ( 
 subpartition lll1 values ('M'), 
@@ -4720,11 +4719,11 @@ partition by range (b)
 subpartition by list (a)
 subpartition template (
 subpartition l1 values (1,2,3,4,5),
-subpartition l2 values (6,7,8,9,10) ),
+subpartition l2 values (6,7,8,9,10) )
 subpartition by list (e)
 subpartition template (
 subpartition ll1 values ('Engineering'),
-subpartition ll2 values ('QA') ),
+subpartition ll2 values ('QA') )
 subpartition by list (c)
 subpartition template (
 subpartition lll1 values ('M'),

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -1343,7 +1343,7 @@ PS_COMMENT VARCHAR(199)
 )
 partition by range (ps_suppkey)
 subpartition by range (ps_partkey)
-,subpartition by range (ps_supplycost) subpartition template (start('1')
+subpartition by range (ps_supplycost) subpartition template (start('1')
 end('1001') every(500))
 (
 partition p1 start('1') end('10001') every(5000)
@@ -1484,7 +1484,7 @@ PS_COMMENT VARCHAR(199)
 )
 partition by range (ps_suppkey)
 subpartition by range (ps_partkey)
-,subpartition by range (ps_supplycost) subpartition template (start('1')
+subpartition by range (ps_supplycost) subpartition template (start('1')
 end('1001') every(500))
 (
 partition p1 start('1') end('10001') every(5000)
@@ -1583,7 +1583,7 @@ subpartition jan02 start (date '2002-01-01'),
 subpartition jan03 start (date '2003-01-01'),
 subpartition jan04 start (date '2004-01-01'),
 subpartition jan05 start (date '2005-01-01')
-),
+)
 subpartition by list (usstate)
 subpartition template (
 subpartition mass values ('MA'),
@@ -1642,7 +1642,7 @@ year date, gender char(1),
 usstate char(2))
 DISTRIBUTED BY (id, gender, year, usstate)
 partition by list (gender)
-subpartition by range (year),
+subpartition by range (year)
 subpartition by list (usstate)
 (
   partition boys values ('M') 
@@ -1677,8 +1677,7 @@ subpartition mass values ('MA'),
 subpartition cali values ('CA'),
 subpartition ohio values ('OH')
 )
-)
-,
+),
   partition girls values ('F')
 (
 subpartition jan01 start (date '2001-01-01')
@@ -3316,7 +3315,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 ERROR:  starting value of partition "b" overlaps previous range
 LINE 3: partition b start('e') end('g')
                     ^
--- MPP-5159
+-- MPP-5159 MPP-26829
 -- Should fail -- missing partition spec and subpartition template follows the
 -- partition declaration.
 CREATE TABLE list_sales (trans_id int, date date, amount
@@ -3328,10 +3327,10 @@ SUBPARTITION TEMPLATE
   SUBPARTITION asia VALUES ('asia'),
   SUBPARTITION europe VALUES ('europe')
 );
-ERROR:  syntax error at or near ";"
-LINE 9: );
-         ^
--- MPP-5185
+ERROR:  syntax error at or near "TEMPLATE"
+LINE 5: SUBPARTITION TEMPLATE
+                     ^
+-- MPP-5185 MPP-26829
 -- Should work
 CREATE TABLE rank_settemp (id int, rank int, year date, gender
 char(1)) DISTRIBUTED BY (id, gender, year)
@@ -3650,11 +3649,11 @@ partition by range (b)
 subpartition by list (a) 
 subpartition template ( 
 subpartition l1 values (1,2,3,4,5), 
-subpartition l2 values (6,7,8,9,10) ),
+subpartition l2 values (6,7,8,9,10) )
 subpartition by list (e) 
 subpartition template ( 
 subpartition ll1 values ('Engineering'), 
-subpartition ll2 values ('QA') ),
+subpartition ll2 values ('QA') )
 subpartition by list (c) 
 subpartition template ( 
 subpartition lll1 values ('M'), 
@@ -4723,11 +4722,11 @@ partition by range (b)
 subpartition by list (a)
 subpartition template (
 subpartition l1 values (1,2,3,4,5),
-subpartition l2 values (6,7,8,9,10) ),
+subpartition l2 values (6,7,8,9,10) )
 subpartition by list (e)
 subpartition template (
 subpartition ll1 values ('Engineering'),
-subpartition ll2 values ('QA') ),
+subpartition ll2 values ('QA') )
 subpartition by list (c)
 subpartition template (
 subpartition lll1 values ('M'),

--- a/src/test/regress/input/bb_mpph.source
+++ b/src/test/regress/input/bb_mpph.source
@@ -2981,7 +2981,7 @@ CREATE TABLE aopart_ORDERS (
     O_SHIPPRIORITY integer,
     O_COMMENT VARCHAR(79)
     )
-    partition by range (o_orderkey) subpartition by range (o_orderdate), subpartition by list (o_orderstatus) subpartition template (values('F','O','P'))
+    partition by range (o_orderkey) subpartition by range (o_orderdate) subpartition by list (o_orderstatus) subpartition template (values('F','O','P'))
     (partition p1 start('1') end('6000001') every(2000000)
     (subpartition sp1 start('1992-01-01') ,subpartition sp2 start('1996-08-03') end('1998-08-03')));
 
@@ -3008,8 +3008,8 @@ CREATE TABLE aopart_LINEITEM (
     WITH (appendonly=true,checksum=false,compresslevel=3)
     partition by list (l_tax)
     subpartition by range (l_suppkey) subpartition template (start('1') end('5000001') every(1666666))
-    ,subpartition by range (l_commitdate) subpartition template (start('1992-01-31') end('1998-11-01') every(interval '15 months'))
-    ,subpartition by list (l_discount) subpartition template (
+    subpartition by range (l_commitdate) subpartition template (start('1992-01-31') end('1998-11-01') every(interval '15 months'))
+    subpartition by list (l_discount) subpartition template (
     values('0','0.1'),
     values('0.06','0.01','0.02','0.07','0.08') WITH (appendonly=true,checksum=false,compresstype=zlib,compresslevel=1),
     values('0.09','0.05','0.04','0.03'))

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -58,7 +58,7 @@ create table mpp3137_region
                     )
 partition by list (r_regionkey)
 subpartition by list (r_name)
-,subpartition by list (r_comment) subpartition template (
+subpartition by list (r_comment) subpartition template (
         values('ges. thinly even pinto beans ca'),
         values('uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl','lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to','hs use ironic, even requests. s'),
         values('ly final courts cajole furiously final excuse'),
@@ -121,7 +121,7 @@ PS_COMMENT VARCHAR(199)
 )
 partition by range (ps_suppkey)
 subpartition by range (ps_partkey)
-,subpartition by range (ps_supplycost) subpartition template (start('1') end('1001') every(500))
+subpartition by range (ps_supplycost) subpartition template (start('1') end('1001') every(500))
 (
 partition p1 start('1') end('10001') every(5000)
 (subpartition sp1 start('1') end('200001') every(66666)
@@ -192,7 +192,7 @@ partition by range (c_custkey)
 subpartition by range (c_acctbal) 
 subpartition template (start('-999.99') end('10000.99') every(11000)
 )
-,subpartition by range (c_nationkey) 
+subpartition by range (c_nationkey) 
 subpartition template (start('0') end('25') every(5))
 (
 partition p1 start('1') end('150001') every(50000)
@@ -348,30 +348,30 @@ drop table mpp3265;
 CREATE TABLE MULTI_PART2(a int, b int, c int, d int, e int, f int, g int, h int, i int, j int, k int, l int, m int, n int, o int, p int, q int, r int, s int, t int, u int, v int, w int, x int, y int, z int)
 distributed by (a)
 partition by range (a)
-subpartition by range (b) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (c) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (d) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (e) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (f) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (g) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (h) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (i) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (j) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (k) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (l) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (m) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (n) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (o) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (p) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (q) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (r) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (s) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (t) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (u) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (v) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (w) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (x) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (y) subpartition template ( start (1) end (2) every (1)),
+subpartition by range (b) subpartition template ( start (1) end (2) every (1))
+subpartition by range (c) subpartition template ( start (1) end (2) every (1))
+subpartition by range (d) subpartition template ( start (1) end (2) every (1))
+subpartition by range (e) subpartition template ( start (1) end (2) every (1))
+subpartition by range (f) subpartition template ( start (1) end (2) every (1))
+subpartition by range (g) subpartition template ( start (1) end (2) every (1))
+subpartition by range (h) subpartition template ( start (1) end (2) every (1))
+subpartition by range (i) subpartition template ( start (1) end (2) every (1))
+subpartition by range (j) subpartition template ( start (1) end (2) every (1))
+subpartition by range (k) subpartition template ( start (1) end (2) every (1))
+subpartition by range (l) subpartition template ( start (1) end (2) every (1))
+subpartition by range (m) subpartition template ( start (1) end (2) every (1))
+subpartition by range (n) subpartition template ( start (1) end (2) every (1))
+subpartition by range (o) subpartition template ( start (1) end (2) every (1))
+subpartition by range (p) subpartition template ( start (1) end (2) every (1))
+subpartition by range (q) subpartition template ( start (1) end (2) every (1))
+subpartition by range (r) subpartition template ( start (1) end (2) every (1))
+subpartition by range (s) subpartition template ( start (1) end (2) every (1))
+subpartition by range (t) subpartition template ( start (1) end (2) every (1))
+subpartition by range (u) subpartition template ( start (1) end (2) every (1))
+subpartition by range (v) subpartition template ( start (1) end (2) every (1))
+subpartition by range (w) subpartition template ( start (1) end (2) every (1))
+subpartition by range (x) subpartition template ( start (1) end (2) every (1))
+subpartition by range (y) subpartition template ( start (1) end (2) every (1))
 subpartition by range (z) subpartition template ( start (1) end (2) every (1))
 ( start (1) end (2) every (1));
 alter table multi_part2 rename to multi_part2_0000000;
@@ -953,3 +953,17 @@ partition by range (f1)
   start (time '09:00') end (time '17:00') EVERY (INTERVAL '1 hour'),
   default partition default_part
 );
+
+-- MPP-26829
+-- negative test for when SUBPARTITION TEMPLATE shows up before any SUBPARTITION BY
+CREATE TABLE MPP_26829
+(a integer, b integer NOT NULL, c integer)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+SUBPARTITION TEMPLATE (START (1) END (12) EVERY (1), DEFAULT SUBPARTITION other_months )
+SUBPARTITION BY LIST (c)
+SUBPARTITION TEMPLATE (
+SUBPARTITION p027 VALUES ('027'),
+SUBPARTITION p141 VALUES ('141'),
+SUBPARTITION p037 VALUES ('037'));
+-- MPP-26829

--- a/src/test/regress/output/bb_mpph.source
+++ b/src/test/regress/output/bb_mpph.source
@@ -8619,7 +8619,7 @@ CREATE TABLE aopart_ORDERS (
     O_SHIPPRIORITY integer,
     O_COMMENT VARCHAR(79)
     )
-    partition by range (o_orderkey) subpartition by range (o_orderdate), subpartition by list (o_orderstatus) subpartition template (values('F','O','P'))
+    partition by range (o_orderkey) subpartition by range (o_orderdate) subpartition by list (o_orderstatus) subpartition template (values('F','O','P'))
     (partition p1 start('1') end('6000001') every(2000000)
     (subpartition sp1 start('1992-01-01') ,subpartition sp2 start('1996-08-03') end('1998-08-03')));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'o_orderkey' as the Greenplum Database data distribution key for this table.
@@ -8661,8 +8661,8 @@ CREATE TABLE aopart_LINEITEM (
     WITH (appendonly=true,checksum=false,compresslevel=3)
     partition by list (l_tax)
     subpartition by range (l_suppkey) subpartition template (start('1') end('5000001') every(1666666))
-    ,subpartition by range (l_commitdate) subpartition template (start('1992-01-31') end('1998-11-01') every(interval '15 months'))
-    ,subpartition by list (l_discount) subpartition template (
+    subpartition by range (l_commitdate) subpartition template (start('1992-01-31') end('1998-11-01') every(interval '15 months'))
+    subpartition by list (l_discount) subpartition template (
     values('0','0.1'),
     values('0.06','0.01','0.02','0.07','0.08') WITH (appendonly=true,checksum=false,compresstype=zlib,compresslevel=1),
     values('0.09','0.05','0.04','0.03'))

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -64,7 +64,7 @@ create table mpp3137_region
                     )
 partition by list (r_regionkey)
 subpartition by list (r_name)
-,subpartition by list (r_comment) subpartition template (
+subpartition by list (r_comment) subpartition template (
         values('ges. thinly even pinto beans ca'),
         values('uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl','lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to','hs use ironic, even requests. s'),
         values('ly final courts cajole furiously final excuse'),
@@ -144,7 +144,7 @@ PS_COMMENT VARCHAR(199)
 )
 partition by range (ps_suppkey)
 subpartition by range (ps_partkey)
-,subpartition by range (ps_supplycost) subpartition template (start('1') end('1001') every(500))
+subpartition by range (ps_supplycost) subpartition template (start('1') end('1001') every(500))
 (
 partition p1 start('1') end('10001') every(5000)
 (subpartition sp1 start('1') end('200001') every(66666)
@@ -227,7 +227,7 @@ partition by range (c_custkey)
 subpartition by range (c_acctbal) 
 subpartition template (start('-999.99') end('10000.99') every(11000)
 )
-,subpartition by range (c_nationkey) 
+subpartition by range (c_nationkey) 
 subpartition template (start('0') end('25') every(5))
 (
 partition p1 start('1') end('150001') every(50000)
@@ -392,30 +392,30 @@ drop table mpp3265;
 CREATE TABLE MULTI_PART2(a int, b int, c int, d int, e int, f int, g int, h int, i int, j int, k int, l int, m int, n int, o int, p int, q int, r int, s int, t int, u int, v int, w int, x int, y int, z int)
 distributed by (a)
 partition by range (a)
-subpartition by range (b) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (c) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (d) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (e) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (f) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (g) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (h) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (i) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (j) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (k) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (l) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (m) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (n) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (o) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (p) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (q) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (r) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (s) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (t) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (u) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (v) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (w) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (x) subpartition template ( start (1) end (2) every (1)),
-subpartition by range (y) subpartition template ( start (1) end (2) every (1)),
+subpartition by range (b) subpartition template ( start (1) end (2) every (1))
+subpartition by range (c) subpartition template ( start (1) end (2) every (1))
+subpartition by range (d) subpartition template ( start (1) end (2) every (1))
+subpartition by range (e) subpartition template ( start (1) end (2) every (1))
+subpartition by range (f) subpartition template ( start (1) end (2) every (1))
+subpartition by range (g) subpartition template ( start (1) end (2) every (1))
+subpartition by range (h) subpartition template ( start (1) end (2) every (1))
+subpartition by range (i) subpartition template ( start (1) end (2) every (1))
+subpartition by range (j) subpartition template ( start (1) end (2) every (1))
+subpartition by range (k) subpartition template ( start (1) end (2) every (1))
+subpartition by range (l) subpartition template ( start (1) end (2) every (1))
+subpartition by range (m) subpartition template ( start (1) end (2) every (1))
+subpartition by range (n) subpartition template ( start (1) end (2) every (1))
+subpartition by range (o) subpartition template ( start (1) end (2) every (1))
+subpartition by range (p) subpartition template ( start (1) end (2) every (1))
+subpartition by range (q) subpartition template ( start (1) end (2) every (1))
+subpartition by range (r) subpartition template ( start (1) end (2) every (1))
+subpartition by range (s) subpartition template ( start (1) end (2) every (1))
+subpartition by range (t) subpartition template ( start (1) end (2) every (1))
+subpartition by range (u) subpartition template ( start (1) end (2) every (1))
+subpartition by range (v) subpartition template ( start (1) end (2) every (1))
+subpartition by range (w) subpartition template ( start (1) end (2) every (1))
+subpartition by range (x) subpartition template ( start (1) end (2) every (1))
+subpartition by range (y) subpartition template ( start (1) end (2) every (1))
 subpartition by range (z) subpartition template ( start (1) end (2) every (1))
 ( start (1) end (2) every (1));
 alter table multi_part2 rename to multi_part2_0000000;
@@ -2936,3 +2936,19 @@ partition by range (f1)
   default partition default_part
 );
 ERROR:  cannot create partition inherited from temporary relation
+-- MPP-26829
+-- negative test for when SUBPARTITION TEMPLATE shows up before any SUBPARTITION BY
+CREATE TABLE MPP_26829
+(a integer, b integer NOT NULL, c integer)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+SUBPARTITION TEMPLATE (START (1) END (12) EVERY (1), DEFAULT SUBPARTITION other_months )
+SUBPARTITION BY LIST (c)
+SUBPARTITION TEMPLATE (
+SUBPARTITION p027 VALUES ('027'),
+SUBPARTITION p141 VALUES ('141'),
+SUBPARTITION p037 VALUES ('037'));
+ERROR:  syntax error at or near "TEMPLATE"
+LINE 5: SUBPARTITION TEMPLATE (START (1) END (12) EVERY (1), DEFAULT...
+                     ^
+-- MPP-26829

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -871,7 +871,7 @@ CREATE TABLE LINEITEM (
                 )
 partition by range (l_discount) 
 subpartition by range (l_quantity) 
-,subpartition by range (l_tax) subpartition template (start('0') end('1.08') every 6 (1))
+subpartition by range (l_tax) subpartition template (start('0') end('1.08') every 6 (1))
 ,subpartition by range (l_receiptdate) subpartition template (subpartition sp1 start('1992-01-03') end('1999-01-01'), subpartition sp2 start('1993-01-03') end ('1997-01-01'))
 (
 partition p1 start('0') end('1.1') 

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -652,7 +652,7 @@ PS_COMMENT VARCHAR(199)
 )
 partition by range (ps_suppkey)
 subpartition by range (ps_partkey)
-,subpartition by range (ps_supplycost) subpartition template (start('1')
+subpartition by range (ps_supplycost) subpartition template (start('1')
 end('1001') every(500))
 (
 partition p1 start('1') end('10001') every(5000)
@@ -734,7 +734,7 @@ PS_COMMENT VARCHAR(199)
 )
 partition by range (ps_suppkey)
 subpartition by range (ps_partkey)
-,subpartition by range (ps_supplycost) subpartition template (start('1')
+subpartition by range (ps_supplycost) subpartition template (start('1')
 end('1001') every(500))
 (
 partition p1 start('1') end('10001') every(5000)
@@ -762,7 +762,7 @@ subpartition jan02 start (date '2002-01-01'),
 subpartition jan03 start (date '2003-01-01'),
 subpartition jan04 start (date '2004-01-01'),
 subpartition jan05 start (date '2005-01-01')
-),
+)
 subpartition by list (usstate)
 subpartition template (
 subpartition mass values ('MA'),
@@ -780,7 +780,7 @@ year date, gender char(1),
 usstate char(2))
 DISTRIBUTED BY (id, gender, year, usstate)
 partition by list (gender)
-subpartition by range (year),
+subpartition by range (year)
 subpartition by list (usstate)
 (
   partition boys values ('M') 
@@ -815,8 +815,8 @@ subpartition mass values ('MA'),
 subpartition cali values ('CA'),
 subpartition ohio values ('OH')
 )
-)
-,
+),
+
   partition girls values ('F')
 (
 subpartition jan01 start (date '2001-01-01')
@@ -1654,7 +1654,7 @@ partition a start('a') end('f'),
 partition b start('e') end('g')
 );
 
--- MPP-5159
+-- MPP-5159 MPP-26829
 -- Should fail -- missing partition spec and subpartition template follows the
 -- partition declaration.
 CREATE TABLE list_sales (trans_id int, date date, amount
@@ -1667,7 +1667,7 @@ SUBPARTITION TEMPLATE
   SUBPARTITION europe VALUES ('europe')
 );
 
--- MPP-5185
+-- MPP-5185 MPP-26829
 -- Should work
 CREATE TABLE rank_settemp (id int, rank int, year date, gender
 char(1)) DISTRIBUTED BY (id, gender, year)
@@ -1829,11 +1829,11 @@ partition by range (b)
 subpartition by list (a) 
 subpartition template ( 
 subpartition l1 values (1,2,3,4,5), 
-subpartition l2 values (6,7,8,9,10) ),
+subpartition l2 values (6,7,8,9,10) )
 subpartition by list (e) 
 subpartition template ( 
 subpartition ll1 values ('Engineering'), 
-subpartition ll2 values ('QA') ),
+subpartition ll2 values ('QA') )
 subpartition by list (c) 
 subpartition template ( 
 subpartition lll1 values ('M'), 
@@ -2412,11 +2412,11 @@ partition by range (b)
 subpartition by list (a)
 subpartition template (
 subpartition l1 values (1,2,3,4,5),
-subpartition l2 values (6,7,8,9,10) ),
+subpartition l2 values (6,7,8,9,10) )
 subpartition by list (e)
 subpartition template (
 subpartition ll1 values ('Engineering'),
-subpartition ll2 values ('QA') ),
+subpartition ll2 values ('QA') )
 subpartition by list (c)
 subpartition template (
 subpartition lll1 values ('M'),


### PR DESCRIPTION
This commit changed the way the grammar was parsing the subpartition
information to ensure that the templates could not exist without a
`SUBPARTITION BY`.

Testing coverage for the case where the `SUBPARTITION TEMPLATE`
expression is written before a `SUBPARTITION BY` was added.

The error displayed when the template appeared after a Partition was
changed to point to the TEMPLATE

Add a deprecation warning to the following syntax as it should be
removed in the next major version of Greenplum.

Deprecated syntax:
 - A comma (",") between `SUBPARTITION TEMPLATE` and its
 corresponding `SUBPARTITION BY` that precedes it.
 - A comma between two consecutive `SUBPARTITION BY` clauses
---

PR for `master` branch that fixes the same issues as #5544 does to `5X_STABLE` 