### PR TITLE
Fix "could not find pathkey item to sort" error with MergeAppend plans.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -992,7 +992,9 @@ make_union_motion(Plan *lefttree, int destSegIndex, bool useExecutorVarFormat)
 
 	outSegIdx[0] = destSegIndex;
 
-	motion = make_motion(NULL, lefttree, NIL, useExecutorVarFormat);
+	motion = make_motion(NULL, lefttree,
+						 0, NULL, NULL, NULL, NULL, /* no ordering */
+						 useExecutorVarFormat);
 	add_slice_to_motion(motion, MOTIONTYPE_FIXED, NULL, 1, outSegIdx);
 	return motion;
 }
@@ -1000,8 +1002,9 @@ make_union_motion(Plan *lefttree, int destSegIndex, bool useExecutorVarFormat)
 Motion *
 make_sorted_union_motion(PlannerInfo *root,
 						 Plan *lefttree,
+						 int numSortCols, AttrNumber *sortColIdx,
+						 Oid *sortOperators, Oid *collations, bool *nullsFirst,
 						 int destSegIndex,
-						 List *sortPathKeys,
 						 bool useExecutorVarFormat)
 {
 	Motion	   *motion;
@@ -1009,7 +1012,9 @@ make_sorted_union_motion(PlannerInfo *root,
 
 	outSegIdx[0] = destSegIndex;
 
-	motion = make_motion(root, lefttree, sortPathKeys, useExecutorVarFormat);
+	motion = make_motion(root, lefttree,
+						 numSortCols, sortColIdx, sortOperators, collations, nullsFirst,
+						 useExecutorVarFormat);
 	add_slice_to_motion(motion, MOTIONTYPE_FIXED, NULL, 1, outSegIdx);
 	return motion;
 }
@@ -1032,7 +1037,9 @@ make_hashed_motion(Plan *lefttree,
 			elog(ERROR, "cannot use expression as distribution key, because it is not hashable");
 	}
 
-	motion = make_motion(NULL, lefttree, NIL, useExecutorVarFormat);
+	motion = make_motion(NULL, lefttree,
+						 0, NULL, NULL, NULL, NULL, /* no ordering */
+						 useExecutorVarFormat);
 	add_slice_to_motion(motion, MOTIONTYPE_HASH, hashExpr, 0, NULL);
 	return motion;
 }
