### PR TITLE
Revise the comment for ALL SUBLINK pullup.

### DIFF
--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -464,10 +464,15 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 		else if (sublink->subLinkType == ALL_SUBLINK)
 		{
 			/*
-			 * GPDB_92_MERGE_FIXME: Should the ALL SUBLINK below be converted?
+			 * GPDB_92_MERGE_FIXME: This is bogus but works.
 			 *
 			 * 	select * from A,B where exists
 			 *     (select * from C where B.i not in (select C.i from C where C.i != 10))
+			 *
+			 * The ALL SUBLINK in above query would not be converted. Otherwise, the Query tree
+			 * would be messed up.
+			 *
+			 * Future work: look into the implementation of `convert_IN_to_antijoin`.
 			 */
 			if (available_rels2 == NULL &&
 					(j = convert_IN_to_antijoin(root, sublink, available_rels1)) != NULL)


### PR DESCRIPTION
Without this FIXME, current implementation for ALL SUBLINK will generate
problematic query tree. While further investigations are still needed, this is
Greenplum specific code and will not block merging with upstream Postgres.

Co-authored-by: Alexandra Wang <lewang@pivotal.io>
Co-authored-by: Richard Guo <guofenglinux@gmail.com>