### PR TITLE
Check opfamily when deduce quals from non-equivalence clauses.

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -215,6 +215,38 @@ get_rightop(const Expr *clause)
 		return NULL;
 }
 
+/*
+ * get_leftscalararrayop
+ *
+ * Returns the left operand of a clause of the form (scalar op ANY/ALL (array))
+ */
+Node *
+get_leftscalararrayop(const Expr *clause)
+{
+	const ScalarArrayOpExpr *expr = (const ScalarArrayOpExpr *) clause;
+
+	if (expr->args != NIL)
+		return linitial(expr->args);
+	else
+		return NULL;
+}
+
+/*
+ * get_rightscalararrayop
+ *
+ * Returns the right operand in a clause of the form (scalar op ANY/ALL (array)).
+ */
+Node *
+get_rightscalararrayop(const Expr *clause)
+{
+	const ScalarArrayOpExpr *expr = (const ScalarArrayOpExpr *) clause;
+
+	if (list_length(expr->args) >= 2)
+		return lsecond(expr->args);
+	else
+		return NULL;
+}
+
 /*****************************************************************************
  *		NOT clause functions
  *****************************************************************************/

--- a/src/include/optimizer/clauses.h
+++ b/src/include/optimizer/clauses.h
@@ -54,6 +54,8 @@ extern Expr *make_opclause(Oid opno, Oid opresulttype, bool opretset,
 			  Oid opcollid, Oid inputcollid);
 extern Node *get_leftop(const Expr *clause);
 extern Node *get_rightop(const Expr *clause);
+extern Node *get_leftscalararrayop(const Expr *clause);
+extern Node *get_rightscalararrayop(const Expr *clause);
 
 extern bool not_clause(Node *clause);
 extern Expr *make_notclause(Expr *notclause);

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3631,6 +3631,43 @@ SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS 
 (0 rows)
 
 -- ----------------------------------------------------------------------