@@ -1042,7 +1049,9 @@ make_broadcast_motion(Plan *lefttree, bool useExecutorVarFormat)
 {
 	Motion	   *motion;
 
-	motion = make_motion(NULL, lefttree, NIL, useExecutorVarFormat);
+	motion = make_motion(NULL, lefttree,
+						 0, NULL, NULL, NULL, NULL, /* no ordering */
+						 useExecutorVarFormat);
 
 	add_slice_to_motion(motion, MOTIONTYPE_FIXED, NULL, 0, NULL);
 	return motion;
@@ -1053,7 +1062,9 @@ make_explicit_motion(Plan *lefttree, AttrNumber segidColIdx, bool useExecutorVar
 {
 	Motion	   *motion;
 
-	motion = make_motion(NULL, lefttree, NIL, useExecutorVarFormat);
+	motion = make_motion(NULL, lefttree,
+						 0, NULL, NULL, NULL, NULL, /* no ordering */
+						 useExecutorVarFormat);
 
 	Assert(segidColIdx > 0 && segidColIdx <= list_length(lefttree->targetlist));
 

--- a/src/backend/cdb/cdbpathtoplan.c
+++ b/src/backend/cdb/cdbpathtoplan.c
@@ -13,15 +13,10 @@
  */
 #include "postgres.h"
 
-#include "optimizer/pathnode.h" /* Path */
-#include "optimizer/planmain.h" /* make_sort_from_pathkeys() */
 #include "optimizer/tlist.h"
 
+#include "cdb/cdbpathlocus.h"
 #include "cdb/cdbllize.h"		/* makeFlow() */
-#include "cdb/cdbmutate.h"		/* make_*_motion() */
-#include "cdb/cdbutil.h"
-#include "cdb/cdbvars.h"		/* gp_singleton_segindex */
-
 #include "cdb/cdbpathtoplan.h"	/* me */
 
 /*
@@ -83,131 +78,3 @@ cdbpathtoplan_create_flow(PlannerInfo *root,
 	flow->locustype = locus.locustype;
 	return flow;
 }								/* cdbpathtoplan_create_flow */
-
-
-/*
- * cdbpathtoplan_create_motion_plan
- */
-Motion *
-cdbpathtoplan_create_motion_plan(PlannerInfo *root,
-								 CdbMotionPath *path,
-								 Plan *subplan)
-{
-	Motion	   *motion = NULL;
-	Path	   *subpath = path->subpath;
-
-	/* Send all tuples to a single process? */
-	if (CdbPathLocus_IsBottleneck(path->path.locus))
-	{
-		int			destSegIndex = -1;	/* to dispatcher */
-
-		if (CdbPathLocus_IsSingleQE(path->path.locus))
-			destSegIndex = gp_singleton_segindex;	/* to singleton qExec */
-
-		if (path->path.pathkeys)
-		{
-			/*
-			 * Build a dummy Sort node.  We'll take its sort key info to
-			 * define our Merge Receive keys.  Unchanged subplan ptr is
-			 * returned to us if ordering is degenerate (all cols constant).
-			 */
-			Sort	   *sort = make_sort_from_pathkeys(root,
-													   subplan,
-													   path->path.pathkeys,
-													   -1.0,
-													   true);
-
-			/* Merge Receive to preserve ordering */
-			if (sort)
-			{
-				/* Result node might have been added below the Sort */
-				subplan = sort->plan.lefttree;
-				motion = make_sorted_union_motion(root,
-												  subplan,
-												  destSegIndex,
-												  path->path.pathkeys,
-												  false /* useExecutorVarFormat */
-					);
-			}
-
-			/* Degenerate ordering... build unordered Union Receive */
-			else
-				motion = make_union_motion(subplan,
-										   destSegIndex,
-										   false	/* useExecutorVarFormat */
-					);
-		}
-
-		/* Unordered Union Receive */
-		else
-			motion = make_union_motion(subplan,
-									   destSegIndex,
-									   false	/* useExecutorVarFormat */
-				);
-	}
-
-	/* Send all of the tuples to all of the QEs in gang above... */
-	else if (CdbPathLocus_IsReplicated(path->path.locus))
-		motion = make_broadcast_motion(subplan,
-									   false	/* useExecutorVarFormat */
-			);
-
-	/* Hashed redistribution to all QEs in gang above... */
-	else if (CdbPathLocus_IsHashed(path->path.locus) ||
-			 CdbPathLocus_IsHashedOJ(path->path.locus))
-	{
-		List	   *hashExpr = cdbpathlocus_get_partkey_exprs(path->path.locus,
-															  path->path.parent->relids,
-															  subplan->targetlist);
-
-		Insist(hashExpr);
-
-		/**
-         * If there are subplans in the hashExpr, push it down to lower level.
-         */
-		if (contain_subplans((Node *) hashExpr))
-		{
-			/* make a Result node to do the projection if necessary */
-			if (!is_projection_capable_plan(subplan))
-			{
-				List	   *tlist = copyObject(subplan->targetlist);
-
-				subplan = (Plan *) make_result(root, tlist, NULL, subplan);
-			}
-			subplan->targetlist = add_to_flat_tlist_junk(subplan->targetlist,
-														 hashExpr,
-														 true /* resjunk */);
-        }
-        motion = make_hashed_motion(subplan,
-                                    hashExpr,
-                                    false /* useExecutorVarFormat */);
-    }
-    else
-        Insist(0);
-
-    /*
-     * Decorate the subplan with a Flow node telling the plan slicer
-     * what kind of gang will be needed to execute the subplan.
-     */
-    subplan->flow = cdbpathtoplan_create_flow(root,
-                                              subpath->locus,
-                                              subpath->parent
-                                                ? subpath->parent->relids
-                                                : NULL,
-                                              subplan);
-
-	/**
-	 * If plan has a flow node, and its child is projection capable,
-	 * then ensure all entries of hashExpr are in the targetlist.
-	 */
-	if (subplan->flow &&
-		subplan->flow->hashExpr &&
-		is_projection_capable_plan(subplan))
-	{
-		subplan->targetlist = add_to_flat_tlist_junk(subplan->targetlist,
-													 subplan->flow->hashExpr,
-													 true /* resjunk */);
-	}
-
-	return motion;
-}								/* cdbpathtoplan_create_motion_plan */

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1537,7 +1537,7 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 					CdbPathLocus singleEntry;
 					CdbPathLocus_MakeEntry(&singleEntry);
 
-					subpath = cdbpath_create_motion_path(root, subpath, pathkeys, false, singleEntry);
+					subpath = cdbpath_create_motion_path(root, subpath, subpath->pathkeys, false, singleEntry);
 				}
 			}
 			else /* fIsNotPartitioned true, fIsPartitionInEntry false */
@@ -1547,7 +1547,7 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 					CdbPathLocus    singleQE;
 					CdbPathLocus_MakeSingleQE(&singleQE);
 
-					subpath = cdbpath_create_motion_path(root, subpath, pathkeys, false, singleQE);
+					subpath = cdbpath_create_motion_path(root, subpath, subpath->pathkeys, false, singleQE);
 				}
 			}
 		}

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -25,8 +25,11 @@ extern Plan *apply_motion(struct PlannerInfo *root, Plan *plan, Query *query);
 
 extern Motion *make_union_motion(Plan *lefttree,
 		                                int destSegIndex, bool useExecutorVarFormat);
