### PR TITLE
Rename cdb* functions and structures from explain_gp.c

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -538,8 +538,8 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
     if (es->analyze)
     {
         /* Attach workarea to QueryDesc so ExecSetParamPlan() can find it. */
-        queryDesc->showstatctx = cdbexplain_showExecStatsBegin(queryDesc,
-															   starttime);
+        queryDesc->showstatctx = gpexplain_showExecStatsBegin(queryDesc,
+															  starttime);
     }
 	else
 		queryDesc->showstatctx = NULL;
@@ -627,8 +627,8 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
      * Display per-slice and whole-query statistics.
      */
     if (es->analyze)
-        cdbexplain_showExecStatsEnd(queryDesc->plannedstmt, queryDesc->showstatctx,
-									queryDesc->estate, es);
+        gpexplain_showExecStatsEnd(queryDesc->plannedstmt, queryDesc->showstatctx,
+                                   queryDesc->estate, es);
 
     /*
 	 * Show non-default GUC settings that might have affected the plan as well
@@ -714,14 +714,14 @@ ExplainPrintPlan(ExplainState *es, QueryDesc *queryDesc)
 	if (es->analyze)
 	{
 		if (!es->currentSlice || sliceRunsOnQD(es->currentSlice))
-			cdbexplain_localExecStats(queryDesc->planstate, es->showstatctx);
+			gpexplain_localExecStats(queryDesc->planstate, es->showstatctx);
 
         /* Fill in the plan's Instrumentation with stats from qExecs. */
         if (estate->dispatcherState && estate->dispatcherState->primaryResults)
-            cdbexplain_recvExecStats(queryDesc->planstate,
-                                     estate->dispatcherState->primaryResults,
-                                     LocallyExecutingSliceIndex(estate),
-                                     es->showstatctx);
+			gpexplain_recvExecStats(queryDesc->planstate,
+									estate->dispatcherState->primaryResults,
+									LocallyExecutingSliceIndex(estate),
+									es->showstatctx);
 	}
 
 	ExplainNode(queryDesc->planstate, NIL, NULL, NULL, es);
@@ -1812,7 +1812,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 
     /* Show executor statistics */
 	if (planstate->instrument && planstate->instrument->need_cdb)
-		cdbexplain_showExecStats(planstate, es);
+		gpexplain_showExecStats(planstate, es);
 
 	/* Show buffer usage */
 	if (es->buffers && planstate->instrument)
