### PR TITLE
Dispatcher can create flexible size gang

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -2254,7 +2254,7 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 	else
 	{
 		CdbComponentDatabaseInfo *qdinfo = 
-				cdbcomponent_getComponentInfo(-1); 
+				cdbcomponent_getComponentInfo(MASTER_CONTENT_ID); 
 
 		pg_ltoa(qdinfo->port, result);
 		extvar->GP_MASTER_PORT = result;

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -2253,8 +2253,8 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 	}
 	else
 	{
-		CdbComponentDatabases *cdb_component_dbs = getCdbComponentDatabases();
-		CdbComponentDatabaseInfo *qdinfo = &cdb_component_dbs->entry_db_info[0];
+		CdbComponentDatabaseInfo *qdinfo = 
+				cdbcomponent_getComponentInfo(-1); 
 
 		pg_ltoa(qdinfo->port, result);
 		extvar->GP_MASTER_PORT = result;
@@ -2263,8 +2263,6 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 			extvar->GP_MASTER_HOST = pstrdup(qdinfo->hostip);
 		else
 			extvar->GP_MASTER_HOST = pstrdup(qdinfo->hostname);
-
-		freeCdbComponentDatabases(cdb_component_dbs);
 	}
 
 	if (MyProcPort)

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3228,7 +3228,7 @@ AbortTransaction(void)
 	if (QueryCancelCleanup)
 	{
 		QueryCancelCleanup = false;
-		disconnectAndDestroyIdleReaderGangs();
+		cdbcomponent_cleanupIdleSegdbs(false);
 	}
 
 	/*

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2747,8 +2747,6 @@ CommitTransaction(void)
 	/* we're now in a consistent state to handle an interrupt. */
 	RESUME_INTERRUPTS();
 
-	AvailableWriterGangValidation();
-
 	/* Release resource group slot at the end of a transaction */
 	if (ShouldUnassignResGroup())
 		UnassignResGroup();

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3226,7 +3226,7 @@ AbortTransaction(void)
 	if (QueryCancelCleanup)
 	{
 		QueryCancelCleanup = false;
-		cdbcomponent_cleanupIdleSegdbs(false);
+		cdbcomponent_cleanupIdleQEs(false);
 	}
 
 	/*

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -155,7 +155,7 @@ cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes)
 
 	for (int i = 0; i < gp->size; ++i)
 	{
-		int			seg = gp->db_descriptors[i].segindex;
+		int			seg = gp->db_descriptors[i]->segindex;
 
 		cdbCopySendData(c, seg, buffer, nbytes);
 	}
@@ -388,7 +388,7 @@ cdbCopyGetData(CdbCopy *c, bool copy_cancel, uint64 *rows_processed)
  */
 static ErrorData *
 processCopyEndResults(CdbCopy *c,
-					  SegmentDatabaseDescriptor *db_descriptors,
+					  SegmentDatabaseDescriptor **db_descriptors,
 					  int *results,
 					  int size,
 					  SegmentDatabaseDescriptor **failedSegDBs,
@@ -410,7 +410,7 @@ processCopyEndResults(CdbCopy *c,
 	{
 		int			result = results[seg];
 
-		q = &db_descriptors[seg];
+		q = db_descriptors[seg];
 
 		/* get command end status */
 		if (result == 0)
@@ -627,7 +627,7 @@ cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed, char *abort
 	int			total_rows_rejected = 0;	/* total num rows rejected by all
 											 * QEs */
 	bool		err_header = false;
-	struct SegmentDatabaseDescriptor *db_descriptors;
+	struct SegmentDatabaseDescriptor **db_descriptors;
 	int			size;
 	ErrorData *edata;
 
@@ -659,7 +659,7 @@ cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed, char *abort
 
 	for (seg = 0; seg < size; seg++)
 	{
-		q = &db_descriptors[seg];
+		q = db_descriptors[seg];
 		elog(DEBUG1, "PQputCopyEnd seg %d    ", q->segindex);
 		/* end this COPY command */
 		results[seg] = PQputCopyEnd(q->conn, abort_msg);

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -142,13 +142,13 @@ FtsIsSegmentUp(CdbComponentDatabaseInfo *dBInfo)
  * returns true if any segment DB is down.
  */
 bool
-FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor *segdbDesc, int size)
+FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor **segdbDesc, int size)
 {
 	int			i = 0;
 
 	for (i = 0; i < size; i++)
 	{
-		CdbComponentDatabaseInfo *segInfo = segdbDesc[i].segment_database_info;
+		CdbComponentDatabaseInfo *segInfo = segdbDesc[i]->segment_database_info;
 
 		elog(DEBUG2, "FtsTestSegmentDBIsDown: looking for real fault on segment dbid %d", (int) segInfo->dbid);
 

--- a/src/backend/cdb/cdbpgdatabase.c
+++ b/src/backend/cdb/cdbpgdatabase.c
@@ -71,7 +71,7 @@ gp_pgdatabase__(PG_FUNCTION_ARGS)
 		mystatus = (Working_State *) palloc(sizeof(Working_State));
 		funcctx->user_fctx = (void *) mystatus;
 
-		mystatus->cdb_component_dbs = getCdbComponentDatabases();
+		mystatus->cdb_component_dbs = cdbcomponent_getCdbComponents(true);
 		mystatus->currIdx = 0;
 
 		MemoryContextSwitchTo(oldcontext);

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -49,6 +49,7 @@
 #include "utils/fmgroids.h"
 #include "utils/sharedsnapshot.h"
 #include "utils/snapmgr.h"
+#include "catalog/namespace.h"
 
 extern bool Test_print_direct_dispatch_info;
 
@@ -953,7 +954,8 @@ doNotifyingAbort(void)
 
 	if (currentGxact->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED)
 	{
-		if (!currentGxactWriterGangLost())
+		if (!currentGxact->writerGangLost &&
+				currentGxact->gxidDispatched)
 		{
 			succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED, /* flags */ 0,
 													 currentGxact->gid, currentGxact->gxid,
@@ -2143,6 +2145,7 @@ initGxact(TMGXACT *gxact)
 	gxact->directTransaction = false;
 	gxact->directTransactionContentId = 0;
 	gxact->writerGangLost = false;
+	gxact->gxidDispatched = false;
 }
 
 bool
@@ -3398,4 +3401,33 @@ bool
 currentGxactWriterGangLost(void)
 {
 	return currentGxact == NULL ? false : currentGxact->writerGangLost;
+}
+
+bool
+isSafeToRecreateWriter(void)
+{
+	/*
+	 * Can not recycle current writer because temp files will be
+	 * dropped in the segement, dispatcher will info the segment
+	 * is down and report an error and reset the session.
+	 */
+	if (TempNamespaceOidIsValid())
+		return false;
+
+	/*
+	 * Can not recycle current writer if current global transaction
+	 * has been dispatched to the writer, otherwise new created
+	 * writer will miss gxid info. 
+	 */
+	if (currentGxact && currentGxact->gxidDispatched)
+		return false;
+
+	return true;
+}
+
+void
+markCurrentGxactDispatched(void)
+{
+	if (currentGxact && currentGxact->state >= DTX_STATE_ACTIVE_DISTRIBUTED)
+		currentGxact->gxidDispatched = true;
 }

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -953,7 +953,7 @@ doNotifyingAbort(void)
 
 	if (currentGxact->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED)
 	{
-		if (GangsExist())
+		if (!currentGxactWriterGangLost())
 		{
 			succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED, /* flags */ 0,
 													 currentGxact->gid, currentGxact->gxid,

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -3408,7 +3408,7 @@ isSafeToRecreateWriter(void)
 {
 	/*
 	 * Can not recycle current writer because temp files will be
-	 * dropped in the segement, dispatcher will info the segment
+	 * dropped in the segement, dispatcher will inform the segment
 	 * is down and report an error and reset the session.
 	 */
 	if (TempNamespaceOidIsValid())

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -41,13 +41,31 @@
 #include "libpq-fe.h"
 #include "libpq-int.h"
 #include "libpq/ip.h"
+#include "cdb/cdbconn.h"
 #include "cdb/cdbfts.h"
+
+#define MAX_CACHED_1_GANGS 1
+
+#define INCR_COUNT(cdbinfo, arg) \
+	(cdbinfo)->arg++; \
+	(cdbinfo)->cdbs->arg++;
+
+#define DECR_COUNT(cdbinfo, arg) \
+	(cdbinfo)->arg--; \
+	(cdbinfo)->cdbs->arg--; \
+	Assert((cdbinfo)->arg >= 0); \
+	Assert((cdbinfo)->cdbs->arg >= 0); \
+
+MemoryContext CdbComponentsContext = NULL;
+static CdbComponentDatabases *cdb_component_dbs = NULL;
 
 /*
  * Helper Functions
  */
+static CdbComponentDatabases *getCdbComponentInfo(bool DnsLookupFailureIsError);
+static void cleanupComponentIdleSegdbs(CdbComponentDatabaseInfo *cdi, bool includeWriter);
+
 static int	CdbComponentDatabaseInfoCompare(const void *p1, const void *p2);
-static void freeCdbComponentDatabaseInfo(CdbComponentDatabaseInfo *cdi);
 
 static void getAddressesForDBid(CdbComponentDatabaseInfo *c, int elevel);
 static HTAB *hostSegsHashTableInit(void);
@@ -67,15 +85,12 @@ typedef struct HostSegsEntry
 } HostSegsEntry;
 
 /*
- * getCdbComponentDatabases
- *
- *
- * Storage for the SegmentInstances block and all subsidiary
- * strucures are allocated from the caller's context.
+ *  Internal function to initialize each component info
  */
-CdbComponentDatabases *
+static CdbComponentDatabases *
 getCdbComponentInfo(bool DNSLookupAsError)
 {
+	MemoryContext oldContext;
 	CdbComponentDatabaseInfo *pOld = NULL;
 	CdbComponentDatabaseInfo *cdbInfo;
 	CdbComponentDatabases *component_databases = NULL;
@@ -114,6 +129,15 @@ getCdbComponentInfo(bool DNSLookupAsError)
 
 	bool		found;
 	HostSegsEntry *hsEntry;
+
+	if (!CdbComponentsContext)
+		CdbComponentsContext = AllocSetContextCreate(TopMemoryContext, "cdb components Context",
+								ALLOCSET_DEFAULT_MINSIZE,
+								ALLOCSET_DEFAULT_INITSIZE,
+								ALLOCSET_DEFAULT_MAXSIZE);
+
+	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
+
 	HTAB	   *hostSegsHash = hostSegsHashTableInit();
 
 	/*
@@ -124,6 +148,9 @@ getCdbComponentInfo(bool DNSLookupAsError)
 	 * run out.
 	 */
 	component_databases = palloc0(sizeof(CdbComponentDatabases));
+
+	component_databases->numActiveQEs = 0;
+	component_databases->numIdleQEs = 0;
 
 	component_databases->segment_db_info =
 		(CdbComponentDatabaseInfo *) palloc0(sizeof(CdbComponentDatabaseInfo) * segment_array_size);
@@ -229,12 +256,16 @@ getCdbComponentInfo(bool DNSLookupAsError)
 			component_databases->total_entry_dbs++;
 		}
 
+		pRow->cdbs = component_databases;
+		pRow->freelist = NIL;
 		pRow->dbid = dbid;
 		pRow->segindex = content;
 		pRow->role = role;
 		pRow->preferred_role = preferred_role;
 		pRow->mode = mode;
 		pRow->status = status;
+		pRow->numIdleQEs = 0;
+		pRow->numActiveQEs = 0;
 
 		/*
 		 * hostname
@@ -339,7 +370,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_EXCEPTION),
-				 errmsg("Greenplum Database number of segments inconsistency: count is %d from pg_catalog.%s table, but %d from getCdbComponentDatabases()",
+				 errmsg("Greenplum Database number of segments inconsistency: count is %d from pg_catalog.%s table, but %d from cdbcomponent_getCdbComponents()",
 						getgpsegmentCount(), GpIdRelationName, component_databases->total_segments)));
 	}
 
@@ -423,24 +454,126 @@ getCdbComponentInfo(bool DNSLookupAsError)
 
 	hash_destroy(hostSegsHash);
 
+	MemoryContextSwitchTo(oldContext);
+
 	return component_databases;
 }
 
 /*
- * getCdbComponentDatabases
+ * Helper function to clean up the idle segdbs list of
+ * a segment component.
+ */
+static void
+cleanupComponentIdleSegdbs(CdbComponentDatabaseInfo *cdi, bool includeWriter)
+{
+	SegmentDatabaseDescriptor	*segdbDesc;
+	MemoryContext				oldContext;
+	ListCell 					*curItem = NULL;
+	ListCell					*nextItem = NULL;
+	ListCell 					*prevItem = NULL;
+
+	Assert(CdbComponentsContext);
+	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
+	curItem = list_head(cdi->freelist);
+
+	while (curItem != NULL)
+	{
+		segdbDesc = (SegmentDatabaseDescriptor *)lfirst(curItem);
+		nextItem = lnext(curItem);
+		Assert(segdbDesc);
+
+		if (segdbDesc->isWriter && !includeWriter)
+		{
+			prevItem = curItem;
+			curItem = nextItem;
+			continue;
+		}
+
+		cdi->freelist = list_delete_cell(cdi->freelist, curItem, prevItem); 
+		DECR_COUNT(cdi, numIdleQEs);
+
+		cdbconn_termSegmentDescriptor(segdbDesc);
+
+		curItem = nextItem;
+
+	}
+
+	MemoryContextSwitchTo(oldContext);
+}
+
+void
+cdbcomponent_cleanupIdleSegdbs(bool includeWriter)
+{
+	CdbComponentDatabases	*cdbs;
+	int						i;
+
+	/* use cdb_component_dbs directly */
+	cdbs = cdb_component_dbs;
+
+	if (cdbs == NULL)		
+		return;
+
+	if (cdbs->segment_db_info != NULL)
+	{
+		for (i = 0; i < cdbs->total_segment_dbs; i++)
+		{
+			CdbComponentDatabaseInfo *cdi = &cdbs->segment_db_info[i];
+			cleanupComponentIdleSegdbs(cdi, includeWriter);
+		}
+	}
+
+	if (cdbs->entry_db_info != NULL)
+	{
+		for (i = 0; i < cdbs->total_entry_dbs; i++)
+		{
+			CdbComponentDatabaseInfo *cdi = &cdbs->entry_db_info[i];
+			cleanupComponentIdleSegdbs(cdi, includeWriter);
+		}
+	}
+
+	return;
+}
+
+/*
+ * cdbcomponent_getCdbComponents 
  *
  *
  * Storage for the SegmentInstances block and all subsidiary
  * strucures are allocated from the caller's context.
  */
 CdbComponentDatabases *
-getCdbComponentDatabases(void)
+cdbcomponent_getCdbComponents(bool DNSLookupAsError)
 {
-	CdbComponentDatabases *cdbs;
+	uint8	ftsVersion = getFtsVersion();
 
 	PG_TRY();
 	{
-		cdbs = getCdbComponentInfo(true);
+		if (cdb_component_dbs == NULL)
+		{
+			cdb_component_dbs = getCdbComponentInfo(DNSLookupAsError);
+			cdb_component_dbs->fts_version = ftsVersion;
+		}
+		else if (cdb_component_dbs->fts_version != ftsVersion)
+		{
+			/*
+			 * A fts version change don't always means a segment is
+			 * down. A mirror InSync status change also change fts
+			 * version, so we need to be careful of destroying exist
+			 * cdb_component_dbs.
+			 *
+			 *
+			 * * A query should has a unique cdb_component_dbs between
+			 * 	 slices and inside slices. 
+			 */
+			if (cdb_component_dbs->numActiveQEs == 0)
+			{
+				ELOG_DISPATCHER_DEBUG("FTS rescanned, get new component databases info.");
+				cdbcomponent_destroyCdbComponents();
+				cdb_component_dbs = getCdbComponentInfo(DNSLookupAsError);
+				cdb_component_dbs->fts_version = ftsVersion;
+			}
+		}
+
 	}
 	PG_CATCH();
 	{
@@ -459,83 +592,247 @@ getCdbComponentDatabases(void)
 	}
 	PG_END_TRY();
 
-	return cdbs;
+	return cdb_component_dbs;
 }
 
-
 /*
- * freeCdbComponentDatabases
+ * cdbcomponet_destroyCdbComponents 
  *
- * Releases the storage occupied by the CdbComponentDatabases
- * struct pointed to by the argument.
+ * Disconnect and destroy all idle QEs, releases the memory
+ * occupied by the CdbComponentDatabases
+ *
+ * callers must clean up QEs used by dispatcher states.
  */
 void
-freeCdbComponentDatabases(CdbComponentDatabases *pDBs)
+cdbcomponent_destroyCdbComponents(void)
 {
-	int			i;
-
-	if (pDBs == NULL)
-		return;
+	/* caller must clean up all segdbs used by dispatcher states */
+	Assert(!cdbcomponent_activeSegdbsExist());
 
 	hash_destroy(segment_ip_cache_htab);
 	segment_ip_cache_htab = NULL;
 
-	if (pDBs->segment_db_info != NULL)
-	{
-		for (i = 0; i < pDBs->total_segment_dbs; i++)
-		{
-			CdbComponentDatabaseInfo *cdi = &pDBs->segment_db_info[i];
+	/* disconnect and destroy idle QEs include writers */
+	cdbcomponent_cleanupIdleSegdbs(true);
 
-			freeCdbComponentDatabaseInfo(cdi);
-		}
-
-		pfree(pDBs->segment_db_info);
-	}
-
-	if (pDBs->entry_db_info != NULL)
-	{
-		for (i = 0; i < pDBs->total_entry_dbs; i++)
-		{
-			CdbComponentDatabaseInfo *cdi = &pDBs->entry_db_info[i];
-
-			freeCdbComponentDatabaseInfo(cdi);
-		}
-
-		pfree(pDBs->entry_db_info);
-	}
-
-	pfree(pDBs);
+	/* delete the memory context */
+	if (CdbComponentsContext)
+		MemoryContextDelete(CdbComponentsContext);	
+	CdbComponentsContext = NULL;
+	cdb_component_dbs = NULL;
 }
 
 /*
- * freeCdbComponentDatabaseInfo:
- * Releases any storage allocated for members variables of a CdbComponentDatabaseInfo struct.
+ * Allocated a segdb
+ *
+ * If thers is idle segdb in the freelist, return it, otherwise, initialize
+ * a new segdb.
+ *
+ * idle segdbs has an established connection with segment, but new segdb is
+ * not setup yet, callers need to establish the connection by themselves.
  */
-static void
-freeCdbComponentDatabaseInfo(CdbComponentDatabaseInfo *cdi)
+SegmentDatabaseDescriptor *
+cdbcomponent_allocateIdleSegdb(int contentId, bool writer)
 {
-	int			i;
+	SegmentDatabaseDescriptor	*segdbDesc = NULL;
+	CdbComponentDatabaseInfo	*cdbinfo;
+	ListCell 					*curItem = NULL;
+	ListCell 					*nextItem = NULL;
+	ListCell					*prevItem = NULL;
+	MemoryContext 				oldContext;
 
-	if (cdi == NULL)
-		return;
+	cdbinfo = cdbcomponent_getComponentInfo(contentId);	
 
-	if (cdi->hostname != NULL)
-		pfree(cdi->hostname);
+	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
 
-	if (cdi->address != NULL)
-		pfree(cdi->address);
-
-	if (cdi->hostip != NULL)
-		pfree(cdi->hostip);
-
-	for (i = 0; i < COMPONENT_DBS_MAX_ADDRS; i++)
+	curItem = list_head(cdbinfo->freelist);
+	while (curItem != NULL)
 	{
-		if (cdi->hostaddrs[i] != NULL)
+		SegmentDatabaseDescriptor *tmp =
+				(SegmentDatabaseDescriptor *)lfirst(curItem);
+
+		nextItem = lnext(curItem);
+		Assert(tmp);
+
+		if (writer != tmp->isWriter)
 		{
-			pfree(cdi->hostaddrs[i]);
-			cdi->hostaddrs[i] = NULL;
+			prevItem = curItem;
+			curItem = nextItem;
+			continue;
 		}
+
+		cdbinfo->freelist = list_delete_cell(cdbinfo->freelist, curItem, prevItem); 
+		/* update numIdleQEs */
+		DECR_COUNT(cdbinfo, numIdleQEs);
+
+		segdbDesc = tmp;
+		break;
 	}
+
+	AssertImply(segdbDesc, segdbDesc->isWriter == writer);
+
+	if (!segdbDesc)
+	{
+		/* for entrydb, it's never be writer */
+		segdbDesc = cdbconn_createSegmentDescriptor(cdbinfo, contentId == -1 ? false: writer);
+	}
+
+	cdbconn_setQEIdentifier(segdbDesc, -1);
+
+	INCR_COUNT(cdbinfo, numActiveQEs);
+
+	MemoryContextSwitchTo(oldContext);
+
+	return segdbDesc;
+}
+
+static bool
+cleanupSegdb(SegmentDatabaseDescriptor *segdbDesc)
+{
+	Assert(segdbDesc != NULL);
+
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR(CleanupSegdb) == FaultInjectorTypeSkip)
+		return false;
+#endif
+
+	if (cdbconn_isBadConnection(segdbDesc))
+		return false;
+
+	/* if segment is down, the gang can not be reused */
+	if (!FtsIsSegmentUp(segdbDesc->segment_database_info))
+		return false; 
+
+	/* If a reader exceed the cached memory limitation, destroy it */
+	if (!segdbDesc->isWriter &&
+		(segdbDesc->conn->mop_high_watermark >> 20) > gp_vmem_protect_gang_cache_limit)
+		return false;
+
+	/* Note, we cancel all "still running" queries */
+	if (!cdbconn_discardResults(segdbDesc, 20))
+		elog(FATAL, "cleanup called when a segworker is still busy");
+
+	/* QE is no longer associated with a slice. */
+	cdbconn_setQEIdentifier(segdbDesc, /* slice index */ -1);	
+
+	return true;
+}
+
+void
+cdbcomponent_recycleIdleSegdb(SegmentDatabaseDescriptor *segdbDesc, bool forceDestroy)
+{
+	CdbComponentDatabaseInfo	*cdbinfo;
+	MemoryContext				oldContext;	
+	int							maxLen;
+
+	Assert(cdb_component_dbs);
+	Assert(CdbComponentsContext);
+
+	cdbinfo = segdbDesc->segment_database_info;
+
+	/* update num of active segment dbs */
+	DECR_COUNT(cdbinfo, numActiveQEs);
+
+	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
+
+	if (forceDestroy || !cleanupSegdb(segdbDesc))
+		goto destroy_segdb;
+
+	/* If freelist length exceed gp_cached_gang_threshold, destroy it */
+	maxLen = segdbDesc->segindex == -1 ?
+					MAX_CACHED_1_GANGS : gp_cached_gang_threshold;
+	if (!segdbDesc->isWriter && list_length(cdbinfo->freelist) >= maxLen)
+		goto destroy_segdb;
+
+	/* Recycle the segment db, put it to freelist */
+	if (segdbDesc->isWriter)
+	{
+		/* writer is always the header of freelist */
+		segdbDesc->segment_database_info->freelist =
+			lcons(segdbDesc, segdbDesc->segment_database_info->freelist);
+	}
+	else
+	{
+		/* attatch reader to the tail of freelist */
+		segdbDesc->segment_database_info->freelist =
+			lappend(segdbDesc->segment_database_info->freelist, segdbDesc);
+	}
+
+	INCR_COUNT(cdbinfo, numIdleQEs);
+
+	MemoryContextSwitchTo(oldContext);
+
+	return;
+
+destroy_segdb:
+
+	cdbconn_termSegmentDescriptor(segdbDesc);
+
+	if (segdbDesc->isWriter)
+	{
+		markCurrentGxactWriterGangLost();
+	}
+
+	MemoryContextSwitchTo(oldContext);
+}
+
+bool
+cdbcomponent_segdbsExist(void)
+{
+	return !cdb_component_dbs ? false :
+			(cdb_component_dbs->numIdleQEs > 0 || cdb_component_dbs->numActiveQEs > 0);
+}
+
+bool
+cdbcomponent_activeSegdbsExist(void)
+{
+	return !cdb_component_dbs ? false : cdb_component_dbs->numActiveQEs > 0;
+}
+
+/*
+ * Find CdbComponentDatabaseInfo in the array by segment index.
+ */
+CdbComponentDatabaseInfo *
+cdbcomponent_getComponentInfo(int contentId)
+{
+	CdbComponentDatabaseInfo *cdbInfo = NULL;
+	CdbComponentDatabases *cdbs;
+
+	cdbs = cdbcomponent_getCdbComponents(true);
+
+	if (contentId < -1 || contentId >= cdbs->total_segments)
+		ereport(FATAL, (errcode(ERRCODE_DATA_EXCEPTION),
+						 errmsg("Unexpected content id %d, should be [-1, %d]",
+								contentId, cdbs->total_segments - 1)));
+	/* entry db */
+	if (contentId == -1)
+	{
+		cdbInfo = &cdbs->entry_db_info[0];	
+		return cdbInfo;
+	}
+
+	/* no mirror, segment_db_info is sorted by content id */
+	if (cdbs->total_segment_dbs == cdbs->total_segments)
+	{
+		cdbInfo = &cdbs->segment_db_info[contentId];
+		return cdbInfo;
+	}
+
+	/* with mirror, segment_db_info is sorted by content id */
+	if (cdbs->total_segment_dbs != cdbs->total_segments)
+	{
+		Assert(cdbs->total_segment_dbs == cdbs->total_segments * 2);
+		cdbInfo = &cdbs->segment_db_info[2 * contentId];
+
+		if (!SEGMENT_IS_ACTIVE_PRIMARY(cdbInfo))
+		{
+			cdbInfo = &cdbs->segment_db_info[2 * contentId + 1];
+		}
+
+		return cdbInfo;
+	}
+
+	return cdbInfo;
 }
 
 /*
@@ -574,7 +871,7 @@ cdb_setup(void)
  *
  */
 void
-			cdb_cleanup(int code __attribute__((unused)), Datum arg
+cdb_cleanup(int code __attribute__((unused)), Datum arg
 						__attribute__((unused)))
 {
 	elog(DEBUG1, "Cleaning up Greenplum components...");

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -564,8 +564,10 @@ cdbcomponent_getCdbComponents(bool DNSLookupAsError)
 			 *
 			 * * A query should has a unique cdb_component_dbs between
 			 * 	 slices and inside slices. 
+			 * * If it's not safe to recycle current writer, use current
+			 *   cdb_component_dbs.
 			 */
-			if (cdb_component_dbs->numActiveQEs == 0)
+			if (cdb_component_dbs->numActiveQEs == 0 && isSafeToRecreateWriter())
 			{
 				ELOG_DISPATCHER_DEBUG("FTS rescanned, get new component databases info.");
 				cdbcomponent_destroyCdbComponents();

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -151,6 +151,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 
 	component_databases->numActiveQEs = 0;
 	component_databases->numIdleQEs = 0;
+	component_databases->qeCounter = 0;
 
 	component_databases->segment_db_info =
 		(CdbComponentDatabaseInfo *) palloc0(sizeof(CdbComponentDatabaseInfo) * segment_array_size);
@@ -676,7 +677,7 @@ cdbcomponent_allocateIdleSegdb(int contentId, bool writer)
 	if (!segdbDesc)
 	{
 		/* for entrydb, it's never be writer */
-		segdbDesc = cdbconn_createSegmentDescriptor(cdbinfo, contentId == -1 ? false: writer);
+		segdbDesc = cdbconn_createSegmentDescriptor(cdbinfo, cdbinfo->cdbs->qeCounter++, contentId == -1 ? false: writer);
 	}
 
 	cdbconn_setQEIdentifier(segdbDesc, -1);

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -635,7 +635,7 @@ cdbcomponent_destroyCdbComponents(void)
  * not setup yet, callers need to establish the connection by themselves.
  */
 SegmentDatabaseDescriptor *
-cdbcomponent_allocateIdleSegdb(int contentId, bool writer)
+cdbcomponent_allocateIdleSegdb(int contentId, SegmentType segmentType)
 {
 	SegmentDatabaseDescriptor	*segdbDesc = NULL;
 	CdbComponentDatabaseInfo	*cdbinfo;
@@ -643,6 +643,7 @@ cdbcomponent_allocateIdleSegdb(int contentId, bool writer)
 	ListCell 					*nextItem = NULL;
 	ListCell					*prevItem = NULL;
 	MemoryContext 				oldContext;
+	bool						isWriter;
 
 	cdbinfo = cdbcomponent_getComponentInfo(contentId);	
 
@@ -657,7 +658,8 @@ cdbcomponent_allocateIdleSegdb(int contentId, bool writer)
 		nextItem = lnext(curItem);
 		Assert(tmp);
 
-		if (writer != tmp->isWriter)
+		if ((segmentType == SEGMENTTYPE_EXPLICT_WRITER && !tmp->isWriter) ||
+			(segmentType == SEGMENTTYPE_EXPLICT_READER && tmp->isWriter))
 		{
 			prevItem = curItem;
 			curItem = nextItem;
@@ -672,12 +674,14 @@ cdbcomponent_allocateIdleSegdb(int contentId, bool writer)
 		break;
 	}
 
-	AssertImply(segdbDesc, segdbDesc->isWriter == writer);
-
 	if (!segdbDesc)
 	{
-		/* for entrydb, it's never be writer */
-		segdbDesc = cdbconn_createSegmentDescriptor(cdbinfo, cdbinfo->cdbs->qeCounter++, contentId == -1 ? false: writer);
+		/*
+		 * 1. for entrydb, it's never be writer.
+		 * 2. for first QE, it must be a writer.
+		 */
+		isWriter = contentId == -1 ? false: (cdbinfo->numIdleQEs == 0 && cdbinfo->numActiveQEs == 0);
+		segdbDesc = cdbconn_createSegmentDescriptor(cdbinfo, cdbinfo->cdbs->qeCounter++, isWriter);
 	}
 
 	cdbconn_setQEIdentifier(segdbDesc, -1);
@@ -1553,3 +1557,21 @@ getgpsegmentCount(void)
 	Assert(GpIdentity.numsegments > 0);
 	return GpIdentity.numsegments;
 }
+
+List *
+cdbcomponent_getCdbComponentsList(void)
+{
+	CdbComponentDatabases *cdbs;
+	List *segments = NIL;
+	int i;
+
+	cdbs = cdbcomponent_getCdbComponents(true);
+
+	for (i = 0; i < cdbs->total_segments; i++)
+	{
+		segments = lappend_int(segments, i);
+	}
+
+	return segments;
+}
+

--- a/src/backend/cdb/dispatcher/README.md
+++ b/src/backend/cdb/dispatcher/README.md
@@ -7,6 +7,8 @@ This document illustrates the interfaces of a GPDB component called dispatcher, 
 The implementation of dispatcher is mainly located under this directory.
 
 ### Terms Used:
+* QD: Query Dispatcher, a backend forked by master with role GP_ROLE_DISPATCH who dispatches plan/command to QEs and get the results from QEs.
+* QE: Query Executor, a backend forked by master/segments with role GP_ROLE_EXECUTOR who gets plan/command from QD and pick a piece of it to execute.
 * Gang: Gang refers to a group of processes on segments. There are 4 types of Gang:
 	* `GANGTYPE_ENTRYDB_READER`: consist of one single process on master node
 	* `GANGTYPE_SINGLETON_READER`: consist of one single process on a segment node
@@ -19,9 +21,13 @@ For a query/plan, QD would build one `GANGTYPE_PRIMARY_WRITER` Gang, and several
 
 ### Interface Routines:
 * Gang creation and tear down:
-	* `AllocateGang`: allocate a gang with specified type on specified segments, the gang is made up of idle segment dbs got from CdbComponentDatabases (see cdbcomponent_allocateIdleSegdb).
-	* `RecycleGang`: put each member of gang back to segment pool if gang can be cleanup correctly including discarding results, connection status check (see cdbcomponent_recycleIdleSegdb), otherwise, destroy it.
-	* `DisconnectAndDestroyAllGangs`: tear down all existing Gangs of this session
+	* `AllocateGang`: allocate a gang with specified gang type on specified segments, the gang is made up of idle QEs got from CdbComponentDatabases, according QE type is requested for gang types (see cdbcomponent_allocateIdleQE):
+		* `GANGTYPE_ENTRYDB_READER`: SEGMENTTYPE_EXPLICT_ANY. 
+		* `GANGTYPE_SINGLETON_READER`: SEGMENTTYPE_EXPLICT_ANY or SEGMENTTYPE_EXPLICT_READER for cursor.
+		* `GANGTYPE_PRIMARY_READER`: SEGMENTTYPE_EXPLICT_ANY or SEGMENTTYPE_EXPLICT_READER for cursor.
+		* `GANGTYPE_PRIMARY_WRITER`: SEGMENTTYPE_EXPLICT_WRITER.
+	* `RecycleGang`: destroy or divide it into idle QEs pool, If gang can be cleanup correctly including discarding results, connection status check (see cdbcomponent_recycleIdleQE), otherwise, destroy it.
+	* `DisconnectAndDestroyAllGangs`: destroy all existing Gangs of this session
 * Gang status check:
 	* `GangOK`: check if a created Gang is healthy
 * Dispatch:
@@ -49,8 +55,7 @@ All dispatcher routines contains few standard steps:
 ### CdbComponentDatabases
 CdbComponentDatabases is a snapshot of current cluster components based on catalog gp_segment_configuration.
 It provides information about each segment component include dbid, contentid, hostname, ip address, current role etc.
-It also maintains a pool of idle segment dbs (SegmentDatabaseDescriptor), dispatcher can reuse those segment dbs
-between statements within a session.
+It also maintains a pool of idle QEs (SegmentDatabaseDescriptor), dispatcher can reuse those QEs between statements in the same session.
 
 CdbComponentDatabases has a memory context named CdbComponentsContext associated.
 
@@ -59,13 +64,13 @@ There are a few functions to manipulate CdbComponentDatabases, Dispatcher can us
 
 * cdbcomponent_getCdbComponents(): get a snapshot of current cluster components from gp_segment_configuration. When FTS version changed since last time, destroy current components snapshot and get a new one if 1) session has no temp tables 2) current gxact need two-phase commit but gxid has not been dispatched to segments yet or current gxact don't need two phase commit.
 
-* cdbcomponent_destroyCdbComponents(): destroy a snapshot of current cluster components include the MemoryContext and pool of idle segment dbs.
+* cdbcomponent_destroyCdbComponents(): destroy a snapshot of current cluster components including the MemoryContext and pool of idle QEs for all segments.
 
-* cdbcomponent_allocateIdleSegdb(contentId, SegmentType): allocate a free segment db by 1) reuse a segment db from pool of idle segment dbs. 2) create a brand new segment db. For case2, the connection is not actually established inside this function, the caller should establish the connections in a batch to gain performance. This function guarantees each segment in a session have only one writer. SegmentType can be:
+* cdbcomponent_allocateIdleQE(contentId, SegmentType): allocate a free QE by 1) reuse a QE from pool of idle QEs. 2) create a brand new QE. For case2, the connection is not actually established inside this function, the caller should establish the connections in a batch to gain performance. This function guarantees each segment in a session have only one writer. SegmentType can be:
 	* SEGMENTTYPE_EXPLICT_WRITER : must be writer, for DTX commands and DDL commands and DML commands need two-phase commit.
 	* SEGMENTTYPE_EXPLICT_READER : must be reader, only be used by cursor.
 	* SEGMENTTYPE_ANY: any type is ok, for most of queries which don't need two-phase commit.
 
-* cdbcomponent_recycleIdleSegdb(SegmentDatabaseDescriptor): recycle/destroy a segment db. a segment db will be destroyed if 1) caller specify forceDestroy to true. 2)connection to segment db is already bad. 3) FTS detect the segment is already down. 4) exceeded the pool size of idle segment dbs. 5) cached memory exceeded the limitation. otherwise, the segment db will be put into a pool for reusing later.
+* cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor): recycle/destroy a QE. a QE will be destroyed if 1) caller specify forceDestroy to true. 2)connection to QE is already bad. 3) FTS detect the segment is already down. 4) exceeded the pool size of idle QEs. 5) cached memory exceeded the limitation. otherwise, the QE will be put into a pool for reusing later.
 
