### PR TITLE
Remove version check that's no longer needed.

### DIFF
--- a/src/test/isolation2/isolation2_main.c
+++ b/src/test/isolation2/isolation2_main.c
@@ -102,15 +102,9 @@ isolation_start_test(const char *testname,
 	add_stringlist_item(resultfiles, outfile);
 	add_stringlist_item(expectfiles, expectfile);
 
-	/*
-	 * GPDB_91_MERGE_FIXME: pg_regress --launcher argument was added in PostgreSQL 9.1.
-	 * We don't have it in GPDB yet. Re-enable this when we merge with 9.1.
-	 */
-#if PG_VERSION_NUM >= 90100
 	if (launcher)
 		offset += snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
 						   "%s ", launcher);
-#endif
 
 	snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
 			 SYSTEMQUOTE "python ./sql_isolation_testcase.py --dbname=\"%s\" < \"%s\" > \"%s\" 2>&1" SYSTEMQUOTE,


### PR DESCRIPTION
We have caught up with PostgreSQL 9.1, so we can renable this support for
the pg_regress --launcher option.