### PR TITLE
Remove obsolete backwards-compatibility code in hba parsing.

### DIFF
--- a/src/backend/libpq/hba.c
+++ b/src/backend/libpq/hba.c
@@ -1305,21 +1305,6 @@ parse_hba_line(List *line, int line_num)
 						 errmsg("authentication option not in name=value format: %s", token->string),
 						 errcontext("line %d of configuration file \"%s\"",
 									line_num, HbaFileName)));
-
-				/* GPDB_92_MERGE_FIXME: Is the code below needed? */
-				if (parsedline->auth_method == uaIdent && strcmp(token->string,"sameuser")==0)
-				{
-					if (list_length(parsedline->databases) == 1 &&
-						strcmp(linitial(parsedline->databases), "all")==0)
-						linitial(parsedline->databases) = pstrdup("sameuser");
-					continue;
-				}
-				else if (parsedline->auth_method == uaIdent)
-				{
-					parsedline->usermap = pstrdup(token->string);
-					continue;
-				}
-	
 				return NULL;
 			}
 


### PR DESCRIPTION
This chunk was introduced back in 2009. The commit message said:
(from the old git repository, long before GPDB was open sourced)

    Some backwards compatability fixes.
    Allow database name to come before arguments in psql
    Allow old pg_hba syntax " local all userid indent sameuser" as well as new syntax  of " local sameuser userid ident".

Back then, there was a comment in the code too, that said:

    XXX: attempt to do some backwards compatible parsing here?

That commit was removed in 2010, when the hba.c code was synced with
PostgreSQL 9.0.

I don't think we need to maintain compatibility with ancient pg_hba.conf
files anymore. If anyone still has a config file with those fields swapped,
it's time to fix the file.