-* cdbcomponent_cleanupIdleSegdbs(includeWriter): disconnect and destroy idle segment dbs of all components. includeWriter tells cleanup idle writers or not.
+* cdbcomponent_cleanupIdleQE(includeWriter): disconnect and destroy idle QEs of all segments. includeWriter tells cleanup idle writers or not.

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -30,8 +30,11 @@ static uint32 cdbconn_get_motion_listener_port(PGconn *conn);
 #include "cdb/cdbconn.h"		/* me */
 #include "cdb/cdbutil.h"		/* CdbComponentDatabaseInfo */
 #include "cdb/cdbvars.h"
+#include "cdb/cdbgang.h"
 
 int			gp_segment_connect_timeout = 180;
+
+static void cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc);
 
 static const char *
 transStatusToString(PGTransactionStatusType status)
@@ -235,11 +238,15 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 	pq_flush();
 }
 
-/* Initialize a QE connection descriptor in storage provided by the caller. */
+/* Initialize a QE connection descriptor in CdbComponentsContext */
 SegmentDatabaseDescriptor *
-cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo)
+cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, bool isWriter)
 {
-	SegmentDatabaseDescriptor *segdbDesc;
+	MemoryContext oldContext;
+	SegmentDatabaseDescriptor *segdbDesc = NULL;
+
+	Assert(CdbComponentsContext);
+	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
 
 	segdbDesc = (SegmentDatabaseDescriptor *)palloc0(sizeof(SegmentDatabaseDescriptor));
 
@@ -254,11 +261,13 @@ cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo)
 
 	/* whoami */
 	segdbDesc->whoami = NULL;
+	segdbDesc->isWriter = isWriter;
 
 	/* Connection error info */
 	segdbDesc->errcode = 0;
 	initPQExpBuffer(&segdbDesc->error_message);
 
+	MemoryContextSwitchTo(oldContext);
 	return segdbDesc;
 }
 
@@ -266,6 +275,10 @@ cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo)
 void
 cdbconn_termSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc)
 {
+	Assert(CdbComponentsContext);
+
+	cdbconn_disconnect(segdbDesc);
+
 	/* Free the error message buffer. */
 	segdbDesc->errcode = 0;
 	termPQExpBuffer(&segdbDesc->error_message);
@@ -531,7 +544,7 @@ cdbconn_doConnectComplete(SegmentDatabaseDescriptor *segdbDesc)
 }
 
 /* Disconnect from QE */
-void
+static void
 cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc)
 {
 	if (PQstatus(segdbDesc->conn) != CONNECTION_BAD)
@@ -643,12 +656,15 @@ cdbconn_resetQEErrorMessage(SegmentDatabaseDescriptor *segdbDesc)
  * Don't call this function in threads.
  */
 void
-setQEIdentifier(SegmentDatabaseDescriptor *segdbDesc,
-				int sliceIndex, MemoryContext mcxt)
+cdbconn_setQEIdentifier(SegmentDatabaseDescriptor *segdbDesc,
+				int sliceIndex)
 {
 	CdbComponentDatabaseInfo *cdbinfo = segdbDesc->segment_database_info;
-	MemoryContext oldContext = MemoryContextSwitchTo(mcxt);
 	StringInfoData string;
+	MemoryContext oldContext;
+
+	Assert(CdbComponentsContext);
+	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
 
 	initStringInfo(&string);
 
@@ -673,7 +689,9 @@ setQEIdentifier(SegmentDatabaseDescriptor *segdbDesc,
 
 	if (segdbDesc->whoami != NULL)
 		pfree(segdbDesc->whoami);
+
 	segdbDesc->whoami = string.data;
+
 	MemoryContextSwitchTo(oldContext);
 }
 

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -236,11 +236,12 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 }
 
 /* Initialize a QE connection descriptor in storage provided by the caller. */
-void
-cdbconn_initSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc,
-							  struct CdbComponentDatabaseInfo *cdbinfo)
+SegmentDatabaseDescriptor *
+cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo)
 {
-	MemSet(segdbDesc, 0, sizeof(*segdbDesc));
+	SegmentDatabaseDescriptor *segdbDesc;
+
+	segdbDesc = (SegmentDatabaseDescriptor *)palloc0(sizeof(SegmentDatabaseDescriptor));
 
 	/* Segment db info */
 	segdbDesc->segment_database_info = cdbinfo;
@@ -257,6 +258,8 @@ cdbconn_initSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc,
 	/* Connection error info */
 	segdbDesc->errcode = 0;
 	initPQExpBuffer(&segdbDesc->error_message);
+
+	return segdbDesc;
 }
 
 /* Free memory of segment descriptor. */

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -240,7 +240,7 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 
 /* Initialize a QE connection descriptor in CdbComponentsContext */
 SegmentDatabaseDescriptor *
-cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, bool isWriter)
+cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, int identifier, bool isWriter)
 {
 	MemoryContext oldContext;
 	SegmentDatabaseDescriptor *segdbDesc = NULL;
@@ -261,6 +261,7 @@ cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, bool i
 
 	/* whoami */
 	segdbDesc->whoami = NULL;
+	segdbDesc->identifier = identifier;
 	segdbDesc->isWriter = isWriter;
 
 	/* Connection error info */

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -105,6 +105,8 @@ cdbdisp_dispatchToGang(struct CdbDispatcherState *ds,
 	 * a separate file.
 	 */
 	(pDispatchFuncs->dispatchToGang) (ds, gp, sliceIndex, disp_direct);
+
+	markCurrentGxactDispatched();
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -33,6 +33,8 @@
 #include "cdb/cdbvars.h"
 #include "utils/resowner.h"
 
+static int numNonExtendedDispatcherState = 0;
+
 typedef struct dispatcher_handle_t
 {
 	struct CdbDispatcherState *dispatcherState;
@@ -48,7 +50,6 @@ static void cleanup_dispatcher_handle(dispatcher_handle_t *h);
 static dispatcher_handle_t *find_dispatcher_handle(CdbDispatcherState *ds);
 static dispatcher_handle_t *allocate_dispatcher_handle(void);
 static void destroy_dispatcher_handle(dispatcher_handle_t *h);
-static void cleanupDispatcherHandle(ResourceOwner owner);
 
 /*
  * default directed-dispatch parameters: don't direct anything.
@@ -295,10 +296,28 @@ CdbDispatchHandleError(struct CdbDispatcherState *ds)
 CdbDispatcherState *
 cdbdisp_makeDispatcherState(bool isExtendedQuery)
 {
-	dispatcher_handle_t *handle = allocate_dispatcher_handle();
-	handle->dispatcherState->recycleGang = true;
+	dispatcher_handle_t *handle;
+
+	if (!isExtendedQuery)
+	{
+		if (numNonExtendedDispatcherState == 1)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("query plan with multiple segworker groups is not supported"),
+					 errhint("likely caused by a function that reads or modifies data in a distributed table")));
+
+
+		}
+
+		numNonExtendedDispatcherState++;	
+	}
+
+	handle = allocate_dispatcher_handle();
+	handle->dispatcherState->destroyGang = false;
 	handle->dispatcherState->isExtendedQuery = isExtendedQuery;
 	handle->dispatcherState->allocatedGangs = NIL;
+
 	return handle->dispatcherState;
 }
 
@@ -330,12 +349,20 @@ void
 cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 {
 	ListCell *lc;
+	CdbDispatchResults *results;
+	dispatcher_handle_t *h;
 
 	if (!ds)
 		return;
 
-	CdbDispatchResults *results = ds->primaryResults;
-	dispatcher_handle_t *h = find_dispatcher_handle(ds);
+	if (!ds->isExtendedQuery)
+	{
+		numNonExtendedDispatcherState--;	
+		Assert(numNonExtendedDispatcherState == 0);
+	}
+
+	results = ds->primaryResults;
+	h = find_dispatcher_handle(ds);
 
 	if (results != NULL && results->resultArray != NULL)
 	{
@@ -353,15 +380,7 @@ cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 	{
 		Gang *gp = lfirst(lc);
 
-		if (gp->type == GANGTYPE_PRIMARY_WRITER)
-			cdbgang_resetPrimaryWriterGang();
-		else
-			cdbgang_decreaseNumReaderGang();
-
-		if (ds->recycleGang)
-			RecycleGang(gp);
-		else
-			DisconnectAndDestroyGang(gp);
+		RecycleGang(gp, ds->destroyGang);
 	}
 
 	ds->allocatedGangs = NIL;
@@ -507,7 +526,7 @@ AtAbort_DispatcherState(void)
 
 	if (CurrentGangCreating != NULL)
 	{
-		DisconnectAndDestroyGang(CurrentGangCreating);
+		RecycleGang(CurrentGangCreating, true);
 		CurrentGangCreating = NULL;
 	}
 
@@ -515,7 +534,7 @@ AtAbort_DispatcherState(void)
 	 * Cleanup all outbound dispatcher states belong to
 	 * current resource owner and its children
 	 */
-	CdbResourceOwnerWalker(CurrentResourceOwner, cleanupDispatcherHandle);
+	CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_cleanupDispatcherHandle);
 
 	Assert(open_dispatcher_handles == NULL);
 
@@ -538,15 +557,15 @@ AtSubAbort_DispatcherState(void)
 
 	if (CurrentGangCreating != NULL)
 	{
-		DisconnectAndDestroyGang(CurrentGangCreating);
+		RecycleGang(CurrentGangCreating, true);
 		CurrentGangCreating = NULL;
 	}
 
-	CdbResourceOwnerWalker(CurrentResourceOwner, cleanupDispatcherHandle);
+	CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_cleanupDispatcherHandle);
 }
 
-static void
-cleanupDispatcherHandle(const ResourceOwner owner)
+void
+cdbdisp_cleanupDispatcherHandle(const struct ResourceOwnerData *owner)
 {
 	dispatcher_handle_t *curr;
 	dispatcher_handle_t *next;
@@ -581,27 +600,7 @@ cdbdisp_markNamedPortalGangsDestroyed(void)
 	while (head != NULL)
 	{
 		if (!head->dispatcherState->isExtendedQuery)
-			head->dispatcherState->recycleGang = false;
+			head->dispatcherState->destroyGang = true;
 		head = head->next;
-	}
-}
-
-/*
- * Unlike dispatcher_abort_callback(), this function will
- * force destroy active dispatcher states
- */
-void
-cdbdisp_cleanupAllDispatcherState(void)
-{
-	dispatcher_handle_t *curr;
-	dispatcher_handle_t *next;
-
-	next = open_dispatcher_handles;
-	while (next)
-	{
-		curr = next;
-		next = curr->next;
-
-		cleanup_dispatcher_handle(curr);
 	}
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -82,15 +82,14 @@ typedef struct CdbDispatchCmdAsync
 
 } CdbDispatchCmdAsync;
 
-static void *cdbdisp_makeDispatchParams_async(int maxSlices, char *queryText, int len);
+static void *cdbdisp_makeDispatchParams_async(int maxSlices, int largestGangSize, char *queryText, int len);
 
 static void cdbdisp_checkDispatchResult_async(struct CdbDispatcherState *ds,
 								  DispatchWaitMode waitMode);
 
 static void cdbdisp_dispatchToGang_async(struct CdbDispatcherState *ds,
 							 struct Gang *gp,
-							 int sliceIndex,
-							 CdbDispatchDirectDesc *dispDirect);
+							 int sliceIndex);
 static void	cdbdisp_waitDispatchFinish_async(struct CdbDispatcherState *ds);
 
 static bool	cdbdisp_checkForCancel_async(struct CdbDispatcherState *ds);
