### PR TITLE
Allow to add motion to unique-ify the path in create_unique_path().

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1844,7 +1844,7 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 		 * in theory we could improve this.
 		 */
 		if (add_motion)
-			return NULL;
+			goto no_unique_path;
 		pathnode->umethod = UNIQUE_PATH_NOOP;
 		pathnode->path.rows = rel->rows;
 		pathnode->path.startup_cost = subpath->startup_cost;
@@ -1880,7 +1880,7 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 		{
 			/* Subpath node could be a motion. See previous comment for details. */
 			if (add_motion)
-				return NULL;
+				goto no_unique_path;
 			pathnode->umethod = UNIQUE_PATH_NOOP;
 			pathnode->path.rows = rel->rows;
 			pathnode->path.startup_cost = subpath->startup_cost;

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1838,7 +1838,7 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 									  uniq_exprs, in_operators))
 	{
 		/*
-		 * For UNIQUE_PATH_NOOP, it is possible that subplan could be a
+		 * For UNIQUE_PATH_NOOP, it is possible that subpath could be a
 		 * motion node. It is not allowed to add a motion node above a
 		 * motion node so we simply disallow this unique path although
 		 * in theory we could improve this.
@@ -1878,7 +1878,7 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 			query_is_distinct_for(rte->subquery,
 								  sub_tlist_colnos, in_operators))
 		{
-			/* Subplan node could be a motion. See previous comment for details. */
+			/* Subpath node could be a motion. See previous comment for details. */
 			if (add_motion)
 				return NULL;
 			pathnode->umethod = UNIQUE_PATH_NOOP;

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1626,6 +1626,7 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 	int			numCols;
 	ListCell   *lc;
 	CdbPathLocus locus;
+	bool		add_motion = false;
 
 	/* Caller made a mistake if subpath isn't cheapest_total ... */
 	Assert(subpath == rel->cheapest_total_path);
@@ -1792,10 +1793,14 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 	if (!CdbPathLocus_IsBottleneck(subpath->locus) &&
 		!cdbpathlocus_is_hashed_on_exprs(subpath->locus, uniq_exprs))
 	{
-		// GPDB_90_MERGE_FIXME: this looks very wrong.
-		goto no_unique_path;
         locus = cdbpathlocus_from_exprs(root, uniq_exprs);
         subpath = cdbpath_create_motion_path(root, subpath, NIL, false, locus);
+		/*
+		 * We probably add agg/sort node above the added motion node, but it is
+		 * possible to add an agg/sort node below this motion node also,
+		 * which might be optimal in some cases?
+		 */
+		add_motion = true;
         Insist(subpath);
 	}
 	else
@@ -1832,6 +1837,14 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 		relation_has_unique_index_for(root, rel, NIL,
 									  uniq_exprs, in_operators))
 	{
+		/*
+		 * For UNIQUE_PATH_NOOP, it is possible that subplan could be a
+		 * motion node. It is not allowed to add a motion node above a
+		 * motion node so we simply disallow this unique path although
+		 * in theory we could improve this.
+		 */
+		if (add_motion)
+			return NULL;
 		pathnode->umethod = UNIQUE_PATH_NOOP;
 		pathnode->path.rows = rel->rows;
 		pathnode->path.startup_cost = subpath->startup_cost;
@@ -1865,6 +1878,9 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 			query_is_distinct_for(rte->subquery,
 								  sub_tlist_colnos, in_operators))
 		{
+			/* Subplan node could be a motion. See previous comment for details. */
+			if (add_motion)
+				return NULL;
 			pathnode->umethod = UNIQUE_PATH_NOOP;
 			pathnode->path.rows = rel->rows;
 			pathnode->path.startup_cost = subpath->startup_cost;

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -284,11 +284,11 @@ select * from t, pt where t1 = pt1 and ptid = tid;
 -- in and exists clauses
 --
 explain select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=2.09..21.45 rows=54 width=31)
-   ->  Hash Semi Join  (cost=2.09..21.45 rows=18 width=31)
-         Hash Cond: pt_1_prt_junk_data.ptid = t.tid
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.10..21.39 rows=54 width=31)
+   ->  Hash Join  (cost=2.10..21.39 rows=18 width=31)
+         Hash Cond: (pt_1_prt_junk_data.ptid = t.tid)
          ->  Append  (cost=0.00..18.54 rows=18 width=31)
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
                      One-Time Filter: PartSelected
