### PR TITLE
docs - ANALYZE command - HLL statistics, incremental analyze

### DIFF
--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -2,8 +2,9 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_gwc_jkd_3s">
   <title>About Database Statistics in Greenplum Database</title>
-  <shortdesc>An overview of statistics gathered by the <codeph>ANALYZE</codeph> command in Greenplum
-    Database.</shortdesc>
+  <shortdesc>An overview of statistics gathered by the <codeph><xref
+        href="../../ref_guide/sql_commands/ANALYZE.xml#topic1">ANALYZE</xref></codeph> command in
+    Greenplum Database.</shortdesc>
   <body>
     <p>Statistics are metadata that describe the data stored in the database. The query optimizer
       needs up-to-date statistics to choose the best execution plan for a query. For example, if a
@@ -61,13 +62,13 @@
               <pd>The object ID of the table or index the column belongs to.</pd>
             </plentry>
             <plentry>
-              <pt>staatnum</pt>
+              <pt>staattnum</pt>
               <pd>The number of the described column, beginning with 1.</pd>
             </plentry>
             <plentry>
               <pt>stainherit</pt>
-              <pd>If true, the statistics include inheritance child columns, not just the
-                values in the specified relation.</pd>
+              <pd>If true, the statistics include inheritance child columns, not just the values in
+                the specified relation.</pd>
             </plentry>
             <plentry>
               <pt>stanullfrac</pt>
@@ -101,14 +102,15 @@
             <plentry>
               <pt>stanumbers<i>N</i></pt>
               <pd>float4 array containing numerical statistics of the appropriate kind for the
-                  <i>N</i>th slot, or NULL if the slot kind does not involve numerical values.</pd>
+                  <i>N</i>th slot, or <codeph>NULL</codeph> if the slot kind does not involve
+                numerical values.</pd>
             </plentry>
             <plentry>
               <pt>stavalues<i>N</i></pt>
-              <pd>Column data values of the appropriate kind for the <i>N</i>th slot, or NULL if the
-                slot kind does not store any data values. Each array's element values are actually
-                of the specific column's data type, so there is no way to define these columns'
-                types more specifically than <i>anyarray</i>.</pd>
+              <pd>Column data values of the appropriate kind for the <i>N</i>th slot, or
+                  <codeph>NULL</codeph> if the slot kind does not store any data values. Each
+                array's element values are actually of the specific column's data type, so there is
+                no way to define these columns' types more specifically than <i>anyarray</i>.</pd>
             </plentry>
           </parml></p>
         <p>The statistics collected for a column vary for different data types, so the
@@ -120,7 +122,7 @@
         <p>The <codeph>stakind<varname>N</varname></codeph> columns each contain a numeric code to
           describe the type of statistics stored in their slot. The <codeph>stakind</codeph> code
           numbers from 1 to 99 are reserved for core PostgreSQL data types. Greenplum Database uses
-          code numbers 1, 2, and 3. A value of 0 means the slot is unused. The following table
+          code numbers 1, 2, 3, 4, and 5. A value of 0 means the slot is unused. The following table
           describes the kinds of statistics stored for the three codes.<table frame="all"
             id="table_upf_1yc_nt">
             <title>Contents of pg_statistic "slots"</title>
@@ -140,14 +142,14 @@
                     <ul id="ul_ipg_gyc_nt">
                       <li><codeph>staop</codeph> contains the object ID of the "=" operator, used to
                         decide whether values are the same or not.</li>
-                      <li><codeph>stavalues</codeph> contains an array of the <i>K</i> most common
-                        non-null values appearing in the column.</li>
+                      <li><codeph>stavalues</codeph> contains an array of the <varname>K</varname>
+                        most common non-null values appearing in the column.</li>
                       <li><codeph>stanumbers</codeph> contains the frequencies (fractions of total
                         row count) of the values in the <codeph>stavalues</codeph> array. </li>
                     </ul>The values are ordered in decreasing frequency. Since the arrays are
-                    variable-size, <i>K</i> can be chosen by the statistics collector. Values must
-                    occur more than once to be added to the <codeph>stavalues</codeph> array; a
-                    unique column has no MCV slot.</entry>
+                    variable-size, <varname>K</varname> can be chosen by the statistics collector.
+                    Values must occur more than once to be added to the <codeph>stavalues</codeph>
+                    array; a unique column has no MCV slot.</entry>
                 </row>
                 <row>
                   <entry>2</entry>
@@ -155,11 +157,13 @@
                       id="ul_t2f_zyc_nt">
                       <li><codeph>staop</codeph> is the object ID of the "&lt;" operator, which
                         describes the sort ordering. </li>
-                      <li><codeph>stavalues</codeph> contains <i>M</i> (where <i>M</i>>=2) non-null
-                        values that divide the non-null column data values into <i>M</i>-1 bins of
-                        approximately equal population. The first <codeph>stavalues</codeph> item is
-                        the minimum value and the last is the maximum value. </li>
-                      <li><codeph>stanumbers</codeph> is not used and should be null. </li>
+                      <li><codeph>stavalues</codeph> contains <varname>M</varname> (where
+                            <codeph><varname>M</varname>>=2</codeph>) non-null values that divide
+                        the non-null column data values into <codeph><varname>M</varname>-1</codeph>
+                        bins of approximately equal population. The first <codeph>stavalues</codeph>
+                        item is the minimum value and the last is the maximum value. </li>
+                      <li><codeph>stanumbers</codeph> is not used and should be
+                          <codeph>NULL</codeph>. </li>
                     </ul><p>If a Most Common Values slot is also provided, then the histogram
                       describes the data distribution after removing the values listed in the MCV
                       array. (It is a <i>compressed histogram</i> in the technical parlance). This
@@ -175,11 +179,67 @@
                       id="ul_yvj_sfd_nt">
                       <li><codeph>staop</codeph> is the object ID of the "&lt;" operator. As with
                         the histogram, more than one entry could theoretically appear.</li>
-                      <li><codeph>stavalues</codeph> is not used and should be NULL. </li>
+                      <li><codeph>stavalues</codeph> is not used and should be
+                        <codeph>NULL</codeph>. </li>
                       <li><codeph>stanumbers</codeph> contains a single entry, the correlation
                         coefficient between the sequence of data values and the sequence of their
                         actual tuple positions. The coefficient ranges from +1 to -1.</li>
                     </ul></entry>
