### PR TITLE
Fix quoting bug in dispatching ALTER DATABASE CONNECTION LIMIT.

### DIFF
--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -1550,17 +1550,16 @@ AlterDatabase(AlterDatabaseStmt *stmt, bool isTopLevel)
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		StringInfoData buffer;
+		char	   *cmd;
 
-		initStringInfo(&buffer);
-		appendStringInfo(&buffer, "ALTER DATABASE \"%s\" CONNECTION LIMIT %d",
-						 stmt->dbname, connlimit);
+		cmd = psprintf("ALTER DATABASE %s CONNECTION LIMIT %d",
+					   quote_identifier(stmt->dbname), connlimit);
 
-		CdbDispatchCommand(buffer.data,
-							DF_NEED_TWO_PHASE|
-							DF_WITH_SNAPSHOT,
-							NULL);
-		pfree(buffer.data);
+		CdbDispatchCommand(cmd,
+						   DF_NEED_TWO_PHASE|
+						   DF_WITH_SNAPSHOT,
+						   NULL);
+		pfree(cmd);
 	}
 }
 

--- a/src/test/regress/expected/connection_limits.out
+++ b/src/test/regress/expected/connection_limits.out
@@ -1,0 +1,35 @@
+--
+-- Test CONNECTION LIMITs on databases.
+--
+drop database if exists limitdb;
+NOTICE:  database "limitdb" does not exist, skipping
+drop database if exists "limit_evil_'""_db";
+NOTICE:  database "limit_evil_'"_db" does not exist, skipping
+drop user if exists connlimit_test_user;
+NOTICE:  role "connlimit_test_user" does not exist, skipping
+create database limitdb connection limit 1;
+alter database limitdb connection limit 2;
+select datconnlimit from pg_database where datname='limitdb';
+ datconnlimit 
+--------------
+            2
+(1 row)
+
+-- Test that the limit works.
+alter database limitdb connection limit 0;
+create user connlimit_test_user; -- superusers are exempt from limits
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+-- should fail, because the connection limit is 0
+\! psql limitdb -c "select 'connected'" -U connlimit_test_user
+psql: FATAL:  too many connections for database "limitdb"
+drop user connlimit_test_user;
+-- Test ALTER DATABASE with funny characters. (There used to be a quoting
+-- bug in dispatching ALTER DATABASE .. CONNECTION LIMIT.)
+alter database limitdb rename to "limit_evil_'""_db";
+alter database "limit_evil_'""_db" connection limit 3;
+select datname, datconnlimit from pg_database where datname like 'limit%db';
+     datname      | datconnlimit 
+------------------+--------------
+ limit_evil_'"_db |            3
+(1 row)
+

--- a/src/test/regress/sql/connection_limits.sql
+++ b/src/test/regress/sql/connection_limits.sql
@@ -1,0 +1,27 @@
+--
+-- Test CONNECTION LIMITs on databases.
+--
+
+drop database if exists limitdb;
+drop database if exists "limit_evil_'""_db";
+drop user if exists connlimit_test_user;
+
+create database limitdb connection limit 1;
+alter database limitdb connection limit 2;
+select datconnlimit from pg_database where datname='limitdb';
+
+-- Test that the limit works.
+alter database limitdb connection limit 0;
+
+create user connlimit_test_user; -- superusers are exempt from limits
+
+-- should fail, because the connection limit is 0
+\! psql limitdb -c "select 'connected'" -U connlimit_test_user
+
+drop user connlimit_test_user;
+
+-- Test ALTER DATABASE with funny characters. (There used to be a quoting
+-- bug in dispatching ALTER DATABASE .. CONNECTION LIMIT.)
+alter database limitdb rename to "limit_evil_'""_db";
+alter database "limit_evil_'""_db" connection limit 3;
+select datname, datconnlimit from pg_database where datname like 'limit%db';


### PR DESCRIPTION
Add test case for it. We don't seem to have any tests for connection limits,
so add a minimal test that the limit works, while we're at it.