@@ -308,14 +308,18 @@ explain select * from pt where ptid in (select tid from t where t1 = 'hello' || 
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
                      One-Time Filter: PartSelected
                      ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.09 rows=3 width=31)
-         ->  Hash  (cost=2.07..2.07 rows=1 width=11)
-               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..2.07 rows=1 width=11)
+         ->  Hash  (cost=2.09..2.09 rows=1 width=11)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=2.06..2.09 rows=1 width=11)
                      Filter: t.tid
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.07 rows=1 width=11)
-                           ->  Seq Scan on t  (cost=0.00..2.04 rows=1 width=11)
-                                 Filter: t1 = ('hello'::text || tid::text)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=2.06..2.09 rows=1 width=11)
+                           ->  HashAggregate  (cost=2.06..2.07 rows=1 width=36)
+                                 Group Key: t.tid
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.06 rows=1 width=11)
+                                       Hash Key: t.tid
+                                       ->  Seq Scan on t  (cost=0.00..2.04 rows=1 width=11)
+                                             Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: legacy query optimizer
-(29 rows)
+(33 rows)
 
 select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -344,11 +348,11 @@ select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
 -- Known_opt_diff: MPP-21320
 -- end_ignore
 explain select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=2.09..21.45 rows=54 width=31)
-   ->  Hash Semi Join  (cost=2.09..21.45 rows=18 width=31)
-         Hash Cond: pt_1_prt_junk_data.ptid = t.tid
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.10..21.39 rows=54 width=31)
+   ->  Hash Join  (cost=2.10..21.39 rows=18 width=31)
+         Hash Cond: (pt_1_prt_junk_data.ptid = t.tid)
          ->  Append  (cost=0.00..18.54 rows=18 width=31)
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
                      One-Time Filter: PartSelected
@@ -368,14 +372,18 @@ explain select * from pt where exists (select 1 from t where tid = ptid and t1 =
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
                      One-Time Filter: PartSelected
                      ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.09 rows=3 width=31)
-         ->  Hash  (cost=2.07..2.07 rows=1 width=11)
-               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..2.07 rows=1 width=11)
+         ->  Hash  (cost=2.09..2.09 rows=1 width=11)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=2.06..2.09 rows=1 width=11)
                      Filter: t.tid
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.07 rows=1 width=11)
-                           ->  Seq Scan on t  (cost=0.00..2.04 rows=1 width=11)
-                                 Filter: t1 = ('hello'::text || tid::text)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=2.06..2.09 rows=1 width=11)
+                           ->  HashAggregate  (cost=2.06..2.07 rows=1 width=36)
+                                 Group Key: t.tid
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.06 rows=1 width=11)
+                                       Hash Key: t.tid
+                                       ->  Seq Scan on t  (cost=0.00..2.04 rows=1 width=11)
+                                             Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: legacy query optimizer
-(29 rows)
+(33 rows)
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -581,41 +581,46 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 (10 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=30000000030.52..30000000030.75 rows=10 width=12)
-   InitPlan 1 (returns $0)  (slice6)
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=30000000026.26..30000000026.48 rows=10 width=12)
+   InitPlan 1 (returns $0)  (slice7)
      ->  Limit  (cost=10000000000.00..10000000001.58 rows=1 width=0)
-           ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000000.00..10000000001.58 rows=1 width=0)
+           ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=10000000000.00..10000000001.58 rows=1 width=0)
                  ->  Limit  (cost=10000000000.00..10000000001.56 rows=1 width=0)
                        ->  Nested Loop  (cost=10000000000.00..10000000005.18 rows=2 width=0)
                              ->  Seq Scan on c c_2  (cost=0.00..3.11 rows=1 width=4)
                                    Filter: i = 10
                              ->  Seq Scan on a a_1  (cost=0.00..2.06 rows=1 width=4)
                                    Filter: i = 10
-   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=20000000028.94..20000000029.17 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=20000000024.67..20000000024.90 rows=10 width=12)
          Merge Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
