### PR TITLE
Remove fixmes on function get_eclass_for_sort_expr

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4733,7 +4733,8 @@ reconstruct_pathkeys(PlannerInfo *root, List *pathkeys, int *resno_map,
 
 				/*
 				 * The param 'rel' is only used on making and findding EC in childredrels.
-				 * But I think the situation does not happen in adding cdb path. So Null is ok.
+				 * But I think the situation does not happen in adding cdb path. So Null is
+				 * ok.
 				 */
 				new_eclass = get_eclass_for_sort_expr(root,
 													  new_tle->expr,

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4731,13 +4731,16 @@ reconstruct_pathkeys(PlannerInfo *root, List *pathkeys, int *resno_map,
 				if (!new_tle)
 					elog(ERROR, "could not find path key expression in constructed subquery's target list");
 
+				/*
+				 * The param 'rel' is only used on making and findding EC in childredrels.
+				 * But I think the situation does not happen in adding cdb path. So Null is ok.
+				 */
 				new_eclass = get_eclass_for_sort_expr(root,
 													  new_tle->expr,
 													  pathkey->pk_eclass->ec_opfamilies,
 													  em->em_datatype,
 													  exprCollation((Node *) tle->expr),
 													  0,
- 				/* GPDB_92_MERGE_FIXME_AFTER_GPDB_RUNS: NULL does not look like a correct parameter. */
 													  NULL,
 													  true);
 				new_pathkey = makePathKey(new_eclass, pathkey->pk_opfamily, pathkey->pk_strategy,

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4733,7 +4733,7 @@ reconstruct_pathkeys(PlannerInfo *root, List *pathkeys, int *resno_map,
 
 				/*
 				 * The param 'rel' is only used on making and findding EC in childredrels.
-				 * But I think the situation does not happen in adding cdb path. So Null is
+				 * But I think the situation does not happen in adding cdb path, So Null is
 				 * ok.
 				 */
 				new_eclass = get_eclass_for_sort_expr(root,

--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1193,7 +1193,7 @@ cdb_make_pathkey_for_expr(PlannerInfo *root,
 									  typeoid,
 									  exprCollation(expr),
 									  0,
-									  NULL, /* GPDB_92_MERGE_FIXME: What is the expected rel here? */
+									  NULL,
 									  true);
 	if (!canonical)
 		pk = makePathKey(eclass, opfamily, strategy, false);


### PR DESCRIPTION
The param 'rel' is only used on making and findding EC in childred
rels. But I think the situation does not happen in adding cdb path.