### PR TITLE
Do not show \dr in psql backslash helper function

### DIFF
--- a/src/bin/psql/help.c
+++ b/src/bin/psql/help.c
@@ -167,7 +167,7 @@ slashUsage(unsigned short int pager)
 	if (currdb == NULL)
 		currdb = "";
 
-	output = PageOutput(94, pager);
+	output = PageOutput(97, pager);
 
 	/* if you add/remove a line here, change the row count above */
 
@@ -226,7 +226,6 @@ slashUsage(unsigned short int pager)
 	fprintf(output, _("  \\do[S]  [PATTERN]      list operators\n"));
 	fprintf(output, _("  \\dO[S+] [PATTERN]      list collations\n"));
 	fprintf(output, _("  \\dp     [PATTERN]      list table, view, and sequence access privileges\n"));
-	fprintf(output, _("  \\dr[S+] [PATTERN]      list foreign tables\n"));  /* GPDB Only */
 	fprintf(output, _("  \\drds [PATRN1 [PATRN2]] list per-database role settings\n"));
 	fprintf(output, _("  \\ds[S+] [PATTERN]      list sequences\n"));
 	fprintf(output, _("  \\dt[S+] [PATTERN]      list tables\n"));


### PR DESCRIPTION
Do not show usage of backslash command dr, since there is no implementation of the command.

Modify PageOutput lines 97 to correspond to real textual lines

`psql -c '\?'`
`\dr[S+] [PATTERN]      list foreign tables`

There is no implementation of `\dr[S+] [PATTERN]`, so should not show.