### PR TITLE
Remove ojscope_relids from RestrictInfo.

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -149,7 +149,7 @@ gen_implied_qual(PlannerInfo *root,
 		return;
 
 	/* No inferences may be performed across an outer join */
-	if (old_rinfo->ojscope_relids)
+	if (old_rinfo->outer_relids)
 		return;
 
 	/*
@@ -177,8 +177,7 @@ gen_implied_qual(PlannerInfo *root,
 								  old_rinfo->pseudoconstant,
 								  new_qualscope,
 								  old_rinfo->outer_relids,
-								  old_rinfo->nullable_relids,
-								  old_rinfo->ojscope_relids);
+								  old_rinfo->nullable_relids);
 	check_mergejoinable(new_rinfo);
 	check_hashjoinable(new_rinfo);
 

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -1150,8 +1150,7 @@ distribute_qual_to_rels(PlannerInfo *root, Node *clause,
 									 pseudoconstant,
 									 relids,
 									 outerjoin_nonnullable,
-									 nullable_relids,
-									 ojscope);
+									 nullable_relids);
 
 	/*
 	 * If it's a join clause (either naturally, or because delayed by
@@ -1658,8 +1657,7 @@ build_implied_join_equality(Oid opno,
 									 false,		/* pseudoconstant */
 									 qualscope,	/* required_relids */
 									 NULL,		/* outer_relids */
-									 nullable_relids,	/* nullable_relids */
-									 qualscope); /* ojscope_relids */
+									 nullable_relids);	/* nullable_relids */
 
 	/* Set mergejoinability/hashjoinability flags */
 	check_mergejoinable(restrictinfo);

--- a/src/backend/optimizer/plan/planpartition.c
+++ b/src/backend/optimizer/plan/planpartition.c
@@ -504,7 +504,6 @@ add_restrictinfos(PlannerInfo *root, DynamicScanInfo *dsinfo, Bitmapset *childre
 								  true,
 								  NULL,
 								  NULL,
-								  NULL,
 								  NULL);
 
 		relinfo->baserestrictinfo = lappend(relinfo->baserestrictinfo, rinfo);
@@ -527,7 +526,7 @@ make_mergeclause(Node *outer, Node *inner)
 
 	xpr = make_notclause((Expr *) opxpr);
 
-	rinfo = make_restrictinfo(xpr, false, false, false, NULL, NULL, NULL, NULL);
+	rinfo = make_restrictinfo(xpr, false, false, false, NULL, NULL, NULL);
 	rinfo->mergeopfamilies = get_mergejoin_opfamilies(opxpr->opno);
 
 	return rinfo;

--- a/src/backend/optimizer/util/restrictinfo.c
+++ b/src/backend/optimizer/util/restrictinfo.c
@@ -27,16 +27,14 @@ static RestrictInfo *make_restrictinfo_internal(Expr *clause,
 						   bool pseudoconstant,
 						   Relids required_relids,
 						   Relids outer_relids,
-						   Relids nullable_relids,
-						   Relids ojscope_relids);
+						   Relids nullable_relids);
 static Expr *make_sub_restrictinfos(Expr *clause,
 					   bool is_pushed_down,
 					   bool outerjoin_delayed,
 					   bool pseudoconstant,
 					   Relids required_relids,
 					   Relids outer_relids,
-					   Relids nullable_relids,
-					   Relids ojscope_relids);
+					   Relids nullable_relids);
 
 
 /*
@@ -61,8 +59,7 @@ make_restrictinfo(Expr *clause,
 				  bool pseudoconstant,
 				  Relids required_relids,
 				  Relids outer_relids,
-				  Relids nullable_relids,
-				  Relids ojscope_relids)
+				  Relids nullable_relids)
 {
 	/*
 	 * If it's an OR clause, build a modified copy with RestrictInfos inserted
@@ -75,8 +72,7 @@ make_restrictinfo(Expr *clause,
 													   pseudoconstant,
 													   required_relids,
 													   outer_relids,
-													   nullable_relids,
-													   ojscope_relids);
+													   nullable_relids);
 
 	/* Shouldn't be an AND clause, else AND/OR flattening messed up */
 	Assert(!and_clause((Node *) clause));
@@ -88,8 +84,7 @@ make_restrictinfo(Expr *clause,
 									  pseudoconstant,
 									  required_relids,
 									  outer_relids,
-									  nullable_relids,
-									  ojscope_relids);
+									  nullable_relids);
 }
 
 /*
@@ -237,7 +232,6 @@ make_restrictinfo_from_bitmapqual(Path *bitmapqual,
 													  false,
 													  NULL,
 													  NULL,
-													  NULL,
 													  NULL));
 		}
 	}
@@ -264,7 +258,6 @@ make_restrictinfo_from_bitmapqual(Path *bitmapqual,
 													   is_pushed_down,
 													   false,
 													   false,
-													   NULL,
 													   NULL,
 													   NULL,
 													   NULL));
@@ -327,7 +320,6 @@ make_restrictinfos_from_actual_clauses(PlannerInfo *root,
 								  pseudoconstant,
 								  NULL,
 								  NULL,
-								  NULL,
 								  NULL);
 		result = lappend(result, rinfo);
 	}
@@ -347,8 +339,7 @@ make_restrictinfo_internal(Expr *clause,
 						   bool pseudoconstant,
 						   Relids required_relids,
 						   Relids outer_relids,
-						   Relids nullable_relids,
-						   Relids ojscope_relids)
+						   Relids nullable_relids)
 {
 	RestrictInfo *restrictinfo = makeNode(RestrictInfo);
 
@@ -360,7 +351,6 @@ make_restrictinfo_internal(Expr *clause,
 	restrictinfo->can_join = false;		/* may get set below */
 	restrictinfo->outer_relids = outer_relids;
 	restrictinfo->nullable_relids = nullable_relids;
