### PR TITLE
Integrate Gang management from portal to Dispatcher and simplify AssignGangs for init plans

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -72,6 +72,7 @@
 #include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h" /* Gp_role, Gp_is_writer, interconnect_setup_timeout */
 #include "utils/vmem_tracker.h"
+#include "cdb/cdbdisp.h"
 
 /*
  *	User-tweakable parameters
@@ -3124,7 +3125,7 @@ AbortTransaction(void)
 	 */
 	AfterTriggerEndXact(false); /* 'false' means it's abort */
 	AtAbort_Portals();
-
+	AtAbort_DispatcherState();
 	AtEOXact_SharedSnapshot();
 
 	/* Perform any Resource Scheduler abort procesing. */
@@ -4940,7 +4941,7 @@ RollbackAndReleaseCurrentSubTransaction(void)
 				DTX_PROTOCOL_COMMAND_SUBTRANSACTION_ROLLBACK_INTERNAL))
 		{
 			elog(ERROR,
-				 "Could not RollbackAndReleaseCurrentSubTransaction dispatch failed");
+				 "DTX RollbackAndReleaseCurrentSubTransaction dispatch failed");
 		}
 	}
 }
@@ -5348,6 +5349,7 @@ AbortSubTransaction(void)
 		AtSubAbort_Portals(s->subTransactionId,
 						   s->parent->subTransactionId,
 						   s->parent->curTransactionOwner);
+		AtSubAbort_DispatcherState();
 		AtEOXact_DispatchOids(false);
 		AtEOSubXact_LargeObject(false, s->subTransactionId,
 								s->parent->subTransactionId);

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2744,8 +2744,6 @@ CommitTransaction(void)
 	/* we're now in a consistent state to handle an interrupt. */
 	RESUME_INTERRUPTS();
 
-	freeGangsForPortal(NULL);
-
 	/* Release resource group slot at the end of a transaction */
 	if (ShouldUnassignResGroup())
 		UnassignResGroup();
@@ -3217,8 +3215,6 @@ AbortTransaction(void)
 	 * State remains TRANS_ABORT until CleanupTransaction().
 	 */
 	RESUME_INTERRUPTS();
-
-	freeGangsForPortal(NULL);
 
 	/* If a query was cancelled, then cleanup reader gangs. */
 	if (QueryCancelCleanup)

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2745,6 +2745,8 @@ CommitTransaction(void)
 	/* we're now in a consistent state to handle an interrupt. */
 	RESUME_INTERRUPTS();
 
+	AvailableWriterGangValidation();
+
 	/* Release resource group slot at the end of a transaction */
 	if (ShouldUnassignResGroup())
 		UnassignResGroup();

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -4778,7 +4778,8 @@ DispatchRollbackToSavepoint(char *name)
 	 * either exit via elog()/ereport() or return false
 	 */
 	if (!dispatchDtxCommand(cmd))
-		elog(ERROR, "Could not rollback to savepoint (%s)", cmd);
+		ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+						errmsg("Could not rollback to savepoint (%s)", cmd)));
 
 	pfree(cmd);
 }
@@ -4942,8 +4943,8 @@ RollbackAndReleaseCurrentSubTransaction(void)
 		if (!doDispatchSubtransactionInternalCmd(
 				DTX_PROTOCOL_COMMAND_SUBTRANSACTION_ROLLBACK_INTERNAL))
 		{
-			elog(ERROR,
-				 "DTX RollbackAndReleaseCurrentSubTransaction dispatch failed");
+			ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+							errmsg("DTX RollbackAndReleaseCurrentSubTransaction dispatch failed")));
 		}
 	}
 }

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -35,6 +35,15 @@
 
 #include <poll.h>
 
+static Gang *
+getCdbCopyPrimaryGang(CdbCopy *c)
+{
+	if (!c || !c->dispatcherState)
+		return NULL;
+
+	return (Gang *)linitial(c->dispatcherState->allocatedGangs);
+}
+
 /*
  * Create a cdbCopy object that includes all the cdb
  * information and state needed by the backend COPY.
@@ -140,7 +149,9 @@ cdbCopyStart(CdbCopy *c, CopyStmt *stmt, struct GpPolicy *policy)
 void
 cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes)
 {
-	Gang	   *gp = (Gang *)linitial(c->dispatcherState->allocatedGangs);
+	Gang	   *gp = getCdbCopyPrimaryGang(c);
+
+	Assert(gp);
 
 	for (int i = 0; i < gp->size; ++i)
 	{
@@ -172,8 +183,8 @@ cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer,
 	 * code above. I didn't do it because it's broken right now
 	 */
 
-	gp = (Gang *)linitial(c->dispatcherState->allocatedGangs);
-
+	gp = getCdbCopyPrimaryGang(c);
+	Assert(gp);
 	q = getSegmentDescriptorFromGang(gp, target_seg);
 
 	/* transmit the COPY data */
@@ -219,7 +230,7 @@ cdbCopyGetData(CdbCopy *c, bool copy_cancel, uint64 *rows_processed)
 	c->copy_out_buf.data[0] = '\0';
 	c->copy_out_buf.cursor = 0;
 
-	gp = (Gang *)linitial(c->dispatcherState->allocatedGangs);
+	gp = getCdbCopyPrimaryGang(c);
 
 	/*
 	 * MPP-7712: we used to issue the cancel-requests for each *row* we got
@@ -628,7 +639,8 @@ cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed, char *abort
 	 * GPDB_91_MERGE_FIXME: ugh, this is nasty. We shouldn't be calling
 	 * cdbCopyEnd twice on the same CdbCopy in the first place!
 	 */
-	if (!c->dispatcherState || !((Gang *)linitial(c->dispatcherState->allocatedGangs)))
+	gp = getCdbCopyPrimaryGang(c);
+	if (!gp)
 		return -1;
 
 	/* clean err message */
@@ -639,7 +651,6 @@ cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed, char *abort
 	/* allocate a failed segment database pointer array */
 	failedSegDBs = (SegmentDatabaseDescriptor **) palloc(c->total_segs * 2 * sizeof(SegmentDatabaseDescriptor *));
 
-	gp = (Gang *)linitial(c->dispatcherState->allocatedGangs);
 	db_descriptors = gp->db_descriptors;
 	size = gp->size;
 
@@ -685,3 +696,4 @@ cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed, char *abort
 
 	return total_rows_rejected;
 }
+

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -140,7 +140,7 @@ cdbCopyStart(CdbCopy *c, CopyStmt *stmt, struct GpPolicy *policy)
 void
 cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes)
 {
-	Gang	   *gp = c->dispatcherState->primaryResults->writer_gang;
+	Gang	   *gp = (Gang *)linitial(c->dispatcherState->allocatedGangs);
 
 	for (int i = 0; i < gp->size; ++i)
 	{
@@ -172,7 +172,7 @@ cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer,
 	 * code above. I didn't do it because it's broken right now
 	 */
 
-	gp = c->dispatcherState->primaryResults->writer_gang;
+	gp = (Gang *)linitial(c->dispatcherState->allocatedGangs);
 
 	q = getSegmentDescriptorFromGang(gp, target_seg);
 
@@ -219,7 +219,7 @@ cdbCopyGetData(CdbCopy *c, bool copy_cancel, uint64 *rows_processed)
 	c->copy_out_buf.data[0] = '\0';
 	c->copy_out_buf.cursor = 0;
 
-	gp = c->dispatcherState->primaryResults->writer_gang;
+	gp = (Gang *)linitial(c->dispatcherState->allocatedGangs);
 
 	/*
 	 * MPP-7712: we used to issue the cancel-requests for each *row* we got
@@ -628,7 +628,7 @@ cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed, char *abort
 	 * GPDB_91_MERGE_FIXME: ugh, this is nasty. We shouldn't be calling
 	 * cdbCopyEnd twice on the same CdbCopy in the first place!
 	 */
-	if (!c->dispatcherState || !c->dispatcherState->primaryResults->writer_gang)
+	if (!c->dispatcherState || !((Gang *)linitial(c->dispatcherState->allocatedGangs)))
 		return -1;
 
 	/* clean err message */
@@ -639,7 +639,7 @@ cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed, char *abort
 	/* allocate a failed segment database pointer array */
 	failedSegDBs = (SegmentDatabaseDescriptor **) palloc(c->total_segs * 2 * sizeof(SegmentDatabaseDescriptor *));
 
-	gp = c->dispatcherState->primaryResults->writer_gang;
+	gp = (Gang *)linitial(c->dispatcherState->allocatedGangs);
 	db_descriptors = gp->db_descriptors;
 	size = gp->size;
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -594,7 +594,7 @@ doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType)
 	bool		badGangs,
 				succeeded = false;
 
-	if (gxactWriterGangLost())
+	if (currentGxactWriterGangLost())
 	{
 		ereport(WARNING, (errmsg("Writer gang of current global transaction is lost")));
 		return false;
@@ -2092,7 +2092,7 @@ dispatchDtxCommand(const char *cmd)
 
 	elog(DTM_DEBUG5, "dispatchDtxCommand: '%s'", cmd);
 
-	if (gxactWriterGangLost())
+	if (currentGxactWriterGangLost())
 	{
 		ereport(WARNING, (errmsg("Writer gang of current global transaction is lost")));
 		return false;
@@ -3414,14 +3414,14 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 }
 
 void
-markGxactWriterGangLost(void)
+markCurrentGxactWriterGangLost(void)
 {
 	if (currentGxact)
 		currentGxact->writerGangLost = true;
 }
 
 bool
-gxactWriterGangLost(void)
+currentGxactWriterGangLost(void)
 {
 	return currentGxact == NULL ? false : currentGxact->writerGangLost;
 }

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1521,8 +1521,6 @@ initTM(void)
 		}
 
 		RestoreToUser(olduser);
-
-		freeGangsForPortal(NULL);
 	}
 }
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -594,6 +594,12 @@ doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType)
 	bool		badGangs,
 				succeeded = false;
 
