### PR TITLE
docs - support fqdn as client address in pg_hba.conf

### DIFF
--- a/gpdb-doc/dita/admin_guide/client_auth.xml
+++ b/gpdb-doc/dita/admin_guide/client_auth.xml
@@ -20,7 +20,7 @@
     <body>
       <p>Client access and authentication is controlled by the standard PostgreSQL host-based
         authentication file, <filepath>pg_hba.conf</filepath>. For detailed information about this
-        file, see <xref href="http://www.postgresql.org/docs/9.0/interactive/auth-pg-hba-conf.html"
+        file, see <xref href="http://www.postgresql.org/docs/9.1/interactive/auth-pg-hba-conf.html"
           scope="external" format="html">The pg_hba.conf File</xref> in the PostgreSQL
         documentation. </p>
       <p>In Greenplum Database, the <filepath>pg_hba.conf</filepath> file of the master instance
@@ -34,7 +34,7 @@
         comment character. A record consists of a number of fields that are separated by spaces or
         tabs. Fields can contain white space if the field value is quoted. Records cannot be
         continued across lines. Each remote client access record has the following format:</p>
-      <codeblock><i>host</i>   <i>database</i>   <i>role</i>   <i>CIDR-address</i>   <i>authentication-method</i></codeblock>
+      <codeblock><i>host</i>   <i>database</i>   <i>role</i>   <i>address</i>   <i>authentication-method</i></codeblock>
       <p>Each UNIX-domain socket access record is in this format:</p>
       <codeblock><i>local</i>   <i>database</i>   <i>role</i>   <i>authentication-method</i></codeblock>
       <p>The following table describes meaning of each field. </p>
@@ -78,38 +78,69 @@
               <entry colname="col2">Specifies which database names this record matches. The value
                   <codeph>all</codeph> specifies that it matches all databases. Multiple database
                 names can be supplied by separating them with commas. A separate file containing
-                database names can be specified by preceding the file name with @.</entry>
+                database names can be specified by preceding the file name with a
+                <codeph>@</codeph>.</entry>
             </row>
             <row>
               <entry colname="col1">role</entry>
               <entry colname="col2">Specifies which database role names this record matches. The
                 value <codeph>all</codeph> specifies that it matches all roles. If the specified
                 role is a group and you want all members of that group to be included, precede the
-                role name with a +. Multiple role names can be supplied by separating them with
-                commas. A separate file containing role names can be specified by preceding the file
-                name with @.</entry>
+                role name with a <codeph>+</codeph>. Multiple role names can be supplied by
+                separating them with commas. A separate file containing role names can be specified
+                by preceding the file name with a <codeph>@</codeph>.</entry>
             </row>
             <row>
