### PR TITLE
Fix command tag in "COPY (SELECT ...) TO <file>".

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -6698,6 +6698,7 @@ copy_dest_receive(TupleTableSlot *slot, DestReceiver *self)
 
 	/* And send the data */
 	CopyOneRowTo(cstate, InvalidOid, slot_get_values(slot), slot_get_isnull(slot));
+	myState->processed++;
 }
 
 /*

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1172,3 +1172,20 @@ CREATE TABLE ao_copy(c int) WITH (appendonly=true);
 COPY ao_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
 COPY ao_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
 DROP TABLE ao_copy;
+
+--
+-- Test row counts
+--
+-- We have to disable QUIET mode for these, so that we get the command tags,
+-- like "COPY 10", in the output.
+\set QUIET off
+copy (select generate_series(1, 10)) to '/tmp/a';
+
+create temp table t (id int4);
+copy t from '/tmp/a';
+copy t to '/tmp/b';
+copy t to '/tmp/b<SEGID>' on segment;
+copy t from '/tmp/b<SEGID>' on segment;
+select count(*) from t;
+
+\set QUIET on

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1361,3 +1361,30 @@ CREATE TABLE ao_copy(c int) WITH (appendonly=true);
 COPY ao_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
 COPY ao_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
 DROP TABLE ao_copy;
+--
+-- Test row counts
+--
+-- We have to disable QUIET mode for these, so that we get the command tags,
+-- like "COPY 10", in the output.
+\set QUIET off
+copy (select generate_series(1, 10)) to '/tmp/a';
+COPY 10
+create temp table t (id int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE
+copy t from '/tmp/a';
+COPY 10
+copy t to '/tmp/b';
+COPY 10
+copy t to '/tmp/b<SEGID>' on segment;
+COPY 10
+copy t from '/tmp/b<SEGID>' on segment;
+COPY 10
+select count(*) from t;
+ count 
+-------
+    20
+(1 row)
+
+\set QUIET on


### PR DESCRIPTION
It used to always say "COPY 0", instead of the number of rows copied. This
source line was added in PostgreSQL 9.0 (commit 8ddc05fb01), but it was
missed in the merge. Add a test case to check the command tags of
different variants of COPY, including this one.