### PR TITLE
pg_upgrade: add regression DB back to the ICW smoke test

### DIFF
--- a/contrib/pg_upgrade/pre_drop_ao.sql
+++ b/contrib/pg_upgrade/pre_drop_ao.sql
@@ -1,0 +1,37 @@
+-- OID preassignment for AO tables appears to be borked; get rid of all of them.
+-- This includes any tables with AO (sub)partitions.
+CREATE OR REPLACE FUNCTION drop_ao_tables() RETURNS void AS $$
+DECLARE
+       ao_parent RECORD;
+       ao_table RECORD;
+BEGIN
+	FOR ao_parent IN
+	SELECT DISTINCT(parent.oid),
+		   parent.relname,
+		   n.nspname
+	FROM pg_catalog.pg_class parent
+		JOIN pg_catalog.pg_namespace n ON (n.oid = parent.relnamespace)
+		JOIN pg_catalog.pg_partition part ON (part.parrelid = parent.oid)
+		JOIN pg_catalog.pg_partition_rule rule ON (rule.paroid = part.oid)
+		JOIN pg_catalog.pg_class child ON (rule.parchildrelid = child.oid)
+	WHERE child.relstorage IN ('a', 'c')
+	LOOP
+		EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(ao_parent.nspname) || '.' || quote_ident(ao_parent.relname) || ' CASCADE';
+	END LOOP;
+
+	FOR ao_table IN
+	SELECT n.nspname,
+		   c.relname
+	FROM pg_catalog.pg_class c
+		JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+	WHERE c.relstorage IN ('a', 'c')
+	LOOP
+		EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(ao_table.nspname) || '.' || quote_ident(ao_table.relname) || ' CASCADE';
+	END LOOP;
+
+	RETURN;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT drop_ao_tables();
+DROP FUNCTION drop_ao_tables();

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -263,7 +263,10 @@ fi
 
 # Run any pre-upgrade tasks to prep the cluster
 if [ -f "test_gpdb_pre.sql" ]; then
-	psql -f test_gpdb_pre.sql postgres
+	if ! psql -f test_gpdb_pre.sql -v ON_ERROR_STOP=1 postgres; then
+		echo "ERROR: unable to execute pre-upgrade cleanup"
+		exit 1
+	fi
 fi
 
 # Ensure that the catalog is sane before attempting an upgrade. While there is

--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -50,6 +50,74 @@ $$ LANGUAGE plpgsql;
 SELECT drop_indexes();
 DROP FUNCTION drop_indexes();
 
+-- Missing toast tables/indexes in new cluster
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_11_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_17_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_196_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_19_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_1_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_1_true_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_23_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_32_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_3_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_4_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_4_true_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_char_variable_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_11_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_17_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_196_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_19_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_1_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_1_true_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_23_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_32_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_3_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_4_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_4_true_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_double_variable_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_11_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_17_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_196_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_19_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_1_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_1_true_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_23_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_32_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_3_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_4_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_4_true_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int2_variable_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_11_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_17_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_196_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_19_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_1_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_1_true_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_23_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_32_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_3_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_4_false_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_4_true_false CASCADE;
+DROP TABLE IF EXISTS adp_dropped.alter_distpol_g_int4_variable_false_false CASCADE;
+DROP TABLE IF EXISTS public.distrib_part_test CASCADE;
+DROP TABLE IF EXISTS public.dml_ao_s CASCADE;
+DROP TABLE IF EXISTS public.dml_co_s CASCADE;
+DROP TABLE IF EXISTS public.dml_heap_s CASCADE;
+DROP TABLE IF EXISTS public.test_tsvector CASCADE;
+DROP TABLE IF EXISTS stat_heap3.stat_heap_t3 CASCADE;
+DROP TABLE IF EXISTS stat_heap3.stat_part_heap_t3 CASCADE;
+DROP TABLE IF EXISTS stat_heap4.stat_heap_t4 CASCADE;
+DROP TABLE IF EXISTS stat_heap4.stat_part_heap_t4 CASCADE;
+DROP TABLE IF EXISTS stat_heap5.stat_heap_t5 CASCADE;
+DROP TABLE IF EXISTS stat_heap5.stat_part_heap_t5 CASCADE;
+DROP TABLE IF EXISTS stat_heap6.stat_heap_t6 CASCADE;
+DROP TABLE IF EXISTS stat_heap6.stat_part_heap_t6 CASCADE;
+
+-- This one's interesting:
+--    No match found in new cluster for old relation with OID 173472 in database "regression": "public.sales_1_prt_bb_pkey" which is an index on "public.newpart"
+--    No match found in old cluster for new relation with OID 556718 in database "regression": "public.newpart_pkey" which is an index on "public.newpart"
+DROP TABLE IF EXISTS public.newpart CASCADE;
+
 \c dsp1;
 
 -- drop all AO tables

