### PR TITLE
Handle aggr_args correctly in the parser

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -5808,7 +5808,7 @@ AlterExtensionContentsStmt:
 					n->action = $4;
 					n->objtype = OBJECT_AGGREGATE;
 					n->objname = $6;
-					n->objargs = $7;
+					n->objargs = extractAggrArgTypes($7);
 					$$ = (Node *)n;
 				}
 			| ALTER EXTENSION name add_drop CAST '(' Typename AS Typename ')'
@@ -7515,7 +7515,7 @@ SecLabelStmt:
 					n->provider = $3;
 					n->objtype = OBJECT_AGGREGATE;
 					n->objname = $6;
-					n->objargs = $7;
+					n->objargs = extractAggrArgTypes($7);
 					n->label = $9;
 					$$ = (Node *) n;
 				}

--- a/src/test/regress/expected/alter_extension.out
+++ b/src/test/regress/expected/alter_extension.out
@@ -1,0 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE AGGREGATE example_agg(int4) (
+    SFUNC = int4larger,
+    STYPE = int4
+);
+ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
+ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);

--- a/src/test/regress/input/security_label.source
+++ b/src/test/regress/input/security_label.source
@@ -21,6 +21,11 @@ CREATE VIEW seclabel_view1 AS SELECT * FROM seclabel_tbl2;
 CREATE FUNCTION seclabel_four() RETURNS integer AS $$SELECT 4$$ language sql;
 CREATE DOMAIN seclabel_domain AS text;
 
+CREATE AGGREGATE seclabel_agg(int4) (
+    SFUNC = int4larger,
+    STYPE = int4
+);
+
 ALTER TABLE seclabel_tbl1 OWNER TO seclabel_user1;
 ALTER TABLE seclabel_tbl2 OWNER TO seclabel_user2;
 
@@ -38,6 +43,8 @@ SECURITY LABEL ON ROLE seclabel_user1 IS 'classified';			-- fail
 SECURITY LABEL FOR 'dummy' ON ROLE seclabel_user1 IS 'classified';		-- fail
 SECURITY LABEL ON ROLE seclabel_user1 IS '...invalid label...';		-- fail
 SECURITY LABEL ON ROLE seclabel_user3 IS 'unclassified';			-- fail
+
+SECURITY LABEL ON AGGREGATE seclabel_agg(int4) IS 'classified';
 
 -- Load dummy external security provider
 LOAD '@libdir@/dummy_seclabel@DLSUFFIX@';
@@ -90,6 +97,8 @@ SECURITY LABEL ON DOMAIN seclabel_domain IS 'classified';		-- OK
 CREATE SCHEMA seclabel_test;
 SECURITY LABEL ON SCHEMA seclabel_test IS 'unclassified';		-- OK
 
+SECURITY LABEL ON AGGREGATE seclabel_agg(int4) IS 'classified';
+
 SELECT objtype, objname, provider, label FROM pg_seclabels
 	ORDER BY objtype, objname;
 
@@ -102,6 +111,7 @@ DROP TABLE seclabel_tbl2;
 DROP USER seclabel_user1;
 DROP USER seclabel_user2;
 DROP SCHEMA seclabel_test;
+DROP AGGREGATE seclabel_agg(int4);
 
 -- make sure we don't have any leftovers
 SELECT objtype, objname, provider, label FROM pg_seclabels

--- a/src/test/regress/output/security_label.source
+++ b/src/test/regress/output/security_label.source
@@ -15,6 +15,10 @@ CREATE TABLE seclabel_tbl2 (x int, y text);
 CREATE VIEW seclabel_view1 AS SELECT * FROM seclabel_tbl2;
 CREATE FUNCTION seclabel_four() RETURNS integer AS $$SELECT 4$$ language sql;
 CREATE DOMAIN seclabel_domain AS text;
+CREATE AGGREGATE seclabel_agg(int4) (
+    SFUNC = int4larger,
+    STYPE = int4
+);
 ALTER TABLE seclabel_tbl1 OWNER TO seclabel_user1;
 ALTER TABLE seclabel_tbl2 OWNER TO seclabel_user2;
 RESET client_min_messages;
@@ -36,6 +40,8 @@ ERROR:  security label provider "dummy" is not loaded
 SECURITY LABEL ON ROLE seclabel_user1 IS '...invalid label...';		-- fail
 ERROR:  no security label providers have been loaded
 SECURITY LABEL ON ROLE seclabel_user3 IS 'unclassified';			-- fail