-              <entry colname="col1">CIDR-address</entry>
-              <entry colname="col2">Specifies the client machine IP address range that this record
-                matches. It contains an IP address in standard dotted decimal notation and a CIDR
-                mask length. IP addresses can only be specified numerically, not as domain or host
-                names. The mask length indicates the number of high-order bits of the client IP
-                address that must match. Bits to the right of this must be zero in the given IP
-                address. There must not be any white space between the IP address, the /, and the
-                CIDR mask length. <p>Typical examples of a CIDR-address are 172.20.143.89/32 for a
-                  single host, or 172.20.143.0/24 for a small network, or 10.6.0.0/16 for a larger
-                  one. To specify a single host, use a CIDR mask of 32 for IPv4 or 128 for IPv6. In
-                  a network address, do not omit trailing zeroes.</p></entry>
+              <entry colname="col1">address</entry>
+              <entry colname="col2">Specifies the client machine addresses that this record matches.
+                This field can contain an IP address range. You can configure the Greenplum Database
+                system use client host names. The <codeph>gpinitsystem</codeph> option
+                  <codeph>--hba_hostnames</codeph> or the configuration file parameter
+                  <codeph>HBA_HOSTNAMES</codeph> enables use of client host names.<p>An IP address
+                  range is specified using standard numeric notation for the range's starting
+                  address, then a slash (<codeph>/</codeph>) and a CIDR mask length. The mask length
+                  indicates the number of high-order bits of the client IP address that must match.
+                  Bits to the right of this should be zero in the given IP address. There must not
+                  be any white space between the IP address, the <codeph>/</codeph>, and the CIDR
+                  mask length.</p><p>Typical examples of an IPv4 address range specified this way
+                  are <codeph>172.20.143.89/32</codeph> for a single host, or
+                    <codeph>172.20.143.0/24</codeph> for a small network, or
+                    <codeph>10.6.0.0/16</codeph> for a larger one. An IPv6 address range might look
+                  like <codeph>::1/128</codeph> for a single host (in this case the IPv6 loopback
+                  address) or <codeph>fe80::7a31:c1ff:0000:0000/96</codeph> for a small network.
+                    <codeph>0.0.0.0/0</codeph> represents all IPv4 addresses, and
+                    <codeph>::0/0</codeph> represents all IPv6 addresses. To specify a single host,
+                  use a mask length of 32 for IPv4 or 128 for IPv6. In a network address, do not
+                  omit trailing zeroes.</p><p>An entry given in IPv4 format will match only IPv4
+                  connections, and an entry given in IPv6 format will match only IPv6 connections,
+                  even if the represented address is in the IPv4-in-IPv6 range.
+                  <note>entries in IPv6 format will be rejected if the host system C library does
+                    not have support for IPv6 addresses.</note></p><p>If Greenplum Database is
+                  enabled to support host names and a host name is specified (an address that is not
+                  an IP address or IP range is treated as a host name), that name is compared with
+                  the result of a reverse name resolution of the client IP address (for example,
+                  reverse DNS lookup, if DNS is used). Host name comparisons are case insensitive.
+                  If there is a match, then a forward name resolution (for example, forward DNS
+                  lookup) is performed on the host name to check whether any of the addresses it
+                  resolves to are equal to the client IP address. If both directions match, then the
+                  entry is considered to match. </p><p>Some host name databases allow associating an
+                  IP address with multiple host names, but the operating system only returns one
+                  host name when asked to resolve an IP address. The host name that is used in
+                    <codeph>pg_hba.conf</codeph> must be the one that address-to-name resolution of
+                  the client IP address returns, otherwise the line will not be considered a
+                  matched. </p><p>When host names are specified in <codeph>pg_hba.conf</codeph>, you
+                  should ensure that name resolution is reasonably fast. It can be of advantage to
+                  set up a local name resolution cache such as <codeph>nscd</codeph>. Also, you can
+                  enable the server configuration parameter <codeph>log_hostname</codeph> to see the
+                  client host name instead of the IP address in the log. </p></entry>
             </row>
             <row>
               <entry colname="col1">IP-address<p>IP-mask</p></entry>
-              <entry colname="col2">These fields can be used as an alternative to the CIDR-address
+              <entry colname="col2">These fields can be used as an alternative to the CIDR address
                 notation. Instead of specifying the mask length, the actual mask is specified in a
-                separate column. For example, 255.0.0.0 represents an IPv4 CIDR mask length of 8,
-                and 255.255.255.255 represents a CIDR mask length of 32. These fields only apply to
-                and 255.255.255.255 represents a CIDR mask length of 32. These fields only apply to
-                host, hostssl, and hostnossl records. </entry>
+                separate column. For example, <codeph>255.0.0.0</codeph> represents an IPv4 CIDR
+                mask length of 8, and <codeph>255.255.255.255</codeph> represents a CIDR mask length
+                of 32.</entry>
             </row>
             <row>
               <entry colname="col1">authentication-method</entry>
@@ -142,9 +173,9 @@
           system user to match the role specified. For local and remote TCP connections, ident
           authentication requires the client's host to run an indent service. You can install an
           ident service on the master host and then use ident authentication for local TCP
