### PR TITLE
Fix error caused by creating too many memory accounts

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -981,7 +981,7 @@ cdbexplain_collectStatsFromNode(PlanState *planstate, CdbExplain_SendStatCtx *ct
 	si->workmemused = instr->workmemused;
 	si->workmemwanted = instr->workmemwanted;
 	si->workfileCreated = instr->workfileCreated;
-	si->peakMemBalance = MemoryAccounting_GetAccountPeakBalance(planstate->plan->memoryAccountId);
+	si->peakMemBalance = MemoryAccounting_GetAccountPeakBalance(planstate->memoryAccountId);
 	si->firststart = instr->firststart;
 	si->numPartScanned = instr->numPartScanned;
 	si->sortMethod = String2ExplainSortMethod(instr->sortMethod);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -267,7 +267,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 	PlannedStmt *plannedStmt = queryDesc->plannedstmt;
 
-	queryDesc->memoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
+	queryDesc->memoryAccountId = MemoryAccounting_CreateExecutorMemoryAccount();
 
 	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -263,15 +263,13 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	Assert(queryDesc != NULL);
 	Assert(queryDesc->estate == NULL);
 	Assert(queryDesc->plannedstmt != NULL);
+	Assert(queryDesc->memoryAccountId == MEMORY_OWNER_TYPE_Undefined);
 
 	PlannedStmt *plannedStmt = queryDesc->plannedstmt;
 
-	if (MEMORY_OWNER_TYPE_Undefined == plannedStmt->memoryAccountId)
-	{
-		plannedStmt->memoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
-	}
+	queryDesc->memoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
 
-	START_MEMORY_ACCOUNT(plannedStmt->memoryAccountId);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	Assert(plannedStmt->intoPolicy == NULL ||
 		GpPolicyIsPartitioned(plannedStmt->intoPolicy) ||
@@ -864,9 +862,9 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 	Assert(estate != NULL);
 	Assert(!(estate->es_top_eflags & EXEC_FLAG_EXPLAIN_ONLY));
 
-	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->plannedstmt->memoryAccountId);
+	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->memoryAccountId);
 
