### PR TITLE
Fix error handling in "COPY <table> TO <file>".

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -5,6 +5,42 @@
  * 	 routines are called from the backend COPY command whenever MPP is in the
  * 	 default dispatch mode.
  *
+ * Usage:
+ *
+ * CdbCopy cdbCopy = makeCdbCopy();
+ *
+ * PG_TRY();
+ * {
+ *     cdbCopyStart(cdbCopy, ...);
+ *
+ *     // process each row
+ *     while (...)
+ *     {
+ *         cdbCopyGetData(cdbCopy, ...)
+ *         or
+ *         cdbCopySendData(cdbCopy, ...)
+ *     }
+ *     cdbCopyEnd(cdbCopy);
+ * }
+ * PG_CATCH();
+ * {
+ *     cdbCopyAbort(cdbCopy);
+ * }
+ * PG_END_TRY();
+ *
+ *
+ * makeCdbCopy() creates a struct to hold information about the on-going COPY.
+ * It does not change the state of the connection yet.
+ *
+ * cdbCopyStart() puts the connections in the gang into COPY mode. If an error
+ * occurs during or after cdbCopyStart(), you must call cdbCopyAbort() to reset
+ * the connections to normal state!
+ *
+ * cdbCopyGetData() and cdbCopySendData() call libpq's PQgetCopyData() and
+ * PQputCopyData(), respectively. If an error occurs, it is thrown with ereport().
+ *
+ * When you're done, call cdbCopyEnd().
+ *
  * Portions Copyright (c) 2005-2008, Greenplum inc
  * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
  *
@@ -35,6 +71,10 @@
 
 #include <poll.h>
 
+static void cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
+				   int64 *total_rows_completed_p,
+				   int64 *total_rows_rejected_p);
+
 static Gang *
 getCdbCopyPrimaryGang(CdbCopy *c)
 {
@@ -58,7 +98,6 @@ makeCdbCopy(bool is_copy_in)
 	/* fresh start */
 	c->total_segs = 0;
 	c->mirror_map = NULL;
-	c->io_errors = false;
 	c->copy_in = is_copy_in;
 	c->skip_ext_partition = false;
 	c->outseglist = NIL;
@@ -66,7 +105,6 @@ makeCdbCopy(bool is_copy_in)
 	c->ao_segnos = NIL;
 	c->hasReplicatedTable = false;
 	c->dispatcherState = NULL;
-	initStringInfo(&(c->err_msg));
 	initStringInfo(&(c->copy_out_buf));
 
 	/* init total_segs */
@@ -95,11 +133,6 @@ void
 cdbCopyStart(CdbCopy *c, CopyStmt *stmt, struct GpPolicy *policy)
 {
 	int			flags;
-
-	/* clean err message */
-	c->err_msg.len = 0;
-	c->err_msg.data[0] = '\0';
-	c->err_msg.cursor = 0;
 
 	stmt = copyObject(stmt);
 
@@ -160,11 +193,6 @@ cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer,
 	Gang	   *gp;
 	int			result;
 
-	/* clean err message */
-	c->err_msg.len = 0;
-	c->err_msg.data[0] = '\0';
-	c->err_msg.cursor = 0;
-
 	/*
 	 * NOTE!! note that another DELIM was added, for the buf_converted in the
 	 * code above. I didn't do it because it's broken right now
@@ -180,16 +208,18 @@ cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer,
 	if (result != 1)
 	{
 		if (result == 0)
-			appendStringInfo(&(c->err_msg),
-							 "Failed to send data to segment %d, attempt blocked\n",
-							 target_seg);
-
-		if (result == -1)
-			appendStringInfo(&(c->err_msg),
-							 "Failed to send data to segment %d: %s\n",
-							 target_seg, PQerrorMessage(q->conn));
-
-		c->io_errors = true;
+		{
+			/* We don't use blocking mode, so this shouldn't happen */
+			ereport(ERROR,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("could not send COPY data to segment %d, attempt blocked",
+							target_seg)));
+		}
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("could not send COPY data to segment %d: %s",
+							target_seg, PQerrorMessage(q->conn))));
 	}
 }
 
