### PR TITLE
Use strcoll directly instead of gp_strcoll.

### DIFF
--- a/src/backend/utils/adt/varlena.c
+++ b/src/backend/utils/adt/varlena.c
@@ -1488,14 +1488,12 @@ varstr_cmp(char *arg1, int len1, char *arg2, int len2, Oid collid)
 		memcpy(a2p, arg2, len2);
 		a2p[len2] = '\0';
 
-		// GPDB_91_MERGE_FIXME: Why does gp_strcoll() exist?
-		// Should we remove it, or add gp_strcoll_l()?
 #ifdef HAVE_LOCALE_T
 		if (mylocale)
 			result = strcoll_l(a1p, a2p, mylocale);
 		else
 #endif
-			result = gp_strcoll(a1p, a2p);
+			result = strcoll(a1p, a2p);
 
 		/*
 		 * In some locales strcoll() can claim that nonidentical strings are

--- a/src/include/utils/string_wrapper.h
+++ b/src/include/utils/string_wrapper.h
@@ -24,49 +24,6 @@
 #define SAFE_STR_LENGTH(s) ((s) == NULL ? 0 : strlen(s))
 
 static inline
-int gp_strcoll(const char *left, const char *right)
-{
-	int result;
-
-	errno = 0;
-	result = strcoll(left, right);
-
-	if ( errno != 0 )
-	{
-		if ( errno == EINVAL || errno == EILSEQ)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_UNTRANSLATABLE_CHARACTER),
-							errmsg("Unable to compare strings because one or both contained data that is not valid "
-							       "for the collation specified by LC_COLLATE ('%s').  First string has length %lu "
-							       "and value (limited to 100 characters): '%.100s'.  Second string has length %lu "
-							       "and value (limited to 100 characters): '%.100s'",
-									GetConfigOption("lc_collate", false, false),
-									(unsigned long) SAFE_STR_LENGTH(left),
-									NULL_TO_DUMMY_STR(left),
-									(unsigned long) SAFE_STR_LENGTH(left),
-									NULL_TO_DUMMY_STR(right))));
-		}
-		else
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INTERNAL_ERROR),
-							errmsg("Unable to compare strings.  "
-							       "Error: %s.  "
-							       "First string has length %lu and value (limited to 100 characters): '%.100s'.  "
-							       "Second string has length %lu and value (limited to 100 characters): '%.100s'",
-									strerror(errno),
-									(unsigned long) SAFE_STR_LENGTH(left),
-									NULL_TO_DUMMY_STR(left),
-									(unsigned long) SAFE_STR_LENGTH(left),
-									NULL_TO_DUMMY_STR(right))));
-		}
-	}
-
-	return result;
-}
-
-static inline
 size_t gp_strxfrm(char *dst, const char *src, size_t n)
 {
 	size_t result;


### PR DESCRIPTION
Let's keep it the same with PostgreSQL.

My understanding is `strcoll` will not change `errno`, am I right?