### PR TITLE
Fix NIL (empty) list confusion with bool

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4190,7 +4190,7 @@ split_aggref(Aggref *aggref, MppGroupContext *ctx)
 			fref->agglevelsup = 0;
 			fref->aggstar = false;
 			fref->aggkind = aggref->aggkind;
-			fref->aggdistinct = false; /* handled in preliminary aggregation */
+			fref->aggdistinct = NIL; /* handled in preliminary aggregation */
 			fref->aggstage = AGGSTAGE_FINAL;
 			fref->location = -1;
 			final_tle = makeTargetEntry((Expr *) fref, attrno, NULL, false);


### PR DESCRIPTION
My compiler (Clang-8) is complaining about this, and I agree:

```
cdbgroup.c:4193:24: warning: expression which evaluates to zero treated
as a null pointer constant of type 'List *' (aka 'struct List *')
[-Wnon-literal-null-conversion]

    fref->aggdistinct = false; /* handled in preliminary aggregation */
                        ^~~~~
../../../src/include/c.h:195:15: note: expanded from macro 'false'
#define false   ((bool) 0)
                ^~~~~~~~~~

```

Commit 35e6033 introduced this, most likely accidentally.

Come to think of it, Postgres (until 11) isn't even using a "real
boolean": we just `typdef char bool`, which is why we are *not* getting
more complaints from more compilers at the default warning level.