-	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccountId);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	/*
 	 * Switch into per-query memory context
@@ -1148,9 +1146,9 @@ standard_ExecutorEnd(QueryDesc *queryDesc)
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->plannedstmt->memoryAccountId);
+	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->memoryAccountId);
 
-	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccountId);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	if (DEBUG1 >= log_min_messages)
 	{
@@ -1313,9 +1311,9 @@ ExecutorRewind(QueryDesc *queryDesc)
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->plannedstmt->memoryAccountId);
+	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->memoryAccountId);
 
-	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccountId);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	/* It's probably not sensible to rescan updating queries */
 	Assert(queryDesc->operation == CMD_SELECT);

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -894,7 +894,7 @@ ExecProcNode(PlanState *node)
 {
 	TupleTableSlot *result = NULL;
 
-	START_MEMORY_ACCOUNT(node->plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(node->memoryAccountId);
 	{
 
 	CHECK_FOR_INTERRUPTS();
@@ -1190,7 +1190,7 @@ MultiExecProcNode(PlanState *node)
 
 	Assert(NULL != node->plan);
 
-	START_MEMORY_ACCOUNT(node->plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(node->memoryAccountId);
 {
 	TRACE_POSTGRESQL_EXECPROCNODE_ENTER(GpIdentity.segindex, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -281,7 +281,7 @@ ExecHashTableCreate(HashState *hashState, HashJoinState *hjstate, List *hashOper
 	ListCell   *ho;
 	MemoryContext oldcxt;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 	Hash *node = (Hash *) hashState->ps.plan;
 
@@ -654,7 +654,7 @@ ExecHashTableDestroy(HashState *hashState, HashJoinTable hashtable)
 	Assert(hashtable);
 	Assert(!hashtable->eagerlyReleased);
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 
 	/*
@@ -879,7 +879,7 @@ ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
 	int			batchno;
 	int			hashTupleSize;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 	PlanState *ps = &hashState->ps;
 
@@ -984,7 +984,7 @@ ExecHashGetHashValue(HashState *hashState, HashJoinTable hashtable,
 	MemoryContext oldContext;
 	bool		result = true;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 
 	Assert(hashkeys_null);
@@ -1125,7 +1125,7 @@ ExecScanHashBucket(HashState *hashState, HashJoinState *hjstate,
 	HashJoinTuple hashTuple = hjstate->hj_CurTuple;
 	uint32		hashvalue = hjstate->hj_CurHashValue;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 	/*
 	 * hj_CurTuple is the address of the tuple last returned from the current
@@ -1275,7 +1275,7 @@ ExecHashTableReset(HashState *hashState, HashJoinTable hashtable)
 	MemoryContext oldcxt;
 	int			nbuckets = hashtable->nbuckets;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 	Assert(!hashtable->eagerlyReleased);
 
@@ -1350,7 +1350,7 @@ ExecHashTableExplainInit(HashState *hashState, HashJoinState *hjstate,
 	MemoryContext oldcxt;
 	int			nbatch = Max(hashtable->nbatch, 1);
 
-    START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+    START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
     {
     /* Switch to a memory context that survives until ExecutorEnd. */
     oldcxt = MemoryContextSwitchTo(hjstate->js.ps.state->es_query_cxt);
@@ -1630,7 +1630,7 @@ ExecHashTableExplainBatchEnd(HashState *hashState, HashJoinTable hashtable)
     HashJoinBatchStats *batchstats = &stats->batchstats[curbatch];
     int                 i;
     
-    START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+    START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
     {
     Assert(!hashtable->eagerlyReleased);
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -200,6 +200,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	PlannerConfig *config;
 	instr_time		starttime;
 	instr_time		endtime;
+	MemoryAccountIdType curMemoryAccountId;
 
 	/*
 	 * Use ORCA only if it is enabled and we are in a master QD process.
@@ -219,7 +220,10 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);
 
-		START_MEMORY_ACCOUNT(MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Optimizer));
+		curMemoryAccountId = MemoryAccounting_CreatePlanningMemoryAccount(
+			MEMORY_OWNER_TYPE_Optimizer);
+
+		START_MEMORY_ACCOUNT(curMemoryAccountId);
 		{
 			result = optimize_query(parse, boundParams);
 		}
@@ -243,11 +247,13 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	if (gp_log_optimization_time)
 		INSTR_TIME_SET_CURRENT(starttime);
 
+	curMemoryAccountId =
+		MemoryAccounting_CreatePlanningMemoryAccount(MEMORY_OWNER_TYPE_Planner);
 	/*
 	 * Incorrectly indented on purpose to avoid re-indenting an entire upstream
 	 * function
 	 */
-	START_MEMORY_ACCOUNT(MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Planner));
+	START_MEMORY_ACCOUNT(curMemoryAccountId);
 	{
 
 	/* Cursor options may come from caller or from DECLARE CURSOR stmt */

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -112,6 +112,7 @@ CreateQueryDesc(PlannedStmt *plannedstmt,
 
 	qd->ddesc = NULL;
 	qd->gpmon_pkt = NULL;
+	qd->memoryAccountId = MEMORY_OWNER_TYPE_Undefined;
 	
 	if (Gp_role != GP_ROLE_EXECUTE)
 		increment_command_count();

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -530,6 +530,7 @@ static const struct config_enum_entry explain_memory_verbosity_options[] = {
 	{"suppress", EXPLAIN_MEMORY_VERBOSITY_SUPPRESS},
 	{"summary", EXPLAIN_MEMORY_VERBOSITY_SUMMARY},
 	{"detail", EXPLAIN_MEMORY_VERBOSITY_DETAIL},
+	{"debug", EXPLAIN_MEMORY_VERBOSITY_DEBUG},
 	{NULL, 0}
 };
 
@@ -4962,7 +4963,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 	{
 		{"explain_memory_verbosity", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Experimental feature: show memory account usage in EXPLAIN ANALYZE."),
-			gettext_noop("Valid values are SUPPRESS, SUMMARY, and DETAIL."),
+			gettext_noop("Valid values are SUPPRESS, SUMMARY, DETAIL, and DEBUG."),
 			GUC_GPDB_ADDOPT
 		},
 		&explain_memory_verbosity,

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -961,7 +961,7 @@ test__MemoryAccounting_GetAccountName__Validate(void **state)
 			"X_BitmapHeapScan", "X_BitmapAppendOnlyScan", "X_TidScan", "X_SubqueryScan", "X_FunctionScan", "X_TableFunctionScan",
 			"X_ValuesScan", "X_NestLoop", "X_MergeJoin", "X_HashJoin", "X_Material", "X_Sort", "X_Agg", "X_Unique", "X_Hash", "X_SetOp",
 			"X_Limit", "X_Motion", "X_ShareInputScan", "X_WindowAgg", "X_Repeat", "X_ModifyTable", "X_LockRows", "X_DML", "X_SplitUpdate", "X_RowTrigger",
-			"X_AssertOp", "X_BitmapTableScan", "X_PartitionSelector", "X_RecursiveUnion", "X_CteScan", "X_WorkTableScan", "X_ForeignScan"};
+			"X_AssertOp", "X_BitmapTableScan", "X_PartitionSelector", "X_RecursiveUnion", "X_CteScan", "X_WorkTableScan", "X_ForeignScan", "X_NestedExecutor"};
 
 	/* Ensure we have all the long living accounts in the longLivingNames array */
 	assert_true(sizeof(longLivingNames) / sizeof(char*) == MEMORY_OWNER_TYPE_END_LONG_LIVING);

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -264,6 +264,9 @@ typedef struct QueryDesc
 
 	/* This is always set NULL by the core system, but plugins can change it */
 	struct Instrumentation *totaltime;	/* total time spent in ExecutorRun */
+
+	/* The overall memory consumption account (i.e., outside of an operator) */
+	MemoryAccountIdType memoryAccountId;
 } QueryDesc;
 
 /* in pquery.c */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1442,6 +1442,9 @@ typedef struct PlanState
 	gpmon_packet_t gpmon_pkt;
 
 	bool		fHadSentNodeStart;
+
+	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
+	MemoryAccountIdType memoryAccountId;
 } PlanState;
 
 /* Gpperfmon helper functions defined in execGpmon.c */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -138,9 +138,6 @@ typedef struct PlannedStmt
 	/* What is the memory reserved for this query's execution? */
 	uint64		query_mem;
 
-	/* The overall memory consumption account (i.e., outside of an operator) */
-	MemoryAccountIdType memoryAccountId;
-
 	/*
 	 * GPDB: Used to keep target information for CTAS and it is needed
 	 * to be dispatched to QEs.
@@ -273,9 +270,6 @@ typedef struct Plan
 	 * How much memory (in KB) should be used to execute this plan node?
 	 */
 	uint64 operatorMemKB;
-
-	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
-	MemoryAccountIdType memoryAccountId;
 
 	/*
 	 * The parent motion node of a plan node.

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -194,21 +194,17 @@ extern MemoryAccountIdType ActiveMemoryAccountId;
  * that will not be executed in current slice
  */
 #define CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, planNode, NodeType) \
-		(MEMORY_OWNER_TYPE_Undefined != planNode->memoryAccountId) ?\
-			planNode->memoryAccountId : \
-			(isAlienPlanNode ? MEMORY_OWNER_TYPE_Exec_AlienShared : \
-				MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
-				work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType));
+		isAlienPlanNode ? MEMORY_OWNER_TYPE_Exec_AlienShared : \
+			MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
+			work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType);
 
 /*
  * SAVE_EXECUTOR_MEMORY_ACCOUNT saves an operator specific memory account
  * into the PlanState of that operator
  */
 #define SAVE_EXECUTOR_MEMORY_ACCOUNT(execState, curMemoryAccountId)\
-		Assert(MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->plan->memoryAccountId || \
-		MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->plan->memoryAccountId || \
-		curMemoryAccountId == ((PlanState *)execState)->plan->memoryAccountId);\
-		((PlanState *)execState)->plan->memoryAccountId = curMemoryAccountId;
+		Assert(MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->memoryAccountId); \
+		((PlanState *)execState)->memoryAccountId = curMemoryAccountId;
 
 extern MemoryAccountIdType
 MemoryAccounting_CreateAccount(long maxLimit, enum MemoryOwnerType ownerType);

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -25,6 +25,8 @@ struct MemoryContextData;
 #define EXPLAIN_MEMORY_VERBOSITY_SUPPRESS  0 /* Suppress memory reporting in explain analyze */
 #define EXPLAIN_MEMORY_VERBOSITY_SUMMARY  1 /* Summary of memory usage for each owner in explain analyze */
 #define EXPLAIN_MEMORY_VERBOSITY_DETAIL  2 /* Detail memory accounting tree for each slice in explain analyze */
+#define EXPLAIN_MEMORY_VERBOSITY_DEBUG  3 /* Detail memory accounting tree with every executor having its own account
+										   * for each slice in explain analyze */
 
 /*
  * MemoryAccount is a private data structure for recording memory usage by
@@ -151,7 +153,8 @@ typedef enum MemoryOwnerType
 	MEMORY_OWNER_TYPE_Exec_CteScan,
 	MEMORY_OWNER_TYPE_Exec_WorkTableScan,
 	MEMORY_OWNER_TYPE_Exec_ForeignScan,
-	MEMORY_OWNER_TYPE_EXECUTOR_END = MEMORY_OWNER_TYPE_Exec_ForeignScan,
+	MEMORY_OWNER_TYPE_Exec_NestedExecutor,
+	MEMORY_OWNER_TYPE_EXECUTOR_END = MEMORY_OWNER_TYPE_Exec_NestedExecutor,
 	MEMORY_OWNER_TYPE_END_SHORT_LIVING = MEMORY_OWNER_TYPE_EXECUTOR_END
 } MemoryOwnerType;
 
@@ -186,25 +189,7 @@ extern MemoryAccountIdType ActiveMemoryAccountId;
 		ActiveMemoryAccountId = oldActiveMemoryAccountId;\
 	} while (0);
 
-/*
- * CREATE_EXECUTOR_MEMORY_ACCOUNT is a convenience macro to create a new
- * operator specific memory account *if* the operator will be executed in
- * the current slice, i.e., it is not part of some other slice (alien
- * plan node). We assign a shared AlienExecutorMemoryAccount for plan nodes
- * that will not be executed in current slice
- */
-#define CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, planNode, NodeType) \
-		isAlienPlanNode ? MEMORY_OWNER_TYPE_Exec_AlienShared : \
-			MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
-			work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType);
 
-/*
- * SAVE_EXECUTOR_MEMORY_ACCOUNT saves an operator specific memory account
- * into the PlanState of that operator
- */
-#define SAVE_EXECUTOR_MEMORY_ACCOUNT(execState, curMemoryAccountId)\
-		Assert(MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->memoryAccountId); \
-		((PlanState *)execState)->memoryAccountId = curMemoryAccountId;
 
 extern MemoryAccountIdType
 MemoryAccounting_CreateAccount(long maxLimit, enum MemoryOwnerType ownerType);
@@ -251,5 +236,49 @@ MemoryAccounting_RequestQuotaIncrease(void);
 
 extern MemoryAccountExplain *
 MemoryAccounting_ExplainCurrentOptimizerAccountInfo(void);
+
+extern MemoryAccountIdType
+MemoryAccounting_CreateMainExecutor(void);
+
+extern MemoryAccountIdType
+MemoryAccounting_GetOrCreateNestedExecutorAccount(void);
+
+extern bool
+MemoryAccounting_IsUnderNestedExecutor(void);
+
+extern bool
+MemoryAccounting_IsMainExecutorCreated(void);
+
+/*
+ * MemoryAccounting_CreateExecutorMemoryAccount will create the main executor
+ * account. Any subsequent calls to this function will assign the executor to
+ * the 'X_NestedExecutor' account.
+ *
+ * If the explain_memory_verbosity guc is set to 'debug' or above, all
+ * executors will be given its own memory account.
+ */
+static inline MemoryAccountIdType
+MemoryAccounting_CreateExecutorMemoryAccount()
+{
+	if (explain_memory_verbosity >= EXPLAIN_MEMORY_VERBOSITY_DEBUG)
+		return MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
+	else
+		if (MemoryAccounting_IsMainExecutorCreated())
+			return MemoryAccounting_GetOrCreateNestedExecutorAccount();
+		else
+			return MemoryAccounting_CreateMainExecutor();
+}
+
+/*
+ * MemoryAccounting_CreatePlanningMemoryAccount creates a memory account for
+ * query planning. If the planner is a direct child of the 'X_NestedExecutor'
+ * account, the planner account will also be assigned to 'X_NestedExecutor'.
+ *
+ * The planner account will always be created if the explain_memory_verbosity
+ * guc is set to 'debug' or above.
+ */
+extern MemoryAccountIdType
+MemoryAccounting_CreatePlanningMemoryAccount(MemoryOwnerType type);
+
 
 #endif   /* MEMACCOUNTING_H */

--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -44,3 +44,146 @@ select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 
  t
 (1 row)
 
+create or replace function has_account_type(query text, search_text text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("^\s+%s" % search_text)
+count = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.match(cur_line)
+    if m is not None:
+        count = count + 1
+return count
+$$
+language plpythonu;
+-- Create functions that will generate nested SQL executors
+CREATE OR REPLACE FUNCTION simple_plpgsql_function(int) RETURNS int AS $$
+ DECLARE RESULT int;
+BEGIN
+ SELECT count(*) FROM pg_class INTO RESULT;
+ RETURN RESULT + $1;
+END;
+$$ LANGUAGE plpgsql NO SQL;
+CREATE OR REPLACE FUNCTION simple_sql_function(argument int) RETURNS bigint AS $$
+SELECT count(*) + argument FROM pg_class;
+$$ LANGUAGE SQL STRICT VOLATILE;
+-- Create a table with tuples only on one segement
+CREATE TABLE all_tuples_on_seg0(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO all_tuples_on_seg0 VALUES (0), (0), (0);
+SELECT gp_segment_id, count(*) FROM all_tuples_on_seg0 GROUP BY 1;
+ gp_segment_id | count 
+---------------+-------
+             0 |     3
+(1 row)
+
+-- The X_NestedExecutor account is only created if we create an executor.
+-- Because all the tuples in all_tuples_on_seg0 are on seg0, only seg0 should
+-- create the X_NestedExecutor account.
+set explain_memory_verbosity to detail;
+-- We expect that only seg0 will create an X_NestedExecutor account, so this
+-- should return '1'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                1
+(1 row)
+
+-- Each node will create a 'main' executor account, so we expect that this
+-- will return '3', one per Query Executor.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+
+-- Same as above, this should return '1'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                1
+(1 row)
+
+-- Same as above, this should return '3'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+
+-- After setting explain_memory_verbosity to 'debug', the X_NestedExecutor
+-- account will no longer be created. Instead, every time we evaluate a code
+-- block in an sql or PL/pgSQL function, it will create a new executor account.
+-- There are three tuples in all_tuples_on_seg0, so we should see three more
+-- Executor accounts than when we had the explain_memory_verbosity guc set to
+-- 'detail'.
+set explain_memory_verbosity to debug;
+-- We expect this will be '0'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- Because there are three tuples in all_tuples_on_seg0, we expect to see three
+-- additional 'Executor' accounts created, a total number of '6'.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                6
+(1 row)
+
+-- Expect '0'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- Expect '6'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                6
+(1 row)
+
+-- Test X_NestedExecutor is created correctly inside multiple slice plans
+set explain_memory_verbosity to detail;
+-- We should see two TableScans- one per slice. Because only one segment has
+-- tuples, only one segment per slice will create the 'X_NestedExecutor'
+-- account. This will return '2'.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                2
+(1 row)
+
+-- There will be two slices, and each slice will create an 'Executor' account
+-- for a total of '6' 'Executor' accounts.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+ has_account_type 
+------------------
+                6
+(1 row)
+
+set explain_memory_verbosity to debug;
+-- We don't create 'X_NestedExecutor' accounts when explain_memory_verbosity is
+-- set to 'debug', so this will return '0'
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- Two slices, each returning three tuples. For each tuple we will create an
+-- 'Executor' account. We also expect one main 'Executor' account per slice, so
+-- expect '12' total Executor accounts
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+ has_account_type 
+------------------
+               12
+(1 row)
+

--- a/src/test/regress/sql/memconsumption.sql
+++ b/src/test/regress/sql/memconsumption.sql
@@ -40,3 +40,89 @@ select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 
 
 set execute_pruned_plan=off;
 select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j') > 0;
+
+create or replace function has_account_type(query text, search_text text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("^\s+%s" % search_text)
+count = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.match(cur_line)
+    if m is not None:
+        count = count + 1
+return count
+$$
+language plpythonu;
+
+-- Create functions that will generate nested SQL executors
+CREATE OR REPLACE FUNCTION simple_plpgsql_function(int) RETURNS int AS $$
+ DECLARE RESULT int;
+BEGIN
+ SELECT count(*) FROM pg_class INTO RESULT;
+ RETURN RESULT + $1;
+END;
+$$ LANGUAGE plpgsql NO SQL;
+
+
+CREATE OR REPLACE FUNCTION simple_sql_function(argument int) RETURNS bigint AS $$
+SELECT count(*) + argument FROM pg_class;
+$$ LANGUAGE SQL STRICT VOLATILE;
+
+-- Create a table with tuples only on one segement
+CREATE TABLE all_tuples_on_seg0(i int);
+INSERT INTO all_tuples_on_seg0 VALUES (0), (0), (0);
+SELECT gp_segment_id, count(*) FROM all_tuples_on_seg0 GROUP BY 1;
+
+-- The X_NestedExecutor account is only created if we create an executor.
+-- Because all the tuples in all_tuples_on_seg0 are on seg0, only seg0 should
+-- create the X_NestedExecutor account.
+set explain_memory_verbosity to detail;
+-- We expect that only seg0 will create an X_NestedExecutor account, so this
+-- should return '1'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Each node will create a 'main' executor account, so we expect that this
+-- will return '3', one per Query Executor.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+-- Same as above, this should return '1'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Same as above, this should return '3'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+
+-- After setting explain_memory_verbosity to 'debug', the X_NestedExecutor
+-- account will no longer be created. Instead, every time we evaluate a code
+-- block in an sql or PL/pgSQL function, it will create a new executor account.
+-- There are three tuples in all_tuples_on_seg0, so we should see three more
+-- Executor accounts than when we had the explain_memory_verbosity guc set to
+-- 'detail'.
+set explain_memory_verbosity to debug;
+-- We expect this will be '0'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Because there are three tuples in all_tuples_on_seg0, we expect to see three
+-- additional 'Executor' accounts created, a total number of '6'.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+-- Expect '0'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Expect '6'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+
+-- Test X_NestedExecutor is created correctly inside multiple slice plans
+set explain_memory_verbosity to detail;
+-- We should see two TableScans- one per slice. Because only one segment has
+-- tuples, only one segment per slice will create the 'X_NestedExecutor'
+-- account. This will return '2'.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+-- There will be two slices, and each slice will create an 'Executor' account
+-- for a total of '6' 'Executor' accounts.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+
+
+set explain_memory_verbosity to debug;
+-- We don't create 'X_NestedExecutor' accounts when explain_memory_verbosity is
+-- set to 'debug', so this will return '0'
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+-- Two slices, each returning three tuples. For each tuple we will create an
+-- 'Executor' account. We also expect one main 'Executor' account per slice, so
+-- expect '12' total Executor accounts
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');


### PR DESCRIPTION
The memory accounting system generates a new memory account for every
execution node initialized in ExecInitNode. The address to these memory
accounts is stored in the shortLivingMemoryAccountArray. If the memory
allocated for shortLivingMemoryAccountArray is full, we will repalloc
the array with double the number of available entries.

After creating approximately 67000000 memory accounts, it will need to
allocate more than 1GB of memory to increase the array size, and throw
an ERROR, canceling the running query.

PL/pgSQL and SQL functions will create new executors/plan nodes that
must be tracked my the memory accounting system. This level of detail is
not necessary for tracking memory leaks, and creating a separate memory
account for every executor will use large amount of memory just to track
these memory accounts.

Instead of tracking millions of individual memory accounts, we
consolidate any child executor account into a special 'X_Project'
account. If explain_memory_verbosity is set to 'detailed' and below,
consolidate all child executors into this account.

If more detail is needed for debugging, set explain_memory_verbosity to
'debug', where, as was the previous behavior, every executor will be
assigned its own MemoryAccountId.

Additionally, move the memoryAccountId into PlanState/QueryDesc, which 
will insure that every time we initialize an executor, it will be assigned a unique
memoryAccountId. This solves several potential problems with nested executors
incorrectly sharing the same memory account.