+	if (gxactWriterGangLost())
+	{
+		ereport(WARNING, (errmsg("Writer gang of current global transaction is lost")));
+		return false;
+	}
+
 	if (cmdType == DTX_PROTOCOL_COMMAND_SUBTRANSACTION_BEGIN_INTERNAL &&
 		currentGxact->state == DTX_STATE_ACTIVE_NOT_DISTRIBUTED)
 		setCurrentGxactState(DTX_STATE_ACTIVE_DISTRIBUTED);
@@ -2086,6 +2092,12 @@ dispatchDtxCommand(const char *cmd)
 
 	elog(DTM_DEBUG5, "dispatchDtxCommand: '%s'", cmd);
 
+	if (gxactWriterGangLost())
+	{
+		ereport(WARNING, (errmsg("Writer gang of current global transaction is lost")));
+		return false;
+	}
+
 	CdbDispatchCommand(cmd, DF_NONE, &cdb_pgresults);
 
 	if (cdb_pgresults.numResults == 0)
@@ -2156,6 +2168,7 @@ initGxact(TMGXACT *gxact)
 
 	gxact->directTransaction = false;
 	gxact->directTransactionContentId = 0;
+	gxact->writerGangLost = false;
 }
 
 bool
@@ -3398,4 +3411,17 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 			break;
 	}
 	elog(DTM_DEBUG5, "performDtxProtocolCommand successful return for distributed transaction %s", gid);
+}
+
+void
+markGxactWriterGangLost(void)
+{
+	if (currentGxact)
+		currentGxact->writerGangLost = true;
+}
+
+bool
+gxactWriterGangLost(void)
+{
+	return currentGxact == NULL ? false : currentGxact->writerGangLost;
 }

--- a/src/backend/cdb/dispatcher/README.md
+++ b/src/backend/cdb/dispatcher/README.md
@@ -22,6 +22,7 @@ For a query/plan, QD would build one `GANGTYPE_PRIMARY_WRITER` Gang, and several
 	* `AllocateReaderGang`: create Gang of type `GANGTYPE_ENTRYDB_READER`, `GANGTYPE_SINGLETON_READER`, `GANGTYPE_PRIMARY_READER` by specification. Gang reuage logic is included.
 	* `AllocateWriterGang`: create Gang of type `GANGTYPE_PRIMARY_WRITER`
 	* `DisconnectAndDestroyGang`: tear down a Gang of any type, but make sure no reader Gang exist before calling this routine for writer Gang
+	* `RecycleGang`: recycle a gang of any type to available list
 	* `DisconnectAndDestroyAllGangs`: tear down all existing Gangs of this session
 * Gang status check:
 	* `GangOK`: check if a created Gang is healthy
@@ -35,3 +36,15 @@ For a query/plan, QD would build one `GANGTYPE_PRIMARY_WRITER` Gang, and several
 	
 ### Dispatcher Mode:
 To improve parallelism, Dispatcher has two different implementations internally, one is using threads, the other leverages asynchronous network programming. When GUC `gp_connections_per_thread` is 0, async dispatcher is used, which is the default configuration
+
+### Dispatcher routines:
+All dispatcher routines contains few standard steps:
+* CdbDispatchPlan/CdbDispatchUtilityStatement/CdbDispatchCommand/CdbDispatchSetCommand/CdbDispDtxProtocolCommand
+	* `cdbdisp_makeDispatcherState`: create a dispatcher state and register it in the resource owner release callback.
+	* `buildGpQueryString/buildGpDtxProtocolCommand`: serialize Plan/Utility/Command to raw text QEs can recognize, must allocate it within DispatcherContex.
+	* `AllocateWriterGang/AssignGangs`: allocate a gang or a bunch of gangs (for Plan) and prepare for execution, gangs are tracked by dispatcher state
+	* `cdbdisp_dispatchToGang`: send serialized raw query to QEs in unblocking mode which means the data in connection is not guaranteed being flushed, this is very usefull if a plan contains multiple slices, so dispatcher don't block when libpq connections is congested 
+	* `cdbdisp_waitDispatchFinish`: as described above, this function will poll on libpq connections and flush the data in bunches 
+	* `cdbdisp_checkDispatchResult`: block until QEs report a command OK response or an error etc
+	* `cdbdisp_getDispatchResults`: fetch results from dispatcher state or error data if an error occurs
+	* `cdbdisp_destroyDispatcherState`: destroy current dispatcher state and recycle gangs allocated by it.

--- a/src/backend/cdb/dispatcher/README.md
+++ b/src/backend/cdb/dispatcher/README.md
@@ -22,7 +22,7 @@ For a query/plan, QD would build one `GANGTYPE_PRIMARY_WRITER` Gang, and several
 	* `AllocateReaderGang`: create Gang of type `GANGTYPE_ENTRYDB_READER`, `GANGTYPE_SINGLETON_READER`, `GANGTYPE_PRIMARY_READER` by specification. Gang reuage logic is included.
 	* `AllocateWriterGang`: create Gang of type `GANGTYPE_PRIMARY_WRITER`
 	* `DisconnectAndDestroyGang`: tear down a Gang of any type, but make sure no reader Gang exist before calling this routine for writer Gang
-	* `RecycleGang`: recycle a gang of any type to available list
+	* `RecycleGang`: put a gang to reusable gang list if gang can be cleanup correctly including discarding results, connection status check.
 	* `DisconnectAndDestroyAllGangs`: tear down all existing Gangs of this session
 * Gang status check:
 	* `GangOK`: check if a created Gang is healthy

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -497,7 +497,7 @@ cleanup_dispatcher_handle(dispatcher_handle_t *h)
 
 /*
  * Cleanup all dispatcher state that belong to
- * current resource owner and it's childrens
+ * current resource owner and its childrens
  */
 void
 AtAbort_DispatcherState(void)
@@ -523,7 +523,7 @@ AtAbort_DispatcherState(void)
 	 * If primary writer gang is destroyed in current Gxact
 	 * reset session and drop temp files
 	 */
-	if (gxactWriterGangLost())
+	if (currentGxactWriterGangLost())
 	{
 		DisconnectAndDestroyAllGangs(true);
 		CheckForResetSession();
@@ -570,12 +570,12 @@ cleanupDispatcherHandle(const ResourceOwner owner)
  * status, on the other hand, SET command should not affect running CURSOR
  * like 'search_path' etc; 
  *
- * Meanwhile when a dispatcher state of named portal is destroyed, it's
- * gang should not be recycled because it's guc was not set, so need to
+ * Meanwhile when a dispatcher state of named portal is destroyed, its
+ * gang should not be recycled because its guc was not set, so need to
  * mark those gangs destroyed when dispatcher state is destroyed.
  */
 void
-cdbdisp_markNamedPortalGangsDestroy(void)
+cdbdisp_markNamedPortalGangsDestroyed(void)
 {
 	dispatcher_handle_t *head = open_dispatcher_handles;
 	while (head != NULL)

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -58,8 +58,6 @@ static void destroy_dispatcher_handle(dispatcher_handle_t *h);
  */
 CdbDispatchDirectDesc default_dispatch_direct_desc = {false, 0, {0}};
 
-static void cdbdisp_clearGangActiveFlag(CdbDispatcherState *ds);
-
 static DispatcherInternalFuncs *pDispatchFuncs = NULL;
 
 /*
@@ -103,25 +101,6 @@ cdbdisp_dispatchToGang(struct CdbDispatcherState *ds,
 	Assert(gp && gp->size > 0);
 	Assert(dispatchResults && dispatchResults->resultArray);
 
-	if (dispatchResults->writer_gang)
-	{
-		/*
-		 * Are we dispatching to the writer-gang when it is already busy ?
-		 */
-		if (gp == dispatchResults->writer_gang)
-		{
-			if (dispatchResults->writer_gang->dispatcherActive)
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("query plan with multiple segworker groups is not supported"),
-						 errhint("likely caused by a function that reads or modifies data in a distributed table")));
-			}
-
-			dispatchResults->writer_gang->dispatcherActive = true;
-		}
-	}
-
 	/*
 	 * WIP: will use a function pointer for implementation later, currently
 	 * just use an internal function to move dispatch thread related code into
@@ -154,18 +133,7 @@ void
 cdbdisp_checkDispatchResult(struct CdbDispatcherState *ds,
 					   DispatchWaitMode waitMode)
 {
-	PG_TRY();
-	{
-		(pDispatchFuncs->checkResults) (ds, waitMode);
-	}
-	PG_CATCH();
-	{
-		cdbdisp_clearGangActiveFlag(ds);
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
-
-	cdbdisp_clearGangActiveFlag(ds);
+	(pDispatchFuncs->checkResults) (ds, waitMode);
 
 	if (log_dispatch_stats)
 		ShowUsage("DISPATCH STATISTICS");
@@ -326,22 +294,34 @@ CdbDispatchHandleError(struct CdbDispatcherState *ds)
  * Allocate memory and initialize CdbDispatcherState.
  *
  * Call cdbdisp_destroyDispatcherState to free it.
- *
- *	 maxSlices: max number of slices of the query/command.
  */
 CdbDispatcherState *