-extern Motion *make_sorted_union_motion(PlannerInfo *root, Plan *lefttree, int destSegIndex,
-										List *sortPathKeys,
+extern Motion *make_sorted_union_motion(PlannerInfo *root,
+						 Plan *lefttree,
+						 int numSortCols, AttrNumber *sortColIdx,
+						 Oid *sortOperators, Oid *collations, bool *nullsFirst,
+						 int destSegIndex,
 						 bool useExecutorVarFormat);
 extern Motion *make_hashed_motion(Plan *lefttree,
 				    List *hashExpr, bool useExecutorVarFormat);

--- a/src/include/cdb/cdbpathtoplan.h
+++ b/src/include/cdb/cdbpathtoplan.h
@@ -22,9 +22,4 @@ cdbpathtoplan_create_flow(PlannerInfo  *root,
                           Relids        relids,
                           Plan         *plan);
 
-Motion *
-cdbpathtoplan_create_motion_plan(PlannerInfo   *root,
-                                 CdbMotionPath *path,
-                                 Plan          *subplan);
-
 #endif   /* CDBPATHTOPLAN_H */

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -142,7 +142,10 @@ extern Sort *make_sort_from_groupcols(PlannerInfo *root, List *groupcls,
 extern List *reconstruct_group_clause(List *orig_groupClause, List *tlist,
 						 AttrNumber *grpColIdx, int numcols);
 
-extern Motion *make_motion(PlannerInfo *root, Plan *lefttree, List *sortPathKeys, bool useExecutorVarFormat);
+extern Motion *make_motion(PlannerInfo *root, Plan *lefttree,
+			int numSortCols, AttrNumber *sortColIdx,
+			Oid *sortOperators, Oid *collations, bool *nullsFirst,
+			bool useExecutorVarFormat);
 extern Sort *make_sort(PlannerInfo *root, Plan *lefttree, int numCols,
 		  AttrNumber *sortColIdx, Oid *sortOperators,
 		  Oid *collations, bool *nullsFirst,

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -5983,7 +5983,17 @@ union all
 select null, null, array_agg((a+1)*x order by x), array_agg((b+1)*y order by y)
 from r6756 r
 order by 1,2;
-ERROR:  could not find pathkey item to sort (createplan.c:5360)
+ a | b |       array_agg       |       array_agg       
+---+---+-----------------------+-----------------------
+ 0 | 0 | {1}                   | {1}
+ 0 | 1 | {2,2}                 | {4,4}
+ 0 |   | {1,2,2}               | {1,4,4}
+ 1 | 0 | {6,6,6}               | {3,3,3}
+ 1 | 1 | {8,8,8,8}             | {8,8,8,8}
+ 1 |   | {6,6,6,8,8,8,8}       | {3,3,3,8,8,8,8}
+   |   | {1,2,2,6,6,6,8,8,8,8} | {1,4,4,3,3,3,8,8,8,8}
+(7 rows)
+
 select a, b, array_agg((a+1)*x order by x), array_agg((b+1)*y order by y)
 from r6756 r
 group by rollup (a,b)

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1712,3 +1712,53 @@ reset optimizer_segments;
 -- @description union_update_test31: Negative Tests  more than one row returned by a sub-query used as an expression
 UPDATE dml_union_r SET b = ( SELECT a FROM dml_union_r EXCEPT ALL SELECT a FROM dml_union_s);
 ERROR:  more than one row returned by a subquery used as an expression
+--
+-- Test for creation of MergeAppend paths.
+--
+-- We used to have a bug in creation of MergeAppend paths, so that this failed
+-- with "could not find pathkey item to sort" error.  See
+-- https://github.com/greenplum-db/gpdb/issues/5695
+--
+create table mergeappend_test ( a int, b int, x int ) distributed by (a,b);
+insert into mergeappend_test select g/100, g/100, g from generate_series(1, 500) g;
+analyze mergeappend_test;
+select a, b, array_dims(array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(array_agg(x)) from mergeappend_test r
+order by 1,2;
+ a | b | array_dims 
+---+---+------------
+ 0 | 0 | [1:99]
+ 1 | 1 | [1:100]
+ 2 | 2 | [1:100]
+ 3 | 3 | [1:100]
+ 4 | 4 | [1:100]
+ 5 | 5 | [1:1]
+   |   | [1:500]
+(7 rows)
+
+-- Check that it's using a MergeAppend
+explain (costs off)
+select a, b, array_dims(array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(array_agg(x)) from mergeappend_test r
+order by 1,2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Merge Append
+   Sort Key: r.a, r.b
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: r.a, r.b
+         ->  GroupAggregate
+               Group Key: r.a, r.b
+               ->  Sort
+                     Sort Key: r.a, r.b
+                     ->  Seq Scan on mergeappend_test r
+   ->  Sort
+         Sort Key: (NULL::integer), (NULL::integer)
+         ->  Aggregate
+               ->  Gather Motion 3:1  (slice2; segments: 3)
+                     ->  Seq Scan on mergeappend_test r
+ Optimizer: legacy query optimizer
+(15 rows)
+

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1730,3 +1730,55 @@ reset optimizer_segments;
 UPDATE dml_union_r SET b = ( SELECT a FROM dml_union_r EXCEPT ALL SELECT a FROM dml_union_s);
 ERROR:  One or more assertions failed  (seg1 antova-mbp.local:40011 pid=42293)
 DETAIL:  Expected no more than one row to be returned by expression
+--
+-- Test for creation of MergeAppend paths.
+--
+-- We used to have a bug in creation of MergeAppend paths, so that this failed
+-- with "could not find pathkey item to sort" error.  See
+-- https://github.com/greenplum-db/gpdb/issues/5695
+--
+create table mergeappend_test ( a int, b int, x int ) distributed by (a,b);
+insert into mergeappend_test select g/100, g/100, g from generate_series(1, 500) g;
+analyze mergeappend_test;
+select a, b, array_dims(array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(array_agg(x)) from mergeappend_test r
+order by 1,2;
+ a | b | array_dims 
+---+---+------------
+ 0 | 0 | [1:99]
+ 1 | 1 | [1:100]
+ 2 | 2 | [1:100]
+ 3 | 3 | [1:100]
+ 4 | 4 | [1:100]
+ 5 | 5 | [1:1]
+   |   | [1:500]
+(7 rows)
+
+-- Check that it's using a MergeAppend
+explain (costs off)
+select a, b, array_dims(array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(array_agg(x)) from mergeappend_test r
+order by 1,2;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   Merge Key: public.mergeappend_test.a, public.mergeappend_test.b
+   ->  Sort
+         Sort Key: public.mergeappend_test.a, public.mergeappend_test.b
+         ->  Append
+               ->  Result
+                     ->  GroupAggregate
+                           Group Key: public.mergeappend_test.a, public.mergeappend_test.b
+                           ->  Sort
+                                 Sort Key: public.mergeappend_test.a, public.mergeappend_test.b
+                                 ->  Table Scan on mergeappend_test
+               ->  Result
+                     ->  Redistribute Motion 1:3  (slice2)
+                           ->  Aggregate
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                                       ->  Table Scan on mergeappend_test
+ Optimizer: PQO version 2.71.0
+(17 rows)
+


### PR DESCRIPTION
When building a Sort node to represent the ordering that is preserved
by a Motion node, in make_motion(), the call to make_sort_from_pathkeys()
would sometimes fail with "could not find pathkey item to sort". This
happened when the ordering was over a UNION ALL operation. When building
Motion nodes for MergeAppend subpaths, the path keys that represented the
ordering referred to the items in the append rel's target list, not the
subpaths. In create_merge_append_plan(), where we do a similar thing for
each subpath, we correctly passed the 'relids' argument to
prepare_sort_from_pathkeys(), so that prepare_sort_from_pathkeys() can
match the target list entries of the append relation with the entries of
the subpaths. But when creating the Motion nodes for each subpath, we
were passing NULL as 'relids' (via make_sort_from_pathkeys()).

At a high level, the fix is straightforward: we need to pass the correct
'relids' argument to prepare_sort_from_pathkeys(), in
cdbpathtoplan_create_motion_plan(). However, the current code structure
makes that not so straightforward, so this required some refactoring of
the make_motion() and related functions:

Previously, make_motion() and make_sorted_union_motion() would take a path
key list as argument, to represent the ordering, and it called
make_sort_from_pathkeys() to extract the sort columns, operators etc.
After this patch, those functions take arrays of sort columns, operators,
etc. directly as arguments, and the caller is expected to do the call to
make_sort_from_pathkeys() to get them, or build them through some other
means. In cdbpathtoplan_create_motion_plan(), call
prepare_sort_from_pathkeys() directly, rather than the
make_sort_from_pathkeys() wrapper, so that we can pass the 'relids'
argument. Because prepare_sort_from_pathkeys() is marked as 'static', move
cdbpathtoplan_create_motion_plan() from cdbpathtoplan.c to createplan.c,
so that it can call it.

Add test case. It's a slightly reduced version of a query that we already
had in 'olap_group' test, but seems better to be explicit. Revert the
change in expected output of 'olap_group', made in commit 28087f4e18,
which memorized the error in the expected output.
    
Fixes https://github.com/greenplum-db/gpdb/issues/5695.