### PR TITLE
Make 'incremental_analyze' more resilient with different settings.

### DIFF
--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1097,9 +1097,9 @@ ALTER TABLE foo ADD partition new_part START (6) INCLUSIVE END (9) EXCLUSIVE;
 NOTICE:  CREATE TABLE will create partition "foo_1_prt_new_part" for table "foo"
 INSERT INTO foo SELECT i, i%3+6 FROM generate_series(1,500)i;
 ANALYZE foo_1_prt_new_part;
+SET log_statement='none';
 SET client_min_messages = 'log';
 ANALYZE MERGE foo;
-LOG:  statement: ANALYZE MERGE foo;
 LOG:  Merging leaf stats
 LOG:  Merging leaf stats
 -- Insert a new column that is not analyzed in the leaf partitions.
@@ -1107,11 +1107,8 @@ LOG:  Merging leaf stats
 -- will create a sample for the root to analyze the newly added columns since 
 -- the leaf partitions does not have any stats for it, yet
 ALTER TABLE foo ADD COLUMN c int;
-LOG:  statement: ALTER TABLE foo ADD COLUMN c int;
 INSERT INTO foo SELECT i, i%9, i%100 FROM generate_series(1,500)i;
-LOG:  statement: INSERT INTO foo SELECT i, i%9, i%100 FROM generate_series(1,500)i;
 ANALYZE rootpartition foo;
-LOG:  statement: ANALYZE rootpartition foo;
 LOG:  Needs sample for foo
 LOG:  Merging leaf stats
 LOG:  Merging leaf stats

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -1,6 +1,7 @@
 -- start_ignore
 DROP DATABASE IF EXISTS incrementalanalyze;
 CREATE DATABASE incrementalanalyze;
+ALTER DATABASE incrementalanalyze SET lc_monetary TO 'C';
 \c incrementalanalyze
 DROP SCHEMA IF EXISTS incremental_analyze;
 CREATE SCHEMA incremental_analyze;
@@ -560,6 +561,7 @@ ANALYZE foo;
 ALTER TABLE foo ADD partition new_part START (6) INCLUSIVE END (9) EXCLUSIVE;
 INSERT INTO foo SELECT i, i%3+6 FROM generate_series(1,500)i;
 ANALYZE foo_1_prt_new_part;
+SET log_statement='none';
 SET client_min_messages = 'log';
 ANALYZE MERGE foo;
 -- Insert a new column that is not analyzed in the leaf partitions.


### PR DESCRIPTION
1. Force lc_monetary='C' in the test database, like pg_regress does for
   the 'regression' database. Otherwise the money values might come out
   e.g. as '£1,234.00' while the expected output has '$1,234.00'

2. Set log_statement='none'. Otherwise, because the test sets
   client_min_messages='log', the output depends on the original
   log_statement setting.