-cdbdisp_makeDispatcherState(void)
+cdbdisp_makeDispatcherState(bool isExtendedQuery)
 {
 	dispatcher_handle_t *handle = allocate_dispatcher_handle();
+	handle->dispatcherState->recycleGang = true;
+	handle->dispatcherState->isExtendedQuery = isExtendedQuery;
+	handle->dispatcherState->allocatedGangs = NIL;
 	return handle->dispatcherState;
 }
 
-void *
-cdbdisp_makeDispatchParams(int maxSlices,
-						  char *queryText,
-						  int queryTextLen)
+void
+cdbdisp_makeDispatchParams(CdbDispatcherState *ds,
+							int maxSlices,
+							char *queryText,
+							int queryTextLen)
 {
-	return (pDispatchFuncs->makeDispatchParams) (maxSlices, queryText, queryTextLen);
+	MemoryContext oldContext;
+	void *dispatchParams;
+
+	Assert(DispatcherContext);
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
+
+	dispatchParams = (pDispatchFuncs->makeDispatchParams) (maxSlices, queryText, queryTextLen);
+
+	ds->dispatchParams = dispatchParams;
+
+	MemoryContextSwitchTo(oldContext);
 }
 
 /*
@@ -352,6 +332,8 @@ cdbdisp_makeDispatchParams(int maxSlices,
 void
 cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 {
+	ListCell *lc;
+
 	if (!ds)
 		return;
 
@@ -369,6 +351,23 @@ cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 		results->resultArray = NULL;
 	}
 
+	/* Recycle or destroy gang accordingly */
+	foreach(lc, ds->allocatedGangs)
+	{
+		Gang *gp = lfirst(lc);
+
+		if (gp->type == GANGTYPE_PRIMARY_WRITER)
+			cdbgang_resetPrimaryWriterGang();
+		else
+			cdbgang_decreaseNumReaderGang();
+
+		if (ds->recycleGang)
+			RecycleGang(gp);
+		else
+			DisconnectAndDestroyGang(gp);
+	}
+
+	ds->allocatedGangs = NIL;
 	ds->dispatchParams = NULL;
 	ds->primaryResults = NULL;
 
@@ -380,19 +379,6 @@ void
 cdbdisp_cancelDispatch(CdbDispatcherState *ds)
 {
 	cdbdisp_checkDispatchResult(ds, DISPATCH_WAIT_CANCEL);
-}
-
-/*
- * Clear our "active" flags; so that we know that the writer gangs are busy -- and don't stomp on
- * internal dispatcher structures.
- */
-static void
-cdbdisp_clearGangActiveFlag(CdbDispatcherState *ds)
-{
-	if (ds && ds->primaryResults && ds->primaryResults->writer_gang)
-	{
-		ds->primaryResults->writer_gang->dispatcherActive = false;
-	}
 }
 
 bool
