### PR TITLE
Fix auto merge root partition stats while analyzing a leaf

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -3759,7 +3759,7 @@ merge_leaf_stats(VacAttrStatsP stats,
 		get_parts(stats->attr->attrelid, 0 /*level*/, 0 /*parent*/,
 				  false /* inctemplate */, true /*includesubparts*/);
 	Assert(pn);
-	elog(LOG, "Merging leaf stats");
+	elog(LOG, "Merging leaf stats  column %d", stats->attr->attnum);
 	List *oid_list = all_leaf_partition_relids(pn); /* all leaves */
 	StdAnalyzeData *mystats = (StdAnalyzeData *) stats->extra_data;
 	int numPartitions = list_length(oid_list);

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1068,6 +1068,158 @@ ALTER TABLE foo ADD COLUMN c int;
 INSERT INTO foo SELECT i, i%9, i%100 FROM generate_series(1,500)i;
 ANALYZE rootpartition foo;
 LOG:  Needs sample for foo
-LOG:  Merging leaf stats
-LOG:  Merging leaf stats
+LOG:  Merging leaf stats  column 1
+LOG:  Merging leaf stats  column 2
 LOG:  Computing Scalar Stats  column 3
+-- Testing auto merging root statistics for all columns
+-- where column attnums are differents due to dropped columns
+-- and split partitions.
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int, c text, d int)
+	DISTRIBUTED BY (d) 
+	PARTITION BY RANGE (a) 
+		(START (0) END (8) EVERY (4), 
+		DEFAULT PARTITION def_part);
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_def_part" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_3" for table "foo"
+INSERT INTO foo SELECT i%13, i, 'something'||i::text, i%121 FROM generate_series(1,1000)i;
+ALTER TABLE foo DROP COLUMN b;
+ALTER TABLE foo SPLIT DEFAULT PARTITION START (8) END (12) INTO (PARTITION new_part, default PARTITION);
+NOTICE:  exchanged partition "def_part" of relation "foo" with relation "pg_temp_57769"
+NOTICE:  dropped partition "def_part" for relation "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_new_part" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_def_part" for table "foo"
+set client_min_messages to 'log';
+ANALYZE foo_1_prt_2;
+LOG:  Needs sample for foo_1_prt_2
+LOG:  Computing Scalar Stats  column 1
+LOG:  Computing Scalar Stats  column 3
+LOG:  Computing Scalar Stats  column 4
+ANALYZE foo_1_prt_3;
+LOG:  Needs sample for foo_1_prt_3
+LOG:  Computing Scalar Stats  column 1
+LOG:  Computing Scalar Stats  column 3
+LOG:  Computing Scalar Stats  column 4
+ANALYZE foo_1_prt_new_part;
+LOG:  Needs sample for foo_1_prt_new_part
+LOG:  Computing Scalar Stats  column 1
+LOG:  Computing Scalar Stats  column 2
+LOG:  Computing Scalar Stats  column 3
+ANALYZE foo_1_prt_def_part;
+LOG:  Needs sample for foo_1_prt_def_part
+LOG:  Computing Scalar Stats  column 1
+LOG:  Computing Scalar Stats  column 2
+LOG:  Computing Scalar Stats  column 3
+LOG:  Merging leaf stats  column 1
+LOG:  Merging leaf stats  column 3
+LOG:  Merging leaf stats  column 4
+reset client_min_messages;
+SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
+     tablename      | attname | null_frac | n_distinct | most_common_vals |           most_common_freqs           |                          histogram_bounds                           
+--------------------+---------+-----------+------------+------------------+---------------------------------------+---------------------------------------------------------------------
+ foo                | a       |         0 |         13 |                  |                                       | {0,3,6,9,12}
+ foo_1_prt_2        | a       |         0 |          4 | {1,2,3,0}        | {0.250814,0.250814,0.250814,0.247557} | 
+ foo_1_prt_3        | a       |         0 |          4 | {4,5,6,7}        | {0.25,0.25,0.25,0.25}                 | 
+ foo_1_prt_def_part | a       |         0 |          1 | {12}             | {1}                                   | 
+ foo_1_prt_new_part | a       |         0 |          4 | {8,9,10,11}      | {0.25,0.25,0.25,0.25}                 | 
+ foo                | c       |         0 |         -1 |                  |                                       | {something1,something33,something554,something776,something999}
+ foo_1_prt_2        | c       |         0 |         -1 |                  |                                       | {something1,something313,something54,something769,something991}
+ foo_1_prt_3        | c       |         0 |         -1 |                  |                                       | {something108,something33,something553,something773,something995}
+ foo_1_prt_def_part | c       |         0 |         -1 |                  |                                       | {something1000,something311,something532,something766,something987}
+ foo_1_prt_new_part | c       |         0 |         -1 |                  |                                       | {something10,something323,something554,something776,something999}
+ foo                | d       |         0 |     -0.121 |                  |                                       | {0,28,59,90,120}
+ foo_1_prt_2        | d       |         0 |  -0.394137 |                  |                                       | {0,27,59,90,120}
+ foo_1_prt_3        | d       |         0 |  -0.392857 |                  |                                       | {0,27,57,89,120}
+ foo_1_prt_def_part | d       |         0 |         -1 |                  |                                       | {0,27,57,88,118}
+ foo_1_prt_new_part | d       |         0 |  -0.392857 |                  |                                       | {0,28,58,88,120}
+(15 rows)
+
+-- Testing auto merging root statistics for a column whose attnum
+-- is aligned and the same in every partition due to dropped columns
+-- and split partitions.
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int, c text, d int)
+	DISTRIBUTED BY (d) 
+	PARTITION BY RANGE (a) 
+		(START (0) END (8) EVERY (4), 
+		DEFAULT PARTITION def_part);
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_def_part" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_3" for table "foo"
+INSERT INTO foo SELECT i%13, i, 'something'||i::text, i%121 FROM generate_series(1,1000)i;
+ALTER TABLE foo DROP COLUMN b;
+ALTER TABLE foo SPLIT DEFAULT PARTITION START (8) END (12) INTO (PARTITION new_part, default PARTITION);
+NOTICE:  exchanged partition "def_part" of relation "foo" with relation "pg_temp_57948"
+NOTICE:  dropped partition "def_part" for relation "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_new_part" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_def_part" for table "foo"
+set client_min_messages to 'log';
+ANALYZE foo_1_prt_2(a);
+LOG:  Needs sample for foo_1_prt_2
+LOG:  Computing Scalar Stats  column 1
+ANALYZE foo_1_prt_3(a);
+LOG:  Needs sample for foo_1_prt_3
+LOG:  Computing Scalar Stats  column 1
+ANALYZE foo_1_prt_new_part(a);
+LOG:  Needs sample for foo_1_prt_new_part
+LOG:  Computing Scalar Stats  column 1
+ANALYZE foo_1_prt_def_part(a);
+LOG:  Needs sample for foo_1_prt_def_part
+LOG:  Computing Scalar Stats  column 1
+LOG:  Merging leaf stats  column 1
+reset client_min_messages;
+SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
+     tablename      | attname | null_frac | n_distinct | most_common_vals |           most_common_freqs           | histogram_bounds 
+--------------------+---------+-----------+------------+------------------+---------------------------------------+------------------
+ foo                | a       |         0 |         13 |                  |                                       | {0,3,6,9,12}
+ foo_1_prt_2        | a       |         0 |          4 | {1,2,3,0}        | {0.250814,0.250814,0.250814,0.247557} | 
+ foo_1_prt_3        | a       |         0 |          4 | {4,5,6,7}        | {0.25,0.25,0.25,0.25}                 | 
+ foo_1_prt_def_part | a       |         0 |          1 | {12}             | {1}                                   | 
+ foo_1_prt_new_part | a       |         0 |          4 | {8,9,10,11}      | {0.25,0.25,0.25,0.25}                 | 
+(5 rows)
+
+-- Testing auto merging root statistics for a column whose attnum
+-- is not aligned and different in partitions due to dropped columns
+-- and split partitions.
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int, c text, d int)
+	DISTRIBUTED BY (d) 
+	PARTITION BY RANGE (a) 
+		(START (0) END (8) EVERY (4), 
+		DEFAULT PARTITION def_part);
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_def_part" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_3" for table "foo"
+INSERT INTO foo SELECT i%13, i, 'something'||i::text, i%121 FROM generate_series(1,1000)i;
+ALTER TABLE foo DROP COLUMN b;
+ALTER TABLE foo SPLIT DEFAULT PARTITION START (8) END (12) INTO (PARTITION new_part, default PARTITION);
+NOTICE:  exchanged partition "def_part" of relation "foo" with relation "pg_temp_58127"
+NOTICE:  dropped partition "def_part" for relation "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_new_part" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_def_part" for table "foo"
+set client_min_messages to 'log';
+ANALYZE foo_1_prt_2(d);
+LOG:  Needs sample for foo_1_prt_2
+LOG:  Computing Scalar Stats  column 4
+ANALYZE foo_1_prt_3(d);
+LOG:  Needs sample for foo_1_prt_3
+LOG:  Computing Scalar Stats  column 4
+ANALYZE foo_1_prt_new_part(d);
+LOG:  Needs sample for foo_1_prt_new_part
+LOG:  Computing Scalar Stats  column 3
+ANALYZE foo_1_prt_def_part(d);
+LOG:  Needs sample for foo_1_prt_def_part
+LOG:  Computing Scalar Stats  column 3
+LOG:  Merging leaf stats  column 4
+reset client_min_messages;
+SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
+     tablename      | attname | null_frac | n_distinct | most_common_vals | most_common_freqs | histogram_bounds 
+--------------------+---------+-----------+------------+------------------+-------------------+------------------
+ foo                | d       |         0 |     -0.121 |                  |                   | {0,28,59,90,120}
+ foo_1_prt_2        | d       |         0 |  -0.394137 |                  |                   | {0,27,59,90,120}
+ foo_1_prt_3        | d       |         0 |  -0.392857 |                  |                   | {0,27,57,89,120}
+ foo_1_prt_def_part | d       |         0 |         -1 |                  |                   | {0,27,57,88,118}
+ foo_1_prt_new_part | d       |         0 |  -0.392857 |                  |                   | {0,28,58,88,120}
+(5 rows)
+


### PR DESCRIPTION
This PR fixes couple of issues for root table statistics merge when
a single partition is analyzed.

1. Auto merge was not functional when a column list is specified in the
analyze command such as `ANALYZE part1 (a)`.

2. When there is misalignment for attnums between partitions, it was not
checking the availability of stats based on the attnum which is not
aligned and discovered properly.

3. Auto merge should check every column's stats availability for each
partition. `forboth` macro was used in a wrong way as if it was a double
for loop which was causing auto merge not to be function when the number
of partitions is not equal to the number of columns.

This commit fixes all these issues.