@@ -203,19 +233,10 @@ cdbCopyGetData(CdbCopy *c, bool copy_cancel, uint64 *rows_processed)
 {
 	SegmentDatabaseDescriptor *q;
 	Gang	   *gp;
-	PGresult   *res;
 	int			nbytes;
-	bool		first_error = true;
-
-	/* clean err message */
-	c->err_msg.len = 0;
-	c->err_msg.data[0] = '\0';
-	c->err_msg.cursor = 0;
 
 	/* clean out buf data */
-	c->copy_out_buf.len = 0;
-	c->copy_out_buf.data[0] = '\0';
-	c->copy_out_buf.cursor = 0;
+	resetStringInfo(&c->copy_out_buf);
 
 	gp = getCdbCopyPrimaryGang(c);
 
@@ -277,46 +298,25 @@ cdbCopyGetData(CdbCopy *c, bool copy_cancel, uint64 *rows_processed)
 			/*
 			 * DONE -- Got all the data rows from this segment, or a cancel
 			 * request.
+			 *
+			 * Remove the segment that completed sending data, from the list
+			 * of in-progress segments.
+			 *
+			 * Note: After PQgetCopyData() returns -1, you need to call
+			 * PGgetResult() to get any possible errors. But we don't do that
+			 * here. That's done later, in the call to cdbCopyEnd() (or
+			 * cdbCopyAbort(), if something went wrong.)
 			 */
 			else if (nbytes == -1)
 			{
-				/*
-				 * Fetch any error status existing on completion of the COPY
-				 * command.
-				 */
-				while (NULL != (res = PQgetResult(q->conn)))
-				{
-					/* if the COPY command had an error */
-					if (PQresultStatus(res) == PGRES_FATAL_ERROR && first_error)
-					{
-						appendStringInfo(&(c->err_msg), "Error from segment %d: %s\n",
-										 source_seg, PQresultErrorMessage(res));
-						first_error = false;
-					}
-
-					if (res->numCompleted > 0)
-					{
-						*rows_processed += res->numCompleted;
-					}
-
-					/* free the PGresult object */
-					PQclear(res);
-				}
-
-				/*
-				 * remove the segment that completed sending data from the
-				 * list
-				 */
 				c->outseglist = list_delete_int(c->outseglist, source_seg);
 
-				/* no more segments with data on the list. we are done */
 				if (list_length(c->outseglist) == 0)
-					return true;	/* done */
+					return true;	/* all segments are done */
 
-				/* start over from first seg as we just changes the seg list */
+				/* start over from first seg as we just changed the seg list */
 				break;
 			}
-
 			/*
 			 * ERROR!
 			 */
@@ -327,39 +327,16 @@ cdbCopyGetData(CdbCopy *c, bool copy_cancel, uint64 *rows_processed)
 				 * try again, exit with error.
 				 */
 				if (nbytes == 0)
-					appendStringInfo(&(c->err_msg),
-									 "Failed to get data from segment %d, attempt blocked\n",
-									 source_seg);
+					ereport(ERROR,
+							(errcode(ERRCODE_IO_ERROR),
+							 errmsg("could not send COPY data to segment %d, attempt blocked",
+									source_seg)));
 
 				if (nbytes == -2)
-				{
-					/* GPDB_91_MERGE_FIXME: How should we handle errors here? We used
-					 * to append them to err_msg, but that doesn't seem right. Surely
-					 * we should ereport()? I put in just a quick elog() for now..
-					 */
-					elog(ERROR, "could not dispatch COPY: %s", PQerrorMessage(q->conn));
-					appendStringInfo(&(c->err_msg),
-									 "Failed to get data from segment %d: %s\n",
-									 source_seg, PQerrorMessage(q->conn));
-
-					/*
-					 * remove the segment that completed sending data from the
-					 * list
-					 */
-					c->outseglist = list_delete_int(c->outseglist, source_seg);
-
-					/* no more segments with data on the list. we are done */
-					if (list_length(c->outseglist) == 0)
-						return true;	/* done */
-
-					/*
-					 * start over from first seg as we just changes the seg
-					 * list
-					 */
-					break;
-				}
-
-				c->io_errors = true;
+					ereport(ERROR,
+							(errcode(ERRCODE_IO_ERROR),
+							 errmsg("could not receive COPY data from segment %d: %s",
+									source_seg, PQerrorMessage(q->conn))));
 			}
 		}
 
