### PR TITLE
Copy tuple from shared buffer during persistent table rebuild

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
@@ -37,3 +37,12 @@ Feature: persistent rebuild tests
           | primary |
           | master  |
 
+    Scenario: Persistent rebuild should work on small shared_buffers value
+        Given the database is running
+        And there is a "ao" table "public.ao_part_table" in "bkdb" having "1000" partitions
+        And the user runs "gpconfig -c shared_buffers -v 512kB"
+        And gpconfig should return a return code of 0
+        And the database is restarted
+        And the information of a "primary" segment on any host is saved
+        When run gppersistent_rebuild with the saved content id
+        Then gppersistent_rebuild should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2152,6 +2152,7 @@ def impl(context, table_type, table_name, db_name, num_partitions):
     if not num_partitions.strip().isdigit():
         raise Exception('Invalid number of partitions specified "%s"' % num_partitions)
 
+    create_database_if_not_exists(context, db_name)
     num_partitions = int(num_partitions.strip()) + 1
     create_large_num_partitions(table_type, table_name, db_name, num_partitions)
 
@@ -3689,7 +3690,7 @@ def impl(context, file, path):
     raise Exception('File was not found in :' + path)
 
 
-@then('database is restarted to kill the hung query')
+@given('the database is restarted')
 def impl(context):
     try:
         stop_database_if_started(context)
@@ -3701,7 +3702,7 @@ def impl(context):
         raise Exception('Failed to stop the database')
 
     start_database_if_not_started(context)
-    if not check_database_is_running():
+    if not check_database_is_running(context):
         raise Exception('Failed to start the database')
 
 


### PR DESCRIPTION
When persistent table rebuild was collecting AO tables from
pg_appendonly catalog table, it was storing the actual tuple from
shared buffer into the hash table created by persistent table rebuild.
When shared buffers get overloaded, those pg_appendonly tuples stored
in the hash table could become invalid. To fix the issue, copy the
pg_appendonly tuples from shared buffers into the current memory
context for later usage.