### PR TITLE
Check at planning time, whether an aggregate has serial/deserial functions.

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -685,7 +685,7 @@ cdb_grouping_planner(PlannerInfo *root,
 		 * functions per DQA and were willing to plan some DQAs as single and
 		 * some as multiple phases.  Not currently, however.
 		 */
-		if (agg_costs->missing_combinefunc)
+		if (agg_costs->hasNonCombine || agg_costs->hasNonSerial)
 			allowed_agg &= ~AGG_MULTIPHASE;
 
 		/*

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -765,7 +765,7 @@ gpdb::IsOrderedAgg
 }
 
 bool
-gpdb::AggHasCombineFunc
+gpdb::IsAggPartialCapable
 	(
 	Oid aggid
 	)
@@ -773,7 +773,7 @@ gpdb::AggHasCombineFunc
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_aggregate */
-		return has_agg_combinefunc(aggid);
+		return is_agg_partial_capable(aggid);
 	}
 	GP_WRAP_END;
 	return false;

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -1598,10 +1598,6 @@ CTranslatorQueryToDXL::TranslateWindowToDXL
 		CDXLNode *project_elem_dxlnode =  TranslateExprToDXLProject(target_entry->expr, target_entry->resname);
 		ULONG colid = CDXLScalarProjElem::Cast(project_elem_dxlnode->GetOperator())->Id();
 
-		if (IsA(target_entry->expr, WindowFunc))
-		{
-			CTranslatorUtils::CheckAggregateWindowFn((Node*) target_entry->expr);
-		}
 		if (!target_entry->resjunk)
 		{
 			if (IsA(target_entry->expr, Var) || IsA(target_entry->expr, WindowFunc))

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1955,11 +1955,11 @@ CTranslatorRelcacheToDXL::RetrieveAgg
 	
 	// GPDB does not support splitting of ordered aggs and aggs without a
 	// combine function
-	BOOL is_splittable = !is_ordered && gpdb::AggHasCombineFunc(agg_oid);
+	BOOL is_splittable = !is_ordered && gpdb::IsAggPartialCapable(agg_oid);
 	
 	// cannot use hash agg for ordered aggs or aggs without a combine func
 	// due to the fact that hashAgg may spill
-	BOOL is_hash_agg_capable = !is_ordered && gpdb::AggHasCombineFunc(agg_oid);
+	BOOL is_hash_agg_capable = !is_ordered && gpdb::IsAggPartialCapable(agg_oid);
 
 	CMDAggregateGPDB *pmdagg = GPOS_NEW(mp) CMDAggregateGPDB
 											(

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2402,33 +2402,6 @@ CTranslatorUtils::CheckRTEPermissions
 	gpdb::CheckRTPermissions(range_table_list);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CTranslatorUtils::CheckAggregateWindowFn
-//
-//	@doc:
-//		Check if the window function is an aggregate and has 
-//      a combine function
-//
-//---------------------------------------------------------------------------
-void
-CTranslatorUtils::CheckAggregateWindowFn
-	(
-	Node *node
-	)
-{
-	GPOS_ASSERT(NULL != node);
-	GPOS_ASSERT(IsA(node, WindowFunc));
-
-	WindowFunc *winfunc = (WindowFunc *) node;
-
-	if (gpdb::AggregateExists(winfunc->winfnoid) && !gpdb::AggHasCombineFunc(winfunc->winfnoid))
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-				GPOS_WSZ_LIT("Aggregate window function without combine function"));
-	}
-}
-
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -575,7 +575,8 @@ make_aggs_for_rollup(PlannerInfo *root,
 	 * Append-Aggs.
 	 */
 	if (context->agg_costs->numOrderedAggs == 0 &&
-		!context->agg_costs->missing_combinefunc)
+		!context->agg_costs->hasNonCombine &&
+		!context->agg_costs->hasNonSerial)
 		result_plan = make_list_aggs_for_rollup(root, context, lefttree);
 	else
 		result_plan = make_append_aggs_for_rollup(root, context, lefttree);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -3777,9 +3777,10 @@ choose_hashed_grouping(PlannerInfo *root,
 	/*
 	 * CDB: The combine function is used to merge transient values during
 	 * hash reloading (see execHHashagg.c). So hash agg is not allowed if one
-	 * of the aggregates doesn't have a combine function.
+	 * of the aggregates doesn't have a combine function. Likewise, if a
+	 * transition value cannot be serialized, a hash agg is not allowed.
 	 */
-	if (agg_costs->missing_combinefunc)
+	if (agg_costs->hasNonCombine || agg_costs->hasNonSerial)
 		return false;
 
 	/*

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -172,8 +172,8 @@ namespace gpdb {
 	// is aggregate ordered
 	bool IsOrderedAgg(Oid aggid);
 	
-	// does aggregate have a combine function
-	bool AggHasCombineFunc(Oid aggid);
+	// does aggregate have a combine function (and serial/deserial functions, if needed)
+	bool IsAggPartialCapable(Oid aggid);
 
 	// intermediate result type of given aggregate
 	Oid GetAggregate(const char* agg, Oid type_oid);

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -367,10 +367,6 @@ namespace gpdxl
 			static 
 			void CheckRTEPermissions(List *range_table_list);
 
-			// check if an aggregate window function has either prelim or inverse prelim func
-			static
-			void CheckAggregateWindowFn(Node *node);
-
 			// check if given column ids are outer references in the tree rooted by given node
                         static
 			void MarkOuterRefs(ULONG *colid, BOOL *is_outer_ref, ULONG num_columns, CDXLNode *node);

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -66,12 +66,13 @@ typedef struct AggClauseCosts
 	int			numAggs;		/* total number of aggregate functions */
 	int			numOrderedAggs; /* number that use DISTINCT or ORDER BY */
 	int			numPureOrderedAggs; /* CDB: number that use ORDER BY, not counting DISTINCT */
+	bool		hasNonCombine;	/* CDB: any agg func w/o a combine func? */
+	bool		hasNonSerial;	/* CDB: is any partial agg non-serializable? */
 	QualCost	transCost;		/* total per-input-row execution costs */
 	Cost		finalCost;		/* total costs of agg final functions */
 	Size		transitionSpace;	/* space for pass-by-ref transition data */
 
 	List   *dqaArgs;	/* CDB: List of distinct DQA argument exprs. */
-	bool	missing_combinefunc; /* CDB: any agg func w/o a prelim func? */
 } AggClauseCosts;
 
 

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -145,7 +145,7 @@ extern char func_data_access(Oid funcid);
 extern char func_exec_location(Oid funcid);
 extern Oid get_agg_transtype(Oid aggid);
 extern bool is_agg_ordered(Oid aggid);