-          connections, for example 127.0.0.1/28. Using ident authentication for remote TCP
-          connections is less secure because it requires you to trust the integrity of the ident
-          service on the client's host.</p>
+          connections, for example <codeph>127.0.0.1/28</codeph>. Using ident authentication for
+          remote TCP connections is less secure because it requires you to trust the integrity of
+          the ident service on the client's host.</p>
         <p>This example shows how to edit the <filepath>pg_hba.conf</filepath> file of the master to
           allow remote client access to all databases from all roles using encrypted password
           authentication.</p>
@@ -172,9 +203,7 @@ host    all   dba   192.168.0.0/32  md5
 # allow all roles access to any database from any
 # host and use ldap to authenticate the user. Greenplum role
 # names must match the LDAP common name.
-host    all   all   192.168.0.0/32  ldap ldapserver=usldap1
-ldapport=1389 ldapprefix="cn="
-ldapsuffix=",ou=People,dc=company,dc=com"</codeblock></li>
+host    all   all   192.168.0.0/32  ldap ldapserver=usldap1 ldapport=1389 ldapprefix="cn=" ldapsuffix=",ou=People,dc=company,dc=com"</codeblock></li>
             <li id="ip141945">Save and close the file.</li>
             <li id="ip142080">Reload the <filepath>pg_hba.conf</filepath> configuration file for
               your changes to take effect:<p>
@@ -261,11 +290,9 @@ max_prepared_transactions=100
 </codeblock>
             </p></li>
         </ol>
-        <note type="note">
-          <p>Raising the values of these parameters may cause Greenplum Database to request more
-            shared memory. To mitigate this effect, consider decreasing other memory-related
-            parameters such as <codeph>gp_cached_segworkers_threshold</codeph>. </p>
-        </note>
+        <note type="note">Raising the values of these parameters may cause Greenplum Database to
+          request more shared memory. To mitigate this effect, consider decreasing other
+          memory-related parameters such as <codeph>gp_cached_segworkers_threshold</codeph>. </note>
       </section>
     </body>
   </topic>

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -26,7 +26,7 @@
       <p>Client access and authentication is controlled by a configuration file named
           <codeph>pg_hba.conf</codeph> (the standard PostgreSQL host-based authentication file). For
         detailed information about this file, see <xref
-          href="http://www.postgresql.org/docs/9.0/interactive/auth-pg-hba-conf.html" format="html"
+          href="http://www.postgresql.org/docs/9.1/interactive/auth-pg-hba-conf.html" format="html"
           scope="external">The pg_hba.conf File</xref> in the PostgreSQL documentation. </p>
       <p>In Greenplum Database, the <codeph>pg_hba.conf</codeph> file of the master instance
         controls client access and authentication to your Greenplum system. The segments also have
@@ -38,7 +38,7 @@
         up of a number of fields which are separated by spaces and/or tabs. Fields can contain white
         space if the field value is quoted. Records cannot be continued across lines. Each remote
         client access record is in this format:
-        <codeblock>host   database   role   CIDR-address   authentication-method
+        <codeblock>host   database   role   address   authentication-method
 </codeblock></p>
       <p>A UNIX-domain socket access record is in this format:
         <codeblock>local   database   role   authentication-method
@@ -51,13 +51,13 @@
           </plentry>
           <plentry>
             <pt>host</pt>
-            <pd> Matches connection attempts made using TCP/IP. Remote TCP/IP connections will not
-              be possible unless the server is started with an appropriate value for the
-              listen_addresses server configuration parameter. </pd>
+            <pd>Matches connection attempts made using TCP/IP. Remote TCP/IP connections will not be
+              possible unless the server is started with an appropriate value for the
+                <codeph>listen_addresses</codeph> server configuration parameter. </pd>
           </plentry>
           <plentry>
             <pt>hostssl</pt>