+                </row>
+                <row>
+                  <entry>4</entry>
+                  <entry><i>Most Common Elements Slot</i> - is similar to a Most Common Values (MCV)
+                    Slot, except that it stores the most common non-null <i>elements</i> of the
+                    column values. This is useful when the column datatype is an array or some other
+                    type with identifiable elements (for instance, <codeph>tsvector</codeph>). <ul
+                      id="ul_kj4_wnm_y2b">
+                      <li><codeph>staop</codeph> contains the equality operator appropriate to the
+                        element type. </li>
+                      <li><codeph>stavalues</codeph> contains the most common element values.</li>
+                      <li><codeph>stanumbers</codeph> contains common element frequencies. </li>
+                    </ul><p>Frequencies are measured as the fraction of non-null rows the element
+                      value appears in, not the frequency of all rows. Also, the values are sorted
+                      into the element type's default order (to support binary search for a
+                      particular value). Since this puts the minimum and maximum frequencies at
+                      unpredictable spots in <codeph>stanumbers</codeph>, there are two extra
+                      members of <codeph>stanumbers</codeph> that hold copies of the minimum and
+                      maximum frequencies. Optionally, there can be a third extra member that holds
+                      the frequency of null elements (the frequency is expressed in the same terms:
+                      the fraction of non-null rows that contain at least one null element). If this
+                      member is omitted, the column is presumed to contain no <codeph>NULL</codeph>
+                      elements. </p>
+                    <note>For <codeph>tsvector</codeph> columns, the <codeph>stavalues</codeph>
+                      elements are of type <codeph>text</codeph>, even though their representation
+                      within <codeph>tsvector</codeph> is not exactly
+                    <codeph>text</codeph>.</note></entry>
+                </row>
+                <row>
+                  <entry>5</entry>
+                  <entry><i>Distinct Elements Count Histogram Slot</i> - describes the distribution
+                    of the number of distinct element values present in each row of an array-type
+                    column. Only non-null rows are considered, and only non-null elements.<ul
+                      id="ul_gmr_jnm_y2b">
+                      <li><codeph>staop</codeph> contains the equality operator appropriate to the
+                        element type. </li>
+                      <li><codeph>stavalues</codeph> is not used and should be
+                        <codeph>NULL</codeph>. </li>
+                      <li><codeph>stanumbers</codeph> contains information about distinct elements.
+                        The last member of <codeph>stanumbers</codeph> is the average count of
+                        distinct element values over all non-null rows. The preceding
+                          <varname>M</varname> (where <codeph><varname>M</varname> >=2</codeph>)
+                        members form a histogram that divides the population of distinct-elements
+                        counts into <codeph><varname>M</varname>-1</codeph> bins of approximately
+                        equal population. The first of these is the minimum observed count, and the
+                        last the maximum.</li>
+                    </ul></entry>
+                </row>
+                <row>
+                  <entry>99</entry>
+                  <entry><i>Hyperloglog Slot</i> - for child leaf partitions of a partitioned table,
+                    stores the <codeph>hyperloglog_counter</codeph> created for sampled data. The
+                      <codeph>hyperloglog_counter</codeph> data structure is converted into a
+                      <codeph>bytea</codeph> and stored in a <codeph>stavalues5</codeph> slot of the
+                      <codeph>pg_statistic</codeph> catalog table.</entry>
                 </row>
               </tbody>
             </tgroup>
@@ -251,6 +311,20 @@
               <dt>correlation</dt>
               <dd>Greenplum Database does not calculate the correlation statistic. </dd>
             </dlentry>
+            <dlentry>
+              <dt>most_common_elems</dt>
+              <dd>An array that contains the most common element values.</dd>
+            </dlentry>
+          </dl><dl>
+            <dlentry>
+              <dt>most_common_elem_freqs</dt>
+              <dd>An array that contains common element frequencies.</dd>
+            </dlentry>
+            <dlentry>
+              <dt>elem_count_histogram</dt>
+              <dd>An array that describes the distribution of the number of distinct element values
+                present in each row of an array-type column. </dd>
+            </dlentry>
           </dl></p>
         <p>Newly created tables and indexes have no statistics. You can check for tables with
           missing statistics using the <codeph>gp_stats_missing</codeph> view, which is in the
@@ -289,13 +363,11 @@
         <p>Refer to the <i>Greenplum Database Management Utility Reference</i> for details of
           running the <codeph>analyzedb</codeph> command.</p>
       </section>
-      <section id="section_cv2_crv_mt">
-        <title>Analyzing Partitioned and Append-Optimized Tables</title>
-        <p>When the <codeph>ANALYZE</codeph> command is run on a partitioned table, it analyzes each
-          leaf-level subpartition, one at a time. You can run <codeph>ANALYZE</codeph> on just new
-          or changed partition files to avoid analyzing partitions that have not changed. If a table
-          is partitioned, you can analyze just new or changed partitions. </p>
-        <p>The <codeph>analyzedb</codeph> command-line utility skips unchanged partitions
+      <section id="section_cv2_crv_mt"><title>Analyzing Partitioned Tables</title><p>When the
+            <codeph>ANALYZE</codeph> command is run on a partitioned table, it analyzes each child
+          leaf partition table, one at a time. You can run <codeph>ANALYZE</codeph> on just new or
+          changed partition files to avoid analyzing partitions that have not changed. </p><p>The
+            <codeph>analyzedb</codeph> command-line utility skips unchanged partitions
           automatically. It also runs concurrent sessions so it can analyze several partitions
           concurrently. It runs five sessions by default, but the number of sessions can be set from
           1 to 10 with the <codeph>-p</codeph> command-line option. Each time
@@ -303,21 +375,32 @@
           and partitions in the <codeph>db_analyze</codeph> directory in the master data directory.
           The next time it runs, <codeph>analyzedb</codeph> compares the current state of each table
           with the saved state and skips analyzing a table or partition if it is unchanged. Heap
-          tables are always analyzed. </p>
-        <p>If GPORCA is enabled (the default), you also need to run <codeph>ANALYZE
-            ROOTPARTITION</codeph> to refresh the root partition statistics. GPORCA requires
-          statistics at the root level for partitioned tables. The legacy optimizer does not use
-          these statistics. Enable GPORCA by setting both the <codeph>optimizer</codeph> and
-            <codeph>optimizer_analyze_root_partition</codeph> system configuration parameters to on.
-          The root level statistics are then updated when you run <codeph>ANALYZE</codeph> or
-            <codeph>ANALYZE ROOTPARTITION</codeph>. The time to run <codeph>ANALYZE
-            ROOTPARTITION</codeph> is similar to the time to analyze a non-partitioned table with
-          the same data since <codeph>ANALYZE ROOTPARTITION</codeph> does not collect statistics on
-          the leaf partitions, the data is only sampled. The <codeph>analyzedb</codeph> utility
-          updates root partition statistics by default but you can add the
-            <codeph>--skip_root_stats</codeph> option to leave root partition statistics empty if
-          you do not use GPORCA.</p>
-      </section>
+          tables are always analyzed. </p><p>If GPORCA is enabled (the default), you also need to
+          run <codeph>ANALYZE</codeph> or <codeph>ANALYZE ROOTPARTITION</codeph> to refresh the root
+          partition statistics. GPORCA requires statistics at the root level for partitioned tables.
+          The legacy optimizer does not use these statistics. </p><p>The time to analyze a
+          partitioned table is similar to the time to analyze a non-partitioned table with the same
+          data since <codeph>ANALYZE</codeph> does not collect statistics on the leaf partitions
+          (the data is only sampled). The <codeph>analyzedb</codeph> utility updates root partition
+          statistics by default but you can add the <codeph>--skip_root_stats</codeph> option to
+          leave root partition statistics empty if you do not use GPORCA. </p>The Greenplum Database
+        server configuration parameter <codeph><xref
+            href="../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
+            >optimizer_analyze_root_partition</xref></codeph> affects when statistics are collected
+        on the root partition of a partitioned table. If the parameter is <codeph>on</codeph> (the
+        default), the <codeph>ROOTPARTITION</codeph> keyword is not required to collect statistics
+        on the root partition when you run <codeph>ANALYZE</codeph>. Root partition statistics are
+        collected when you run <codeph>ANALYZE</codeph> on the root partition, or when you run
+          <codeph>ANALYZE</codeph> on a child leaf partition of the partitioned table and the other
+        child leaf partitions have statistics. If the parameter is <codeph>off</codeph>, you must
+        run <codeph>ANALZYE ROOTPARTITION</codeph> to collect root partition statistics.<p>If you do
+          not intend to execute queries on partitioned tables with GPORCA (setting the server
+          configuration parameter <codeph><xref
+              href="../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
+              >optimizer</xref></codeph> to <codeph>off</codeph>), you can also set the server
+          configuration parameter <codeph>optimizer_analyze_root_partition</codeph> to
+            <codeph>off</codeph> to limit when <codeph>ANALYZE</codeph> updates the root partition
+          statistics. </p></section>
       <section> </section>
     </body>
   </topic>

