### PR TITLE
xlogdump should use page header to compute current record location

### DIFF
--- a/contrib/xlogdump/xlogdump_rmgr.c
+++ b/contrib/xlogdump/xlogdump_rmgr.c
@@ -20,6 +20,7 @@
 #include "commands/dbcommands.h"
 #include "cdb/cdbappendonlyam.h"
 #include "access/xlogmm.h"
+#include "access/xlog_internal.h"
 
 #if PG_VERSION_NUM >=90000
 #include "utils/relmapper.h"
@@ -279,6 +280,28 @@ print_rmgr_xlog(XLogRecPtr cur, XLogRecord *record, uint8 info, bool hideTimesta
 	case XLOG_FPW_CHANGE:
 	{
 		snprintf(buf, sizeof(buf), "full_page_write changed:");
+		break;
+	}
+#endif
+
+#if PG_VERSION_NUM >= 80300
+	case XLOG_HINT:
+	{
+		char		spaceName[NAMEDATALEN] = "";
+		char		dbName[NAMEDATALEN]    = "";
+		char		relName[NAMEDATALEN]   = "";
+		BkpBlock  bkb;
+		char *blk = XLogRecGetData(record);
+
+		memcpy(&bkb, blk, sizeof(BkpBlock));
+
+		getSpaceName(bkb.node.spcNode, spaceName, sizeof(spaceName));
+		getDbName(bkb.node.dbNode, dbName, sizeof(dbName));
+		getRelName(bkb.node.relNode, relName, sizeof(relName));
+
+		snprintf(buf, sizeof(buf), "xlog hint: bkpblock s/d/r:%s/%s/%s blk:%u hole_off/len:%u/%u",
+		         spaceName, dbName, relName,
+		         bkb.block, bkb.hole_offset, bkb.hole_length);
 		break;
 	}
 #endif


### PR DESCRIPTION
Previously, xlogdump would use segment ID obtained by parsing the xlog filename
to compute current record's logid and offset.  We came across at least one case
where this logic fails, leading to current xlog locations completely unrelated
to previous xlog location.  We found that this can happen during xlog recycle
when the segment will reuse previously allocated xlog segment files.  This
patch fixes the logic to use page start address recorded in header of each xlog
page.