### PR TITLE
Fix CREATE OR REPLACE LANGUAGE.

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4320,6 +4320,7 @@ _outCreatePLangStmt(StringInfo str, const CreatePLangStmt *node)
 {
 	WRITE_NODE_TYPE("CREATEPLANGSTMT");
 
+	WRITE_BOOL_FIELD(replace);
 	WRITE_STRING_FIELD(plname);
 	WRITE_NODE_FIELD(plhandler);
 	WRITE_NODE_FIELD(plinline);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2401,6 +2401,7 @@ _readCreatePLangStmt(void)
 {
 	READ_LOCALS(CreatePLangStmt);
 
+	READ_BOOL_FIELD(replace);
 	READ_STRING_FIELD(plname);
 	READ_NODE_FIELD(plhandler);
 	READ_NODE_FIELD(plinline);

--- a/src/test/regress/expected/bfv_legacy.out
+++ b/src/test/regress/expected/bfv_legacy.out
@@ -1,9 +1,15 @@
 --
 -- SETUP: Helper functions for query plan verification
 --
+-- The helper functions are written in python.
+create or replace language plpythonu;
+-- While we're at it, test that CREATE OR REPLACE LANGUAGE works when
+-- the language exists already (we had a little bug at one point, where
+-- the "OR REPLACE" was not dispatched to segments, and this failed)
+create or replace language plpythonu;
 --start_ignore
-create language plpythonu;
 drop schema if exists bfv_legacy cascade;
+NOTICE:  schema "bfv_legacy" does not exist, skipping
 --end_ignore
 create schema bfv_legacy;
 set search_path=bfv_legacy;

--- a/src/test/regress/expected/bfv_legacy_optimizer.out
+++ b/src/test/regress/expected/bfv_legacy_optimizer.out
@@ -1,9 +1,15 @@
 --
 -- SETUP: Helper functions for query plan verification
 --
+-- The helper functions are written in python.
+create or replace language plpythonu;
+-- While we're at it, test that CREATE OR REPLACE LANGUAGE works when
+-- the language exists already (we had a little bug at one point, where
+-- the "OR REPLACE" was not dispatched to segments, and this failed)
+create or replace language plpythonu;
 --start_ignore
-create language plpythonu;
 drop schema if exists bfv_legacy cascade;
+NOTICE:  schema "bfv_legacy" does not exist, skipping
 --end_ignore
 create schema bfv_legacy;
 set search_path=bfv_legacy;

--- a/src/test/regress/sql/bfv_legacy.sql
+++ b/src/test/regress/sql/bfv_legacy.sql
@@ -1,8 +1,16 @@
 --
 -- SETUP: Helper functions for query plan verification
 --
+
+-- The helper functions are written in python.
+create or replace language plpythonu;
+
+-- While we're at it, test that CREATE OR REPLACE LANGUAGE works when
+-- the language exists already (we had a little bug at one point, where
+-- the "OR REPLACE" was not dispatched to segments, and this failed)
+create or replace language plpythonu;
+
 --start_ignore
-create language plpythonu;
 drop schema if exists bfv_legacy cascade;
 --end_ignore
 


### PR DESCRIPTION
The 'replace' field was missing from the out/read functions. Because of
that, if the language already existed, the command would fail on the
segments with "language already exists" error.

For the sake of completeness, add a test, although it seems pretty unlikely
for this particular bug to reappear in the future.

No backpatching required, as the OR REPLACE option was added in PostgreSQL
9.0.