### PR TITLE
Refactor DROP PROTOCOL command.

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -868,7 +868,7 @@ objectNamesToOids(GrantObjectType objtype, List *objnames)
 			foreach(cell, objnames)
 			{
 				char	   *ptcname = strVal(lfirst(cell));
-				Oid			ptcid = LookupExtProtocolOid(ptcname, false);
+				Oid			ptcid = get_extprotocol_oid(ptcname, false);
 
 				objects = lappend_oid(objects, ptcid);
 			}

--- a/src/backend/catalog/pg_extprotocol.c
+++ b/src/backend/catalog/pg_extprotocol.c
@@ -182,40 +182,6 @@ ExtProtocolCreate(const char *protocolName,
 	return protOid;
 }
 
-void
-ExtProtocolDeleteByOid(Oid	protOid)
-{
-	Relation	rel;
-	ScanKeyData skey;
-	SysScanDesc scan;
-	HeapTuple	tup;
-	bool		found = false;
-
-	/*
-	 * Search pg_extprotocol.
-	 */
-	rel = heap_open(ExtprotocolRelationId, RowExclusiveLock);
-
-	ScanKeyInit(&skey,
-				ObjectIdAttributeNumber,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(protOid));
-	scan = systable_beginscan(rel, ExtprotocolOidIndexId, true,
-							  SnapshotNow, 1, &skey);
-
-	while (HeapTupleIsValid(tup = systable_getnext(scan)))
-	{
-		simple_heap_delete(rel, &tup->t_self);
-		found = true;
-	}
-	systable_endscan(scan);
-
-	if (!found)
-		elog(ERROR, "protocol %u could not be found", protOid);
-
-	heap_close(rel, NoLock);
-}
-
 /*
  * ValidateProtocolFunction -- common code for finding readfn, writefn or validatorfn
  */
@@ -370,7 +336,7 @@ LookupExtProtocolFunction(const char *prot_name,
  * protocol Oid.
  */
 Oid
-LookupExtProtocolOid(const char *prot_name, bool missing_ok)
+get_extprotocol_oid(const char *prot_name, bool missing_ok)
 {
 	Oid			protOid = InvalidOid;
 	Relation	rel;

--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -158,7 +158,7 @@ InsertExtTableEntry(Oid 	tbloid,
 			myself.objectSubId = 0;
 
 			referenced.classId = ExtprotocolRelationId;
-			referenced.objectId = LookupExtProtocolOid(protocol, true);
+			referenced.objectId = get_extprotocol_oid(protocol, true);
 			referenced.objectSubId = 0;
 
 			/*

--- a/src/backend/commands/dropcmds.c
+++ b/src/backend/commands/dropcmds.c
@@ -231,6 +231,10 @@ does_not_exist_skipping(ObjectType objtype, List *objname, List *objargs)
 			name = NameListToString(objname);
 			args = strVal(linitial(objargs));
 			break;
+		case OBJECT_EXTPROTOCOL:
+			msg = gettext_noop("protocol \"%s\" does not exist, skipping");
+			name = NameListToString(objname);
+			break;
 		default:
 			elog(ERROR, "unexpected object type (%d)", (int) objtype);
 			break;

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -256,7 +256,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 				{
 					Oid			ownerId = GetUserId();
 					char	   *protname = uri->customprotocol;
-					Oid			ptcId = LookupExtProtocolOid(protname, false);
+					Oid			ptcId = get_extprotocol_oid(protname, false);
 					AclResult	aclresult;
 
 					/* Check we have the right permissions on this protocol */

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -912,10 +912,6 @@ standard_ProcessUtility(Node *parsetree,
 					case OBJECT_FOREIGN_TABLE:
 						RemoveRelations((DropStmt *) parsetree);
 						break;
-					case OBJECT_EXTPROTOCOL:
-						/* GPDB_92_MERGE_FIXME: Could we move it to RemoveObjects()? */
-						RemoveExtProtocols(stmt);
-						break;
 					default:
 						RemoveObjects((DropStmt *) parsetree);
 						break;

--- a/src/include/catalog/pg_extprotocol.h
+++ b/src/include/catalog/pg_extprotocol.h
@@ -82,16 +82,12 @@ ExtProtocolCreate(const char *protocolName,
 				  List *validatorfuncName,
 				  bool trusted);
 
-extern void
-ExtProtocolDeleteByOid(Oid	protOid);
-
 extern Oid
 LookupExtProtocolFunction(const char *prot_name, 
 						  ExtPtcFuncType prot_type,
 						  bool error);
 
-extern Oid
-LookupExtProtocolOid(const char *prot_name, bool error_if_missing);
+extern Oid get_extprotocol_oid(const char *prot_name, bool error_if_missing);
 
 extern char *
 ExtProtocolGetNameByOid(Oid	protOid);

--- a/src/include/commands/extprotocolcmds.h
+++ b/src/include/commands/extprotocolcmds.h
@@ -9,10 +9,9 @@
 #ifndef EXTPROTOCOLCMDS_H
 #define EXTPROTOCOLCMDS_H
 
-#include "nodes/parsenodes.h"
+#include "nodes/pg_list.h"
 
 extern void DefineExtProtocol(List *name, List *parameters, bool trusted);
-extern void RemoveExtProtocols(DropStmt *dtop);
 extern void RemoveExtProtocolById(Oid protOid);
 extern void AlterExtProtocolOwner(const char *name, Oid newOwnerId);
 extern void RenameExtProtocol(const char *oldname, const char *newname);


### PR DESCRIPTION
The handling of DROP commands for various objects was refactored in
PostgreSQL 9.2, to reducate code duplication (commit 82a4a777d9). This
commit changes DROP PROTOCOL command handling to follow that model. No
user-visible changes.