--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -236,8 +236,8 @@
                 <row>
                   <entry>99</entry>
                   <entry><i>Hyperloglog Slot</i> - for child leaf partitions of a partitioned table,
-                    stores the <codeph>hyperloglog_counter</codeph> created for sampled data. The
-                      <codeph>hyperloglog_counter</codeph> data structure is converted into a
+                    stores the <codeph>hyperloglog_counter</codeph> created for the sampled data.
+                    The <codeph>hyperloglog_counter</codeph> data structure is converted into a
                       <codeph>bytea</codeph> and stored in a <codeph>stavalues5</codeph> slot of the
                       <codeph>pg_statistic</codeph> catalog table.</entry>
                 </row>
@@ -380,11 +380,11 @@
           partition statistics. GPORCA requires statistics at the root level for partitioned tables.
           The legacy optimizer does not use these statistics. </p><p>The time to analyze a
           partitioned table is similar to the time to analyze a non-partitioned table with the same
-          data since <codeph>ANALYZE</codeph> does not collect statistics on the leaf partitions
-          (the data is only sampled). The <codeph>analyzedb</codeph> utility updates root partition
-          statistics by default but you can add the <codeph>--skip_root_stats</codeph> option to
-          leave root partition statistics empty if you do not use GPORCA. </p>The Greenplum Database
-        server configuration parameter <codeph><xref
+          data since <codeph>ANALYZE ROOTPARTITION</codeph> does not collect statistics on the leaf
+          partitions (the data is only sampled). The <codeph>analyzedb</codeph> utility updates root
+          partition statistics by default but you can add the <codeph>--skip_root_stats</codeph>
+          option to leave root partition statistics empty if you do not use GPORCA. </p>The
+        Greenplum Database server configuration parameter <codeph><xref
             href="../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
             >optimizer_analyze_root_partition</xref></codeph> affects when statistics are collected
         on the root partition of a partitioned table. If the parameter is <codeph>on</codeph> (the

--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -122,8 +122,8 @@
         <p>The <codeph>stakind<varname>N</varname></codeph> columns each contain a numeric code to
           describe the type of statistics stored in their slot. The <codeph>stakind</codeph> code
           numbers from 1 to 99 are reserved for core PostgreSQL data types. Greenplum Database uses
-          code numbers 1, 2, 3, 4, and 5. A value of 0 means the slot is unused. The following table
-          describes the kinds of statistics stored for the three codes.<table frame="all"
+          code numbers 1, 2, 3, 4, 5, and 99. A value of 0 means the slot is unused. The following
+          table describes the kinds of statistics stored for the three codes.<table frame="all"
             id="table_upf_1yc_nt">
             <title>Contents of pg_statistic "slots"</title>
             <tgroup cols="2">

--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -396,7 +396,7 @@
         run <codeph>ANALZYE ROOTPARTITION</codeph> to collect root partition statistics.<p>If you do
           not intend to execute queries on partitioned tables with GPORCA (setting the server
           configuration parameter <codeph><xref
-              href="../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
+              href="../../ref_guide/config_params/guc-list.xml#optimizer"
               >optimizer</xref></codeph> to <codeph>off</codeph>), you can also set the server
           configuration parameter <codeph>optimizer_analyze_root_partition</codeph> to
             <codeph>off</codeph> to limit when <codeph>ANALYZE</codeph> updates the root partition

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
@@ -85,7 +85,7 @@
     <body>
       <p>If you do not intend to execute queries on partitioned tables with GPORCA (setting the
         server configuration parameter <codeph><xref
-            href="../../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
+            href="../../../ref_guide/config_params/guc-list.xml#optimizer"
             >optimizer</xref></codeph> to <codeph>off</codeph>), then you can disable the automatic
         collection of statistics on the root partition of the partitioned table. The server
         configuration parameter <codeph><xref

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
@@ -10,18 +10,18 @@
     <p>If you execute queries on partitioned tables, you should collect statistics on the root
       partition and periodically update those statistics to ensure that GPORCA can generate optimal
       query plans. If the root partition statistics are not up-to-date or do not exist, GPORCA still
-      performs dynamic partition elimination for queries against the table However, the query plan
+      performs dynamic partition elimination for queries against the table. However, the query plan
       might not be optimal. </p>
   </body>
   <topic id="topic_w1y_srn_wbb">
     <title>Running ANALYZE</title>
     <body>
-      <p>By default, running the <codeph>ANALYZE</codeph> on the root partition of a partitioned
-        table samples the leaf partition data in a table, and stores the statistics for the root
-        partition. <codeph>ANALYZE</codeph> collects statistics on the root and leaf partitions,
-        including HLL statistics on the leaf partitions. <codeph>ANALYZE ROOTPARTITION</codeph>
-        collects statistics only on the root partition, the leaf partition data is only sampled. The
-        server configuration parameter <codeph><xref
+      <p>By default, running the <codeph>ANALYZE</codeph> command on the root partition of a
+        partitioned table samples the leaf partition data in the table, and stores the statistics
+        for the root partition. <codeph>ANALYZE</codeph> collects statistics on the root and leaf
+        partitions, including HyperLogLog (HLL) statistics on the leaf partitions. <codeph>ANALYZE
+          ROOTPARTITION</codeph> collects statistics only on the root partition. The server
+        configuration parameter <codeph><xref
             href="../../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
             >optimizer_analyze_root_partition</xref></codeph> controls whether the
           <codeph>ROOTPARTITION</codeph> keyword is required to collect root statistics for the root
@@ -37,9 +37,10 @@
         there are significant changes to leaf partition data.</p>
       <p>Follow these best practices for running <codeph>ANALYZE</codeph> or <codeph>ANALYZE
           ROOTPARTITION</codeph> on partitioned tables in your system:<ul id="ul_vm4_fsn_wbb">
-          <li>Always run <codeph>ANALYZE</codeph> or <codeph>ANALYZE ROOTPARTITION</codeph> at least
-            once for each newly-created partitioned table, after adding initial data. You can run
-              <codeph>ANALYZE</codeph> on a new or changed leaf partition. By default, the command
+          <li>Run <codeph>ANALYZE &lt;<varname>root_partition</varname>></codeph> on a new
+            partitioned table after adding initial data. Run <codeph>ANALYZE
+                &lt;<varname>leaf_partition</varname>></codeph> on a new leaf partition or a leaf
+            partition where data has changed. By default, running the command on a leaf partition
             updates the root partition statistics if the other leaf partitions have statistics.</li>
           <li>Update root partition statistics when you observe query performance regression in
               <codeph>EXPLAIN</codeph> plans against the table, or after significant changes to leaf
@@ -86,8 +87,8 @@
         server configuration parameter <codeph><xref
             href="../../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
             >optimizer</xref></codeph> to <codeph>off</codeph>), then you can disable the automatic
