### PR TITLE
Set motion node's rescannable field to false.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -140,7 +140,9 @@ cdbpath_create_motion_path(PlannerInfo *root,
 			pathnode->path.total_cost = subpath->total_cost;
 			pathnode->path.memory = subpath->memory;
 			pathnode->path.motionHazard = subpath->motionHazard;
-			pathnode->path.rescannable = subpath->rescannable;
+
+			/* Motion nodes are never rescannable. */
+			pathnode->path.rescannable = false;
 			return (Path *) pathnode;
 		}
 
@@ -168,7 +170,9 @@ cdbpath_create_motion_path(PlannerInfo *root,
 			pathnode->path.total_cost = subpath->total_cost;
 			pathnode->path.memory = subpath->memory;
 			pathnode->path.motionHazard = subpath->motionHazard;
-			pathnode->path.rescannable = subpath->rescannable;
+
+			/* Motion nodes are never rescannable. */
+			pathnode->path.rescannable = false;
 			return (Path *) pathnode;
 		}
 

--- a/src/test/regress/expected/rpt_joins.out
+++ b/src/test/regress/expected/rpt_joins.out
@@ -2136,6 +2136,29 @@ where f2 = 53;
  53 |    |    | 
 (1 row)
 
+--
+-- regression test for nest loop join of rpt and entry
+--
+create temp table t_5628 (c1 int, c2 int) distributed replicated;
+insert into t_5628 values (1,1), (2,2);
+explain (costs off) select max(c1) from pg_class left join t_5628 on true;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate
+   ->  Nested Loop Left Join
+         ->  Seq Scan on pg_class
+         ->  Materialize
+               ->  Gather Motion 1:1  (slice1; segments: 1)
+                     ->  Seq Scan on t_5628
+ Optimizer: legacy query optimizer
+(7 rows)
+
+select max(c1) from pg_class left join t_5628 on true;
+ max 
+-----
+   2
+(1 row)
+
 drop schema rpt_joins cascade;
 NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to table j1_tbl

--- a/src/test/regress/sql/rpt_joins.sql
+++ b/src/test/regress/sql/rpt_joins.sql
@@ -442,4 +442,12 @@ select * from
       left join zv1 on (f3 = f1)
 where f2 = 53;
 
+--
+-- regression test for nest loop join of rpt and entry
+--
+create temp table t_5628 (c1 int, c2 int) distributed replicated;
+insert into t_5628 values (1,1), (2,2);
+explain (costs off) select max(c1) from pg_class left join t_5628 on true;
+select max(c1) from pg_class left join t_5628 on true;
+
 drop schema rpt_joins cascade;


### PR DESCRIPTION
This commit fix the github issue #5628.

We can not create a motion directly in the RHS of Nested loop
join, because Motion node is not rescannable.

In the previous codes, we set the rescannable field the value
same as subpath's even if the RHS is SegmentGeneral or SingleQE.
We fix this by setting the motion's rescannable to false directly.

Co-authored-by: Shujie Zhang <shzhang@pivotal.io>
Co-authored-by: Zhenghua Lyu <zlv@pivotal.io>