### PR TITLE
Clarify comments around const-evaluation of Params.

### DIFF
--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -842,8 +842,13 @@ BuildCachedPlan(CachedPlanSource *plansource, List *qlist,
 	plan = (CachedPlan *) palloc(sizeof(CachedPlan));
 	plan->magic = CACHEDPLAN_MAGIC;
 	plan->stmt_list = plist;
-	/* GPDB_92_MERGE_FIXME: pg upstream does not set for boundParams, but
-	 * previous gpdb code considers that. Why? */
+
+	/*
+	 * In GPDB, the planner is more aggressive, and e.g. eagerly evaluates
+	 * stable functions in the planner already. Such plans are marked as
+	 * 'one-off', and mustn't be reused. Likewise, plans for CTAS are not
+	 * reused, because the plan depends on the target data distribution.
+	 */
 	if (plan_list_is_oneoff(plist) || intoClause)
 	{
 		plan->saved_xmin = BootstrapTransactionId;

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -124,6 +124,18 @@ EXPLAIN EXECUTE prep_prune;
  Optimizer status: legacy query optimizer
 (6 rows)
 
+-- Also test that Params are const-evaluated.
+PREPARE prep_prune_param AS select * from pt_lt_tab WHERE col2 = $1;
+EXPLAIN EXECUTE prep_prune_param(10);
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000003.12 rows=1 width=12)
+   ->  Append  (cost=10000000000.00..10000000003.12 rows=1 width=12)
+         ->  Seq Scan on pt_lt_tab_1_prt_part1 pt_lt_tab  (cost=10000000000.00..10000000003.12 rows=1 width=12)
+               Filter: col2 = 10::numeric
+ Optimizer: legacy query optimizer
+(5 rows)
+
 -- @description B-tree single index key = non-partitioning key
 CREATE INDEX idx1 on pt_lt_tab(col1);
 NOTICE:  building index for child partition "pt_lt_tab_1_prt_part1"

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -126,6 +126,20 @@ EXPLAIN EXECUTE prep_prune;
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
 (9 rows)
 
+-- Also test that Params are const-evaluated.
+PREPARE prep_prune_param AS select * from pt_lt_tab WHERE col2 = $1;
+EXPLAIN EXECUTE prep_prune_param(10);
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+         ->  Partition Selector for pt_lt_tab (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 5)
+         ->  Dynamic Table Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+               Filter: col2 = 10::numeric
+ Optimizer: PQO version 2.70.0
+(7 rows)
+
 -- @description B-tree single index key = non-partitioning key
 CREATE INDEX idx1 on pt_lt_tab(col1);
 NOTICE:  building index for child partition "pt_lt_tab_1_prt_part1"

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -124,6 +124,10 @@ PREPARE prep_prune AS select * from pt_lt_tab WHERE col2 = stabletestfunc();
 -- The plan should only scan one partition, where col2 = 10.
 EXPLAIN EXECUTE prep_prune;
 
+-- Also test that Params are const-evaluated.
+PREPARE prep_prune_param AS select * from pt_lt_tab WHERE col2 = $1;
+EXPLAIN EXECUTE prep_prune_param(10);
+
 
 -- @description B-tree single index key = non-partitioning key
 CREATE INDEX idx1 on pt_lt_tab(col1);


### PR DESCRIPTION
GPDB has a concept of "one-off" plans. In PostgreSQL, the planner doesn't
normally const-evaluate stable functions, but GPDB does that. Such plans
cannot be reused across invocations, so they're marked as "one-off".

Before the PostgreSQL 9.2 merge, the same "one-off" flag was used to mark
plans where query Params were aggressively const-evaluated, for similar
reasons. That mechanism was obsoleted in 9.2, however, when the concept
of "custom" and "generic" plans was introduced. The planner will now try
to create "custom" plans for the specific query parameters, without any
GPDB adde code.

The snippet in In eval_const_expressions that this removes was a no-op.
There used to be an extra condition, before the 9.2 merge, so that it
const-evaluated Params more aggressively. But that was removed as part
of the merge, and as a result, the removed if()'s condition was always
false. We don't need the more aggressive stance here, because the upstream
custom plans mechanism does the same. Move the comment explaining the
aggressive const-evaluation of stable functions to evaluate_function(),
that seems like a better place for it, anyway.

Remove the GPDB_92_MERGE_FIXME comment in BuildCachedPlan(). I'm not sure
why we had a check for boundParams there before. AFAICS, marking the plans
as one-off in eval_const_expressions_mutator (the code that was removed),
should've been enough, and the check for boundParams in plancache.c was
redundant (and sub-optimal, because some plans were marked not-for-reuse,
which could've been reused safely). In any case, there isn't anything
special about query parameters in this code anymore, it's all upstream
code, so we don't need an extra boundParams check either.

Add a test case for the const-evaluation of query Params, too. It was
passing before these changes as well, but seems good to have a test for it.