@@ -278,8 +277,7 @@ cdbdisp_waitDispatchFinish_async(struct CdbDispatcherState *ds)
 static void
 cdbdisp_dispatchToGang_async(struct CdbDispatcherState *ds,
 							 struct Gang *gp,
-							 int sliceIndex,
-							 CdbDispatchDirectDesc *dispDirect)
+							 int sliceIndex)
 {
 	int			i;
 
@@ -295,14 +293,6 @@ cdbdisp_dispatchToGang_async(struct CdbDispatcherState *ds,
 		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
 
 		Assert(segdbDesc != NULL);
-
-		if (dispDirect->directed_dispatch)
-		{
-			/* We can direct dispatch to one segment DB only */
-			Assert(dispDirect->count == 1);
-			if (dispDirect->content[0] != segdbDesc->segindex)
-				continue;
-		}
 
 		/*
 		 * Initialize the QE's CdbDispatchResult object.
@@ -361,9 +351,9 @@ cdbdisp_checkDispatchResult_async(struct CdbDispatcherState *ds,
  * memory context.
  */
 static void *
-cdbdisp_makeDispatchParams_async(int maxSlices, char *queryText, int len)
+cdbdisp_makeDispatchParams_async(int maxSlices, int largestGangSize, char *queryText, int len)
 {
-	int			maxResults = maxSlices * getgpsegmentCount();
+	int			maxResults = maxSlices * largestGangSize;
 	int			size = 0;
 
 	CdbDispatchCmdAsync *pParms = palloc0(sizeof(CdbDispatchCmdAsync));

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -291,7 +291,7 @@ cdbdisp_dispatchToGang_async(struct CdbDispatcherState *ds,
 	{
 		CdbDispatchResult *qeResult;
 
-		SegmentDatabaseDescriptor *segdbDesc = &gp->db_descriptors[i];
+		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
 
 		Assert(segdbDesc != NULL);
 

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -282,6 +282,7 @@ cdbdisp_dispatchToGang_async(struct CdbDispatcherState *ds,
 							 CdbDispatchDirectDesc *dispDirect)
 {
 	int			i;
+
 	CdbDispatchCmdAsync *pParms = (CdbDispatchCmdAsync *) ds->dispatchParams;
 
 	/*

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -117,6 +117,7 @@ cdbdisp_dispatchX(QueryDesc *queryDesc,
 
 static char *serializeParamListInfo(ParamListInfo paramLI, int *len_p);
 
+static List * formIdleSegmentIdList(void);
 /*
  * Compose and dispatch the MPPEXEC commands corresponding to a plan tree
  * within a complete parallel plan. (A plan tree will correspond either
@@ -266,13 +267,10 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 
 	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
 
-	AllocateWriterGang(ds);
+	AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, cdbcomponent_getCdbComponentsList());
 
-	/* 
-	 * FIXME: it's now not easy to get all idle gang, will fix
-	 * in following commits
-	 */ 
-	cdbcomponent_cleanupIdleSegdbs(false);
+	/* put all idle segment to a gang so QD can send SET command to them */
+	AllocateGang(ds, GANGTYPE_PRIMARY_READER, formIdleSegmentIdList());
 	
 	cdbdisp_makeDispatchResults(ds, list_length(ds->allocatedGangs), cancelOnError);
 	cdbdisp_makeDispatchParams (ds, list_length(ds->allocatedGangs), queryText, queryTextLength);
@@ -281,7 +279,7 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 	{
 		Gang	   *rg = lfirst(le);
 
-		cdbdisp_dispatchToGang(ds, rg, -1, DEFAULT_DISP_DIRECT);
+		cdbdisp_dispatchToGang(ds, rg, -1);
 	}
 
 	cdbdisp_waitDispatchFinish(ds);
@@ -396,13 +394,14 @@ cdbdisp_dispatchCommandInternal(DispatchCommandQueryParms *pQueryParms,
 	/*
 	 * Allocate a primary QE for every available segDB in the system.
 	 */
-	primaryGang = AllocateWriterGang(ds);
+	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER,
+										cdbcomponent_getCdbComponentsList());
 	Assert(primaryGang);
 
 	cdbdisp_makeDispatchResults(ds, 1, flags & DF_CANCEL_ON_ERROR);
 	cdbdisp_makeDispatchParams (ds, 1, queryText, queryTextLength);
 
-	cdbdisp_dispatchToGang(ds, primaryGang, -1, DEFAULT_DISP_DIRECT);
+	cdbdisp_dispatchToGang(ds, primaryGang, -1);
 
 	cdbdisp_waitDispatchFinish(ds);
 
@@ -662,6 +661,13 @@ compare_slice_order(const void *aa, const void *bb)
 	{
 		return 1;
 	}
+
+	/* sort slice with larger size first because it has a bigger chance to contain writers */
+	if (a->slice->primaryGang->size > b->slice->primaryGang->size)
+		return -1;
+
+	if (a->slice->primaryGang->size < b->slice->primaryGang->size)
+		return 1;
 
 	if (a->children == b->children)
 		return 0;
@@ -1069,7 +1075,6 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 
 	for (iSlice = 0; iSlice < nSlices; iSlice++)
 	{
-		CdbDispatchDirectDesc direct;
 		Gang	   *primaryGang = NULL;
 		Slice	   *slice = NULL;
 		int			si = -1;
@@ -1098,17 +1103,6 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 
 		if (slice->directDispatch.isDirectDispatch)
 		{
-			direct.directed_dispatch = true;
-			Assert(list_length(slice->directDispatch.contentIds) == 1);
-			direct.count = 1;
-
-			/*
-			 * We only support single content right now. If this changes then
-			 * we need to change from a list to another structure to avoid n^2
-			 * cases
-			 */
-			direct.content[0] = linitial_int(slice->directDispatch.contentIds);
-
 			if (Test_print_direct_dispatch_info)
 			{
 				elog(INFO, "Dispatch command to SINGLE content");
@@ -1116,9 +1110,6 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		}
 		else
 		{
-			direct.directed_dispatch = false;
-			direct.count = 0;
-
 			if (Test_print_direct_dispatch_info)
 			{
 				elog(INFO, "Dispatch command to ALL contents");
@@ -1137,7 +1128,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		}
 		SIMPLE_FAULT_INJECTOR(BeforeOneSliceDispatched);
 
-		cdbdisp_dispatchToGang(ds, primaryGang, si, &direct);
+		cdbdisp_dispatchToGang(ds, primaryGang, si);
 
 		SIMPLE_FAULT_INJECTOR(AfterOneSliceDispatched);
 	}
@@ -1415,13 +1406,14 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	/*
 	 * Allocate a primary QE for every available segDB in the system.
 	 */
-	primaryGang = AllocateWriterGang(ds);
+	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER,
+										cdbcomponent_getCdbComponentsList());
 	Assert(primaryGang);
 
 	cdbdisp_makeDispatchResults(ds, 1, flags & DF_CANCEL_ON_ERROR);
 	cdbdisp_makeDispatchParams (ds, 1, queryText, queryTextLength);
 
-	cdbdisp_dispatchToGang(ds, primaryGang, -1, DEFAULT_DISP_DIRECT);
+	cdbdisp_dispatchToGang(ds, primaryGang, -1);
 
 	cdbdisp_waitDispatchFinish(ds);
 
@@ -1449,4 +1441,33 @@ CdbDispatchCopyEnd(struct CdbCopy *cdbCopy)
 	ds = cdbCopy->dispatcherState;
 	cdbCopy->dispatcherState = NULL;
 	cdbdisp_destroyDispatcherState(ds);
+}
+
+/*
+ * Helper function only used by CdbDispatchSetCommand()
+ *
+ * Return a List of segment id who has idle segment dbs, the list
+ * may contain duplicated segment id. eg, if segment 0 has two
+ * idle segment dbs in freelist, the list looks like 0 -> 0.
+ */
+static List *
+formIdleSegmentIdList(void)
+{
+	CdbComponentDatabases	*cdbs;
+	List					*segments = NIL;
+	int						i, j;
+
+	cdbs = cdbcomponent_getCdbComponents(true);
+
+	if (cdbs->segment_db_info != NULL)
+	{
+		for (i = 0; i < cdbs->total_segment_dbs; i++)
+		{
+			CdbComponentDatabaseInfo *cdi = &cdbs->segment_db_info[i];
+			for (j = 0; j < cdi->numIdleQEs; j++)
+				segments = lappend_int(segments, cdi->segindex);
+		}
+	}
+
+	return segments;
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1165,6 +1165,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 			if (InterruptPending)
 				break;
 		}
+		SIMPLE_FAULT_INJECTOR(BeforeOneSliceDispatched);
 
 		cdbdisp_dispatchToGang(ds, primaryGang, si, &direct);
 

--- a/src/backend/cdb/dispatcher/cdbdisp_thread.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_thread.c
@@ -120,7 +120,7 @@ typedef struct CdbDispatchCmdThreads
  */
 static volatile int32 RunningThreadCount = 0;
 
-static int	getMaxThreadsPerGang(void);
+static int	getMaxThreadsPerGang(int largestGangSize);
 
 static bool shouldStillDispatchCommand(DispatchCommandParms *pParms,
 						   CdbDispatchResult *dispatchResult);
@@ -148,15 +148,14 @@ static void
 static bool
 			cdbdisp_shouldCancel(struct CdbDispatcherState *ds);
 
-static void *cdbdisp_makeDispatchThreads(int maxSlices, char *queryText, int queryTextLen);
+static void *cdbdisp_makeDispatchThreads(int maxSlices, int largestGangSize, char *queryText, int queryTextLen);
 
 static void CdbCheckDispatchResult_internal(struct CdbDispatcherState *ds,
 								DispatchWaitMode waitMode);
 
 static void cdbdisp_dispatchToGang_internal(struct CdbDispatcherState *ds,
 								struct Gang *gp,
-								int sliceIndex,
-								CdbDispatchDirectDesc *dispDirect);
+								int sliceIndex);
 
 DispatcherInternalFuncs DispatcherSyncFuncs =
 {
@@ -177,8 +176,7 @@ DispatcherInternalFuncs DispatcherSyncFuncs =
 static int
 cdbdisp_initDispatchParmsForGang(struct CdbDispatcherState *ds,
 								 struct Gang *gp,
-								 int sliceIndex,
-								 CdbDispatchDirectDesc *disp_direct)
+								 int sliceIndex)
 {
 	CdbDispatchCmdThreads *pThreads = NULL;
 	int			segdbsToDispatch = 0;
@@ -202,14 +200,6 @@ cdbdisp_initDispatchParmsForGang(struct CdbDispatcherState *ds,
 		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
 
 		Assert(segdbDesc != NULL);
-
-		if (disp_direct->directed_dispatch)
-		{
-			/* currently we allow direct-to-one dispatch, only */
-			Assert(disp_direct->count == 1);
-			if (disp_direct->content[0] != segdbDesc->segindex)
-				continue;
-		}
 
 		/*
 		 * Initialize the QE's CdbDispatchResult object.
@@ -247,13 +237,12 @@ cdbdisp_initDispatchParmsForGang(struct CdbDispatcherState *ds,
 void
 cdbdisp_dispatchToGang_internal(struct CdbDispatcherState *ds,
 								struct Gang *gp,
-								int sliceIndex,
-								CdbDispatchDirectDesc *disp_direct)
+								int sliceIndex)
 {
 	int			i = 0;
 	CdbDispatchCmdThreads *pThreads = (CdbDispatchCmdThreads *) ds->dispatchParams;
 	int			threadStartIndex = pThreads->threadCount;
-	int			newThreads = cdbdisp_initDispatchParmsForGang(ds, gp, sliceIndex, disp_direct);
+	int			newThreads = cdbdisp_initDispatchParmsForGang(ds, gp, sliceIndex);
 
 	/*
 	 * Create the threads. (which also starts the dispatching).
@@ -440,9 +429,9 @@ cdbdisp_waitThreads(void)
  * memory context.
  */
 void *
-cdbdisp_makeDispatchThreads(int maxSlices, char *queryText, int queryTextLen)
+cdbdisp_makeDispatchThreads(int maxSlices, int largestGangSize, char *queryText, int queryTextLen)
 {
-	int			maxThreadsPerGang = getMaxThreadsPerGang();
+	int			maxThreadsPerGang = getMaxThreadsPerGang(largestGangSize);
 	int			maxThreads = maxThreadsPerGang * maxSlices;
 
 	int			maxConn = gp_connections_per_thread;
@@ -943,9 +932,9 @@ cdbdisp_checkSegmentDBAlive(DispatchCommandParms *pParms)
 }
 
 static int
-getMaxThreadsPerGang(void)
+getMaxThreadsPerGang(int largestGangSize)
 {
-	return 1 + (largestGangsize() - 1) / gp_connections_per_thread;
+	return 1 + (largestGangSize - 1) / gp_connections_per_thread;
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbdisp_thread.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_thread.c
@@ -199,7 +199,7 @@ cdbdisp_initDispatchParmsForGang(struct CdbDispatcherState *ds,
 		CdbDispatchResult *qeResult = NULL;
 		DispatchCommandParms *pParms = NULL;
 		int			parmsIndex = 0;
-		SegmentDatabaseDescriptor *segdbDesc = &gp->db_descriptors[i];
+		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
 
 		Assert(segdbDesc != NULL);
 

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -942,7 +942,7 @@ cdbdisp_makeDispatchResults(CdbDispatcherState *ds,
 	Assert(DispatcherContext);
 	oldContext = MemoryContextSwitchTo(DispatcherContext);
 
-	resultCapacity = largestGangsize() * sliceCapacity;
+	resultCapacity = ds->largestGangSize * sliceCapacity;
 	nbytes = resultCapacity * sizeof(results->resultArray[0]);
 
 	results = palloc0(sizeof(*results));

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -1018,12 +1018,3 @@ RecycleGang(Gang *gp, bool forceDestroy)
 		cdbcomponent_recycleIdleSegdb(segdbDesc, forceDestroy);
 	}
 }
-
-void
-AvailableWriterGangValidation(void)
-{
-	if (availablePrimaryWriterGang && !GangOK(availablePrimaryWriterGang))
-	{
-		DisconnectAndDestroyAllGangs(true);
-	}
-}

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -48,13 +48,12 @@
 #include "cdb/cdbtm.h"			/* discardDtxTransaction() */
 #include "cdb/cdbutil.h"		/* CdbComponentDatabaseInfo */
 #include "cdb/cdbvars.h"		/* Gp_role, etc. */
+#include "cdb/cdbconn.h"		/* Gp_role, etc. */
 #include "storage/bfz.h"
 #include "libpq/libpq-be.h"
 #include "libpq/ip.h"
 
 #include "utils/guc_tables.h"
-
-#define MAX_CACHED_1_GANGS 1
 
 /*
  * Which gang this QE belongs to; this would be used in PostgresMain to find out
@@ -67,26 +66,14 @@ int			qe_gang_id = 0;
  */
 int			host_segments = 0;
 
-MemoryContext GangContext = NULL;
-Gang	   *CurrentGangCreating = NULL;
+Gang      *CurrentGangCreating = NULL;
 
 CreateGangFunc pCreateGangFunc = NULL;
-
-/*
- * Points to the result of getCdbComponentDatabases()
- */
-static CdbComponentDatabases *cdb_component_dbs = NULL;
 
 static int	largest_gangsize = 0;
 
 static bool NeedResetSession = false;
 static Oid	OldTempNamespace = InvalidOid;
-
-static List *availableReaderGangsN = NIL;
-static List *availableReaderGangs1 = NIL;
-static Gang *availablePrimaryWriterGang= NULL;
-static Gang *primaryWriterGang = NULL;
-static int numAllocatedReaderGangs = 0;
 
 /*
  * Every gang created must have a unique identifier
@@ -96,15 +83,8 @@ static int	gang_id_counter = 2;
 
 
 static Gang *createGang(GangType type, int gang_id, int size, int content);
-static void disconnectAndDestroyAllReaderGangs(bool destroyAllocated);
 
-static bool cleanupGang(Gang *gp);
 static void resetSessionForPrimaryGangLoss(void);
-static CdbComponentDatabaseInfo *copyCdbComponentDatabaseInfo(
-							 CdbComponentDatabaseInfo *dbInfo);
-static CdbComponentDatabaseInfo *findDatabaseInfoBySegIndex(
-						   CdbComponentDatabases *cdbs, int segIndex);
-static Gang *getAvailableGang(GangType type, int size, int content);
 
 /*
  * Create a reader gang.
@@ -114,32 +94,15 @@ static Gang *getAvailableGang(GangType type, int size, int content);
 Gang *
 AllocateReaderGang(CdbDispatcherState *ds, GangType type, char *portal_name)
 {
-	MemoryContext oldContext = NULL;
 	Gang	   *gp = NULL;
 	int			size = 0;
 	int			content = 0;
-
-	ELOG_DISPATCHER_DEBUG("AllocateReaderGang for portal %s: availableReaderGangsN %d, "
-						  "availableReaderGangs1 %d",
-						  (portal_name ? portal_name : "<unnamed>"),
-						  list_length(availableReaderGangsN),
-						  list_length(availableReaderGangs1));
+	MemoryContext oldContext;
 
 	if (Gp_role != GP_ROLE_DISPATCH)
 	{
 		elog(FATAL, "dispatch process called with role %d", Gp_role);
 	}
-
-	if (GangContext == NULL)
-	{
-		GangContext = AllocSetContextCreate(TopMemoryContext, "Gang Context",
-											ALLOCSET_DEFAULT_MINSIZE,
-											ALLOCSET_DEFAULT_INITSIZE,
-											ALLOCSET_DEFAULT_MAXSIZE);
-	}
-	Assert(GangContext != NULL);
-
-	oldContext = MemoryContextSwitchTo(GangContext);
 
 	switch (type)
 	{
@@ -162,19 +125,14 @@ AllocateReaderGang(CdbDispatcherState *ds, GangType type, char *portal_name)
 			Assert(false);
 	}
 
-	/*
-	 * First, we look for an unallocated but created gang of the right type if
-	 * it exists, we return it. Else, we create a new gang
-	 */
-	gp = getAvailableGang(type, size, content);
-	if (gp == NULL)
-	{
-		ELOG_DISPATCHER_DEBUG("Creating a new reader size %d gang for %s",
-							  size, (portal_name ? portal_name : "unnamed portal"));
+	ELOG_DISPATCHER_DEBUG("Creating a new reader size %d gang for %s",
+						  size, (portal_name ? portal_name : "unnamed portal"));
 
-		gp = createGang(type, gang_id_counter++, size, content);
-		gp->allocated = true;
-	}
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
+
+	gp = createGang(type, gang_id_counter++, size, content);
+	gp->allocated = true;
+	ds->allocatedGangs = lcons(gp, ds->allocatedGangs);
 
 	/*
 	 * make sure no memory is still allocated for previous portal name that
@@ -188,16 +146,6 @@ AllocateReaderGang(CdbDispatcherState *ds, GangType type, char *portal_name)
 
 	MemoryContextSwitchTo(oldContext);
 
-	oldContext = MemoryContextSwitchTo(DispatcherContext);
-	ds->allocatedGangs = lcons(gp, ds->allocatedGangs);
-	numAllocatedReaderGangs++;
-	MemoryContextSwitchTo(oldContext);
-
-	ELOG_DISPATCHER_DEBUG("on return: availableReaderGangsN %d, "
-						  "availableReaderGangs1 %d",
-						  list_length(availableReaderGangsN),
-						  list_length(availableReaderGangs1));
-
 	return gp;
 }
 
@@ -207,9 +155,10 @@ AllocateReaderGang(CdbDispatcherState *ds, GangType type, char *portal_name)
 Gang *
 AllocateWriterGang(CdbDispatcherState *ds)
 {
+	MemoryContext oldContext;
 	Gang	   *writerGang = NULL;
-	MemoryContext oldContext = NULL;
 	int			i = 0;
+	int nsegdb = getgpsegmentCount();
 
 	ELOG_DISPATCHER_DEBUG("AllocateWriterGang begin.");
 
@@ -218,71 +167,23 @@ AllocateWriterGang(CdbDispatcherState *ds)
 		elog(FATAL, "dispatch process called with role %d", Gp_role);
 	}
 
-	if (GangContext == NULL)
-	{
-		GangContext = AllocSetContextCreate(TopMemoryContext, "Gang Context",
-											ALLOCSET_DEFAULT_MINSIZE,
-											ALLOCSET_DEFAULT_INITSIZE,
-											ALLOCSET_DEFAULT_MAXSIZE);
-	}
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
 
-	if (primaryWriterGang)
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("query plan with multiple segworker groups is not supported"),
-				 errhint("likely caused by a function that reads or modifies data in a distributed table")));
-	}
+	writerGang = createGang(GANGTYPE_PRIMARY_WRITER, PRIMARY_WRITER_GANG_ID, nsegdb, -1);
+	writerGang->allocated = true;
 
 	/*
-	 * First, we look for an unallocated but created gang of the right type if
-	 * it exists, we return it. Else, we create a new gang
+	 * set "whoami" for utility statement. non-utility statement will
+	 * overwrite it in function getCdbProcessList.
 	 */
-	if (availablePrimaryWriterGang != NULL)
-	{
-		if (!GangOK(availablePrimaryWriterGang))
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-					 errmsg("could not connect to segment: initialization of segworker group failed")));
-		}
-		else
-		{
-			ELOG_DISPATCHER_DEBUG("Reusing an existing primary writer gang");
-			writerGang = availablePrimaryWriterGang;
-			availablePrimaryWriterGang = NULL;
-		}
-	}
-
-	if (writerGang == NULL)
-	{
-		int			nsegdb = getgpsegmentCount();
-
-		insist_log(IsTransactionOrTransactionBlock(),
-				   "cannot allocate segworker group outside of transaction");
-
-		oldContext = MemoryContextSwitchTo(GangContext);
-
-		writerGang = createGang(GANGTYPE_PRIMARY_WRITER,
-								PRIMARY_WRITER_GANG_ID, nsegdb, -1);
-		writerGang->allocated = true;
-
-		/*
-		 * set "whoami" for utility statement. non-utility statement will
-		 * overwrite it in function getCdbProcessList.
-		 */
-		for (i = 0; i < writerGang->size; i++)
-			setQEIdentifier(writerGang->db_descriptors[i], -1, writerGang->perGangContext);
-
-		MemoryContextSwitchTo(oldContext);
-	}
+	for (i = 0; i < writerGang->size; i++)
+		cdbconn_setQEIdentifier(writerGang->db_descriptors[i], -1);
 
 	ELOG_DISPATCHER_DEBUG("AllocateWriterGang end.");
 
-	primaryWriterGang = writerGang;
-	oldContext = MemoryContextSwitchTo(DispatcherContext);
 	ds->allocatedGangs = lcons(writerGang, ds->allocatedGangs);
-	oldContext = MemoryContextSwitchTo(oldContext);
+
+	MemoryContextSwitchTo(oldContext);
 
 	return writerGang;
 }
@@ -341,88 +242,6 @@ segment_failure_due_to_recovery(const char *error_message)
 }
 
 /*
- * Read gp_segment_configuration catalog table and build a CdbComponentDatabases.
- *
- * Read the catalog if FTS is reconfigured.
- *
- * We don't want to destroy cdb_component_dbs when one gang get destroyed, so allocate
- * it in GangContext instead of perGangContext.
- */
-CdbComponentDatabases *
-getComponentDatabases(void)
-{
-	Assert(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY);
-
-	uint8		ftsVersion = getFtsVersion();
-	MemoryContext oldContext = MemoryContextSwitchTo(GangContext);
-
-	if (cdb_component_dbs == NULL)
-	{
-		cdb_component_dbs = getCdbComponentDatabases();
-		cdb_component_dbs->fts_version = ftsVersion;
-	}
-	else if (cdb_component_dbs->fts_version != ftsVersion)
-	{
-		ELOG_DISPATCHER_DEBUG("FTS rescanned, get new component databases info.");
-		freeCdbComponentDatabases(cdb_component_dbs);
-		cdb_component_dbs = getCdbComponentDatabases();
-		cdb_component_dbs->fts_version = ftsVersion;
-	}
-
-	MemoryContextSwitchTo(oldContext);
-
-	return cdb_component_dbs;
-}
-
-/*
- * Make a copy of CdbComponentDatabaseInfo.
- *
- * Caller destroy it.
- */
-static CdbComponentDatabaseInfo *
-copyCdbComponentDatabaseInfo(
-							 CdbComponentDatabaseInfo *dbInfo)
-{
-	int			i = 0;
-	int			size = sizeof(CdbComponentDatabaseInfo);
-	CdbComponentDatabaseInfo *newInfo = palloc0(size);
-
-	memcpy(newInfo, dbInfo, size);
-
-	if (dbInfo->hostip)
-		newInfo->hostip = pstrdup(dbInfo->hostip);
-
-	/* So far, we don't need them. */
-	newInfo->address = NULL;
-	newInfo->hostname = NULL;
-	for (i = 0; i < COMPONENT_DBS_MAX_ADDRS; i++)
-		newInfo->hostaddrs[i] = NULL;
-
-	return newInfo;
-}
-
-/*
- * Find CdbComponentDatabases in the array by segment index.
- */
-static CdbComponentDatabaseInfo *
-findDatabaseInfoBySegIndex(
-						   CdbComponentDatabases *cdbs, int segIndex)
-{
-	Assert(cdbs != NULL);
-	int			i = 0;
-	CdbComponentDatabaseInfo *cdbInfo = NULL;
-
-	for (i = 0; i < cdbs->total_segment_dbs; i++)
-	{
-		cdbInfo = &cdbs->segment_db_info[i];
-		if (segIndex == cdbInfo->segindex)
-			break;
-	}
-
-	return cdbInfo;
-}
-
-/*
  * Reads the GP catalog tables and build a CdbComponentDatabases structure.
  * It then converts this to a Gang structure and initializes all the non-connection related fields.
  *
@@ -433,10 +252,7 @@ Gang *
 buildGangDefinition(GangType type, int gang_id, int size, int content)
 {
 	Gang	   *newGangDefinition = NULL;
-	CdbComponentDatabaseInfo *cdbinfo = NULL;
-	CdbComponentDatabaseInfo *cdbInfoCopy = NULL;
 	SegmentDatabaseDescriptor *segdbDesc = NULL;
-	MemoryContext perGangContext = NULL;
 
 	int			segCount = 0;
 	int			i = 0;
@@ -444,23 +260,8 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 	ELOG_DISPATCHER_DEBUG("buildGangDefinition:Starting %d qExec processes for %s gang",
 						  size, gangTypeToString(type));
 
-	Assert(CurrentMemoryContext == GangContext);
+	Assert(CurrentMemoryContext == DispatcherContext);
 	Assert(size == 1 || size == getgpsegmentCount());
-
-	/* read gp_segment_configuration and build CdbComponentDatabases */
-	cdb_component_dbs = getComponentDatabases();
-
-	if (cdb_component_dbs == NULL ||
-		cdb_component_dbs->total_segments <= 0 ||
-		cdb_component_dbs->total_segment_dbs <= 0)
-		insist_log(false, "schema not populated while building segworker group");
-
-	perGangContext = AllocSetContextCreate(GangContext, "Per Gang Context",
-										   ALLOCSET_DEFAULT_MINSIZE,
-										   ALLOCSET_DEFAULT_INITSIZE,
-										   ALLOCSET_DEFAULT_MAXSIZE);
-	Assert(perGangContext != NULL);
-	MemoryContextSwitchTo(perGangContext);
 
 	/* allocate a gang */
 	newGangDefinition = (Gang *) palloc0(sizeof(Gang));
@@ -468,67 +269,60 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 	newGangDefinition->size = size;
 	newGangDefinition->gang_id = gang_id;
 	newGangDefinition->allocated = false;
-	newGangDefinition->noReuse = false;
 	newGangDefinition->dispatcherActive = false;
 	newGangDefinition->portal_name = NULL;
-	newGangDefinition->perGangContext = perGangContext;
 	newGangDefinition->db_descriptors =
 		(SegmentDatabaseDescriptor **) palloc0(size * sizeof(SegmentDatabaseDescriptor*));
 
-	/* initialize db_descriptors */
-	switch (type)
+	PG_TRY();
 	{
-		case GANGTYPE_ENTRYDB_READER:
-			cdbinfo = &cdb_component_dbs->entry_db_info[0];
-			cdbInfoCopy = copyCdbComponentDatabaseInfo(cdbinfo);
-			segdbDesc = cdbconn_createSegmentDescriptor(cdbInfoCopy);
-			setQEIdentifier(segdbDesc, -1, perGangContext);
-			newGangDefinition->db_descriptors[0] = segdbDesc;
-			break;
+		/* initialize db_descriptors */
+		switch (type)
+		{
+			case GANGTYPE_ENTRYDB_READER:
+				segdbDesc = cdbcomponent_allocateIdleSegdb(-1, false);
+				newGangDefinition->db_descriptors[0] = segdbDesc;
+				break;
 
-		case GANGTYPE_SINGLETON_READER:
-			cdbinfo = findDatabaseInfoBySegIndex(cdb_component_dbs, content);
-			cdbInfoCopy = copyCdbComponentDatabaseInfo(cdbinfo);
-			segdbDesc = cdbconn_createSegmentDescriptor(cdbInfoCopy);
-			setQEIdentifier(segdbDesc, -1, perGangContext);
-			newGangDefinition->db_descriptors[0] = segdbDesc;
-			break;
+			case GANGTYPE_SINGLETON_READER:
+				segdbDesc = cdbcomponent_allocateIdleSegdb(content, false);
+				newGangDefinition->db_descriptors[0] = segdbDesc;
+				break;
 
-		case GANGTYPE_PRIMARY_READER:
-		case GANGTYPE_PRIMARY_WRITER:
+			case GANGTYPE_PRIMARY_READER:
+			case GANGTYPE_PRIMARY_WRITER:
 
-			/*
-			 * We loop through the segment_db_info.  Each item has a segindex.
-			 * They are sorted by segindex, and there can be > 1
-			 * segment_db_info for a given segindex (currently, there can be 1
-			 * or 2)
-			 */
-			for (i = 0; i < cdb_component_dbs->total_segment_dbs; i++)
-			{
-				cdbinfo = &cdb_component_dbs->segment_db_info[i];
-				if (SEGMENT_IS_ACTIVE_PRIMARY(cdbinfo))
+				/*
+				 * We loop through the segment_db_info.  Each item has a segindex.
+				 * They are sorted by segindex, and there can be > 1
+				 * segment_db_info for a given segindex (currently, there can be 1
+				 * or 2)
+				 */
+				for (i = 0; i < getgpsegmentCount(); i++)
 				{
-					cdbInfoCopy = copyCdbComponentDatabaseInfo(cdbinfo);
-					segdbDesc = cdbconn_createSegmentDescriptor(cdbInfoCopy);
-					setQEIdentifier(segdbDesc, -1, perGangContext);
+					segdbDesc = cdbcomponent_allocateIdleSegdb(i, type == GANGTYPE_PRIMARY_WRITER);
+
 					newGangDefinition->db_descriptors[segCount] = segdbDesc;
 					segCount++;
 				}
-			}
 
-			if (size != segCount)
-			{
-				DisconnectAndDestroyAllGangs(true);
-				elog(ERROR, "Not all primary segment instances are active and connected");
-			}
-			break;
+				if (size != segCount)
+				{
+					elog(ERROR, "Not all primary segment instances are active and connected");
+				}
+				break;
 
-		default:
-			Assert(false);
+			default:
+				Assert(false);
+		}
 	}
+	PG_CATCH();
+	{
+		RecycleGang(newGangDefinition, true);
+	}
+	PG_END_TRY();
 
 	ELOG_DISPATCHER_DEBUG("buildGangDefinition done");
-	MemoryContextSwitchTo(GangContext);
 	return newGangDefinition;
 }
 
@@ -627,7 +421,7 @@ makeOptions(void)
 
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
-	qdinfo = &cdb_component_dbs->entry_db_info[0];
+	qdinfo = cdbcomponent_getComponentInfo(-1); 
 	appendStringInfo(&string, " -c gp_qd_hostname=%s", qdinfo->hostip);
 	appendStringInfo(&string, " -c gp_qd_port=%d", qdinfo->port);
 
@@ -752,139 +546,6 @@ bad:
 	elog(FATAL, "Segment dispatched with invalid option: 'gpqeid=%s'", gpqeid_value);
 }
 
-/*
- * This is where we keep track of all the gangs that exist for this session.
- * On a QD, gangs can either be "available" (not currently in use), or "allocated".
- */
-void
-AllocateAllIdleReaderGangs(CdbDispatcherState *ds)
-{
-	ListCell   *le;
-	MemoryContext oldContext;
-
-	Assert(DispatcherContext);
-	oldContext = MemoryContextSwitchTo(DispatcherContext);
-
-	/*
-	 * Do not use list_concat() here, it would destructively modify the lists!
-	 */
-	foreach(le, availableReaderGangsN)
-	{
-		ds->allocatedGangs = lappend(ds->allocatedGangs, lfirst(le));
-		numAllocatedReaderGangs++;
-	}
-	availableReaderGangsN = NIL;
-
-	foreach(le, availableReaderGangs1)
-	{
-		ds->allocatedGangs = lappend(ds->allocatedGangs, lfirst(le));
-		numAllocatedReaderGangs++;
-	}
-	availableReaderGangs1 = NIL;
-
-	MemoryContextSwitchTo(oldContext);
-}
-
-static Gang *
-getAvailableGang(GangType type, int size, int content)
-{
-	Gang	   *retGang = NULL;
-
-	switch (type)
-	{
-		case GANGTYPE_SINGLETON_READER:
-		case GANGTYPE_ENTRYDB_READER:
-			if (availableReaderGangs1 != NULL)	/* There are gangs already
-												 * created */
-			{
-				ListCell   *cur_item = NULL;
-				ListCell   *prev_item = NULL;
-				ListCell   *next_item = NULL;
-
-				cur_item = list_head(availableReaderGangs1);
-
-				while (cur_item != NULL)
-				{
-					Gang	   *gang = (Gang *) lfirst(cur_item);
-
-					Assert(gang != NULL);
-					Assert(gang->size == size);
-
-					next_item = lnext(cur_item);
-
-					if (gang->db_descriptors[0]->segindex == content)
-					{
-						availableReaderGangs1 = list_delete_cell(availableReaderGangs1, cur_item, prev_item);
-
-						/* sanity check */
-						if (!GangOK(gang))
-						{
-							/* connection is bad or segment is down */
-							DisconnectAndDestroyGang(gang);
-						}
-						else
-						{
-							ELOG_DISPATCHER_DEBUG("reusing an available reader 1-gang for seg%d", content);
-							retGang = gang;
-							break;
-						}
-						/* prev_item does not advance */
-					}
-					else
-					{
-						prev_item = cur_item;
-					}
-
-					cur_item = next_item;
-				}
-			}
-			break;
-
-		case GANGTYPE_PRIMARY_READER:
-			if (availableReaderGangsN != NULL)	/* There are gangs already
-												 * created */
-			{
-				ListCell   *cur_item = NULL;
-				ListCell   *prev_item = NULL;
-				ListCell   *next_item = NULL;
-
-				cur_item = list_head(availableReaderGangsN);
-
-				while (cur_item != NULL)
-				{
-					Gang	   *gang = (Gang *) lfirst(cur_item);
-
-					Assert(gang != NULL);
-					Assert(gang->size == size);
-					next_item = lnext(cur_item);
-
-					availableReaderGangsN = list_delete_cell(availableReaderGangsN, cur_item, prev_item);
-
-					/* sanity check */
-					if (!GangOK(gang))
-					{
-						/* connection is bad or segment is down */
-						DisconnectAndDestroyGang(gang);
-					}
-					else
-					{
-						ELOG_DISPATCHER_DEBUG("reusing an available reader N-gang");
-						retGang = gang;
-						break;
-					}
-					/* prev_item does not advance */
-					cur_item = next_item;
-				}
-			}
-			break;
-
-		default:
-			Assert(false);
-	}
-
-	return retGang;
-}
-
 struct SegmentDatabaseDescriptor *
 getSegmentDescriptorFromGang(const Gang *gp, int seg)
 {
@@ -963,7 +624,7 @@ getCdbProcessList(Gang *gang, int sliceIndex, DirectDispatchInfo *directDispatch
 		SegmentDatabaseDescriptor *segdbDesc = gang->db_descriptors[directDispatchContentId];
 		CdbProcess *process = makeCdbProcess(segdbDesc);
 
-		setQEIdentifier(segdbDesc, sliceIndex, gang->perGangContext);
+		cdbconn_setQEIdentifier(segdbDesc, sliceIndex);
 		list = lappend(list, (void*)process);
 	}
 	else
@@ -973,7 +634,7 @@ getCdbProcessList(Gang *gang, int sliceIndex, DirectDispatchInfo *directDispatch
 			SegmentDatabaseDescriptor *segdbDesc = gang->db_descriptors[i];
 			CdbProcess *process = makeCdbProcess(segdbDesc);
 
-			setQEIdentifier(segdbDesc, sliceIndex, gang->perGangContext);
+			cdbconn_setQEIdentifier(segdbDesc, sliceIndex);
 			list = lappend(list, process);
 
 			ELOG_DISPATCHER_DEBUG("Gang assignment (gang_id %d): slice%d seg%d %s:%d pid=%d",
@@ -1000,14 +661,13 @@ getCdbProcessesForQD(int isPrimary)
 	CdbProcess *proc;
 
 	Assert(Gp_role == GP_ROLE_DISPATCH);
-	Assert(cdb_component_dbs != NULL);
 
 	if (!isPrimary)
 	{
 		elog(FATAL, "getCdbProcessesForQD: unsupported request for master mirror process");
 	}
 
-	qdinfo = &(cdb_component_dbs->entry_db_info[0]);
+	qdinfo = cdbcomponent_getComponentInfo(-1);
 
 	Assert(qdinfo->segindex == -1);
 	Assert(SEGMENT_IS_ACTIVE_PRIMARY(qdinfo));
@@ -1033,84 +693,6 @@ getCdbProcessesForQD(int isPrimary)
 	return list;
 }
 
-/*
- * Destroy or recycle Gangs
- */
-
-/*
- * Disconnect and destroy a Gang.
- *
- * Loop through all the connections of this Gang and disconnect it.
- * Free the resource of this Gang.
- *
- * Caller needs to free all the reader Gangs if this is a writer gang.
- * Caller needs to reset session id if this is a writer gang.
- */
-void
-DisconnectAndDestroyGang(Gang *gp)
-{
-	int			i = 0;
-
-	if (gp == NULL)
-		return;
-
-	ELOG_DISPATCHER_DEBUG("DisconnectAndDestroyGang entered: id = %d", gp->gang_id);
-
-	if (gp->allocated)
-		ELOG_DISPATCHER_DEBUG("Warning: DisconnectAndDestroyGang called on an allocated gang");
-
-	/*
-	 * Loop through the segment_database_descriptors array and, for each
-	 * SegmentDatabaseDescriptor: 1) discard the query results (if any), 2)
-	 * disconnect the session, and 3) discard any connection error message.
-	 */
-	for (i = 0; i < gp->size; i++)
-	{
-		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
-
-		Assert(segdbDesc != NULL);
-		cdbconn_disconnect(segdbDesc);
-		cdbconn_termSegmentDescriptor(segdbDesc);
-	}
-
-	if (gp->type == GANGTYPE_PRIMARY_WRITER)
-		markCurrentGxactWriterGangLost();
-
-	MemoryContextDelete(gp->perGangContext);
-
-	ELOG_DISPATCHER_DEBUG("DisconnectAndDestroyGang done");
-}
-
-/*
- * disconnectAndDestroyAllReaderGangs
- *
- * Here we destroy all reader gangs regardless of the portal they belong to.
- * TODO: This may need to be done more carefully when multiple cursors are
- * enabled.
- * If the parameter destroyAllocated is true, then destroy allocated as well as
- * available gangs.
- */
-static void
-disconnectAndDestroyAllReaderGangs(bool destroyAllocated)
-{
-	Gang	   *gp = NULL;
-	ListCell   *lc = NULL;
-
-	foreach(lc, availableReaderGangsN)
-	{
-		gp = (Gang *) lfirst(lc);
-		DisconnectAndDestroyGang(gp);
-	}
-	availableReaderGangsN = NULL;
-
-	foreach(lc, availableReaderGangs1)
-	{
-		gp = (Gang *) lfirst(lc);
-		DisconnectAndDestroyGang(gp);
-	}
-	availableReaderGangs1 = NULL;
-}
-
 void
 DisconnectAndDestroyAllGangs(bool resetSession)
 {
@@ -1122,278 +704,60 @@ DisconnectAndDestroyAllGangs(bool resetSession)
     /* Destroy CurrentGangCreating before GangContext is reset */
     if (CurrentGangCreating != NULL)
     {
-        DisconnectAndDestroyGang(CurrentGangCreating);
+        RecycleGang(CurrentGangCreating, true);
         CurrentGangCreating = NULL;
     }
 
-	/* In here, clean up all active dispatcher state */
-	cdbdisp_cleanupAllDispatcherState();
-
-	/* for now, destroy all readers, regardless of the portal that owns them */
-	disconnectAndDestroyAllReaderGangs(true);
-
-	DisconnectAndDestroyGang(availablePrimaryWriterGang);
-	availablePrimaryWriterGang = NULL;
+	/* cleanup all out bound dispatcher state */
+	CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_cleanupDispatcherHandle);
+	
+	/* destroy cdb_component_dbs, disconnect all connections with QEs */
+	cdbcomponent_destroyCdbComponents();
 
 	if (resetSession)
 		resetSessionForPrimaryGangLoss();
-
-	/*
-	 * As all the reader and writer gangs are destroyed, reset the
-	 * corresponding GangContext to prevent leaks
-	 */
-	if (NULL != GangContext)
-	{
-		MemoryContextReset(GangContext);
-		cdb_component_dbs = NULL;
-	}
 
 	ELOG_DISPATCHER_DEBUG("DisconnectAndDestroyAllGangs done");
 }
 
 /*
- * Destroy all idle (i.e available) reader gangs.
- * It is always safe to get rid of the reader gangs.
- *
- * call only from an idle session.
- */
-void
-disconnectAndDestroyIdleReaderGangs(void)
-{
-	ELOG_DISPATCHER_DEBUG("disconnectAndDestroyIdleReaderGangs beginning");
-
-	disconnectAndDestroyAllReaderGangs(false);
-
-	ELOG_DISPATCHER_DEBUG("disconnectAndDestroyIdleReaderGangs done");
-
-	return;
-}
-
-/*
- * Destroy all idle (i.e available) reader gangs.
- * It is always safe to get rid of the reader gangs.
+ * Destroy all idle (i.e available) QEs.
+ * It is always safe to get rid of the reader QEs.
  *
  * If we are not in a transaction and we do not have a TempNamespace, destroy
- * writer gangs as well.
+ * writer QEs as well.
  *
  * call only from an idle session.
  */
-void DisconnectAndDestroyUnusedGangs(void)
+void DisconnectAndDestroyUnusedQEs(void)
 {
-	/*
-	 * Free gangs to free up resources on the segDBs.
-	 */
-	if (GangsExist())
+	if (IsTransactionOrTransactionBlock() || TempNamespaceOidIsValid())
 	{
-		if (IsTransactionOrTransactionBlock() || TempNamespaceOidIsValid())
-		{
-			/*
-			 * If we are in a transaction, we can't release the writer gang,
-			 * as this will abort the transaction.
-			 *
-			 * If we have a TempNameSpace, we can't release the writer gang, as this
-			 * would drop any temp tables we own.
-			 *
-			 * Since we are idle, any reader gangs will be available but not allocated.
-			 */
-			disconnectAndDestroyIdleReaderGangs();
-		}
-		else
-		{
-			/*
-			 * Get rid of ALL gangs... Readers and primary writer.
-			 * After this, we have no resources being consumed on the segDBs at all.
-			 *
-			 * Our session wasn't destroyed due to an fatal error or FTS action, so
-			 * we don't need to do anything special.  Specifically, we DON'T want
-			 * to act like we are now in a new session, since that would be confusing
-			 * in the log.
-			 *
-			 */
-			DisconnectAndDestroyAllGangs(false);
-		}
-	}
-}
-
-/*
- * Cleanup a Gang, make it recyclable.
- *
- * A return value of "true" means that the gang was intact (or NULL).
- *
- * A return value of false, means that a problem was detected and the
- * gang has been disconnected (and so should not be put back onto the
- * available list). Caller should call DisconnectAndDestroyGang on it.
- */
-static bool
-cleanupGang(Gang *gp)
-{
-	int			i = 0;
-
-	ELOG_DISPATCHER_DEBUG("cleanupGang: cleaning gang id %d type %d size %d, "
-						  "was used for portal: %s",
-						  gp->gang_id, gp->type, gp->size,
-						  (gp->portal_name ? gp->portal_name : "(unnamed)"));
-
-#ifdef FAULT_INJECTOR
-	if (SIMPLE_FAULT_INJECTOR(CleanupGang) == FaultInjectorTypeSkip)
-		return false;
-#endif
-
-	if (gp->noReuse)
-		return false;
-
-	if (gp->allocated)
-		ELOG_DISPATCHER_DEBUG("cleanupGang called on a gang that is allocated");
-
-	/*
-	 * if the process is in the middle of blowing up... then we don't do
-	 * anything here.  making libpq and other calls can definitely result in
-	 * things getting HUNG.
-	 */
-	if (proc_exit_inprogress)
-		return true;
-
-	/*
-	 * Loop through the segment_database_descriptors array and, for each
-	 * SegmentDatabaseDescriptor: 1) discard the query results (if any)
-	 */
-	for (i = 0; i < gp->size; i++)
-	{
-		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
-
-		Assert(segdbDesc != NULL);
-
-		if (cdbconn_isBadConnection(segdbDesc))
-			return false;
-
-		/* if segment is down, the gang can not be reused */
-		if (!FtsIsSegmentUp(segdbDesc->segment_database_info))
-			return false;
-
-		/* Note, we cancel all "still running" queries */
-		if (!cdbconn_discardResults(segdbDesc, 20))
-			elog(FATAL, "cleanup called when a segworker is still busy");
-
-		/* QE is no longer associated with a slice. */
-		setQEIdentifier(segdbDesc, /* slice index */ -1, gp->perGangContext);
-	}
-
-	/* disassociate this gang with any portal that it may have belonged to */
-	if (gp->portal_name != NULL)
-	{
-		pfree(gp->portal_name);
-		gp->portal_name = NULL;
-	}
-
-	gp->allocated = false;
-
-	ELOG_DISPATCHER_DEBUG("cleanupGang done");
-	return true;
-}
-
-/*
- * Get max maxVmemChunksTracked of a gang.
- *
- * return in MB.
- */
-static int
-getGangMaxVmem(Gang *gp)
-{
-	int64		maxmop = 0;
-	int			i = 0;
-
-	for (i = 0; i < gp->size; ++i)
-	{
-		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
-
-		Assert(segdbDesc != NULL);
-
-		if (!cdbconn_isBadConnection(segdbDesc))
-			maxmop = Max(maxmop, segdbDesc->conn->mop_high_watermark);
-	}
-
-	return (maxmop >> 20);
-}
-
-/*
- * remove elements from gang list when:
- * 1. list size > cachelimit
- * 2. max mop of this gang > gp_vmem_protect_gang_cache_limit
- */
-static List *
-cleanupPortalGangList(List *gplist, int cachelimit)
-{
-	ListCell   *cell = NULL;
-	ListCell   *prevcell = NULL;
-	int			nLeft = list_length(gplist);
-
-	if (gplist == NULL)
-		return NULL;
-
-	cell = list_head(gplist);
-	while (cell != NULL)
-	{
-		Gang	   *gang = (Gang *) lfirst(cell);
-
-		Assert(gang->type != GANGTYPE_PRIMARY_WRITER);
-
-		if (nLeft > cachelimit ||
-			getGangMaxVmem(gang) > gp_vmem_protect_gang_cache_limit)
-		{
-			DisconnectAndDestroyGang(gang);
-			gplist = list_delete_cell(gplist, cell, prevcell);
-			nLeft--;
-
-			if (prevcell != NULL)
-				cell = lnext(prevcell);
-			else
-				cell = list_head(gplist);
-		}
-		else
-		{
-			prevcell = cell;
-			cell = lnext(cell);
-		}
-	}
-
-	return gplist;
-}
-
-/*
- * Portal drop... Clean up what gangs we hold
- */
-void
-cleanupPortalGangs(Portal portal)
-{
-	MemoryContext oldContext;
-	const char *portal_name;
-
-	if (portal->name && strcmp(portal->name, "") != 0)
-	{
-		portal_name = portal->name;
-		ELOG_DISPATCHER_DEBUG("cleanupPortalGangs %s", portal_name);
+		/*
+		 * If we are in a transaction, we can't release the writer gang,
+		 * as this will abort the transaction.
+		 *
+		 * If we have a TempNameSpace, we can't release the writer gang, as this
+		 * would drop any temp tables we own.
+		 *
+		 * Since we are idle, any reader gangs will be available but not allocated.
+		 */
+		cdbcomponent_cleanupIdleSegdbs(false);
 	}
 	else
 	{
-		portal_name = NULL;
-		ELOG_DISPATCHER_DEBUG("cleanupPortalGangs (unamed portal)");
+		/*
+		 * Get rid of ALL gangs... Readers and primary writer.
+		 * After this, we have no resources being consumed on the segDBs at all.
+		 *
+		 * Our session wasn't destroyed due to an fatal error or FTS action, so
+		 * we don't need to do anything special.  Specifically, we DON'T want
+		 * to act like we are now in a new session, since that would be confusing
+		 * in the log.
+		 *
+		 */
+		cdbcomponent_cleanupIdleSegdbs(true);
 	}
-
-	if (GangContext)
-		oldContext = MemoryContextSwitchTo(GangContext);
-	else
-		oldContext = MemoryContextSwitchTo(TopMemoryContext);
-
-	availableReaderGangsN = cleanupPortalGangList(availableReaderGangsN, gp_cached_gang_threshold);
-	availableReaderGangs1 = cleanupPortalGangList(availableReaderGangs1, MAX_CACHED_1_GANGS);
-
-	ELOG_DISPATCHER_DEBUG("cleanupPortalGangs '%s'. Reader gang inventory: "
-						  "availableN=%d available1=%d",
-						  (portal_name ? portal_name : "unnamed portal"),
-						  list_length(availableReaderGangsN),
-						  list_length(availableReaderGangs1));
-
-	MemoryContextSwitchTo(oldContext);
 }
 
 /*
@@ -1415,7 +779,7 @@ CheckForResetSession(void)
 	/* Do the session id change early. */
 
 	/* If we have gangs, we can't change our session ID. */
-	Assert(!GangsExist());
+	Assert(!cdbcomponent_segdbsExist());
 
 	oldSessionId = gp_session_id;
 	ProcNewMppSessionId(&newSessionId);
@@ -1593,12 +957,6 @@ GangOK(Gang *gp)
 	if (gp == NULL)
 		return false;
 
-	if (gp->gang_id < 1 ||
-		gp->gang_id > 100000000 ||
-		gp->type > GANGTYPE_PRIMARY_WRITER ||
-		(gp->size != getgpsegmentCount() && gp->size != 1))
-		return false;
-
 	/*
 	 * Gang is direct-connect (no agents).
 	 */
@@ -1615,16 +973,6 @@ GangOK(Gang *gp)
 
 	return true;
 }
-
-bool
-GangsExist(void)
-{
-	return (availablePrimaryWriterGang != NULL ||
-			availableReaderGangsN != NIL ||
-			availableReaderGangs1 != NIL ||
-			numAllocatedReaderGangs > 0);
-}
-
 
 int
 largestGangsize(void)
@@ -1649,47 +997,26 @@ cdbgang_setAsync(bool async)
 }
 
 void