@@ -371,50 +348,125 @@ cdbCopyGetData(CdbCopy *c, bool copy_cancel, uint64 *rows_processed)
 }
 
 /*
- * Process the results from segments after sending the end of copy command.
+ * Commands to end the cdbCopy.
+ *
+ * If an error occurrs, or if an error is reported by one of the segments,
+ * cdbCopyEnd() throws it with ereport(), after closing the COPY and cleaning
+ * up any resources associated with it.
+ *
+ * cdbCopyAbort() usually does not throw an error. It is used in error-recovery
+ * codepaths, typically in a PG_CATCH() block, and the caller is about to
+ * re-throw the original error that caused the abortion.
  */
-static ErrorData *
-processCopyEndResults(CdbCopy *c,
-					  SegmentDatabaseDescriptor **db_descriptors,
-					  int *results,
-					  int size,
-					  bool *err_header,
-					  int *failed_count,
-					  int *total_rows_rejected,
-					  int64 *total_rows_completed)
+void
+cdbCopyAbort(CdbCopy *c)
 {
-	int			seg;
-	struct pollfd	*pollRead = (struct pollfd *) palloc(sizeof(struct pollfd));
+	cdbCopyEndInternal(c, "aborting COPY in QE due to error in QD",
+					   NULL, NULL);
+}
+
+/*
+ * End the copy command on all segment databases,
+ * and fetch the total number of rows completed by all QEs
+ */
+void
+cdbCopyEnd(CdbCopy *c,
+		   int64 *total_rows_completed_p,
+		   int64 *total_rows_rejected_p)
+{
+	CHECK_FOR_INTERRUPTS();
+
+	cdbCopyEndInternal(c, NULL,
+					   total_rows_completed_p,
+					   total_rows_rejected_p);
+}
+
+static void
+cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
+				   int64 *total_rows_completed_p,
+				   int64 *total_rows_rejected_p)
+{
+	Gang	   *gp;
+	int			num_bad_connections = 0;
+	int64		total_rows_completed = 0;	/* total num rows completed by all
+											 * QEs */
+	int64		total_rows_rejected = 0;	/* total num rows rejected by all
+											 * QEs */
 	ErrorData *first_error = NULL;
+	int			seg;
+	struct pollfd	*pollRead;
+	bool		io_errors = false;
+	StringInfoData io_err_msg;
 
-	for (seg = 0; seg < size; seg++)
+	initStringInfo(&io_err_msg);
+
+	/*
+	 * Don't try to end a copy that already ended with the destruction of the
+	 * writer gang. We know that this has happened if the CdbCopy's
+	 * primary_writer is NULL.
+	 *
+	 * GPDB_91_MERGE_FIXME: ugh, this is nasty. We shouldn't be calling
+	 * cdbCopyEnd twice on the same CdbCopy in the first place!
+	 */
+	gp = getCdbCopyPrimaryGang(c);
+	if (!gp)
 	{
-		SegmentDatabaseDescriptor *q = db_descriptors[seg];
-		int			result = results[seg];
-		int64		segment_rows_rejected = 0;	/* num of rows rejected by this QE */
-		int64		segment_rows_completed = 0; /* num of rows completed by this QE */
-		PGresult   *res;
+		if (total_rows_completed_p != NULL)
+			*total_rows_completed_p = 0;
+		if (total_rows_rejected_p != NULL)
+			*total_rows_completed_p = -1;
+		return;
+	}
 
-		/* get command end status */
-		if (result == 0)
+	/*
+	 * In COPY in mode, call PQputCopyEnd() to tell the segments that we're done.
+	 */
+	if (c->copy_in)
+	{
+		for (seg = 0; seg < gp->size; seg++)
 		{
-			/* attempt blocked */
+			SegmentDatabaseDescriptor *q = gp->db_descriptors[seg];
+			int			result;
 
-			/*
-			 * CDB TODO: Can this occur?  The libpq documentation says, "this
-			 * case is only possible if the connection is in nonblocking
-			 * mode... wait for write-ready and try again", i.e., the proper
-			 * response would be to retry, not error out.
-			 */
-			if (!(*err_header))
-				appendStringInfo(&(c->err_msg),
-								 "Failed to complete COPY on the following:\n");
-			*err_header = true;
+			elog(DEBUG1, "PQputCopyEnd seg %d    ", q->segindex);
+			/* end this COPY command */
+			result = PQputCopyEnd(q->conn, abort_msg);
 
-			appendStringInfo(&(c->err_msg), "primary segment %d, dbid %d, attempt blocked\n",
-							 seg, q->segment_database_info->dbid);
-			c->io_errors = true;
+			/* get command end status */
+			if (result == -1)
+			{
+				/* error */
+				appendStringInfo(&io_err_msg,
+								 "Failed to send end-of-copy to segment %d: %s",
+								 seg, PQerrorMessage(q->conn));
+				io_errors = true;
+			}
+			if (result == 0)
+			{
+				/* attempt blocked */
+
+				/*
+				 * CDB TODO: Can this occur?  The libpq documentation says, "this
+				 * case is only possible if the connection is in nonblocking
+				 * mode... wait for write-ready and try again", i.e., the proper
+				 * response would be to retry, not error out.
+				 */
+				appendStringInfo(&io_err_msg,
+								 "primary segment %d, dbid %d, attempt blocked\n",
+								 seg, q->segment_database_info->dbid);
+				io_errors = true;
+			}
 		}
+	}
+
+	pollRead = (struct pollfd *) palloc(sizeof(struct pollfd));
+	for (seg = 0; seg < gp->size; seg++)
+	{
+		SegmentDatabaseDescriptor *q = gp->db_descriptors[seg];
+		int			result;
+		PGresult   *res;
+		int64		segment_rows_completed = 0; /* # of rows completed by this QE */
+		int64		segment_rows_rejected = 0;	/* # of rows rejected by this QE */
 
 		pollRead->fd = PQsocket(q->conn);
 		pollRead->events = POLLIN;
@@ -530,137 +582,79 @@ processCopyEndResults(CdbCopy *c,
 				segment_rows_completed = res->numCompleted;
 
 			/* Get AO tuple counts */
-			c->aotupcounts = PQprocessAoTupCounts(c->partitions, c->aotupcounts, res->aotupcounts, res->naotupcounts);
+			c->aotupcounts = PQprocessAoTupCounts(c->partitions, c->aotupcounts,
+												  res->aotupcounts, res->naotupcounts);
 			/* free the PGresult object */
 			PQclear(res);
 		}
 		RESUME_INTERRUPTS();
 
 		/*
-		 * Finished with this segment db.
-		 *
-		 * Add the number of rows completed and rejected from this segment
+		 * add up the number of rows completed and rejected from this segment
 		 * to the totals. Only count from primary segs.
 		 */
 		if (segment_rows_rejected > 0)
-			*total_rows_rejected += segment_rows_rejected;
-		if ((NULL != total_rows_completed) && (segment_rows_completed > 0))
-			*total_rows_completed += segment_rows_completed;
+			total_rows_rejected += segment_rows_rejected;
+		if (segment_rows_completed > 0)
+			total_rows_completed += segment_rows_completed;
 
 		/* Lost the connection? */
 		if (PQstatus(q->conn) == CONNECTION_BAD)
 		{
-			if (!*(err_header))
-				appendStringInfo(&(c->err_msg),
-								 "ERROR - Failed to complete COPY on the following:\n");
-			*err_header = true;
-
 			/* command error */
-			c->io_errors = true;
-			appendStringInfo(&(c->err_msg), "Primary segment %d, dbid %d, with error: %s\n",
-							 seg, q->segment_database_info->dbid, PQerrorMessage(q->conn));
+			io_errors = true;
+			appendStringInfo(&io_err_msg,
+							 "Primary segment %d, dbid %d, with error: %s\n",
+							 seg, q->segment_database_info->dbid,
+							 PQerrorMessage(q->conn));
 
 			/* Free the PGconn object. */
 			PQfinish(q->conn);
 			q->conn = NULL;
 
 			/* Let FTS deal with it! */
-			(*failed_count)++;
+			num_bad_connections++;
 		}
 	}
-
-	return first_error;
-}
-
-int
-cdbCopyAbort(CdbCopy *c)
-{
-	return cdbCopyEndAndFetchRejectNum(c, NULL,
-									   "aborting COPY in QE due to error in QD");
-}
-
-/*
- * End the copy command on all segment databases,
- * and fetch the total number of rows completed by all QEs
- * 
- * GPDB_91_MERGE_FIXME: we allow % value to be specified as segment reject
- * limit, however, the total rejected rows is not allowed to be > INT_MAX.
- */
-int
-cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed, char *abort_msg)
-{
-	SegmentDatabaseDescriptor *q;
-	Gang	   *gp;
-	int		   *results;		/* final result of COPY command execution */
-	int			seg;
-
-	int			failed_count = 0;
-	int			total_rows_rejected = 0;	/* total num rows rejected by all
-											 * QEs */
-	bool		err_header = false;
-	struct SegmentDatabaseDescriptor **db_descriptors;
-	int			size;
-	ErrorData *edata;
-
-	/*
-	 * Don't try to end a copy that already ended with the destruction of the
-	 * writer gang. We know that this has happened if the CdbCopy's
-	 * primary_writer is NULL.
-	 *
-	 * GPDB_91_MERGE_FIXME: ugh, this is nasty. We shouldn't be calling
-	 * cdbCopyEnd twice on the same CdbCopy in the first place!
-	 */
-	gp = getCdbCopyPrimaryGang(c);
-	if (!gp)
-		return -1;
-
-	/* clean err message */
-	c->err_msg.len = 0;
-	c->err_msg.data[0] = '\0';
-	c->err_msg.cursor = 0;
-
-	db_descriptors = gp->db_descriptors;
-	size = gp->size;
-
-	/* results from each segment */
-	results = (int *) palloc0(sizeof(int) * size);
-
-	for (seg = 0; seg < size; seg++)
-	{
-		q = db_descriptors[seg];
-		elog(DEBUG1, "PQputCopyEnd seg %d    ", q->segindex);
-		/* end this COPY command */
-		results[seg] = PQputCopyEnd(q->conn, abort_msg);
-	}
-
-	if (NULL != total_rows_completed)
-		*total_rows_completed = 0;
-
-	edata = processCopyEndResults(c, db_descriptors, results, size,
-								  &err_header,
-								  &failed_count, &total_rows_rejected,
-								  total_rows_completed);
 
 	CdbDispatchCopyEnd(c);
 
 	/* If lost contact with segment db, try to reconnect. */
-	if (failed_count > 0)
+	if (num_bad_connections > 0)
 	{
-		elog(LOG, "%s", c->err_msg.data);
+		elog(LOG, "error occurred while ending COPY: %s", io_err_msg.data);
 		elog(LOG, "COPY signals FTS to probe segments");
+
 		SendPostmasterSignal(PMSIGNAL_WAKEN_FTS);
 		DisconnectAndDestroyAllGangs(true);
+
 		ereport(ERROR,
-				(errmsg_internal("MPP detected %d segment failures, system is reconnected", failed_count),
-				 errSendAlert(true)));
+				(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+				 (errmsg("MPP detected %d segment failures, system is reconnected",
+						 num_bad_connections),
+				  errSendAlert(true))));
 	}
 
