### PR TITLE
Fix deparsing of DISTINCT-qualified window aggregate, and add tests

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -5531,9 +5531,10 @@ get_windowref_expr(WindowRef *wref, deparse_context *context)
 		nargs++;
 	}
 
-	appendStringInfo(buf, "%s(",
+	appendStringInfo(buf, "%s(%s",
 					 generate_function_name(wref->winfnoid,
-											nargs, argtypes, NULL));
+											nargs, argtypes, NULL),
+					 wref->windistinct ? "DISTINCT " : "");
 
 	get_rule_expr((Node *) wref->args, context, true);
 	appendStringInfoChar(buf, ')');

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -8538,4 +8538,95 @@ explain with CTE as (select i, row_number() over (partition by j) j from window_
 (18 rows)
 
 insert into window_preds with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where i = 1;
+--
+-- Tests for DISTINCT-qualified window aggregates
+--
+-- This is a GPDB extension, not implemented in PostgreSQL.
+--
+select dt, pn, count(distinct pn) over (partition by dt) from sale;
+     dt     | pn  | count 
+------------+-----+-------
+ 01-01-1401 | 100 |     1
+ 03-01-1401 | 200 |     1
+ 04-01-1401 | 200 |     1
+ 05-01-1401 | 100 |     1
+ 05-02-1401 | 300 |     1
+ 06-01-1401 | 400 |     5
+ 06-01-1401 | 400 |     5
+ 06-01-1401 | 500 |     5
+ 06-01-1401 | 500 |     5
+ 06-01-1401 | 600 |     5
+ 06-01-1401 | 700 |     5
+ 06-01-1401 | 800 |     5
+(12 rows)
+
+select dt, pn, count(distinct pn) over (partition by dt), sum(distinct pn) over (partition by dt) from sale;
+     dt     | pn  | count | sum  
+------------+-----+-------+------
+ 01-01-1401 | 100 |     1 |  100
+ 03-01-1401 | 200 |     1 |  200
+ 04-01-1401 | 200 |     1 |  200
+ 05-01-1401 | 100 |     1 |  100
+ 05-02-1401 | 300 |     1 |  300
+ 06-01-1401 | 400 |     5 | 3000
+ 06-01-1401 | 400 |     5 | 3000
+ 06-01-1401 | 500 |     5 | 3000
+ 06-01-1401 | 500 |     5 | 3000
+ 06-01-1401 | 600 |     5 | 3000
+ 06-01-1401 | 700 |     5 | 3000
+ 06-01-1401 | 800 |     5 | 3000
+(12 rows)
+
+select dt, pn, sum(distinct pn) over (partition by dt), sum(pn) over (partition by dt) from sale;
+     dt     | pn  | sum  | sum  
+------------+-----+------+------
+ 01-01-1401 | 100 |  100 |  100
+ 03-01-1401 | 200 |  200 |  200
+ 04-01-1401 | 200 |  200 |  200
+ 05-01-1401 | 100 |  100 |  100
+ 05-02-1401 | 300 |  300 |  300
+ 06-01-1401 | 400 | 3000 | 3900
+ 06-01-1401 | 400 | 3000 | 3900
+ 06-01-1401 | 500 | 3000 | 3900
+ 06-01-1401 | 500 | 3000 | 3900
+ 06-01-1401 | 600 | 3000 | 3900
+ 06-01-1401 | 700 | 3000 | 3900
+ 06-01-1401 | 800 | 3000 | 3900
+(12 rows)
+
+-- Also test with a pass-by-ref type, to make sure we don't get confused with memory contexts.
+select pcolor, pname, count(distinct pname) over (partition by pcolor) from product;
+  pcolor   |   pname   | count 
+-----------+-----------+-------
+ Black     | Dream     |     2
+ Black     | Sword     |     2
+ Chocolate | Donuts    |     1
+ Clear     | Justice   |     1
+ Grey      | Castle    |     3
+ Grey      | Fries     |     3
+ Grey      | Hamburger |     3
+ Plain     | Donuts    |     1
+(8 rows)
+
+-- Disallowed or not-implemented cases
+select dt, pn, count(distinct pn) over (partition by pn order by dt) from sale;
+ERROR:  DISTINCT cannot be used with window specification containing an ORDER BY clause
+LINE 1: select dt, pn, count(distinct pn) over (partition by pn orde...
+                       ^
+select dt, pn, count(distinct pn) over (partition by pn rows unbounded preceding ) from sale;
+ERROR:  DISTINCT cannot be used with window specification containing a framing clause
+LINE 1: select dt, pn, count(distinct pn) over (partition by pn rows...
+                       ^
+select dt, pn, count(distinct pn) over (partition by pn rows between unbounded preceding and unbounded following ) from sale;
+ERROR:  DISTINCT cannot be used with window specification containing a framing clause
+LINE 1: select dt, pn, count(distinct pn) over (partition by pn rows...
+                       ^
+-- not supported with true window functions.
+select dt, pn, lead(distinct pn) over (partition by pn) from sale;
+ERROR:  DISTINCT is not implemented for window functions
+LINE 1: select dt, pn, lead(distinct pn) over (partition by pn) from...
+                       ^
+-- not supported with aggregates with multiple arguments.
+select dt, pn, corr(distinct pn, pn) over (partition by dt), sum(pn) over (partition by dt) from sale;
+ERROR:  DISTINCT is supported only for single-argument window aggregates
 -- End of Test

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -8614,19 +8614,31 @@ ERROR:  DISTINCT cannot be used with window specification containing an ORDER BY
 LINE 1: select dt, pn, count(distinct pn) over (partition by pn orde...
                        ^
 select dt, pn, count(distinct pn) over (partition by pn rows unbounded preceding ) from sale;
-ERROR:  DISTINCT cannot be used with window specification containing a framing clause
+ERROR:  window specifications with a framing clause must have an ORDER BY clause
 LINE 1: select dt, pn, count(distinct pn) over (partition by pn rows...
                        ^
 select dt, pn, count(distinct pn) over (partition by pn rows between unbounded preceding and unbounded following ) from sale;
-ERROR:  DISTINCT cannot be used with window specification containing a framing clause
+ERROR:  window specifications with a framing clause must have an ORDER BY clause
 LINE 1: select dt, pn, count(distinct pn) over (partition by pn rows...
                        ^
 -- not supported with true window functions.
 select dt, pn, lead(distinct pn) over (partition by pn) from sale;
-ERROR:  DISTINCT is not implemented for window functions
+ERROR:  DISTINCT specified, but lead is not an aggregate function
 LINE 1: select dt, pn, lead(distinct pn) over (partition by pn) from...
                        ^
 -- not supported with aggregates with multiple arguments.
 select dt, pn, corr(distinct pn, pn) over (partition by dt), sum(pn) over (partition by dt) from sale;
-ERROR:  DISTINCT is supported only for single-argument window aggregates
+ERROR:  DISTINCT is supported only for single-argument aggregates
+-- Test deparsing (for \d+ and pg_dump)
+create view distinct_windowagg_view as select sum(distinct g/2) OVER (partition by g/4) from generate_series (1, 5) g;
+\d+ distinct_windowagg_view
+        View "public.distinct_windowagg_view"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ sum    | bigint |           | plain   | 
+View definition:
+ SELECT sum(DISTINCT g.g / 2) OVER (
+ PARTITION BY g.g / 4) AS sum
+   FROM generate_series(1, 5) g(g);
+
 -- End of Test

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -8564,4 +8564,95 @@ explain with CTE as (select i, row_number() over (partition by j) j from window_
 (22 rows)
 
 insert into window_preds with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where i = 1;
+--
+-- Tests for DISTINCT-qualified window aggregates
+--
+-- This is a GPDB extension, not implemented in PostgreSQL.
+--
+select dt, pn, count(distinct pn) over (partition by dt) from sale;
+     dt     | pn  | count 
+------------+-----+-------
+ 01-01-1401 | 100 |     1
+ 03-01-1401 | 200 |     1
+ 04-01-1401 | 200 |     1
+ 05-01-1401 | 100 |     1
+ 05-02-1401 | 300 |     1
+ 06-01-1401 | 400 |     5
+ 06-01-1401 | 400 |     5
+ 06-01-1401 | 500 |     5
+ 06-01-1401 | 500 |     5
+ 06-01-1401 | 600 |     5
+ 06-01-1401 | 700 |     5
+ 06-01-1401 | 800 |     5
+(12 rows)
+
+select dt, pn, count(distinct pn) over (partition by dt), sum(distinct pn) over (partition by dt) from sale;
+     dt     | pn  | count | sum  
+------------+-----+-------+------
+ 01-01-1401 | 100 |     1 |  100
+ 03-01-1401 | 200 |     1 |  200
+ 04-01-1401 | 200 |     1 |  200
+ 05-01-1401 | 100 |     1 |  100
+ 05-02-1401 | 300 |     1 |  300
+ 06-01-1401 | 400 |     5 | 3000
+ 06-01-1401 | 400 |     5 | 3000
+ 06-01-1401 | 500 |     5 | 3000
+ 06-01-1401 | 500 |     5 | 3000
+ 06-01-1401 | 600 |     5 | 3000
+ 06-01-1401 | 700 |     5 | 3000
+ 06-01-1401 | 800 |     5 | 3000
+(12 rows)
+
+select dt, pn, sum(distinct pn) over (partition by dt), sum(pn) over (partition by dt) from sale;
+     dt     | pn  | sum  | sum  
+------------+-----+------+------
+ 01-01-1401 | 100 |  100 |  100
+ 03-01-1401 | 200 |  200 |  200
+ 04-01-1401 | 200 |  200 |  200
+ 05-01-1401 | 100 |  100 |  100
+ 05-02-1401 | 300 |  300 |  300
+ 06-01-1401 | 400 | 3000 | 3900
+ 06-01-1401 | 400 | 3000 | 3900
+ 06-01-1401 | 500 | 3000 | 3900
+ 06-01-1401 | 500 | 3000 | 3900
+ 06-01-1401 | 600 | 3000 | 3900
+ 06-01-1401 | 700 | 3000 | 3900
+ 06-01-1401 | 800 | 3000 | 3900
+(12 rows)
+
+-- Also test with a pass-by-ref type, to make sure we don't get confused with memory contexts.
+select pcolor, pname, count(distinct pname) over (partition by pcolor) from product;
+  pcolor   |   pname   | count 
+-----------+-----------+-------
+ Black     | Dream     |     2
+ Black     | Sword     |     2
+ Chocolate | Donuts    |     1
+ Clear     | Justice   |     1
+ Grey      | Castle    |     3
+ Grey      | Fries     |     3
+ Grey      | Hamburger |     3
+ Plain     | Donuts    |     1
+(8 rows)
+
+-- Disallowed or not-implemented cases
+select dt, pn, count(distinct pn) over (partition by pn order by dt) from sale;
+ERROR:  DISTINCT cannot be used with window specification containing an ORDER BY clause
+LINE 1: select dt, pn, count(distinct pn) over (partition by pn orde...
+                       ^
+select dt, pn, count(distinct pn) over (partition by pn rows unbounded preceding ) from sale;
+ERROR:  DISTINCT cannot be used with window specification containing a framing clause
+LINE 1: select dt, pn, count(distinct pn) over (partition by pn rows...
+                       ^
+select dt, pn, count(distinct pn) over (partition by pn rows between unbounded preceding and unbounded following ) from sale;
+ERROR:  DISTINCT cannot be used with window specification containing a framing clause
+LINE 1: select dt, pn, count(distinct pn) over (partition by pn rows...
+                       ^
+-- not supported with true window functions.
+select dt, pn, lead(distinct pn) over (partition by pn) from sale;
+ERROR:  DISTINCT is not implemented for window functions
+LINE 1: select dt, pn, lead(distinct pn) over (partition by pn) from...
+                       ^
+-- not supported with aggregates with multiple arguments.
+select dt, pn, corr(distinct pn, pn) over (partition by dt), sum(pn) over (partition by dt) from sale;
+ERROR:  DISTINCT is supported only for single-argument window aggregates
 -- End of Test

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -8640,19 +8640,31 @@ ERROR:  DISTINCT cannot be used with window specification containing an ORDER BY
 LINE 1: select dt, pn, count(distinct pn) over (partition by pn orde...
                        ^
 select dt, pn, count(distinct pn) over (partition by pn rows unbounded preceding ) from sale;
-ERROR:  DISTINCT cannot be used with window specification containing a framing clause
+ERROR:  window specifications with a framing clause must have an ORDER BY clause
 LINE 1: select dt, pn, count(distinct pn) over (partition by pn rows...
                        ^
 select dt, pn, count(distinct pn) over (partition by pn rows between unbounded preceding and unbounded following ) from sale;
-ERROR:  DISTINCT cannot be used with window specification containing a framing clause
+ERROR:  window specifications with a framing clause must have an ORDER BY clause
 LINE 1: select dt, pn, count(distinct pn) over (partition by pn rows...
                        ^
 -- not supported with true window functions.
 select dt, pn, lead(distinct pn) over (partition by pn) from sale;
-ERROR:  DISTINCT is not implemented for window functions
+ERROR:  DISTINCT specified, but lead is not an aggregate function
 LINE 1: select dt, pn, lead(distinct pn) over (partition by pn) from...
                        ^
 -- not supported with aggregates with multiple arguments.
 select dt, pn, corr(distinct pn, pn) over (partition by dt), sum(pn) over (partition by dt) from sale;
-ERROR:  DISTINCT is supported only for single-argument window aggregates
+ERROR:  DISTINCT is supported only for single-argument aggregates
+-- Test deparsing (for \d+ and pg_dump)
+create view distinct_windowagg_view as select sum(distinct g/2) OVER (partition by g/4) from generate_series (1, 5) g;
+\d+ distinct_windowagg_view
+        View "public.distinct_windowagg_view"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ sum    | bigint |           | plain   | 
+View definition:
+ SELECT sum(DISTINCT g.g / 2) OVER (
+ PARTITION BY g.g / 4) AS sum
+   FROM generate_series(1, 5) g(g);
+
 -- End of Test

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1697,4 +1697,31 @@ explain with CTE as (select i, row_number() over (partition by j) j from window_
 insert into window_preds with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where i = 1;
 
 
+--
+-- Tests for DISTINCT-qualified window aggregates
+--
+-- This is a GPDB extension, not implemented in PostgreSQL.
+--
+select dt, pn, count(distinct pn) over (partition by dt) from sale;
+select dt, pn, count(distinct pn) over (partition by dt), sum(distinct pn) over (partition by dt) from sale;
+select dt, pn, sum(distinct pn) over (partition by dt), sum(pn) over (partition by dt) from sale;
+
+-- Also test with a pass-by-ref type, to make sure we don't get confused with memory contexts.
+
+select pcolor, pname, count(distinct pname) over (partition by pcolor) from product;
+
+
+-- Disallowed or not-implemented cases
+select dt, pn, count(distinct pn) over (partition by pn order by dt) from sale;
+
+select dt, pn, count(distinct pn) over (partition by pn rows unbounded preceding ) from sale;
+select dt, pn, count(distinct pn) over (partition by pn rows between unbounded preceding and unbounded following ) from sale;
+
+-- not supported with true window functions.
+select dt, pn, lead(distinct pn) over (partition by pn) from sale;
+
+-- not supported with aggregates with multiple arguments.
+select dt, pn, corr(distinct pn, pn) over (partition by dt), sum(pn) over (partition by dt) from sale;
+
+
 -- End of Test

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1723,5 +1723,9 @@ select dt, pn, lead(distinct pn) over (partition by pn) from sale;
 -- not supported with aggregates with multiple arguments.
 select dt, pn, corr(distinct pn, pn) over (partition by dt), sum(pn) over (partition by dt) from sale;
 
+-- Test deparsing (for \d+ and pg_dump)
+create view distinct_windowagg_view as select sum(distinct g/2) OVER (partition by g/4) from generate_series (1, 5) g;
+\d+ distinct_windowagg_view
+
 
 -- End of Test


### PR DESCRIPTION
For 5X_STABLE:

1. Add test for DISTINCT_qualified window aggregates. These are the same tests I'm adding to master in PR #5556.

2. Fix bug with deparsing DISTINCT-qualified window aggregates. (issue #2996)

I'm going to open a PR to fix #2996  also in master, after PR #5556 is committed, because the tests conflict otherwise. But it's the going to be the essentially the same patch as this one.