### PR TITLE
tuptoaster: test differing TOAST chunk sizes with fault injection

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -20,7 +20,6 @@
 
 #include "access/reloptions.h"
 #include "access/transam.h"
-#include "access/tuptoaster.h"
 #include "access/url.h"
 #include "access/xlog_internal.h"
 #include "cdb/cdbappendonlyam.h"
@@ -162,7 +161,6 @@ bool		gp_create_table_random_default_distribution = true;
 bool		gp_allow_non_uniform_partitioning_ddl = true;
 bool		gp_enable_exchange_default_partition = false;
 int			dtx_phase2_retry_count = 0;
-int			gp_test_toast_max_chunk_size_override = 0;
 
 bool		log_dispatch_stats = false;
 
@@ -4348,16 +4346,6 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_max_slices,
 		0, 0, INT_MAX, NULL, NULL
-	},
-
-	{
-		{"gp_test_toast_max_chunk_size_override", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Testing support for TOAST_MAX_CHUNK_SIZE changes."),
-			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
-		},
-		&gp_test_toast_max_chunk_size_override,
-		0, 0, TOAST_MAX_CHUNK_SIZE, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -251,6 +251,8 @@ FI_IDENT(BeforeFtsNotify, "before_fts_notify")
 FI_IDENT(BeforeAcquireLockDuringCreateAoBlkdirTable, "before_acquire_lock_during_create_ao_blkdir_table")
 /* inject fault during gang creation, before check for interrupts */
 FI_IDENT(CreateGangInProgress, "create_gang_in_progress")
+/* inject fault when creating new TOAST tables, to modify the chunk size */
+FI_IDENT(DecreaseToastMaxChunkSize, "decrease_toast_max_chunk_size")
 #endif
 
 /*

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -274,7 +274,6 @@ extern bool gp_create_table_random_default_distribution;
 extern bool gp_allow_non_uniform_partitioning_ddl;
 extern bool gp_enable_exchange_default_partition;
 extern int  dtx_phase2_retry_count;
-extern int	gp_test_toast_max_chunk_size_override;
 
 /* WAL replication debug gucs */
 extern bool debug_walrepl_snd;

--- a/src/test/regress/expected/toast.out
+++ b/src/test/regress/expected/toast.out
@@ -94,9 +94,26 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE toast_chunk_test ALTER COLUMN a SET STORAGE EXTERNAL;
 -- Alter our TOAST_MAX_CHUNK_SIZE and insert a value we know will be toasted.
-SET gp_test_toast_max_chunk_size_override = 7993;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+SELECT DISTINCT gp_inject_fault('decrease_toast_max_chunk_size', 'skip', dbid)
+	   FROM pg_catalog.gp_segment_configuration
+	   WHERE role = 'p';
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 INSERT INTO toast_chunk_test VALUES (repeat('abcdefghijklmnopqrstuvwxyz', 1000)::bytea);
-RESET gp_test_toast_max_chunk_size_override;
+SELECT DISTINCT gp_inject_fault('decrease_toast_max_chunk_size', 'reset', dbid)
+	   FROM pg_catalog.gp_segment_configuration
+	   WHERE role = 'p';
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 -- The toasted value should still be read correctly.
 SELECT * FROM toast_chunk_test WHERE a <> repeat('abcdefghijklmnopqrstuvwxyz', 1000)::bytea;
  a 


### PR DESCRIPTION
Instead of a test-only GUC, use the fault injector to modify the TOAST chunk sizes when testing. This is in preparation for a backport to 5X, where we don't want the new GUC to be exposed to users.