### PR TITLE
Actually register moving-aggregate support for boolean aggregates

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301808237
+#define CATALOG_VERSION_NO	301808311
 
 #endif

--- a/src/include/catalog/pg_aggregate.h
+++ b/src/include/catalog/pg_aggregate.h
@@ -283,9 +283,9 @@ DATA(insert ( 2828	n 0 float8_regr_accum	float8_covar_samp		float8_regr_combine 
 DATA(insert ( 2829	n 0 float8_regr_accum	float8_corr				float8_regr_combine -	-	-				-				-			f f 0	1022	0	0		0	"{0,0,0,0,0,0}" _null_ ));
 
 /* boolean-and and boolean-or */
-DATA(insert ( 2517	n 0 booland_statefunc	-	booland_statefunc	-	-		-	-	-	f f 58	16	0	0	0	_null_ _null_ ));
-DATA(insert ( 2518	n 0 boolor_statefunc	-	boolor_statefunc	-	-		-	-	-	f f 59	16	0	0	0	_null_ _null_ ));
-DATA(insert ( 2519	n 0 booland_statefunc	-	booland_statefunc	-	-		-	-	-	f f 58	16	0	0	0	_null_ _null_ ));
+DATA(insert ( 2517	n 0 booland_statefunc	-	booland_statefunc	-	-		bool_accum		bool_accum_inv	bool_alltrue	f f 58	16	0	2281	16	_null_ _null_ ));
+DATA(insert ( 2518	n 0 boolor_statefunc	-	boolor_statefunc	-	-		bool_accum		bool_accum_inv	bool_anytrue	f f 59	16	0	2281	16	_null_ _null_ ));
+DATA(insert ( 2519	n 0 booland_statefunc	-	booland_statefunc	-	-		bool_accum		bool_accum_inv	bool_alltrue	f f 58	16	0	2281	16	_null_ _null_ ));
 
 /* bitwise integer */
 DATA(insert ( 2236	n 0 int2and		-				int2and -	-	-				-				-				f f 0	21		0	0		0	_null_ _null_ ));


### PR DESCRIPTION
This really should have been squashed into the same commit as
84e533094f3, and it has been pointed out during review of
greenplum-db/gpdb#5528, but somehow slipped through the cracks.

Original message from Tom Lane:
> Provide moving-aggregate support for boolean aggregates.
>
> David Rowley and Florian Pflug, reviewed by Dean Rasheed

(cherry picked from commit d95425c8b9d3ea1681bd91b76ce73be95ca5ee21)