+-- Test: opfamily check in deduction from non-equivalence clauses
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS qp_opf_a;
+NOTICE:  table "qp_opf_a" does not exist, skipping
+DROP TABLE IF EXISTS qp_opf_b;
+NOTICE:  table "qp_opf_b" does not exist, skipping
+CREATE TABLE qp_opf_a (f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE qp_opf_b (f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO qp_opf_a VALUES ('0'), ('-0');
+INSERT INTO qp_opf_b VALUES ('0'), ('-0');
+-- end_ignore
+EXPLAIN SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.04..2.12 rows=4 width=16)
+   ->  Hash Join  (cost=1.04..2.12 rows=2 width=16)
+         Hash Cond: qp_opf_a.f = qp_opf_b.f
+         ->  Seq Scan on qp_opf_a  (cost=0.00..1.03 rows=1 width=8)
+               Filter: f::text <> '-0'::text
+         ->  Hash  (cost=1.02..1.02 rows=1 width=8)
+               ->  Seq Scan on qp_opf_b  (cost=0.00..1.02 rows=1 width=8)
+ Optimizer: legacy query optimizer
+(8 rows)
+
+SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
+ f | f  
+---+----
+ 0 | -0
+ 0 |  0
+(2 rows)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3634,58 +3634,99 @@ SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS 
 -- Test: non-equivalence clauses
 -- ----------------------------------------------------------------------
 -- start_ignore
-DROP TABLE IF EXISTS qp_opf_a;
-NOTICE:  table "qp_opf_a" does not exist, skipping
-DROP TABLE IF EXISTS qp_opf_b;
-NOTICE:  table "qp_opf_b" does not exist, skipping
-CREATE TABLE qp_opf_a (f float8);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f' as the Greenplum Database data distribution key for this table.
+DROP TABLE IF EXISTS qp_non_eq_a;
+NOTICE:  table "qp_non_eq_a" does not exist, skipping
+DROP TABLE IF EXISTS qp_non_eq_b;
+NOTICE:  table "qp_non_eq_b" does not exist, skipping
+CREATE TABLE qp_non_eq_a (i int, f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE TABLE qp_opf_b (f float8);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f' as the Greenplum Database data distribution key for this table.
+CREATE TABLE qp_non_eq_b (i int, f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO qp_opf_a VALUES ('0'), ('-0');
-INSERT INTO qp_opf_b VALUES ('0'), ('-0');
+INSERT INTO qp_non_eq_a VALUES (1, '0'), (2, '-0');
+INSERT INTO qp_non_eq_b VALUES (3, '0'), (1, '-0');
 -- end_ignore
-EXPLAIN SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1.04..2.12 rows=4 width=16)
-   ->  Hash Join  (cost=1.04..2.12 rows=2 width=16)
-         Hash Cond: qp_opf_a.f = qp_opf_b.f
-         ->  Seq Scan on qp_opf_a  (cost=0.00..1.03 rows=1 width=8)
-               Filter: f::text <> '-0'::text
-         ->  Hash  (cost=1.02..1.02 rows=1 width=8)
-               ->  Seq Scan on qp_opf_b  (cost=0.00..1.02 rows=1 width=8)
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.04..3.17 rows=4 width=24)
+   ->  Hash Join  (cost=1.04..3.17 rows=2 width=24)
+         Hash Cond: qp_non_eq_a.f = qp_non_eq_b.f
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.08 rows=1 width=12)
+               ->  Seq Scan on qp_non_eq_a  (cost=0.00..2.04 rows=1 width=12)
+                     Filter: f::text <> '-0'::text
+         ->  Hash  (cost=1.02..1.02 rows=1 width=12)
+               ->  Seq Scan on qp_non_eq_b  (cost=0.00..1.02 rows=1 width=12)
+ Optimizer: legacy query optimizer
+(9 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+ 1 | 0 | 3 |  0
+(2 rows)
+
+EXPLAIN SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.12..3.18 rows=4 width=24)
+   ->  Hash Join  (cost=1.12..3.18 rows=2 width=24)
+         Hash Cond: qp_non_eq_a.f = qp_non_eq_b.f
+         ->  Seq Scan on qp_non_eq_a  (cost=0.00..2.02 rows=1 width=12)
+         ->  Hash  (cost=1.08..1.08 rows=1 width=12)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.08 rows=1 width=12)
+                     ->  Seq Scan on qp_non_eq_b  (cost=0.00..1.04 rows=1 width=12)
+                           Filter: CASE WHEN f::text = '-0'::text THEN 1::double precision ELSE (-1)::double precision END < 0::double precision
+ Optimizer: legacy query optimizer
+(9 rows)
+
+SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+ i | f  | i | f 
+---+----+---+---
+ 2 | -0 | 3 | 0
+ 1 |  0 | 3 | 0
+(2 rows)
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.05..3.12 rows=4 width=24)
+   ->  Hash Join  (cost=1.05..3.12 rows=2 width=24)
+         Hash Cond: qp_non_eq_a.i = qp_non_eq_b.i
+         ->  Seq Scan on qp_non_eq_a  (cost=0.00..2.03 rows=1 width=12)
+               Filter: i = ANY ('{1,2,3}'::integer[])
+         ->  Hash  (cost=1.03..1.03 rows=1 width=12)
+               ->  Seq Scan on qp_non_eq_b  (cost=0.00..1.03 rows=1 width=12)
+                     Filter: i = ANY ('{1,2,3}'::integer[])
+ Optimizer: legacy query optimizer
+(9 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+(1 row)
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.04..3.12 rows=4 width=24)
+   ->  Hash Join  (cost=1.04..3.12 rows=2 width=24)
+         Hash Cond: qp_non_eq_a.i = qp_non_eq_b.i
+         ->  Seq Scan on qp_non_eq_a  (cost=0.00..2.03 rows=1 width=12)
+               Filter: i::numeric = ANY ('{1,2,3}'::numeric[])
+         ->  Hash  (cost=1.02..1.02 rows=1 width=12)
+               ->  Seq Scan on qp_non_eq_b  (cost=0.00..1.02 rows=1 width=12)
  Optimizer: legacy query optimizer
 (8 rows)
 
-SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
- f | f  
----+----
- 0 | -0
- 0 |  0
-(2 rows)
-
-EXPLAIN SELECT * FROM qp_opf_a INNER JOIN qp_opf_b ON qp_opf_a.f = qp_opf_b.f AND CASE WHEN qp_opf_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1.05..2.11 rows=4 width=16)
-   ->  Hash Join  (cost=1.05..2.11 rows=2 width=16)
-         Hash Cond: qp_opf_a.f = qp_opf_b.f
-         ->  Seq Scan on qp_opf_a  (cost=0.00..1.02 rows=1 width=8)
-         ->  Hash  (cost=1.04..1.04 rows=1 width=8)
-               ->  Seq Scan on qp_opf_b  (cost=0.00..1.04 rows=1 width=8)
-                     Filter: CASE WHEN f::text = '-0'::text THEN 1::double precision ELSE (-1)::double precision END < 0::double precision
- Optimizer: legacy query optimizer
-(8 rows)
-
-SELECT * FROM qp_opf_a INNER JOIN qp_opf_b ON qp_opf_a.f = qp_opf_b.f AND CASE WHEN qp_opf_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
- f  | f 
-----+---
-  0 | 0
- -0 | 0
-(2 rows)
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+(1 row)
 
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3631,7 +3631,7 @@ SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS 
 (0 rows)
 
 -- ----------------------------------------------------------------------