-            <pd> Matches connection attempts made using TCP/IP, but only when the connection is made
+            <pd>Matches connection attempts made using TCP/IP, but only when the connection is made
               with SSL encryption. SSL must be enabled at server start time by setting the
                 <codeph>ssl</codeph> configuration parameter. Requires SSL authentication be
               configured in <codeph>postgresql.conf</codeph>. See <xref
@@ -80,32 +80,64 @@
             <pt> role </pt>
             <pd>Specifies which database role names this record matches. The value all specifies
               that it matches all roles. If the specified role is a group and you want all members
-              of that group to be included, precede the role name with a +. Multiple role names can
-              be supplied by separating them with commas. A separate file containing role names can
-              be specified by preceding the file name with @. </pd>
+              of that group to be included, precede the role name with a <codeph>+</codeph>.
+              Multiple role names can be supplied by separating them with commas. A separate file
+              containing role names can be specified by preceding the file name with a
+                <codeph>@</codeph>. </pd>
           </plentry>
           <plentry>
-            <pt> CIDR-address </pt>
-            <pd> Specifies the client machine IP address range that this record matches. It contains
-              an IP address in standard dotted decimal notation and a CIDR mask length. IP addresses
-              can only be specified numerically, not as domain or host names. The mask length
-              indicates the number of high-order bits of the client IP address that must match. Bits
-              to the right of this must be zero in the given IP address. There must not be any white
-              space between the IP address, the /, and the CIDR mask length. <p>Typical examples of
-                a CIDR-address are 172.20.143.89/32 for a single host, or 172.20.143.0/24 for a
-                small network, or 10.6.0.0/16 for a larger one. To specify a single host, use a CIDR
-                mask of 32 for IPv4 or 128 for IPv6. In a network address, do not omit trailing
-                zeroes.</p>
-            </pd>
+            <pt> address </pt>
+            <pd>Specifies the client machine addresses that this record matches. This field can
+              contain an IP address range. You can configure the Greenplum Database system use
+              client host names. The <codeph>gpinitsystem</codeph> option
+                <codeph>--hba_hostnames</codeph> or the configuration file parameter
+                <codeph>HBA_HOSTNAMES</codeph> enables use of client host names.</pd>
+            <pd>An IP address range is specified using standard numeric notation for the range's
+              starting address, then a slash (<codeph>/</codeph>) and a CIDR mask length. The mask
+              length indicates the number of high-order bits of the client IP address that must
+              match. Bits to the right of this should be zero in the given IP address. There must
+              not be any white space between the IP address, the <codeph>/</codeph>, and the CIDR
+              mask length.</pd>
+            <pd>Typical examples of an IPv4 address range specified this way are
+                <codeph>172.20.143.89/32</codeph> for a single host, or
+                <codeph>172.20.143.0/24</codeph> for a small network, or
+                <codeph>10.6.0.0/16</codeph> for a larger one. An IPv6 address range might look like
+                <codeph>::1/128</codeph> for a single host (in this case the IPv6 loopback address)
+              or <codeph>fe80::7a31:c1ff:0000:0000/96</codeph> for a small network.
+                <codeph>0.0.0.0/0</codeph> represents all IPv4 addresses, and <codeph>::0/0</codeph>
+              represents all IPv6 addresses. To specify a single host, use a mask length of 32 for
+              IPv4 or 128 for IPv6. In a network address, do not omit trailing zeroes.</pd>
+            <pd>An entry given in IPv4 format will match only IPv4 connections, and an entry given
+              in IPv6 format will match only IPv6 connections, even if the represented address is in
+              the IPv4-in-IPv6 range.
+              <note>entries in IPv6 format will be rejected if the host system C library does not
+                have support for IPv6 addresses.</note></pd>
+            <pd>If Greenplum Database is enabled to support host names and a host name is specified
+              (an address that is not an IP address or IP range is treated as a host name), that
+              name is compared with the result of a reverse name resolution of the client IP address
+              (for example, reverse DNS lookup, if DNS is used). Host name comparisons are case
+              insensitive. If there is a match, then a forward name resolution (for example, forward
+              DNS lookup) is performed on the host name to check whether any of the addresses it
+              resolves to are equal to the client IP address. If both directions match, then the
+              entry is considered to match. </pd>
+            <pd>Some host name databases allow associating an IP address with multiple host names,
+              but the operating system only returns one host name when asked to resolve an IP
+              address. The host name that is used in <codeph>pg_hba.conf</codeph> must be the one
+              that address-to-name resolution of the client IP address returns, otherwise the line
+              will not be considered a matched. </pd>
+            <pd>When host names are specified in <codeph>pg_hba.conf</codeph>, you should ensure
+              that name resolution is reasonably fast. It can be of advantage to set up a local name
+              resolution cache such as <codeph>nscd</codeph>. Also, you can enable the server
+              configuration parameter <codeph>log_hostname</codeph> to see the client host name
+              instead of the IP address in the log. </pd>
           </plentry>
           <plentry>
             <pt>IP-address</pt>
             <pt>IP-mask </pt>