@@ -529,6 +515,12 @@ dispatcher_abort_callback(ResourceReleasePhase phase,
 	if (phase != RESOURCE_RELEASE_AFTER_LOCKS)
 		return;
 
+	if (CurrentGangCreating != NULL)
+	{
+		DisconnectAndDestroyGang(CurrentGangCreating);
+		CurrentGangCreating = NULL;
+	}
+
 	next = open_dispatcher_handles;
 	while (next)
 	{
@@ -542,5 +534,47 @@ dispatcher_abort_callback(ResourceReleasePhase phase,
 
 			cleanup_dispatcher_handle(curr);
 		}
+	}
+}
+
+/*
+ * Called by CdbDispatchSetCommand(), SET command can not be dispatched
+ * to named portal (like CURSOR). On the one hand, it might be in a busy
+ * status, on the other hand, SET command should not affect running CURSOR
+ * like 'search_path' etc; 
+ *
+ * Meanwhile when a dispatcher state of named portal is destroyed, it's
+ * gang should not be recycled because it's guc was not set, so need to
+ * mark those gangs destroyed when dispatcher state is destroyed.
+ */
+void
+cdbdisp_markNamedPortalGangsDestroy(void)
+{
+	dispatcher_handle_t *head = open_dispatcher_handles;
+	while (head != NULL)
+	{
+		if (!head->dispatcherState->isExtendedQuery)
+			head->dispatcherState->recycleGang = false;
+		head = head->next;
+	}
+}
+
+/*
+ * Unlike dispatcher_abort_callback(), this function will
+ * force destroy active dispatcher states
+ */
+void
+cdbdisp_cleanupAllDispatcherState(void)
+{
+	dispatcher_handle_t *curr;
+	dispatcher_handle_t *next;
+
+	next = open_dispatcher_handles;
+	while (next)
+	{
+		curr = next;
+		next = curr->next;
+
+		cleanup_dispatcher_handle(curr);
 	}
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -309,12 +309,6 @@ cdbdisp_dispatchToGang_async(struct CdbDispatcherState *ds,
 		qeResult = cdbdisp_makeResult(ds->primaryResults, segdbDesc, sliceIndex);
 		if (qeResult == NULL)
 		{
-			/*
-			 * writer_gang could be NULL if this is an extended query.
-			 */
-			if (ds->primaryResults->writer_gang)
-				ds->primaryResults->writer_gang->dispatcherActive = true;
-
 			elog(FATAL, "could not allocate resources for segworker communication");
 		}
 		pParms->dispatchResultPtrArray[pParms->dispatchCount++] = qeResult;

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -299,7 +299,7 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 	 * dispatched. Meanwhile such gang should not be reused because
 	 * it's guc was not set.
 	 */
-	cdbdisp_markNamedPortalGangsDestroy();
+	cdbdisp_markNamedPortalGangsDestroyed();
 
 	if (qeError)
 	{

--- a/src/backend/cdb/dispatcher/cdbdisp_thread.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_thread.c
@@ -216,12 +216,6 @@ cdbdisp_initDispatchParmsForGang(struct CdbDispatcherState *ds,
 		qeResult = cdbdisp_makeResult(ds->primaryResults, segdbDesc, sliceIndex);
 		if (qeResult == NULL)
 		{
-			/*
-			 * writer_gang could be NULL if this is an extended query.
-			 */
-			if (ds->primaryResults->writer_gang)
-				ds->primaryResults->writer_gang->dispatcherActive = true;
-
 			elog(FATAL, "could not allocate resources for segworker communication");
 		}
 

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -1077,8 +1077,7 @@ DisconnectAndDestroyGang(Gang *gp)
 
 	if (gp->type == GANGTYPE_PRIMARY_WRITER)
 	{
-		disconnectAndDestroyAllReaderGangs(false);
-		Assert(!readerGangsExist());
+		markGxactWriterGangLost();
 	}
 
 	MemoryContextDelete(gp->perGangContext);
@@ -1238,6 +1237,11 @@ cleanupGang(Gang *gp)
 						  "was used for portal: %s",
 						  gp->gang_id, gp->type, gp->size,
 						  (gp->portal_name ? gp->portal_name : "(unnamed)"));
+
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR(CleanupGang) == FaultInjectorTypeSkip)
+		return false;
+#endif
 
 	if (gp->noReuse)
 		return false;

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -770,18 +770,18 @@ AllocateAllIdleReaderGangs(CdbDispatcherState *ds)
 	/*
 	 * Do not use list_concat() here, it would destructively modify the lists!
 	 */
-    foreach(le, availableReaderGangsN)
-    {
-        ds->allocatedGangs = lappend(ds->allocatedGangs, lfirst(le));
+	foreach(le, availableReaderGangsN)
+	{
+		ds->allocatedGangs = lappend(ds->allocatedGangs, lfirst(le));
 		numAllocatedReaderGangs++;
-    }
+	}
 	availableReaderGangsN = NIL;
 
-    foreach(le, availableReaderGangs1)
-    {
-        ds->allocatedGangs = lappend(ds->allocatedGangs, lfirst(le));
+	foreach(le, availableReaderGangs1)
+	{
+		ds->allocatedGangs = lappend(ds->allocatedGangs, lfirst(le));
 		numAllocatedReaderGangs++;
-    }
+	}
 	availableReaderGangs1 = NIL;
 
 	MemoryContextSwitchTo(oldContext);
@@ -1076,9 +1076,7 @@ DisconnectAndDestroyGang(Gang *gp)
 	}
 
 	if (gp->type == GANGTYPE_PRIMARY_WRITER)
-	{
-		markGxactWriterGangLost();
-	}
+		markCurrentGxactWriterGangLost();
 
 	MemoryContextDelete(gp->perGangContext);
 

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -1700,3 +1700,12 @@ cdbgang_decreaseNumReaderGang(void)
 {
 	numAllocatedReaderGangs--;
 }
+
+void
+AvailableWriterGangValidation(void)
+{
+	if (availablePrimaryWriterGang && !GangOK(availablePrimaryWriterGang))
+	{
+		DisconnectAndDestroyAllGangs(true);
+	}
+}

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -39,6 +39,7 @@
 #include "libpq-int.h"
 #include "cdb/cdbconn.h"		/* SegmentDatabaseDescriptor */
 #include "cdb/cdbfts.h"
+#include "cdb/cdbdisp.h"		/* me */
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbgang.h"		/* me */
 #include "cdb/cdbgang_thread.h"
@@ -80,11 +81,11 @@ static int	largest_gangsize = 0;
 static bool NeedResetSession = false;
 static Oid	OldTempNamespace = InvalidOid;
 
-static List *allocatedReaderGangsN = NIL;
 static List *availableReaderGangsN = NIL;
-static List *allocatedReaderGangs1 = NIL;
 static List *availableReaderGangs1 = NIL;
+static Gang *availablePrimaryWriterGang= NULL;
 static Gang *primaryWriterGang = NULL;
+static int numAllocatedReaderGangs = 0;
 
 /*
  * Every gang created must have a unique identifier
@@ -96,14 +97,12 @@ static int	gang_id_counter = 2;
 static Gang *createGang(GangType type, int gang_id, int size, int content);
 static void disconnectAndDestroyAllReaderGangs(bool destroyAllocated);
 
-static bool isTargetPortal(const char *p1, const char *p2);
 static bool cleanupGang(Gang *gp);
 static void resetSessionForPrimaryGangLoss(void);
 static CdbComponentDatabaseInfo *copyCdbComponentDatabaseInfo(
 							 CdbComponentDatabaseInfo *dbInfo);
 static CdbComponentDatabaseInfo *findDatabaseInfoBySegIndex(
 						   CdbComponentDatabases *cdbs, int segIndex);
-static void addGangToAllocated(Gang *gp);
 static Gang *getAvailableGang(GangType type, int size, int content);
 #ifdef USE_ASSERT_CHECKING
 static bool readerGangsExist(void);
@@ -115,28 +114,23 @@ static bool readerGangsExist(void);
  * @type can be GANGTYPE_ENTRYDB_READER, GANGTYPE_SINGLETON_READER or GANGTYPE_PRIMARY_READER.
  */
 Gang *
-AllocateReaderGang(GangType type, char *portal_name)
+AllocateReaderGang(CdbDispatcherState *ds, GangType type, char *portal_name)
 {
 	MemoryContext oldContext = NULL;
 	Gang	   *gp = NULL;
 	int			size = 0;
 	int			content = 0;
 
-	ELOG_DISPATCHER_DEBUG("AllocateReaderGang for portal %s: allocatedReaderGangsN %d, availableReaderGangsN %d, "
-						  "allocatedReaderGangs1 %d, availableReaderGangs1 %d",
+	ELOG_DISPATCHER_DEBUG("AllocateReaderGang for portal %s: availableReaderGangsN %d, "
+						  "availableReaderGangs1 %d",
 						  (portal_name ? portal_name : "<unnamed>"),
-						  list_length(allocatedReaderGangsN),
 						  list_length(availableReaderGangsN),
-						  list_length(allocatedReaderGangs1),
 						  list_length(availableReaderGangs1));
 
 	if (Gp_role != GP_ROLE_DISPATCH)
 	{
 		elog(FATAL, "dispatch process called with role %d", Gp_role);
 	}
-
-	insist_log(IsTransactionOrTransactionBlock(),
-			   "cannot allocate segworker group outside of transaction");
 
 	if (GangContext == NULL)
 	{
@@ -146,6 +140,7 @@ AllocateReaderGang(GangType type, char *portal_name)
 											ALLOCSET_DEFAULT_MAXSIZE);
 	}
 	Assert(GangContext != NULL);
+
 	oldContext = MemoryContextSwitchTo(GangContext);
 
 	switch (type)
@@ -193,15 +188,16 @@ AllocateReaderGang(GangType type, char *portal_name)
 	/* let the gang know which portal it is being assigned to */
 	gp->portal_name = (portal_name ? pstrdup(portal_name) : (char *) NULL);
 
-	addGangToAllocated(gp);
-
 	MemoryContextSwitchTo(oldContext);
 
-	ELOG_DISPATCHER_DEBUG("on return: allocatedReaderGangs %d, availableReaderGangsN %d, "
-						  "allocatedReaderGangs1 %d, availableReaderGangs1 %d",
-						  list_length(allocatedReaderGangsN),
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
+	ds->allocatedGangs = lcons(gp, ds->allocatedGangs);
+	numAllocatedReaderGangs++;
+	MemoryContextSwitchTo(oldContext);
+
+	ELOG_DISPATCHER_DEBUG("on return: availableReaderGangsN %d, "
+						  "availableReaderGangs1 %d",
 						  list_length(availableReaderGangsN),
-						  list_length(allocatedReaderGangs1),
 						  list_length(availableReaderGangs1));
 
 	return gp;
@@ -211,7 +207,7 @@ AllocateReaderGang(GangType type, char *portal_name)
  * Create a writer gang.
  */
 Gang *
-AllocateWriterGang()
+AllocateWriterGang(CdbDispatcherState *ds)
 {
 	Gang	   *writerGang = NULL;
 	MemoryContext oldContext = NULL;
@@ -224,13 +220,29 @@ AllocateWriterGang()
 		elog(FATAL, "dispatch process called with role %d", Gp_role);
 	}
 
+	if (GangContext == NULL)
+	{
+		GangContext = AllocSetContextCreate(TopMemoryContext, "Gang Context",
+											ALLOCSET_DEFAULT_MINSIZE,
+											ALLOCSET_DEFAULT_INITSIZE,
+											ALLOCSET_DEFAULT_MAXSIZE);
+	}
+
+	if (primaryWriterGang)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("query plan with multiple segworker groups is not supported"),
+				 errhint("likely caused by a function that reads or modifies data in a distributed table")));
+	}
+
 	/*
 	 * First, we look for an unallocated but created gang of the right type if
 	 * it exists, we return it. Else, we create a new gang
 	 */
-	if (primaryWriterGang != NULL)
+	if (availablePrimaryWriterGang != NULL)
 	{
-		if (!GangOK(primaryWriterGang))
+		if (!GangOK(availablePrimaryWriterGang))
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
@@ -239,7 +251,8 @@ AllocateWriterGang()
 		else
 		{
 			ELOG_DISPATCHER_DEBUG("Reusing an existing primary writer gang");
-			writerGang = primaryWriterGang;
+			writerGang = availablePrimaryWriterGang;
+			availablePrimaryWriterGang = NULL;
 		}
 	}
 
@@ -250,15 +263,6 @@ AllocateWriterGang()
 		insist_log(IsTransactionOrTransactionBlock(),
 				   "cannot allocate segworker group outside of transaction");
 
-		if (GangContext == NULL)
-		{
-			GangContext = AllocSetContextCreate(TopMemoryContext,
-												"Gang Context",
-												ALLOCSET_DEFAULT_MINSIZE,
-												ALLOCSET_DEFAULT_INITSIZE,
-												ALLOCSET_DEFAULT_MAXSIZE);
-		}
-		Assert(GangContext != NULL);
 		oldContext = MemoryContextSwitchTo(GangContext);
 
 		writerGang = createGang(GANGTYPE_PRIMARY_WRITER,
@@ -278,6 +282,10 @@ AllocateWriterGang()
 	ELOG_DISPATCHER_DEBUG("AllocateWriterGang end.");
 
 	primaryWriterGang = writerGang;
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
+	ds->allocatedGangs = lcons(writerGang, ds->allocatedGangs);
+	oldContext = MemoryContextSwitchTo(oldContext);
+
 	return writerGang;
 }
 
