### PR TITLE
Support PREFUNC as an alias for COMBINEFUNC, for backwards compatibility.

### DIFF
--- a/doc/src/sgml/ref/create_aggregate.sgml
+++ b/doc/src/sgml/ref/create_aggregate.sgml
@@ -25,7 +25,6 @@ CREATE AGGREGATE <replaceable class="parameter">name</replaceable> ( [ <replacea
     SFUNC = <replaceable class="PARAMETER">sfunc</replaceable>,
     STYPE = <replaceable class="PARAMETER">state_data_type</replaceable>
     [ , SSPACE = <replaceable class="PARAMETER">state_data_size</replaceable> ]
-    [ , PREFUNC = <replaceable class="PARAMETER">prefunc</replaceable> ]
     [ , FINALFUNC = <replaceable class="PARAMETER">ffunc</replaceable> ]
     [ , FINALFUNC_EXTRA ]
     [ , COMBINEFUNC = <replaceable class="PARAMETER">combinefunc</replaceable> ]

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_AGGREGATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_AGGREGATE.xml
@@ -146,6 +146,10 @@ ordered aggregate, using the syntax:
 <p>The <codeph>ORDERED</codeph> keyword is accepted for backwards compatibility, but
   is ignored.</p>
 
+<p>In previous versions of Greenplum Database, the <codeph>COMBINEFUNC</codeph> option was called
+<codeph>PREFUNC</codeph>. It is still accepted for backwards compatibility, as a synonym for
+<codeph>COMBINEFUNC</codeph>.</p>
+
 </section><section id="section7"><title>Example</title><p>The following simple example creates an aggregate function that computes
 the sum of two columns. </p><p>Before creating the aggregate function, create two functions that
 are used as the <codeph>SFUNC</codeph> and <codeph>COMBINEFUNC</codeph> functions

--- a/src/backend/commands/aggregatecmds.c
+++ b/src/backend/commands/aggregatecmds.c
@@ -131,6 +131,10 @@ DefineAggregate(List *name, List *args, bool oldstyle, List *parameters,
 			finalfuncName = defGetQualifiedName(defel);
 		else if (pg_strcasecmp(defel->defname, "combinefunc") == 0)
 			combinefuncName = defGetQualifiedName(defel);
+		/* Alias for COMBINEFUNC, for backwards-compatibility with
+		 * GPDB 5 and below */
+		else if (pg_strcasecmp(defel->defname, "prefunc") == 0)
+			combinefuncName = defGetQualifiedName(defel);
 		else if (pg_strcasecmp(defel->defname, "serialfunc") == 0)
 			serialfuncName = defGetQualifiedName(defel);
 		else if (pg_strcasecmp(defel->defname, "deserialfunc") == 0)

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -285,3 +285,26 @@ select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
 -- currently.
 select avg(unique2), generate_series(1,3) as g from tenk1 order by g desc;
 ERROR:  set-valued function called in context that cannot accept a set
+--
+-- "PREFUNC" is accepted as an alias for "COMBINEFUNC", for compatibility with
+-- GPDB 5 and below.
+--
+create function int8pl_with_notice(int8, int8) returns int8
+AS $$
+begin
+  raise notice 'combinefunc called';
+  return $1 + $2;
+end;
+$$ language plpgsql strict;
+create aggregate mysum_prefunc(int4) (
+  sfunc = int4_sum,
+  stype=bigint,
+  prefunc=int8pl_with_notice
+);
+select mysum_prefunc(a::int4) from aggtest;
+NOTICE:  combinefunc called
+ mysum_prefunc 
+---------------
+           198
+(1 row)
+

--- a/src/test/regress/expected/gp_aggregates_optimizer.out
+++ b/src/test/regress/expected/gp_aggregates_optimizer.out
@@ -291,3 +291,26 @@ select avg(unique2), generate_series(1,3) as g from tenk1 order by g desc;
  4999.5000000000000000 | 1
 (3 rows)
 
+--
+-- "PREFUNC" is accepted as an alias for "COMBINEFUNC", for compatibility with
+-- GPDB 5 and below.
+--
+create function int8pl_with_notice(int8, int8) returns int8
+AS $$
+begin
+  raise notice 'combinefunc called';
+  return $1 + $2;
+end;
+$$ language plpgsql strict;
+create aggregate mysum_prefunc(int4) (
+  sfunc = int4_sum,
+  stype=bigint,
+  prefunc=int8pl_with_notice
+);
+select mysum_prefunc(a::int4) from aggtest;
+NOTICE:  combinefunc called
+ mysum_prefunc 
+---------------
+           198
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -63,7 +63,7 @@ test: dtm_retry
 
 # The appendonly test cannot be run concurrently with tests that have
 # serializable transactions (may conflict with AO vacuum operations).
-test: rangefuncs_cdb gp_aggregates gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish
+test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.


### PR DESCRIPTION
Commit b8545d57a5 renamed CREATE AGGREGATE's PREFUNC option into
COMBINEFUNC, because that's what it's called in the upstream. However,
there might be old SQL scripts lying around that still the old PREFUNC
option. CREATE AGGREGATE gives only a warning about unrecognized options,
so such a command would still succeed, and create the aggregate, but
without the combine function. As a courtesy to users upgrading from GPDB 5
and below, support PREFUNC as an alias for COMBINEFUNC.

In the passing, remove PREFUNC from the \h page for CREATE AGGREGATE. That
was meant to be removed in commit b8545d57a5, and I don't think should list
backwards-compatibility options like this in \h. Add a note to the dita docs
for it, instead.

Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/Aq3aeA3Jm3w/sTeQs2iMBAAJ