### PR TITLE
Fix psql \dE command to display both foreign and external tables.

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -3578,6 +3578,8 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 		appendPQExpBuffer(&buf, "'h', 'a', 'c',");
 	if (showExternal)
 		appendPQExpBuffer(&buf, "'x',");
+	if (showForeign)
+		appendPQExpBuffer(&buf, "'f',");
 	if (showViews)
 		appendPQExpBuffer(&buf, "'v',");
 	appendPQExpBuffer(&buf, "''");		/* dummy */

--- a/src/bin/psql/help.c
+++ b/src/bin/psql/help.c
@@ -233,9 +233,8 @@ slashUsage(unsigned short int pager)
 	fprintf(output, _("  \\dT[S+] [PATTERN]      list data types\n"));
 	fprintf(output, _("  \\du[+]  [PATTERN]      list roles\n"));
 	fprintf(output, _("  \\dv[S+] [PATTERN]      list views\n"));
-	/* GPDB_91_MERGE_FIXME: can we use \dE for both external and foreign tables? */
-	fprintf(output, _("  \\dE     [PATTERN]      list external tables\n"));
-	fprintf(output, _("  \\dE[S+] [PATTERN]      list foreign tables\n"));
+	/* In GPDB, we use \dE for both external and foreign tables. */
+	fprintf(output, _("  \\dE[S+] [PATTERN]      list foreign and external tables\n"));
 	fprintf(output, _("  \\dx[+]  [PATTERN]      list extensions\n"));
 	fprintf(output, _("  \\l[+]                  list all databases\n"));
 	fprintf(output, _("  \\sf[+] FUNCNAME        show a function's definition\n"));

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -141,3 +141,30 @@ COMMENT ON ROLE test_psql_du_e9 IS 'test_role_description';
  test_psql_du_e9 | Superuser, Cannot login, Replication | {}        | test_role_description
 
 DROP ROLE test_psql_du_e9;
+--
+-- Test that \dE displays both external and foreign tables
+--
+CREATE FOREIGN DATA WRAPPER dummy_wrapper;
+COMMENT ON FOREIGN DATA WRAPPER dummy_wrapper IS 'useless';
+CREATE SERVER dummy_server FOREIGN DATA WRAPPER dummy_wrapper;
+CREATE FOREIGN TABLE "dE_foreign_table" (c1 integer)
+  SERVER dummy_server;
+CREATE EXTERNAL TABLE "dE_external_table"  (c1 integer)
+  LOCATION ('file://localhost/dummy') FORMAT 'text';
+-- Change the owner, so that the expected output is not sensitive to current
+-- username.
+CREATE ROLE test_psql_de_role;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+ALTER FOREIGN TABLE "dE_foreign_table" OWNER TO test_psql_de_role;
+ALTER EXTERNAL TABLE "dE_external_table" OWNER TO test_psql_de_role;
+\dE "dE"*
+                             List of relations
+ Schema |       Name        |     Type      |       Owner       | Storage  
+--------+-------------------+---------------+-------------------+----------
+ public | dE_external_table | table         | test_psql_de_role | external
+ public | dE_foreign_table  | foreign table | test_psql_de_role | 
+(2 rows)
+
+-- Clean up
+DROP OWNED BY test_psql_de_role;
+DROP ROLE test_psql_de_role;

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -78,3 +78,28 @@ COMMENT ON ROLE test_psql_du_e9 IS 'test_role_description';
 \du test_psql_du_e9
 \du+ test_psql_du_e9
 DROP ROLE test_psql_du_e9;
+
+
+--
+-- Test that \dE displays both external and foreign tables
+--
+CREATE FOREIGN DATA WRAPPER dummy_wrapper;
+COMMENT ON FOREIGN DATA WRAPPER dummy_wrapper IS 'useless';
+CREATE SERVER dummy_server FOREIGN DATA WRAPPER dummy_wrapper;
+CREATE FOREIGN TABLE "dE_foreign_table" (c1 integer)
+  SERVER dummy_server;
+
+CREATE EXTERNAL TABLE "dE_external_table"  (c1 integer)
+  LOCATION ('file://localhost/dummy') FORMAT 'text';
+
+-- Change the owner, so that the expected output is not sensitive to current
+-- username.
+CREATE ROLE test_psql_de_role;
+ALTER FOREIGN TABLE "dE_foreign_table" OWNER TO test_psql_de_role;
+ALTER EXTERNAL TABLE "dE_external_table" OWNER TO test_psql_de_role;
+
+\dE "dE"*
+
+-- Clean up
+DROP OWNED BY test_psql_de_role;
+DROP ROLE test_psql_de_role;


### PR DESCRIPTION
It would previously not display foreign tables, because they were filtered
out by the GPDB-added condition on relstorage. Fix, and add test case.