-RecycleGang(Gang *gp)
+RecycleGang(Gang *gp, bool forceDestroy)
 {
-	MemoryContext oldContext;
+	int i;
 
 	if (!gp)
 		return;
 
-	if (!cleanupGang(gp))
-		return DisconnectAndDestroyGang(gp);
-
-	oldContext = MemoryContextSwitchTo(GangContext);
-
-	switch (gp->type)
+	/*
+	 * Loop through the segment_database_descriptors array and, for each
+	 * SegmentDatabaseDescriptor: 1) discard the query results (if any), 2)
+	 * disconnect the session, and 3) discard any connection error message.
+	 */
+	for (i = 0; i < gp->size; i++)
 	{
-		case GANGTYPE_SINGLETON_READER:
-		case GANGTYPE_ENTRYDB_READER:
-			availableReaderGangs1 = lappend(availableReaderGangs1, gp);
-			break;
+		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
 
-		case GANGTYPE_PRIMARY_READER:
-			availableReaderGangsN = lappend(availableReaderGangsN, gp);
-			break;
-		case GANGTYPE_PRIMARY_WRITER:
-			availablePrimaryWriterGang = gp;
-			break;
-		default:
-			Assert(false);
+		Assert(segdbDesc != NULL);
+
+		cdbcomponent_recycleIdleSegdb(segdbDesc, forceDestroy);
 	}
-
-	MemoryContextSwitchTo(oldContext);
-}
-
-void
-cdbgang_resetPrimaryWriterGang(void)
-{
-	primaryWriterGang = NULL;
-}
-void
-cdbgang_decreaseNumReaderGang(void)
-{
-	numAllocatedReaderGangs--;
 }
 
 void

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -272,7 +272,7 @@ AllocateWriterGang(CdbDispatcherState *ds)
 		 * overwrite it in function getCdbProcessList.
 		 */
 		for (i = 0; i < writerGang->size; i++)
-			setQEIdentifier(&writerGang->db_descriptors[i], -1, writerGang->perGangContext);
+			setQEIdentifier(writerGang->db_descriptors[i], -1, writerGang->perGangContext);
 
 		MemoryContextSwitchTo(oldContext);
 	}
@@ -473,7 +473,7 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 	newGangDefinition->portal_name = NULL;
 	newGangDefinition->perGangContext = perGangContext;
 	newGangDefinition->db_descriptors =
-		(SegmentDatabaseDescriptor *) palloc0(size * sizeof(SegmentDatabaseDescriptor));
+		(SegmentDatabaseDescriptor **) palloc0(size * sizeof(SegmentDatabaseDescriptor*));
 
 	/* initialize db_descriptors */
 	switch (type)
@@ -481,17 +481,17 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 		case GANGTYPE_ENTRYDB_READER:
 			cdbinfo = &cdb_component_dbs->entry_db_info[0];
 			cdbInfoCopy = copyCdbComponentDatabaseInfo(cdbinfo);
-			segdbDesc = &newGangDefinition->db_descriptors[0];
-			cdbconn_initSegmentDescriptor(segdbDesc, cdbInfoCopy);
+			segdbDesc = cdbconn_createSegmentDescriptor(cdbInfoCopy);
 			setQEIdentifier(segdbDesc, -1, perGangContext);
+			newGangDefinition->db_descriptors[0] = segdbDesc;
 			break;
 
 		case GANGTYPE_SINGLETON_READER:
 			cdbinfo = findDatabaseInfoBySegIndex(cdb_component_dbs, content);
 			cdbInfoCopy = copyCdbComponentDatabaseInfo(cdbinfo);
-			segdbDesc = &newGangDefinition->db_descriptors[0];
-			cdbconn_initSegmentDescriptor(segdbDesc, cdbInfoCopy);
+			segdbDesc = cdbconn_createSegmentDescriptor(cdbInfoCopy);
 			setQEIdentifier(segdbDesc, -1, perGangContext);
+			newGangDefinition->db_descriptors[0] = segdbDesc;
 			break;
 
 		case GANGTYPE_PRIMARY_READER:
@@ -508,10 +508,10 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 				cdbinfo = &cdb_component_dbs->segment_db_info[i];
 				if (SEGMENT_IS_ACTIVE_PRIMARY(cdbinfo))
 				{
-					segdbDesc = &newGangDefinition->db_descriptors[segCount];
 					cdbInfoCopy = copyCdbComponentDatabaseInfo(cdbinfo);
-					cdbconn_initSegmentDescriptor(segdbDesc, cdbInfoCopy);
+					segdbDesc = cdbconn_createSegmentDescriptor(cdbInfoCopy);
 					setQEIdentifier(segdbDesc, -1, perGangContext);
+					newGangDefinition->db_descriptors[segCount] = segdbDesc;
 					segCount++;
 				}
 			}
@@ -812,7 +812,7 @@ getAvailableGang(GangType type, int size, int content)
 
 					next_item = lnext(cur_item);
 