@@ -346,7 +354,6 @@ CdbComponentDatabases *
 getComponentDatabases(void)
 {
 	Assert(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY);
-	Assert(GangContext != NULL);
 
 	uint8		ftsVersion = getFtsVersion();
 	MemoryContext oldContext = MemoryContextSwitchTo(GangContext);
@@ -750,51 +757,34 @@ bad:
 /*
  * This is where we keep track of all the gangs that exist for this session.
  * On a QD, gangs can either be "available" (not currently in use), or "allocated".
- *
- * On a Dispatch Agent, we just store them in the "available" lists, as the DA doesn't
- * keep track of allocations (it assumes the QD will keep track of what is allocated or not).
- *
  */
-List *
-getAllIdleReaderGangs()
+void
+AllocateAllIdleReaderGangs(CdbDispatcherState *ds)
 {
-	List	   *res = NIL;
 	ListCell   *le;
+	MemoryContext oldContext;
+
+	Assert(DispatcherContext);
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
 
 	/*
 	 * Do not use list_concat() here, it would destructively modify the lists!
 	 */
-	foreach(le, availableReaderGangsN)
-	{
-		res = lappend(res, lfirst(le));
-	}
-	foreach(le, availableReaderGangs1)
-	{
-		res = lappend(res, lfirst(le));
-	}
+    foreach(le, availableReaderGangsN)
+    {
+        ds->allocatedGangs = lappend(ds->allocatedGangs, lfirst(le));
+		numAllocatedReaderGangs++;
+    }
+	availableReaderGangsN = NIL;
 
-	return res;
-}
+    foreach(le, availableReaderGangs1)
+    {
+        ds->allocatedGangs = lappend(ds->allocatedGangs, lfirst(le));
+		numAllocatedReaderGangs++;
+    }
+	availableReaderGangs1 = NIL;
 
-List *
-getAllAllocatedReaderGangs()
-{
-	List	   *res = NIL;
-	ListCell   *le;
-
-	/*
-	 * Do not use list_concat() here, it would destructively modify the lists!
-	 */
-	foreach(le, allocatedReaderGangsN)
-	{
-		res = lappend(res, lfirst(le));
-	}
-	foreach(le, allocatedReaderGangs1)
-	{
-		res = lappend(res, lfirst(le));
-	}
-
-	return res;
+	MemoryContextSwitchTo(oldContext);
 }
 
 static Gang *
@@ -895,26 +885,6 @@ getAvailableGang(GangType type, int size, int content)
 	}
 
 	return retGang;
-}
-
-static void
-addGangToAllocated(Gang *gp)
-{
-	Assert(CurrentMemoryContext == GangContext);
-
-	switch (gp->type)
-	{
-		case GANGTYPE_SINGLETON_READER:
-		case GANGTYPE_ENTRYDB_READER:
-			allocatedReaderGangs1 = lappend(allocatedReaderGangs1, gp);
-			break;
-
-		case GANGTYPE_PRIMARY_READER:
-			allocatedReaderGangsN = lappend(allocatedReaderGangsN, gp);
-			break;
-		default:
-			Assert(false);
-	}
 }
 
 struct SegmentDatabaseDescriptor *
@@ -1086,8 +1056,6 @@ DisconnectAndDestroyGang(Gang *gp)
 	if (gp == NULL)
 		return;
 
-	AssertImply(gp->type == GANGTYPE_PRIMARY_WRITER, !readerGangsExist());
-
 	ELOG_DISPATCHER_DEBUG("DisconnectAndDestroyGang entered: id = %d", gp->gang_id);
 
 	if (gp->allocated)
@@ -1105,6 +1073,12 @@ DisconnectAndDestroyGang(Gang *gp)
 		Assert(segdbDesc != NULL);
 		cdbconn_disconnect(segdbDesc);
 		cdbconn_termSegmentDescriptor(segdbDesc);
+	}
+
+	if (gp->type == GANGTYPE_PRIMARY_WRITER)
+	{
+		disconnectAndDestroyAllReaderGangs(false);
+		Assert(!readerGangsExist());
 	}
 
 	MemoryContextDelete(gp->perGangContext);
@@ -1140,23 +1114,6 @@ disconnectAndDestroyAllReaderGangs(bool destroyAllocated)
 		DisconnectAndDestroyGang(gp);
 	}
 	availableReaderGangs1 = NULL;
-
-	if (destroyAllocated)
-	{
-		foreach(lc, allocatedReaderGangsN)
-		{
-			gp = (Gang *) lfirst(lc);
-			DisconnectAndDestroyGang(gp);
-		}
-		allocatedReaderGangsN = NULL;
-
-		foreach(lc, allocatedReaderGangs1)
-		{
-			gp = (Gang *) lfirst(lc);
-			DisconnectAndDestroyGang(gp);
-		}
-		allocatedReaderGangs1 = NULL;
-	}
 }
 
 void
@@ -1167,18 +1124,21 @@ DisconnectAndDestroyAllGangs(bool resetSession)
 
 	ELOG_DISPATCHER_DEBUG("DisconnectAndDestroyAllGangs");
 
-	/* Destroy CurrentGangCreating before GangContext is reset */
-	if (CurrentGangCreating != NULL)
-	{
-		DisconnectAndDestroyGang(CurrentGangCreating);
-		CurrentGangCreating = NULL;
-	}
+    /* Destroy CurrentGangCreating before GangContext is reset */
+    if (CurrentGangCreating != NULL)
+    {
+        DisconnectAndDestroyGang(CurrentGangCreating);
+        CurrentGangCreating = NULL;
+    }
+
+	/* In here, clean up all active dispatcher state */
+	cdbdisp_cleanupAllDispatcherState();
 
 	/* for now, destroy all readers, regardless of the portal that owns them */
 	disconnectAndDestroyAllReaderGangs(true);
 
-	DisconnectAndDestroyGang(primaryWriterGang);
-	primaryWriterGang = NULL;
+	DisconnectAndDestroyGang(availablePrimaryWriterGang);
+	availablePrimaryWriterGang = NULL;
 
 	if (resetSession)
 		resetSessionForPrimaryGangLoss();