@@ -2169,7 +2169,7 @@ show_sort_keys(SortState *sortstate, List *ancestors, ExplainState *es)
 static void
 show_sort_info(SortState *sortstate, ExplainState *es)
 {
-	CdbExplain_NodeSummary *ns;
+	GPExplain_NodeSummary *ns;
 	int			i;
 
 	if (!es->analyze)

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -93,7 +93,7 @@
 #include "cdb/cdbaocsam.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
-#include "cdb/cdbexplain.h"             /* cdbexplain_sendExecStats() */
+#include "cdb/cdbexplain.h"             /* gpexplain_sendExecStats() */
 #include "cdb/cdbplan.h"
 #include "cdb/cdbsrlz.h"
 #include "cdb/cdbsubplan.h"
@@ -1009,7 +1009,7 @@ standard_ExecutorRun(QueryDesc *queryDesc,
         {
             PG_TRY();
             {
-                cdbexplain_sendExecStats(queryDesc);
+                gpexplain_sendExecStats(queryDesc);
             }
             PG_CATCH();
             {
@@ -1208,7 +1208,7 @@ standard_ExecutorEnd(QueryDesc *queryDesc)
         estate->es_sliceTable->instrument_options &&
         (estate->es_sliceTable->instrument_options & INSTRUMENT_CDB) &&
         Gp_role == GP_ROLE_EXECUTE)
-        cdbexplain_sendExecStats(queryDesc);
+        gpexplain_sendExecStats(queryDesc);
 
 	/*
 	 * if needed, collect mpp dispatch results and tear down

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -30,7 +30,7 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "access/heapam.h"
-#include "cdb/cdbexplain.h"             /* cdbexplain_recvExecStats */
+#include "cdb/cdbexplain.h"             /* gpexplain_recvExecStats */
 #include "cdb/cdbvars.h"
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbdisp_query.h"
@@ -1166,9 +1166,9 @@ PG_TRY();
 		{
 			/* Jam stats into subplan's Instrumentation nodes. */
 			explainRecvStats = true;
-			cdbexplain_recvExecStats(planstate, ds->primaryResults,
-									 LocallyExecutingSliceIndex(queryDesc->estate),
-									 econtext->ecxt_estate->showstatctx);
+			gpexplain_recvExecStats(planstate, ds->primaryResults,
+									LocallyExecutingSliceIndex(queryDesc->estate),
+									econtext->ecxt_estate->showstatctx);
 		}
 
 		/* Main plan use same estate, must reset dispatcherState  */
@@ -1190,7 +1190,7 @@ PG_CATCH();
 	/* If EXPLAIN ANALYZE, collect local and distributed execution stats. */
 	if (planstate->instrument && planstate->instrument->need_cdb)
 	{
-		cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
+        gpexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
 		if (!explainRecvStats &&
 			shouldDispatch &&
 			queryDesc->estate->dispatcherState)
@@ -1198,10 +1198,10 @@ PG_CATCH();
 			/* Wait for all gangs to finish.  Cancel slowpokes. */
 			cdbdisp_cancelDispatch(queryDesc->estate->dispatcherState);
 
-			cdbexplain_recvExecStats(planstate,
-									 queryDesc->estate->dispatcherState->primaryResults,
-									 LocallyExecutingSliceIndex(queryDesc->estate),
-									 econtext->ecxt_estate->showstatctx);
+			gpexplain_recvExecStats(planstate,
+									queryDesc->estate->dispatcherState->primaryResults,
+									LocallyExecutingSliceIndex(queryDesc->estate),
+									econtext->ecxt_estate->showstatctx);
 		}
 	}
 
@@ -1240,7 +1240,7 @@ PG_END_TRY();
 
 	/* If EXPLAIN ANALYZE, collect local execution stats. */
 	if (planstate->instrument && planstate->instrument->need_cdb)
-		cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
+        gpexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
 
 	/* Restore memory high-water mark for root slice of main query. */
 	MemoryContextSetPeakSpace(planstate->state->es_query_cxt, savepeakspace);

--- a/src/backend/executor/test/nodeSubplan_test.c
+++ b/src/backend/executor/test/nodeSubplan_test.c
@@ -10,8 +10,8 @@
  * from explain.c. Since the mocker.py utility has trouble mocking this
  * structure, we include the relevant functions we need here instead.
  */
-void cdbexplain_localExecStats(struct PlanState *planstate,
-						  struct CdbExplain_ShowStatCtx *showstatctx)
+void gpexplain_localExecStats(struct PlanState *planstate,
+                              struct GPExplain_ShowStatCtx *showstatctx)
 {
 	check_expected(planstate);
 	check_expected(showstatctx);
@@ -19,10 +19,10 @@ void cdbexplain_localExecStats(struct PlanState *planstate,
 }
 
 void
-cdbexplain_recvExecStats(struct PlanState *planstate,
-						 struct CdbDispatchResults *dispatchResults,
-						 int sliceIndex,
-						 struct CdbExplain_ShowStatCtx *showstatctx)
+gpexplain_recvExecStats(struct PlanState *planstate,
+						struct CdbDispatchResults *dispatchResults,
+						int sliceIndex,
+						struct GPExplain_ShowStatCtx *showstatctx)
 {
 	check_expected(planstate);
 	check_expected(dispatchResults);
@@ -32,7 +32,7 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 }
 
 void
-cdbexplain_sendExecStats(QueryDesc *queryDesc)
+gpexplain_sendExecStats(QueryDesc *queryDesc)
 {
 	mock();
 }
@@ -99,9 +99,9 @@ test__ExecSetParamPlan__Check_Dispatch_Results(void **state)
 	/* Force SetupInterconnect to fail */
 	will_be_called_with_sideeffect(SetupInterconnect, &setupinterconnect_fail, NULL);
 
-	expect_any(cdbexplain_localExecStats,planstate);
-	expect_any(cdbexplain_localExecStats,showstatctx);
-	will_be_called(cdbexplain_localExecStats);
+	expect_any(gpexplain_localExecStats,planstate);
+	expect_any(gpexplain_localExecStats,showstatctx);
+	will_be_called(gpexplain_localExecStats);
 
 	expect_any(cdbdisp_cancelDispatch,ds);
 	will_be_called(cdbdisp_cancelDispatch);
@@ -109,11 +109,11 @@ test__ExecSetParamPlan__Check_Dispatch_Results(void **state)
 	expect_any(CdbDispatchHandleError, ds);
 	will_be_called(CdbDispatchHandleError);
 
-	expect_any(cdbexplain_recvExecStats,planstate);
-	expect_any(cdbexplain_recvExecStats,dispatchResults);
-	expect_any(cdbexplain_recvExecStats,sliceIndex);
-	expect_any(cdbexplain_recvExecStats,showstatctx);
-	will_be_called(cdbexplain_recvExecStats);
+	expect_any(gpexplain_recvExecStats,planstate);
+	expect_any(gpexplain_recvExecStats,dispatchResults);
+	expect_any(gpexplain_recvExecStats,sliceIndex);
+	expect_any(gpexplain_recvExecStats,showstatctx);
+	will_be_called(gpexplain_recvExecStats);
 
 	/* Catch PG_RE_THROW(); after cleaning with CdbCheckDispatchResult */
 	PG_TRY();

--- a/src/include/cdb/cdbexplain.h
+++ b/src/include/cdb/cdbexplain.h
@@ -24,7 +24,7 @@ struct PlanState;                       /* #include "nodes/execnodes.h" */
 struct QueryDesc;                       /* #include "executor/execdesc.h" */
 struct StringInfoData;                  /* #include "lib/stringinfo.h" */
 
-struct CdbExplain_ShowStatCtx;          /* private, in "cdb/cdbexplain.c" */
+struct GPExplain_ShowStatCtx;          /* private, in "cdb/cdbexplain.c" */
 struct PlannedStmt;
 
 static inline void
@@ -64,61 +64,61 @@ cdbexplain_agg_avg(CdbExplain_Agg *agg)
 
 
 /*
- * cdbexplain_localExecStats
+ * gpexplain_localExecStats
  *    Called by qDisp to build NodeSummary and SliceSummary blocks
  *    containing EXPLAIN ANALYZE statistics for a root slice that
  *    has been executed locally in the qDisp process.  Attaches these
  *    structures to the PlanState nodes' Instrumentation objects for
- *    later use by cdbexplain_showExecStats().
+ *    later use by gpexplain_showExecStats().
  *
  * 'planstate' is the top PlanState node of the slice.
- * 'showstatctx' is a CdbExplain_ShowStatCtx object which was created by
- *      calling cdbexplain_showExecStatsBegin().
+ * 'showstatctx' is a GPExplain_ShowStatCtx object which was created by
+ *      calling gpexplain_showExecStatsBegin().
  */
 void
-cdbexplain_localExecStats(struct PlanState                 *planstate,
-                          struct CdbExplain_ShowStatCtx    *showstatctx);
+gpexplain_localExecStats(struct PlanState *planstate,
+                         struct GPExplain_ShowStatCtx *showstatctx);
 
 /*
- * cdbexplain_sendExecStats
+ * gpexplain_sendExecStats
  *    Called by qExec process to send EXPLAIN ANALYZE statistics to qDisp.
  *    On the qDisp, libpq will attach this data to the PGresult object.
  */
 void
-cdbexplain_sendExecStats(struct QueryDesc *queryDesc);
+gpexplain_sendExecStats(struct QueryDesc *queryDesc);
 
 /*
- * cdbexplain_recvExecStats
+ * gpexplain_recvExecStats
  *    Called by qDisp to transfer a slice's EXPLAIN ANALYZE statistics
  *    from the CdbDispatchResults structures to the PlanState tree.
  *    Recursively does the same for slices that are descendants of the
  *    one specified.
  *
- * 'showstatctx' is a CdbExplain_ShowStatCtx object which was created by
- *      calling cdbexplain_showExecStatsBegin().
+ * 'showstatctx' is a GPExplain_ShowStatCtx object which was created by
+ *      calling gpexplain_showExecStatsBegin().
  */
 void
-cdbexplain_recvExecStats(struct PlanState              *planstate,
-                         struct CdbDispatchResults     *dispatchResults,
-                         int                            sliceIndex,
-                         struct CdbExplain_ShowStatCtx *showstatctx);
+gpexplain_recvExecStats(struct PlanState *planstate,
+                        struct CdbDispatchResults *dispatchResults,
+                        int sliceIndex,
+                        struct GPExplain_ShowStatCtx *showstatctx);
 
 /*
- * cdbexplain_showExecStatsBegin
- *    Called by qDisp process to create a CdbExplain_ShowStatCtx structure
+ * gpexplain_showExecStatsBegin
+ *    Called by qDisp process to create a GPExplain_ShowStatCtx structure
  *    in which to accumulate overall statistics for a query.
  *
  * 'explaincxt' is a MemoryContext from which to allocate the ShowStatCtx as
  *      well as any needed buffers and the like.  The explaincxt ptr is saved
  *      in the ShowStatCtx.  The caller is expected to reset or destroy the
- *      explaincxt not too long after calling cdbexplain_showExecStatsEnd(); so
+ *      explaincxt not too long after calling gpexplain_showExecStatsEnd(); so
  *      we don't bother to pfree() memory that we allocate from this context.
  * 'querystarttime' is the timestamp of the start of the query, in a
  *      platform-dependent format.
  */
-struct CdbExplain_ShowStatCtx *
-cdbexplain_showExecStatsBegin(struct QueryDesc *queryDesc,
-                              instr_time        querystarttime);
+struct GPExplain_ShowStatCtx *
+gpexplain_showExecStatsBegin(struct QueryDesc *queryDesc,
+                             instr_time querystarttime);
 
 
 

--- a/src/include/commands/explain.h
+++ b/src/include/commands/explain.h
@@ -41,7 +41,7 @@ typedef struct ExplainState
 	List	   *grouping_stack; /* format-specific grouping state */
 
     /* CDB */
-    struct CdbExplain_ShowStatCtx  *showstatctx;    /* EXPLAIN ANALYZE info */
+    struct GPExplain_ShowStatCtx  *showstatctx;    /* EXPLAIN ANALYZE info */
     Slice          *currentSlice;   /* slice whose nodes we are visiting */
 
 	PlanState  *parentPlanState;

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -21,7 +21,7 @@
 #include "tcop/dest.h"
 #include "gpmon/gpmon.h"
 
-struct CdbExplain_ShowStatCtx;  /* private, in "cdb/cdbexplain.c" */
+struct GPExplain_ShowStatCtx;  /* private, in "cdb/cdbexplain.c" */
 
 
 /* GangType enumeration is used in several structures related to CDB
@@ -257,7 +257,7 @@ typedef struct QueryDesc
 	QueryDispatchDesc *ddesc;
 
 	/* CDB: EXPLAIN ANALYZE statistics */
-	struct CdbExplain_ShowStatCtx  *showstatctx;
+	struct GPExplain_ShowStatCtx  *showstatctx;
 
 	/* Gpmon */
 	gpmon_packet_t *gpmon_pkt;

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -20,7 +20,7 @@
 #include "utils/resowner.h"
 #include "storage/s_lock.h"
 
-struct CdbExplain_NodeSummary;          /* private def in cdb/cdbexplain.c */
+struct GPExplain_NodeSummary;          /* private def in cdb/cdbexplain.c */
 
 typedef struct BufferUsage
 {
@@ -81,7 +81,7 @@ typedef struct Instrumentation
 	const char *sortMethod;		/* CDB: Type of sort */
 	const char *sortSpaceType;	/* CDB: Sort space type (Memory / Disk) */
 	long		sortSpaceUsed;	/* CDB: Memory / Disk used by sort(KBytes) */
-	struct CdbExplain_NodeSummary *cdbNodeSummary;	/* stats from all qExecs */
+	struct GPExplain_NodeSummary *cdbNodeSummary;	/* stats from all qExecs */
 } Instrumentation;
 
 extern PGDLLIMPORT BufferUsage pgBufferUsage;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -33,7 +33,7 @@
  */
 #define InvalidPartitionSelectorId  0
 
-struct CdbExplain_ShowStatCtx;          /* private, in "cdb/cdbexplain.c" */
+struct GPExplain_ShowStatCtx;          /* private, in "cdb/cdbexplain.c" */
 struct ChunkTransportState;             /* #include "cdb/cdbinterconnect.h" */
 struct StringInfoData;                  /* #include "lib/stringinfo.h" */
 struct MemTupleBinding;
@@ -637,7 +637,7 @@ typedef struct EState
 	struct CdbDispatcherState *dispatcherState;
 
 	/* CDB: EXPLAIN ANALYZE statistics */
-	struct CdbExplain_ShowStatCtx  *showstatctx;
+	struct GPExplain_ShowStatCtx  *showstatctx;
 
 	/* CDB: partitioning state info */
 	PartitionState *es_partition_state;


### PR DESCRIPTION
All the functions cdb* were renamed to gp* and all the
structures Cdb* where renamed to GP*