### PR TITLE
Remove unused upstream macro.

### DIFF
--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -363,11 +363,6 @@ static inline bool slot_attisnull(TupleTableSlot *slot, int attnum)
 	return memtuple_attisnull(slot->PRIVATE_tts_memtuple, slot->tts_mt_bind, attnum);
 }
 
-#ifdef GPDB_83_MERGE_FIXME
-#define TTS_HAS_PHYSICAL_TUPLE(slot)  \
-	((slot)->tts_tuple != NULL && (slot)->tts_tuple != &((slot)->tts_minhdr))
-#endif
-
 /* in executor/execTuples.c */
 extern void init_slot(TupleTableSlot *slot, TupleDesc tupdesc);
 


### PR DESCRIPTION
This isn't currently used in GPDB, and it wouldn't work as it is anyway,
because TupleTableSlots are quite different in GPDB. There's no point in
keeping this around as a FIXME, so let's just remove it.