@@ -1356,30 +1316,6 @@ getGangMaxVmem(Gang *gp)
 }
 
 /*
- * the gang is working for portal p1. we are only interested in gangs
- * from portal p2. if p1 and p2 are the same portal return true. false
- * otherwise.
- */
-static
-bool
-isTargetPortal(const char *p1, const char *p2)
-{
-	/* both are unnamed portals (represented as NULL) */
-	if (!p1 && !p2)
-		return true;
-
-	/* one is unnamed, the other is named */
-	if (!p1 || !p2)
-		return false;
-
-	/* both are the same named portal */
-	if (strcmp(p1, p2) == 0)
-		return true;
-
-	return false;
-}
-
-/*
  * remove elements from gang list when:
  * 1. list size > cachelimit
  * 2. max mop of this gang > gp_vmem_protect_gang_cache_limit
@@ -1452,160 +1388,12 @@ cleanupPortalGangs(Portal portal)
 	availableReaderGangs1 = cleanupPortalGangList(availableReaderGangs1, MAX_CACHED_1_GANGS);
 
 	ELOG_DISPATCHER_DEBUG("cleanupPortalGangs '%s'. Reader gang inventory: "
-						  "allocatedN=%d availableN=%d allocated1=%d available1=%d",
+						  "availableN=%d available1=%d",
 						  (portal_name ? portal_name : "unnamed portal"),
-						  list_length(allocatedReaderGangsN),
 						  list_length(availableReaderGangsN),
-						  list_length(allocatedReaderGangs1),
 						  list_length(availableReaderGangs1));
 
 	MemoryContextSwitchTo(oldContext);
-}
-
-/*
- * freeGangsForPortal
- *
- * Free all gangs that were allocated for a specific portal
- * (could either be a cursor name or an unnamed portal)
- *
- * Be careful when moving gangs onto the available list, if
- * cleanupGang() tells us that the gang has a problem, the gang has
- * been free()ed and we should discard it -- otherwise it is good as
- * far as we can tell.
- */
-void
-freeGangsForPortal(char *portal_name)
-{
-	MemoryContext oldContext;
-	ListCell   *cur_item = NULL;
-	ListCell   *prev_item = NULL;
-
-	if (Gp_role != GP_ROLE_DISPATCH)
-		return;
-
-	if (CurrentGangCreating != NULL)
-	{
-		GangType	type = CurrentGangCreating->type;
-
-		Assert(type >= GANGTYPE_UNALLOCATED &&
-			   type <= GANGTYPE_PRIMARY_WRITER);
-
-		DisconnectAndDestroyGang(CurrentGangCreating);
-		CurrentGangCreating = NULL;
-
-		if (type == GANGTYPE_PRIMARY_WRITER)
-		{
-			DisconnectAndDestroyAllGangs(true);
-			CheckForResetSession();
-		}
-	}
-
-	/*
-	 * the primary writer gangs "belong" to the unnamed portal -- if we have
-	 * multiple active portals trying to release, we can't just release and
-	 * re-release the writers each time !
-	 */
-	if (portal_name == NULL &&
-		primaryWriterGang != NULL &&
-		!cleanupGang(primaryWriterGang))
-	{
-		DisconnectAndDestroyAllGangs(true);
-		return;
-	}
-
-	if (allocatedReaderGangsN == NULL && allocatedReaderGangs1 == NULL)
-		return;
-
-	/*
-	 * Now we iterate through the list of allocated reader gangs and we free
-	 * all the gangs that belong to the portal that was specified by our
-	 * caller.
-	 */
-	ELOG_DISPATCHER_DEBUG("freeGangsForPortal '%s'. Reader gang inventory: "
-						  "allocatedN=%d availableN=%d allocated1=%d available1=%d",
-						  (portal_name ? portal_name : "unnamed portal"),
-						  list_length(allocatedReaderGangsN),
-						  list_length(availableReaderGangsN),
-						  list_length(allocatedReaderGangs1),
-						  list_length(availableReaderGangs1));
-
-	Assert(GangContext != NULL);
-	oldContext = MemoryContextSwitchTo(GangContext);
-
-	cur_item = list_head(allocatedReaderGangsN);
-	while (cur_item != NULL)
-	{
-		Gang	   *gp = (Gang *) lfirst(cur_item);
-		ListCell   *next_item = lnext(cur_item);
-
-		if (isTargetPortal(gp->portal_name, portal_name))
-		{
-			ELOG_DISPATCHER_DEBUG("Returning a reader N-gang to the available list");
-
-			/* cur_item must be removed */
-			allocatedReaderGangsN = list_delete_cell(allocatedReaderGangsN,
-													 cur_item, prev_item);
-
-			/* we only return the gang to the available list if it is good */
-			if (cleanupGang(gp))
-				availableReaderGangsN = lappend(availableReaderGangsN, gp);
-			else
-				DisconnectAndDestroyGang(gp);
-
-			cur_item = next_item;
-		}
-		else
-		{
-			ELOG_DISPATCHER_DEBUG("Skipping the release of a reader N-gang. It is used by another portal");
-
-			/* cur_item must be preserved */
-			prev_item = cur_item;
-			cur_item = next_item;
-		}
-	}
-
-	prev_item = NULL;
-	cur_item = list_head(allocatedReaderGangs1);
-	while (cur_item != NULL)
-	{
-		Gang	   *gp = (Gang *) lfirst(cur_item);
-		ListCell   *next_item = lnext(cur_item);
-
-		if (isTargetPortal(gp->portal_name, portal_name))
-		{
-			ELOG_DISPATCHER_DEBUG("Returning a reader 1-gang to the available list");
-
-			/* cur_item must be removed */
-			allocatedReaderGangs1 = list_delete_cell(allocatedReaderGangs1,
-													 cur_item, prev_item);
-
-			/* we only return the gang to the available list if it is good */
-			if (cleanupGang(gp))
-				availableReaderGangs1 = lappend(availableReaderGangs1, gp);
-			else
-				DisconnectAndDestroyGang(gp);
-
-			cur_item = next_item;
-		}
-		else
-		{
-			ELOG_DISPATCHER_DEBUG("Skipping the release of a reader 1-gang. It is used by another portal");
-
-			/* cur_item must be preserved */
-			prev_item = cur_item;
-			cur_item = next_item;
-		}
-	}
-
-	MemoryContextSwitchTo(oldContext);
-
-	ELOG_DISPATCHER_DEBUG("Gangs released for portal '%s'. Reader gang inventory: "
-						  "allocatedN=%d availableN=%d allocated1=%d available1=%d",
-						  (portal_name ? portal_name : "unnamed portal"),
-						  list_length(allocatedReaderGangsN),
-						  list_length(availableReaderGangsN),
-						  list_length(allocatedReaderGangs1),
-						  list_length(availableReaderGangs1));
 }
 
 /*
@@ -1830,23 +1618,20 @@ GangOK(Gang *gp)
 bool
 GangsExist(void)
 {
-	return (primaryWriterGang != NULL ||
-			allocatedReaderGangsN != NIL ||
+	return (availablePrimaryWriterGang != NULL ||
 			availableReaderGangsN != NIL ||
-			allocatedReaderGangs1 != NIL ||
-			availableReaderGangs1 != NIL);
+			availableReaderGangs1 != NIL ||
+			numAllocatedReaderGangs > 0);
 }
 
-#ifdef USE_ASSERT_CHECKING
+
 static bool
 readerGangsExist(void)
 {
-	return (allocatedReaderGangsN != NIL ||
-			availableReaderGangsN != NIL ||
-			allocatedReaderGangs1 != NIL ||
-			availableReaderGangs1 != NIL);
+	return (availableReaderGangsN != NIL ||
+			availableReaderGangs1 != NIL ||
+			numAllocatedReaderGangs > 0);
 }
-#endif
 
 int
 largestGangsize(void)
@@ -1868,4 +1653,48 @@ cdbgang_setAsync(bool async)
 		pCreateGangFunc = pCreateGangFuncAsync;
 	else
 		pCreateGangFunc = pCreateGangFuncThreaded;
+}
+
+void
+RecycleGang(Gang *gp)
+{
+	MemoryContext oldContext;
+
+	if (!gp)
+		return;
+
+	if (!cleanupGang(gp))
+		return DisconnectAndDestroyGang(gp);
+
+	oldContext = MemoryContextSwitchTo(GangContext);
+
+	switch (gp->type)
+	{
+		case GANGTYPE_SINGLETON_READER:
+		case GANGTYPE_ENTRYDB_READER:
+			availableReaderGangs1 = lappend(availableReaderGangs1, gp);
+			break;
+
+		case GANGTYPE_PRIMARY_READER:
+			availableReaderGangsN = lappend(availableReaderGangsN, gp);
+			break;
+		case GANGTYPE_PRIMARY_WRITER:
+			availablePrimaryWriterGang = gp;
+			break;
+		default:
+			Assert(false);
+	}
+
+	MemoryContextSwitchTo(oldContext);
+}
+
+void
+cdbgang_resetPrimaryWriterGang(void)
+{
+	primaryWriterGang = NULL;
+}
+void
+cdbgang_decreaseNumReaderGang(void)
+{
+	numAllocatedReaderGangs--;
 }

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -337,7 +337,6 @@ PortalCleanup(Portal portal)
 				 */
 				if (Gp_role == GP_ROLE_DISPATCH)
 				{
-					freeGangsForPortal((char *) portal->name);
 					cleanupPortalGangs(portal);
 				}
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -578,26 +578,6 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 		Assert(queryDesc->planstate);
 
-		if (Gp_role == GP_ROLE_DISPATCH &&
-			(queryDesc->plannedstmt->planTree->dispatch == DISPATCH_PARALLEL ||
-			 queryDesc->plannedstmt->nMotionNodes > 0))
-		{
-			if (!(eflags & EXEC_FLAG_EXPLAIN_ONLY))
-			{
-				/*
-				 * Since we intend to execute the plan, inventory the slice tree,
-				 * allocate gangs, and associate them with slices.
-				 *
-				 * For now, always use segment 'gp_singleton_segindex' for
-				 * singleton gangs.
-				 *
-				 * On return, gangs have been allocated and CDBProcess lists have
-				 * been filled in in the slice table.)
-				 */
-				AssignGangs(queryDesc);
-			}
-		}
-
 #ifdef USE_ASSERT_CHECKING
 		AssertSliceTableIsValid((struct SliceTable *) estate->es_sliceTable, queryDesc->plannedstmt);
 #endif

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1229,14 +1229,6 @@ standard_ExecutorEnd(QueryDesc *queryDesc)
 	WorkfileQueryspace_ReleaseEntry();
 
 	/*
-	 * Release any gangs we may have assigned.
-	 */
-	if (Gp_role == GP_ROLE_DISPATCH && 
-		(queryDesc->plannedstmt->planTree->dispatch == DISPATCH_PARALLEL ||
-		 queryDesc->plannedstmt->nMotionNodes > 0))
-		ReleaseGangs(queryDesc);
-
-	/*
 	 * Remove our own query's motion layer.
 	 */
 	RemoveMotionLayer(estate->motionlayer_context, true);

--- a/src/backend/utils/resowner/resowner.c
+++ b/src/backend/utils/resowner/resowner.c
@@ -1249,3 +1249,18 @@ PrintFileLeakWarning(File file)
 		 "temporary file leak: File %d still referenced",
 		 file);
 }
+
+/*
+ * Cdb: walk through a resource owner and it's childrens
+ */
+void
+CdbResourceOwnerWalker(ResourceOwner owner, ResourceWalkerCallback callback)
+{
+	ResourceOwner child;
+
+	(*callback)(owner);
+
+	/* Recurse to handle descendants */
+	for (child = owner->firstchild; child != NULL; child = child->nextchild)
+		CdbResourceOwnerWalker(child, callback);
+}

