### PR TITLE
Fix gpperfmon bug that ATExecSetDistributedBy statement produce wrong tsubmit time

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14394,6 +14394,12 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 						untransformRelOptions(newOptions),
 						&tmprv,
 						useExistingColumnAttributes);
+
+		/*
+		 * bypass gpmon info collecting in following ExecutorStart
+		 * to be consistent with other alter table commands,
+		 * ALTER TABLE SET DISTRIBUTED BY should not be logged in gpperfmon.
+		 */
 		queryDesc->gpmon_pkt = NULL;
 
 		/* 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14394,6 +14394,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 						untransformRelOptions(newOptions),
 						&tmprv,
 						useExistingColumnAttributes);
+		queryDesc->gpmon_pkt = NULL;
 
 		/* 
 		 * We need to update our snapshot here to make sure we see all


### PR DESCRIPTION
This commit fix gpperfmon bug that records inserted in queries_history show a tsubmit date/time of 1969-12-31 19:00:00, in order to be consistent with other alter table commands, bypass gpmon info collecting, don't be logged in gpperfmon for ALTER TABLE SET DISTRIBUTED BY.