### PR TITLE
Handle large datums and remove 91_FIXME in varlena.c

### DIFF
--- a/src/include/access/tuptoaster.h
+++ b/src/include/access/tuptoaster.h
@@ -150,6 +150,16 @@ extern struct varlena *heap_tuple_fetch_attr(struct varlena * attr);
 extern void varattrib_untoast_ptr_len(Datum d, char **datastart, int *len, void **tofree);
 
 /* ----------
+ * varattrib_untoast_ptr_len_without_check
+ *
+ *		Fast path to get the pointer and length, avoid palloc if possible.
+ *		If datum is null, return a null datastart and len -1.
+ * ----------
+ */
+extern void varattrib_untoast_ptr_len_without_check(Datum d, char **datastart,
+													int *len, void **tofree);
+
+/* ----------
  * varattrib_untoast_len
  *
  *		Fast path to get the length, avoid palloc if possible.


### PR DESCRIPTION
We used to have modified implementation here before the 9.1 merge,
that could handle large datums, larger than 250 MB. In 9.1 merge,
we cover it to upstream. Now rewrite those changes over the new
code here.