### PR TITLE
Fix gpdbrestore to properly restore sequences during filtered restores

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
@@ -376,6 +376,51 @@ class GpRestoreFilterProcessLineTestCase(unittest.TestCase):
         self.assertFalse(newState.further_investigation_required)
         self.assertEqual(newState.schema, 'schemaICareAbout')
 
+    def test_sequence_owned_by_in_comments_exists_in_schema_file(self):
+        arguments = Arguments()
+        arguments.schemas_in_schema_file = ['schemaICareAbout']
+        state = ParserState()
+        state.schema = 'schemaICareAbout'
+        input_line = '-- Name: some_sequence; Type: SEQUENCE OWNED BY; Schema: schemaICareAbout; Owner: user_role_b;'
+
+        newState, line = process_line(state, input_line, arguments)
+
+        self.assertTrue(newState.output)
+        self.assertFalse(newState.function_ddl)
+        self.assertFalse(newState.further_investigation_required)
+        self.assertEquals(line, input_line)
+        self.assertEqual(newState.schema, 'schemaICareAbout')
+
+    def test_sequence_set_in_comments_exists_in_schema_file(self):
+        arguments = Arguments()
+        arguments.schemas_in_schema_file = ['schemaICareAbout']
+        state = ParserState()
+        state.schema = 'schemaICareAbout'
+        input_line = '-- Name: some_sequence; Type: SEQUENCE SET; Schema: schemaICareAbout; Owner: user_role_b;'
+
+        newState, line = process_line(state, input_line, arguments)
+
+        self.assertTrue(newState.output)
+        self.assertFalse(newState.function_ddl)
+        self.assertFalse(newState.further_investigation_required)
+        self.assertEquals(line, input_line)
+        self.assertEqual(newState.schema, 'schemaICareAbout')
+
+    def test_default_in_comments_exists_in_schema_file(self):
+        arguments = Arguments()
+        arguments.schemas_in_schema_file = ['schemaICareAbout']
+        state = ParserState()
+        state.schema = 'schemaICareAbout'
+        input_line = '-- Name: some_sequence; Type: DEFAULT; Schema: schemaICareAbout; Owner: user_role_b;'
+
+        newState, line = process_line(state, input_line, arguments)
+
+        self.assertTrue(newState.output)
+        self.assertFalse(newState.function_ddl)
+        self.assertFalse(newState.further_investigation_required)
+        self.assertEquals(line, input_line)
+        self.assertEqual(newState.schema, 'schemaICareAbout')
+
     def test_constraint_expression_in_comments_exists_in_table_file(self):
         arguments = Arguments(set(['schemaICareAbout']), set([('schemaICareAbout', 'table')]))
         arguments.schemas_in_schema_file = None

--- a/gpMgmt/bin/gprestore_filter.py
+++ b/gpMgmt/bin/gprestore_filter.py
@@ -205,6 +205,8 @@ def _handle_expressions_in_comments(state, line, arguments):
         elif data_type in ['CAST', 'PROCEDURAL LANGUAGE']:  # Restored to pg_catalog, so always filtered in
             state.output = True
             state.change_cast_func_schema = True  # When changing schemas, we need to ensure that functions used in casts reference the new schema
+        elif data_type in ['SEQUENCE OWNED BY', 'SEQUENCE SET', 'DEFAULT']:
+            state.output = check_valid_schema(state.schema, schemas_in_table_file, schemas_in_schema_file)
         return True, state, line
     return False, state, line
 


### PR DESCRIPTION
Previously, gpdbrestore was not restoring any ALTER statements related to sequences
during filtered restores. Now, the gprestore_filter script will properly output these statements.

This PR is specific to 5X, as gpdbrestore has been removed in master.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>