### PR TITLE
Fix assertion failure trying to build a Motion on a non-hashable column.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1315,7 +1315,19 @@ Motion *
 make_hashed_motion(Plan *lefttree,
 				   List *hashExpr, bool useExecutorVarFormat)
 {
-	Motion *motion;
+	Motion	   *motion;
+	ListCell   *lc;
+
+	/*
+	 * The expressions used as the distribution key must be "GPDB-hashable".
+	 * There's also an assertion for this in setrefs.c, but better to catch
+	 * these as early as possible.
+	 */
+	foreach(lc, hashExpr)
+	{
+		if (!isGreenplumDbHashable(exprType((Node *) lfirst(lc))))
+			elog(ERROR, "cannot use expression as distribution key, because it is not hashable");
+	}
 
 	motion = make_motion(lefttree, false,
 						 0, NULL, NULL, NULL, useExecutorVarFormat);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1277,6 +1277,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	double		dNumGroups = 0;
 	double		numDistinct = 1;
 	List	   *distinctExprs = NIL;
+	List	   *distinct_dist_keys = NIL;
+	List	   *distinct_dist_exprs = NIL;
 
 	double		motion_cost_per_row =
 	(gp_motion_cost_per_row > 0.0) ?
@@ -1950,6 +1952,12 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	 */
 	if (parse->distinctClause != NULL)
 	{
+		make_distribution_keys_for_groupclause(root,
+											   parse->distinctClause,
+											   result_plan->targetlist,
+											   &distinct_dist_keys,
+											   &distinct_dist_exprs);
+
 		distinctExprs = get_sortgrouplist_exprs(parse->distinctClause,
 												result_plan->targetlist);
 		numDistinct = estimate_num_groups(root, distinctExprs,
@@ -1962,9 +1970,10 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 
 		if (Gp_role == GP_ROLE_DISPATCH && CdbPathLocus_IsPartitioned(current_locus))
 		{
-			List	   *distinct_pathkeys = make_pathkeys_for_sortclauses(root, parse->distinctClause,
-											  result_plan->targetlist, true);
-			bool		needMotion = !cdbpathlocus_collocates(root, current_locus, distinct_pathkeys, false /* exact_match */ );
+			bool		needMotion;
+
+			needMotion = !cdbpathlocus_collocates(root, current_locus,
+												  distinct_dist_keys, false /* exact_match */ );
 
 			/* Apply the preunique optimization, if enabled and worthwhile. */
 			if (root->config->gp_enable_preunique && needMotion)
@@ -2030,10 +2039,16 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 
 			if (needMotion)
 			{
-				result_plan = (Plan *) make_motion_hash(root, result_plan, distinctExprs);
+				if (distinct_dist_exprs)
+				{
+					result_plan = (Plan *) make_motion_hash(root, result_plan, distinct_dist_exprs);
+					current_pathkeys = NIL;		/* Any pre-existing order now lost. */
+				}
+				else
+				{
+					result_plan = (Plan *) make_motion_gather(result_plan, -1, true);
+				}
 				result_plan->total_cost += motion_cost_per_row * result_plan->plan_rows;
-				current_pathkeys = NULL;		/* Any pre-existing order now
-												 * lost. */
 			}
 		}
 		else if ( result_plan->flow->flotype == FLOW_SINGLETON )

--- a/src/include/optimizer/paths.h
+++ b/src/include/optimizer/paths.h
@@ -209,6 +209,9 @@ extern List *make_pathkeys_for_sortclauses(PlannerInfo *root,
 							  bool canonicalize);
 extern void cache_mergeclause_eclasses(PlannerInfo *root,
 						   RestrictInfo *restrictinfo);
+extern void make_distribution_keys_for_groupclause(PlannerInfo *root, List *groupclause, List *tlist,
+									   List **partition_dist_keys,
+									   List **partition_dist_exprs);
 extern List *find_mergeclauses_for_pathkeys(PlannerInfo *root,
 							   List *pathkeys,
 							   bool outer_keys,

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1559,6 +1559,45 @@ EXPLAIN SELECT count(unnest(foo)) FROM tbl_agg_srf;
 
 SELECT count(unnest(foo)) FROM tbl_agg_srf;
 ERROR:  set-valued function called in context that cannot accept a set  (seg0 slice1 127.0.0.1:25432 pid=43830)
+-- Test cases where the planner would like to distribute on a column, to implement
+-- grouping or distinct, but can't because the datatype isn't GPDB-hashable.
+-- These are all variants of the the same issue; all of these used to miss the
+-- check on whether the column is GPDB_hashble, producing an assertion failure.
+create table int2vectortab (distkey int, t int2vector) distributed by (distkey);
+insert into int2vectortab values
+  (1, '1'),
+  (2, '1 2'),
+  (3, '1 2 3'),
+  (22,'22'),
+  (22,'1 2');
+select distinct t from int2vectortab group by distkey, t;
+   t   
+-------
+ 1
+ 1 2
+ 1 2 3
+ 22
+(4 rows)
+
+select * from int2vectortab union select * from int2vectortab;
+ distkey |   t   
+---------+-------
+       1 | 1
+       2 | 1 2
+       3 | 1 2 3
+      22 | 1 2
+      22 | 22
+(5 rows)
+
+-- This is currently broken on 5X_STABLE, although it's been fixed in master.
+-- See https://github.com/greenplum-db/gpdb/issues/5662
+--
+-- start_matchsubs
+-- m/ERROR:.*\(cdbmutate\.c\:\d+\)/
+-- s/\(cdbmutate\.c:\d+\)//
+-- end_matchsubs
+select count(*) over (partition by t) from int2vectortab;
+ERROR:  cannot use expression as distribution key, because it is not hashable (cdbmutate.c:1329)
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1558,6 +1558,53 @@ EXPLAIN SELECT count(unnest(foo)) FROM tbl_agg_srf;
 
 SELECT count(unnest(foo)) FROM tbl_agg_srf;
 ERROR:  set-valued function called in context that cannot accept a set  (seg1 slice1 127.0.0.1:25433 pid=43559)
+-- Test cases where the planner would like to distribute on a column, to implement
+-- grouping or distinct, but can't because the datatype isn't GPDB-hashable.
+-- These are all variants of the the same issue; all of these used to miss the
+-- check on whether the column is GPDB_hashble, producing an assertion failure.
+create table int2vectortab (distkey int, t int2vector) distributed by (distkey);
+insert into int2vectortab values
+  (1, '1'),
+  (2, '1 2'),
+  (3, '1 2 3'),
+  (22,'22'),
+  (22,'1 2');
+select distinct t from int2vectortab group by distkey, t;
+   t   
+-------
+ 1
+ 1 2
+ 1 2 3
+ 22
+(4 rows)
+
+select * from int2vectortab union select * from int2vectortab;
+ distkey |   t   
+---------+-------
+       1 | 1
+       2 | 1 2
+       3 | 1 2 3
+      22 | 1 2
+      22 | 22
+(5 rows)
+
+-- This is currently broken on 5X_STABLE, although it's been fixed in master.
+-- See https://github.com/greenplum-db/gpdb/issues/5662
+--
+-- start_matchsubs
+-- m/ERROR:.*\(cdbmutate\.c\:\d+\)/
+-- s/\(cdbmutate\.c:\d+\)//
+-- end_matchsubs
+select count(*) over (partition by t) from int2vectortab;
+ count 
+-------
+     1
+     1
+     1
+     2
+     2
+(5 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1383,6 +1383,31 @@ CREATE TABLE tbl_agg_srf (foo int[]) DISTRIBUTED RANDOMLY;
 INSERT INTO tbl_agg_srf VALUES (array[1,2,3]);
 EXPLAIN SELECT count(unnest(foo)) FROM tbl_agg_srf;
 SELECT count(unnest(foo)) FROM tbl_agg_srf;
+
+-- Test cases where the planner would like to distribute on a column, to implement
+-- grouping or distinct, but can't because the datatype isn't GPDB-hashable.
+-- These are all variants of the the same issue; all of these used to miss the
+-- check on whether the column is GPDB_hashble, producing an assertion failure.
+create table int2vectortab (distkey int, t int2vector) distributed by (distkey);
+insert into int2vectortab values
+  (1, '1'),
+  (2, '1 2'),
+  (3, '1 2 3'),
+  (22,'22'),
+  (22,'1 2');
+
+select distinct t from int2vectortab group by distkey, t;
+select * from int2vectortab union select * from int2vectortab;
+-- This is currently broken on 5X_STABLE, although it's been fixed in master.
+-- See https://github.com/greenplum-db/gpdb/issues/5662
+--
+-- start_matchsubs
+-- m/ERROR:.*\(cdbmutate\.c\:\d+\)/
+-- s/\(cdbmutate\.c:\d+\)//
+-- end_matchsubs
+select count(*) over (partition by t) from int2vectortab;
+
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;


### PR DESCRIPTION
Be more careful to not build a Redistribute Motion on an expression that's
not GPDB-hashable.

This is a backport of commit a031b9c014 from master. It did not apply
cleanly to 5X_STABLE, which is why this leaves one of the test queries
still failing, but now with a clean elog() rather than an assertion
failure. The error message is memorized in the output, and opened a
separate github issue to track it, but I'd like to get at least this much
pushed now.

See github issue https://github.com/greenplum-db/gpdb/issues/5662
