### PR TITLE
Avoid out of shared memory adding portal increments.

### DIFF
--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -356,7 +356,7 @@ PortalCleanup(Portal portal)
 	/* 
 	 * If resource scheduling is enabled, release the resource lock. 
 	 */
-	if (portal->releaseResLock)
+	if (IsResQueueLockedForPortal(portal))
 	{
 		portal->releaseResLock = false;
         ResUnLockPortal(portal);

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -358,7 +358,6 @@ PortalCleanup(Portal portal)
 	 */
 	if (IsResQueueLockedForPortal(portal))
 	{
-		portal->releaseResLock = false;
         ResUnLockPortal(portal);
 	}
 

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2236,7 +2236,7 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, int64 tcount)
 				 */
 				if (ActivePortal)
 				{
-					if (!ActivePortal->releaseResLock)
+					if (!IsResQueueLockedForPortal(ActivePortal))
 					{
 						/** TODO: siva - can we ever reach this point? */
 						ActivePortal->status = PORTAL_QUEUE;

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2238,7 +2238,6 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, int64 tcount)
 					if (!IsResQueueLockedForPortal(ActivePortal))
 					{
 						/** TODO: siva - can we ever reach this point? */
-						ActivePortal->status = PORTAL_QUEUE;
 						ResLockPortal(ActivePortal, queryDesc);
 						ActivePortal->status = PORTAL_ACTIVE;
 					} 

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2213,7 +2213,6 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, int64 tcount)
 
 			/* 
 			 * Checking if we need to put this through resource queue.
-			 * Same as in pquery.c, except we check ActivePortal->releaseResLock.
 			 * If the Active portal already hold a lock on the queue, we cannot
 			 * acquire it again.
 			 */
