### PR TITLE
Remove FIXME comment; on second thoughts, the query is fine.

### DIFF
--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -969,7 +969,6 @@ select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
 
 --
 --q38
--- GPDB_90_MERGE_FIXME: We should generate c2 IS NOT NULL derived filter.
 --
 explain select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
                                  QUERY PLAN                                 

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1030,7 +1030,6 @@ select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
 
 --
 --q38
--- GPDB_90_MERGE_FIXME: We should generate c2 IS NOT NULL derived filter.
 --
 explain select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
                                   QUERY PLAN                                  

--- a/src/test/regress/sql/notin.sql
+++ b/src/test/regress/sql/notin.sql
@@ -337,7 +337,6 @@ select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
 
 --
 --q38
--- GPDB_90_MERGE_FIXME: We should generate c2 IS NOT NULL derived filter.
 --
 explain select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
 select c1 from t1 where not exists (select c2 from t2 where c2 = c1);


### PR DESCRIPTION
In GPDB5, we used to get a IS NOT NULL condition in this query, but lost
that as part of the 9.0 merge. The plan difference was flagged as a FIXME,
because the IS NOT NULL filter could save some time, by eliminating rows
early on, that we know can't match the join qual. On second thoughts, I
think we should just live with it, even if it might be a performance
regression in some queries, because:

* Even in GPDB 5, you only got the extra Filter with the Postgres planner.
  ORCA never bothered with it.

* The same Filter could be added to most joins, but we were only doing it
  for NOT IN queries. That suggest that it wasn't done as a performance
  optimization in the first place, but it was probably required for
  correctness for some plans.

* Eliminating the rows early doesn't matter much in the typical case that
  you have a Join node immediately on top of the Scan node. (The main case
  where it helps is if there is a Motion or Sort node inbetween.)

* It's rare in practice, to do joins on a column that contains a lot of
  NULLs.

All in all, I think it would be an interesting little optimization to do,
but we should do it consistently for all joins. And we should do that in
PostgreSQL community first, as it's not really MPP-related. So for now,
in GPDB, just remove the comment and accept the plan as it is, without
the Filter.