### PR TITLE
Raise the max value of MAX_GP_MAX_CSV_LINE_LENGTH GUC from 4MB to 1GB

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4617,7 +4617,7 @@
     <title>gp_max_csv_line_length</title>
     <body>
       <p>The maximum length of a line in a CSV formatted file that will be imported into the system.
-        The default is 1MB (1048576 bytes). Maximum allowed is 4MB (4194304 bytes). The default may
+        The default is 1MB (1048576 bytes). Maximum allowed is 1GB (1073741824 bytes). The default may
         need to be increased if using the <i>gp_toolkit</i> administrative schema to read Greenplum
         Database log files.</p>
       <table id="gp_max_csv_line_length_table">

--- a/src/include/cdb/cdbcsv.h
+++ b/src/include/cdb/cdbcsv.h
@@ -16,6 +16,6 @@
 #ifndef CDBCSV_H
 #define CDBCSV_H
 
-#define MAX_GP_MAX_CSV_LINE_LENGTH (4 * 1024 * 1024)
+#define MAX_GP_MAX_CSV_LINE_LENGTH (1024 * 1024 * 1024)
 
 #endif   /* CDBCSV_H */


### PR DESCRIPTION
GPDB limits the length of a line in CSV format when COPYing into the
database. This limit was originially created to fail fast when attemping
to COPY in a line containing malformed CSV. However, this GUC also
limits correctly formatted CSV from being read in if the line exceeds
MAX_GP_MAX_CSV_LINE_LENGTH.

We now allow this GUC to be set up to 1GB. This will not change the
default value of this GUC.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>

This PR is against 5X_STABLE. The logic using this GUC is removed in master and a subsequent PR will remove this GUC in the master branch.