-					if (gang->db_descriptors[0].segindex == content)
+					if (gang->db_descriptors[0]->segindex == content)
 					{
 						availableReaderGangs1 = list_delete_cell(availableReaderGangs1, cur_item, prev_item);
 
@@ -895,8 +895,8 @@ getSegmentDescriptorFromGang(const Gang *gp, int seg)
 
 	for (i = 0; i < gp->size; i++)
 	{
-		if (gp->db_descriptors[i].segindex == seg)
-			return &(gp->db_descriptors[i]);
+		if (gp->db_descriptors[i]->segindex == seg)
+			return gp->db_descriptors[i];
 	}
 
 	return NULL;
@@ -960,7 +960,7 @@ getCdbProcessList(Gang *gang, int sliceIndex, DirectDispatchInfo *directDispatch
 		Assert(list_length(directDispatch->contentIds) == 1);
 
 		int			directDispatchContentId = linitial_int(directDispatch->contentIds);
-		SegmentDatabaseDescriptor *segdbDesc = &gang->db_descriptors[directDispatchContentId];
+		SegmentDatabaseDescriptor *segdbDesc = gang->db_descriptors[directDispatchContentId];
 		CdbProcess *process = makeCdbProcess(segdbDesc);
 
 		setQEIdentifier(segdbDesc, sliceIndex, gang->perGangContext);
@@ -970,7 +970,7 @@ getCdbProcessList(Gang *gang, int sliceIndex, DirectDispatchInfo *directDispatch
 	{
 		for (i = 0; i < gang->size; i++)
 		{
-			SegmentDatabaseDescriptor *segdbDesc = &gang->db_descriptors[i];
+			SegmentDatabaseDescriptor *segdbDesc = gang->db_descriptors[i];
 			CdbProcess *process = makeCdbProcess(segdbDesc);
 
 			setQEIdentifier(segdbDesc, sliceIndex, gang->perGangContext);
@@ -1066,7 +1066,7 @@ DisconnectAndDestroyGang(Gang *gp)
 	 */
 	for (i = 0; i < gp->size; i++)
 	{
-		SegmentDatabaseDescriptor *segdbDesc = &(gp->db_descriptors[i]);
+		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
 
 		Assert(segdbDesc != NULL);
 		cdbconn_disconnect(segdbDesc);
@@ -1259,7 +1259,7 @@ cleanupGang(Gang *gp)
 	 */
 	for (i = 0; i < gp->size; i++)
 	{
-		SegmentDatabaseDescriptor *segdbDesc = &(gp->db_descriptors[i]);
+		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
 
 		Assert(segdbDesc != NULL);
 
@@ -1304,7 +1304,7 @@ getGangMaxVmem(Gang *gp)
 
 	for (i = 0; i < gp->size; ++i)
 	{
-		SegmentDatabaseDescriptor *segdbDesc = &(gp->db_descriptors[i]);
+		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
 
 		Assert(segdbDesc != NULL);
 
@@ -1605,7 +1605,7 @@ GangOK(Gang *gp)
 
 	for (i = 0; i < gp->size; i++)
 	{
-		SegmentDatabaseDescriptor *segdbDesc = &(gp->db_descriptors[i]);
+		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
 
 		if (cdbconn_isBadConnection(segdbDesc))
 			return false;

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -71,127 +71,67 @@ Gang      *CurrentGangCreating = NULL;
 
 CreateGangFunc pCreateGangFunc = NULL;
 
-static int	largest_gangsize = 0;
-
 static bool NeedResetSession = false;
 static Oid	OldTempNamespace = InvalidOid;
-
-static Gang *createGang(GangType type, int gang_id, int size, int content);
 
 static void resetSessionForPrimaryGangLoss(void);
 
 /*
- * Create a reader gang.
- *
- * @type can be GANGTYPE_ENTRYDB_READER, GANGTYPE_SINGLETON_READER or GANGTYPE_PRIMARY_READER.
- */
-Gang *
-AllocateReaderGang(CdbDispatcherState *ds, GangType type, char *portal_name)
-{
-	Gang	   *gp = NULL;
-	int			size = 0;
-	int			content = 0;
-	MemoryContext oldContext;
-
-	if (Gp_role != GP_ROLE_DISPATCH)
-	{
-		elog(FATAL, "dispatch process called with role %d", Gp_role);
-	}
-
-	switch (type)
-	{
-		case GANGTYPE_ENTRYDB_READER:
-			content = -1;
-			size = 1;
-			break;
-
-		case GANGTYPE_SINGLETON_READER:
-			content = gp_singleton_segindex;
-			size = 1;
-			break;
-
-		case GANGTYPE_PRIMARY_READER:
-			content = 0;
-			size = getgpsegmentCount();
-			break;
-
-		default:
-			Assert(false);
-	}
-
-	ELOG_DISPATCHER_DEBUG("Creating a new reader size %d gang for %s",
-						  size, (portal_name ? portal_name : "unnamed portal"));
-
-	oldContext = MemoryContextSwitchTo(DispatcherContext);
-
-	gp = createGang(type, 0, size, content);
-	gp->allocated = true;
-	ds->allocatedGangs = lcons(gp, ds->allocatedGangs);
-
-	/*
-	 * make sure no memory is still allocated for previous portal name that
-	 * this gang belonged to
-	 */
-	if (gp->portal_name)
-		pfree(gp->portal_name);
-
-	/* let the gang know which portal it is being assigned to */
-	gp->portal_name = (portal_name ? pstrdup(portal_name) : (char *) NULL);
-
-	MemoryContextSwitchTo(oldContext);
-
-	return gp;
-}
-
-/*
- * Create a writer gang.
- */
-Gang *
-AllocateWriterGang(CdbDispatcherState *ds)
-{
-	MemoryContext oldContext;
-	Gang	   *writerGang = NULL;
-	int			i = 0;
-	int nsegdb = getgpsegmentCount();
-
-	ELOG_DISPATCHER_DEBUG("AllocateWriterGang begin.");
-
-	if (Gp_role != GP_ROLE_DISPATCH)
-	{
-		elog(FATAL, "dispatch process called with role %d", Gp_role);
-	}
-
-	oldContext = MemoryContextSwitchTo(DispatcherContext);
-
-	writerGang = createGang(GANGTYPE_PRIMARY_WRITER, 0, nsegdb, -1);
-	writerGang->allocated = true;
-
-	/*
-	 * set "whoami" for utility statement. non-utility statement will
-	 * overwrite it in function getCdbProcessList.
-	 */
-	for (i = 0; i < writerGang->size; i++)
-		cdbconn_setQEIdentifier(writerGang->db_descriptors[i], -1);
-
-	ELOG_DISPATCHER_DEBUG("AllocateWriterGang end.");
-
-	ds->allocatedGangs = lcons(writerGang, ds->allocatedGangs);
-
-	MemoryContextSwitchTo(oldContext);
-
-	return writerGang;
-}
-
-/*
  * Creates a new gang by logging on a session to each segDB involved.
  *
- * call this function in GangContext memory context.
  * elog ERROR or return a non-NULL gang.
  */
-static Gang *
-createGang(GangType type, int gang_id, int size, int content)
+Gang *
+AllocateGang(CdbDispatcherState *ds, GangType type, List *segments)
 {
-	return pCreateGangFunc(type, gang_id, size, content);
+	MemoryContext	oldContext;
+	SegmentType 	segmentType;
+	Gang			*newGang = NULL;
+	int				i;
+
+	ELOG_DISPATCHER_DEBUG("AllocateGang begin.");
+
+	if (Gp_role != GP_ROLE_DISPATCH)
+	{
+		elog(FATAL, "dispatch process called with role %d", Gp_role);
+	}
+
+	if (segments == NIL)
+		return NULL;
+
+	Assert(DispatcherContext);
+	oldContext = MemoryContextSwitchTo(DispatcherContext);
+
+	if (type == GANGTYPE_PRIMARY_WRITER)
+		segmentType = SEGMENTTYPE_EXPLICT_WRITER;
+	/* for extended query like cursor, must specify a reader */
+	else if (ds->isExtendedQuery)
+		segmentType = SEGMENTTYPE_EXPLICT_READER;
+	else
+		segmentType = SEGMENTTYPE_ANY;
+
+	newGang = pCreateGangFunc(segments, segmentType);
+	newGang->allocated = true;
+	newGang->type = type;
+
+	ds->allocatedGangs = lcons(newGang, ds->allocatedGangs);
+	ds->largestGangSize = Max(ds->largestGangSize, newGang->size);
+
+	ELOG_DISPATCHER_DEBUG("AllocateGang end.");
+
+	if (type == GANGTYPE_PRIMARY_WRITER)
+	{
+		/*
+		 * set "whoami" for utility statement. non-utility statement will
+		 * overwrite it in function getCdbProcessList.
+		 */
+		for (i = 0; i < newGang->size; i++)
+			cdbconn_setQEIdentifier(newGang->db_descriptors[i], -1);
+	}
+
+	MemoryContextSwitchTo(oldContext);
+
+	return newGang;
 }
 
 /*
@@ -243,27 +183,25 @@ segment_failure_due_to_recovery(const char *error_message)
  * Returns a not-null pointer.
  */
 Gang *
-buildGangDefinition(GangType type, int gang_id, int size, int content)
+buildGangDefinition(List *segments, SegmentType segmentType)
 {
-	Gang	   *newGangDefinition = NULL;
-	SegmentDatabaseDescriptor *segdbDesc = NULL;
+	Gang *newGangDefinition = NULL;
+	ListCell *lc;
+	int	i = 0;
+	int	size;
+	int contentId;
 
-	int			segCount = 0;
-	int			i = 0;
+	size = list_length(segments);
 
-	ELOG_DISPATCHER_DEBUG("buildGangDefinition:Starting %d qExec processes for %s gang",
-						  size, gangTypeToString(type));
+	ELOG_DISPATCHER_DEBUG("buildGangDefinition:Starting %d qExec processes for gang", size);
 
 	Assert(CurrentMemoryContext == DispatcherContext);
-	Assert(size == 1 || size == getgpsegmentCount());
 
 	/* allocate a gang */
 	newGangDefinition = (Gang *) palloc0(sizeof(Gang));
-	newGangDefinition->type = type;
+	newGangDefinition->type = GANGTYPE_UNALLOCATED;
 	newGangDefinition->size = size;
-	newGangDefinition->gang_id = gang_id;
 	newGangDefinition->allocated = false;
-	newGangDefinition->dispatcherActive = false;
 	newGangDefinition->portal_name = NULL;
 	newGangDefinition->db_descriptors =
 		(SegmentDatabaseDescriptor **) palloc0(size * sizeof(SegmentDatabaseDescriptor*));
@@ -271,48 +209,17 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 	PG_TRY();
 	{
 		/* initialize db_descriptors */
-		switch (type)
+		foreach_with_count (lc, segments , i)
 		{
-			case GANGTYPE_ENTRYDB_READER:
-				segdbDesc = cdbcomponent_allocateIdleSegdb(-1, false);
-				newGangDefinition->db_descriptors[0] = segdbDesc;
-				break;
-
-			case GANGTYPE_SINGLETON_READER:
-				segdbDesc = cdbcomponent_allocateIdleSegdb(content, false);
-				newGangDefinition->db_descriptors[0] = segdbDesc;
-				break;
-
-			case GANGTYPE_PRIMARY_READER:
-			case GANGTYPE_PRIMARY_WRITER:
-
-				/*
-				 * We loop through the segment_db_info.  Each item has a segindex.
-				 * They are sorted by segindex, and there can be > 1
-				 * segment_db_info for a given segindex (currently, there can be 1
-				 * or 2)
-				 */
-				for (i = 0; i < getgpsegmentCount(); i++)
-				{
-					segdbDesc = cdbcomponent_allocateIdleSegdb(i, type == GANGTYPE_PRIMARY_WRITER);
-
-					newGangDefinition->db_descriptors[segCount] = segdbDesc;
-					segCount++;
-				}
-
-				if (size != segCount)
-				{
-					elog(ERROR, "Not all primary segment instances are active and connected");
-				}
-				break;
-
-			default:
-				Assert(false);
+			contentId = lfirst_int(lc);
+			newGangDefinition->db_descriptors[i] =
+						cdbcomponent_allocateIdleSegdb(contentId, segmentType);
 		}
 	}
 	PG_CATCH();
 	{
-		RecycleGang(newGangDefinition, true);
+		RecycleGang(newGangDefinition, true /* destroy */);
+		PG_RE_THROW();
 	}
 	PG_END_TRY();
 
@@ -595,51 +502,34 @@ makeCdbProcess(SegmentDatabaseDescriptor *segdbDesc)
  * @directDispatch: might be null
  */
 void
-setupCdbProcessList(Slice *slice )
+setupCdbProcessList(Slice *slice)
 {
 	int			i = 0;
 	Gang		*gang = slice->primaryGang;
-	DirectDispatchInfo *directDispatch = &slice->directDispatch;
 
 	ELOG_DISPATCHER_DEBUG("getCdbProcessList slice%d gangtype=%d gangsize=%d",
 						  slice->sliceIndex, gang->type, gang->size);
 	Assert(gang);
 	Assert(Gp_role == GP_ROLE_DISPATCH);
-	Assert((gang->type == GANGTYPE_PRIMARY_WRITER && gang->size == getgpsegmentCount()) ||
-		   (gang->type == GANGTYPE_PRIMARY_READER && gang->size == getgpsegmentCount()) ||
+	Assert(gang->type == GANGTYPE_PRIMARY_WRITER ||
+		   gang->type == GANGTYPE_PRIMARY_READER ||
 		   (gang->type == GANGTYPE_ENTRYDB_READER && gang->size == 1) ||
 		   (gang->type == GANGTYPE_SINGLETON_READER && gang->size == 1));
 
 
-	if (directDispatch != NULL && directDispatch->isDirectDispatch)
+	for (i = 0; i < gang->size; i++)
 	{
-		/* Currently, direct dispatch is to one segment db. */
-		Assert(list_length(directDispatch->contentIds) == 1);
-
-		int			directDispatchContentId = linitial_int(directDispatch->contentIds);
-		SegmentDatabaseDescriptor *segdbDesc = gang->db_descriptors[directDispatchContentId];
+		SegmentDatabaseDescriptor *segdbDesc = gang->db_descriptors[i];
 		CdbProcess *process = makeCdbProcess(segdbDesc);
 
 		cdbconn_setQEIdentifier(segdbDesc, slice->sliceIndex);
 
 		slice->primaryProcesses = lappend(slice->primaryProcesses, process);
 		slice->processesMap = bms_add_member(slice->processesMap, segdbDesc->identifier);
-	}
-	else
-	{
-		for (i = 0; i < gang->size; i++)
-		{
-			SegmentDatabaseDescriptor *segdbDesc = gang->db_descriptors[i];
-			CdbProcess *process = makeCdbProcess(segdbDesc);
 
-			cdbconn_setQEIdentifier(segdbDesc, slice->sliceIndex);
-
-			slice->primaryProcesses = lappend(slice->primaryProcesses, process);
-			slice->processesMap = bms_add_member(slice->processesMap, segdbDesc->identifier);
-			ELOG_DISPATCHER_DEBUG("Gang assignment (gang_id %d): slice%d seg%d %s:%d pid=%d",
-								  gang->gang_id, slice->sliceIndex, process->contentid,
-								  process->listenerAddr, process->listenerPort, process->pid);
-		}
+		ELOG_DISPATCHER_DEBUG("Gang assignment (gang_id %d): slice%d seg%d %s:%d pid=%d",
+							  gang->gang_id, slice->sliceIndex, process->contentid,
+							  process->listenerAddr, process->listenerPort, process->pid);
 	}
 }
 
@@ -969,19 +859,6 @@ GangOK(Gang *gp)
 	}
 
 	return true;
-}
-
-int
-largestGangsize(void)
-{
-	return largest_gangsize;
-}
-
-void
-setLargestGangsize(int size)
-{
-	if (largest_gangsize < size)
-		largest_gangsize = size;
 }
 
 void

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -56,10 +56,11 @@
 #include "utils/guc_tables.h"
 
 /*
- * Which gang this QE belongs to; this would be used in PostgresMain to find out
- * the slice this QE should execute
+ * Unique QE identifier, it's set when the QE is started up, it
+ * will be use to go through slice table to find which slice
+ * this QE should execute.
  */
-int			qe_gang_id = 0;
+int			qe_identifier = 0;
 
 /*
  * number of primary segments on this host
@@ -74,13 +75,6 @@ static int	largest_gangsize = 0;
 
 static bool NeedResetSession = false;
 static Oid	OldTempNamespace = InvalidOid;
-
-/*
- * Every gang created must have a unique identifier
- */
-#define PRIMARY_WRITER_GANG_ID 1
-static int	gang_id_counter = 2;
-
 
 static Gang *createGang(GangType type, int gang_id, int size, int content);
 
@@ -130,7 +124,7 @@ AllocateReaderGang(CdbDispatcherState *ds, GangType type, char *portal_name)
 
 	oldContext = MemoryContextSwitchTo(DispatcherContext);
 
-	gp = createGang(type, gang_id_counter++, size, content);
+	gp = createGang(type, 0, size, content);
 	gp->allocated = true;
 	ds->allocatedGangs = lcons(gp, ds->allocatedGangs);
 
@@ -169,7 +163,7 @@ AllocateWriterGang(CdbDispatcherState *ds)
 
 	oldContext = MemoryContextSwitchTo(DispatcherContext);
 
-	writerGang = createGang(GANGTYPE_PRIMARY_WRITER, PRIMARY_WRITER_GANG_ID, nsegdb, -1);
+	writerGang = createGang(GANGTYPE_PRIMARY_WRITER, 0, nsegdb, -1);
 	writerGang->allocated = true;
 
 	/*
@@ -446,7 +440,7 @@ makeOptions(void)
  */
 bool
 build_gpqeid_param(char *buf, int bufsz,
-				   bool is_writer, int gangId, int hostSegs)
+				   bool is_writer, int identifier, int hostSegs)
 {
 	int		len;
 #ifdef HAVE_INT64_TIMESTAMP
@@ -461,7 +455,7 @@ build_gpqeid_param(char *buf, int bufsz,
 
 	len = snprintf(buf, bufsz, "%d;" TIMESTAMP_FORMAT ";%s;%d;%d",
 				   gp_session_id, PgStartTime,
-				   (is_writer ? "true" : "false"), gangId, hostSegs);
+				   (is_writer ? "true" : "false"), identifier, hostSegs);
 
 	return (len > 0 && len < bufsz);
 }
@@ -522,9 +516,10 @@ cdbgang_parse_gpqeid_params(struct Port *port __attribute__((unused)),
 	if (gpqeid_next_param(&cp, &np))
 		SetConfigOption("gp_is_writer", cp, PGC_POSTMASTER, PGC_S_OVERRIDE);
 
+	/* qe_identifier */
 	if (gpqeid_next_param(&cp, &np))
 	{
-		qe_gang_id = (int) strtol(cp, NULL, 10);
+		qe_identifier = (int) strtol(cp, NULL, 10);
 	}
 
 	if (gpqeid_next_param(&cp, &np))
@@ -536,7 +531,7 @@ cdbgang_parse_gpqeid_params(struct Port *port __attribute__((unused)),
 	if (!cp || np)
 		goto bad;
 
-	if (gp_session_id <= 0 || PgStartTime <= 0 || qe_gang_id <= 0 || host_segments <= 0)
+	if (gp_session_id <= 0 || PgStartTime <= 0 || qe_identifier < 0 || host_segments <= 0)
 		goto bad;
 
 	pfree(gpqeid);
@@ -599,15 +594,16 @@ makeCdbProcess(SegmentDatabaseDescriptor *segdbDesc)
  *
  * @directDispatch: might be null
  */
-List *
-getCdbProcessList(Gang *gang, int sliceIndex, DirectDispatchInfo *directDispatch)
+void
+setupCdbProcessList(Slice *slice )
 {
-	List	   *list = NULL;
 	int			i = 0;
+	Gang		*gang = slice->primaryGang;
+	DirectDispatchInfo *directDispatch = &slice->directDispatch;
 
 	ELOG_DISPATCHER_DEBUG("getCdbProcessList slice%d gangtype=%d gangsize=%d",
-						  sliceIndex, gang->type, gang->size);
-
+						  slice->sliceIndex, gang->type, gang->size);
+	Assert(gang);
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 	Assert((gang->type == GANGTYPE_PRIMARY_WRITER && gang->size == getgpsegmentCount()) ||
 		   (gang->type == GANGTYPE_PRIMARY_READER && gang->size == getgpsegmentCount()) ||
@@ -624,8 +620,10 @@ getCdbProcessList(Gang *gang, int sliceIndex, DirectDispatchInfo *directDispatch
 		SegmentDatabaseDescriptor *segdbDesc = gang->db_descriptors[directDispatchContentId];
 		CdbProcess *process = makeCdbProcess(segdbDesc);
 
-		cdbconn_setQEIdentifier(segdbDesc, sliceIndex);
-		list = lappend(list, (void*)process);
+		cdbconn_setQEIdentifier(segdbDesc, slice->sliceIndex);
+
+		slice->primaryProcesses = lappend(slice->primaryProcesses, process);
+		slice->processesMap = bms_add_member(slice->processesMap, segdbDesc->identifier);
 	}
 	else
 	{
@@ -634,16 +632,15 @@ getCdbProcessList(Gang *gang, int sliceIndex, DirectDispatchInfo *directDispatch
 			SegmentDatabaseDescriptor *segdbDesc = gang->db_descriptors[i];
 			CdbProcess *process = makeCdbProcess(segdbDesc);
 
-			cdbconn_setQEIdentifier(segdbDesc, sliceIndex);
-			list = lappend(list, process);
+			cdbconn_setQEIdentifier(segdbDesc, slice->sliceIndex);
 
+			slice->primaryProcesses = lappend(slice->primaryProcesses, process);
+			slice->processesMap = bms_add_member(slice->processesMap, segdbDesc->identifier);
 			ELOG_DISPATCHER_DEBUG("Gang assignment (gang_id %d): slice%d seg%d %s:%d pid=%d",
-								  gang->gang_id, sliceIndex, process->contentid,
+								  gang->gang_id, slice->sliceIndex, process->contentid,
 								  process->listenerAddr, process->listenerPort, process->pid);
 		}
 	}
-
-	return list;
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -22,7 +22,6 @@
 #include "miscadmin.h"			/* MyDatabaseId */
 #include "pgstat.h"			/* pgstat_report_sessionid() */
 #include "storage/proc.h"		/* MyProc */
-#include "storage/ipc.h"
 #include "utils/memutils.h"
 
 #include "access/xact.h"

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -116,7 +116,7 @@ create_gang_retry:
 			 * valid segdb we error out.  Also, if this segdb is invalid, we
 			 * must fail the connection.
 			 */
-			segdbDesc = &newGangDefinition->db_descriptors[i];
+			segdbDesc = newGangDefinition->db_descriptors[i];
 
 			/*
 			 * Build the connection string.  Writer-ness needs to be processed
@@ -170,7 +170,7 @@ create_gang_retry:
 
 			for (i = 0; i < size; i++)
 			{
-				segdbDesc = &newGangDefinition->db_descriptors[i];
+				segdbDesc = newGangDefinition->db_descriptors[i];
 
 				/*
 				 * Skip established connections and in-recovery-mode
@@ -258,7 +258,7 @@ create_gang_retry:
 
 				for (i = 0; i < size; i++)
 				{
-					segdbDesc = &newGangDefinition->db_descriptors[i];
+					segdbDesc = newGangDefinition->db_descriptors[i];
 					if (connStatusDone[i])
 						continue;
 

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -126,7 +126,7 @@ create_gang_retry:
 			 */
 			ret = build_gpqeid_param(gpqeid, sizeof(gpqeid),
 									 type == GANGTYPE_PRIMARY_WRITER,
-									 gang_id,
+									 segdbDesc->identifier,
 									 segdbDesc->segment_database_info->hostSegs);
 
 			if (!ret)

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -63,7 +63,7 @@ static void checkConnectionStatus(Gang *gp,
 					  int *countInRecovery,
 					  int *countSuccessful,
 					  struct PQExpBufferData *errorMessage);
-static Gang *createGang_thread(GangType type, int gang_id, int size, int content);
+static Gang *createGang_thread(List *segments, SegmentType segmentType);
 
 CreateGangFunc pCreateGangFuncThreaded = createGang_thread;
 
@@ -74,7 +74,7 @@ CreateGangFunc pCreateGangFuncThreaded = createGang_thread;
  * elog ERROR or return a non-NULL gang.
  */
 static Gang *
-createGang_thread(GangType type, int gang_id, int size, int content)
+createGang_thread(List *segments, SegmentType segmentType)
 {
 	Gang	   *newGangDefinition = NULL;
 	SegmentDatabaseDescriptor *segdbDesc = NULL;
@@ -86,15 +86,14 @@ createGang_thread(GangType type, int gang_id, int size, int content)
 	int			create_gang_retry_counter = 0;
 	int			in_recovery_mode_count = 0;
 	int			successful_connections = 0;
+	int			size;
 
 	PQExpBufferData create_gang_error;
 
-	ELOG_DISPATCHER_DEBUG("createGang type = %d, gang_id = %d, size = %d, content = %d",
-						  type, gang_id, size, content);
+	size = list_length(segments);
+	ELOG_DISPATCHER_DEBUG("createGang :size %d", size);
 
 	/* check arguments */
-	Assert(size == 1 || size == getgpsegmentCount());
-	Assert(CurrentResourceOwner != NULL);
 	Assert(gp_connections_per_thread > 0);
 
 	initPQExpBuffer(&create_gang_error);
@@ -112,12 +111,10 @@ createGang_thread(GangType type, int gang_id, int size, int content)
 	threadCount = 0;
 
 	/* allocate and initialize a gang structure */
-	newGangDefinition = buildGangDefinition(type, gang_id, size, content);
+	newGangDefinition = buildGangDefinition(segments, segmentType);
 	CurrentGangCreating = newGangDefinition;
-
 create_gang_retry:
 	Assert(newGangDefinition != NULL);
-	Assert(newGangDefinition->size == size);
 
 	resetPQExpBuffer(&create_gang_error);
 
@@ -132,7 +129,7 @@ create_gang_retry:
 	Assert(threadCount > 0);
 
 	/* initialize connect parameters */
-	doConnectParmsAr = makeConnectParms(threadCount, type, gang_id);
+	doConnectParmsAr = makeConnectParms(threadCount, GANGTYPE_UNALLOCATED, -1);
 	for (i = 0; i < size; i++)
 	{
 		parmIndex = i / gp_connections_per_thread;
@@ -204,7 +201,6 @@ create_gang_retry:
 
 	if (size == successful_connections)
 	{
-		setLargestGangsize(size);
 		termPQExpBuffer(&create_gang_error);
 
 		CurrentGangCreating = NULL;
@@ -225,8 +221,7 @@ create_gang_retry:
 	if (successful_connections + in_recovery_mode_count == size)
 	{
 		if (gp_gang_creation_retry_count &&
-			create_gang_retry_counter++ < gp_gang_creation_retry_count &&
-			type == GANGTYPE_PRIMARY_WRITER)
+			create_gang_retry_counter++ < gp_gang_creation_retry_count)
 		{
 			ELOG_DISPATCHER_DEBUG("createGang: gang creation failed, but retryable.");
 
@@ -291,7 +286,7 @@ thread_DoConnect(void *arg)
 		 * are recognized.
 		 */
 		ret = build_gpqeid_param(gpqeid, sizeof(gpqeid),
-						   		 pParms->type == GANGTYPE_PRIMARY_WRITER,
+						   		 segdbDesc->isWriter,
 								 segdbDesc->identifier,
 								 segdbDesc->segment_database_info->hostSegs);
 

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -311,8 +311,8 @@ thread_DoConnect(void *arg)
 		 * are recognized.
 		 */
 		ret = build_gpqeid_param(gpqeid, sizeof(gpqeid),
-								 pParms->type == GANGTYPE_PRIMARY_WRITER,
-								 pParms->gangId,
+						   		 pParms->type == GANGTYPE_PRIMARY_WRITER,
+								 segdbDesc->identifier,
 								 segdbDesc->segment_database_info->hostSegs);
 
 		if (!ret)

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -145,7 +145,7 @@ create_gang_retry:
 	{
 		parmIndex = i / gp_connections_per_thread;
 		pParms = &doConnectParmsAr[parmIndex];
-		segdbDesc = &newGangDefinition->db_descriptors[i];
+		segdbDesc = newGangDefinition->db_descriptors[i];
 		pParms->segdbDescPtrArray[pParms->db_count++] = segdbDesc;
 	}
 
@@ -414,7 +414,7 @@ checkConnectionStatus(Gang *gp,
 	 */
 	for (i = 0; i < size; i++)
 	{
-		segdbDesc = &gp->db_descriptors[i];
+		segdbDesc = gp->db_descriptors[i];
 
 		/*
 		 * check connection established or not, if not, we may have to

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -149,7 +149,7 @@ test__createWriterGang(void **state)
 	ds.allocatedGangs = NIL;
 
 	will_return(IsTransactionOrTransactionBlock, true);
-	will_return(getCdbComponentDatabases, s_cdb);
+	will_return(cdbcomponent_getCdbComponents, s_cdb);
 	will_return_count(getgpsegmentCount, segmentCount, -1);
 	will_return_count(getFtsVersion, ftsVersion, 1);
 

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -136,111 +136,6 @@ mockLibpq(PGconn *pgConn, uint32 motionListener, int qePid)
 	will_return_count(PQbackendPID, qePid, -1);
 }
 
-static void
-test__createWriterGang(void **state)
-{
-	int			segmentCount = TOTOAL_SEGMENTS;
-	uint8		ftsVersion = 1;
-	PGconn	   *conn = &pgconn;
-	uint32		motionListener = 10000;
-	int			qePid = 2000;
-	int			i = 0;
-	CdbDispatcherState ds;
-	ds.allocatedGangs = NIL;
-
-	will_return(IsTransactionOrTransactionBlock, true);
-	will_return(cdbcomponent_getCdbComponents, s_cdb);
-	will_return_count(getgpsegmentCount, segmentCount, -1);
-	will_return_count(getFtsVersion, ftsVersion, 1);
-
-	expect_any(FaultInjector_InjectFaultIfSet, identifier);
-	expect_any(FaultInjector_InjectFaultIfSet, ddlStatement);
-	expect_any(FaultInjector_InjectFaultIfSet, databaseName);
-	expect_any(FaultInjector_InjectFaultIfSet, tableName);
-	will_return(FaultInjector_InjectFaultIfSet, false);
-
-	mockLibpq(conn, motionListener, qePid);
-
-	cdbgang_setAsync(false);
-
-	Gang	   *gang = AllocateWriterGang(&ds);
-
-	/* validate gang */
-	assert_int_equal(gang->size, TOTOAL_SEGMENTS);
-	assert_int_equal(gang->gang_id, 1);
-	assert_int_equal(gang->portal_name, NULL);
-	assert_int_equal(gang->type, GANGTYPE_PRIMARY_WRITER);
-	assert_int_equal(gang->noReuse, false);
-	assert_int_equal(gang->dispatcherActive, false);
-	assert_int_equal(gang->allocated, true);
-
-	for (i = 0; i < gang->size; i++)
-	{
-		SegmentDatabaseDescriptor *segdb = &gang->db_descriptors[i];
-		CdbComponentDatabaseInfo *cdbinfo = segdb->segment_database_info;
-
-		assert_int_equal(segdb->backendPid, qePid);
-		assert_int_equal(segdb->conn, conn);
-		assert_int_equal(segdb->errcode, 0);
-		assert_int_equal(segdb->error_message.len, 0);
-		assert_int_equal(segdb->motionListener, motionListener);
-		assert_int_equal(segdb->segindex, i);
-
-		validateCdbInfo(segdb->segment_database_info, segdb->segindex);
-	}
-}
-
-static void
-test__createReaderGang(void **state)
-{
-	int			segmentCount = TOTOAL_SEGMENTS;
-	uint8		ftsVersion = 1;
-	PGconn	   *conn = &pgconn;
-	const char *portalName = "portal1";
-	uint32		motionListener = 10000;
-	int			qePid = 2000;
-	int			i = 0;
-	CdbDispatcherState ds;
-	ds.allocatedGangs = NIL;
-
-	will_return_count(getgpsegmentCount, segmentCount, -1);
-	will_return_count(getFtsVersion, ftsVersion, 1);
-
-	expect_any(FaultInjector_InjectFaultIfSet, identifier);
-	expect_any(FaultInjector_InjectFaultIfSet, ddlStatement);
-	expect_any(FaultInjector_InjectFaultIfSet, databaseName);
-	expect_any(FaultInjector_InjectFaultIfSet, tableName);
-	will_return(FaultInjector_InjectFaultIfSet, false);
-	mockLibpq(conn, motionListener, qePid);
-
-	cdbgang_setAsync(false);
-	Gang	   *gang = AllocateReaderGang(&ds, GANGTYPE_PRIMARY_READER, portalName);
-
-	/* validate gang */
-	assert_int_equal(gang->size, TOTOAL_SEGMENTS);
-	assert_int_equal(gang->gang_id, 2);
-	assert_string_equal(gang->portal_name, portalName);
-	assert_int_equal(gang->type, GANGTYPE_PRIMARY_READER);
-	assert_int_equal(gang->noReuse, false);
-	assert_int_equal(gang->dispatcherActive, false);
-	assert_int_equal(gang->allocated, true);
-
-	for (i = 0; i < gang->size; i++)
-	{
-		SegmentDatabaseDescriptor *segdb = &gang->db_descriptors[i];
-		CdbComponentDatabaseInfo *cdbinfo = segdb->segment_database_info;
-
-		assert_int_equal(segdb->backendPid, qePid);
-		assert_int_equal(segdb->conn, conn);
-		assert_int_equal(segdb->errcode, 0);
-		assert_int_equal(segdb->error_message.len, 0);
-		assert_int_equal(segdb->motionListener, motionListener);
-		assert_int_equal(segdb->segindex, i);
-
-		validateCdbInfo(segdb->segment_database_info, segdb->segindex);
-	}
-}
-
 /*
  * Make sure resetSessionForPrimaryGangLoss doesn't access catalog.
  */
@@ -270,8 +165,7 @@ main(int argc, char *argv[])
 	const		UnitTest tests[] =
 	{
 		unit_test(test__resetSessionForPrimaryGangLoss),
-		unit_test(test__createWriterGang),
-	unit_test(test__createReaderGang),};
+	};
 
 	MemoryContextInit();
 	DispatcherContext = AllocSetContextCreate(TopMemoryContext,

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -525,7 +525,6 @@ void
 SetupInterconnect(EState *estate)
 {
 	interconnect_handle_t *h;
-	ChunkTransportState *icContext = NULL;
 	MemoryContext oldContext;
 
 	if (estate->interconnect_context)
@@ -543,20 +542,15 @@ SetupInterconnect(EState *estate)
 	oldContext = MemoryContextSwitchTo(InterconnectContext);
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
-		icContext = SetupUDPIFCInterconnect(estate->es_sliceTable);
+		SetupUDPIFCInterconnect(estate);
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
-		icContext = SetupTCPInterconnect(estate->es_sliceTable);
+		SetupTCPInterconnect(estate);
 	else
 		Assert("unsupported expected interconnect type");
 
-	/* add back-pointer for dispatch check. */
-	icContext->estate = estate;
-
 	MemoryContextSwitchTo(oldContext);
 
-	h->interconnect_context = icContext;
-	estate->interconnect_context = icContext;
-	estate->es_interconnect_is_setup = true;
+	h->interconnect_context = estate->interconnect_context;
 }
 
 /*

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3164,13 +3164,13 @@ SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable)
  * SetupUDPIFCInterconnect
  * 		setup UDP interconnect.
  */
-ChunkTransportState *
-SetupUDPIFCInterconnect(SliceTable *sliceTable)
+void
+SetupUDPIFCInterconnect(EState *estate)
 {
 	ChunkTransportState *icContext = NULL;
 	PG_TRY();
 	{
-		icContext = SetupUDPIFCInterconnect_Internal(sliceTable);
+		icContext = SetupUDPIFCInterconnect_Internal(estate->es_sliceTable);
 
 		/* Internal error if we locked the mutex but forgot to unlock it. */
 		Assert(pthread_mutex_unlock(&ic_control_info.lock) != 0);
@@ -3181,7 +3181,10 @@ SetupUDPIFCInterconnect(SliceTable *sliceTable)
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	return icContext;
+
+	icContext->estate = estate;
+	estate->interconnect_context = icContext;
+	estate->es_interconnect_is_setup = true;
 }
 
 

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -329,31 +329,12 @@ PortalCleanup(Portal portal)
 			{
 				/* Ensure CurrentResourceOwner is restored on error */
 				CurrentResourceOwner = saveResourceOwner;
-
-				/*
-				 * If ExecutorEnd() threw an error, our gangs might be sitting
-				 * on the allocated-list without having been properly free()ed.
-				 *
-				 * For cursor-queries with large numbers of slices, this
-				 * can "leak" a lot of resources on the segments.
-				 */
-				if (Gp_role == GP_ROLE_DISPATCH)
-				{
-					cleanupPortalGangs(portal);
-				}
-
 				PG_RE_THROW();
 			}
 			PG_END_TRY();
 			CurrentResourceOwner = saveResourceOwner;
 		}
 	}
-
-	/*
-	 * Terminate unneeded QE processes.
-	 */
-	if (Gp_role == GP_ROLE_DISPATCH)
-		cleanupPortalGangs(portal);
 
 	/* 
 	 * If resource scheduling is enabled, release the resource lock. 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -108,6 +108,7 @@
 #include "cdb/cdbllize.h"
 #include "cdb/memquota.h"
 #include "cdb/cdbtargeteddispatch.h"
+#include "cdb/cdbutil.h"
 
 
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
@@ -136,6 +137,7 @@ static char *ExecBuildSlotValueDescription(TupleTableSlot *slot,
 static void EvalPlanQualStart(EPQState *epqstate, EState *parentestate,
 				  Plan *planTree);
 
+static void FillSliceGangInfo(Slice *slice);
 static void FillSliceTable(EState *estate, PlannedStmt *stmt);
 
 static PartitionNode *BuildPartitionNodeFromRoot(Oid relid);
@@ -4378,6 +4380,39 @@ typedef struct
 	int			currentSliceId;
 } FillSliceTable_cxt;
 
+static void
+FillSliceGangInfo(Slice *slice)
+{
+	switch (slice->gangType)
+	{
+		case GANGTYPE_UNALLOCATED:
+			break;
+		case GANGTYPE_PRIMARY_WRITER:
+		case GANGTYPE_PRIMARY_READER:
+			if (slice->directDispatch.isDirectDispatch)
+			{
+				slice->gangSize = 1;
+				slice->segments = slice->directDispatch.contentIds;
+			}
+			else
+			{
+				slice->segments = cdbcomponent_getCdbComponentsList();
+				slice->gangSize = list_length(slice->segments);
+			}
+			break;
+		case GANGTYPE_ENTRYDB_READER:
+			slice->gangSize = 1;
+			slice->segments = list_make1_int(-1);
+			break;
+		case GANGTYPE_SINGLETON_READER:
+			slice->gangSize = 1;
+			slice->segments = list_make1_int(gp_singleton_segindex);
+			break;
+		default:
+			elog(ERROR, "unexpected gang type");
+	}
+}
+
 static bool
 FillSliceTable_walker(Node *node, void *context)
 {
@@ -4428,7 +4463,8 @@ FillSliceTable_walker(Node *node, void *context)
 				Slice	   *currentSlice = (Slice *) list_nth(sliceTable->slices, cxt->currentSliceId);
 
 				currentSlice->gangType = GANGTYPE_PRIMARY_WRITER;
-				currentSlice->gangSize = getgpsegmentCount();
+
+				FillSliceGangInfo(currentSlice);
 			}
 		}
 	}
@@ -4447,7 +4483,8 @@ FillSliceTable_walker(Node *node, void *context)
 			Slice	   *currentSlice = (Slice *) list_nth(sliceTable->slices, cxt->currentSliceId);
 
 			currentSlice->gangType = GANGTYPE_PRIMARY_WRITER;
-			currentSlice->gangSize = getgpsegmentCount();
+
+			FillSliceGangInfo(currentSlice);
 		}
 	}
 
@@ -4485,15 +4522,17 @@ FillSliceTable_walker(Node *node, void *context)
 
 		if (sendFlow->flotype != FLOW_SINGLETON)
 		{
-			sendSlice->gangSize = getgpsegmentCount();
 			sendSlice->gangType = GANGTYPE_PRIMARY_READER;
+
+			FillSliceGangInfo(sendSlice);
 		}
 		else
 		{
-			sendSlice->gangSize = 1;
 			sendSlice->gangType =
 				sendFlow->segindex == -1 ?
 				GANGTYPE_ENTRYDB_READER : GANGTYPE_SINGLETON_READER;
+
+			FillSliceGangInfo(sendSlice);
 		}
 
 		sendSlice->numGangMembersToBeActive =
@@ -4551,7 +4590,7 @@ FillSliceTable(EState *estate, PlannedStmt *stmt)
 		Slice	   *currentSlice = (Slice *) linitial(sliceTable->slices);
 
 		currentSlice->gangType = GANGTYPE_PRIMARY_WRITER;
-		currentSlice->gangSize = getgpsegmentCount();
+		FillSliceGangInfo(currentSlice);
 	}
 
 	/*

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1747,6 +1747,7 @@ InitSliceTable(EState *estate, int nMotions, int nSubplans)
         slice->rootIndex = (i > 0 && i <= nMotions) ? -1 : i;
 		slice->gangType = GANGTYPE_UNALLOCATED;
 		slice->gangSize = 0;
+		slice->segments = NIL;
 		slice->numGangMembersToBeActive = 0;
 		slice->directDispatch.isDirectDispatch = false;
 		slice->directDispatch.contentIds = NIL;
@@ -1830,29 +1831,8 @@ sliceCalculateNumSendingProcesses(Slice *slice)
 	}
 }
 
-/*
- * Context for AssignGangs() and helper functions.
- */
-typedef struct SliceReq
-{
-	int			numNgangs;
-	int			num1gangs_primary_reader;
-    int         num1gangs_entrydb_reader;
-	int			nxtNgang;
-	int			nxt1gang_primary_reader;
-	int			nxt1gang_entrydb_reader;
-	Gang	  **vecNgangs;
-	Gang	  **vec1gangs_primary_reader;
-	Gang	  **vec1gangs_entrydb_reader;
-	bool		writer;
-
-}	SliceReq;
-
 /* Forward declarations */
-static void InitSliceReq(SliceReq * req);
-static void InventorySliceTree(Slice ** sliceMap, int sliceIndex, SliceReq * req);
-static void AssociateSlicesToProcesses(Slice ** sliceMap, int sliceIndex, SliceReq * req);
-static void FinalizeSliceTree(Slice ** sliceMap, int sliceIndex, SliceReq * req);
+static void InventorySliceTree(CdbDispatcherState *ds, List * slices, int sliceIndex);
 
 /*
  * Function AssignGangs runs on the QD and finishes construction of the
@@ -1875,106 +1855,24 @@ static void FinalizeSliceTree(Slice ** sliceMap, int sliceIndex, SliceReq * req)
 void
 AssignGangs(CdbDispatcherState *ds, QueryDesc *queryDesc)
 {
-	EState	   *estate = queryDesc->estate;
-	SliceTable *sliceTable = estate->es_sliceTable;
-	ListCell   *cell;
-	Slice	   *slice;
-	int			i,
-				nslices;
-	Slice	  **sliceMap;
-	SliceReq	inv;
+	SliceTable	*sliceTable;
+	ListCell  	*cell;
+	Slice		*slice;
+	EState		*estate;
 	int			rootIdx;
 
-	/* Make a map so we can access slices quickly by index. */
-	nslices = list_length(sliceTable->slices);
-	sliceMap = (Slice **) palloc(nslices * sizeof(Slice *));
-	i = 0;
+	estate = queryDesc->estate;
+	sliceTable = estate->es_sliceTable;
+	rootIdx = RootSliceIndex(queryDesc->estate);
+
+	/* cleanup processMap because initPlan and main Plan share the same slice table */
 	foreach(cell, sliceTable->slices)
 	{
 		slice = (Slice *) lfirst(cell);
-		Assert(i == slice->sliceIndex);
-		sliceMap[i] = slice;
-		/* cleanup processMap because initPlan and main Plan share the same slice table */
 		slice->processesMap = NULL;
-		i++;
 	}
 
-	rootIdx = RootSliceIndex(queryDesc->estate);
-
-	/* Initialize gang requirement inventory */
-	InitSliceReq(&inv);
-
-	/* Capture main slice tree requirement. */
-	InventorySliceTree(sliceMap, rootIdx, &inv);
-	FinalizeSliceTree(sliceMap, rootIdx, &inv);
-
-	/*
-	 * Get the gangs we'll use.
-	 *
-	 * As a general rule the first gang is a writer and the rest are readers.
-	 * If this happens to be an extended query protocol then all gangs are readers.
-	 */
-	if (inv.numNgangs > 0)
-	{
-		inv.vecNgangs = (Gang **) palloc(sizeof(Gang *) * inv.numNgangs);
-		for (i = 0; i < inv.numNgangs; i++)
-		{
-			if (i == 0 && !queryDesc->extended_query)
-			{
-				inv.vecNgangs[i] = AllocateWriterGang(ds);
-				Assert(inv.vecNgangs[i] != NULL);
-			}
-			else
-			{
-				inv.vecNgangs[i] = AllocateReaderGang(ds, GANGTYPE_PRIMARY_READER, queryDesc->portal_name);
-			}
-		}
-	}
-	if (inv.num1gangs_primary_reader > 0)
-	{
-		inv.vec1gangs_primary_reader = (Gang **) palloc(sizeof(Gang *) * inv.num1gangs_primary_reader);
-		for (i = 0; i < inv.num1gangs_primary_reader; i++)
-		{
-			inv.vec1gangs_primary_reader[i] = AllocateReaderGang(ds, GANGTYPE_SINGLETON_READER, queryDesc->portal_name);
-		}
-	}
-	if (inv.num1gangs_entrydb_reader > 0)
-	{
-		inv.vec1gangs_entrydb_reader = (Gang **) palloc(sizeof(Gang *) * inv.num1gangs_entrydb_reader);
-		for (i = 0; i < inv.num1gangs_entrydb_reader; i++)
-		{
-			inv.vec1gangs_entrydb_reader[i] = AllocateReaderGang(ds, GANGTYPE_ENTRYDB_READER, queryDesc->portal_name);
-		}
-	}
-
-	/* Use the gangs to construct the CdbProcess lists in slices. */
-	inv.nxtNgang = 0;
-    inv.nxt1gang_primary_reader = 0;
-    inv.nxt1gang_entrydb_reader = 0;
-
-	AssociateSlicesToProcesses(sliceMap, rootIdx, &inv); /* Main tree. */
-
-	/* Clean up */
-	pfree(sliceMap);
-	if (inv.vecNgangs != NULL)
-		pfree(inv.vecNgangs);
-	if (inv.vec1gangs_primary_reader != NULL)
-		pfree(inv.vec1gangs_primary_reader);
-	if (inv.vec1gangs_entrydb_reader != NULL)
-		pfree(inv.vec1gangs_entrydb_reader);
-
-}
-
-void
-InitSliceReq(SliceReq * req)
-{
-	req->numNgangs = 0;
-    req->num1gangs_primary_reader = 0;
-    req->num1gangs_entrydb_reader = 0;
-	req->writer = FALSE;
-	req->vecNgangs = NULL;
-	req->vec1gangs_primary_reader = NULL;
-	req->vec1gangs_entrydb_reader = NULL;
+	InventorySliceTree(ds, sliceTable->slices, rootIdx);
 }
 
 /*
@@ -1983,171 +1881,28 @@ InitSliceReq(SliceReq * req)
  * generally useful.
  */
 void
-InventorySliceTree(Slice ** sliceMap, int sliceIndex, SliceReq * req)
-{
-	ListCell   *cell;
-	int			childIndex;
-	Slice	   *slice = sliceMap[sliceIndex];
-
-	switch (slice->gangType)
-	{
-		case GANGTYPE_UNALLOCATED:
-			/* Roots that run on the  QD don't need a gang. */
-			break;
-
-		case GANGTYPE_ENTRYDB_READER:
-            Assert(slice->gangSize == 1);
-			req->num1gangs_entrydb_reader++;
-			break;
-
-		case GANGTYPE_SINGLETON_READER:
-			req->num1gangs_primary_reader++;
-			break;
-
-		case GANGTYPE_PRIMARY_WRITER:
-			req->writer = TRUE;
-			/* fall through */
-
-		case GANGTYPE_PRIMARY_READER:
-			Assert(slice->gangSize == getgpsegmentCount());
-			req->numNgangs++;
-			break;
-	}
-
-	foreach(cell, slice->children)
-	{
-		childIndex = lfirst_int(cell);
-		InventorySliceTree(sliceMap, childIndex, req);
-	}
-}
-
-/*
- * Helper function to adjust slice tree for replicated table.
- *
- * Main slice or init plans that working on replicated table may
- * generate all gangs with 1-size, but in GPDB, main slice and
- * init plans all need a N-size gang to act as primary writer,
- * so this function will try to promote a 1-size gang to N-size
- * gang and set it as direct dispatch.
- */
-static void
-FinalizeSliceTree(Slice ** sliceMap, int sliceIndex, SliceReq * req)
+InventorySliceTree(CdbDispatcherState *ds, List *slices, int sliceIndex)
 {
 	ListCell *cell;
 	int childIndex;
-	Slice *slice = sliceMap[sliceIndex];
+	Slice *slice = list_nth(slices, sliceIndex);
 
-	if (req->numNgangs > 0)
-		return;
-
-	switch (slice->gangType)
+	if (slice->gangType == GANGTYPE_UNALLOCATED)
 	{
-		case GANGTYPE_UNALLOCATED:
-		case GANGTYPE_ENTRYDB_READER:
-		case GANGTYPE_PRIMARY_WRITER:
-		case GANGTYPE_PRIMARY_READER:
-			break;
-
-		case GANGTYPE_SINGLETON_READER:
-			Assert(req->num1gangs_primary_reader > 0);
-			req->num1gangs_primary_reader--;
-			req->numNgangs++;
-			slice->gangType = GANGTYPE_PRIMARY_READER;
-			slice->gangSize = getgpsegmentCount();
-			slice->numGangMembersToBeActive = 1;
-			Assert(!slice->directDispatch.isDirectDispatch);
-			slice->directDispatch.isDirectDispatch = true;
-			/*
-			 * Important: Do not make a random contentIds here,
-			 * always use first QE as worker, otherwise interconnect
-			 * will mess it up.
-			 */
-			slice->directDispatch.contentIds = list_make1_int(gp_singleton_segindex);
-			break;
+		slice->primaryGang = NULL;
+		slice->primaryProcesses = getCdbProcessesForQD(true);
+	}
+	else
+	{
+		Assert(slice->segments != NIL);
+		slice->primaryGang = AllocateGang(ds, slice->gangType, slice->segments);
+		setupCdbProcessList(slice);
 	}
 
 	foreach(cell, slice->children)
 	{
 		childIndex = lfirst_int(cell);
-		FinalizeSliceTree(sliceMap, childIndex, req);
-	}
-}
-
-
-#ifdef USE_ASSERT_CHECKING
-static int
-countNonNullValues(List *list)
-{
-	int res = 0;
-	ListCell *lc;
-
-	foreach(lc,list)
-		if ( lfirst(lc) != NULL)
-			res++;
-	return res;
-}
-#endif
-
-/*
- * Helper for AssignGangs uses the gangs in the inventory to fill in the
- * CdbProcess lists in the slice tree.	Recursive.	Closely coupled with
- * AssignGangs.  Not generally useful.
- */
-void
-AssociateSlicesToProcesses(Slice ** sliceMap, int sliceIndex, SliceReq * req)
-{
-	ListCell   *cell;
-	int			childIndex;
-	Slice	   *slice = sliceMap[sliceIndex];
-
-	switch (slice->gangType)
-	{
-		case GANGTYPE_UNALLOCATED:
-			/* Roots that run on the  QD don't need a gang. */
-
-			slice->primaryGang = NULL;
-			slice->primaryProcesses = getCdbProcessesForQD(true);
-			break;
-
-		case GANGTYPE_ENTRYDB_READER:
-			Assert(slice->gangSize == 1);
-			slice->primaryGang = req->vec1gangs_entrydb_reader[req->nxt1gang_entrydb_reader++];
-			Assert(slice->primaryGang != NULL);
-			setupCdbProcessList(slice);
-			Assert(sliceCalculateNumSendingProcesses(slice) == countNonNullValues(slice->primaryProcesses));
-			break;
-
-		case GANGTYPE_PRIMARY_WRITER:
-			Assert(slice->gangSize == getgpsegmentCount());
-			Assert(req->numNgangs > 0 && req->writer);
-			Assert(req->vecNgangs[0] != NULL);
-
-			slice->primaryGang = req->vecNgangs[req->nxtNgang++];
-			Assert(slice->primaryGang != NULL);
-			setupCdbProcessList(slice);
-			break;
-
-		case GANGTYPE_SINGLETON_READER:
-			Assert(slice->gangSize == 1);
-			slice->primaryGang = req->vec1gangs_primary_reader[req->nxt1gang_primary_reader++];
-			Assert(slice->primaryGang != NULL);
-			setupCdbProcessList(slice);
-			Assert(sliceCalculateNumSendingProcesses(slice) == countNonNullValues(slice->primaryProcesses));
-			break;
-
-		case GANGTYPE_PRIMARY_READER:
-			Assert(slice->gangSize == getgpsegmentCount());
-			slice->primaryGang = req->vecNgangs[req->nxtNgang++];
-			Assert(slice->primaryGang != NULL);
-			setupCdbProcessList(slice);
-			Assert(sliceCalculateNumSendingProcesses(slice) == countNonNullValues(slice->primaryProcesses));
-			break;
-	}
-
-	foreach(cell, slice->children)
-	{
-		childIndex = lfirst_int(cell);
-		AssociateSlicesToProcesses(sliceMap, childIndex, req);
+		InventorySliceTree(ds, slices, childIndex);
 	}
 }
 

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -359,10 +359,7 @@ static
 CdbComponentDatabases *readCdbComponentInfoAndUpdateStatus(MemoryContext probeContext)
 {
 	int i;
-	MemoryContext save = MemoryContextSwitchTo(probeContext);
-	/* cdbs is free'd by FtsLoop(). */
-	CdbComponentDatabases *cdbs = getCdbComponentInfo(false);
-	MemoryContextSwitchTo(save);
+	CdbComponentDatabases *cdbs = cdbcomponent_getCdbComponents(false);
 
 	for (i=0; i < cdbs->total_segment_dbs; i++)
 	{
@@ -517,7 +514,7 @@ void FtsLoop()
 
 		if (cdbs != NULL)
 		{
-			freeCdbComponentDatabases(cdbs);
+			cdbcomponent_destroyCdbComponents();
 			cdbs = NULL;
 		}
 

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2647,7 +2647,7 @@ gpdb::GetComponentDatabases(void)
 	GP_WRAP_START;
 	{
 		/* catalog tables: gp_segment_config */
-		return getCdbComponentDatabases();
+		return cdbcomponent_getCdbComponents(true);
 	}
 	GP_WRAP_END;
 	return NULL;

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4754,6 +4754,7 @@ _copySlice(const Slice *from)
 	COPY_SCALAR_FIELD(parentIndex);
 	COPY_NODE_FIELD(children);
 	COPY_NODE_FIELD(primaryProcesses);
+	COPY_BITMAPSET_FIELD(processesMap);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4352,6 +4352,7 @@ _outSlice(StringInfo str, const Slice *node)
 	WRITE_NODE_FIELD(directDispatch.contentIds); /* List of int */
 	WRITE_DUMMY_FIELD(primaryGang);
 	WRITE_NODE_FIELD(primaryProcesses); /* List of (CDBProcess *) */
+	WRITE_BITMAPSET_FIELD(processesMap);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2370,6 +2370,7 @@ _readSlice(void)
 	READ_NODE_FIELD(directDispatch.contentIds); /* List of int index */
 	READ_DUMMY_FIELD(primaryGang, NULL);
 	READ_NODE_FIELD(primaryProcesses); /* List of (CDBProcess *) */
+	READ_BITMAPSET_FIELD(processesMap);
 
 	READ_DONE();
 }

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2776,6 +2776,7 @@ _readSlice(void)
 	READ_NODE_FIELD(directDispatch.contentIds); /* List of int index */
 	READ_DUMMY_FIELD(primaryGang, NULL);
 	READ_NODE_FIELD(primaryProcesses); /* List of (CDBProcess *) */
+	READ_BITMAPSET_FIELD(processesMap);
 
 	READ_DONE();
 }

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1540,7 +1540,7 @@ create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly)
 	}
 
 	/* get the total valid primary segdb count */
-	db_info = getCdbComponentDatabases();
+	db_info = cdbcomponent_getCdbComponents(true);
 	total_primaries = 0;
 	for (i = 0; i < db_info->total_segment_dbs; i++)
 	{
@@ -2111,8 +2111,6 @@ create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly)
 			filenames = lappend(filenames, n);
 		}
 	}
-
-	freeCdbComponentDatabases(db_info);
 
 	return filenames;
 }

--- a/src/backend/tcop/idle_resource_cleaner.c
+++ b/src/backend/tcop/idle_resource_cleaner.c
@@ -108,7 +108,7 @@ IdleGangTimeoutHandler(void)
 
 		idle_gang_timeout_occurred = 0;
 
-		DisconnectAndDestroyUnusedGangs();
+		DisconnectAndDestroyUnusedQEs();
 
 		if (notify_enabled)
 			EnableNotifyInterrupt();

--- a/src/backend/tcop/idle_resource_cleaner.c
+++ b/src/backend/tcop/idle_resource_cleaner.c
@@ -37,7 +37,7 @@ static volatile sig_atomic_t idle_gang_timeout_occurred;
 void
 StartIdleResourceCleanupTimers()
 {
-	if (IdleSessionGangTimeout <= 0 || !GangsExist())
+	if (IdleSessionGangTimeout <= 0 || !cdbcomponent_segdbsExist())
 		return;
 
 	enable_timeout_after(GANG_TIMEOUT, IdleSessionGangTimeout);

--- a/src/backend/tcop/idle_resource_cleaner.c
+++ b/src/backend/tcop/idle_resource_cleaner.c
@@ -37,7 +37,7 @@ static volatile sig_atomic_t idle_gang_timeout_occurred;
 void
 StartIdleResourceCleanupTimers()
 {
-	if (IdleSessionGangTimeout <= 0 || !cdbcomponent_segdbsExist())
+	if (IdleSessionGangTimeout <= 0 || !cdbcomponent_qesExist())
 		return;
 
 	enable_timeout_after(GANG_TIMEOUT, IdleSessionGangTimeout);

--- a/src/backend/tcop/test/idle_resource_cleaner_test.c
+++ b/src/backend/tcop/test/idle_resource_cleaner_test.c
@@ -31,7 +31,7 @@ test__StartIdleResourceCleanupTimersWhenIdleGangTimeoutIs0AndNoSessionTimeoutHoo
 	get_idle_session_timeout_hook = NULL;
 
 	/*
-	 * cmockery implicitly asserts that GangsExist and enable_sig_alarm are
+	 * cmockery implicitly asserts that cdbcomponent_segdbsExist and enable_sig_alarm are
 	 * not called
 	 */
 
@@ -44,7 +44,7 @@ test__StartIdleResourceCleanupTimersWhenNoGangsExistAndNoSessionTimeoutHook(
 {
 	IdleSessionGangTimeout = 10000;
 
-	will_return(GangsExist, false);
+	will_return(cdbcomponent_segdbsExist, false);
 	/* cmockery implicitly asserts that enable_sig_alarm is not called */
 
 	StartIdleResourceCleanupTimers();
@@ -58,7 +58,7 @@ test__StartIdleResourceCleanupTimersWhenGangsExistAndNoSessionTimeoutHook(
 
 	NextTimeoutAction = -1;
 
-	will_return(GangsExist, true);
+	will_return(cdbcomponent_segdbsExist, true);
 	expect_value(enable_sig_alarm, delayms, 10000);
 	expect_value(enable_sig_alarm, is_statement_timeout, false);
 	will_return(enable_sig_alarm, true);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3626,7 +3626,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&gp_cached_gang_threshold,
-		5, 0, INT_MAX,
+		5, 1, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -515,7 +515,6 @@ InitResGroups(void)
 	HeapTuple	tuple;
 	SysScanDesc	sscan;
 	int			numGroups;
-	CdbComponentDatabases *cdbComponentDBs;
 	CdbComponentDatabaseInfo *qdinfo;
 	ResGroupCaps		caps;
 	Relation			relResGroup;
@@ -541,8 +540,7 @@ InitResGroups(void)
 	if (Gp_role == GP_ROLE_DISPATCH && pResGroupControl->segmentsOnMaster == 0)
 	{
 		Assert(IS_QUERY_DISPATCHER());
-		cdbComponentDBs = getCdbComponentDatabases();
-		qdinfo = &cdbComponentDBs->entry_db_info[0];
+		qdinfo = cdbcomponent_getComponentInfo(-1); 
 		pResGroupControl->segmentsOnMaster = qdinfo->hostSegs;
 		Assert(pResGroupControl->segmentsOnMaster > 0);
 	}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -540,7 +540,7 @@ InitResGroups(void)
 	if (Gp_role == GP_ROLE_DISPATCH && pResGroupControl->segmentsOnMaster == 0)
 	{
 		Assert(IS_QUERY_DISPATCHER());
-		qdinfo = cdbcomponent_getComponentInfo(-1); 
+		qdinfo = cdbcomponent_getComponentInfo(MASTER_CONTENT_ID); 
 		pResGroupControl->segmentsOnMaster = qdinfo->hostSegs;
 		Assert(pResGroupControl->segmentsOnMaster > 0);
 	}

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -434,7 +434,7 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		 */
 		if (ResourceCleanupIdleGangs)
 		{
-			cdbcomponent_cleanupIdleSegdbs(false);
+			cdbcomponent_cleanupIdleQEs(false);
 		}
 
 		/*

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -434,7 +434,7 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		 */
 		if (ResourceCleanupIdleGangs)
 		{
-			disconnectAndDestroyIdleReaderGangs();
+			cdbcomponent_cleanupIdleSegdbs(false);
 		}
 
 		/*

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -62,14 +62,11 @@ typedef struct SegmentDatabaseDescriptor
     uint32		            motionListener; /* interconnect listener port */
     int32					backendPid;
     char                   *whoami;         /* QE identifier for msgs */
-
+    bool		isWriter;
 } SegmentDatabaseDescriptor;
 
-
-/* Initialize a segment descriptor in storage provided by the caller. */
 SegmentDatabaseDescriptor *
-cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo  *cdbinfo);
-
+cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo  *cdbinfo, bool isWriter);
 
 /* Free all memory owned by a segment descriptor. */
 void
@@ -88,10 +85,6 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 					   const char *options);
 void
 cdbconn_doConnectComplete(SegmentDatabaseDescriptor *segdbDesc);
-
-
-/* Disconnect from QE */
-void cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc);
 
 /*
  * Read result from connection and discard it.
@@ -113,7 +106,7 @@ bool cdbconn_isConnectionOk(SegmentDatabaseDescriptor *segdbDesc);
 void cdbconn_resetQEErrorMessage(SegmentDatabaseDescriptor *segdbDesc);
 
 /* Set the slice index for error messages related to this QE. */
-void setQEIdentifier(SegmentDatabaseDescriptor *segdbDesc, int sliceIndex, MemoryContext mcxt);
+void cdbconn_setQEIdentifier(SegmentDatabaseDescriptor *segdbDesc, int sliceIndex);
 
 /*
  * Send cancel/finish signal to still-running QE through libpq.

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -67,9 +67,8 @@ typedef struct SegmentDatabaseDescriptor
 
 
 /* Initialize a segment descriptor in storage provided by the caller. */
-void
-cdbconn_initSegmentDescriptor(SegmentDatabaseDescriptor        *segdbDesc,
-                              struct CdbComponentDatabaseInfo  *cdbinfo);
+SegmentDatabaseDescriptor *
+cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo  *cdbinfo);
 
 
 /* Free all memory owned by a segment descriptor. */

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -62,11 +62,13 @@ typedef struct SegmentDatabaseDescriptor
     uint32		            motionListener; /* interconnect listener port */
     int32					backendPid;
     char                   *whoami;         /* QE identifier for msgs */
-    bool		isWriter;
+	bool					isWriter;
+	int						identifier;		/* unique identifier in the cdbcomponent segment pool */
 } SegmentDatabaseDescriptor;
 
 SegmentDatabaseDescriptor *
-cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo  *cdbinfo, bool isWriter);
+
+cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo  *cdbinfo, int identifier, bool isWriter);
 
 /* Free all memory owned by a segment descriptor. */
 void

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -26,6 +26,7 @@ struct CdbDispatchResults; /* #include "cdb/cdbdispatchresult.h" */
 struct CdbPgResults;
 struct Gang; /* #include "cdb/cdbgang.h" */
 struct ResourceOwnerData;
+enum GangType;
 
 /*
  * Types of message to QE when we wait for it.
@@ -54,6 +55,7 @@ typedef struct CdbDispatcherState
 	bool destroyGang;
 	struct CdbDispatchResults *primaryResults;
 	void *dispatchParams;
+	int	largestGangSize;
 } CdbDispatcherState;
 
 typedef struct DispatcherInternalFuncs
@@ -61,10 +63,9 @@ typedef struct DispatcherInternalFuncs
 	void (*procExitCallBack)(void);
 	bool (*checkForCancel)(struct CdbDispatcherState *ds);
 	int (*getWaitSocketFd)(struct CdbDispatcherState *ds);
-	void* (*makeDispatchParams)(int maxSlices, char *queryText, int queryTextLen);
+	void* (*makeDispatchParams)(int maxSlices, int largestGangSize, char *queryText, int queryTextLen);
 	void (*checkResults)(struct CdbDispatcherState *ds, DispatchWaitMode waitMode);
-	void (*dispatchToGang)(struct CdbDispatcherState *ds, struct Gang *gp,
-			int sliceIndex, CdbDispatchDirectDesc *direct);
+	void (*dispatchToGang)(struct CdbDispatcherState *ds, struct Gang *gp, int sliceIndex);
 	void (*waitDispatchFinish)(struct CdbDispatcherState *ds);
 
 }DispatcherInternalFuncs;
@@ -102,8 +103,7 @@ typedef struct DispatcherInternalFuncs
 void
 cdbdisp_dispatchToGang(struct CdbDispatcherState *ds,
 					   struct Gang *gp,
-					   int sliceIndex,
-					   CdbDispatchDirectDesc *direct);
+					   int sliceIndex);
 
 /*
  * cdbdisp_waitDispatchFinish:

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -25,6 +25,7 @@
 struct CdbDispatchResults; /* #include "cdb/cdbdispatchresult.h" */
 struct CdbPgResults;
 struct Gang; /* #include "cdb/cdbgang.h" */
+struct ResourceOwnerData;
 
 /*
  * Types of message to QE when we wait for it.
@@ -50,7 +51,7 @@ typedef struct CdbDispatcherState
 {
 	bool isExtendedQuery;
 	List *allocatedGangs;
-	bool recycleGang;
+	bool destroyGang;
 	struct CdbDispatchResults *primaryResults;
 	void *dispatchParams;
 } CdbDispatcherState;
@@ -187,7 +188,7 @@ void cdbdisp_setAsync(bool async);
 
 void cdbdisp_markNamedPortalGangsDestroyed(void);
 
-void cdbdisp_cleanupAllDispatcherState(void);
+void cdbdisp_cleanupDispatcherHandle(const struct ResourceOwnerData * owner);
 
 void AtAbort_DispatcherState(void);
 

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -51,7 +51,7 @@ extern int	FtsShmemSize(void);
 extern void FtsShmemInit(void);
 
 extern bool FtsIsSegmentUp(CdbComponentDatabaseInfo *dBInfo);
-extern bool FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor *, int);
+extern bool FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor **, int);
 
 extern bool verifyFtsSyncCount(void);
 extern void ftsLock(void);

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -56,12 +56,6 @@ typedef struct Gang
 
 	/* For debugging purposes only. These do not add any actual functionality. */
 	bool allocated;
-
-	/* should be destroyed if set */
-	bool noReuse;
-
-	/* memory context */
-	MemoryContext perGangContext;
 } Gang;
 
 extern int qe_gang_id;
@@ -87,18 +81,14 @@ extern List *getCdbProcessesForQD(int isPrimary);
 
 extern void freeGangsForPortal(char *portal_name);
 
-extern void RecycleGang(Gang *gp);
+extern void RecycleGang(Gang *gp, bool forceDestroy);
 extern void DisconnectAndDestroyGang(Gang *gp);
 extern void DisconnectAndDestroyAllGangs(bool resetSession);
-extern void DisconnectAndDestroyUnusedGangs(void);
+extern void DisconnectAndDestroyUnusedQEs(void);
 
 extern void CheckForResetSession(void);
 
 extern List *getAllIdleReaderGangs(struct CdbDispatcherState *ds);
-
-extern CdbComponentDatabases *getComponentDatabases(void);
-
-extern bool GangsExist(void);
 
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);
 
@@ -108,7 +98,7 @@ char *makeOptions(void);
 extern bool segment_failure_due_to_recovery(const char *error_message);
 
 /*
- * disconnectAndDestroyIdleReaderGangs()
+ * DisconnectAndDestroyIdleQEs()
  *
  * This routine is used when a session has been idle for a while (waiting for the
  * client to send us SQL to execute). The idea is to consume less resources while sitting idle.
@@ -118,18 +108,14 @@ extern bool segment_failure_due_to_recovery(const char *error_message);
  * other end of the connection, and that person has walked away from their terminal, or just hasn't
  * decided what to do next. We could be idle for a very long time (many hours).
  *
- * Of course, freeing gangs means that the next time the user does send in an SQL statement,
- * we need to allocate gangs (at least the writer gang) to do anything. This entails extra work,
+ * Of course, freeing QEs means that the next time the user does send in an SQL statement,
+ * we need to allocate QEs (at least the writer QEs) to do anything. This entails extra work,
  * so we don't want to do this if we don't think the session has gone idle.
  *
  * Only call these routines from an idle session.
  *
  * This routine is also called from the sigalarm signal handler (hopefully that is safe to do).
  */
-extern void disconnectAndDestroyIdleReaderGangs(void);
-
-extern void cleanupPortalGangs(Portal portal);
-
 extern int largestGangsize(void);
 extern void setLargestGangsize(int size);
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -58,7 +58,7 @@ typedef struct Gang
 	bool allocated;
 } Gang;
 
-extern int qe_gang_id;
+extern int qe_identifier;
 
 extern int host_segments;
 
@@ -73,7 +73,7 @@ extern Gang *AllocateWriterGang(struct CdbDispatcherState *ds);
 
 extern void AllocateAllIdleReaderGangs(struct CdbDispatcherState *ds);
 
-extern List *getCdbProcessList(Gang *gang, int sliceIndex, struct DirectDispatchInfo *directDispatch);
+extern void setupCdbProcessList(Slice *slice);
 
 extern bool GangOK(Gang *gp);
 
@@ -93,7 +93,7 @@ extern List *getAllIdleReaderGangs(struct CdbDispatcherState *ds);
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);
 
 Gang *buildGangDefinition(GangType type, int gang_id, int size, int content);
-bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int gangId, int hostSegs);
+bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, int hostSegs);
 char *makeOptions(void);
 extern bool segment_failure_due_to_recovery(const char *error_message);
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -67,12 +67,6 @@ extern Gang *CurrentGangCreating;
 
 extern const char *gangTypeToString(GangType type);
 