--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -3,10 +3,11 @@
 -- exist at the time of running upgrades. If objects are to be manipulated
 -- in other databases, make sure to change to the correct database first.
 
-DROP DATABASE regression;
-DROP DATABASE dsp3;
-DROP DATABASE isolation2test;
+DROP DATABASE IF EXISTS regression;
+DROP DATABASE IF EXISTS dsp3;
+DROP DATABASE IF EXISTS isolation2test;
 
+DROP DATABASE IF EXISTS pgutest;
 CREATE DATABASE pgutest;
 \c pgutest;
 

--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -3,13 +3,68 @@
 -- exist at the time of running upgrades. If objects are to be manipulated
 -- in other databases, make sure to change to the correct database first.
 
-DROP DATABASE IF EXISTS regression;
-DROP DATABASE IF EXISTS dsp3;
+-- drop all AO tables
+\ir pre_drop_ao.sql
+
 DROP DATABASE IF EXISTS isolation2test;
 
-DROP DATABASE IF EXISTS pgutest;
-CREATE DATABASE pgutest;
-\c pgutest;
+\c regression;
 
-CREATE TABLE t (a integer, b numeric);
-CREATE TABLE tt (a integer, b numeric) WITH (appendonly = true);
+-- drop all AO tables
+\ir pre_drop_ao.sql
+
+-- Greenplum pg_upgrade doesn't support indexes on partitions since they can't
+-- be reliably dump/restored in all situations. Drop all such indexes before
+-- attempting the upgrade.
+CREATE OR REPLACE FUNCTION drop_indexes() RETURNS void AS $$
+DECLARE
+       part_indexes RECORD;
+BEGIN
+       FOR part_indexes IN
+       WITH partitions AS (
+           SELECT DISTINCT n.nspname,
+                  c.relname
+           FROM pg_catalog.pg_partition p
+                JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid)
+                JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+           UNION
+           SELECT n.nspname,
+                  partitiontablename AS relname
+           FROM pg_catalog.pg_partitions p
+                JOIN pg_catalog.pg_class c ON (p.partitiontablename = c.relname)
+                JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+       )
+       SELECT nspname,
+              relname,
+              indexname
+       FROM partitions
+            JOIN pg_catalog.pg_indexes ON (relname = tablename
+                                                                               AND nspname = schemaname)
+       LOOP
+               EXECUTE 'DROP INDEX IF EXISTS ' || quote_ident(part_indexes.nspname) || '.' || quote_ident(part_indexes.indexname);
+       END LOOP;
+       RETURN;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT drop_indexes();
+DROP FUNCTION drop_indexes();
+
+\c dsp1;
+
+-- drop all AO tables
+\ir pre_drop_ao.sql
+
+\c dsp2;
+
+-- drop all AO tables
+\ir pre_drop_ao.sql
+
+\c dsp3;
+
+-- drop all AO tables
+\ir pre_drop_ao.sql
+
+-- toast table and index aren't correctly migrated for this relation, for some
+-- reason
+DROP TABLE IF EXISTS public.alter_table_reorg_heap CASCADE;


### PR DESCRIPTION
As part of the 9.3 pg_upgrade backport, the regression database was temporarily dropped from the upgrade smoke tests to get things working. This PR adds the regression database back to the ICW, filtering out all the tables that are known to not upgrade correctly.

The list is pretty long -- the new logic to drop all AO tables cuts the regression database in half -- but this should make it easier to parallelize pg_upgrade fixes.

attn: @Eulerizeit 