### PR TITLE
Storage in listTables function does not show anything conditionally

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -3517,8 +3517,10 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 	if (isGPDB())   /* GPDB? */
 		appendPQExpBuffer(&buf,
 				  ", CASE c.relstorage WHEN 'h' THEN '%s' WHEN 'x' THEN '%s' WHEN 'a' "
-				  "THEN '%s' WHEN 'v' THEN '%s' WHEN 'c' THEN '%s' END as \"%s\"\n",
-				  gettext_noop("heap"), gettext_noop("external"), gettext_noop("append only"), gettext_noop("none"), gettext_noop("append only columnar"), gettext_noop("Storage"));
+				  "THEN '%s' WHEN 'v' THEN '%s' WHEN 'c' THEN '%s' WHEN 'p' THEN '%s' "
+				  "WHEN 'f' THEN '%s' END as \"%s\"\n",
+				  gettext_noop("heap"), gettext_noop("external"), gettext_noop("append only"), gettext_noop("none"), gettext_noop("append only columnar"), 
+				  gettext_noop("Apache Parquet"), gettext_noop("external data source"), gettext_noop("Storage"));
 
 	if (showIndexes)
 		appendPQExpBuffer(&buf,

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -3515,12 +3515,17 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 					  gettext_noop("Owner"));
 
 	if (isGPDB())   /* GPDB? */
-		appendPQExpBuffer(&buf,
-				  ", CASE c.relstorage WHEN 'h' THEN '%s' WHEN 'x' THEN '%s' WHEN 'a' "
-				  "THEN '%s' WHEN 'v' THEN '%s' WHEN 'c' THEN '%s' WHEN 'p' THEN '%s' "
-				  "WHEN 'f' THEN '%s' END as \"%s\"\n",
-				  gettext_noop("heap"), gettext_noop("external"), gettext_noop("append only"), gettext_noop("none"), gettext_noop("append only columnar"), 
-				  gettext_noop("Apache Parquet"), gettext_noop("external data source"), gettext_noop("Storage"));
+	{
+		appendPQExpBuffer(&buf, ", CASE c.relstorage");
+		appendPQExpBuffer(&buf, " WHEN 'h' THEN '%s'", gettext_noop("heap"));
+		appendPQExpBuffer(&buf, " WHEN 'x' THEN '%s'", gettext_noop("external"));
+		appendPQExpBuffer(&buf, " WHEN 'a' THEN '%s'", gettext_noop("append only"));
+		appendPQExpBuffer(&buf, " WHEN 'v' THEN '%s'", gettext_noop("none"));
+		appendPQExpBuffer(&buf, " WHEN 'c' THEN '%s'", gettext_noop("append only columnar"));
+		appendPQExpBuffer(&buf, " WHEN 'p' THEN '%s'", gettext_noop("Apache Parquet"));
+		appendPQExpBuffer(&buf, " WHEN 'f' THEN '%s'", gettext_noop("foreign"));
+		appendPQExpBuffer(&buf, " END as \"%s\"\n", gettext_noop("Storage"));
+	}
 
 	if (showIndexes)
 		appendPQExpBuffer(&buf,

--- a/src/include/catalog/pg_class.h
+++ b/src/include/catalog/pg_class.h
@@ -174,6 +174,8 @@ DESCR("");
  * RELSTORAGE_HEAP    - stored on disk using heap storage.
  * RELSTORAGE_AOROWS  - stored on disk using append only storage.
  * RELSTORAGE_AOCOLS  - stored on dist using append only column storage.
+ * RELSTORAGE_PARQUET - nested data structures in a flat columnar format,
+ * 						stores in any Hadoop ecosystem like Hive, Impala, Pig, and Spark.
  * RELSTORAGE_VIRTUAL - has virtual storage, meaning, relation has no
  *						data directly stored forit  (right now this
  *						relates to views and comp types).

--- a/src/include/catalog/pg_class.h
+++ b/src/include/catalog/pg_class.h
@@ -175,7 +175,7 @@ DESCR("");
  * RELSTORAGE_AOROWS  - stored on disk using append only storage.
  * RELSTORAGE_AOCOLS  - stored on dist using append only column storage.
  * RELSTORAGE_PARQUET - nested data structures in a flat columnar format,
- * 						stores in any Hadoop ecosystem like Hive, Impala, Pig, and Spark.
+ * 						stored in any Hadoop ecosystem like Hive, Impala, Pig, and Spark.
  * RELSTORAGE_VIRTUAL - has virtual storage, meaning, relation has no
  *						data directly stored forit  (right now this
  *						relates to views and comp types).

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -162,7 +162,7 @@ ALTER EXTERNAL TABLE "dE_external_table" OWNER TO test_psql_de_role;
  Schema |       Name        |     Type      |       Owner       | Storage  
 --------+-------------------+---------------+-------------------+----------
  public | dE_external_table | table         | test_psql_de_role | external
- public | dE_foreign_table  | foreign table | test_psql_de_role | 
+ public | dE_foreign_table  | foreign table | test_psql_de_role | foreign
 (2 rows)
 
 -- Clean up


### PR DESCRIPTION
Storage in listTables function does not show anything when 
the pg_catalog.pg_class's relstorage is 'p' or 'f'

Add comment for RELSTORAGE_PARQUET in pg_class.h

### Expected behavior
```
\dE+
                                        List of relations
 Schema | Name  |     Type      |      Owner      |       Storage        |  Size   | Description
--------+-------+---------------+-----------------+----------------------+---------+-------------
 public | pglog | foreign table | sbai_pivotal_io | external data source | 0 bytes |
(1 row)
```

### Actual behavior
```
\dE+
                                 List of relations
 Schema | Name  |     Type      |      Owner      | Storage |  Size   | Description
--------+-------+---------------+-----------------+---------+---------+-------------
 public | pglog | foreign table | sbai_pivotal_io |         | 0 bytes |
(1 row)
```