-         ->  Limit  (cost=20000000028.94..20000000028.97 rows=4 width=12)
-               ->  Sort  (cost=20000000028.94..20000000029.62 rows=90 width=12)
+         ->  Limit  (cost=20000000024.67..20000000024.70 rows=4 width=12)
+               ->  Sort  (cost=20000000024.67..20000000025.35 rows=90 width=12)
                      Sort Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
-                     ->  Result  (cost=20000000003.79..20000000023.11 rows=90 width=12)
+                     ->  Result  (cost=20000000005.51..20000000018.84 rows=90 width=12)
                            One-Time Filter: NOT $0
-                           ->  Nested Loop  (cost=20000000003.79..20000000023.11 rows=90 width=12)
-                                 ->  Hash Semi Join  (cost=10000000003.79..10000000010.77 rows=10 width=8)
-                                       Hash Cond: (qp_correlated_query.a.j = qp_correlated_query.c.j)
-                                       ->  Nested Loop  (cost=10000000000.00..10000000006.40 rows=10 width=12)
+                           ->  Hash Join  (cost=20000000005.51..20000000018.84 rows=90 width=12)
+                                 Hash Cond: qp_correlated_query.c.j = qp_correlated_query.a.j
+                                 ->  Nested Loop  (cost=20000000003.29..20000000013.66 rows=18 width=12)
+                                       ->  Nested Loop  (cost=10000000003.29..10000000008.34 rows=2 width=8)
+                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
+                                                   ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
+                                             ->  Materialize  (cost=3.29..3.40 rows=3 width=4)
+                                                   ->  HashAggregate  (cost=3.29..3.36 rows=3 width=4)
+                                                         Group Key: qp_correlated_query.c.j
+                                                         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.27 rows=3 width=4)
+                                                               Hash Key: qp_correlated_query.c.j
+                                                               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Materialize  (cost=0.00..3.58 rows=9 width=4)
+                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
+                                                   ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                 ->  Hash  (cost=2.15..2.15 rows=2 width=8)
+                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..2.15 rows=2 width=8)
+                                             Hash Key: qp_correlated_query.a.j
                                              ->  Seq Scan on a  (cost=0.00..2.05 rows=2 width=8)
-                                             ->  Materialize  (cost=0.00..3.39 rows=6 width=4)
-                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
-                                                         ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
-                                       ->  Hash  (cost=3.45..3.45 rows=9 width=4)
-                                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
-                                                   ->  Seq Scan on c c_1  (cost=0.00..3.09 rows=3 width=4)
-                                 ->  Materialize  (cost=0.00..3.58 rows=9 width=4)
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
-                                             ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
  Optimizer: legacy query optimizer
-(32 rows)
+(37 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -594,30 +594,30 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C wh
                              ->  Seq Scan on a a_1  (cost=0.00..2.06 rows=1 width=4)
                                    Filter: i = 10
    ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=20000000024.67..20000000024.90 rows=10 width=12)
-         Merge Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+         Merge Key: a.i, b.i, c.j
          ->  Limit  (cost=20000000024.67..20000000024.70 rows=4 width=12)
                ->  Sort  (cost=20000000024.67..20000000025.35 rows=90 width=12)
-                     Sort Key: qp_correlated_query.a.i, b.i, qp_correlated_query.c.j
+                     Sort Key: a.i, b.i, c.j
                      ->  Result  (cost=20000000005.51..20000000018.84 rows=90 width=12)
                            One-Time Filter: NOT $0
                            ->  Hash Join  (cost=20000000005.51..20000000018.84 rows=90 width=12)
-                                 Hash Cond: qp_correlated_query.c.j = qp_correlated_query.a.j
+                                 Hash Cond: (c_1.j = a.j)
                                  ->  Nested Loop  (cost=20000000003.29..20000000013.66 rows=18 width=12)
                                        ->  Nested Loop  (cost=10000000003.29..10000000008.34 rows=2 width=8)
                                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
                                                    ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
                                              ->  Materialize  (cost=3.29..3.40 rows=3 width=4)
                                                    ->  HashAggregate  (cost=3.29..3.36 rows=3 width=4)