-        collect statistics on the root partition of the partitioned table. The server configuration
-        parameter <codeph><xref
+        collection of statistics on the root partition of the partitioned table. The server
+        configuration parameter <codeph><xref
             href="../../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
             >optimizer_analyze_root_partition</xref></codeph> controls whether the
           <codeph>ROOTPARTITION</codeph> keyword is required to collect root statistics for the root

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
@@ -4,67 +4,59 @@
   <title>Collecting Root Partition Statistics</title>
   <shortdesc>For a partitioned table, GPORCA uses statistics of the table root partition to generate
     query plans. These statistics are used for determining the join order, for splitting and joining
-    aggregate nodes, and for costing the query steps. This is in contrast to the legacy planner,
-    which uses the statistics of each leaf partition. If you execute queries on partitioned tables,
-    you must collect statistics on the root partition and periodically update those statistics to
-    ensure that GPORCA can generate optimal query plans.</shortdesc>
-  <topic id="topic_r5d_hv1_kr">
-    <title>Setting the optimizer_analyze_root_partition Parameter</title>
-    <body>
-      <p>A primary way to ensure that you collect root partition statistics is to set the
-          <codeph>optimizer_analyze_root_partition</codeph> configuration parameter to
-          <codeph>on</codeph>. When the parameter is enabled, Greenplum Database collects root
-        partition statistics (<codeph>ANALYZE ROOTPARTITION</codeph> operation) any time you run an
-          <codeph>ANALYZE</codeph> command against a partitioned table.  </p>
-      <ol id="ol_n22_hv1_kr">
-        <li>Log into the Greenplum Database master host as <codeph>gpadmin</codeph>, the Greenplum
-          Database administrator.</li>
-        <li>Set the values of the server configuration parameters. These Greenplum Database
-            <codeph>gpconfig</codeph> utility commands sets the value of the parameters to
-            <codeph>on</codeph>:<codeblock>$ gpconfig -c optimizer_analyze_root_partition -v on --masteronly</codeblock></li>
-        <li>Restart Greenplum Database. This Greenplum Database <codeph>gpstop</codeph> utility
-          command reloads the <codeph>postgresql.conf</codeph> files of the master and segments
-          without shutting down Greenplum Database. <codeblock>gpstop -u</codeblock></li>
-      </ol>
-    </body>
-  </topic>
+    aggregate nodes, and for costing the query steps. In contrast, the legacy planner uses the
+    statistics of each leaf partition.</shortdesc>
+  <body>
+    <p>If you execute queries on partitioned tables, you should collect statistics on the root
+      partition and periodically update those statistics to ensure that GPORCA can generate optimal
+      query plans. If the root partition statistics are not up-to-date or do not exist, GPORCA still
+      performs dynamic partition elimination for queries against the table However, the query plan
+      might not be optimal. </p>
+  </body>
   <topic id="topic_w1y_srn_wbb">
-    <title>Running ANALYZE ROOTPARTITION</title>
+    <title>Running ANALYZE</title>
     <body>
-      <p>The <codeph>ANALYZE ROOTPARTITION</codeph> command samples the leaf partition data in a
-        table, and stores the statistics in the root partition. The leaf partition data is only
-        sampled, but statistics are not collected on the leaf partitions. Keep in mind that
-          <codeph>ANALYZE ROOTPARTITION</codeph> always scans the entire table before updating the
-        root partition statistics. If your table is very large, this operation can take a
+      <p>By default, running the <codeph>ANALYZE</codeph> on the root partition of a partitioned
+        table samples the leaf partition data in a table, and stores the statistics for the root
+        partition. <codeph>ANALYZE</codeph> collects statistics on the root and leaf partitions,
+        including HLL statistics on the leaf partitions. <codeph>ANALYZE ROOTPARTITION</codeph>
+        collects statistics only on the root partition, the leaf partition data is only sampled. The
+        server configuration parameter <codeph><xref
+            href="../../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
+            >optimizer_analyze_root_partition</xref></codeph> controls whether the
+          <codeph>ROOTPARTITION</codeph> keyword is required to collect root statistics for the root
+        partition of a partitioned table. See the <codeph><xref
+            href="../../../ref_guide/sql_commands/ANALYZE.xml#topic1">ANALYZE</xref></codeph>
+        command for information about collecting statistics on partitioned tables.</p>
+      <p>Keep in mind that <codeph>ANALYZE</codeph> always scans the entire table before updating
+        the root partition statistics. If your table is very large, this operation can take a
         significant amount of time. <codeph>ANALYZE ROOTPARTITION</codeph> also uses an
           <codeph>ACCESS SHARE</codeph> lock that prevents certain operations, such as
           <codeph>TRUNCATE</codeph> and <codeph>VACUUM</codeph> operations, during execution. For
-        these reason, you should schedule <codeph>ANALYZE ROOTPARTITION</codeph> operations
-        periodically, or when there are significant changes to leaf partition data.</p>
-      <p>Keep in mind that even if the root partition statistics are not up-to-date or do not exist,
-        GPORCA will still perform dynamic partition elimination for queries against the table.</p>
-      <p>Follow these best practices for running <codeph>ANALYZE ROOTPARTITION</codeph> in your
-          system:<ul id="ul_vm4_fsn_wbb">
-          <li>Always run <codeph>ANALYZE ROOTPARTITION</codeph> at least once for each newly-created
-            partitioned table, after adding initial data. If you execute a query on a root partition
-            that has no statistics but has tuples, you receive the
-            notice:<codeblock>NOTICE: One or more columns in the following table(s) do not have statistics: &lt;table_name>
-HINT: For non-partitioned tables, run analyze &lt;table_name>(&lt;column_list>). For partitioned tables, 
-run analyze rootpartition &lt;table_name>(&lt;column_list>). See log for columns missing statistics.</codeblock></li>
+        these reasons, you should schedule <codeph>ANALYZE</codeph> operations periodically, or when
+        there are significant changes to leaf partition data.</p>
+      <p>Follow these best practices for running <codeph>ANALYZE</codeph> or <codeph>ANALYZE
+          ROOTPARTITION</codeph> on partitioned tables in your system:<ul id="ul_vm4_fsn_wbb">
+          <li>Always run <codeph>ANALYZE</codeph> or <codeph>ANALYZE ROOTPARTITION</codeph> at least
+            once for each newly-created partitioned table, after adding initial data. You can run
+              <codeph>ANALYZE</codeph> on a new or changed leaf partition. By default, the command
+            updates the root partition statistics if the other leaf partitions have statistics.</li>
           <li>Update root partition statistics when you observe query performance regression in
