### PR TITLE
Remove unused fields from WindowFunc.

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -573,26 +573,8 @@ CTranslatorDXLToScalar::TranslateDXLScalarWindowRefToScalar
 	window_func->winstar = dxlop->IsStarArg();
 	window_func->winagg = dxlop->IsSimpleAgg();
 
-	EdxlWinStage dxl_win_stage = dxlop->GetDxlWinStage();
-	GPOS_ASSERT(dxl_win_stage != EdxlwinstageSentinel);
-
-	ULONG mapping[][2] =
-			{
-			{WINSTAGE_IMMEDIATE, EdxlwinstageImmediate},
-			{WINSTAGE_PRELIMINARY, EdxlwinstagePreliminary},
-			{WINSTAGE_ROWKEY, EdxlwinstageRowKey},
-			};
-
-	const ULONG arity = GPOS_ARRAY_SIZE(mapping);
-	for (ULONG ul = 0; ul < arity; ul++)
-	{
-		ULONG *elem = mapping[ul];
-		if ((ULONG) dxl_win_stage == elem[1])
-		{
-			window_func->winstage = (WinStage) elem[0];
-			break;
-		}
-	}
+	if (dxlop->GetDxlWinStage() != EdxlwinstageImmediate)
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("Unsupported window function stage"));
 
 	// translate the arguments of the window function
 	window_func->args = TranslateScalarChildren(window_func->args, scalar_winref_node, colid_var);

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1537,30 +1537,10 @@ CTranslatorScalarToDXL::TranslateWindowFuncToDXL
 
 	const WindowFunc *window_func = (WindowFunc *) expr;
 
-	static ULONG mapping[][2] =
-		{
-		{WINSTAGE_IMMEDIATE, EdxlwinstageImmediate},
-		{WINSTAGE_PRELIMINARY, EdxlwinstagePreliminary},
-		{WINSTAGE_ROWKEY, EdxlwinstageRowKey},
-		};
-
 	// ORCA doesn't support the FILTER clause yet.
 	if (window_func->aggfilter)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Aggregate functions with FILTER"));
-	}
-
-	const ULONG arity = GPOS_ARRAY_SIZE(mapping);
-	EdxlWinStage dxl_win_stage = EdxlwinstageSentinel;
-
-	for (ULONG ul = 0; ul < arity; ul++)
-	{
-		ULONG *elem = mapping[ul];
-		if ((ULONG) window_func->winstage == elem[0])
-		{
-			dxl_win_stage = (EdxlWinStage) elem[1];
-			break;
-		}
 	}
 
 	ULONG win_spec_pos = (ULONG) 0;
@@ -1568,8 +1548,6 @@ CTranslatorScalarToDXL::TranslateWindowFuncToDXL
 	{
 		win_spec_pos = (ULONG) window_func->winref - 1;
 	}
-
-	GPOS_ASSERT(EdxlwinstageSentinel != dxl_win_stage && "Invalid window stage");
 
 	/*
 	 * ORCA's ScalarWindowRef object doesn't have fields for the 'winstar'
@@ -1585,7 +1563,7 @@ CTranslatorScalarToDXL::TranslateWindowFuncToDXL
 													window_func->windistinct,
 													window_func->winstar,
 													window_func->winagg,
-													dxl_win_stage,
+													EdxlwinstageImmediate,
 													win_spec_pos
 													);
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1663,8 +1663,6 @@ _copyWindowFunc(const WindowFunc *from)
 	COPY_SCALAR_FIELD(winstar);
 	COPY_SCALAR_FIELD(winagg);
 	COPY_SCALAR_FIELD(windistinct);
-	COPY_SCALAR_FIELD(winindex);
-	COPY_SCALAR_FIELD(winstage);
 	COPY_LOCATION_FIELD(location);
 
 	return newnode;

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -240,8 +240,6 @@ _equalWindowFunc(const WindowFunc *a, const WindowFunc *b)
 	COMPARE_SCALAR_FIELD(winstar);
 	COMPARE_SCALAR_FIELD(winagg);
 	COMPARE_SCALAR_FIELD(windistinct);
-	COMPARE_SCALAR_FIELD(winindex);
-	COMPARE_SCALAR_FIELD(winstage);
 	COMPARE_LOCATION_FIELD(location);
 
 	return true;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1426,8 +1426,6 @@ _outWindowFunc(StringInfo str, const WindowFunc *node)
 	WRITE_BOOL_FIELD(winstar);
 	WRITE_BOOL_FIELD(winagg);
 	WRITE_BOOL_FIELD(windistinct);
-	WRITE_UINT_FIELD(winindex);
-	WRITE_ENUM_FIELD(winstage, WinStage);
 	WRITE_LOCATION_FIELD(location);
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1386,8 +1386,6 @@ _readWindowFunc(void)
 	READ_BOOL_FIELD(winstar);
 	READ_BOOL_FIELD(winagg);
 	READ_BOOL_FIELD(windistinct);
-	READ_UINT_FIELD(winindex);
-	READ_ENUM_FIELD(winstage, WinStage);
 	READ_LOCATION_FIELD(location);
 
 	READ_DONE();

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -336,16 +336,6 @@ typedef struct GroupId
 	Expr      xpr;
 } GroupId;
 
-/* WinStage enumeration indicates what stage of the evaluation of a
- * window function is expressed by a WindowRef.
- */
-typedef enum WinStage
-{
-	WINSTAGE_IMMEDIATE = 0, /* Evaluate window function. */
-	WINSTAGE_PRELIMINARY, /* Evaluate preliminary function. */
-	WINSTAGE_ROWKEY /* WINSTAGE_IMMEDIATE for row key generation. */
-} WinStage;
-
 /*
  * WindowFunc: describes a window function call
  *
@@ -367,9 +357,6 @@ typedef struct WindowFunc
 	bool		winstar;		/* TRUE if argument list was really '*' */
 	bool		winagg;			/* is function a simple aggregate? */
 	bool		windistinct;	/* TRUE if it's agg(DISTINCT ...) */
-	/* Following fields are significant only in a Plan tree. */
-	Index		winindex;		/* RefInfo index during planning. */
-	WinStage	winstage;		/* Stage of execution. */
 	int			location;		/* token location, or -1 if unknown */
 } WindowFunc;
 


### PR DESCRIPTION
These were remnants from the old window functions implementation, before
the big rewrite during 8.4 merge. There was code in the ORCA translator
to map these to/from DXL, but since we didn't do anything with the fields
at execution time, I'm pretty sure we should never see anything but
"immediate" stage window functions, even from ORCA. Add a check for that,
and remove the mappings.