-            <pd> These fields can be used as an alternative to the CIDR-address notation. Instead of
+            <pd>These fields can be used as an alternative to the CIDR address notation. Instead of
               specifying the mask length, the actual mask is specified in a separate column. For
-              example, 255.0.0.0 represents an IPv4 CIDR mask length of 8, and 255.255.255.255
-              represents a CIDR mask length of 32. These fields only apply to host, hostssl, and
-              hostnossl records. </pd>
+              example, <codeph>255.0.0.0</codeph> represents an IPv4 CIDR mask length of 8, and
+                <codeph>255.255.255.255</codeph> represents a CIDR mask length of 32. </pd>
           </plentry>
           <plentry>
             <pt> authentication-method </pt>
@@ -134,8 +166,9 @@
         user to match the role specified. For local and remote TCP connections, ident authentication
         requires the client's host to run an indent service. You could install an ident service on
         the master host and then use ident authentication for local TCP connections, for example
-        127.0.0.1/28. Using ident authentication for remote TCP connections is less secure because
-        it requires you to trust the integrity of the ident service on the client's host. </p>
+          <codeph>127.0.0.1/28</codeph>. Using ident authentication for remote TCP connections is
+        less secure because it requires you to trust the integrity of the ident service on the
+        client's host. </p>
       <p>This example shows how to edit the <codeph>pg_hba.conf</codeph> file of the master to allow
         remote client access to all databases from all roles using encrypted password
         authentication. </p>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
