### PR TITLE
Introduce optimizer guc to enable generating streaming material

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("2.71.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.72.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 2.71.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 2.72.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13405,7 +13405,7 @@ int
 main ()
 {
 
-return strncmp("2.71.", GPORCA_VERSION_STRING, 5);
+return strncmp("2.72.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13415,7 +13415,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 2.71.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 2.72.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v2.71.0@gpdb/stable
+orca/v2.72.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.71.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v2.72.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -310,6 +310,13 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] =
 		},
 
 		{
+		EopttraceMotionHazardHandling,
+		&optimizer_enable_streaming_material,
+		false,  // m_fNegate
+		GPOS_WSZ_LIT("Enable motion hazard handling during NLJ optimization and generate streaming material when appropriate")
+		},
+
+		{
 		EopttraceEnforceCorrelatedExecution,
 		&optimizer_enforce_subplans,
 		false,  // m_negate_param

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -388,6 +388,7 @@ bool		optimizer_enable_multiple_distinct_aggs;
 bool		optimizer_enable_direct_dispatch;
 bool		optimizer_enable_hashjoin_redistribute_broadcast_children;
 bool		optimizer_enable_broadcast_nestloop_outer_child;
+bool		optimizer_enable_streaming_material;
 bool		optimizer_enable_assert_maxonerow;
 bool		optimizer_enable_constant_expression_evaluation;
 bool		optimizer_enable_bitmapscan;
@@ -2665,6 +2666,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_broadcast_nestloop_outer_child,
+		true,
+		NULL, NULL, NULL
+	},
+	{
+		{"optimizer_enable_streaming_material", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable plans with a streaming material node in the optimizer."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_streaming_material,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -445,6 +445,7 @@ extern bool optimizer_enable_outerjoin_rewrite;
 extern bool optimizer_enable_multiple_distinct_aggs;
 extern bool optimizer_enable_hashjoin_redistribute_broadcast_children;
 extern bool optimizer_enable_broadcast_nestloop_outer_child;
+extern bool optimizer_enable_streaming_material;
 extern bool optimizer_enable_assert_maxonerow;
 extern bool optimizer_enable_constant_expression_evaluation;
 extern bool optimizer_enable_bitmapscan;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10628,6 +10628,54 @@ FROM   (SELECT *
      4
 (1 row)
 
+--
+-- Test to ensure that ORCA produces correct results with both blocking and
+-- streaming materialze as controlled by optimizer_enable_streaming_material
+-- GUC.
+--
+-- start_ignore
+create table t_outer (c1 integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t_inner (c2 integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_outer values (generate_series (1,10));
+insert into t_inner values (generate_series (1,300));
+-- end_ignore
+set optimizer_enable_streaming_material = on;
+select c1 from t_outer where not c1 =all (select c2 from t_inner);
+ c1 
+----
+  8
+  9
+ 10
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+(10 rows)
+
+set optimizer_enable_streaming_material = off;
+select c1 from t_outer where not c1 =all (select c2 from t_inner);
+ c1 
+----
+  8
+  9
+ 10
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+(10 rows)
+
+reset optimizer_enable_streaming_material;
 -- start_ignore
 drop table bar;
 -- end_ignore

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10690,6 +10690,54 @@ FROM   (SELECT *
      4
 (1 row)
 
+--
+-- Test to ensure that ORCA produces correct results with both blocking and
+-- streaming materialze as controlled by optimizer_enable_streaming_material
+-- GUC.
+--
+-- start_ignore
+create table t_outer (c1 integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t_inner (c2 integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_outer values (generate_series (1,10));
+insert into t_inner values (generate_series (1,300));
+-- end_ignore
+set optimizer_enable_streaming_material = on;
+select c1 from t_outer where not c1 =all (select c2 from t_inner);
+ c1 
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(10 rows)
+
+set optimizer_enable_streaming_material = off;
+select c1 from t_outer where not c1 =all (select c2 from t_inner);
+ c1 
+----
+  8
+  9
+ 10
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+(10 rows)
+
+reset optimizer_enable_streaming_material;
 -- start_ignore
 drop table bar;
 ERROR:  table "bar" does not exist

--- a/src/test/regress/expected/segspace.out
+++ b/src/test/regress/expected/segspace.out
@@ -396,7 +396,7 @@ create table testsisc (i1 int, i2 int, i3 int, i4 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into testsisc select i, i % 1000, i % 100000, i % 75 from generate_series(0,1000000) i;
-set statement_mem="1MB";
+set statement_mem="2MB";
 set gp_enable_mk_sort=off;
 set gp_cte_sharing=on;
 drop table if exists foo;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1892,6 +1892,24 @@ FROM   (SELECT *
                code
         FROM   tab_3)a;
 
+--
+-- Test to ensure that ORCA produces correct results with both blocking and
+-- streaming materialze as controlled by optimizer_enable_streaming_material
+-- GUC.
+--
+-- start_ignore
+create table t_outer (c1 integer);
+create table t_inner (c2 integer);
+insert into t_outer values (generate_series (1,10));
+insert into t_inner values (generate_series (1,300));
+-- end_ignore
+
+set optimizer_enable_streaming_material = on;
+select c1 from t_outer where not c1 =all (select c2 from t_inner);
+set optimizer_enable_streaming_material = off;
+select c1 from t_outer where not c1 =all (select c2 from t_inner);
+reset optimizer_enable_streaming_material;
+
 -- start_ignore
 drop table bar;
 -- end_ignore

--- a/src/test/regress/sql/segspace.sql
+++ b/src/test/regress/sql/segspace.sql
@@ -268,7 +268,7 @@ drop table if exists testsisc;
 create table testsisc (i1 int, i2 int, i3 int, i4 int);
 insert into testsisc select i, i % 1000, i % 100000, i % 75 from generate_series(0,1000000) i;
 
-set statement_mem="1MB";
+set statement_mem="2MB";
 set gp_enable_mk_sort=off;
 set gp_cte_sharing=on;
 


### PR DESCRIPTION
Previously, while optimizing nestloop joins, ORCA always generated a blocking materialize node `(cdb_strict=true)`. Though, this conservative nature ensured that the join node produced by ORCA will always be deadlock safe; we sometimes produced slow running plans.

Via [this](https://github.com/greenplum-db/gporca/pull/394) PR, ORCA will be capable of producing blocking materialize only when needed by detecting motion hazard in nestloop joins. A streaming material node will be produced when there is no motion hazard.

This commit adds a guc to control this behavior. When set to off, we fallback to old behavior of always producing a blocking materialize.

Also bump the `statement_mem` for a test in `segspace`. After this change, for the test query, we produce a streaming spool which changes the number of operator groups in memory quota calculation and query fails with: `ERROR:  insufficient memory reserved for statement`. Bump the statement_mem by 1MB to test the fault injection.

Signed-off-by: Abhijit Subramanya <asubramanya@pivotal.io>