-	pfree(results);
+	/*
+	 * Unless we are aborting the COPY, report any errors with ereport()
+	 */
+	if (!abort_msg)
+	{
+		/* errors reported by the segments */
+		if (first_error)
+			ReThrowError(first_error);
 
-	/* If we are aborting the COPY, ignore errors sent by the server. */
-	if (edata && !abort_msg)
-		ReThrowError(edata);
+		/* errors that occurred in the COPY itself */
+		if (io_errors)
+			ereport(ERROR,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("could not complete COPY on some segments"),
+					 errdetail("%s", io_err_msg.data)));
+	}
 
-	return total_rows_rejected;
+	if (total_rows_completed_p != NULL)
+		*total_rows_completed_p = total_rows_completed;
+	if (total_rows_rejected_p != NULL)
+		*total_rows_rejected_p = total_rows_rejected;
+	return;
 }
-

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2410,7 +2410,6 @@ CopyToDispatch(CopyState cstate)
 	int			attr_count;
 	Form_pg_attribute *attr;
 	CdbCopy    *cdbCopy;
-	StringInfoData cdbcopy_err;
 	uint64		processed = 0;
 
 	tupDesc = cstate->rel->rd_att;
@@ -2427,9 +2426,6 @@ CopyToDispatch(CopyState cstate)
 	cdbCopy->hasReplicatedTable = GpPolicyIsReplicated(cstate->rel->rd_cdbpolicy);
 
 	/* XXX: lock all partitions */
