### PR TITLE
Remove a rowmark/junk_filter related FIXME in ExecInitModifyTable()

### DIFF
--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -171,11 +171,7 @@ GpPolicyIsReplicated(const GpPolicy *policy)
 bool
 GpPolicyIsPartitioned(const GpPolicy *policy)
 {
-	if (policy == NULL)
-		return false;
-
-	return GpPolicyIsHashPartitioned(policy) ||
-		GpPolicyIsRandomPartitioned(policy);
+	return (policy != NULL && policy->ptype == POLICYTYPE_PARTITIONED);
 }
 
 bool

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1885,12 +1885,10 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 		switch (rc->markType)
 		{
 			case ROW_MARK_TABLE_EXCLUSIVE:
-				/* CDB: On QD, lock whole table in X mode, if distributed ao able. */
 				relid = getrelid(rc->rti, rangeTable);
 				relation = heap_open(relid, ExclusiveLock);
 				break;
 			case ROW_MARK_TABLE_SHARE:
-				/* CDB: On QD, lock whole table in S mode, if distributed. */
 				relid = getrelid(rc->rti, rangeTable);
 				relation = heap_open(relid, RowShareLock);
 				break;

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1813,8 +1813,7 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 			if (rte->rtekind == RTE_RELATION)
 			{
 				Relation relation = heap_open(rte->relid, NoLock);
-				if (relation->rd_cdbpolicy &&
-					relation->rd_cdbpolicy->ptype == POLICYTYPE_PARTITIONED)
+				if (GpPolicyIsPartitioned(relation->rd_cdbpolicy))
 					isdistributed = true;
 				heap_close(relation, NoLock);
 				if (isdistributed)
@@ -1844,14 +1843,6 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 			mtstate->mt_arowmarks[i] = lappend(mtstate->mt_arowmarks[i], aerm);
 		}
 	}
-
-	/* GPDB_90_MERGE_FIXME: This code was heavily refactored in the merge.
-	 * This used to be in ExecInsert, in execMain.c. It was also heavily
-	 * modified in GPDB, to handle rowmarks differently, and to disable
-	 * some sanity checks for ORCA. I did not copy over those GPDB changes,
-	 * because I wasn't sure how, and wasn't sure which of the changes
-	 * were still needed.
-	 */
 
 	/* select first subplan */
 	mtstate->mt_whichplan = 0;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2764,6 +2764,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		 * The reason is that gpdb is an MPP database, the result tuples may not be on
 		 * the same segment. And for cursor statement, reader gang cannot get Xid to lock
 		 * the tuples. (More details: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/p-6_dNjnRMQ)
+		 * Upgrading the lock mode (see below) for distributed table is probably
+		 * not needed for all the cases and we may want to enhance this later.
 		 */
 		foreach(lc, root->rowMarks)
 		{


### PR DESCRIPTION
Checked our previous GPDB hacking code and newest implementation.
I found that some previous gpdb related code do not apply to
current gpdb code. So removing the FIXME. This patch also slightly
refactors some code and changes some other existing comments.