### PR TITLE
Fix COPY <table> FROM <file> WITH OIDS.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4984,6 +4984,9 @@ PROCESS_SEGMENT_DATA:
 
 						mtuple = ExecFetchSlotMemTuple(slot, false);
 
+						if (cstate->oids && file_has_oids)
+							MemTupleSetOid(mtuple, resultRelInfo->ri_aoInsertDesc->mt_bind, loaded_oid);
+
 						/* inserting into an append only relation */
 						appendonly_insert(resultRelInfo->ri_aoInsertDesc, mtuple, &tupleOid, (AOTupleId *) &insertedTid);
 					}
@@ -5005,6 +5008,10 @@ PROCESS_SEGMENT_DATA:
 						HeapTuple tuple;
 
 						tuple = ExecFetchSlotHeapTuple(slot);
+
+						if (cstate->oids && file_has_oids)
+							HeapTupleSetOid(tuple, loaded_oid);
+
 						heap_insert(resultRelInfo->ri_RelationDesc, tuple, mycid, use_wal, use_fsm, GetCurrentTransactionId());
 						insertedTid = tuple->t_self;
 					}

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -152,7 +152,7 @@ COPY copy_regression_oids from stdin with oids csv;
 60000,a text data
 60001,a text data
 \.
-SELECT * FROM copy_regression_oids ORDER BY oid;
+SELECT oid, * FROM copy_regression_oids;
 
 DROP TABLE copy_regression_oids;
 

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -144,13 +144,13 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
 COPY copy_regression_oids from stdin with oids delimiter '|';
 COPY copy_regression_oids from stdin with oids csv;
-SELECT * FROM copy_regression_oids ORDER BY oid;
-      a      
--------------
- a text data
- a text data
- a text data
- a text data
+SELECT oid, * FROM copy_regression_oids;
+  oid  |      a      
+-------+-------------
+ 50000 | a text data
+ 50001 | a text data
+ 60000 | a text data
+ 60001 | a text data
 (4 rows)
 
 DROP TABLE copy_regression_oids;


### PR DESCRIPTION
The OIDs from the input file were not used, and new OIDs were assigned
instead. I broke this in commit d7ffd8eaa2. We had a test case for COPY
WITH OIDS, but it didn't select the oid column from the resulting table,
to check that the oids given in the input were actually used. Fix the test
so that it covers this.

In master, the code has been refactored heavily, and this bug was fixed,
perhaps inadvertently.