-                                                         Group Key: qp_correlated_query.c.j
+                                                         Group Key: c_1.j
                                                          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.27 rows=3 width=4)
-                                                               Hash Key: qp_correlated_query.c.j
-                                                               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                                               Hash Key: c_1.j
+                                                               ->  Seq Scan on c c_1  (cost=0.00..3.09 rows=3 width=4)
                                        ->  Materialize  (cost=0.00..3.58 rows=9 width=4)
                                              ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
                                                    ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
                                  ->  Hash  (cost=2.15..2.15 rows=2 width=8)
                                        ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..2.15 rows=2 width=8)
-                                             Hash Key: qp_correlated_query.a.j
+                                             Hash Key: a.j
                                              ->  Seq Scan on a  (cost=0.00..2.05 rows=2 width=8)
  Optimizer: legacy query optimizer
 (37 rows)

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1626,21 +1626,24 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=644.00..644.01 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=414.25..643.75 rows=100 width=4)
-         ->  Hash Join  (cost=414.25..639.75 rows=34 width=4)
-               Hash Cond: a.unique1 = b.hundred
-               ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=8)
-               ->  Hash  (cost=413.00..413.00 rows=34 width=4)
-                     ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
-                           Group Key: b.hundred
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
-                                 Hash Key: b.hundred
-                                 ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=642.06..642.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=642.00..642.05 rows=1 width=8)
+         ->  Aggregate  (cost=642.00..642.01 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=414.25..641.75 rows=34 width=4)
+                     Hash Key: a.ten
+                     ->  Hash Join  (cost=414.25..639.75 rows=34 width=4)
+                           Hash Cond: a.unique1 = b.hundred
+                           ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=8)
+                           ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                                 ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                                       Group Key: b.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
+                                             Hash Key: b.hundred
+                                             ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
  Optimizer: legacy query optimizer
-(12 rows)
+(15 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
@@ -1665,21 +1668,24 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=644.00..644.01 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=414.25..643.75 rows=100 width=4)
-         ->  Hash Join  (cost=414.25..639.75 rows=34 width=4)
-               Hash Cond: a.unique1 = b.hundred
-               ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=8)
-               ->  Hash  (cost=413.00..413.00 rows=34 width=4)
-                     ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
-                           Group Key: b.hundred
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
-                                 Hash Key: b.hundred
-                                 ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=642.06..642.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=642.00..642.05 rows=1 width=8)
+         ->  Aggregate  (cost=642.00..642.01 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=414.25..641.75 rows=34 width=4)
+                     Hash Key: a.ten
+                     ->  Hash Join  (cost=414.25..639.75 rows=34 width=4)
+                           Hash Cond: a.unique1 = b.hundred
+                           ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=8)
+                           ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                                 ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                                       Group Key: b.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
+                                             Hash Key: b.hundred
+                                             ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
  Optimizer: legacy query optimizer
-(12 rows)
+(15 rows)
 
 --
 -- In case of simple exists query, planner can generate alternative

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1606,80 +1606,80 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=728.58..728.59 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=728.51..728.56 rows=1 width=8)
-         ->  Aggregate  (cost=728.51..728.52 rows=1 width=8)
-               ->  Hash Semi Join  (cost=512.09..728.00 rows=34 width=0)
-                     Hash Cond: a.unique1 = b.hundred
-                     ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=4)
-                     ->  Hash  (cost=387.65..387.65 rows=3319 width=4)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.65 rows=3319 width=4)
-                                 Hash Key: b.hundred
-                                 ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=4)
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
-(12 rows)
-
-EXPLAIN select count(distinct ss.ten) from
-  (select ten from tenk1 a
-   where unique1 IN (select hundred from tenk1 b)) ss;
                                                         QUERY PLAN                                                         
 ---------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=728.80..728.81 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=728.74..728.79 rows=1 width=8)