-
-	/* allocate memory for error and copy strings */
-	initStringInfo(&cdbcopy_err);
 
 	/*
 	 * Start a COPY command in every db of every segment in Greenplum Database.
@@ -2531,6 +2527,8 @@ CopyToDispatch(CopyState cstate)
 			}
 		} while(!done);
 
+		cdbCopyEnd(cdbCopy, NULL, NULL);
+
 		/* now it's safe to destroy the whole dispatcher state */
 		CdbDispatchCopyEnd(cdbCopy);
 	}
@@ -2538,13 +2536,8 @@ CopyToDispatch(CopyState cstate)
 	PG_CATCH();
 	{
 		MemoryContext oldcontext = MemoryContextSwitchTo(cstate->copycontext);
-		appendBinaryStringInfo(&cdbcopy_err, cdbCopy->err_msg.data, cdbCopy->err_msg.len);
 
 		cdbCopyAbort(cdbCopy);
-
-		ereport(LOG,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("%s", cdbcopy_err.data)));
 
 		MemoryContextSwitchTo(oldcontext);
 		PG_RE_THROW();
@@ -2562,15 +2555,6 @@ CopyToDispatch(CopyState cstate)
 	/* we can throw the error now if QueryCancelPending was set previously */
 	CHECK_FOR_INTERRUPTS();
 