-extern Gang *AllocateReaderGang(struct CdbDispatcherState *ds, GangType type, char *portal_name);
-
-extern Gang *AllocateWriterGang(struct CdbDispatcherState *ds);
-
-extern void AllocateAllIdleReaderGangs(struct CdbDispatcherState *ds);
-
 extern void setupCdbProcessList(Slice *slice);
 
 extern bool GangOK(Gang *gp);
@@ -81,6 +75,7 @@ extern List *getCdbProcessesForQD(int isPrimary);
 
 extern void freeGangsForPortal(char *portal_name);
 
+extern Gang *AllocateGang(struct CdbDispatcherState *ds, enum GangType type, List *segments);
 extern void RecycleGang(Gang *gp, bool forceDestroy);
 extern void DisconnectAndDestroyGang(Gang *gp);
 extern void DisconnectAndDestroyAllGangs(bool resetSession);
@@ -92,8 +87,9 @@ extern List *getAllIdleReaderGangs(struct CdbDispatcherState *ds);
 
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);
 
-Gang *buildGangDefinition(GangType type, int gang_id, int size, int content);
+Gang *buildGangDefinition(List *segments, SegmentType segmentType);
 bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, int hostSegs);
+
 char *makeOptions(void);
 extern bool segment_failure_due_to_recovery(const char *error_message);
 
