### PR TITLE
Fix assertion during COPY of "unknown" data type

### DIFF
--- a/src/test/regress/expected/copy2.out
+++ b/src/test/regress/expected/copy2.out
@@ -177,6 +177,15 @@ SELECT * FROM testnull;
     | 
 (4 rows)
 
+-- "unknown" types can be dumped and restored: these attributes are
+-- NULL-terminated in memory (attlen == -2), so the COPY code needs to handle
+-- them explicitly.
+CREATE TEMP TABLE type_unknown ( a unknown );
+WARNING:  column "a" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+COPY type_unknown FROM stdin;
+COPY type_unknown TO stdout;
+unknown
 DROP TABLE x, y;
 DROP FUNCTION fn_x_before();
 DROP FUNCTION fn_x_after();

--- a/src/test/regress/sql/copy2.sql
+++ b/src/test/regress/sql/copy2.sql
@@ -178,6 +178,16 @@ COPY testnull FROM stdin WITH NULL AS E'\\0';
 
 SELECT * FROM testnull;
 
+-- "unknown" types can be dumped and restored: these attributes are
+-- NULL-terminated in memory (attlen == -2), so the COPY code needs to handle
+-- them explicitly.
+CREATE TEMP TABLE type_unknown ( a unknown );
+
+COPY type_unknown FROM stdin;
+unknown
+\.
+
+COPY type_unknown TO stdout;
 
 DROP TABLE x, y;
 DROP FUNCTION fn_x_before();


### PR DESCRIPTION
The "unknown" type has an attlen of -2, which signifies that the actual length is determined by `strlen()`. We weren't handling this case in the new copy dispatch code, which led to an assertion during pg_dump of the regression database.