-	/*
-	 * report all accumulated errors back to the client.
-	 */
-	if (cdbCopy->io_errors)
-		ereport(ERROR,
-				(errcode(ERRCODE_IO_ERROR),
-				 errmsg("%s", cdbcopy_err.data)));
-
-	pfree(cdbcopy_err.data);
 	pfree(cdbCopy);
 
 	return processed;
@@ -3997,16 +3981,17 @@ CopyFrom(CopyState cstate)
 	 */
 	if (cstate->dispatch_mode == COPY_DISPATCH)
 	{
-		int64			total_completed_from_qes;
-		int			total_rejected_from_qes;
+		int64		total_completed_from_qes;
+		int64		total_rejected_from_qes;
 
-		total_rejected_from_qes = cdbCopyEndAndFetchRejectNum(cdbCopy, &total_completed_from_qes, NULL);
-
+		cdbCopyEnd(cdbCopy,
+				   &total_completed_from_qes,
+				   &total_rejected_from_qes);
 		if (cstate->cdbsreh)
 		{
 			/* emit a NOTICE with number of rejected rows */
-			int			total_rejected = 0;
-			int total_rejected_from_qd = cstate->cdbsreh->rejectcount;
+			int64		total_rejected = 0;
+			int64		total_rejected_from_qd = cstate->cdbsreh->rejectcount;
 
 			/*
 			 * If error log has been requested, then we send the row to the segment

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -30,13 +30,10 @@ typedef struct CdbCopy
 	int			total_segs;		/* total number of segments in cdb */
 	int		   *mirror_map;		/* indicates how many db's each segment has */
 	bool		copy_in;		/* direction: true for COPY FROM false for COPY TO */
-	bool		io_errors;		/* true if any I/O error occurred trying to
-								 * communicate with segDB's */
 	bool		skip_ext_partition;/* skip external partition */ 
 
-	StringInfoData	err_msg;		/* error message for cdbcopy operations */
 	StringInfoData	copy_out_buf;/* holds a chunk of data from the database */
-		
+
 	List			*outseglist;    /* segs that currently take part in copy out. 
 									 * Once a segment gave away all it's data rows
 									 * it is taken out of the list */
@@ -55,11 +52,9 @@ extern void cdbCopyStart(CdbCopy *cdbCopy, CopyStmt *stmt, struct GpPolicy *poli
 extern void cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes);
 extern void cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer, int nbytes);
 extern bool cdbCopyGetData(CdbCopy *c, bool cancel, uint64 *rows_processed);
-extern int cdbCopyAbort(CdbCopy *c);
-/*
- * GPDB_91_MERGE_FIXME: let's consistently use uint64 as type for counting rows
- * of any kind.
- */
-extern int cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed, char *abort_msg);
+extern void cdbCopyAbort(CdbCopy *c);
+extern void cdbCopyEnd(CdbCopy *c,
+		   int64 *total_rows_completed_p,
+		   int64 *total_rows_rejected_p);
 
 #endif   /* CDBCOPY_H */

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -25,18 +25,6 @@
 
 struct CdbDispatcherState;
 