--- a/src/backend/utils/resowner/resowner.c
+++ b/src/backend/utils/resowner/resowner.c
@@ -1258,6 +1258,9 @@ CdbResourceOwnerWalker(ResourceOwner owner, ResourceWalkerCallback callback)
 {
 	ResourceOwner child;
 
+	if (!owner)
+		return;
+
 	(*callback)(owner);
 
 	/* Recurse to handle descendants */

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -189,4 +189,7 @@ void cdbdisp_markNamedPortalGangsDestroy(void);
 
 void cdbdisp_cleanupAllDispatcherState(void);
 
+void AtAbort_DispatcherState(void);
+
+void AtSubAbort_DispatcherState(void);
 #endif   /* CDBDISP_H */

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -48,6 +48,9 @@ extern CdbDispatchDirectDesc default_dispatch_direct_desc;
 
 typedef struct CdbDispatcherState
 {
+	bool isExtendedQuery;
+	List *allocatedGangs;
+	bool recycleGang;
 	struct CdbDispatchResults *primaryResults;
 	void *dispatchParams;
 } CdbDispatcherState;
@@ -159,7 +162,7 @@ cdbdisp_cancelDispatch(CdbDispatcherState *ds);
  *
  * Call cdbdisp_destroyDispatcherState to free it.
  */
-CdbDispatcherState * cdbdisp_makeDispatcherState(void);
+CdbDispatcherState * cdbdisp_makeDispatcherState(bool isExtendedQuery);
 
 /*
  * Free memory in CdbDispatcherState
@@ -169,10 +172,11 @@ CdbDispatcherState * cdbdisp_makeDispatcherState(void);
  */
 void cdbdisp_destroyDispatcherState(CdbDispatcherState *ds);
 
-void *
-cdbdisp_makeDispatchParams(int maxSlices,
-						  char *queryText,
-						  int queryTextLen);
+void
+cdbdisp_makeDispatchParams(CdbDispatcherState *ds,
+						   int maxSlices,
+						   char *queryText,
+						   int queryTextLen);
 
 bool cdbdisp_checkForCancel(CdbDispatcherState * ds);
 int cdbdisp_getWaitSocketFd(CdbDispatcherState *ds);
@@ -180,5 +184,9 @@ int cdbdisp_getWaitSocketFd(CdbDispatcherState *ds);
 void cdbdisp_onProcExit(void);
 
 void cdbdisp_setAsync(bool async);
+
+void cdbdisp_markNamedPortalGangsDestroy(void);
+
+void cdbdisp_cleanupAllDispatcherState(void);
 
 #endif   /* CDBDISP_H */

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -185,7 +185,7 @@ void cdbdisp_onProcExit(void);
 
 void cdbdisp_setAsync(bool async);
 
-void cdbdisp_markNamedPortalGangsDestroy(void);
+void cdbdisp_markNamedPortalGangsDestroyed(void);
 
 void cdbdisp_cleanupAllDispatcherState(void);
 

--- a/src/include/cdb/cdbdispatchresult.h
+++ b/src/include/cdb/cdbdispatchresult.h
@@ -162,11 +162,6 @@ typedef struct CdbDispatchResults
 	
 	/* num of slots in sliceMap */
 	int sliceCapacity;
-	
-	/*during dispatch, it is important to check to see that
-	 * the writer gang isn't already doing something -- this is an
-	 * important, missing sanity check */
-	struct Gang *writer_gang;
 } CdbDispatchResults;
 
 
@@ -331,12 +326,12 @@ cdbdisp_checkResultsErrcode(struct CdbDispatchResults *meeleResults);
 
 /*
  * cdbdisp_makeDispatchResults:
- * Allocates a CdbDispatchResults object in the current memory context.
  * Will be freed in function cdbdisp_destroyDispatcherState by deleting the
  * memory context.
  */
-CdbDispatchResults *
-cdbdisp_makeDispatchResults(int sliceCapacity,
+void
+cdbdisp_makeDispatchResults(struct CdbDispatcherState *ds,
+							int sliceCapacity,
 							bool cancelOnError);
 
 void

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -29,6 +29,7 @@ struct QueryDesc;
 struct DirectDispatchInfo;
 struct EState;
 struct PQExpBufferData;
+struct CdbDispatcherState;
 
 /*
  * A gang represents a single group of workers on each connected segDB
@@ -72,9 +73,11 @@ extern Gang *CurrentGangCreating;
 
 extern const char *gangTypeToString(GangType type);
 
-extern Gang *AllocateReaderGang(GangType type, char *portal_name);
+extern Gang *AllocateReaderGang(struct CdbDispatcherState *ds, GangType type, char *portal_name);
 
-extern Gang *AllocateWriterGang(void);
+extern Gang *AllocateWriterGang(struct CdbDispatcherState *ds);
+
+extern void AllocateAllIdleReaderGangs(struct CdbDispatcherState *ds);
 
 extern List *getCdbProcessList(Gang *gang, int sliceIndex, struct DirectDispatchInfo *directDispatch);
 
@@ -84,15 +87,14 @@ extern List *getCdbProcessesForQD(int isPrimary);
 
 extern void freeGangsForPortal(char *portal_name);
 
+extern void RecycleGang(Gang *gp);
 extern void DisconnectAndDestroyGang(Gang *gp);
 extern void DisconnectAndDestroyAllGangs(bool resetSession);
 extern void DisconnectAndDestroyUnusedGangs(void);
 
 extern void CheckForResetSession(void);
 
-extern List *getAllIdleReaderGangs(void);
-
-extern List *getAllAllocatedReaderGangs(void);
+extern List *getAllIdleReaderGangs(struct CdbDispatcherState *ds);
 
 extern CdbComponentDatabases *getComponentDatabases(void);
 
@@ -178,5 +180,6 @@ typedef struct CdbProcess
 typedef Gang *(*CreateGangFunc)(GangType type, int gang_id, int size, int content);
 
 extern void cdbgang_setAsync(bool async);
-
+extern void cdbgang_resetPrimaryWriterGang(void);
+extern void cdbgang_decreaseNumReaderGang(void);
 #endif   /* _CDBGANG_H_ */

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -182,4 +182,5 @@ typedef Gang *(*CreateGangFunc)(GangType type, int gang_id, int size, int conten
 extern void cdbgang_setAsync(bool async);
 extern void cdbgang_resetPrimaryWriterGang(void);
 extern void cdbgang_decreaseNumReaderGang(void);
+extern void AvailableWriterGangValidation(void);
 #endif   /* _CDBGANG_H_ */

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -232,6 +232,7 @@ typedef struct TMGXACT
 
 	bool						directTransaction;
 	uint16						directTransactionContentId;
+	bool						writerGangLost;
 }	TMGXACT;
 
 typedef struct TMGXACTSTATUS
@@ -347,4 +348,7 @@ extern void UtilityModeCloseDtmRedoFile(void);
 
 extern bool doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType);
 
+extern void markGxactWriterGangLost(void);
+
+extern bool gxactWriterGangLost(void);
 #endif   /* CDBTM_H */

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -348,7 +348,7 @@ extern void UtilityModeCloseDtmRedoFile(void);
 
 extern bool doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType);
 
-extern void markGxactWriterGangLost(void);
+extern void markCurrentGxactWriterGangLost(void);
 
-extern bool gxactWriterGangLost(void);
+extern bool currentGxactWriterGangLost(void);
 #endif   /* CDBTM_H */

--- a/src/include/executor/execUtils.h
+++ b/src/include/executor/execUtils.h
@@ -18,6 +18,7 @@
 
 struct EState;
 struct QueryDesc;
+struct CdbDispatcherState;
 
 extern void InitSliceTable(struct EState *estate, int nMotions, int nSubplans);
 extern Slice *getCurrentSlice(struct EState *estate, int sliceIndex);
@@ -25,8 +26,7 @@ extern bool sliceRunsOnQD(Slice *slice);
 extern bool sliceRunsOnQE(Slice *slice);
 extern int sliceCalculateNumSendingProcesses(Slice *slice);
 
