### PR TITLE
Fix EXPLAIN timing off option.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -482,16 +482,16 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 	int			eflags;
 	int			instrument_option = 0;
 
-	if (es->analyze)
-	{
-		/*
-		 * GPDB_90_MERGE_FIXME: we need to backport more from the 9.2 timeframe
-		 * to deal with each separate INSTRUMENT_ flag correctly.
-		 */
-		instrument_option |= (INSTRUMENT_ALL & ~INSTRUMENT_BUFFERS);
-	}
+	if (es->analyze && es->timing)
+		instrument_option |= INSTRUMENT_TIMER;
+	else if (es->analyze)
+		instrument_option |= INSTRUMENT_ROWS;
+
 	if (es->buffers)
 		instrument_option |= INSTRUMENT_BUFFERS;
+
+	if (es->analyze)
+		instrument_option |= INSTRUMENT_CDB;
 
 	/*
 	 * Start timing.


### PR DESCRIPTION
This chunk of code was left out during the 9.2 merge. As a result, "EXPLAIN
(analyze, timing off) still collected and printed the timing information.
In other words, the "timing off" had no effect.

No test added, because EXPLAIN ANALYZE is a bit tricky to deal with in
regression testing. I think gpdiff.pl would mask out this difference in
the EXPLAIN output. Or if not, then the extra memory information and
"Total runtime" that's printed in EXPLAIN ANALYZE would cause spurious
failures. The code is now pretty much identical to upstream, so I'm not too
worried about the lack of coverage.