-            EXPLAIN plans against the table, or after significant changes to leaf partition data.
-            For example, if you add a new leaf partition at some point after generating root
-            partition statistics, consider running <codeph>ANALYZE ROOTPARTITION</codeph> to update
-            root partition statistics with the new tuples inserted from the new leaf partition.</li>
-          <li>For very large tables, run <codeph>ANALYZE ROOTPARTITION</codeph> only weekly, or at
-            some interval longer than daily.</li>
+              <codeph>EXPLAIN</codeph> plans against the table, or after significant changes to leaf
+            partition data. For example, if you add a new leaf partition at some point after
+            generating root partition statistics, consider running <codeph>ANALYZE</codeph> or
+              <codeph>ANALYZE ROOTPARTITION</codeph> to update root partition statistics with the
+            new tuples inserted from the new leaf partition.</li>
+          <li>For very large tables, run <codeph>ANALYZE</codeph> or <codeph>ANALYZE
+              ROOTPARTITION</codeph> only weekly, or at some interval longer than daily.</li>
           <li>Avoid running <codeph>ANALYZE</codeph> with no arguments, because doing so executes
             the command on all database tables including partitioned tables. With large databases,
             these global <codeph>ANALYZE</codeph> operations are difficult to monitor, and it can be
             difficult to predict the time needed for completion.</li>
-          <li>Consider running multiple <codeph>ANALYZE ROOTPARTITION &lt;table_name></codeph>
-            operations in parallel to speed the operation of statistics collection, if your I/O
-            throughput can support the load.</li>
+          <li>Consider running multiple <codeph>ANALYZE &lt;<varname>table_name</varname>></codeph>
+            or <codeph>ANALYZE ROOTPARTITION &lt;<varname>table_name</varname>></codeph> operations
+            in parallel to speed the operation of statistics collection, if your I/O throughput can
+            support the load.</li>
           <li>You can also use the Greenplum Database utility <codeph>analyzedb</codeph> to update
             table statistics. Using <codeph>analyzedb</codeph> ensures that tables that were
             previously analzyed are not re-analyzed if no modifications were made to the leaf
@@ -85,6 +77,36 @@ run analyze rootpartition &lt;table_name>(&lt;column_list>). See log for columns
         partitions. For example, if you know which partitions hold necessary tuples for a query, you
         can directly query the leaf partition table itself; in this case GPORCA uses the leaf
         partition statistics.</p>
+    </body>
+  </topic>
+  <topic id="topic_r5d_hv1_kr">
+    <title>Disabling Automatic Root Partition Statistics Collection</title>
+    <body>
+      <p>If you do not intend to execute queries on partitioned tables with GPORCA (setting the
+        server configuration parameter <codeph><xref
+            href="../../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
+            >optimizer</xref></codeph> to <codeph>off</codeph>), then you can disable the automatic
+        collect statistics on the root partition of the partitioned table. The server configuration
+        parameter <codeph><xref
+            href="../../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
+            >optimizer_analyze_root_partition</xref></codeph> controls whether the
+          <codeph>ROOTPARTITION</codeph> keyword is required to collect root statistics for the root
+        partition of a partitioned table. The default setting for the parameter is
+          <codeph>on</codeph>, the <codeph>ANALYZE</codeph> command can collect root partition
+        statistics without the <codeph>ROOTPARTITION</codeph> keyword. You can disable automatic
+        collection of root partition statistics by setting the parameter to <codeph>off</codeph>.
+        When the value is <codeph>off</codeph>, you must run <codeph>ANALZYE ROOTPARTITION</codeph>
+        to collect root partition statistics.</p>
+      <ol id="ol_n22_hv1_kr">
+        <li>Log into the Greenplum Database master host as <codeph>gpadmin</codeph>, the Greenplum
+          Database administrator.</li>
+        <li>Set the values of the server configuration parameters. These Greenplum Database
+            <codeph>gpconfig</codeph> utility commands sets the value of the parameters to
+            <codeph>off</codeph>:<codeblock>$ gpconfig -c optimizer_analyze_root_partition -v off --masteronly</codeblock></li>
+        <li>Restart Greenplum Database. This Greenplum Database <codeph>gpstop</codeph> utility
+          command reloads the <codeph>postgresql.conf</codeph> files of the master and segments
+          without shutting down Greenplum Database. <codeblock>gpstop -u</codeblock></li>
+      </ol>
     </body>
   </topic>
 </topic>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4476,7 +4476,6 @@
       </table>
     </body>
   </topic>
-
   <topic id="gp_motion_cost_per_row">
     <title>gp_motion_cost_per_row</title>
     <body>
@@ -7231,13 +7230,22 @@
   <topic id="optimizer_analyze_root_partition">
     <title>optimizer_analyze_root_partition</title>
     <body>
-      <p>For a partitioned table, collects statistics for the root partition when the
-          <cmdname>ANALYZE</cmdname> command is run on the table. GPORCA uses the root partition
-        statistics when generating a query plan. The legacy query optimizer does not use these
-        statistics. When the value of the server configuration parameter <codeph><xref
-            href="#optimizer" format="dita"/></codeph> is on (the default), the value of this
-        parameter should also be on (the default). For information about collecting table statistics
-        on partitioned tables, see <codeph><xref href="../sql_commands/ANALYZE.xml"/></codeph>.</p>
+      <p>For a partitioned table, controls whether the <codeph>ROOTPARTITION</codeph> keyword is
+        required to collect root partition statistics when the <cmdname>ANALYZE</cmdname> command is
+        run on the table. GPORCA uses the root partition statistics when generating a query plan.
+        The legacy query optimizer does not use these statistics. </p>
+      <p>The default setting for the parameter is <codeph>on</codeph>, the <codeph>ANALYZE</codeph>
+        command can collect root partition statistics without the <codeph>ROOTPARTITION</codeph>
+        keyword. Root partition statistics are collected when you run <codeph>ANALYZE</codeph> on
+        the root partition, or when you run <codeph>ANALYZE</codeph> on a child leaf partition of
+        the partitioned table and the other child leaf partitions have statistics. When the value is
+          <codeph>off</codeph>, you must run <codeph>ANALZYE ROOTPARTITION</codeph> to collect root
+        partition statistics. </p>
+      <p>When the value of the server configuration parameter <codeph><xref href="#optimizer"
+            format="dita"/></codeph> is <codeph>on</codeph> (the default), the value of this
+        parameter should also be <codeph>on</codeph>. For information about collecting table
+        statistics on partitioned tables, see <codeph><xref href="../sql_commands/ANALYZE.xml"
+          /></codeph>.</p>
       <p>For information about the legacy query optimizer and GPORCA, see <xref
           href="../../admin_guide/query/topics/query.xml">Querying Data</xref><ph
           otherprops="op-print"> in the <cite>Greenplum Database Administrator
