### PR TITLE
Fix compilation error in print_path()

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2382,7 +2382,6 @@ print_path(PlannerInfo *root, Path *path, int indent)
 			break;
 		case T_ResultPath:
 			ptype = "Result";
-			subpath = ((ResultPath *) path)->subpath;
 			break;
 		case T_MaterialPath:
 			ptype = "Material";


### PR DESCRIPTION
print_path() is useful for planner debugging.

Co-authored-by: Alexandra Wang <lewang@pivotal.io>
Co-authored-by: Paul Guo <paulguo@gmail.com>