### PR TITLE
Add missing GP_WRAP_START/END to gpdb::MakeGpPolicy.

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -3233,6 +3233,8 @@ gpdb::IsAbortRequested
 	void
 	)
 {
+	// No GP_WRAP_START/END needed here. We just check these global flags,
+	// it cannot throw an ereport().
 	return (QueryCancelPending || ProcDiePending);
 }
 
@@ -3244,6 +3246,10 @@ gpdb::MakeGpPolicy
                int nattrs
        )
 {
-       return makeGpPolicy(mcxt, ptype, nattrs);
+	GP_WRAP_START;
+	{
+		return makeGpPolicy(mcxt, ptype, nattrs);
+	}
+	GP_WRAP_END;
 }
 // EOF


### PR DESCRIPTION
makeGpPolicy() uses palloc(), which can throw an error, so wrappers are
needed. Also add a comment to gpdb:IsAbortRequested to explain why it
doesn't need wrappers. I suspect the missing wrappers in MakeGpPolicy()
happened because it was copy-pasted from IsAbortRequested.