### PR TITLE
gppersistentrebuild: Fix directory for transaction file space

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
@@ -37,6 +37,16 @@ Feature: persistent rebuild tests
           | primary |
           | master  |
 
+    Scenario: persistent_rebuild after transaction files have been moved to another filespace
+        Given the database is running
+        And a filespace_config_file for filespace "tempfs" is created using config file "tempfs_config" in directory "/tmp"
+        And a filespace is created using config file "tempfs_config" in directory "/tmp"
+        And transaction files are moved to the filespace "tempfs"
+        And the information of a "primary" segment on any host is saved
+        Then run gppersistent_rebuild with the saved content id
+        And gppersistent_rebuild should return a return code of 0
+        And transaction files are moved to the filespace "pg_system"
+
     Scenario: Persistent rebuild should work on small shared_buffers value
         Given the database is running
         And there is a "ao" table "public.ao_part_table" in "bkdb" having "1000" partitions

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -598,6 +598,28 @@ def impl(context, USER, HOST, PORT, config_file, dir):
     run_command(context, cmdStr)
 
 
+@given('a filespace_config_file for filespace "{fs_name}" is created using config file "{config_file}" in directory "{dir}"')
+def impl(context, fs_name, config_file, dir):
+    user = None
+    host = None
+    port = None
+    config_file_path = dir + "/" + config_file
+    create_gpfilespace_config(host, port, user, fs_name, config_file_path, dir)
+
+@given('a filespace is created using config file "{config_file}" in directory "{dir}"')
+def impl(context, config_file, dir):
+    config_file_path = dir + "/" + config_file
+    cmdStr = 'gpfilespace -c "%s"' % config_file_path
+    run_command(context, cmdStr)
+
+
+@given('transaction files are moved to the filespace {fs_name}')
+@then('transaction files are moved to the filespace {fs_name}')
+def impl(context, fs_name):
+    cmdStr = 'gpfilespace  --movetransfilespace "%s"' % fs_name
+    run_command(context, cmdStr)
+
+
 @given('the user modifies the external_table.sql file "{filepath}" with host "{HOST}" and port "{port}"')
 @when('the user modifies the external_table.sql file "{filepath}" with host "{HOST}" and port "{port}"')
 def impl(context, filepath, HOST, port):


### PR DESCRIPTION
The gpgpersisteentrebuild utility fails in
BackupPersistentTableFiles._copy_Xactlog_files() if transaction files have been
moved to a filespace other than the pg_system filespace.

The fix is to check if the base directory contains the
`gp_transaction_files_filespace` file, and if so, use that to find out the
current location of the transaction files.

This is a PR for 5X_STABLE.

Co-authored-by: Nadeem Ghani <nghani@pivotal.io>
Co-authored-by: Kalen Krempely <kkrempely@pivotal.io>