+ERROR:  no security label providers have been loaded
+SECURITY LABEL ON AGGREGATE seclabel_agg(int4) IS 'classified';
 ERROR:  no security label providers have been loaded
 -- Load dummy external security provider
 LOAD '@abs_builddir@/dummy_seclabel@DLSUFFIX@';
@@ -90,20 +96,22 @@ SECURITY LABEL ON FUNCTION seclabel_four() IS 'classified';		-- OK
 SECURITY LABEL ON DOMAIN seclabel_domain IS 'classified';		-- OK
 CREATE SCHEMA seclabel_test;
 SECURITY LABEL ON SCHEMA seclabel_test IS 'unclassified';		-- OK
+SECURITY LABEL ON AGGREGATE seclabel_agg(int4) IS 'classified';
 SELECT objtype, objname, provider, label FROM pg_seclabels
 	ORDER BY objtype, objname;
- objtype  |     objname     | provider |    label     
-----------+-----------------+----------+--------------
- column   | seclabel_tbl1.a | dummy    | unclassified
- domain   | seclabel_domain | dummy    | classified
- function | seclabel_four() | dummy    | classified
- role     | seclabel_user1  | dummy    | classified
- role     | seclabel_user2  | dummy    | unclassified
- schema   | seclabel_test   | dummy    | unclassified
- table    | seclabel_tbl1   | dummy    | top secret
- table    | seclabel_tbl2   | dummy    | classified
- view     | seclabel_view1  | dummy    | classified
-(9 rows)
+  objtype  |        objname        | provider |    label     
+-----------+-----------------------+----------+--------------
+ aggregate | seclabel_agg(integer) | dummy    | classified
+ column    | seclabel_tbl1.a       | dummy    | unclassified
+ domain    | seclabel_domain       | dummy    | classified
+ function  | seclabel_four()       | dummy    | classified
+ role      | seclabel_user1        | dummy    | classified
+ role      | seclabel_user2        | dummy    | unclassified
+ schema    | seclabel_test         | dummy    | unclassified
+ table     | seclabel_tbl1         | dummy    | top secret
+ table     | seclabel_tbl2         | dummy    | classified
+ view      | seclabel_view1        | dummy    | classified
+(10 rows)
 
 -- clean up objects
 DROP FUNCTION seclabel_four();
@@ -114,6 +122,7 @@ DROP TABLE seclabel_tbl2;
 DROP USER seclabel_user1;
 DROP USER seclabel_user2;
 DROP SCHEMA seclabel_test;
+DROP AGGREGATE seclabel_agg(int4);
 -- make sure we don't have any leftovers
 SELECT objtype, objname, provider, label FROM pg_seclabels
 	ORDER BY objtype, objname;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -145,7 +145,7 @@ test: select_views portals_p2 cluster dependency guc bitmapops tsearch tsdicts f
 # NB: temp.sql does a reconnect which transiently uses 2 connections,
 # so keep this parallel group to at most 19 tests
 # ----------
-test: plancache limit plpgsql copy2 temp domain rangefuncs prepare without_oid conversion truncate alter_table sequence polymorphism rowtypes with xml
+test: plancache limit plpgsql copy2 temp domain rangefuncs prepare without_oid conversion truncate alter_table alter_extension sequence polymorphism rowtypes with xml
 
 # large objects are not supported by GPDB
 # test: largeobject

--- a/src/test/regress/sql/alter_extension.sql
+++ b/src/test/regress/sql/alter_extension.sql
@@ -1,0 +1,9 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+CREATE AGGREGATE example_agg(int4) (
+    SFUNC = int4larger,
+    STYPE = int4
+);
+
+ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
+ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);


### PR DESCRIPTION
In GPDB AGGREGATE functions can be either 'ordered' or 'hypothetical',
and as a result the token aggr_args has more information than in
upstream. Excepting CREATE [ORDERED] AGGREGATE, the parser will extract
the function arguments from the aggr_args token using
extractAggrArgTypes().

The ALTER EXTENSION ADD/DROP AGGREGATE and SECURITY LIMIT syntax has
been added as part of the merge of PostgreSQL between 9.0 and 9.2, so
add a call to extract the function arguments.