@@ -2240,9 +2239,7 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, int64 tcount)
 					{
 						/** TODO: siva - can we ever reach this point? */
 						ActivePortal->status = PORTAL_QUEUE;
-					
-						ActivePortal->releaseResLock =
-							ResLockPortal(ActivePortal, queryDesc);
+						ResLockPortal(ActivePortal, queryDesc);
 						ActivePortal->status = PORTAL_ACTIVE;
 					} 
 				}

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -253,7 +253,7 @@ ProcessQuery(Portal portal,
 		 * queries, or this is a SELECT INTO then lock the portal here.  Skip
 		 * if this query is added by the rewriter or we are superuser.
 		 */
-		if (IsResQueueEnabled() && !superuser() && portal->releaseResLock == false)
+		if (IsResQueueEnabled() && !superuser() && !IsResQueueLockedForPortal(portal))
 		{
 			if ((!ResourceSelectOnly || portal->sourceTag == T_SelectStmt) &&
 				stmt->canSetTag)
@@ -706,7 +706,7 @@ PortalStart(Portal portal, ParamListInfo params,
 						 * If not in SPI context, acquire resource queue lock with
 						 * no additional checks.
 						 */
-						if (!SPI_context() || !saveActivePortal || !saveActivePortal->releaseResLock)
+						if (!SPI_context() || !saveActivePortal || !IsResQueueLockedForPortal(saveActivePortal))
 							portal->releaseResLock = ResLockPortal(portal, queryDesc);
 					}
 				}

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -253,7 +253,7 @@ ProcessQuery(Portal portal,
 		 * queries, or this is a SELECT INTO then lock the portal here.  Skip
 		 * if this query is added by the rewriter or we are superuser.
 		 */
-		if (IsResQueueEnabled() && !superuser())
+		if (IsResQueueEnabled() && !superuser() && portal->releaseResLock == false)
 		{
 			if ((!ResourceSelectOnly || portal->sourceTag == T_SelectStmt) &&
 				stmt->canSetTag)

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -258,8 +258,6 @@ ProcessQuery(Portal portal,
 			if ((!ResourceSelectOnly || portal->sourceTag == T_SelectStmt) &&
 				stmt->canSetTag)
 			{
-				portal->status = PORTAL_QUEUE;
-
 				ResLockPortal(portal, queryDesc);
 			}
 			else
@@ -693,7 +691,6 @@ PortalStart(Portal portal, ParamListInfo params,
 					 */
 					if (IsResQueueEnabled() && !superuser())
 					{
-						portal->status = PORTAL_QUEUE;
 						/*
 						 * MPP-16369 - If we are in SPI context, only acquire
 						 * resource queue lock if the outer portal hasn't

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -260,7 +260,7 @@ ProcessQuery(Portal portal,
 			{
 				portal->status = PORTAL_QUEUE;
 
-				portal->releaseResLock = ResLockPortal(portal, queryDesc);
+				ResLockPortal(portal, queryDesc);
 			}
 			else
 			{
@@ -601,7 +601,7 @@ PortalStart(Portal portal, ParamListInfo params,
 	AssertArg(PortalIsValid(portal));
 	AssertState(portal->status == PORTAL_DEFINED);
 
-	portal->releaseResLock = false;
+	portal->hasResQueueLock = false;
     
 	portal->ddesc = ddesc;
 
@@ -707,7 +707,7 @@ PortalStart(Portal portal, ParamListInfo params,
 						 * no additional checks.
 						 */
 						if (!SPI_context() || !saveActivePortal || !IsResQueueLockedForPortal(saveActivePortal))
-							portal->releaseResLock = ResLockPortal(portal, queryDesc);
+							ResLockPortal(portal, queryDesc);
 					}
 				}
 

--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -523,7 +523,7 @@ PortalDrop(Portal portal, bool isTopCommit)
 	 */
 	PortalHashTableDelete(portal);
 
-	if (portal->releaseResLock)
+	if (IsResQueueLockedForPortal(portal))
 	{
 		portal->releaseResLock = false;
 		ResUnLockPortal(portal);
@@ -1029,7 +1029,7 @@ AtExitCleanup_ResPortals(void)
 	{
 		Portal		portal = hentry->portal;
 
-		if (portal->releaseResLock)
+		if (IsResQueueLockedForPortal(portal))
 			ResUnLockPortal(portal);
 
 	}

--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -525,7 +525,6 @@ PortalDrop(Portal portal, bool isTopCommit)
 
 	if (IsResQueueLockedForPortal(portal))
 	{
-		portal->releaseResLock = false;
 		ResUnLockPortal(portal);
 	}
 

--- a/src/backend/utils/resscheduler/README
+++ b/src/backend/utils/resscheduler/README
@@ -276,7 +276,7 @@ Notes
      In the current incarnation of the code it means:
 
        portal->queueId != InvalidOid
-       portal->releaseResLock == true
+       portal->hasResQueueLock == true
 
      Typically every portal gets queueId set at creation, but this may get
      reset when the to-lock-or-not-to-lock decision comes around (see

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -624,7 +624,7 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 
 bool
 IsResQueueLockedForPortal(Portal portal) {
-	return portal->releaseResLock;
+	return portal->hasResQueueLock;
 }
 
 

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -622,6 +622,11 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	return true;
 }
 
+bool
+IsResQueueLockedForPortal(Portal portal) {
+	return portal->releaseResLock;
+}
+
 
 /*
  * ResLockCheckLimit -- test whether the given process acquiring the this lock

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -552,6 +552,8 @@ ResLockPortal(Portal portal, QueryDesc *qDesc)
 
 	plan = qDesc->plannedstmt->planTree;
 
+	portal->status = PORTAL_QUEUE;
+
 	queueid = portal->queueId;
 
 	/* 

--- a/src/include/utils/portal.h
+++ b/src/include/utils/portal.h
@@ -150,7 +150,7 @@ typedef struct PortalData
 	/* Status data */
 	PortalStatus status;		/* see above */
 	bool		portalPinned;	/* a pinned portal can't be dropped */
-	bool		releaseResLock;	/* true => resscheduler lock must be released */
+	bool		hasResQueueLock;	/* true => resscheduler lock must be released */
 
 	/* If not NULL, Executor is active; call ExecutorEnd eventually: */
 	QueryDesc  *queryDesc;		/* info needed for executor invocation */

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -130,6 +130,7 @@ typedef enum
 extern LockAcquireResult ResLockAcquire(LOCKTAG *locktag, 
 										ResPortalIncrement *incrementSet);
 extern bool				ResLockRelease(LOCKTAG *locktag, uint32 resPortalId);
+extern bool             IsResQueueLockedForPortal(Portal portal);
 extern int				ResLockCheckLimit(LOCK *lock, PROCLOCK *proclock, 
 										  ResPortalIncrement *incrementSet,
 										  bool increment);

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -166,7 +166,7 @@ extern ResAlterQueueResult ResAlterQueue(Oid queueid,
 						  bool overcommit, float4 ignorelimit);
 extern bool ResDestroyQueue(Oid queueid);
 
-extern bool ResLockPortal(Portal portal, QueryDesc *qDesc);
+extern void ResLockPortal(Portal portal, QueryDesc *qDesc);
 extern void ResUnLockPortal(Portal portal);
 
 extern void ResCheckPortalType(Portal portal);
@@ -178,7 +178,7 @@ extern uint32 ResCreatePortalId(const char *name);
 extern void AtCommit_ResScheduler(void);
 extern void AtAbort_ResScheduler(void);
 extern void ResHandleUtilityStmt(Portal portal, Node *stmt);
-extern bool ResLockUtilityPortal(Portal portal, float4 ignoreCostLimit);
+extern void ResLockUtilityPortal(Portal portal, float4 ignoreCostLimit);
 
  /**
   * What is the memory limit on a queue per the catalog in bytes. Returns -1 if not set.

--- a/src/test/regress/expected/resource_queue_with_rule.out
+++ b/src/test/regress/expected/resource_queue_with_rule.out
@@ -1,0 +1,37 @@
+-- Given I am logged in as a non-super user
+	CREATE USER resource_queue_test_user WITH PASSWORD 'testpwd';
+	GRANT ALL PRIVILEGES ON DATABASE regression to resource_queue_test_user;
+	set role resource_queue_test_user;
+-- And I have created a rule linking two tables
+	DROP TABLE IF EXISTS test_table;
+NOTICE:  table "test_table" does not exist, skipping
+	CREATE TABLE test_table (col1 INT NULL) DISTRIBUTED BY (col1);
+	
+	DROP TABLE IF EXISTS test_table_deletions;
+NOTICE:  table "test_table_deletions" does not exist, skipping
+	CREATE TABLE test_table_deletions (col1 INT NULL) DISTRIBUTED BY (col1);
+	
+	CREATE OR REPLACE RULE test_rule AS ON DELETE TO test_table
+	        DO ALSO INSERT INTO test_table_deletions VALUES (OLD.col1);
+-- When I run a query that triggers the rule
+	INSERT INTO test_table VALUES (1);
+	SELECT * FROM test_table;
+ col1 
+------
+    1
+(1 row)
+
+	DELETE FROM test_table;
+-- Then the output should not contain this error:
+-- ERROR: out of shared memory adding portal increments;
+-- Error while executing the query (SQLSTATE=53200) (7)
+-- And there should not be any rows in the table:
+	SELECT * FROM test_table;
+ col1 
+------
+(0 rows)
+
+-- Cleanup after test:
+	RESET ROLE;
+	DROP OWNED BY resource_queue_test_user CASCADE;
+	DROP USER resource_queue_test_user;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -20,7 +20,7 @@ test: instr_in_shmem_setup
 # run separately - because slot counter may influenced by other parallel queries
 test: instr_in_shmem
 
-test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp returning_gp
+test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp returning_gp resource_queue_with_rule
 test: spi_processed64bit
 test: python_processed64bit
 

--- a/src/test/regress/sql/resource_queue_with_rule.sql
+++ b/src/test/regress/sql/resource_queue_with_rule.sql
@@ -1,0 +1,30 @@
+-- Given I am logged in as a non-super user
+	CREATE USER resource_queue_test_user WITH PASSWORD 'testpwd';
+	GRANT ALL PRIVILEGES ON DATABASE regression to resource_queue_test_user;
+	set role resource_queue_test_user;
+
+-- And I have created a rule linking two tables
+	DROP TABLE IF EXISTS test_table;
+	CREATE TABLE test_table (col1 INT NULL) DISTRIBUTED BY (col1);
+	
+	DROP TABLE IF EXISTS test_table_deletions;
+	CREATE TABLE test_table_deletions (col1 INT NULL) DISTRIBUTED BY (col1);
+	
+	CREATE OR REPLACE RULE test_rule AS ON DELETE TO test_table
+	        DO ALSO INSERT INTO test_table_deletions VALUES (OLD.col1);
+
+-- When I run a query that triggers the rule
+	INSERT INTO test_table VALUES (1);
+	SELECT * FROM test_table;
+	DELETE FROM test_table;
+-- Then the output should not contain this error:
+-- ERROR: out of shared memory adding portal increments;
+-- Error while executing the query (SQLSTATE=53200) (7)
+
+-- And there should not be any rows in the table:
+	SELECT * FROM test_table;
+
+-- Cleanup after test:
+	RESET ROLE;
+	DROP OWNED BY resource_queue_test_user CASCADE;
+	DROP USER resource_queue_test_user;


### PR DESCRIPTION
Avoid acquiring a resource queue lock for the same portal more than
once while calling ProcessQuery for the portal.

An example where this situation occurs can be found in the provided test.