### PR TITLE
Fix race condition introduced by InterconnectStopAckIsLost fault inje…

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5580,7 +5580,6 @@ doSendStopMessageUDPIFC(ChunkTransportState *transportStates, int16 motNodeID)
 												   "" /* databaseName */ ,
 												   "" /* tableName */ ) == FaultInjectorTypeSkip)
 				{
-					pthread_mutex_unlock(&ic_control_info.lock);
 					continue;
 				}
 #endif


### PR DESCRIPTION
In commit fb9081fc29b, we introduced a fault injector to drop a stop
ack. It released a pthread_mutex_lock by accident which makes interconnect
structures in a race condition. As a result, an FATAL error was reported
as "FATAL:  freelist NULL: count 2 max 1 buf (nil) (ic_udpifc.c:3501)".
