### PR TITLE
Pass InvalidSnapshot to PortalStart

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1340,7 +1340,7 @@ exec_mpp_query(const char *query_string,
 		/*
 		 * Start the portal.
 		 */
-		PortalStart(portal, paramLI, 0, false, ddesc);
+		PortalStart(portal, paramLI, 0, InvalidSnapshot, ddesc);
 
 		/*
 		 * Select text output format, the default.


### PR DESCRIPTION
When a new snapshot is requested, `InvalidSnapshot` should be passed to `PortalStart()`. The current coding will pass zero which will be treated as an implied `NULL` in this case, but it yields a compiler warning. Fix by passing `InvalidSnapshot`.
```
  postgres.c:1343:35: warning: expression which evaluates to zero treated as a
                      null pointer constant of type 'Snapshot'
					  (aka 'struct SnapshotData *') [-Wnon-literal-null-conversion]
                  PortalStart(portal, paramLI, 0, false, ddesc);
                                                ^~~~~
  ../../../src/include/c.h:195:15: note: expanded from macro 'false'
  #define false   ((bool) 0)
                  ^~~~~~~~~~
```