-typedef enum SegDbState
-{
-	/*
-	 * (it is best to avoid names like OUT that are likely to be #define'd or
-	 * typedef'd in some platform-dependent runtime library header file)
-	 */
-	SEGDB_OUT,					/* Not participating in COPY (invalid etc...) */
-	SEGDB_IDLE,					/* Participating but COPY not yet started */
-	SEGDB_COPY,					/* COPY in progress */
-	SEGDB_DONE					/* COPY completed (with or without errors) */
-}	SegDbState;
-
 typedef struct CdbCopy
 {
 	int			total_segs;		/* total number of segments in cdb */
@@ -46,10 +34,7 @@ typedef struct CdbCopy
 								 * communicate with segDB's */
 	bool		skip_ext_partition;/* skip external partition */ 
 
-	SegDbState		**segdb_state;
-	
 	StringInfoData	err_msg;		/* error message for cdbcopy operations */
-	StringInfoData  err_context; /* error context from QE error */
 	StringInfoData	copy_out_buf;/* holds a chunk of data from the database */
 		
 	List			*outseglist;    /* segs that currently take part in copy out. 

--- a/src/include/cdb/cdbsreh.h
+++ b/src/include/cdb/cdbsreh.h
@@ -88,7 +88,7 @@ extern CdbSreh *makeCdbSreh(int rejectlimit, bool is_limit_in_rows,
 							char *filename, char *relname, bool log_to_file);
 extern void destroyCdbSreh(CdbSreh *cdbsreh);
 extern void HandleSingleRowError(CdbSreh *cdbsreh);
-extern void ReportSrehResults(CdbSreh *cdbsreh, int total_rejected);
+extern void ReportSrehResults(CdbSreh *cdbsreh, int64 total_rejected);
 extern void SendNumRows(int numrejected, int64 numcompleted);
 extern void SendNumRowsRejected(int numrejected);
 extern bool IsErrorTable(Relation rel);

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1111,6 +1111,9 @@ CREATE TABLE lineitem_aborted (LIKE lineitem);
 COPY lineitem_aborted FROM '/tmp/aborted.data';
 SELECT count(*) < 57190 FROM lineitem_aborted;
 
+SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'reset', 1);
+
+
 -- Test external partition
 CREATE TABLE sales (
     id integer,
@@ -1183,6 +1186,8 @@ unknown
 \.
 
 COPY type_unknown TO stdout;
+
+
 --
 -- Test row counts
 --
@@ -1199,3 +1204,49 @@ copy t from '/tmp/b<SEGID>' on segment;
 select count(*) from t;
 
 \set QUIET on
+
+
+--
+-- Test error handling during COPY TO
+--
+-- To trigger an error, we use an output function that throws an
+-- error on a particular value. The trigger value is 1234.
+--
+CREATE TYPE broken_int4;
+CREATE FUNCTION broken_int4in(cstring)
+   RETURNS broken_int4
+   AS 'int4in'
+   LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE FUNCTION broken_int4out(broken_int4)
+   RETURNS cstring
+   AS '@abs_builddir@/regress@DLSUFFIX@', 'broken_int4out'
+   LANGUAGE C IMMUTABLE STRICT;
+
+CREATE TYPE broken_int4 (
+   internallength = 4,
+   input = broken_int4in,
+   output = broken_int4out,
+   alignment = int4,
+   passedbyvalue
+);
+
+-- Create a table, using the funny datatype, and load it with integers
+-- 1-10000. The input function works normally, so this works, but if you
+-- try to select the row with value 1234 from it, the output function will
+-- throw an error.
+CREATE TABLE broken_type_test (b broken_int4);
+insert into broken_type_test select g::text::broken_int4 from generate_series(1, 10000) g;
+
+-- Should work, since we don't hit the trigger value 1234. (In principle,
+-- that's not guaranteed; there's no ORDER BY, so the system could return
+-- any 10 rows. In practice, this seems pretty safe.)
+copy (select * from broken_type_test limit 10) to '/tmp/g';
+
+-- Should fail, because we try to output everything, including 1234
+copy (select * from broken_type_test) to '/tmp/g';
+copy broken_type_test to '/tmp/g';
+
+-- Don't leave behind a table that you can't dump.
+drop table broken_type_test;
+drop type broken_int4 cascade; -- drops the I/O functions, too.

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1312,6 +1312,13 @@ SELECT count(*) < 57190 FROM lineitem_aborted;
  t
 (1 row)
 
+SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 -- Test external partition
 CREATE TABLE sales (
     id integer,
@@ -1399,3 +1406,51 @@ select count(*) from t;
 (1 row)
 
 \set QUIET on
+--
+-- Test error handling during COPY TO
+--
+-- To trigger an error, we use an output function that throws an
+-- error on a particular value. The trigger value is 1234.
+--
+CREATE TYPE broken_int4;
+CREATE FUNCTION broken_int4in(cstring)
+   RETURNS broken_int4
+   AS 'int4in'
+   LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type broken_int4 is only a shell
+CREATE FUNCTION broken_int4out(broken_int4)
+   RETURNS cstring
+   AS '@abs_builddir@/regress@DLSUFFIX@', 'broken_int4out'
+   LANGUAGE C IMMUTABLE STRICT;
+NOTICE:  argument type broken_int4 is only a shell
+CREATE TYPE broken_int4 (
+   internallength = 4,
+   input = broken_int4in,
+   output = broken_int4out,
+   alignment = int4,
+   passedbyvalue
+);
+-- Create a table, using the funny datatype, and load it with integers
+-- 1-10000. The input function works normally, so this works, but if you
+-- try to select the row with value 1234 from it, the output function will
+-- throw an error.
+CREATE TABLE broken_type_test (b broken_int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+insert into broken_type_test select g::text::broken_int4 from generate_series(1, 10000) g;
+-- Should work, since we don't hit the trigger value 1234. (In principle,
+-- that's not guaranteed; there's no ORDER BY, so the system could return
+-- any 10 rows. In practice, this seems pretty safe.)
+copy (select * from broken_type_test limit 10) to '/tmp/g';
+-- Should fail, because we try to output everything, including 1234
+copy (select * from broken_type_test) to '/tmp/g';
+ERROR:  testing failure in output function
+DETAIL:  The trigger value was 1234
+copy broken_type_test to '/tmp/g';
+ERROR:  testing failure in output function
+DETAIL:  The trigger value was 1234
+-- Don't leave behind a table that you can't dump.
+drop table broken_type_test;
+drop type broken_int4 cascade; -- drops the I/O functions, too.
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function broken_int4in(cstring)
+drop cascades to function broken_int4out(broken_int4)

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -102,6 +102,10 @@ extern Datum check_shared_buffer_cache_for_dboid(PG_FUNCTION_ARGS);
 extern void gp_set_next_oid(PG_FUNCTION_ARGS);
 extern Datum gp_get_next_oid(PG_FUNCTION_ARGS);
 
+/* Broken output function, for testing */
+extern Datum broken_int4out(PG_FUNCTION_ARGS);
+
+
 /* Triggers */
 
 typedef struct
@@ -2067,4 +2071,24 @@ Datum
 gp_get_next_oid(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_OID(ShmemVariableCache->nextOid);
+}
+
+/*
+ * This is like int4out, but throws an error on '1234'.
+ *
+ * Used in the error handling test in 'gpcopy'.
+ */
+PG_FUNCTION_INFO_V1(broken_int4out);
+Datum
+broken_int4out(PG_FUNCTION_ARGS)
+{
+	int32		arg = PG_GETARG_INT32(0);
+
+	if (arg == 1234)
+		ereport(ERROR,
+				(errcode(ERRCODE_FAULT_INJECT),
+				 errmsg("testing failure in output function"),
+				 errdetail("The trigger value was 1234")));
+
+	return DirectFunctionCall1(int4out, Int32GetDatum(arg));
 }


### PR DESCRIPTION
If an error occurred in the segments, in a `COPY <table> TO <file>`
command, the COPY was stopped, but the error was not reported to the user.
That gave the false impression that it finished successfully, but what you
actually got was an incomplete file.

A test case is included. It uses a little helper output function that
sometimes throws an error. Output functions are fairly unlikely to fail,
but it could happen e.g. because of an out of memory error, or a disk
failure. The "COPY (SELECT ...) TO <file>" variant did not suffer from
this (otherwise, a query that throws an error would've been a much simpler
way to test this.)

The reason for this was that the code in cdbCopyGetData() that called
PQgetResult(), and extracted the error message from the result, didn't
indicate to the caller in any way that the error happened. To fix, delay
the call to PQgetResult(), to a later call to cdbCopyEnd(). cdbCopyEnd()
already had the logic to extract the error information from the PGresult,
and throw it to the user. While we're at it, refactor cdbCopyEnd a
little bit, to give the callers a nicer function signature.

I also changed a few places that used 32-bit int to store rejected row
counts, to use int64 instead. There was a FIXME comment about that. I
didn't fix all the places that do that, though, so I moved the FIXME to
one of the remaining places.

Apply to master branch only. GPDB 5 didn't handle this too well, either;
with the included test case, you got an error like this:

postgres=# copy broken_type_test to '/tmp/x';
ERROR:  missing error text

That's not very nice, but at least you get an error, even if it's not a very
good one. The code looks quite different in 5X_STABLE, so I'm not going to
attempt improving that.