-extern void AssignGangs(QueryDesc *queryDesc);
-extern void ReleaseGangs(QueryDesc *queryDesc);
+extern void AssignGangs(struct CdbDispatcherState *ds, QueryDesc *queryDesc);
 
 extern Motion *findSenderMotion(PlannedStmt *plannedstmt, int sliceIndex);
 extern Bitmapset *getLocallyExecutableSubplans(PlannedStmt *plannedstmt, Plan *root);

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -253,6 +253,8 @@ FI_IDENT(BeforeAcquireLockDuringCreateAoBlkdirTable, "before_acquire_lock_during
 FI_IDENT(CreateGangInProgress, "create_gang_in_progress")
 /* inject fault when creating new TOAST tables, to modify the chunk size */
 FI_IDENT(DecreaseToastMaxChunkSize, "decrease_toast_max_chunk_size")
+/* inject fault to let cleanupGang return false */
+FI_IDENT(CleanupGang, "cleanup_gang")
 #endif
 
 /*

--- a/src/include/utils/resowner.h
+++ b/src/include/utils/resowner.h
@@ -64,6 +64,7 @@ typedef void (*ResourceReleaseCallback) (ResourceReleasePhase phase,
 													 bool isTopLevel,
 													 void *arg);
 
+typedef void (*ResourceWalkerCallback) (const ResourceOwner owner);
 
 /*
  * Functions in resowner.c
@@ -140,5 +141,8 @@ extern void ResourceOwnerRememberFile(ResourceOwner owner,
 						  File file);
 extern void ResourceOwnerForgetFile(ResourceOwner owner,
 						File file);
+
+extern void CdbResourceOwnerWalker(ResourceOwner owner,
+							ResourceWalkerCallback callback);
 
 #endif   /* RESOWNER_H */

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -109,6 +109,16 @@ dbid
 (1 row)
 -- end_ignore
 
+-- primary writer gang should be invalid now, use a sql
+-- to recycle it.
+-- start_ignore
+begin; end;
+ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=28733: server closed the connection unexpectedly
+DETAIL:  
+	This probably means the server terminated abnormally
+	before or while processing the request.
+-- end_ignore
+
 select gp_inject_fault_infinite('fts_handle_message', 'infinite_loop', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 gp_inject_fault_infinite
 ------------------------

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -109,16 +109,6 @@ dbid
 (1 row)
 -- end_ignore
 
--- primary writer gang should be invalid now, use a sql
--- to recycle it.
--- start_ignore
-begin; end;
-ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=28733: server closed the connection unexpectedly
-DETAIL:  
-	This probably means the server terminated abnormally
-	before or while processing the request.
--- end_ignore
-
 select gp_inject_fault_infinite('fts_handle_message', 'infinite_loop', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 gp_inject_fault_infinite
 ------------------------

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -113,19 +113,16 @@ END
 -- crash_recovery
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21988)
-ERROR:  could not connect to segment: initialization of segworker group failed
 1<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21999: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
-ERROR:  could not connect to segment: initialization of segworker group failed
 2<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21994: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
-ERROR:  could not connect to segment: initialization of segworker group failed
 
 -- wait for segment to complete recovering
 0U: SELECT 1;

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -101,19 +101,16 @@ t
 (1 row)
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21369)
-ERROR:  could not connect to segment: initialization of segworker group failed
 1<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21379: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
-ERROR:  could not connect to segment: initialization of segworker group failed
 2<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21384: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
-ERROR:  could not connect to segment: initialization of segworker group failed
 
 -- wait for segment to complete recovering
 0U: SELECT 1;

--- a/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
+++ b/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
@@ -97,7 +97,7 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed
 CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 19 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;
@@ -125,7 +125,7 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed
 CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 19 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;
@@ -153,7 +153,7 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed
 CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 18 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;
@@ -181,7 +181,7 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed
 CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 18 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;
@@ -209,7 +209,7 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed
 CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 18 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;

--- a/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
+++ b/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
@@ -70,8 +70,7 @@ DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
 ERROR:  PANIC for debug_dtm_action = 4, debug_dtm_action_protocol =  Begin Internal Subtransaction (postgres.c:1490)  (seg1 127.0.1.1:25433 pid=27784)
-CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 8 during statement block entry
-ERROR:  could not connect to segment: initialization of segworker group failed
+CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 9 during statement block entry
 -- make sure segment recovery is complete after panic.
 0U: select 1;
 ?column?
@@ -98,9 +97,8 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  could not connect to segment: initialization of segworker group failed
-CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 18 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 19 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;
 ?column?
@@ -127,9 +125,8 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  could not connect to segment: initialization of segworker group failed
-CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 18 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 19 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;
 ?column?
@@ -156,9 +153,8 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  could not connect to segment: initialization of segworker group failed
-CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 17 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 18 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;
 ?column?
@@ -185,9 +181,8 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  could not connect to segment: initialization of segworker group failed
-CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 17 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 18 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;
 ?column?
@@ -214,9 +209,8 @@ SET
 DROP TABLE IF EXISTS employees;
 DROP
 select test_protocol_allseg(1, 2,'f');
-ERROR:  could not connect to segment: initialization of segworker group failed
-CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 17 during exception cleanup
-ERROR:  could not connect to segment: initialization of segworker group failed
+ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed (SOMEFILE:SOMEFUNC)
+CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 18 during exception cleanup
 -- make sure segment recovery is complete after panic.
 0U: select 1;
 ?column?

--- a/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
@@ -77,12 +77,6 @@ where content = 0;
 select dbid from gp_segment_configuration where content = 0 and role = 'p';
 -- end_ignore
 
--- primary writer gang should be invalid now, use a sql
--- to recycle it.
--- start_ignore
-begin; end;
--- end_ignore
-
 select gp_inject_fault_infinite('fts_handle_message', 'infinite_loop', dbid)
 from gp_segment_configuration
 where content = 0 and role = 'p';

--- a/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
@@ -77,6 +77,12 @@ where content = 0;
 select dbid from gp_segment_configuration where content = 0 and role = 'p';
 -- end_ignore
 
+-- primary writer gang should be invalid now, use a sql
+-- to recycle it.
+-- start_ignore
+begin; end;
+-- end_ignore
+
 select gp_inject_fault_infinite('fts_handle_message', 'infinite_loop', dbid)
 from gp_segment_configuration
 where content = 0 and role = 'p';

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -8,6 +8,8 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^ \(seg\d .*:\d+\)//
 -- m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
+-- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
+-- s/session id \=\s*\d+/session id \= DUMMY/gm
 -- end_matchsubs
 
 -- skip FTS probes always
@@ -374,6 +376,25 @@ end;
 \connect
 begin isolation level read uncommitted;
 end;
+
+-- Test session will be reset if the writer gang of current global
+-- transaction is lost
+begin;
+create temp table disp_temp_test (c1 int, c2 int);
+insert into disp_temp_test values (1, 2);
+savepoint s1;
+create temp table disp_temp_test1 (c1 int, c2 int);
+insert into disp_temp_test1 values (1, 2);
+select gp_inject_fault('cleanup_gang', 'skip', 1);
+-- Let cleanupGang return false and writer gang be destroyed
+select * from disp_temp_test1 where c1 / 0 = 9;
+rollback to savepoint s1;
+rollback;
+-- session is reset, temp table is dropped.
+select * from disp_temp_test;
+select * from disp_temp_test1;
+-- reset fault
+select gp_inject_fault('cleanup_gang', 'reset', 1);
 
 -- resume FTS probes
 select gp_inject_fault('fts_probe', 'reset', 1);

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -6,6 +6,8 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^ \(seg\d .*:\d+\)//
 -- m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
+-- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
+-- s/session id \=\s*\d+/session id \= DUMMY/gm
 -- end_matchsubs
 -- skip FTS probes always
 select gp_inject_fault_infinite('fts_probe', 'skip', 1);
@@ -684,6 +686,50 @@ end;
 \connect
 begin isolation level read uncommitted;
 end;
+-- Test session will be reset if the writer gang of current global
+-- transaction is lost
+begin;
+create temp table disp_temp_test (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into disp_temp_test values (1, 2);
+savepoint s1;
+create temp table disp_temp_test1 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into disp_temp_test1 values (1, 2);
+select gp_inject_fault('cleanup_gang', 'skip', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- Let cleanupGang return false and writer gang be destroyed
+select * from disp_temp_test1 where c1 / 0 = 9;
+ERROR:  division by zero  (seg2 slice1 127.0.0.1:25434 pid=27218)
+rollback to savepoint s1;
+WARNING:  Writer gang of current global transaction is lost
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 104)
+ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1) (xact.c:4779)
+rollback;
+-- session is reset, temp table is dropped.
+select * from disp_temp_test;
+ERROR:  relation "disp_temp_test" does not exist
+LINE 1: select * from disp_temp_test;
+                      ^
+select * from disp_temp_test1;
+ERROR:  relation "disp_temp_test1" does not exist
+LINE 1: select * from disp_temp_test1;
+                      ^
+-- reset fault
+select gp_inject_fault('cleanup_gang', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 -- resume FTS probes
 select gp_inject_fault('fts_probe', 'reset', 1);
 NOTICE:  Success:

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -711,7 +711,7 @@ ERROR:  division by zero  (seg2 slice1 127.0.0.1:25434 pid=27218)
 rollback to savepoint s1;
 WARNING:  Writer gang of current global transaction is lost
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 104)
-ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1) (xact.c:4779)
+ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1)
 rollback;
 -- session is reset, temp table is dropped.
 select * from disp_temp_test;


### PR DESCRIPTION
 Integrate Gang management from portal to Dispatcher

    Previously, Gang was managed by portal, freeGangsForPortal()
    was used to cleanup gang resource, DTM related commands also
    needed a gang to dispatch command outside of a portal and
    used freeGangsForPortal() too. There might be multiple
    command/plan/utility executed within one portal, all commands
    relied on a dispatcher routine like CdbDispatchCommand /
    CdbDispatchPlan/CdbDispatchUtility... to dispatch, gangs were
    created by each dispatcher routines, but not be recycled or
    destroyed when a routine finished except for primary writer
    gang, one defect of this is gang resource cannot be reused
    between dispatcher routines. GPDB already had an optimization
    for init plans, if a plan contained init plans, AssignGangs
    was called before execution of any of them it went through
    the whole slice tree and created the maximum gang that both
    main plan and init plans needed, this was doable because init
    plans and main plan were executed sequentially, but it also
    made AssignGangs logic complex, meanwhile, reusing an not
    clean gang was not safe.

    Another confusing thing was the gang and dispatcher were
    managed separately which cause context inconsistent like:
    when a dispatcher state was destroyed, gang was not recycled,
    when a gang was destroyed by portal, the dispatcher state was
    still in use and may refer to the context of a destroyed gang.

    As described above, this commit integrates gang management
    with dispatcher, a dispather state is responsible for creating
    and tracking gangs as needed and destroy them when dispatcher
    state is destroyed.