### PR TITLE
Add PG_PRINTF_ATTRIBUTE to 'report_progress' function, which deserves it.

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -684,7 +684,8 @@ void check_greenplum(void);
 
 /* reporting.c */
 
-void report_progress(ClusterInfo *cluster, progress_type op, char *fmt,...);
+void report_progress(ClusterInfo *cluster, progress_type op, char *fmt,...)
+__attribute__((format(PG_PRINTF_ATTRIBUTE, 3, 4)));
 void close_progress(void);
 
 /*


### PR DESCRIPTION
My compiler is telling me that we should do this, and I agree:

```
reporting.c: In function ‘report_progress’:
reporting.c:84:2: warning: function might be possible candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
  vsnprintf(message, sizeof(message), fmt, args);
  ^~~~~~~~~
```