### PR TITLE
pg_upgrade: fix GPDB-specific long options

### DIFF
--- a/contrib/pg_upgrade/option.c
+++ b/contrib/pg_upgrade/option.c
@@ -57,9 +57,9 @@ parseCommandLine(int argc, char *argv[])
 
 		/* Greenplum specific parameters */
 		{"mode", required_argument, NULL, 1},
-		{"progress", no_argument, NULL, '2'},
-		{"add-checksum", no_argument, NULL, '3'},
-		{"remove-checksum", no_argument, NULL, '4'},
+		{"progress", no_argument, NULL, 2},
+		{"add-checksum", no_argument, NULL, 3},
+		{"remove-checksum", no_argument, NULL, 4},
 
 		{NULL, 0, NULL, 0}
 	};


### PR DESCRIPTION
The `--progress`, `--add-checksum`, and `--remove-checksum` options weren't being recognized because their `option.val`s were set to the characters '2', '3', and '4' (integer values 50, 51, and 52, respectively), while the option handling was comparing to the literal values 2, 3, and 4. Switch back to integers.