-extern bool has_agg_combinefunc(Oid aggid);
+extern bool is_agg_partial_capable(Oid aggid);
 extern bool get_func_leakproof(Oid funcid);
 extern float4 get_func_cost(Oid funcid);
 extern float4 get_func_rows(Oid funcid);

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -308,3 +308,21 @@ NOTICE:  combinefunc called
            198
 (1 row)
 
+-- Test an aggregate with 'internal' transition type, and a combine function,
+-- but no serial/deserial functions. This is valid, but we have no use for
+-- the combine function in GPDB in that case.
+CREATE AGGREGATE my_numeric_avg(numeric) (
+  stype = internal,
+  sfunc = numeric_avg_accum,
+  finalfunc = numeric_avg,
+  combinefunc = numeric_avg_combine
+);
+create temp table numerictesttab as select g::numeric as n from generate_series(1,10) g;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'n' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select my_numeric_avg(n) from numerictesttab;
+   my_numeric_avg   
+--------------------
+ 5.5000000000000000
+(1 row)
+

--- a/src/test/regress/expected/gp_aggregates_optimizer.out
+++ b/src/test/regress/expected/gp_aggregates_optimizer.out
@@ -314,3 +314,21 @@ NOTICE:  combinefunc called
            198
 (1 row)
 
+-- Test an aggregate with 'internal' transition type, and a combine function,
+-- but no serial/deserial functions. This is valid, but we have no use for
+-- the combine function in GPDB in that case.
+CREATE AGGREGATE my_numeric_avg(numeric) (
+  stype = internal,
+  sfunc = numeric_avg_accum,
+  finalfunc = numeric_avg,
+  combinefunc = numeric_avg_combine
+);
+create temp table numerictesttab as select g::numeric as n from generate_series(1,10) g;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'n' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select my_numeric_avg(n) from numerictesttab;
+   my_numeric_avg   
+--------------------
+ 5.5000000000000000
+(1 row)
+

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -117,3 +117,19 @@ create aggregate mysum_prefunc(int4) (
   prefunc=int8pl_with_notice
 );
 select mysum_prefunc(a::int4) from aggtest;
+
+
+-- Test an aggregate with 'internal' transition type, and a combine function,
+-- but no serial/deserial functions. This is valid, but we have no use for
+-- the combine function in GPDB in that case.
+
+CREATE AGGREGATE my_numeric_avg(numeric) (
+  stype = internal,
+  sfunc = numeric_avg_accum,
+  finalfunc = numeric_avg,
+  combinefunc = numeric_avg_combine
+);
+
+create temp table numerictesttab as select g::numeric as n from generate_series(1,10) g;
+
+select my_numeric_avg(n) from numerictesttab;


### PR DESCRIPTION
Two semi-related commits:

1. Allow ORCA to create plans for window functions without combine function.

I'm not 100% sure about this change. I believe that all the WindowAgg plans that ORCA generates work without combine functions, these days. I believe the old window functions implementation required that, but the new one, after the big window functions rewrite, no longer does. But if someone who knows ORCA better could verify that, that'd be great. 

2. Add checks in the planner, for aggregates that have a combine function, but no serial/deserial support.

This is the thing discussed in the comments in https://github.com/greenplum-db/gpdb/pull/5528#issuecomment-417560986.