### PR TITLE
dispatcher: Return NULL pointer rather than implied NULL via false

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -154,7 +154,7 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		}
 
 		cdbdisp_destroyDispatcherState(ds);
-		return false;
+		return NULL;
 	}
 
 	cdbdisp_returnResults(pr, &cdb_pgresults);


### PR DESCRIPTION
CdbDispatchDtxProtocolCommand() is defined to return `struct pg_result **`, but returned `false` in an error path which forces zero imply a NULL pointer. The caller of this function has another error check and wouldn't actually read the returned value, but it should still be doing the right thing. Fix by returning NULL instead.  This resolves the following clang compiler warning:
```
  cdbdisp_dtx.c:157:10: warning: expression which evaluates to zero treated as
                        a null pointer constant of type 'struct pg_result **'
                        [-Wnon-literal-null-conversion]
                  return false;
                         ^~~~~
  ../../../../src/include/c.h:195:15: note: expanded from macro 'false'
  #define false   ((bool) 0)
                  ^~~~~~~~~~
```