@@ -116,9 +112,6 @@ extern bool segment_failure_due_to_recovery(const char *error_message);
  *
  * This routine is also called from the sigalarm signal handler (hopefully that is safe to do).
  */
-extern int largestGangsize(void);
-extern void setLargestGangsize(int size);
-
 #ifdef WIN32
 extern int gp_pthread_create(DWORD *thread, void *(*start_routine)(void *), void *arg, const char *caller);
 #else
@@ -163,7 +156,7 @@ typedef struct CdbProcess
 	int contentid;
 } CdbProcess;
 
-typedef Gang *(*CreateGangFunc)(GangType type, int gang_id, int size, int content);
+typedef Gang *(*CreateGangFunc)(List *segments, SegmentType segmentType);
 
 extern void cdbgang_setAsync(bool async);
 extern void cdbgang_resetPrimaryWriterGang(void);

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -52,7 +52,7 @@ typedef struct Gang
 	/*
 	 * Array of QEs/segDBs that make up this gang. Sorted by segment index.
 	 */
-	struct SegmentDatabaseDescriptor *db_descriptors;	
+	struct SegmentDatabaseDescriptor **db_descriptors;	
 
 	/* For debugging purposes only. These do not add any actual functionality. */
 	bool allocated;

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -168,5 +168,4 @@ typedef Gang *(*CreateGangFunc)(GangType type, int gang_id, int size, int conten
 extern void cdbgang_setAsync(bool async);
 extern void cdbgang_resetPrimaryWriterGang(void);
 extern void cdbgang_decreaseNumReaderGang(void);
-extern void AvailableWriterGangValidation(void);
 #endif   /* _CDBGANG_H_ */

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -17,6 +17,8 @@
 #include "nodes/plannodes.h"
 #include "storage/s_lock.h"
 
+struct Gang;
+
 /**
  * DTX states, used to track the state of the distributed transaction
  *   from the QD's point of view.

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -233,6 +233,7 @@ typedef struct TMGXACT
 	bool						directTransaction;
 	uint16						directTransactionContentId;
 	bool						writerGangLost;
+	bool						gxidDispatched;
 }	TMGXACT;
 
 typedef struct TMGXACTSTATUS
@@ -349,4 +350,7 @@ extern bool doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType);
 extern void markCurrentGxactWriterGangLost(void);
 
 extern bool currentGxactWriterGangLost(void);
+
+extern bool isSafeToRecreateWriter(void);
+extern void markCurrentGxactDispatched(void);
 #endif   /* CDBTM_H */

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -156,16 +156,16 @@ extern void cdb_cleanup(int code, Datum arg  __attribute__((unused)) );
 CdbComponentDatabases * cdbcomponent_getCdbComponents(bool DNSLookupAsError);
 void cdbcomponent_destroyCdbComponents(void);
 
-void cdbcomponent_cleanupIdleSegdbs(bool includeWriter);
+void cdbcomponent_cleanupIdleQEs(bool includeWriter);
 
 CdbComponentDatabaseInfo * cdbcomponent_getComponentInfo(int contentId);
 
-struct SegmentDatabaseDescriptor * cdbcomponent_allocateIdleSegdb(int contentId, SegmentType segmentType);
+struct SegmentDatabaseDescriptor * cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType);
 
-void cdbcomponent_recycleIdleSegdb(struct SegmentDatabaseDescriptor *segdbDesc, bool forceDestroy);
+void cdbcomponent_recycleIdleQE(struct SegmentDatabaseDescriptor *segdbDesc, bool forceDestroy);
 
-bool cdbcomponent_segdbsExist(void);
-bool cdbcomponent_activeSegdbsExist(void);
+bool cdbcomponent_qesExist(void);
+bool cdbcomponent_activeQEsExist(void);
 
 List *cdbcomponent_getCdbComponentsList(void);
 /*

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -115,6 +115,7 @@ struct CdbComponentDatabases
 	uint8		fts_version;	/* the version of fts */
 	int			numActiveQEs;
 	int			numIdleQEs;
+	int			qeCounter;
 };
 
 /*

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -23,6 +23,7 @@
 
 #include <math.h>
 #include "catalog/gp_segment_config.h"
+#include "nodes/pg_list.h"
 
 /* cdb_rand returns a random float value between 0 and 1 inclusive */
 #define cdb_rand() ((double) random() / (double) MAX_RANDOM_VALUE)
@@ -30,6 +31,13 @@
 /* cdb_randint returns integer value between lower and upper inclusive */
 #define cdb_randint(upper,lower) \
 	( (int) floor( cdb_rand()*(((upper)-(lower))+0.999999) ) + (lower) )
+
+struct SegmentDatabaseDescriptor;
+
+extern MemoryContext CdbComponentsContext;
+
+typedef struct CdbComponentDatabaseInfo CdbComponentDatabaseInfo;
+typedef struct CdbComponentDatabases CdbComponentDatabases;
 
 /* --------------------------------------------------------------------------------------------------
  * Structure for MPP 2.0 database information
@@ -43,7 +51,7 @@
  *
  */
 #define COMPONENT_DBS_MAX_ADDRS (8)
-typedef struct CdbComponentDatabaseInfo
+struct CdbComponentDatabaseInfo
 {
 	int16		dbid;			/* the dbid of this database */
 	int16		segindex;		/* content indicator: -1 for entry database,
@@ -64,7 +72,12 @@ typedef struct CdbComponentDatabaseInfo
 
 	char	   *hostaddrs[COMPONENT_DBS_MAX_ADDRS];	/* cached lookup of names */	
 	int16		hostSegs;		/* number of primary segments on the same hosts */
-} CdbComponentDatabaseInfo;
+	List		*freelist;		/* list of idle segment dbs */
+	int			numIdleQEs;
+	int			numActiveQEs;
+
+	CdbComponentDatabases	*cdbs; /* point to owners */
+};
 
 #define SEGMENT_IS_ACTIVE_MIRROR(p) \
 	((p)->role == GP_SEGMENT_CONFIGURATION_ROLE_MIRROR ? true : false)
@@ -85,7 +98,7 @@ typedef struct CdbComponentDatabaseInfo
  * The storage for instances of this structure returned by getCdbSegmentInstances() is palloc'd.
  * freeCdbSegmentDatabases() can be used to release the structure.
  */
-typedef struct CdbComponentDatabases
+struct CdbComponentDatabases
 {
 	CdbComponentDatabaseInfo *segment_db_info;	/* array of
 												 * SegmentDatabaseInfo's for
@@ -100,7 +113,9 @@ typedef struct CdbComponentDatabases
 	int			my_segindex;	/* the content of this database */
 	bool		my_isprimary;	/* the isprimary flag of this database */
 	uint8		fts_version;	/* the version of fts */
-} CdbComponentDatabases;
+	int			numActiveQEs;
+	int			numIdleQEs;
+};
 
 /*
  * performs all necessary setup required for initializing Greenplum Database components.
@@ -120,7 +135,7 @@ extern void cdb_cleanup(int code, Datum arg  __attribute__((unused)) );
 
 
 /*
- * getCdbComponentDatabases() returns a pointer to a CdbComponentDatabases
+ * cdbcomponent_getCdbComponents() returns a pointer to a CdbComponentDatabases
  * structure. Both the segment_db_info array and the entry_db_info_array are ordered by segindex,
  * isprimary desc.
  *
@@ -128,28 +143,18 @@ extern void cdb_cleanup(int code, Datum arg  __attribute__((unused)) );
  * are contained in palloc'd storage allocated from the current storage context.
  * The same is true for pointer-based values in CdbComponentDatabaseInfo.  The caller is responsible
  * for setting the current storage context and releasing the storage occupied the returned values.
- *
- * The function freeCdbComponentDatabases() is used to release the structure
- * returned by getCdbComponentDatabases().
- *
  */
-extern CdbComponentDatabases *getCdbComponentDatabases(void);
+CdbComponentDatabases * cdbcomponent_getCdbComponents(bool DNSLookupAsError);
+void cdbcomponent_destroyCdbComponents(void);
+void cdbcomponent_cleanupIdleSegdbs(bool includeWriter);
 
-/*
- * freeCdbComponentDatabases() releases the palloc'd storage returned by
- * getCdbComponentDatabases().
- */
-extern void freeCdbComponentDatabases(CdbComponentDatabases *pDBs);
+CdbComponentDatabaseInfo * cdbcomponent_getComponentInfo(int contentId);
 
