### PR TITLE
Set left_ec/right_ec in gen_implied_qual()

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -199,19 +199,12 @@ gen_implied_qual(PlannerInfo *root,
 	}
 
 	/*
-	 * If the clause has a mergejoinable operator, process the equivalence
-	 * class with below_outer_join being true. This would set left_ec/right_ec.
-	 * Ohterwise, a mergejoinable operator with NULL left_ec/right_ec will
-	 * cause update_mergeclause_eclasses fails at assertion.
+	 * If the clause has a mergejoinable operator, set the EquivalenceClass
+	 * links. Otherwise, a mergejoinable operator with NULL left_ec/right_ec
+	 * will cause update_mergeclause_eclasses fails at assertion.
 	 */
 	if (new_rinfo->mergeopfamilies)
-	{
-		if (process_equivalence(root, new_rinfo, true))
-			return;
-		/* EC rejected it, so set left_ec/right_ec the hard way ... */
 		initialize_mergeclause_eclasses(root, new_rinfo);
-		/* ... and fall through to distribute_restrictinfo_to_rels */
-	}
 
 	distribute_restrictinfo_to_rels(root, new_rinfo);
 }

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -328,19 +328,7 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 		/* Is it a convertible ANY or EXISTS clause? */
 		if (sublink->subLinkType == ANY_SUBLINK)
 		{
-			/*
-			 * GPDB_92_MERGE_FIXME: debug with the following two queries:
-			 *
-			 * select * from A where exists
-			 * 		(select * from B where A.i in
-			 * 			(select C.i from C where C.i = B.i));
-			 *
-			 *
-			 * select * from C,A where C.i in
-			 * 		(select C.i from C where C.i = A.i);
-			 */
-			if (available_rels2 == NULL &&
-					(j = convert_ANY_sublink_to_join(root, sublink,
+			if ((j = convert_ANY_sublink_to_join(root, sublink,
 												 available_rels1)) != NULL)
 			{
 				/* Yes; insert the new join node into the join tree */

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -167,6 +167,31 @@ select A.i, B.i, C.j from A, B, C where A.j in (select C.j from C where C.j = A.
 ---+---+---
 (0 rows)
 
+-- Test for sublink pull-up based on both left-hand and right-hand input
+explain (costs off)
+select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
+                 QUERY PLAN                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: c.i = b.i AND a.i = b.i
+         ->  Hash Semi Join
+               Hash Cond: a.i = c.i
+               ->  Seq Scan on a
+               ->  Hash
+                     ->  Seq Scan on c
+         ->  Hash
+               ->  Seq Scan on b
+ Optimizer: legacy query optimizer
+(11 rows)
+
+select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
+ i | j 
+---+---
+ 1 | 1
+ 1 | 1
+(2 rows)
+
 -- -- -- --
 -- Basic queries with NOT IN clause
 -- -- -- --

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -167,6 +167,35 @@ select A.i, B.i, C.j from A, B, C where A.j in (select C.j from C where C.j = A.
 ---+---+---
 (0 rows)
 
+-- Test for sublink pull-up based on both left-hand and right-hand input
+explain (costs off)
+select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: a.i = c.i
+         ->  Table Scan on a
+         ->  Hash
+               ->  GroupAggregate
+                     Group Key: c.i
+                     ->  Sort
+                           Sort Key: c.i
+                           ->  Hash Join
+                                 Hash Cond: c.i = b.i
+                                 ->  Table Scan on c
+                                 ->  Hash
+                                       ->  Table Scan on b
+ Optimizer: PQO version 2.70.0
+(15 rows)
+
+select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
+ i | j 
+---+---
+ 1 | 1
+ 1 | 1
+(2 rows)
+
 -- -- -- --
 -- Basic queries with NOT IN clause
 -- -- -- --

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -107,6 +107,12 @@ select A.i, B.i, C.j from A, B, C where A.j = any(select sum(C.j) from C where C
 select A.i, B.i, C.j from A, B, C where A.j in ( select C.j from C where exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j in (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 
+
+-- Test for sublink pull-up based on both left-hand and right-hand input
+explain (costs off)
+select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
+select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
+
 -- -- -- --
 -- Basic queries with NOT IN clause
 -- -- -- --


### PR DESCRIPTION
Re-enable ANY_SUBLINK pullup based on LHS input.

Previously, for query below, we disabled ANY_SUBLINK pullup to work
around the assertion failure that left_ec/right_ec not being set.

```
select * from A where exists
     (select * from B where A.i in
         (select C.i from C where C.i = B.i));
```

This commit sets left_ec/right_ec properly in gen_implied_qual() and
re-enables above ANY_SUBLINK pullup.

Co-authored-by: Alexandra Wang <lewang@pivotal.io>
Co-authored-by: Richard Guo <guofenglinux@gmail.com>