### PR TITLE
Explicitly initialize PlannerGlobal->non_eq_clauses.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -537,6 +537,7 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	root->init_plans = NIL;
 	root->cte_plan_ids = NIL;
 	root->eq_classes = NIL;
+	root->non_eq_clauses = NIL;
 	root->init_plans = NIL;
 
 	root->list_cteplaninfo = NIL;

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -963,6 +963,7 @@ pull_up_simple_subquery(PlannerInfo *root, Node *jtnode, RangeTblEntry *rte,
 	subroot->init_plans = NIL;
 	subroot->cte_plan_ids = NIL;
 	subroot->eq_classes = NIL;
+	subroot->non_eq_clauses = NIL;
 	subroot->append_rel_list = NIL;
 	subroot->rowMarks = NIL;
 	subroot->hasRecursion = false;

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -216,7 +216,7 @@ typedef struct PlannerInfo
 
 	List	   *eq_classes;		/* list of active EquivalenceClasses */
 
-	List	   *non_eq_clauses;
+	List	   *non_eq_clauses;	/* list of non-equivalence clauses */
 
 	List	   *canon_pathkeys; /* list of "canonical" PathKeys */
 


### PR DESCRIPTION
Co-authored-by: Alexandra Wang <lewang@pivotal.io>
Co-authored-by: Richard Guo <guofenglinux@gmail.com>