-// UNDONE: This was a private procedure... are there any issues in making it public???
-/*
- * getCdbComponentInfo
- *
- *
- * Storage for the SegmentInstances block and all subsidiary
- * structures are allocated from the caller's context.
- */
-extern CdbComponentDatabases *getCdbComponentInfo(bool DnsLookupFailureIsError);
+struct SegmentDatabaseDescriptor * cdbcomponent_allocateIdleSegdb(int contentId, bool writer);
+void cdbcomponent_recycleIdleSegdb(struct SegmentDatabaseDescriptor *segdbDesc, bool forceDestroy);
+
+bool cdbcomponent_segdbsExist(void);
+bool cdbcomponent_activeSegdbsExist(void);
 
 /*
  * Given total number of primary segment databases and a number of segments

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -118,6 +118,14 @@ struct CdbComponentDatabases
 	int			qeCounter;
 };
 
+//
+typedef enum SegmentType
+{
+	SEGMENTTYPE_EXPLICT_WRITER = 1,
+	SEGMENTTYPE_EXPLICT_READER,
+	SEGMENTTYPE_ANY
+}SegmentType;
+
 /*
  * performs all necessary setup required for initializing Greenplum Database components.
  *
@@ -147,16 +155,19 @@ extern void cdb_cleanup(int code, Datum arg  __attribute__((unused)) );
  */
 CdbComponentDatabases * cdbcomponent_getCdbComponents(bool DNSLookupAsError);
 void cdbcomponent_destroyCdbComponents(void);
+
 void cdbcomponent_cleanupIdleSegdbs(bool includeWriter);
 
 CdbComponentDatabaseInfo * cdbcomponent_getComponentInfo(int contentId);
 
-struct SegmentDatabaseDescriptor * cdbcomponent_allocateIdleSegdb(int contentId, bool writer);
+struct SegmentDatabaseDescriptor * cdbcomponent_allocateIdleSegdb(int contentId, SegmentType segmentType);
+
 void cdbcomponent_recycleIdleSegdb(struct SegmentDatabaseDescriptor *segdbDesc, bool forceDestroy);
 
 bool cdbcomponent_segdbsExist(void);
 bool cdbcomponent_activeSegdbsExist(void);
 
+List *cdbcomponent_getCdbComponentsList(void);
 /*
  * Given total number of primary segment databases and a number of segments
  * to "skip" - this routine creates a boolean map (array) the size of total

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -315,8 +315,8 @@ extern void markUDPConnInactiveIFC(MotionConn *conn);
 extern void CleanupMotionTCP(void);
 extern void CleanupMotionUDPIFC(void);
 extern void WaitInterconnectQuitUDPIFC(void);
-extern ChunkTransportState *SetupTCPInterconnect(SliceTable *sliceTable);
-extern ChunkTransportState *SetupUDPIFCInterconnect(SliceTable *sliceTable);
+extern void SetupTCPInterconnect(EState *estate);
+extern void SetupUDPIFCInterconnect(EState *estate);
 extern void TeardownTCPInterconnect(ChunkTransportState *transportStates,
 								 bool forceEOS, bool hasError);
 extern void TeardownUDPIFCInterconnect(ChunkTransportState *transportStates,

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -108,6 +108,9 @@ typedef struct Slice
 	 * implemented.
 	 */
 	List	   *primaryProcesses;
+
+	/* A bitmap to identify which QE should execute this slice */
+	Bitmapset  *processesMap;
 } Slice;
 
 /*

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -107,10 +107,11 @@ typedef struct Slice
 	 * The number of processes must agree with the the plan slice to be
 	 * implemented.
 	 */
-	List	   *primaryProcesses;
-
+	List		*primaryProcesses;
 	/* A bitmap to identify which QE should execute this slice */
-	Bitmapset  *processesMap;
+	Bitmapset	*processesMap;
+	/* A list of segment ids who will execute this slice */
+	List		*segments;
 } Slice;
 
 /*

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -192,6 +192,8 @@ FI_IDENT(SendQEDetailsInitBackend, "send_qe_details_init_backend")
 FI_IDENT(ProcessStartupPacketFault, "process_startup_packet")
 /* inject fault in cdbdisp_dispatchX*/
 FI_IDENT(AfterOneSliceDispatched, "after_one_slice_dispatched")
+/* inject fault in cdbdisp_dispatchX*/
+FI_IDENT(BeforeOneSliceDispatched, "before_one_slice_dispatched")
 /* inject fault in interconnect to skip sending the stop ack */
 FI_IDENT(InterconnectStopAckIsLost, "interconnect_stop_ack_is_lost")
 /* inject fault in interconnect to make palloc0 fail in setup */

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -254,7 +254,7 @@ FI_IDENT(CreateGangInProgress, "create_gang_in_progress")
 /* inject fault when creating new TOAST tables, to modify the chunk size */
 FI_IDENT(DecreaseToastMaxChunkSize, "decrease_toast_max_chunk_size")
 /* inject fault to let cleanupGang return false */
-FI_IDENT(CleanupSegdb, "cleanup_segdb")
+FI_IDENT(CleanupQE, "cleanup_qe")
 #endif
 
 /*

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -252,7 +252,7 @@ FI_IDENT(CreateGangInProgress, "create_gang_in_progress")
 /* inject fault when creating new TOAST tables, to modify the chunk size */
 FI_IDENT(DecreaseToastMaxChunkSize, "decrease_toast_max_chunk_size")
 /* inject fault to let cleanupGang return false */
-FI_IDENT(CleanupGang, "cleanup_gang")
+FI_IDENT(CleanupSegdb, "cleanup_segdb")
 #endif
 
 /*

--- a/src/include/utils/resowner.h
+++ b/src/include/utils/resowner.h
@@ -63,7 +63,7 @@ typedef void (*ResourceReleaseCallback) (ResourceReleasePhase phase,
 													 bool isTopLevel,
 													 void *arg);
 
-typedef void (*ResourceWalkerCallback) (const ResourceOwner owner);
+typedef void (*ResourceWalkerCallback) (const struct ResourceOwnerData * owner);
 
 /*
  * Functions in resowner.c

--- a/src/test/isolation2/expected/dispatcher_fts_error.out
+++ b/src/test/isolation2/expected/dispatcher_fts_error.out
@@ -1,0 +1,345 @@
+-- Tests FTS can handle DNS error.
+create extension if not exists gp_inject_fault;
+CREATE
+
+-- start_matchsubs
+-- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/
+-- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
+-- end_matchsubs
+
+-- to make test deterministic and fast
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+-- start_ignore
+20180920:05:00:20:030048 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-c gp_fts_probe_retries -v 2 --masteronly'
+
+-- end_ignore
+(exited with code 0)
+
+-- Allow extra time for mirror promotion to complete recovery to avoid
+-- gprecoverseg BEGIN failures due to gang creation failure as some primaries
+-- are not up. Setting these increase the number of retries in gang creation in
+-- case segment is in recovery. Approximately we want to wait 30 seconds.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly;
+-- start_ignore
+20180920:05:00:21:030140 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly;
+-- start_ignore
+20180920:05:00:21:030228 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20180920:05:00:22:030314 gpstop:gpdbvm:gpadmin-[INFO]:-Starting gpstop with args: -u
+20180920:05:00:22:030314 gpstop:gpdbvm:gpadmin-[INFO]:-Gathering information and validating the environment...
+20180920:05:00:22:030314 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20180920:05:00:22:030314 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
+20180920:05:00:22:030314 gpstop:gpdbvm:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.9598.gc5dfd9c build dev-oss'
+20180920:05:00:22:030314 gpstop:gpdbvm:gpadmin-[INFO]:-Signalling all postmaster processes to reload
+. 
+
+-- end_ignore
+(exited with code 0)
+
+-- start_ignore
+create language plpythonu;
+CREATE
+-- end_ignore
+
+create or replace function pg_ctl(datadir text, command text) returns text as $$ import subprocess 
+cmd = 'pg_ctl -D %s ' % datadir if command in ('stop'): cmd = cmd + '-w -m immediate %s' % command else: return 'Invalid command input' 
+return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
+CREATE
+
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+count
+-----
+0    
+(1 row)
+
+1:BEGIN;
+BEGIN
+1:END;
+END
+2:BEGIN;
+BEGIN
+3:BEGIN;
+BEGIN
+3:CREATE TEMP TABLE tmp3 (c1 int, c2 int);
+CREATE
+3:DECLARE c1 CURSOR for select * from tmp3;
+DECLARE
+4:CREATE TEMP TABLE tmp4 (c1 int, c2 int);
+CREATE
+5:BEGIN;
+BEGIN
+5:CREATE TEMP TABLE tmp5 (c1 int, c2 int);
+CREATE
+5:SAVEPOINT s1;
+SAVEPOINT
+5:CREATE TEMP TABLE tmp51 (c1 int, c2 int);
+CREATE
+
+-- stop a primary in order to trigger a mirror promotion
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+pg_ctl                                              
+----------------------------------------------------
+waiting for server to shut down done
+server stopped
+
+(1 row)
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
+(1 row)
+
+-- verify a segment is down
+select count(*) from gp_segment_configuration where status = 'd';
+count
+-----
+1    
+(1 row)
+-- session 1: in no transaction and no temp table created, it's safe to
+--            update cdb_component_dbs and use the new promoted primary
+1:BEGIN;
+BEGIN
+1:END;
+END
+-- session 2: in transaction, gxid is dispatched to writer gang, cann't
+--            update cdb_component_dbs, following query should fail
+2:END;
+ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=30365: server closed the connection unexpectedly
+DETAIL:  
+	This probably means the server terminated abnormally
+	before or while processing the request.
+-- session 3: in transaction and has a cursor, cann't update
+--            cdb_component_dbs, following query should fail
+3:FETCH ALL FROM c1;
+c1|c2
+--+--
+(0 rows)
+3:END;
+ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=30374: server closed the connection unexpectedly
+DETAIL:  
+	This probably means the server terminated abnormally
+	before or while processing the request.
+-- session 4: not in transaction but has temp table, cann't update
+--            cdb_component_dbs, following query should fail and session
+--            is reset
+4:select * from tmp4;
+ERROR:  Error on receive from seg0 slice1 127.0.0.1:25432 pid=30391: server closed the connection unexpectedly
+DETAIL:  
+	This probably means the server terminated abnormally
+	before or while processing the request.
+4:select * from tmp4;
+ERROR:  relation "tmp4" does not exist
+LINE 1: select * from tmp4;
+                      ^
+-- session 5: has a subtransaction, cann't update cdb_component_dbs,
+--            following query should fail
+5:select * from tmp51;
+ERROR:  Error on receive from seg0 slice1 127.0.0.1:25432 pid=30399: server closed the connection unexpectedly
+DETAIL:  
+	This probably means the server terminated abnormally
+	before or while processing the request.
+5:ROLLBACK TO SAVEPOINT s1;
+ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1)
+5:END;
+END
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+5q: ... <quitting>
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF;
+-- start_ignore
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Starting gprecoverseg with args: -aF
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.9598.gc5dfd9c build dev-oss'
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.2beta2 (Greenplum Database 6.0.0-alpha.0+dev.9598.gc5dfd9c build dev-oss) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit compiled on Sep 20 2018 03:50:32 (with assert checking)'
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Recovery type              = Standard
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Recovery 1 of 1
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Synchronization mode                 = Full
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Failed instance host                 = gpdbvm
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Failed instance address              = gpdbvm
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Failed instance port                 = 25432
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Source instance host        = gpdbvm
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Source instance address     = gpdbvm
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Source instance port        = 25435
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-1 segment(s) to recover
+20180920:05:00:25:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Ensuring 1 failed segment(s) are stopped
+ 
+20180920:05:00:26:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
+20180920:05:00:26:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Validating remote directories
+. 
+20180920:05:00:27:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Configuring new segments
+. 
+20180920:05:00:29:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Updating mirrors
+. 
+20180920:05:00:30:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Starting mirrors
+20180920:05:00:30:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-era is e0110b50959363aa_180920041106
+20180920:05:00:30:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
+. 
+20180920:05:00:31:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Process results...
+20180920:05:00:31:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Triggering FTS probe
+20180920:05:00:31:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
+20180920:05:00:31:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Updating segments for streaming is completed.
+20180920:05:00:31:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-For segments updated successfully, streaming will continue in the background.
+20180920:05:00:31:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Use  gpstate -s  to check the streaming progress.
+20180920:05:00:31:030437 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
+
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select mode = 's' from gp_segment_configuration where content = 0 limit 1) then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
+DO
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Starting gprecoverseg with args: -ar
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.9598.gc5dfd9c build dev-oss'
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.2beta2 (Greenplum Database 6.0.0-alpha.0+dev.9598.gc5dfd9c build dev-oss) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit compiled on Sep 20 2018 03:50:32 (with assert checking)'
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Recovery type              = Rebalance
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Unbalanced segment 1 of 2
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Unbalanced instance host        = gpdbvm
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Unbalanced instance address     = gpdbvm
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Unbalanced instance port        = 25435
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Balanced role                   = Mirror
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Current role                    = Primary
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Unbalanced segment 2 of 2
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Unbalanced instance host        = gpdbvm
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Unbalanced instance address     = gpdbvm
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Unbalanced instance port        = 25432
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Balanced role                   = Primary
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Current role                    = Mirror
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Getting unbalanced segments
+20180920:05:00:31:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Stopping unbalanced primary segments...
+. 
+20180920:05:00:32:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Triggering segment reconfiguration
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Starting segment synchronization
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-=============================START ANOTHER RECOVER=========================================
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.9598.gc5dfd9c build dev-oss'
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.2beta2 (Greenplum Database 6.0.0-alpha.0+dev.9598.gc5dfd9c build dev-oss) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit compiled on Sep 20 2018 03:50:32 (with assert checking)'
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Recovery type              = Standard
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Recovery 1 of 1
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Synchronization mode                 = Full
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Failed instance host                 = gpdbvm
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Failed instance address              = gpdbvm
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Failed instance port                 = 25435
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Source instance host        = gpdbvm
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Source instance address     = gpdbvm
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Source instance port        = 25432
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-1 segment(s) to recover
+20180920:05:00:34:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Ensuring 1 failed segment(s) are stopped
+ 
+20180920:05:00:35:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
+20180920:05:00:36:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Validating remote directories
+. 
+20180920:05:00:37:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Configuring new segments
+.. 
+20180920:05:00:39:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Updating mirrors
+. 
+20180920:05:00:40:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Starting mirrors
+20180920:05:00:40:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-era is e0110b50959363aa_180920041106
+20180920:05:00:40:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
+. 
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Process results...
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Triggering FTS probe
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Updating segments for streaming is completed.
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-For segments updated successfully, streaming will continue in the background.
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Use  gpstate -s  to check the streaming progress.
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-==============================END ANOTHER RECOVER==========================================
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-The rebalance operation has completed successfully.
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-There is a resynchronization running in the background to bring all
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-segments in sync.
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Use gpstate -e to check the resynchronization progress.
+20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
+
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select mode = 's' from gp_segment_configuration where content = 0 limit 1) then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
+DO
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';
+count
+-----
+0    
+(1 row)
+
+!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+-- start_ignore
+20180920:05:00:42:031183 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-r gp_fts_probe_retries --masteronly'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
+-- start_ignore
+20180920:05:00:43:031272 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-r gp_gang_creation_retry_count --skipvalidation --masteronly'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+-- start_ignore
+20180920:05:00:43:031356 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-r gp_gang_creation_retry_timer --skipvalidation --masteronly'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20180920:05:00:43:031440 gpstop:gpdbvm:gpadmin-[INFO]:-Starting gpstop with args: -u
+20180920:05:00:43:031440 gpstop:gpdbvm:gpadmin-[INFO]:-Gathering information and validating the environment...
+20180920:05:00:43:031440 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20180920:05:00:43:031440 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
+20180920:05:00:43:031440 gpstop:gpdbvm:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.9598.gc5dfd9c build dev-oss'
+20180920:05:00:43:031440 gpstop:gpdbvm:gpadmin-[INFO]:-Signalling all postmaster processes to reload
+. 
+
+-- end_ignore
+(exited with code 0)
+
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -121,6 +121,7 @@ test: add_column_after_vacuum_skip_drop_column
 test: vacuum_after_vacuum_skip_drop_column
 
 # Tests for FTS
+test: dispatcher_fts_error 
 test: fts_dns_error
 test: segwalrep/commit_blocking
 test: segwalrep/fts_unblock_primary

--- a/src/test/isolation2/sql/dispatcher_fts_error.sql
+++ b/src/test/isolation2/sql/dispatcher_fts_error.sql
@@ -1,0 +1,125 @@
+-- Tests FTS can handle DNS error.
+create extension if not exists gp_inject_fault;
+
+-- start_matchsubs
+-- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/
+-- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
+-- end_matchsubs
+
+-- to make test deterministic and fast
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+
+-- Allow extra time for mirror promotion to complete recovery to avoid
+-- gprecoverseg BEGIN failures due to gang creation failure as some primaries
+-- are not up. Setting these increase the number of retries in gang creation in
+-- case segment is in recovery. Approximately we want to wait 30 seconds.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+
+create or replace function pg_ctl(datadir text, command text)
+returns text as $$
+    import subprocess
+
+    cmd = 'pg_ctl -D %s ' % datadir
+    if command in ('stop'):
+        cmd = cmd + '-w -m immediate %s' % command
+    else:
+        return 'Invalid command input'
+
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+$$ language plpythonu;
+
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+
+1:BEGIN;
+1:END;
+2:BEGIN;
+3:BEGIN;
+3:CREATE TEMP TABLE tmp3 (c1 int, c2 int);
+3:DECLARE c1 CURSOR for select * from tmp3;
+4:CREATE TEMP TABLE tmp4 (c1 int, c2 int);
+5:BEGIN;
+5:CREATE TEMP TABLE tmp5 (c1 int, c2 int);
+5:SAVEPOINT s1;
+5:CREATE TEMP TABLE tmp51 (c1 int, c2 int);
+
+-- stop a primary in order to trigger a mirror promotion
+select pg_ctl((select datadir from gp_segment_configuration c
+where c.role='p' and c.content=0), 'stop');
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+
+-- verify a segment is down
+select count(*) from gp_segment_configuration where status = 'd';
+-- session 1: in no transaction and no temp table created, it's safe to
+--            update cdb_component_dbs and use the new promoted primary 
+1:BEGIN;
+1:END;
+-- session 2: in transaction, gxid is dispatched to writer gang, cann't
+--            update cdb_component_dbs, following query should fail
+2:END;
+-- session 3: in transaction and has a cursor, cann't update
+--            cdb_component_dbs, following query should fail 
+3:FETCH ALL FROM c1;
+3:END;
+-- session 4: not in transaction but has temp table, cann't update
+--            cdb_component_dbs, following query should fail and session
+--            is reset 
+4:select * from tmp4;
+4:select * from tmp4;
+-- session 5: has a subtransaction, cann't update cdb_component_dbs,
+--            following query should fail 
+5:select * from tmp51;
+5:ROLLBACK TO SAVEPOINT s1;
+5:END;
+1q:
+2q:
+3q:
+4q:
+5q:
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF;
+
+-- loop while segments come in sync
+do $$
+begin /* in func */
+  for i in 1..120 loop /* in func */
+    if (select mode = 's' from gp_segment_configuration where content = 0 limit 1) then /* in func */
+      return; /* in func */
+    end if; /* in func */
+    perform gp_request_fts_probe_scan(); /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$;
+
+!\retcode gprecoverseg -ar;
+
+-- loop while segments come in sync
+do $$
+begin /* in func */
+  for i in 1..120 loop /* in func */
+    if (select mode = 's' from gp_segment_configuration where content = 0 limit 1) then /* in func */
+      return; /* in func */
+    end if; /* in func */
+    perform gp_request_fts_probe_scan(); /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$;
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';
+
+!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -390,7 +390,7 @@ savepoint s1;
 create temp table disp_temp_test1 (c1 int, c2 int);
 insert into disp_temp_test1 values (1, 2);
 -- Let cleanupSegdb() return false and writer gang be destroyed
-select gp_inject_fault('cleanup_segdb', 'skip', 1);
+select gp_inject_fault('cleanup_qe', 'skip', 1);
 select * from disp_temp_test1 where c1 / 0 = 9;
 rollback to savepoint s1;
 rollback;
@@ -398,7 +398,7 @@ rollback;
 select * from disp_temp_test;
 select * from disp_temp_test1;
 -- reset fault
-select gp_inject_fault('cleanup_segdb', 'reset', 1);
+select gp_inject_fault('cleanup_qe', 'reset', 1);
 
 -- resume FTS probes
 select gp_inject_fault('fts_probe', 'reset', 1);

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -379,8 +379,8 @@ insert into disp_temp_test values (1, 2);
 savepoint s1;
 create temp table disp_temp_test1 (c1 int, c2 int);
 insert into disp_temp_test1 values (1, 2);
-select gp_inject_fault('cleanup_gang', 'skip', 1);
--- Let cleanupGang return false and writer gang be destroyed
+-- Let cleanupSegdb() return false and writer gang be destroyed
+select gp_inject_fault('cleanup_segdb', 'skip', 1);
 select * from disp_temp_test1 where c1 / 0 = 9;
 rollback to savepoint s1;
 rollback;
@@ -388,7 +388,7 @@ rollback;
 select * from disp_temp_test;
 select * from disp_temp_test1;
 -- reset fault
-select gp_inject_fault('cleanup_gang', 'reset', 1);
+select gp_inject_fault('cleanup_segdb', 'reset', 1);
 
 -- resume FTS probes
 select gp_inject_fault('fts_probe', 'reset', 1);

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -283,6 +283,16 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 
 select gp_inject_fault('after_one_slice_dispatched', 'reset', 1);
 
+-- Case 1.6
+-- For a query need two phase commit, if error happens before commands are actually
+-- dispatched, the query can be cancelled correctly.
+-- 
+select gp_inject_fault('before_one_slice_dispatched', 'error', 1);
+update dispatch_test_t1 set c2 = 3 from dispatch_test_t2, dispatch_test_t3
+where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
+
+select gp_inject_fault('before_one_slice_dispatched', 'reset', 1);
+
 -- test logging of gang management
 SET gp_log_gang = 'debug';
 

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -686,7 +686,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into disp_temp_test1 values (1, 2);
 -- Let cleanupSegdb() return false and writer gang be destroyed
-select gp_inject_fault('cleanup_segdb', 'skip', 1);
+select gp_inject_fault('cleanup_qe', 'skip', 1);
 NOTICE:  Success:
  gp_inject_fault 
 -----------------
@@ -710,7 +710,7 @@ ERROR:  relation "disp_temp_test1" does not exist
 LINE 1: select * from disp_temp_test1;
                       ^
 -- reset fault
-select gp_inject_fault('cleanup_segdb', 'reset', 1);
+select gp_inject_fault('cleanup_qe', 'reset', 1);
 NOTICE:  Success:
  gp_inject_fault 
 -----------------

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -664,14 +664,14 @@ create temp table disp_temp_test1 (c1 int, c2 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into disp_temp_test1 values (1, 2);
-select gp_inject_fault('cleanup_gang', 'skip', 1);
+-- Let cleanupSegdb() return false and writer gang be destroyed
+select gp_inject_fault('cleanup_segdb', 'skip', 1);
 NOTICE:  Success:
  gp_inject_fault 
 -----------------
  t
 (1 row)
 
--- Let cleanupGang return false and writer gang be destroyed
 select * from disp_temp_test1 where c1 / 0 = 9;
 ERROR:  division by zero  (seg2 slice1 127.0.0.1:25434 pid=27218)
 rollback to savepoint s1;
@@ -689,7 +689,7 @@ ERROR:  relation "disp_temp_test1" does not exist
 LINE 1: select * from disp_temp_test1;
                       ^
 -- reset fault
-select gp_inject_fault('cleanup_gang', 'reset', 1);
+select gp_inject_fault('cleanup_segdb', 'reset', 1);
 NOTICE:  Success:
  gp_inject_fault 
 -----------------

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -507,6 +507,27 @@ NOTICE:  Success:
  t
 (1 row)
 
+-- Case 1.6
+-- For a query need two phase commit, if error happens before commands are actually
+-- dispatched, the query can be cancelled correctly.
+-- 
+select gp_inject_fault('before_one_slice_dispatched', 'error', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+update dispatch_test_t1 set c2 = 3 from dispatch_test_t2, dispatch_test_t3
+where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
+ERROR:  fault triggered, fault name:'before_one_slice_dispatched' fault type:'error'
+select gp_inject_fault('before_one_slice_dispatched', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 -- test logging of gang management
 SET gp_log_gang = 'debug';
 -- test INFO raised from segments with various kinds of fields

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -498,7 +498,7 @@ hasGangsExist(PG_FUNCTION_ARGS)
 {
 	if (Gp_role != GP_ROLE_DISPATCH)
 		elog(ERROR, "hasGangsExist can only be executed on master");
-	if (GangsExist())
+	if (cdbcomponent_segdbsExist())
 		PG_RETURN_BOOL(true);
 	PG_RETURN_BOOL(false);
 }

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -498,7 +498,7 @@ hasGangsExist(PG_FUNCTION_ARGS)
 {
 	if (Gp_role != GP_ROLE_DISPATCH)
 		elog(ERROR, "hasGangsExist can only be executed on master");
-	if (cdbcomponent_segdbsExist())
+	if (cdbcomponent_qesExist())
 		PG_RETURN_BOOL(true);
 	PG_RETURN_BOOL(false);
 }


### PR DESCRIPTION
There are a lot of restrictions in the current code base when creating gang:
1. GANGTYPE_PRIMARY_READER/GANGTYPE_PRIMARY_WRITER must be N-size (N = number of segments), even for direct dispatch, it still creates N-size gang.
2. A plan must contain a GANGTYPE_PRIMARY_WRITER gang, otherwise, you need to promote the gang to a  GANGTYPE_PRIMARY_WRITER before createing gang. One example is the simple SELECT query, GANGTYPE_PRIMARY_READER is promoted to GANGTYPE_PRIMARY_WRITER. Another example is select * from replicated_table, the plan is generated with only one GANGTYPE_SINGLETON_READER, but we need to promote it to GANGTYPE_PRIMARY_WRITER and set it as a direct dispatching before creating gang.
3. We can not create a gang which consists of entry_db + normal_db, the implementation of pg_locks is restricted by it.
4. We can not create partial segments or duplicate segments in a gang. For query like "update xxx set xxx where col = 1 or col = 3", we can create a 2-size gang as needed. For Join and other grouping operators, we can assign more workers in a gang to gain performance (this is just a guess, the better way is considering the query parallelisation feature of postgresql 9.6).


The main idea to resolve this is simply managing segment workers in a lower granularity.
Previously, there are bunches of lists like primaryWriterGang, AllocatedGangsList, availableReaderGangsN, availableReaderGangs1 to manage running/idle segment workers in GANG level. Now we use CdbComponentDatabases to manage those segment workers, CdbComponentDatabases maintains a set of segment components, each segment component maintain its workers by itself.

When creating gang, dispatcher specifies a List of segment Ids and CdbComponentDatabases return idle workers by requesting workers from each segment component. each segment component do 3 things:
1. maintain a free list of idle workers so idle workers can be reused.
2. guarantee each component has only one writer worker in the session.
3. guarantee writer worker is always the first one to serve a query.

CdbComponentDatabases is FTS sensitive, so Dispatcher can be more FTS sensitive, now we can transparent the FTS failover to the users in certain cases.