--- Test: opfamily check in deduction from non-equivalence clauses
+-- Test: non-equivalence clauses
 -- ----------------------------------------------------------------------
 -- start_ignore
 DROP TABLE IF EXISTS qp_opf_a;
@@ -3665,6 +3665,26 @@ SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::t
 ---+----
  0 | -0
  0 |  0
+(2 rows)
+
+EXPLAIN SELECT * FROM qp_opf_a INNER JOIN qp_opf_b ON qp_opf_a.f = qp_opf_b.f AND CASE WHEN qp_opf_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.05..2.11 rows=4 width=16)
+   ->  Hash Join  (cost=1.05..2.11 rows=2 width=16)
+         Hash Cond: qp_opf_a.f = qp_opf_b.f
+         ->  Seq Scan on qp_opf_a  (cost=0.00..1.02 rows=1 width=8)
+         ->  Hash  (cost=1.04..1.04 rows=1 width=8)
+               ->  Seq Scan on qp_opf_b  (cost=0.00..1.04 rows=1 width=8)
+                     Filter: CASE WHEN f::text = '-0'::text THEN 1::double precision ELSE (-1)::double precision END < 0::double precision
+ Optimizer: legacy query optimizer
+(8 rows)
+
+SELECT * FROM qp_opf_a INNER JOIN qp_opf_b ON qp_opf_a.f = qp_opf_b.f AND CASE WHEN qp_opf_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+ f  | f 
+----+---
+  0 | 0
+ -0 | 0
 (2 rows)
 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3812,30 +3812,135 @@ SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS 
 (0 rows)
 
 -- ----------------------------------------------------------------------