@@ -14,6 +14,7 @@
             [<b>-B</b> <varname>parallel_processes</varname>] 
             [<b>-p</b> <varname>postgresql_conf_param_file</varname>]
             [<b>-s</b> <varname>standby_master_host</varname> [<b>-P</b> <varname>standby_master_port</varname>]
+            [<b>--hba_hostnames</b>] 
             [<b>-m</b> <varname>number</varname> | <b>--max_connections</b>=<varname>number</varname>]
             [<b>-b</b> <varname>size</varname> | <b>--shared_buffers</b>=<varname>size</varname>]
             [<b>-n <varname>locale</varname> | --locale</b>=<varname>locale</varname>] [<b>--lc-collate</b>=<varname>locale</varname>] 
@@ -74,13 +75,13 @@
                     errors.</li>
                 <li id="it147961">Starts the Greenplum Database system.</li>
             </ul>
-            <note>This utility uses secure shell (SSH) connections between systems to
-                perform its tasks. In large Greenplum Database deployments, cloud deployments,
-                or deployments with a large number of segments per host, this utility may
-                exceed the host's maximum threshold for unauthenticated connections.
-                Consider updating the SSH <codeph>MaxStartups</codeph> configuration parameter
-                to increase this threshold. For more information about SSH configuration
-                options, refer to the SSH documentation for your Linux distribution.</note>
+            <note>This utility uses secure shell (SSH) connections between systems to perform its
+                tasks. In large Greenplum Database deployments, cloud deployments, or deployments
+                with a large number of segments per host, this utility may exceed the host's maximum
+                threshold for unauthenticated connections. Consider updating the SSH
+                    <codeph>MaxStartups</codeph> configuration parameter to increase this threshold.
+                For more information about SSH configuration options, refer to the SSH documentation
+                for your Linux distribution.</note>
         </section>
         <section id="section4">
             <title>Options</title>
@@ -112,8 +113,8 @@
                     <pt>-h <varname>hostfile_gpinitsystem</varname></pt>
                     <pd>Optional. The full path and filename of a file that contains the host
                         addresses of your segment hosts. If not specified on the command line, you
-                        can specify the host file using the MACHINE_LIST_FILE parameter in the
-                            <varname>gpinitsystem_config</varname> file.</pd>
+                        can specify the host file using the <codeph>MACHINE_LIST_FILE</codeph>
+                        parameter in the <varname>gpinitsystem_config</varname> file.</pd>
                 </plentry>
                 <plentry>
                     <pt>-I <varname>input_configuration_file</varname></pt>
@@ -127,6 +128,16 @@
                                 <varname>cluster_configuration_file</varname></codeph> option or the
                             <codeph>-I <varname>input_configuration_file</varname></codeph> option
                         to <codeph>gpinitsystem</codeph>. </pd>
+                </plentry>
+                <plentry>
+                    <pt>--hba_hostnames</pt>
+                    <pd>Enables use of host names in the <codeph>pg_hba.conf</codeph> file when
+                        specifying client addresses that can connect to Greenplum Database. If not
+                        enabled, only IP addresses or IP address ranges can be specified. If not
+                        specified on the command line, you can enable the use of client host names
+                        using the <codeph>HBA_HOSTNAMES</codeph> parameter in the
+                            <varname>gpinitsystem_config</varname> file. This option is set when the
+                        system is initialized and cannot be changed later.</pd>
                 </plentry>
                 <plentry>
                     <pt>--locale=<varname>locale</varname> | -n <varname>locale</varname></pt>
@@ -482,8 +493,15 @@ declare -a MIRROR_ARRAY=(
                     <pd>To determine if heap checksums are enabled in a Greenplum Database system,
                         you can query the <codeph>data_checksums</codeph> server configuration
                         parameter with the <codeph>gpconfig</codeph> management
-                        utility:<codeblock>$ gpconfig -s data_checksums</codeblock>
-                    </pd>
+                        utility:<codeblock>$ gpconfig -s data_checksums</codeblock></pd>
+                </plentry>
+                <plentry>
+                    <pt>HBA_HOSTNAMES</pt>
+                    <pd><b>Optional.</b> This parameter enables using client host names in the
+                            <codeph>pg_hba.conf</codeph> file when specifying client addresses that
+                        can connect to Greenplum Database. If not specified, only IP addresses or IP
+                        address ranges can be specified. This option is set when the system is
+                        initialized and cannot be changed later. </pd>
                 </plentry>
             </parml>
         </section>


### PR DESCRIPTION
--update pg_hba.conf information
--add gpintisystem --hba_hostnames option and HBA_HOSTNAMES parameter

This will be backported 5X_STABLE

Link to HTML format documents with changes in GPDB doc review site

pg_hba.conf information
http://docs-gpdb-review-staging.cfapps.io/review/admin_guide/client_auth.html
http://docs-gpdb-review-staging.cfapps.io/review/security-guide/topics/Authenticate.html

gpinitsystem utility
http://docs-gpdb-review-staging.cfapps.io/review/utility_guide/admin_utilities/gpinitsystem.html