-	restrictinfo->ojscope_relids = ojscope_relids;
 
 	/**
 	 * If this is a IS NOT FALSE boolean test, we can peek underneath.
@@ -473,8 +463,7 @@ make_sub_restrictinfos(Expr *clause,
 					   bool pseudoconstant,
 					   Relids required_relids,
 					   Relids outer_relids,
-					   Relids nullable_relids,
-					   Relids ojscope_relids)
+					   Relids nullable_relids)
 {
 	if (or_clause((Node *) clause))
 	{
@@ -489,8 +478,7 @@ make_sub_restrictinfos(Expr *clause,
 													pseudoconstant,
 													NULL,
 													outer_relids,
-													nullable_relids,
-													ojscope_relids));
+													nullable_relids));
 		return (Expr *) make_restrictinfo_internal(clause,
 												   make_orclause(orlist),
 												   is_pushed_down,
@@ -498,8 +486,7 @@ make_sub_restrictinfos(Expr *clause,
 												   pseudoconstant,
 												   required_relids,
 												   outer_relids,
-												   nullable_relids,
-												   ojscope_relids);
+												   nullable_relids);
 	}
 	else if (and_clause((Node *) clause))
 	{
@@ -514,8 +501,7 @@ make_sub_restrictinfos(Expr *clause,
 													 pseudoconstant,
 													 required_relids,
 													 outer_relids,
-													 nullable_relids,
-													 ojscope_relids));
+													 nullable_relids));
 		return make_andclause(andlist);
 	}
 	else
@@ -526,8 +512,7 @@ make_sub_restrictinfos(Expr *clause,
 												   pseudoconstant,
 												   required_relids,
 												   outer_relids,
-												   nullable_relids,
-												   ojscope_relids);
+												   nullable_relids);
 }
 
 /*

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -1377,16 +1377,6 @@ typedef struct HashPath
  * (In short, is_pushed_down is only false for non-degenerate outer join
  * conditions.	Possibly we should rename it to reflect that meaning?)
  *
- * In GPDB, is an there is an additional field, "ojscope_relids". If
- * this clause is an outer join's JOIN/ON condition, "ojscope_relids" indicates
- * the extra relations that need to be in scope, independent of what appears
- * in the clause itself. In PostgreSQL, those are included in "required_relids",
- * but to do "predicate propagation" in GPDB, we need to preserve the original
- * ojscope relations. We might derive more RestrictInfos from this RestrictInfo,
- * with a modified clause, and must be careful to not push/pull the derived
- * RestrictInfos to places where the original RestrictInfo could not be legally
- * placed.
- *
  * RestrictInfo nodes also contain an outerjoin_delayed flag, which is true
  * if the clause's applicability must be delayed due to any outer joins
  * appearing below it (ie, it has to be postponed to some join level higher
@@ -1466,12 +1456,6 @@ typedef struct RestrictInfo
 
 	/* The set of relids required to evaluate the clause: */
 	Relids		required_relids;
-
-	/*
-	 * The set of relids required to evaluate the clause because this is an outer
-	 * join clause. required_relids is a union of this and clause_relids.
-	 */
-	Relids		ojscope_relids;
 
 	/* If an outer-join clause, the outer-side relations, else NULL: */
 	Relids		outer_relids;

--- a/src/include/optimizer/restrictinfo.h
+++ b/src/include/optimizer/restrictinfo.h
@@ -19,7 +19,7 @@
 
 /* Convenience macro for the common case of a valid-everywhere qual */
 #define make_simple_restrictinfo(clause)  \
-	make_restrictinfo(clause, true, false, false, NULL, NULL, NULL, NULL)
+	make_restrictinfo(clause, true, false, false, NULL, NULL, NULL)
 
 extern RestrictInfo *make_restrictinfo(Expr *clause,
 				  bool is_pushed_down,
@@ -27,8 +27,7 @@ extern RestrictInfo *make_restrictinfo(Expr *clause,
 				  bool pseudoconstant,
 				  Relids required_relids,
 				  Relids outer_relids,
-				  Relids nullable_relids,
-				  Relids ojscope_relids);
+				  Relids nullable_relids);
 extern List *make_restrictinfo_from_bitmapqual(Path *bitmapqual,
 								  bool is_pushed_down,
 								  bool include_predicates);


### PR DESCRIPTION
The only consumer of RestrictInfo->ojscope_relids is
gen_implied_qual(), to tell if RestrictInfo is an outer join clause.
RestrictInfo->outer_relids can be used to do the same job. So remove
ojscope_relids from RestrictInfo and from arguments of
make_restrictinfo(). PostgreSQL does not have ojscope_relids for
RestrictInfo.