### PR TITLE
docs - deprecate GUC gp_max_csv_line_length

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4617,9 +4617,10 @@
     <title>gp_max_csv_line_length</title>
     <body>
       <p>The maximum length of a line in a CSV formatted file that will be imported into the system.
-        The default is 1MB (1048576 bytes). Maximum allowed is 1GB (1073741824 bytes). The default may
-        need to be increased if using the <i>gp_toolkit</i> administrative schema to read Greenplum
-        Database log files.</p>
+        The default is 1MB (1048576 bytes). Maximum allowed is 1GB (1073741824 bytes). The default
+        may need to be increased if using the <i>gp_toolkit</i> administrative schema to read
+        Greenplum Database log files.</p>
+      <note>This parameter is deprecated and will be removed in a future release.</note>
       <table id="gp_max_csv_line_length_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>


### PR DESCRIPTION

5X_STABLE.

GUC has been removed in master. See PR https://github.com/greenplum-db/gpdb/pull/5563