### PR TITLE
pg_dump: improve speed of partition handling

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13105,13 +13105,13 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 				PQExpBuffer 	partquery = createPQExpBuffer();
 				PGresult	   *partres;
 
-				appendPQExpBuffer(partquery, "SELECT c.oid "
-											 "FROM pg_catalog.pg_class pp "
-											 "     JOIN pg_catalog.pg_partitions p ON ( "
-											 "       pp.relname = p.tablename AND "
-											 "       pp.oid = '%u'::pg_catalog.oid) "
-											 "     JOIN pg_catalog.pg_class c ON ( "
-											 "       p.partitiontablename = c.relname)",
+				appendPQExpBuffer(partquery, "SELECT DISTINCT(child.oid) "
+											 "FROM pg_catalog.pg_partition part, "
+											 "     pg_catalog.pg_partition_rule rule, "
+											 "     pg_catalog.pg_class child "
+											 "WHERE part.parrelid = '%u'::pg_catalog.oid "
+											 "  AND rule.paroid = part.oid "
+											 "  AND child.oid = rule.parchildrelid",
 											 tbinfo->dobj.catId.oid);
 				partres = ExecuteSqlQuery(fout, partquery->data, PGRES_TUPLES_OK);
 


### PR DESCRIPTION
`pg_partitions` is a massively complicated view, and here we are using it just to grab the relnames of the partition/subpartition tables so that we can join them back to `pg_class` and get their OIDs. The
`pg_partition`/`_rule` catalog tables already have the OIDs; there's no reason to use the view. Perform the join here manually and speed up the process.

This change is motivated by a serious performance regression when dumping the regression database schema -- this query was taking about half a second to execute, and `EXPLAIN` showed about a dozen nested loop joins. The new query is nice and compact.

Co-authored-by: @doty-pivotal 