@@ -8898,7 +8906,8 @@
     <body>
       <p>How many keepalives may be lost before the connection is considered dead. A value of 0 uses
         the system default. If TCP_KEEPCNT is not supported, this parameter must be 0. </p>
-      <p>Use this parameter for all connections that are not between a primary and mirror segment.</p>
+      <p>Use this parameter for all connections that are not between a primary and mirror
+        segment.</p>
       <table id="tcp_keepalives_count_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -8927,7 +8936,8 @@
     <body>
       <p>Number of seconds between sending keepalives on an otherwise idle connection. A value of 0
         uses the system default. If TCP_KEEPIDLE is not supported, this parameter must be 0.</p>
-      <p>Use this parameter for all connections that are not between a primary and mirror segment.</p>
+      <p>Use this parameter for all connections that are not between a primary and mirror
+        segment.</p>
       <table id="tcp_keepalives_idle_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -8956,7 +8966,8 @@
     <body>
       <p>How many seconds to wait for a response to a keepalive before retransmitting. A value of 0
         uses the system default. If TCP_KEEPINTVL is not supported, this parameter must be 0.</p>
-      <p>Use this parameter for all connections that are not between a primary and mirror segment.</p>
+      <p>Use this parameter for all connections that are not between a primary and mirror
+        segment.</p>
       <table id="tcp_keepalives_interval_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -9601,9 +9612,9 @@
         </ul></p>
       <p>You can set the value to <codeph>false</codeph> to disable authentication when testing the
         communication between the Greenplum Database external table and the <codeph>gpfdist</codeph>
-        utility that is serving the external data.<note type="warning">Disabling SSL certificate
-          authentication exposes a security risk by not validating the <codeph>gpfdists</codeph> SSL
-          certificate. </note></p>
+        utility that is serving the external data.
+        <note type="warning">Disabling SSL certificate authentication exposes a security risk by not
+          validating the <codeph>gpfdists</codeph> SSL certificate. </note></p>
       <p>For information about the <codeph>gpfdists</codeph> protocol, see <xref
           href="../../admin_guide/external/g-gpfdists-protocol.xml">gpfdists:// Protocol</xref>. For
         information about running the <codeph>gpfdist</codeph> utility, see <xref

