### PR TITLE
Clean up max, flags, and docs of 'track_activity_query_size' setting.

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -685,9 +685,6 @@
               <xref href="#password_hash_algorithm"/>
             </li>
             <li>
-              <xref href="#pgstat_track_activity_query_size"/>
-            </li>
-            <li>
               <xref href="#pljava_classpath"/>
             </li>
             <li>
@@ -791,6 +788,9 @@
             </li>
             <li>
               <xref href="#track_activities"/>
+            </li>
+            <li>
+              <xref href="#track_activity_query_size"/>
             </li>
             <li>
               <xref href="#track_counts"/>
@@ -7986,34 +7986,6 @@
       </table>
     </body>
   </topic>
-  <topic id="pgstat_track_activity_query_size">
-    <title>pgstat_track_activity_query_size</title>
-    <body>
-      <p>Sets the maximum length limit for the query text stored in <codeph>current_query</codeph>
-        column of the system catalog view pg_stat_activity. The minimum length is 1024 characters. </p>
-      <table id="pgstat_track_activity_query_size_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">integer</entry>
-              <entry colname="col2">1024</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
   <topic id="pljava_classpath">
     <title>pljava_classpath</title>
     <body>
@@ -9144,6 +9116,34 @@
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">on</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="track_activity_query_size">
+    <title>track_activity_query_size</title>
+    <body>
+      <p>Sets the maximum length limit for the query text stored in <codeph>current_query</codeph>
+        column of the system catalog view pg_stat_activity. The minimum length is 1024 characters. </p>
+      <table id="track_activity_query_size_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">integer</entry>
+              <entry colname="col2">1024</entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2480,18 +2480,13 @@ static struct config_int ConfigureNamesInt[] =
 		NULL, NULL, NULL
 	},
 
-	/* GPDB_84_MERGE_FIXME: we have merged the track_activity_query_size GUC
-	 * from 8.4 into GPDB's pgstat_track_activity_query_size. Besides the name
-	 * change, the two differ in min/max settings, GUC group, flags, and
-	 * description. Make sure we did this right. */
 	{
 		{"track_activity_query_size", PGC_POSTMASTER, RESOURCES_MEM,
 			gettext_noop("Sets the size reserved for pg_stat_activity.query, in bytes."),
-			NULL,
-			GUC_NOT_IN_SAMPLE
+			NULL
 		},
 		&pgstat_track_activity_query_size,
-		1024, 100, INT_MAX,
+		1024, 100, 102400,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
In GPDB 5, this setting was called 'pgstat_track_activity_query_size',
but in the 8.4 merge, it was renamed to just 'track_activity_query_size',
to match upstream. Clean it up to match upstream:

* Change the maximum from INT_MAX to 100 kB. 100 kB should be enough for
  everybody.

* It is in the sample configuration file now , so remove GUC_NOT_IN_SAMPLE
  flag

* Fix documentation. I just replaced 'pgstat_track_activity_query_size'
  with 'track_activity_query_size', and moved the paragraphs to keep
  alphabetical order. Other than the name, the old text still seems valid.