### PR TITLE
Correct cost calculation for SplitUpdate plan

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1721,8 +1721,9 @@ make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan, RangeTblEntr
 
 	/*
 	 * Now the plan tree has been determined, we have no choice, so use the
-	 * cost of lower plan node directly, plus the cpu_tuple_cost of each row
-	 * TODO: width here is incorrect, until we merge upstream commit 3fc6e2d
+	 * cost of lower plan node directly, plus the cpu_tuple_cost of each row.
+	 * GPDB_96_MERGE_FIXME: width here is incorrect, until we merge
+	 * upstream commit 3fc6e2d
 	 */
 	splitupdate->plan.startup_cost = subplan->startup_cost;
 	splitupdate->plan.total_cost = subplan->total_cost;

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -21,6 +21,7 @@
 #include "parser/parse_expr.h"	/* for expr_type() */
 #include "parser/parse_oper.h"	/* for compatible_oper_opid() */
 #include "utils/relcache.h"		/* RelationGetPartitioningKey() */
+#include "optimizer/cost.h"
 #include "optimizer/tlist.h"	/* get_sortgroupclause_tle() */
 #include "optimizer/planmain.h"
 #include "optimizer/predtest.h"
@@ -1236,10 +1237,6 @@ add_absent_targetlist_mutator(Plan *plan,
 
 	Assert(is_plan_node(node));
 
-	/*
-	 * GPDB_90_MERGE_FIXME: We also need to change width and cost here. But since the plan has been
-	 * generated at this stage, it is not clear how we could recalculate the cost.
-	 */
 	if (node->type >= T_SeqScan && node->type <=T_WorkTableScan)
 	{
 		Scan		*scan;
@@ -1724,11 +1721,13 @@ make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan, RangeTblEntr
 
 	/*
 	 * Now the plan tree has been determined, we have no choice, so use the
-	 * cost of lower plan node directly.
+	 * cost of lower plan node directly, plus the cpu_tuple_cost of each row
+	 * TODO: width here is incorrect, until we merge upstream commit 3fc6e2d
 	 */
 	splitupdate->plan.startup_cost = subplan->startup_cost;
 	splitupdate->plan.total_cost = subplan->total_cost;
 	splitupdate->plan.plan_rows = 2 * subplan->plan_rows;
+	splitupdate->plan.total_cost += (splitupdate->plan.plan_rows * cpu_tuple_cost);
 	splitupdate->plan.plan_width = subplan->plan_width;
 
 	/* we need an motion node above the SplitUpdate, so mark it as strewn */

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6405,6 +6405,28 @@ make_modifytable(PlannerInfo *root, CmdType operation, bool canSetTag,
 	Assert(returningLists == NIL ||
 		   list_length(resultRelations) == list_length(returningLists));
 
+
+
+	node->plan.lefttree = NULL;
+	node->plan.righttree = NULL;
+	node->plan.qual = NIL;
+	/* setrefs.c will fill in the targetlist, if needed */
+	node->plan.targetlist = NIL;
+
+	node->operation = operation;
+	node->canSetTag = canSetTag;
+	node->resultRelations = resultRelations;
+	node->resultRelIndex = -1;	/* will be set correctly in setrefs.c */
+	node->plans = subplans;
+	node->returningLists = returningLists;
+	node->rowMarks = rowMarks;
+	node->epqParam = epqParam;
+	node->action_col_idxes = NIL;
+	node->ctid_col_idxes = NIL;
+	node->oid_col_idxes = NIL;
+
+	adjust_modifytable_flow(root, node);
+
 	/*
 	 * Compute cost as sum of subplan costs.
 	 */
@@ -6426,26 +6448,6 @@ make_modifytable(PlannerInfo *root, CmdType operation, bool canSetTag,
 		plan->plan_width = rint(total_size / plan->plan_rows);
 	else
 		plan->plan_width = 0;
-
-	node->plan.lefttree = NULL;
-	node->plan.righttree = NULL;
-	node->plan.qual = NIL;
-	/* setrefs.c will fill in the targetlist, if needed */
-	node->plan.targetlist = NIL;
-
-	node->operation = operation;
-	node->canSetTag = canSetTag;
-	node->resultRelations = resultRelations;
-	node->resultRelIndex = -1;	/* will be set correctly in setrefs.c */
-	node->plans = subplans;
-	node->returningLists = returningLists;
-	node->rowMarks = rowMarks;
-	node->epqParam = epqParam;
-	node->action_col_idxes = NIL;
-	node->ctid_col_idxes = NIL;
-	node->oid_col_idxes = NIL;
-
-	adjust_modifytable_flow(root, node);
 
 	return node;
 }

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -328,6 +328,17 @@ SELECT gp_segment_id, * FROM tab5;
              2 |  9 |  9 |  9 |  9 |  9
 (10 rows)
 
+EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
+                      QUERY PLAN
+------------------------------------------------------
+ Update on tab3
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: (c1 + 1), c2, c3
+         ->  Split
+               ->  Seq Scan on tab3
+ Optimizer: legacy query optimizer
+(6 rows)
+
 -- clean up
 drop table tab3;
 drop table tab5;

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -1,0 +1,347 @@
+--
+-- UPDATE ... SET <col> = DEFAULT;
+--
+CREATE TABLE update_test (
+    a   INT DEFAULT 10,
+    b   INT,
+    c   TEXT
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'e' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO update_test(a,b,c) VALUES (5, 10, 'foo');
+INSERT INTO update_test(b,a) VALUES (15, 10);
+SELECT a,b,c FROM update_test ORDER BY a,b,c;
+ a  | b  |  c  
+----+----+-----
+  5 | 10 | foo
+ 10 | 15 | 
+(2 rows)
+
+UPDATE update_test SET a = DEFAULT, b = DEFAULT;
+SELECT a,b,c FROM update_test ORDER BY a,b,c;
+ a  | b |  c  
+----+---+-----
+ 10 |   | foo
+ 10 |   | 
+(2 rows)
+
+-- aliases for the UPDATE target table
+UPDATE update_test AS t SET b = 10 WHERE t.a = 10;
+SELECT a,b,c FROM update_test ORDER BY a,b,c;
+ a  | b  |  c  
+----+----+-----
+ 10 | 10 | foo
+ 10 | 10 | 
+(2 rows)
+
+UPDATE update_test t SET b = t.b + 10 WHERE t.a = 10;
+SELECT a,b,c FROM update_test ORDER BY a,b,c;
+ a  | b  |  c  
+----+----+-----
+ 10 | 20 | foo
+ 10 | 20 | 
+(2 rows)
+
+--
+-- Test VALUES in FROM
+--
+UPDATE update_test SET a=v.i FROM (VALUES(100, 20)) AS v(i, j)
+  WHERE update_test.b = v.j;
+SELECT a,b,c FROM update_test ORDER BY a,b,c;
+  a  | b  |  c  
+-----+----+-----
+ 100 | 20 | foo
+ 100 | 20 | 
+(2 rows)
+
+--
+-- Test multiple-set-clause syntax
+--
+UPDATE update_test SET (c,b,a) = ('bugle', b+11, DEFAULT) WHERE c = 'foo';
+SELECT a,b,c FROM update_test ORDER BY a,b,c;
+  a  | b  |   c   
+-----+----+-------
+  10 | 31 | bugle
+ 100 | 20 | 
+(2 rows)
+
+UPDATE update_test SET (c,b) = ('car', a+b), a = a + 1 WHERE a = 10;
+SELECT a,b,c FROM update_test ORDER BY a,b,c;
+  a  | b  |  c  
+-----+----+-----
+  11 | 41 | car
+ 100 | 20 | 
+(2 rows)
+
+-- fail, multi assignment to same column:
+UPDATE update_test SET (c,b) = ('car', a+b), b = a + 1 WHERE a = 10;
+ERROR:  multiple assignments to same column "b"
+-- XXX this should work, but doesn't yet:
+UPDATE update_test SET (a,b) = (select a,b FROM update_test where c = 'foo')
+  WHERE a = 10;
+ERROR:  syntax error at or near "select"
+LINE 1: UPDATE update_test SET (a,b) = (select a,b FROM update_test ...
+                                        ^
+-- if an alias for the target table is specified, don't allow references
+-- to the original table name
+UPDATE update_test AS t SET b = update_test.b + 10 WHERE t.a = 10;
+ERROR:  invalid reference to FROM-clause entry for table "update_test"
+LINE 1: UPDATE update_test AS t SET b = update_test.b + 10 WHERE t.a...
+                                        ^
+HINT:  Perhaps you meant to reference the table alias "t".
+-- Make sure that we can update to a TOASTed value.
+UPDATE update_test SET c = repeat('x', 10000) WHERE c = 'car';
+SELECT a, b, char_length(c) FROM update_test;
+  a  | b  | char_length 
+-----+----+-------------
+ 100 | 20 |            
+  11 | 41 |       10000
+(2 rows)
+
+DROP TABLE update_test;
+--
+-- text types. We should support the following updates.
+--
+drop table tab1;
+ERROR:  table "tab1" does not exist
+drop table tab2;
+ERROR:  table "tab2" does not exist
+CREATE TABLE tab1 (a varchar(15), b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a varchar(15), b integer) DISTRIBUTED BY (a);
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+drop table tab1;
+drop table tab2;
+CREATE TABLE tab1 (a text, b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a text, b integer) DISTRIBUTED BY (a);
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+drop table tab1;
+drop table tab2;
+CREATE TABLE tab1 (a varchar, b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a varchar, b integer) DISTRIBUTED BY (a);
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+drop table tab1;
+drop table tab2;
+CREATE TABLE tab1 (a char(15), b integer) DISTRIBUTED BY (a);
+CREATE TABLE tab2 (a char(15), b integer) DISTRIBUTED BY (a);
+UPDATE tab1 SET b = tab2.b FROM tab2 WHERE tab1.a = tab2.a;
+drop table tab1;
+drop table tab2;
+DROP TABLE IF EXISTS update_distr_key; 
+NOTICE:  table "update_distr_key" does not exist, skipping
+CREATE TABLE update_distr_key (a int, b int) DISTRIBUTED BY (a); 
+INSERT INTO update_distr_key select i, i* 10 from generate_series(0, 9) i; 
+UPDATE update_distr_key SET a = 5 WHERE b = 10; 
+SELECT * from update_distr_key; 
+ a | b  
+---+----
+ 3 | 30
+ 4 | 40
+ 5 | 50
+ 6 | 60
+ 7 | 70
+ 5 | 10
+ 8 | 80
+ 9 | 90
+ 0 |  0
+ 2 | 20
+(10 rows)
+
+DROP TABLE update_distr_key;
+-- below cases is to test multi-hash-cols
+CREATE TABLE tab3(c1 int, c2 int, c3 int, c4 int, c5 int) DISTRIBUTED BY (c1, c2, c3);
+CREATE TABLE tab5(c1 int, c2 int, c3 int, c4 int, c5 int) DISTRIBUTED BY (c1, c2, c3, c4, c5);
+INSERT INTO tab3 SELECT i, i, i, i, i FROM generate_series(1, 10)i;
+INSERT INTO tab5 SELECT i, i, i, i, i FROM generate_series(1, 10)i;
+-- test tab3
+SELECT gp_segment_id, * FROM tab3;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  1 |  1 |  1 |  1 |  1
+             0 |  3 |  3 |  3 |  3 |  3
+             0 |  5 |  5 |  5 |  5 |  5
+             0 | 10 | 10 | 10 | 10 | 10
+             1 |  2 |  2 |  2 |  2 |  2
+             1 |  4 |  4 |  4 |  4 |  4
+             1 |  6 |  6 |  6 |  6 |  6
+             1 |  9 |  9 |  9 |  9 |  9
+             2 |  7 |  7 |  7 |  7 |  7
+             2 |  8 |  8 |  8 |  8 |  8
+(10 rows)
+
+UPDATE tab3 set c1 = 9 where c4 = 1;
+SELECT gp_segment_id, * FROM tab3;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             1 |  2 |  2 |  2 |  2 |  2
+             1 |  4 |  4 |  4 |  4 |  4
+             1 |  6 |  6 |  6 |  6 |  6
+             1 |  9 |  9 |  9 |  9 |  9
+             1 |  9 |  1 |  1 |  1 |  1
+             0 |  3 |  3 |  3 |  3 |  3
+             0 |  5 |  5 |  5 |  5 |  5
+             0 | 10 | 10 | 10 | 10 | 10
+             2 |  7 |  7 |  7 |  7 |  7
+             2 |  8 |  8 |  8 |  8 |  8
+(10 rows)
+
+UPDATE tab3 set (c1,c2) = (5,6) where c4 = 1;
+SELECT gp_segment_id, * FROM tab3;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  3 |  3 |  3 |  3 |  3
+             0 |  5 |  5 |  5 |  5 |  5
+             0 | 10 | 10 | 10 | 10 | 10
+             0 |  5 |  6 |  1 |  1 |  1
+             2 |  7 |  7 |  7 |  7 |  7
+             2 |  8 |  8 |  8 |  8 |  8
+             1 |  2 |  2 |  2 |  2 |  2
+             1 |  4 |  4 |  4 |  4 |  4
+             1 |  6 |  6 |  6 |  6 |  6
+             1 |  9 |  9 |  9 |  9 |  9
+(10 rows)
+
+UPDATE tab3 set (c1,c2,c3) = (3,2,1) where c4 = 1;
+SELECT gp_segment_id, * FROM tab3;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             2 |  7 |  7 |  7 |  7 |  7
+             2 |  8 |  8 |  8 |  8 |  8
+             0 |  3 |  3 |  3 |  3 |  3
+             0 |  5 |  5 |  5 |  5 |  5
+             0 | 10 | 10 | 10 | 10 | 10
+             1 |  2 |  2 |  2 |  2 |  2
+             1 |  4 |  4 |  4 |  4 |  4
+             1 |  6 |  6 |  6 |  6 |  6
+             1 |  9 |  9 |  9 |  9 |  9
+             1 |  3 |  2 |  1 |  1 |  1
+(10 rows)
+
+UPDATE tab3 set c1 = 11 where c2 = 10 and c2 < 1;
+SELECT gp_segment_id, * FROM tab3;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             1 |  2 |  2 |  2 |  2 |  2
+             1 |  4 |  4 |  4 |  4 |  4
+             1 |  6 |  6 |  6 |  6 |  6
+             1 |  9 |  9 |  9 |  9 |  9
+             1 |  3 |  2 |  1 |  1 |  1
+             2 |  7 |  7 |  7 |  7 |  7
+             2 |  8 |  8 |  8 |  8 |  8
+             0 |  3 |  3 |  3 |  3 |  3
+             0 |  5 |  5 |  5 |  5 |  5
+             0 | 10 | 10 | 10 | 10 | 10
+(10 rows)
+
+-- test tab5
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  1 |  1 |  1 |  1 |  1
+             0 |  2 |  2 |  2 |  2 |  2
+             0 |  6 |  6 |  6 |  6 |  6
+             0 |  7 |  7 |  7 |  7 |  7
+             1 |  5 |  5 |  5 |  5 |  5
+             1 | 10 | 10 | 10 | 10 | 10
+             2 |  3 |  3 |  3 |  3 |  3
+             2 |  4 |  4 |  4 |  4 |  4
+             2 |  8 |  8 |  8 |  8 |  8
+             2 |  9 |  9 |  9 |  9 |  9
+(10 rows)
+
+UPDATE tab5 set c1 = 1000 where c4 = 1;
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id |  c1  | c2 | c3 | c4 | c5 
+---------------+------+----+----+----+----
+             1 |    5 |  5 |  5 |  5 |  5
+             1 |   10 | 10 | 10 | 10 | 10
+             1 | 1000 |  1 |  1 |  1 |  1
+             2 |    3 |  3 |  3 |  3 |  3
+             2 |    4 |  4 |  4 |  4 |  4
+             2 |    8 |  8 |  8 |  8 |  8
+             2 |    9 |  9 |  9 |  9 |  9
+             0 |    2 |  2 |  2 |  2 |  2
+             0 |    6 |  6 |  6 |  6 |  6
+             0 |    7 |  7 |  7 |  7 |  7
+(10 rows)
+
+UPDATE tab5 set (c1,c2) = (9,10) where c4 = 1;
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  2 |  2 |  2 |  2 |  2
+             0 |  6 |  6 |  6 |  6 |  6
+             0 |  7 |  7 |  7 |  7 |  7
+             2 |  3 |  3 |  3 |  3 |  3
+             2 |  4 |  4 |  4 |  4 |  4
+             2 |  8 |  8 |  8 |  8 |  8
+             2 |  9 |  9 |  9 |  9 |  9
+             2 |  9 | 10 |  1 |  1 |  1
+             1 |  5 |  5 |  5 |  5 |  5
+             1 | 10 | 10 | 10 | 10 | 10
+(10 rows)
+
+UPDATE tab5 set (c1,c2,c4) = (5,8,6) where c4 = 1;
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             1 |  5 |  5 |  5 |  5 |  5
+             1 | 10 | 10 | 10 | 10 | 10
+             0 |  2 |  2 |  2 |  2 |  2
+             0 |  6 |  6 |  6 |  6 |  6
+             0 |  7 |  7 |  7 |  7 |  7
+             0 |  5 |  8 |  1 |  6 |  1
+             2 |  3 |  3 |  3 |  3 |  3
+             2 |  4 |  4 |  4 |  4 |  4
+             2 |  8 |  8 |  8 |  8 |  8
+             2 |  9 |  9 |  9 |  9 |  9
+(10 rows)
+
+UPDATE tab5 set (c1,c2,c3,c4,c5) = (1,2,3,0,6) where c5 = 1;
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             2 |  3 |  3 |  3 |  3 |  3
+             2 |  4 |  4 |  4 |  4 |  4
+             2 |  8 |  8 |  8 |  8 |  8
+             2 |  9 |  9 |  9 |  9 |  9
+             0 |  2 |  2 |  2 |  2 |  2
+             0 |  6 |  6 |  6 |  6 |  6
+             0 |  7 |  7 |  7 |  7 |  7
+             1 |  5 |  5 |  5 |  5 |  5
+             1 | 10 | 10 | 10 | 10 | 10
+             1 |  1 |  2 |  3 |  0 |  6
+(10 rows)
+
+UPDATE tab5 set c1 = 11 where c3 = 10 and c3 < 1;
+SELECT gp_segment_id, * FROM tab5;
+ gp_segment_id | c1 | c2 | c3 | c4 | c5 
+---------------+----+----+----+----+----
+             0 |  2 |  2 |  2 |  2 |  2
+             0 |  6 |  6 |  6 |  6 |  6
+             0 |  7 |  7 |  7 |  7 |  7
+             1 |  5 |  5 |  5 |  5 |  5
+             1 | 10 | 10 | 10 | 10 | 10
+             1 |  1 |  2 |  3 |  0 |  6
+             2 |  3 |  3 |  3 |  3 |  3
+             2 |  4 |  4 |  4 |  4 |  4
+             2 |  8 |  8 |  8 |  8 |  8
+             2 |  9 |  9 |  9 |  9 |  9
+(10 rows)
+
+EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Update
+   ->  Result
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (public.tab3.c1 + 1), public.tab3.c2, public.tab3.c3
+               ->  Result
+                     ->  Split
+                           ->  Result
+                                 ->  Table Scan on tab3
+ Optimizer: PQO version 2.72.0
+(9 rows)
+
+-- clean up
+drop table tab3;
+drop table tab5;

--- a/src/test/regress/sql/update.sql
+++ b/src/test/regress/sql/update.sql
@@ -139,6 +139,8 @@ SELECT gp_segment_id, * FROM tab5;
 UPDATE tab5 set c1 = 11 where c3 = 10 and c3 < 1;
 SELECT gp_segment_id, * FROM tab5;
 
+EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
+
 -- clean up
 drop table tab3;
 drop table tab5;


### PR DESCRIPTION
This partly addresses a GPDB_90_MERGE_FIXME introduced in 73801e8. As mentioned
in the FIXME, this will not help generating a better plan because we have no
choice other than simply adding the SplitUpdate node. Note that only the cost
is adjusted, the width is still incorrect. We will not fix width for now
because upstream commit 3fc6e2d will fix it.

Co-authored-by: Shujie Zhang <shzhang@pivotal.io>
Co-authored-by: Alexandra Wang <leiwangcheme@gmail.com>