### PR TITLE
Avoid unnecessary float8 to int8 conversion.

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -556,7 +556,7 @@ CloseWritableFileSeg(AppendOnlyInsertDesc aoInsertDesc)
 
 	elogif(Debug_appendonly_print_insert, LOG,
 		   "Append-only scan closed write file segment #%d for table %s "
-		   "(file length " INT64_FORMAT ", insert count %f, VarBlock count %f",
+		   "(file length " INT64_FORMAT ", insert count " INT64_FORMAT ", VarBlock count " INT64_FORMAT,
 		   aoInsertDesc->cur_segno,
 		   NameStr(aoInsertDesc->aoi_rel->rd_rel->relname),
 		   fileLen,

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -30,6 +30,7 @@
 #include "miscadmin.h"
 #include "storage/lmgr.h"
 #include "utils/builtins.h"
+#include "utils/int8.h"
 #include "utils/lsyscache.h"
 #include "utils/snapmgr.h"
 
@@ -1370,8 +1371,7 @@ GetTotalTupleCountFromSegments(Relation parentrel,
 							 i, sqlstmt.data);
 
 					value = PQgetvalue(pgresult, j, 0);
-					tupcount = DatumGetFloat8(
-											  DirectFunctionCall1(float8in, CStringGetDatum(value)));
+					tupcount = DatumGetInt64(DirectFunctionCall1(int8in, CStringGetDatum(value)));
 					value = PQgetvalue(pgresult, j, 1);
 					segno = pg_atoi(value, sizeof(int32), 0);
 					total_tupcount[segno] += tupcount;

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -35,7 +35,6 @@
 
 #include "access/appendonlytid.h"
 
-#include "cdb/cdbvarblock.h"
 #include "cdb/cdbbufferedappend.h"
 #include "cdb/cdbbufferedread.h"
 #include "cdb/cdbvarblock.h"
@@ -66,8 +65,8 @@ typedef struct AppendOnlyInsertDescData
 	File			appendFile;
 	int				appendFilePathNameMaxLen;
 	char			*appendFilePathName;
-	float8			insertCount;
-	float8			varblockCount;
+	int64			insertCount;
+	int64			varblockCount;
 	int64           rowCount; /* total row count before insert */
 	int64           numSequences; /* total number of available sequences */
 	int64           lastSequence; /* last used sequence */


### PR DESCRIPTION
Commit 0948e878f77 changed the datatype of pg_aoseg_<oid>.tupcount tables
from float8 to int8, but we missed that in this one query.