--- a/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
@@ -29,9 +29,8 @@ ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition</varname> [ (<var
         HyperLogLog (HLL) statistics, on the leaf child partitions. HLL statistics are used are used
         to derive number of distinct values (NDV) for queries against partitioned tables.<ul
           id="ul_nxx_p3p_x2b">
-          <li>During query optimization, HLL statistics generate a more accurate number of distinct
-            values (NDV) estimates than the standard table statistics when aggregating estimates
-            across multiple leaf child partitions. </li>
+          <li>When aggregating NDV estimates across multiple leaf child partitions, HLL statistics
+            generate a more accurate NDV estimates than the standard table statistics. </li>
           <li>When updating HLL statistics, <codeph>ANALYZE</codeph> operations are required only on
             leaf child partitions that have changed. For example, <codeph>ANALYZE</codeph> is
             required if the leaf child partition data has changed, or if the leaf child partition

--- a/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
@@ -7,25 +7,43 @@
     <p id="sql_command_desc">Collects statistics about a database.</p>
     <section id="section2">
       <title>Synopsis</title>
-      <codeblock id="sql_command_synopsis">ANALYZE [VERBOSE] [ROOTPARTITION [ALL] ] 
-   [<varname>table</varname> [ (<varname>column</varname> [, ...] ) ]]</codeblock>
+      <codeblock id="sql_command_synopsis">ANALYZE [VERBOSE] [<varname>table</varname> [ (<varname>column</varname> [, ...] ) ]]
+
+ANALYZE [VERBOSE] {<varname>root_partition</varname>|<varname>leaf_partition</varname>} [ (<varname>column</varname> [, ...] )] 
+
+ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition</varname> [ (<varname>column</varname> [, ...] )]}</codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
       <p><codeph>ANALYZE</codeph> collects statistics about the contents of tables in the database,
         and stores the results in the system table <i>pg_statistic</i>. Subsequently, Greenplum
         Database uses these statistics to help determine the most efficient execution plans for
-        queries.</p>
+        queries. For information about the table statistics that are collected, see <xref
+          href="#topic1/section5" format="dita">Notes</xref>.</p>
       <p>With no parameter, <codeph>ANALYZE</codeph> collects statistics for every table in the
         current database. You can specify a table name to collect statistics for a single table. You
         can specify a set of column names, in which case the statistics only for those columns are
         collected.</p>
       <p><codeph>ANALYZE</codeph> does not collect statistics on external tables. </p>
+      <p>For partitioned tables, <codeph>ANALYZE</codeph> collects additional statistics,
+        HyperLogLog (HLL) statistics, on the leaf child partitions. HLL statistics are used during
+        optimization of queries against partitioned tables.<ul id="ul_nxx_p3p_x2b">
+          <li>During query optimization, HLL statistics generate a more accurate number of distinct
+            values (NDV) estimates than the standard table statistics when aggregating estimates
+            across multiple leaf child partitions. </li>
+          <li>When updating HLL statistics, <codeph>ANALYZE</codeph> operations are required only on
+            leaf child partitions that have changed. For example, <codeph>ANALYZE</codeph> is
+            required if the leaf child partition data has changed, or if the leaf child partition
+            has been exchanged with another table.</li>
+        </ul></p>
       <note type="important">If you intend to execute queries on partitioned tables with GPORCA
         enabled (the default), then you must collect statistics on the root partition of the
-        partitioned table with the <codeph>ANALYZE ROOTPARTITION</codeph> command. For information
-        about GPORCA, see "Querying Data" in the <cite>Greenplum Database Administrator
-        Guide</cite>.</note>
+        partitioned table with the <codeph>ANALYZE</codeph> or <codeph>ANALYZE
+          ROOTPARTITION</codeph> command. For information about collecting statistics on partitioned
+        tables and when the <codeph>ROOTPARTITION</codeph> keyword is required, see <xref
+          href="#topic1/section5" format="dita">Notes</xref>. For information about GPORCA, see
+          <xref href="../../admin_guide/query/topics/query-piv-opt-overview.xml"/><ph
+          otherprops="op-print"> in the <cite>Greenplum Database Administrator Guide</cite></ph>. </note>
       <note>You can also use the Greenplum Database utility <codeph>analyzedb</codeph> to update
         table statistics. The <codeph>analyzedb</codeph> utility can update statistics for multiple
         tables concurrently. The utility can also check table statistics and update statistics only
@@ -36,11 +54,34 @@
       <title>Parameters</title>
       <parml>
         <plentry>
+          <pt>{ <varname>root_partition</varname> | <varname>leaf_partition</varname> } [
+              (<varname>column</varname> [, ...] ) ]</pt>
+          <pd>Collect statistics for partitioned tables including HLL statistics. HLL statistics are
+            collected only on leaf child partitions. </pd>
+          <pd><codeph>ANALYZE <varname>root_partition</varname></codeph>, collects statistics on all
+            leaf child partitions and the root partition. </pd>
+          <pd><codeph>ANALYZE <varname>leaf_partition</varname></codeph>, collects statistics on the
+            leaf child partition. </pd>
+          <pd>By default, if you specify a leaf child partition, and all other leaf child partitions
+            have statistics, <codeph>ANALYZE</codeph> updates the root partition statistics. If not
+            all leaf child partitions have statistics, <codeph>ANALYZE</codeph> logs information
+            about the leaf child partitions that do not have statistics. For information about when
+            root partition statistics are collected, see <xref href="#topic1/section5" format="dita"
+              >Notes</xref>.</pd>
+        </plentry>
+        <plentry>
           <pt>ROOTPARTITION [ALL]</pt>
           <pd>Collect statistics only on the root partition of partitioned tables based on the data
-            in the partitioned table. Statistics are not collected on the leaf child partitions, the
-            data is only sampled. When you specify <codeph>ROOTPARTITION</codeph>, you must specify either <codeph>ALL</codeph> or the
-            name of a partitioned table. </pd>
+            in the partitioned table. If possible ,<codeph>ANALYZE</codeph> uses leaf child
+            partition statistics to generate root partition statistics. Otherwise,
+              <codeph>ANALYZE</codeph> collects the statistics by sampling leaf child partition
+            data. Statistics are not collected on the leaf child partitions, the data is only
+            sampled. HLL statistics are not collected. If possible ,<codeph>ANALYZE</codeph> uses
+            leaf child partition statistics. </pd>
+          <pd>For information about when the <codeph>ROOTPARTITION</codeph> keyword is required, see
+              <xref href="#topic1/section5" format="dita">Notes</xref>.</pd>
+          <pd>When you specify <codeph>ROOTPARTITION</codeph>, you must specify either
+              <codeph>ALL</codeph> or the name of a partitioned table. </pd>
           <pd>If you specify <codeph>ALL</codeph> with <codeph>ROOTPARTITION</codeph>, Greenplum
             Database collects statistics for the root partition of all partitioned tables in the
             database. If there are no partitioned tables in the database, a message stating that
@@ -71,7 +112,7 @@
               <li>The column for which statistics is being computed.</li>
               <li>The queries that are issued to collect the different statistics for a single
                 column.</li>
-              <li>The statistics that are generated.</li>
+              <li>The statistics that are collected.</li>
             </ul></pd>
         </plentry>
         <plentry>
@@ -95,51 +136,68 @@
         changes in the contents of a table. Accurate statistics helps Greenplum Database choose the
         most appropriate query plan, and thereby improve the speed of query processing. A common
         strategy is to run <codeph><xref href="./VACUUM.xml#topic1" type="topic" format="dita"
-          /></codeph> and <codeph>ANALYZE</codeph> once a day during a low-usage time of day.</p>
+          /></codeph> and <codeph>ANALYZE</codeph> once a day during a low-usage time of day. You
+        can check for tables with missing statistics using the <codeph>gp_stats_missing</codeph>
+        view, which is in the <codeph>gp_toolkit</codeph>
+        schema:<codeblock>SELECT * from gp_toolkit.gp_stats_missing;</codeblock></p>
       <p><codeph>ANALYZE</codeph> requires <codeph>SHARE UPDATE EXCLUSIVE</codeph> lock on the
         target table. This lock conflicts with these locks: <codeph>SHARE UPDATE EXCLUSIVE</codeph>,
           <codeph>SHARE</codeph>, <codeph>SHARE ROW EXCLUSIVE</codeph>, <codeph>EXCLUSIVE</codeph>,
           <codeph>ACCESS EXCLUSIVE</codeph>.</p>
+      <p>If you run <codeph>ANALYZE</codeph> on a table that does not contain data, statistics are
+        not collected for the table. For example, if you perform a <codeph>TRUNCATE</codeph>
+        operation on a table that has statistics, and then run <codeph>ANALYZE</codeph> on the
+        table, the statistics do not change.</p>
       <p>For a partitioned table, specifying which portion of the table to analyze, the root
-        partition or subpartitions (leaf child tables) can be useful if the partitioned table has
-        large number of partitions that have been analyzed and only a few leaf child tables have
-        changed. </p>
+        partition or subpartitions (leaf child partition tables) can be useful if the partitioned
+        table has a large number of partitions that have been analyzed and only a few leaf child
+        partitions have changed.</p>
       <ul>
         <li id="bd138200">When you run <codeph>ANALYZE</codeph> on the root partitioned table,
-          statistics are collected for all the leaf child tables (the lowest-level tables in the
-          hierarchy of child tables created by Greenplum Database for use by the partitioned
-          table).</li>
-        <li id="bd138204">When you run <codeph>ANALYZE</codeph> on a leaf child table, statistics
-          are collected only for that leaf child table. When you run <codeph>ANALYZE</codeph> on a
-          child table that is not a leaf child table, statistics are not collected. <p>For example,
-            you can create a partitioned table with partitions for the years 2006 to 2016 and
-            subpartitions for each month in each year. If you run <codeph>ANALYZE</codeph> on the
-            child table for the year 2013 no statistics are collected. If you run
-              <codeph>ANALYZE</codeph> on the leaf child table for March of 2013, statistics are
-            collected only for that leaf child table.</p><note>When you create a partitioned table
-            with the <codeph>CREATE TABLE</codeph> command, Greenplum Database creates the table
-            that you specify (the root partition or parent table), and also creates a hierarchy of
-            tables based on the partition hierarchy that you specified (the child tables).
-            Partitioned tables, child tables and their inheritance level relationships are tracked
-            in the system view <i>pg_partitions</i>.</note></li>
+          statistics are collected for all the leaf child partitions. Leaf child partitions are the
+          lowest-level tables in the hierarchy of child tables created by Greenplum Database for use
+          by the partitioned table. </li>
+        <li id="bd138204">When you run <codeph>ANALYZE</codeph> on a leaf child partition,
+          statistics are collected only for that leaf child partition and the root partition. When
+          you run <codeph>ANALYZE</codeph> on a child table that is not a leaf child partition,
+          statistics are not collected. <p>For example, you can create a partitioned table with
+            partitions for the years 2006 to 2016 and subpartitions for each month in each year. If
+            you run <codeph>ANALYZE</codeph> on the child table for the year 2013 no statistics are
+            collected. If you run <codeph>ANALYZE</codeph> on the leaf child partition for March of
+            2013, statistics are collected only for that leaf child partition. </p>
+          <note>When you create a partitioned table with the <codeph>CREATE TABLE</codeph> command,
+            Greenplum Database creates the table that you specify (the root partition or parent
+            table), and also creates a hierarchy of tables based on the partition hierarchy that you
+            specified (the child tables). Partitioned tables, child tables and their inheritance
+            level relationships are tracked in the system view <i>pg_partitions</i>.</note></li>
+        <li>For a leaf child partition that has changed, (for example, you make significant updates
+          to the leaf child partition data or exchange the leaf child partition), you can run
+            <codeph>ANALYZE</codeph> on a leaf child partition to collect table statistics and HLL
+          statistics. By default, if all other leaf child partitions have statistics, the command
+          updates the root partition statistics. </li>
       </ul>
       <p>For a partitioned table that contains a leaf child partition that has been exchanged to use
         an external table, <codeph>ANALYZE</codeph> does not collect statistics for the external
         table partition:</p>
       <ul id="ol_x5n_2ff_ss">
-        <li>If <codeph>ANALYZE [ROOTPARTITION]</codeph> is run, external table partitions are not
-          sampled and root table statistics do not include external table partition. </li>
         <li>If <codeph>ANALYZE</codeph> is run on an external table partition, the partition is not
           analyzed.</li>
+        <li>If <codeph>ANALYZE</codeph> or <codeph>ANALYZE ROOTPARTITION</codeph> is run on the root
+          partition, external table partitions are not sampled and root table statistics do not
+          include external table partition. </li>
         <li>If the <codeph>VERBOSE</codeph> clause is specified, an informational message is
           displayed: <codeph>skipping external table</codeph>.</li>
       </ul>
       <p>The Greenplum Database server configuration parameter <codeph><xref
             href="../config_params/guc-list.xml#optimizer_analyze_root_partition"
             >optimizer_analyze_root_partition</xref></codeph> affects when statistics are collected
-        on the root partition of a partitioned table. If the parameter is enabled, statistics are
-        also collected on the root partition when you run <codeph>ANALYZE</codeph> (without the
-          <codeph>ROOTPARTITION</codeph> keyword) and specify the root partition.</p>
+        on the root partition of a partitioned table. If the parameter is <codeph>on</codeph> (the
+        default), the <codeph>ROOTPARTITION</codeph> keyword is not required to collect statistics
+        on the root partition when you run <codeph>ANALYZE</codeph>. Root partition statistics are
+        collected when you run <codeph>ANALYZE</codeph> on the root partition, or when you run
+          <codeph>ANALYZE</codeph> on a child leaf partition of the partitioned table and the other
+        child leaf partitions have statistics. If the parameter is <codeph>off</codeph>, you must
+        run <codeph>ANALZYE ROOTPARTITION</codeph> to collect root partition statistics.</p>
       <p>The statistics collected by <codeph>ANALYZE</codeph> usually include a list of some of the
         most common values in each column and a histogram showing the approximate data distribution
         in each column. One or both of these may be omitted if <codeph>ANALYZE</codeph> deems them
@@ -177,11 +235,11 @@
         removes the empty pages and allows an <codeph>ANALYZE</codeph> operation to collect accurate
         statistics. </p>
       <p>If there are no statistics for the table, the server configuration parameter <codeph><xref
-            href="../config_params/guc-list.xml#gp_enable_relsize_collection"/></codeph>
-        controls whether the legacy query optimizer uses a default statistics file or estimates the
-        size of a table using the <codeph>pg_relation_size</codeph> function. By default, the legacy
-        optimizer uses the default statistics file to estimate the number of rows if statistics are
-        not available.</p>
+            href="../config_params/guc-list.xml#gp_enable_relsize_collection"/></codeph> controls
+        whether the legacy query optimizer uses a default statistics file or estimates the size of a
+        table using the <codeph>pg_relation_size</codeph> function. By default, the legacy optimizer
+        uses the default statistics file to estimate the number of rows if statistics are not
+        available.</p>
     </section>
     <section id="section6">
       <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
@@ -26,8 +26,9 @@ ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition</varname> [ (<var
         collected.</p>
       <p><codeph>ANALYZE</codeph> does not collect statistics on external tables. </p>
       <p>For partitioned tables, <codeph>ANALYZE</codeph> collects additional statistics,
-        HyperLogLog (HLL) statistics, on the leaf child partitions. HLL statistics are used during
-        optimization of queries against partitioned tables.<ul id="ul_nxx_p3p_x2b">
+        HyperLogLog (HLL) statistics, on the leaf child partitions. HLL statistics are used are used
+        to derive number of distinct values (NDV) for queries against partitioned tables.<ul
+          id="ul_nxx_p3p_x2b">
           <li>During query optimization, HLL statistics generate a more accurate number of distinct
             values (NDV) estimates than the standard table statistics when aggregating estimates
             across multiple leaf child partitions. </li>
@@ -72,12 +73,11 @@ ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition</varname> [ (<var
         <plentry>
           <pt>ROOTPARTITION [ALL]</pt>
           <pd>Collect statistics only on the root partition of partitioned tables based on the data
-            in the partitioned table. If possible ,<codeph>ANALYZE</codeph> uses leaf child
+            in the partitioned table. If possible, <codeph>ANALYZE</codeph> uses leaf child
             partition statistics to generate root partition statistics. Otherwise,
               <codeph>ANALYZE</codeph> collects the statistics by sampling leaf child partition
             data. Statistics are not collected on the leaf child partitions, the data is only
-            sampled. HLL statistics are not collected. If possible ,<codeph>ANALYZE</codeph> uses
-            leaf child partition statistics. </pd>
+            sampled. HLL statistics are not collected. </pd>
           <pd>For information about when the <codeph>ROOTPARTITION</codeph> keyword is required, see
               <xref href="#topic1/section5" format="dita">Notes</xref>.</pd>
           <pd>When you specify <codeph>ROOTPARTITION</codeph>, you must specify either
@@ -172,9 +172,9 @@ ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition</varname> [ (<var
             level relationships are tracked in the system view <i>pg_partitions</i>.</note></li>
         <li>For a leaf child partition that has changed, (for example, you make significant updates
           to the leaf child partition data or exchange the leaf child partition), you can run
-            <codeph>ANALYZE</codeph> on a leaf child partition to collect table statistics and HLL
-          statistics. By default, if all other leaf child partitions have statistics, the command
-          updates the root partition statistics. </li>
+            <codeph>ANALYZE</codeph> on a leaf child partition to collect table statistics. By
+          default, if all other leaf child partitions have statistics, the command updates the root
+          partition statistics. </li>
       </ul>
       <p>For a partitioned table that contains a leaf child partition that has been exchanged to use
         an external table, <codeph>ANALYZE</codeph> does not collect statistics for the external


### PR DESCRIPTION
also updates topics related to partitioned table statistics.

**Link to HTML format documents with major changes in GPDB doc review site**

ANALYZE command
http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/sql_commands/ANALYZE.html

optimizer_analyze_root_partition GUC
http://docs-gpdb-review-staging.cfapps.io/review/ref_guide/config_params/guc-list.html#optimizer_analyze_root_partition

Changes to ORCA information about root partitions.
http://docs-gpdb-review-staging.cfapps.io/review/admin_guide/query/topics/query-piv-opt-root-partition.html

Add slots 4,5 to pg_statistic slots table and update partitioned table stats information
http://docs-gpdb-review-staging.cfapps.io/review/admin_guide/intro/about_statistics.html

**This will be backported to 5X_STABLE with these changes**

--stakind5 is not available
--stakind5 =99 is moved to stakind4.