### PR TITLE
5X: toast table fixes for upgrade

### DIFF
--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -40,6 +40,8 @@
 #include "utils/rel.h"
 #include "utils/typcache.h"
 
+/* GPDB additions */
+#include "utils/faultinjector.h"
 
 #undef TOAST_DEBUG
 
@@ -1431,6 +1433,8 @@ toast_save_datum(Relation rel, Datum value, bool isFrozen,
 	char	   *data_p;
 	int32		data_todo;
 
+	int32		max_chunk_size = TOAST_MAX_CHUNK_SIZE;
+
 	/*
 	 * Open the toast relation and its index.  We can use the index to check
 	 * uniqueness of the OID we assign to the toasted item, even though it has
@@ -1508,6 +1512,21 @@ toast_save_datum(Relation rel, Datum value, bool isFrozen,
 	t_isnull[1] = false;
 	t_isnull[2] = false;
 
+#ifdef FAULT_INJECTOR
+	/*
+	 * GPDB: for upgrade testing purposes, allow the maximum chunk size to be
+	 * modified (here, we decrease it by one). The result must still fit into
+	 * TOAST_MAX_CHUNK_SIZE so that it doesn't overflow our chunk_data struct.
+	 */
+	if (FaultInjector_InjectFaultIfSet(DecreaseToastMaxChunkSize,
+									   DDLNotSpecified,
+									   "", /* databaseName */
+									   ""  /* tableName */) != FaultInjectorTypeNotSpecified)
+	{
+		max_chunk_size--;
+	}
+#endif
+
 	/*
 	 * Split up the item into chunks
 	 */
@@ -1516,7 +1535,7 @@ toast_save_datum(Relation rel, Datum value, bool isFrozen,
 		/*
 		 * Calculate the size of this chunk
 		 */
-		chunk_size = Min(TOAST_MAX_CHUNK_SIZE, data_todo);
+		chunk_size = Min(max_chunk_size, data_todo);
 
 		/*
 		 * Build a tuple and store it
@@ -1669,11 +1688,18 @@ toast_fetch_datum(struct varlena * attr)
 	char	   *chunkdata;
 	int32		chunksize;
 
+	/*
+	 * GPDB: start with the assumption that chunks max out at
+	 * TOAST_MAX_CHUNK_SIZE. This may later prove false (e.g. if we've upgraded
+	 * from GPDB 4.3), in which case we'll readjust numchunks later.
+	 */
+	int32		actual_max_chunk_size = TOAST_MAX_CHUNK_SIZE;
+
 	/* Must copy to access aligned fields */
 	VARATT_EXTERNAL_GET_POINTER(toast_pointer, attr);
 
 	ressize = toast_pointer.va_extsize;
-	numchunks = ((ressize - 1) / TOAST_MAX_CHUNK_SIZE) + 1;
+	numchunks = ((ressize - 1) / actual_max_chunk_size) + 1;
 
 	result = (struct varlena *) palloc(ressize + VARHDRSZ);
 
@@ -1748,21 +1774,42 @@ toast_fetch_datum(struct varlena * attr)
 				 residx, nextidx,
 				 toast_pointer.va_valueid,
 				 RelationGetRelationName(toastrel));
+
+		if ((residx == 0) && (chunksize < ressize)
+			&& (chunksize != actual_max_chunk_size))
+		{
+			/*
+			 * GPDB: This toasted tuple is using a different max chunk size.
+			 * This can happen after an upgrade, for instance. Realign our
+			 * expectations.
+			 *
+			 * Only perform this check on the first chunk (the max size isn't
+			 * allowed to change partway through), and only if we expect more
+			 * chunks to come after this based on ressize.
+			 */
+			elog(DEBUG4, "readjusting max chunk size from %d to %d for toast value %u in %s",
+				 actual_max_chunk_size, chunksize, toast_pointer.va_valueid,
+				 RelationGetRelationName(toastrel));
+
+			actual_max_chunk_size = chunksize;
+			numchunks = ((ressize - 1) / actual_max_chunk_size) + 1;
+		}
+
 		if (residx < numchunks - 1)
 		{
-			if (chunksize != TOAST_MAX_CHUNK_SIZE)
+			if (chunksize != actual_max_chunk_size)
 				elog(ERROR, "unexpected chunk size %d (expected %d) in chunk %d of %d for toast value %u in %s",
-					 chunksize, (int) TOAST_MAX_CHUNK_SIZE,
+					 chunksize, (int) actual_max_chunk_size,
 					 residx, numchunks,
 					 toast_pointer.va_valueid,
 					 RelationGetRelationName(toastrel));
 		}
 		else if (residx == numchunks - 1)
 		{
-			if ((residx * TOAST_MAX_CHUNK_SIZE + chunksize) != ressize)
+			if ((residx * actual_max_chunk_size + chunksize) != ressize)
 				elog(ERROR, "unexpected chunk size %d (expected %d) in final chunk %d for toast value %u in %s",
 					 chunksize,
-					 (int) (ressize - residx * TOAST_MAX_CHUNK_SIZE),
+					 (int) (ressize - residx * actual_max_chunk_size),
 					 residx,
 					 toast_pointer.va_valueid,
 					 RelationGetRelationName(toastrel));
@@ -1777,7 +1824,7 @@ toast_fetch_datum(struct varlena * attr)
 		/*
 		 * Copy the data into proper place in our result
 		 */
-		memcpy(VARDATA(result) + residx * TOAST_MAX_CHUNK_SIZE,
+		memcpy(VARDATA(result) + residx * actual_max_chunk_size,
 			   chunkdata,
 			   chunksize);
 
@@ -1838,6 +1885,13 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 	int32		chcpystrt;
 	int32		chcpyend;
 
+	/*
+	 * GPDB: start with the assumption that chunks max out at
+	 * TOAST_MAX_CHUNK_SIZE. This may later prove false (e.g. if we've upgraded
+	 * from GPDB 4.3), in which case we'll readjust everything later.
+	 */
+	int32		actual_max_chunk_size = TOAST_MAX_CHUNK_SIZE;
+
 	Assert(VARATT_IS_EXTERNAL(attr));
 
 	/* Must copy to access aligned fields */
@@ -1850,7 +1904,6 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 	Assert(!VARATT_EXTERNAL_IS_COMPRESSED(toast_pointer));
 
 	attrsize = toast_pointer.va_extsize;
-	totalchunks = ((attrsize - 1) / TOAST_MAX_CHUNK_SIZE) + 1;
 
 	if (sliceoffset >= attrsize)
 	{
@@ -1871,13 +1924,6 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 	if (length == 0)
 		return (struct varlena *)result;			/* Can save a lot of work at this point! */
 
-	startchunk = sliceoffset / TOAST_MAX_CHUNK_SIZE;
-	endchunk = (sliceoffset + length - 1) / TOAST_MAX_CHUNK_SIZE;
-	numchunks = (endchunk - startchunk) + 1;
-
-	startoffset = sliceoffset % TOAST_MAX_CHUNK_SIZE;
-	endoffset = (sliceoffset + length - 1) % TOAST_MAX_CHUNK_SIZE;
-
 	/*
 	 * Open the toast relation and its index
 	 */
@@ -1886,6 +1932,74 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 	toastidx = index_open(toastrel->rd_rel->reltoastidxid, AccessShareLock);
 
 	check_toast_indisvalid(toastrel, toastidx);
+
+	{
+		/*
+		 * GPDB: because we allow upgrades from clusters with different
+		 * TOAST_MAX_CHUNK_SIZEs, we can't compute our chunk offsets yet. Open
+		 * the first chunk and check its size.
+		 */
+		ScanKeyInit(&toastkey[0],
+					(AttrNumber) 1,
+					BTEqualStrategyNumber, F_OIDEQ,
+					ObjectIdGetDatum(toast_pointer.va_valueid));
+		ScanKeyInit(&toastkey[1],
+					(AttrNumber) 2,
+					BTEqualStrategyNumber, F_INT4EQ,
+					Int32GetDatum(0));
+		nscankeys = 2;
+
+		toastscan = index_beginscan(toastrel, toastidx,
+									SnapshotToast, nscankeys, toastkey);
+
+		if ((ttup = index_getnext(toastscan, ForwardScanDirection)) != NULL)
+		{
+			/*
+			 * Have a chunk, extract the sequence number and the data
+			 */
+			residx = DatumGetInt32(fastgetattr(ttup, 2, toasttupDesc, &isnull));
+			Assert(!isnull);
+			chunk = DatumGetPointer(fastgetattr(ttup, 3, toasttupDesc, &isnull));
+			Assert(!isnull);
+
+			if (!VARATT_IS_EXTENDED(chunk))
+			{
+				chunksize = VARSIZE(chunk) - VARHDRSZ;
+			}
+			else if (VARATT_IS_SHORT(chunk))
+			{
+				/* could happen due to heap_form_tuple doing its thing */
+				chunksize = VARSIZE_SHORT(chunk) - VARHDRSZ_SHORT;
+			}
+			else
+			{
+				/* should never happen */
+				elog(ERROR, "found toasted toast chunk for toast value %u in %s",
+					 toast_pointer.va_valueid,
+					 RelationGetRelationName(toastrel));
+				chunksize = 0;		/* keep compiler quiet */
+			}
+
+			if (chunksize < attrsize)
+			{
+				/*
+				 * Only adjust the max chunk size if this isn't the only chunk.
+				 */
+				actual_max_chunk_size = chunksize;
+			}
+		}
+
+		index_endscan(toastscan);
+	}
+
+	totalchunks = ((attrsize - 1) / actual_max_chunk_size) + 1;
+
+	startchunk = sliceoffset / actual_max_chunk_size;
+	endchunk = (sliceoffset + length - 1) / actual_max_chunk_size;
+	numchunks = (endchunk - startchunk) + 1;
+
+	startoffset = sliceoffset % actual_max_chunk_size;
+	endoffset = (sliceoffset + length - 1) % actual_max_chunk_size;
 
 	/*
 	 * Setup a scan key to fetch from the index. This is either two keys or
@@ -1968,19 +2082,19 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 				 RelationGetRelationName(toastrel));
 		if (residx < totalchunks - 1)
 		{
-			if (chunksize != TOAST_MAX_CHUNK_SIZE)
+			if (chunksize != actual_max_chunk_size)
 				elog(ERROR, "unexpected chunk size %d (expected %d) in chunk %d of %d for toast value %u in %s when fetching slice",
-					 chunksize, (int) TOAST_MAX_CHUNK_SIZE,
+					 chunksize, (int) actual_max_chunk_size,
 					 residx, totalchunks,
 					 toast_pointer.va_valueid,
 					 RelationGetRelationName(toastrel));
 		}
 		else if (residx == totalchunks - 1)
 		{
-			if ((residx * TOAST_MAX_CHUNK_SIZE + chunksize) != attrsize)
+			if ((residx * actual_max_chunk_size + chunksize) != attrsize)
 				elog(ERROR, "unexpected chunk size %d (expected %d) in final chunk %d for toast value %u in %s when fetching slice",
 					 chunksize,
-					 (int) (attrsize - residx * TOAST_MAX_CHUNK_SIZE),
+					 (int) (attrsize - residx * actual_max_chunk_size),
 					 residx,
 					 toast_pointer.va_valueid,
 					 RelationGetRelationName(toastrel));
@@ -2003,7 +2117,7 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 			chcpyend = endoffset;
 
 		memcpy(VARDATA(result) +
-			   (residx * TOAST_MAX_CHUNK_SIZE - sliceoffset) + chcpystrt,
+			   (residx * actual_max_chunk_size - sliceoffset) + chcpystrt,
 			   chunkdata + chcpystrt,
 			   (chcpyend - chcpystrt) + 1);
 

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -82,6 +82,26 @@ static struct varlena *toast_fetch_datum_slice(struct varlena * attr,
 						int32 sliceoffset, int32 length);
 
 
+/*
+ * GPDB: Check to be sure that a toast table's index is valid before making use
+ * of it in a query.
+ *
+ * GPDB_94_MERGE_FIXME: This function exists only because we don't yet have
+ * upstream commit 2ef085d0e. Once that's merged, we can get rid of this.
+ */
+static void
+check_toast_indisvalid(Relation toastrel, Relation toastidx)
+{
+	Assert(RelationIsValid(toastidx));
+	Assert(RelationIsValid(toastrel));
+	Assert(PointerIsValid(toastidx->rd_index));
+
+	if (!IndexIsValid(toastidx->rd_index))
+		elog(ERROR, "no valid index found for toast relation with Oid %d",
+			 RelationGetRelid(toastrel));
+}
+
+
 /* ----------
  * heap_tuple_fetch_attr -
  *
@@ -1420,6 +1440,8 @@ toast_save_datum(Relation rel, Datum value, bool isFrozen,
 	toasttupDesc = toastrel->rd_att;
 	toastidx = index_open(toastrel->rd_rel->reltoastidxid, RowExclusiveLock);
 
+	check_toast_indisvalid(toastrel, toastidx);
+
 	/*
 	 * Get the data pointer and length, and compute va_rawsize and va_extsize.
 	 *
@@ -1585,6 +1607,8 @@ toast_delete_datum(Relation rel __attribute__((unused)), Datum value)
 	toastrel = heap_open(toast_pointer.va_toastrelid, RowExclusiveLock);
 	toastidx = index_open(toastrel->rd_rel->reltoastidxid, RowExclusiveLock);
 
+	check_toast_indisvalid(toastrel, toastidx);
+
 	/*
 	 * Setup a scan key to fetch from the index by va_valueid (we don't
 	 * particularly care whether we see them in sequence or not)
@@ -1664,6 +1688,8 @@ toast_fetch_datum(struct varlena * attr)
 	toastrel = heap_open(toast_pointer.va_toastrelid, AccessShareLock);
 	toasttupDesc = toastrel->rd_att;
 	toastidx = index_open(toastrel->rd_rel->reltoastidxid, AccessShareLock);
+
+	check_toast_indisvalid(toastrel, toastidx);
 
 	/*
 	 * Setup a scan key to fetch from the index by va_valueid
@@ -1858,6 +1884,8 @@ toast_fetch_datum_slice(struct varlena * attr, int32 sliceoffset, int32 length)
 	toastrel = heap_open(toast_pointer.va_toastrelid, AccessShareLock);
 	toasttupDesc = toastrel->rd_att;
 	toastidx = index_open(toastrel->rd_rel->reltoastidxid, AccessShareLock);
+
+	check_toast_indisvalid(toastrel, toastidx);
 
 	/*
 	 * Setup a scan key to fetch from the index. This is either two keys or

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -359,6 +359,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault before create resource group committing */
 	_("create_gang_in_progress"),
 		/* inject fault during gang creation, before check for interrupts */
+	_("decrease_toast_max_chunk_size"),
+		/* inject fault when creating new TOAST tables, to modify the chunk size */
 	_("not recognized"),
 };
 
@@ -1064,6 +1066,8 @@ FaultInjector_NewHashEntry(
 			case AutoVacWorkerBeforeDoAutovacuum:
 			case CreateResourceGroupFail:
 			case CreateGangInProgress:
+
+			case DecreaseToastMaxChunkSize:
 
 				break;
 			default:

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -243,6 +243,8 @@ typedef enum FaultInjectorIdentifier_e {
 	CreateResourceGroupFail,
 	CreateGangInProgress,
 
+	DecreaseToastMaxChunkSize,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/binary_swap/expected/pretest_cleanup.out
+++ b/src/test/binary_swap/expected/pretest_cleanup.out
@@ -8,3 +8,10 @@
 -- runs before the rest of the binary swap tests.
 \connect regression
 DROP VIEW IF EXISTS distinct_windowagg_view;
+-- start_ignore
+-- This table exists to make sure that toast tables of different chunk sizes are
+-- handled by GPDB. Early versions of the 5.x server will fail to dump this
+-- correctly.
+DROP TABLE IF EXISTS public.toast_chunk_test;
+NOTICE:  table "toast_chunk_test" does not exist, skipping
+-- end_ignore

--- a/src/test/binary_swap/sql/pretest_cleanup.sql
+++ b/src/test/binary_swap/sql/pretest_cleanup.sql
@@ -10,3 +10,10 @@
 \connect regression
 
 DROP VIEW IF EXISTS distinct_windowagg_view;
+
+-- start_ignore
+-- This table exists to make sure that toast tables of different chunk sizes are
+-- handled by GPDB. Early versions of the 5.x server will fail to dump this
+-- correctly.
+DROP TABLE IF EXISTS public.toast_chunk_test;
+-- end_ignore

--- a/src/test/isolation2/expected/invalidated_toast_index.out
+++ b/src/test/isolation2/expected/invalidated_toast_index.out
@@ -1,0 +1,59 @@
+--
+-- Test to make sure the error for an invalidated toast index is sane. This is
+-- done as an isolation2 test to make it easy to update the catalogs on all
+-- segments.
+--
+
+CREATE TABLE toastable_heap(a text, b varchar, c int);
+CREATE
+
+-- Force external storage for toasted columns.
+ALTER TABLE toastable_heap ALTER COLUMN a SET STORAGE EXTERNAL;
+ALTER
+ALTER TABLE toastable_heap ALTER COLUMN b SET STORAGE EXTERNAL;
+ALTER
+
+-- Insert two values that we know will be toasted.
+INSERT INTO toastable_heap VALUES(repeat('a',100000), repeat('b',100001), 1);
+INSERT 1
+INSERT INTO toastable_heap VALUES(repeat('A',100000), repeat('B',100001), 2);
+INSERT 1
+
+-- start_ignore
+--
+-- Invalidate the index of the toast table for our relation. Because this is a
+-- catalog change, we have to execute it on the master and all segments.
+--
+-- This is done in an ignore block so it can run correctly with any number of
+-- segments.
+*U: SET allow_system_table_mods = 'DML';
+SET
+
+SET
+
+SET
+
+SET
+*U: UPDATE pg_index SET indisvalid = false FROM pg_class heap, pg_class toast WHERE indexrelid = toast.reltoastidxid AND toast.oid  = heap.reltoastrelid AND heap.oid   = 'toastable_heap'::regclass;
+UPDATE 1
+
+UPDATE 1
+
+UPDATE 1
+
+UPDATE 1
+-- end_ignore
+
+-- Fetch, slice, save, and delete should all fail.
+SELECT * FROM toastable_heap;
+ERROR:  no valid index found for toast relation with Oid 107484 (tuptoaster.c:101)  (seg0 slice1 127.0.0.1:25432 pid=41177) (cdbdisp.c:254)
+SELECT substr(a, 500, 1) FROM toastable_heap;
+ERROR:  no valid index found for toast relation with Oid 107484 (tuptoaster.c:101)  (seg0 slice1 127.0.0.1:25432 pid=41177) (cdbdisp.c:254)
+UPDATE toastable_heap SET b = repeat('b',100001) WHERE c = 2;
+ERROR:  no valid index found for toast relation with Oid 107484 (tuptoaster.c:101)  (seg0 127.0.0.1:25432 pid=41177) (cdbdisp.c:254)
+DELETE FROM toastable_heap WHERE c = 1;
+ERROR:  no valid index found for toast relation with Oid 107484 (tuptoaster.c:101)  (seg2 127.0.0.1:25434 pid=41179) (cdbdisp.c:254)
+
+-- Don't leave an unusable table in the DB for others to trip over.
+DROP TABLE toastable_heap;
+DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
@@ -416,7 +416,20 @@ DECLARE
 DECLARE
 71:DECLARE c3 CURSOR for select count(*) from foo_concurrency_test t1, bar_concurrency_test t2 where t1.c2 = t2.c2;
 DECLARE
-71: 71:Fetch ALL FROM c1;
+71:Fetch ALL FROM c1;
+c1|c2
+--+--
+1 |1 
+2 |2 
+3 |3 
+4 |4 
+5 |5 
+6 |6 
+7 |7 
+8 |8 
+9 |9 
+10|10
+(10 rows)
 71:Fetch ALL FROM c2;
 c1|c2
 --+--

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -8,4 +8,8 @@ s/^\d+.*gpfaultinjector.*-\[INFO\]:-//
 # entry db matches
 m/\s+\(entry db(.*)+\spid=\d+\)/
 s/\s+\(entry db(.*)+\spid=\d+\)//
+
+# ignore OID and file/line number diffs for invalid toast indexes
+m/^ERROR:  no valid index found for toast relation/
+s/with Oid \d+ \(.*\)/with Oid OID/
 -- end_matchsubs

--- a/src/test/isolation2/input/uao/vacuum_while_insert.source
+++ b/src/test/isolation2/input/uao/vacuum_while_insert.source
@@ -26,9 +26,29 @@ insert into ao select generate_series(1,1000);
 
 DELETE FROM ao WHERE a < 128;
 1: BEGIN;
-1>: insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);COMMIT;
+1>: insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;COMMIT;
 4: BEGIN;
-4>: insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000);COMMIT;
+4>: insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;insert into ao select generate_series(1001,2000);insert into ao select generate_series(1001,2000)
+    ;COMMIT;
 2: VACUUM ao;
 1<:
 4<:

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -15,6 +15,7 @@ test: instr_in_shmem_setup
 test: instr_in_shmem_terminate
 test: instr_in_shmem_cleanup
 test: vacuum_full_recently_dead_tuple_due_to_distributed_snapshot
+test: invalidated_toast_index
 
 test: setup
 # Tests on Append-Optimized tables (row-oriented).

--- a/src/test/isolation2/sql/invalidated_toast_index.sql
+++ b/src/test/isolation2/sql/invalidated_toast_index.sql
@@ -1,0 +1,40 @@
+--
+-- Test to make sure the error for an invalidated toast index is sane. This is
+-- done as an isolation2 test to make it easy to update the catalogs on all
+-- segments.
+--
+
+CREATE TABLE toastable_heap(a text, b varchar, c int);
+
+-- Force external storage for toasted columns.
+ALTER TABLE toastable_heap ALTER COLUMN a SET STORAGE EXTERNAL;
+ALTER TABLE toastable_heap ALTER COLUMN b SET STORAGE EXTERNAL;
+
+-- Insert two values that we know will be toasted.
+INSERT INTO toastable_heap VALUES(repeat('a',100000), repeat('b',100001), 1);
+INSERT INTO toastable_heap VALUES(repeat('A',100000), repeat('B',100001), 2);
+
+-- start_ignore
+--
+-- Invalidate the index of the toast table for our relation. Because this is a
+-- catalog change, we have to execute it on the master and all segments.
+--
+-- This is done in an ignore block so it can run correctly with any number of
+-- segments.
+*U: SET allow_system_table_mods = 'DML';
+*U: UPDATE pg_index
+        SET indisvalid = false
+        FROM pg_class heap, pg_class toast
+        WHERE indexrelid = toast.reltoastidxid
+          AND toast.oid  = heap.reltoastrelid
+          AND heap.oid   = 'toastable_heap'::regclass;
+-- end_ignore
+
+-- Fetch, slice, save, and delete should all fail.
+SELECT * FROM toastable_heap;
+SELECT substr(a, 500, 1) FROM toastable_heap;
+UPDATE toastable_heap SET b = repeat('b',100001) WHERE c = 2;
+DELETE FROM toastable_heap WHERE c = 1;
+
+-- Don't leave an unusable table in the DB for others to trip over.
+DROP TABLE toastable_heap;

--- a/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
@@ -218,7 +218,6 @@ CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
 71:DECLARE c1 CURSOR for select c1, c2 from foo_concurrency_test order by c1 limit 10;
 71:DECLARE c2 CURSOR for select c1, c2 from bar_concurrency_test order by c1 limit 10;
 71:DECLARE c3 CURSOR for select count(*) from foo_concurrency_test t1, bar_concurrency_test t2 where t1.c2 = t2.c2;
-71:
 71:Fetch ALL FROM c1;
 71:Fetch ALL FROM c2;
 71:Fetch ALL FROM c3;

--- a/src/test/isolation2/sql/starve_case.sql
+++ b/src/test/isolation2/sql/starve_case.sql
@@ -52,14 +52,16 @@ LANGUAGE plpgsql STABLE;
 1: begin;
 1: select * from starve;
 
-2: insert into starve_helper select 'session2', setting::int from pg_settings where name = 'gp_session_id';
+2: insert into starve_helper select 'session2', setting::int from pg_settings
+   where name = 'gp_session_id';
 -- Wait on access exclusive lock.
 2: begin;
 2>: alter table starve rename column c to d;
 
 select wait_until_locks_awaited('session2');
 
-3: insert into starve_helper select 'session3', setting::int from pg_settings where name = 'gp_session_id';
+3: insert into starve_helper select 'session3', setting::int
+   from pg_settings where name = 'gp_session_id';
 -- ENTRY_DB_SINGLETON reader requests access share lock on table
 -- starve.  The lockmode conflicts with already existing waiter's
 -- lockmode (access exclusive).  And the writer is not holding any
@@ -71,14 +73,16 @@ select wait_until_locks_awaited('session3');
 
 -- Check the lock table, expect both session2 and session3 to wait.
 -- expect: 2 rows with AccessExclusiveLock and AccessSharedLock
-select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
+select mode from pg_locks where granted=false and relation='starve'::regclass
+and gp_segment_id=-1;
 
 -- Let everyone move forward.
 1: commit;
 
 -- session2 is granted the lock on starve table first.
 2<:
-2: select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
+2: select mode from pg_locks where granted=false and
+   relation='starve'::regclass and gp_segment_id=-1;
 2: commit;
 
 -- session3 is granted the lock after session2 commits.  We should
@@ -97,14 +101,16 @@ truncate table starve_helper;
 1: begin;
 1: select * from starve;
 
-2: insert into starve_helper select 'session2', setting::int from pg_settings where name = 'gp_session_id';
+2: insert into starve_helper select 'session2', setting::int from
+   pg_settings where name = 'gp_session_id';
 -- Wait on access exclusive lock.
 2: begin;
 2>: alter table starve add column e int default 0;
 
 select wait_until_locks_awaited('session2');
 
-3: insert into starve_helper select 'session3', setting::int from pg_settings where name = 'gp_session_id';
+3: insert into starve_helper select 'session3', setting::int from pg_settings
+   where name = 'gp_session_id';
 3: begin;
 -- Wait on RowExclusiveLock on table starve because session2 is
 -- waiting on the same lock with a conflicting lockmode.
@@ -116,7 +122,8 @@ select wait_until_locks_awaited('session3');
 -- Session2 must go first.
 2<:
 -- Ensure that session3 is still waiting.
-2: select mode from pg_locks where granted=false and relation='starve'::regclass and gp_segment_id=-1;
+2: select mode from pg_locks where granted=false and relation='starve'::regclass
+   and gp_segment_id=-1;
 2: commit;
 
 -- Session3 gets the lock only after session2 commits.

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -29,7 +29,10 @@ import traceback
 class SQLIsolationExecutor(object):
     def __init__(self, dbname=''):
         self.processes = {}
-        self.command_pattern = re.compile(r"^(\d+)([&\\<\\>Uq]*?)\:(.*)")
+        # The re.S flag makes the "." in the regex match newlines.
+        # When matched against a command in process_command(), all
+        # lines in the command are matched and sent as SQL query.
+        self.command_pattern = re.compile(r"^(\d+)([&\\<\\>Uq]*?)\:(.*)", re.S)
         if dbname:
             self.dbname = dbname
         else:

--- a/src/test/regress/expected/toast.out
+++ b/src/test/regress/expected/toast.out
@@ -73,3 +73,48 @@ SELECT char_length(a), char_length(b), c, d FROM toastable_ao;
 DROP TABLE toastable_heap;
 DROP TABLE toastable_ao;
 -- TODO: figure out a way to verify that the toast tables are dropped
+-- Test TOAST_MAX_CHUNK_SIZE changes for upgrade.
+CREATE TABLE toast_chunk_test (a bytea);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE toast_chunk_test ALTER COLUMN a SET STORAGE EXTERNAL;
+-- Alter our TOAST_MAX_CHUNK_SIZE and insert a value we know will be toasted.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+SELECT DISTINCT gp_inject_fault('decrease_toast_max_chunk_size', 'skip', dbid)
+	   FROM pg_catalog.gp_segment_configuration
+	   WHERE role = 'p';
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+INSERT INTO toast_chunk_test VALUES (repeat('abcdefghijklmnopqrstuvwxyz', 1000)::bytea);
+SELECT DISTINCT gp_inject_fault('decrease_toast_max_chunk_size', 'reset', dbid)
+	   FROM pg_catalog.gp_segment_configuration
+	   WHERE role = 'p';
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- The toasted value should still be read correctly.
+SELECT * FROM toast_chunk_test WHERE a <> repeat('abcdefghijklmnopqrstuvwxyz', 1000)::bytea;
+ a 
+---
+(0 rows)
+
+-- Random access into the toast table should work equally well.
+SELECT encode(substring(a from 521*26+1 for 26), 'escape') FROM toast_chunk_test;
+           encode           
+----------------------------
+ abcdefghijklmnopqrstuvwxyz
+(1 row)
+

--- a/src/test/regress/sql/toast.sql
+++ b/src/test/regress/sql/toast.sql
@@ -45,3 +45,23 @@ DROP TABLE toastable_heap;
 DROP TABLE toastable_ao;
 
 -- TODO: figure out a way to verify that the toast tables are dropped
+
+-- Test TOAST_MAX_CHUNK_SIZE changes for upgrade.
+CREATE TABLE toast_chunk_test (a bytea);
+ALTER TABLE toast_chunk_test ALTER COLUMN a SET STORAGE EXTERNAL;
+
+-- Alter our TOAST_MAX_CHUNK_SIZE and insert a value we know will be toasted.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+SELECT DISTINCT gp_inject_fault('decrease_toast_max_chunk_size', 'skip', dbid)
+	   FROM pg_catalog.gp_segment_configuration
+	   WHERE role = 'p';
+INSERT INTO toast_chunk_test VALUES (repeat('abcdefghijklmnopqrstuvwxyz', 1000)::bytea);
+SELECT DISTINCT gp_inject_fault('decrease_toast_max_chunk_size', 'reset', dbid)
+	   FROM pg_catalog.gp_segment_configuration
+	   WHERE role = 'p';
+
+-- The toasted value should still be read correctly.
+SELECT * FROM toast_chunk_test WHERE a <> repeat('abcdefghijklmnopqrstuvwxyz', 1000)::bytea;
+
+-- Random access into the toast table should work equally well.
+SELECT encode(substring(a from 521*26+1 for 26), 'escape') FROM toast_chunk_test;


### PR DESCRIPTION
_This is a reroll of #5517, which was missing some needed commits._

The purpose of this patchset is to backport two commits from master (ae8ea7f, 28acba6) which improve the handling of toast tables after upgrade. Those two patches require a handful of supporting patches in turn; this is part of the overall upgrade cleanup for `5X_STABLE`.

Commit 28acba6 in upstream (backported as d7620fc here), which allows toast tables with a different `TOAST_MAX_CHUNK_SIZE` to exist in the cluster, causes a failure in the 5X binary swap tests because older versions of 5X can't handle the regression case. We've added a `pretest_cleanup` step to binary swap, similar to the cleanup stage of the pg_upgrade tests, so that tables like this can be dropped.

The [test pipeline for this PR](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-pchampion) is currently green.

attn: @jimmyyih 