### PR TITLE
 Fix function return type confusion in parse_hba_line

### DIFF
--- a/src/backend/libpq/hba.c
+++ b/src/backend/libpq/hba.c
@@ -761,7 +761,7 @@ check_same_host_or_net(SockAddr *raddr, IPCompareMethod method)
 						authname, argname), \
 				 errcontext("line %d of configuration file \"%s\"", \
 						line_num, HbaFileName))); \
-		return false; \
+		return NULL; \
 	} \
 } while (0);
 

--- a/src/backend/libpq/hba.c
+++ b/src/backend/libpq/hba.c
@@ -1362,7 +1362,7 @@ parse_hba_line(List *line, int line_num)
 					 errmsg("cannot use 'ldaptls' or 'ldapport' with 'ldapserver' start with 'ldaps://'"),
 					 errcontext("line %d of configuration file \"%s\"",
 								line_num, HbaFileName)));
-			return false;
+			return NULL;
 
 		}
 	}


### PR DESCRIPTION
Upstream 9.2 commit e5e2fc842c4 changed the return type of `parse_hba_line` from bool to a pointer but at the time Alvaro didn't change a few macros that returned boolean. A `false` is an integral value of zero, and will be implicitly coerced to a null pointer. So this is functionally correct. But this is also a great source of future bugs. Fix them in this PR.

This fixes two warnings from Clang:

```
make: Entering directory '/home/csteam/workspace/gpdb/src/backend/libpq'
ccache clang-8 -O3 -std=gnu99  -Wall -Wmissing-prototypes -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-address -g -ggdb  -Werror=uninitialized -Werror=implicit-function-declaration -I../../../src/include -D_GNU_SOURCE -I/usr/include/libxml2  -I../../../src/interfaces/libpq -I../../../src/port  -c -o hba.o hba.c -MMD -MP -MF .deps/hba.Po
hba.c:1325:3: warning: expression which evaluates to zero treated as a null pointer constant of type 'HbaLine *' (aka 'struct HbaLine *') [-Wnon-literal-null-conversion]
                MANDATORY_AUTH_ARG(parsedline->ldapserver, "ldapserver", "ldap");
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
hba.c:764:10: note: expanded from macro 'MANDATORY_AUTH_ARG'
                return false; \
                       ^~~~~
../../../src/include/c.h:195:15: note: expanded from macro 'false'
#define false   ((bool) 0)
                ^~~~~~~~~~
hba.c:1365:11: warning: expression which evaluates to zero treated as a null pointer constant of type 'HbaLine *' (aka 'struct HbaLine *') [-Wnon-literal-null-conversion]
                        return false;
                               ^~~~~
../../../src/include/c.h:195:15: note: expanded from macro 'false'
#define false   ((bool) 0)
                ^~~~~~~~~~
hba.c:1372:3: warning: expression which evaluates to zero treated as a null pointer constant of type 'HbaLine *' (aka 'struct HbaLine *') [-Wnon-literal-null-conversion]
                MANDATORY_AUTH_ARG(parsedline->radiusserver, "radiusserver", "radius");
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
hba.c:764:10: note: expanded from macro 'MANDATORY_AUTH_ARG'
                return false; \
                       ^~~~~
../../../src/include/c.h:195:15: note: expanded from macro 'false'
#define false   ((bool) 0)
                ^~~~~~~~~~
hba.c:1373:3: warning: expression which evaluates to zero treated as a null pointer constant of type 'HbaLine *' (aka 'struct HbaLine *') [-Wnon-literal-null-conversion]
                MANDATORY_AUTH_ARG(parsedline->radiussecret, "radiussecret", "radius");
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
hba.c:764:10: note: expanded from macro 'MANDATORY_AUTH_ARG'
                return false; \
                       ^~~~~
../../../src/include/c.h:195:15: note: expanded from macro 'false'
#define false   ((bool) 0)
                ^~~~~~~~~~
hba.c:1378:3: warning: expression which evaluates to zero treated as a null pointer constant of type 'HbaLine *' (aka 'struct HbaLine *') [-Wnon-literal-null-conversion]
                MANDATORY_AUTH_ARG(parsedline->radiusserver, "radiusserver", "radius");
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
hba.c:764:10: note: expanded from macro 'MANDATORY_AUTH_ARG'
                return false; \
                       ^~~~~
../../../src/include/c.h:195:15: note: expanded from macro 'false'
#define false   ((bool) 0)
                ^~~~~~~~~~
hba.c:1379:3: warning: expression which evaluates to zero treated as a null pointer constant of type 'HbaLine *' (aka 'struct HbaLine *') [-Wnon-literal-null-conversion]
                MANDATORY_AUTH_ARG(parsedline->radiussecret, "radiussecret", "radius");
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
hba.c:764:10: note: expanded from macro 'MANDATORY_AUTH_ARG'
                return false; \
                       ^~~~~
../../../src/include/c.h:195:15: note: expanded from macro 'false'
#define false   ((bool) 0)
                ^~~~~~~~~~
6 warnings generated.
```