### PR TITLE
Add check in parse analysis for the number of DISTINCT args.

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -2135,6 +2135,9 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 			 *
 			 * For now we use the scalar equalfn field of AggStatePerAggData
 			 * for DQAs instead of treating DQAs more generally.
+			 *
+			 * We should've checked this in parse analysis already, but better
+			 * safe than sorry.
 			 */
 			if (numArguments != 1)
 				ereport(ERROR,

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -441,8 +441,8 @@ count_agg_clauses_walker(Node *node, AggClauseCounts *counts)
 			Node *arg;
 			
 			counts->numDistinctAggs++;
-			
-			/* This check anticipates the one in ExecInitAgg(). */
+
+			/* we checked this in parse analysis already, but better safe than sorry. */
 			if ( list_length(aggref->args) != 1 )
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -452,6 +452,12 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
                      errmsg("aggregate ORDER BY is not implemented for window functions"),
                      parser_errposition(pstate, location)));
 
+		/* DISTINCT is only support for single-argument aggregates */
+		if (agg_distinct && list_length(fargs) != 1)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("DISTINCT is supported only for single-argument aggregates")));
+
         /*
          * If this is a "true" window function, rather than an aggregate
          * derived window function then it will have a tuple in pg_window
@@ -599,7 +605,13 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 					 errmsg("ORDER BY and DISTINCT are mutually exclusive"),
 					 parser_errposition(pstate, location)));
 		}
-        
+
+		/* DISTINCT is only support for single-argument aggregates */
+		if (agg_distinct && list_length(fargs) != 1 )
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("DISTINCT is supported only for single-argument aggregates")));
+
         /* 
          * Build the aggregate node and transform it
          *

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -640,12 +640,17 @@ create or replace view agg_view1 as
   select aggfns(distinct a,b,c)
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
          generate_series(1,3) i;
-select * from agg_view1;
 ERROR:  DISTINCT is supported only for single-argument aggregates
+select * from agg_view1;
+                    aggfns                     
+-----------------------------------------------
+ {"(1,3,foo)","(0,,)","(2,2,bar)","(3,1,baz)"}
+(1 row)
+
 select pg_get_viewdef('agg_view1'::regclass);
-                                                                                       pg_get_viewdef                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT aggfns(DISTINCT v.a, v.b, v.c) AS aggfns FROM (VALUES (1,3,'foo'::text), (0,NULL::integer,NULL::text), (2,2,'bar'::text), (3,1,'baz'::text)) v(a, b, c), generate_series(1, 3) i(i);
+                                                                     pg_get_viewdef                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT aggfns(v.a, v.b, v.c) AS aggfns FROM (VALUES (1,3,'foo'::text), (0,NULL::integer,NULL::text), (2,2,'bar'::text), (3,1,'baz'::text)) v(a, b, c);
 (1 row)
 
 -- TODO: support distinct + order by

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -646,12 +646,17 @@ create or replace view agg_view1 as
   select aggfns(distinct a,b,c)
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
          generate_series(1,3) i;
-select * from agg_view1;
 ERROR:  DISTINCT is supported only for single-argument aggregates
+select * from agg_view1;
+                    aggfns                     
+-----------------------------------------------
+ {"(1,3,foo)","(0,,)","(2,2,bar)","(3,1,baz)"}
+(1 row)
+
 select pg_get_viewdef('agg_view1'::regclass);
-                                                                                       pg_get_viewdef                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT aggfns(DISTINCT v.a, v.b, v.c) AS aggfns FROM (VALUES (1,3,'foo'::text), (0,NULL::integer,NULL::text), (2,2,'bar'::text), (3,1,'baz'::text)) v(a, b, c), generate_series(1, 3) i(i);
+                                                                     pg_get_viewdef                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT aggfns(v.a, v.b, v.c) AS aggfns FROM (VALUES (1,3,'foo'::text), (0,NULL::integer,NULL::text), (2,2,'bar'::text), (3,1,'baz'::text)) v(a, b, c);
 (1 row)
 
 -- TODO: support distinct + order by


### PR DESCRIPTION
We had this check in the count_agg_clauses(), and in the executor, but that
misses some cases. Planner normally calls count_agg_clauses(), but not if
optimizer=on. Furthermore, if gp_resource_manager='queue', then
count_agg_clauses() was still called with ORCA, to count the number of
"memory intensive" operators, which still hit the test. But if you had
gp_resource_manager='group', and optimizer=on, then count_agg_clauses()
was not called, and we missed the check. And the plan generated by ORCA
didn't pass the DISTINCT to the Agg node either, so you got incorrect
results.

One user-visible change of this is that it's no longer possible to create
a view that contains a disallowed DISTINCT aggregate. Previously, you could
create the view, but selecting from it failed. Now we fail at CREATE VIEW
already. This explains the change in the 'aggregates' test output.

This is for 5X_STABLE only. In master, we have implemented DISTINCT with
multiple arguments, and don't have this check anymore.