+-- Test: non-equivalence clauses
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS qp_non_eq_a;
+NOTICE:  table "qp_non_eq_a" does not exist, skipping
+DROP TABLE IF EXISTS qp_non_eq_b;
+NOTICE:  table "qp_non_eq_b" does not exist, skipping
+CREATE TABLE qp_non_eq_a (i int, f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE qp_non_eq_b (i int, f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO qp_non_eq_a VALUES (1, '0'), (2, '-0');
+INSERT INTO qp_non_eq_b VALUES (3, '0'), (1, '-0');
+-- end_ignore
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: qp_non_eq_b.f = qp_non_eq_a.f
+         ->  Table Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Table Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
+                           Filter: f::text <> '-0'::text
+ Optimizer: PQO version 2.72.0
+(9 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 3 |  0
+ 1 | 0 | 1 | -0
+(2 rows)
+
+EXPLAIN SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: qp_non_eq_a.f = qp_non_eq_b.f
+         ->  Table Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Table Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
+                           Filter: CASE WHEN f::text = '-0'::text THEN 1::double precision ELSE (-1)::double precision END < 0::double precision
+ Optimizer: PQO version 2.72.0
+(9 rows)
+
+SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+ i | f  | i | f 
+---+----+---+---
+ 1 |  0 | 3 | 0
+ 2 | -0 | 3 | 0
+(2 rows)
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: qp_non_eq_a.i = qp_non_eq_b.i
+         ->  Table Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
+               Filter: (i = ANY ('{1,2,3}'::integer[])) AND (i = 1 OR i = 2 OR i = 3)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Table Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
+                     Filter: i = 1 OR i = 2 OR i = 3
+ Optimizer: PQO version 2.72.0
+(9 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+(1 row)
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: qp_non_eq_a.i = qp_non_eq_b.i
+         ->  Table Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
+               Filter: i::numeric = ANY ('{1,2,3}'::numeric[])
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Table Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: PQO version 2.72.0
+(8 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+(1 row)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore
 drop schema qp_correlated_query cascade;
-NOTICE:  drop cascades to table qp_tjoin4
-NOTICE:  drop cascades to table qp_tjoin3
-NOTICE:  drop cascades to table qp_tjoin2
-NOTICE:  drop cascades to table qp_tjoin1
-NOTICE:  drop cascades to table tversion
-NOTICE:  drop cascades to table t1
-NOTICE:  drop cascades to function f(integer)
-NOTICE:  drop cascades to table csq_emp
-NOTICE:  drop cascades to table with_test2
-NOTICE:  drop cascades to table with_test1
-NOTICE:  drop cascades to table employee
-NOTICE:  drop cascades to table job
-NOTICE:  drop cascades to table product_order
-NOTICE:  drop cascades to table product
-NOTICE:  drop cascades to table d
-NOTICE:  drop cascades to table qp_csq_t4
-NOTICE:  drop cascades to table c
-NOTICE:  drop cascades to table b
-NOTICE:  drop cascades to table a
-NOTICE:  drop cascades to table qp_csq_t3
-NOTICE:  drop cascades to table qp_csq_t2
-NOTICE:  drop cascades to table qp_csq_t1
+NOTICE:  drop cascades to 28 other objects
+DETAIL:  drop cascades to table qp_csq_t1
+drop cascades to table qp_csq_t2
+drop cascades to table qp_csq_t3
+drop cascades to table a
+drop cascades to table b
+drop cascades to table c
+drop cascades to table d
+drop cascades to table e
+drop cascades to table qp_csq_t4
+drop cascades to table product
+drop cascades to table product_order
+drop cascades to table job
+drop cascades to table employee
+drop cascades to table with_test1
+drop cascades to table with_test2
+drop cascades to table csq_emp
+drop cascades to function f(integer)
+drop cascades to table t1
+drop cascades to table tversion
+drop cascades to table qp_tjoin1
+drop cascades to table qp_tjoin2
+drop cascades to table qp_tjoin3
+drop cascades to table qp_tjoin4
+drop cascades to table qp_tab1
+drop cascades to table qp_tab2
+drop cascades to table qp_tab3
+drop cascades to table qp_non_eq_a
+drop cascades to table qp_non_eq_b
 -- end_ignore

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -860,7 +860,7 @@ EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
 
 -- ----------------------------------------------------------------------
--- Test: opfamily check in deduction from non-equivalence clauses
+-- Test: non-equivalence clauses
 -- ----------------------------------------------------------------------
 
 -- start_ignore
@@ -875,6 +875,9 @@ INSERT INTO qp_opf_b VALUES ('0'), ('-0');
 
 EXPLAIN SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
 SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
+
+EXPLAIN SELECT * FROM qp_opf_a INNER JOIN qp_opf_b ON qp_opf_a.f = qp_opf_b.f AND CASE WHEN qp_opf_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+SELECT * FROM qp_opf_a INNER JOIN qp_opf_b ON qp_opf_a.f = qp_opf_b.f AND CASE WHEN qp_opf_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
 
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -860,6 +860,23 @@ EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
 
 -- ----------------------------------------------------------------------
+-- Test: opfamily check in deduction from non-equivalence clauses
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS qp_opf_a;
+DROP TABLE IF EXISTS qp_opf_b;
+
+CREATE TABLE qp_opf_a (f float8);
+CREATE TABLE qp_opf_b (f float8);
+INSERT INTO qp_opf_a VALUES ('0'), ('-0');
+INSERT INTO qp_opf_b VALUES ('0'), ('-0');
+-- end_ignore
+
+EXPLAIN SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
+SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -864,20 +864,26 @@ SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS 
 -- ----------------------------------------------------------------------
 
 -- start_ignore
-DROP TABLE IF EXISTS qp_opf_a;
-DROP TABLE IF EXISTS qp_opf_b;
+DROP TABLE IF EXISTS qp_non_eq_a;
+DROP TABLE IF EXISTS qp_non_eq_b;
 
-CREATE TABLE qp_opf_a (f float8);
-CREATE TABLE qp_opf_b (f float8);
-INSERT INTO qp_opf_a VALUES ('0'), ('-0');
-INSERT INTO qp_opf_b VALUES ('0'), ('-0');
+CREATE TABLE qp_non_eq_a (i int, f float8);
+CREATE TABLE qp_non_eq_b (i int, f float8);
+INSERT INTO qp_non_eq_a VALUES (1, '0'), (2, '-0');
+INSERT INTO qp_non_eq_b VALUES (3, '0'), (1, '-0');
 -- end_ignore
 
-EXPLAIN SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
-SELECT * FROM qp_opf_a, qp_opf_b WHERE qp_opf_a.f = qp_opf_b.f AND qp_opf_a.f::text <> '-0';
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
 
-EXPLAIN SELECT * FROM qp_opf_a INNER JOIN qp_opf_b ON qp_opf_a.f = qp_opf_b.f AND CASE WHEN qp_opf_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
-SELECT * FROM qp_opf_a INNER JOIN qp_opf_b ON qp_opf_a.f = qp_opf_b.f AND CASE WHEN qp_opf_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+EXPLAIN SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
 
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql


### PR DESCRIPTION
When we deduce new clauses, we should only use operators from the same
opfamily, so that the operators can have consistent semantics. Otherwise
we may get wrong results.

Deduction from equivalence class performs opfamily check. This patch add
the same check for non-equivalence clause.