-         ->  Aggregate  (cost=728.74..728.75 rows=1 width=8)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=512.00..728.49 rows=34 width=4)
-                     Hash Key: a.ten
-                     ->  Hash Semi Join  (cost=512.00..726.49 rows=34 width=4)
-                           Hash Cond: a.unique1 = b.hundred
-                           ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=8)
-                           ->  Hash  (cost=387.00..387.00 rows=3334 width=4)
+ Aggregate  (cost=640.06..640.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=640.00..640.05 rows=1 width=8)
+         ->  Aggregate  (cost=640.00..640.01 rows=1 width=8)
+               ->  Hash Join  (cost=414.25..639.75 rows=34 width=0)
+                     Hash Cond: a.unique1 = b.hundred
+                     ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=4)
+                     ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                           ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                                 Group Key: b.hundred
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
                                        Hash Key: b.hundred
                                        ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
  Optimizer: legacy query optimizer
 (13 rows)
 
+EXPLAIN select count(distinct ss.ten) from
+  (select ten from tenk1 a
+   where unique1 IN (select hundred from tenk1 b)) ss;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=644.00..644.01 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=414.25..643.75 rows=100 width=4)
+         ->  Hash Join  (cost=414.25..639.75 rows=34 width=4)
+               Hash Cond: a.unique1 = b.hundred
+               ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=8)
+               ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                     ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                           Group Key: b.hundred
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
+                                 Hash Key: b.hundred
+                                 ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
+ Optimizer: legacy query optimizer
+(12 rows)
+
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=729.85..729.86 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=729.78..729.83 rows=1 width=8)
-         ->  Aggregate  (cost=729.78..729.79 rows=1 width=8)
-               ->  Hash Semi Join  (cost=513.07..729.27 rows=34 width=0)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=640.06..640.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=640.00..640.05 rows=1 width=8)
+         ->  Aggregate  (cost=640.00..640.01 rows=1 width=8)
+               ->  Hash Join  (cost=414.25..639.75 rows=34 width=0)
                      Hash Cond: a.unique1 = b.hundred
-                     ->  Seq Scan on tenk1 a  (cost=0.00..188.78 rows=3326 width=4)
-                     ->  Hash  (cost=388.34..388.34 rows=3326 width=4)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..388.34 rows=3326 width=4)
-                                 Hash Key: b.hundred
-                                 ->  Seq Scan on tenk1 b  (cost=0.00..188.78 rows=3326 width=4)
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
-(12 rows)
+                     ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=4)
+                     ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                           ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                                 Group Key: b.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
+                                       Hash Key: b.hundred
+                                       ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
+ Optimizer: legacy query optimizer
+(13 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=729.07..729.08 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=729.01..729.06 rows=1 width=8)
-         ->  Aggregate  (cost=729.01..729.02 rows=1 width=8)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=512.21..728.76 rows=34 width=4)
-                     Hash Key: a.ten
-                     ->  Hash Semi Join  (cost=512.21..726.76 rows=34 width=4)
-                           Hash Cond: a.unique1 = b.hundred
-                           ->  Seq Scan on tenk1 a  (cost=0.00..187.05 rows=3335 width=8)
-                           ->  Hash  (cost=387.15..387.15 rows=3335 width=4)
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.15 rows=3335 width=4)
-                                       Hash Key: b.hundred
-                                       ->  Seq Scan on tenk1 b  (cost=0.00..187.05 rows=3335 width=4)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=644.00..644.01 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=414.25..643.75 rows=100 width=4)
+         ->  Hash Join  (cost=414.25..639.75 rows=34 width=4)
+               Hash Cond: a.unique1 = b.hundred
+               ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=8)
+               ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                     ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                           Group Key: b.hundred
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
+                                 Hash Key: b.hundred
+                                 ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
  Optimizer: legacy query optimizer
-(13 rows)
+(12 rows)
 
 --
 -- In case of simple exists query, planner can generate alternative


### PR DESCRIPTION
create_unique_path() could be used to convert semi join to inner join.
Previously, during the Semi-join refactor in commit d4ce092, creating unique
path was disabled for the case where duplicats might be on different QEs.

In this patch we enable adding motion to unique_ify the path, only if unique
mothod is not UNIQUE_PATH_NOOP. We don't create unique path for that case
because if later on during plan creation, it is possible to create a motion
above this unique path whose subpath is a motion. In that case, the unique path
node will be ignored and we will get a motion plan node above a motion plan
node and that is bad. We could further improve that, but not in this patch.

Co-authored-by: Alexandra Wang <lewang@pivotal.io>
Co-authored-by: Paul Guo <paulguo@gmail.com>