### PR TITLE
Remove all trace of unused GUC gp_max_csv_line_length

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -774,9 +774,6 @@
                   <codeph>gp_log_format</codeph>
                 </p>
                 <p>
-                  <codeph>gp_max_csv_line_length</codeph>
-                </p>
-                <p>
                   <codeph>gp_reraise_signal</codeph>
                 </p>
               </stentry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -344,9 +344,6 @@
               <xref href="#gp_log_gang"/>
             </li>
             <li>
-              <xref href="#gp_max_csv_line_length"/>
-            </li>
-            <li>
               <xref href="#gp_max_local_distributed_cache"/>
             </li>
             <li>
@@ -4342,36 +4339,6 @@
             <row>
               <entry colname="col1">csv<p>text</p></entry>
               <entry colname="col2">csv</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="gp_max_csv_line_length">
-    <title>gp_max_csv_line_length</title>
-    <body>
-      <p>The maximum length of a line in a CSV formatted file that will be imported into the system.
-        The default is 1MB (1048576 bytes). Maximum allowed is 4MB (4194304 bytes). The default may
-        need to be increased if using the <i>gp_toolkit</i> administrative schema to read Greenplum
-        Database log files.</p>
-      <table id="gp_max_csv_line_length_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">number of bytes</entry>
-              <entry colname="col2">1048576</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -815,10 +815,6 @@
                 <xref href="guc-list.xml#gp_log_format" type="section">gp_log_format</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_max_csv_line_length" type="section"
-                  >gp_max_csv_line_length</xref>
-              </p>
-              <p>
                 <xref href="guc-list.xml#gp_reraise_signal" type="section">gp_reraise_signal</xref>
               </p>
             </stentry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -136,7 +136,6 @@
             <topicref href="guc-list.xml#gp_log_fts"/>
             <topicref href="guc-list.xml#gp_log_gang"/>
             <topicref href="guc-list.xml#gp_log_interconnect"/>
-            <topicref href="guc-list.xml#gp_max_csv_line_length"/>
             <topicref href="guc-list.xml#gp_max_local_distributed_cache"/>
             <topicref href="guc-list.xml#gp_max_packet_size"/>
             <topicref href="guc-list.xml#gp_max_plan_size"/>

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -102,9 +102,6 @@ int			gp_reject_percent_threshold;	/* SREH reject % kicks off only
 											 * after * <num> records have been
 											 * processed	*/
 
-int			gp_max_csv_line_length; /* max allowed len for csv data line in
-									 * bytes */
-
 bool		gp_select_invisible = false;	/* debug mode to allow select to
 											 * see "invisible" rows */
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3352,16 +3352,6 @@ struct config_int ConfigureNamesInt_gp[] =
 		NULL, NULL, NULL
 	},
 
-	{
-		{"gp_max_csv_line_length", PGC_USERSET, EXTERNAL_TABLES,
-			gettext_noop("Maximum allowed length of a csv input data row in bytes"),
-			NULL,
-		},
-		&gp_max_csv_line_length,
-		1 * 1024 * 1024, 32 * 1024, 4 * 1024 * 1024,
-		NULL, NULL, NULL
-	},
-
 	/*
 	 * Solaris doesn't support setting SO_SNDTIMEO, so setting this won't work
 	 * on Solaris (MPP-22526)

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -173,17 +173,6 @@ extern int			gp_cached_gang_threshold;
 extern int			gp_reject_percent_threshold;
 
 /*
- * gp_max_csv_line_length
- *
- * maximum csv line length for COPY and external tables. It is best to keep
- * the default value of 64K to as it protects against a never ending rejection
- * of valid csv data as a result of a quote related formatting error. however,
- * there may be cases where data lines are indeed larger than 64K and that's
- * when this guc must be increased in order to be able to load the data.
- */
-extern int 			gp_max_csv_line_length;
-
-/*
  * For use while debugging DTM issues: alter MVCC semantics such that
  * "invisible" rows are returned.
  */


### PR DESCRIPTION
This GUC is now unused after the major COPY refactor.

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Kevin Yeap <kyeap@pivotal.io>