### PR TITLE
5X: backport EXTERNAL TABLE fixes for pg_dump

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -6196,7 +6196,7 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 			options = "";
 
 			if (command && strlen(command) > 0)
-				on_clause = command;
+				on_clause = urilocations;
 			else
 				on_clause = NULL;
 		}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -9566,7 +9566,8 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 						   "x.fmttype, x.fmtopts, x.command, "
 						   "x.rejectlimit, x.rejectlimittype, "
 						   "n.nspname AS errnspname, d.relname AS errtblname, "
-						   "pg_catalog.pg_encoding_to_char(x.encoding), x.writable "
+						   "pg_catalog.pg_encoding_to_char(x.encoding), "
+						   "x.writable, null AS options "
 					"FROM pg_catalog.pg_class c "
 					"JOIN pg_catalog.pg_exttable x ON ( c.oid = x.reloid ) "
 					"LEFT JOIN pg_catalog.pg_class d ON ( d.oid = x.fmterrtbl ) "
@@ -9585,7 +9586,8 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 						   "x.fmttype, x.fmtopts, x.command, "
 						   "x.rejectlimit, x.rejectlimittype, "
 						   "n.nspname AS errnspname, d.relname AS errtblname, "
-						   "pg_catalog.pg_encoding_to_char(x.encoding), null as writable "
+						   "pg_catalog.pg_encoding_to_char(x.encoding), "
+						   "null as writable, null as options "
 					"FROM pg_catalog.pg_class c "
 					"JOIN pg_catalog.pg_exttable x ON ( c.oid = x.reloid ) "
 					"LEFT JOIN pg_catalog.pg_class d ON ( d.oid = x.fmterrtbl ) "
@@ -9604,7 +9606,8 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 						   "x.fmttype, x.fmtopts, x.command, "
 						   "-1 as rejectlimit, null as rejectlimittype,"
 						   "null as errnspname, null as errtblname, "
-						   "null as encoding, null as writable "
+						   "null as encoding, null as writable, "
+						   "null as options "
 					"FROM pg_catalog.pg_exttable x, pg_catalog.pg_class c "
 					"WHERE x.reloid = c.oid AND c.oid = '%u'::oid",
 					tbinfo->dobj.catId.oid);
@@ -9628,40 +9631,20 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 		}
 
 
-		if (gpdb5OrLater)
-		{
-			urilocations = PQgetvalue(res, 0, 0);
-			execlocations = PQgetvalue(res, 0, 1);
-			fmttype = PQgetvalue(res, 0, 2);
-			fmtopts = PQgetvalue(res, 0, 3);
-			command = PQgetvalue(res, 0, 4);
-			rejlim = PQgetvalue(res, 0, 5);
-			rejlimtype = PQgetvalue(res, 0, 6);
-			errnspname = PQgetvalue(res, 0, 7);
-			errtblname = PQgetvalue(res, 0, 8);
-			extencoding = PQgetvalue(res, 0, 9);
-			writable = PQgetvalue(res, 0, 10);
-			options = PQgetvalue(res, 0, 11);
+		urilocations = PQgetvalue(res, 0, 0);
+		execlocations = PQgetvalue(res, 0, 1);
+		fmttype = PQgetvalue(res, 0, 2);
+		fmtopts = PQgetvalue(res, 0, 3);
+		command = PQgetvalue(res, 0, 4);
+		rejlim = PQgetvalue(res, 0, 5);
+		rejlimtype = PQgetvalue(res, 0, 6);
+		errnspname = PQgetvalue(res, 0, 7);
+		errtblname = PQgetvalue(res, 0, 8);
+		extencoding = PQgetvalue(res, 0, 9);
+		writable = PQgetvalue(res, 0, 10);
+		options = PQgetvalue(res, 0, 11);
 
-			on_clause = execlocations;
-		}
-		else
-		{
-			urilocations = PQgetvalue(res, 0, 0);
-			execlocations = PQgetvalue(res, 0, 1);
-			fmttype = PQgetvalue(res, 0, 2);
-			fmtopts = PQgetvalue(res, 0, 3);
-			command = PQgetvalue(res, 0, 4);
-			rejlim = PQgetvalue(res, 0, 5);
-			rejlimtype = PQgetvalue(res, 0, 6);
-			errnspname = PQgetvalue(res, 0, 7);
-			errtblname = PQgetvalue(res, 0, 8);
-			extencoding = PQgetvalue(res, 0, 9);
-			writable = PQgetvalue(res, 0, 10);
-			options = "";
-
-			on_clause = execlocations;
-		}
+		on_clause = execlocations;
 
 		if ((command && strlen(command) > 0) ||
 			(strncmp(urilocations + 1, "http", strlen("http")) == 0))

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -9539,75 +9539,75 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 		if (gpdb5OrLater)
 		{
 			appendPQExpBuffer(query,
-						  "SELECT x.urilocation, x.execlocation, x.fmttype, x.fmtopts, x.command, "
-								  "x.rejectlimit, x.rejectlimittype, "
-						      "(SELECT relname "
-						          "FROM pg_catalog.pg_class "
-								  "WHERE Oid=x.fmterrtbl) AS errtblname, "
-								  "x.fmterrtbl = x.reloid AS errortofile , "
-								  "pg_catalog.pg_encoding_to_char(x.encoding), "
-								  "x.writable, "
-								  "array_to_string(ARRAY( "
-								  "SELECT pg_catalog.quote_ident(option_name) || ' ' || "
-								  "pg_catalog.quote_literal(option_value) "
-								  "FROM pg_options_to_table(x.options) "
-								  "ORDER BY option_name"
-								  "), E',\n    ') AS options "
-						  "FROM pg_catalog.pg_exttable x, pg_catalog.pg_class c "
-						  "WHERE x.reloid = c.oid AND c.oid = '%u'::oid ", tbinfo->dobj.catId.oid);
+					"SELECT x.urilocation, x.execlocation, x.fmttype, x.fmtopts, x.command, "
+						   "x.rejectlimit, x.rejectlimittype, "
+						   "(SELECT relname "
+							"FROM pg_catalog.pg_class "
+							"WHERE Oid=x.fmterrtbl) AS errtblname, "
+						   "x.fmterrtbl = x.reloid AS errortofile , "
+						   "pg_catalog.pg_encoding_to_char(x.encoding), "
+						   "x.writable, "
+						   "array_to_string(ARRAY( "
+						   "SELECT pg_catalog.quote_ident(option_name) || ' ' || "
+						   "pg_catalog.quote_literal(option_value) "
+						   "FROM pg_options_to_table(x.options) "
+						   "ORDER BY option_name"
+						   "), E',\n    ') AS options "
+					"FROM pg_catalog.pg_exttable x, pg_catalog.pg_class c "
+					"WHERE x.reloid = c.oid AND c.oid = '%u'::oid ", tbinfo->dobj.catId.oid);
 		}
 		else if (g_fout->remoteVersion >= 80214)
 		{
 			appendPQExpBuffer(query,
-					   "SELECT x.location, "
-							  "CASE WHEN x.command <> '' THEN x.location "
-								   "ELSE '{ALL_SEGMENTS}' "
-							  "END AS execlocation, "
-							  "x.fmttype, x.fmtopts, x.command, "
-							  "x.rejectlimit, x.rejectlimittype, "
-						 "n.nspname AS errnspname, d.relname AS errtblname, "
-					"pg_catalog.pg_encoding_to_char(x.encoding), x.writable "
-							  "FROM pg_catalog.pg_class c "
-					 "JOIN pg_catalog.pg_exttable x ON ( c.oid = x.reloid ) "
-				"LEFT JOIN pg_catalog.pg_class d ON ( d.oid = x.fmterrtbl ) "
-							  "LEFT JOIN pg_catalog.pg_namespace n ON ( n.oid = d.relnamespace ) "
-							  "WHERE c.oid = '%u'::oid ",
-							  tbinfo->dobj.catId.oid);
+					"SELECT x.location, "
+						   "CASE WHEN x.command <> '' THEN x.location "
+								"ELSE '{ALL_SEGMENTS}' "
+						   "END AS execlocation, "
+						   "x.fmttype, x.fmtopts, x.command, "
+						   "x.rejectlimit, x.rejectlimittype, "
+						   "n.nspname AS errnspname, d.relname AS errtblname, "
+						   "pg_catalog.pg_encoding_to_char(x.encoding), x.writable "
+					"FROM pg_catalog.pg_class c "
+					"JOIN pg_catalog.pg_exttable x ON ( c.oid = x.reloid ) "
+					"LEFT JOIN pg_catalog.pg_class d ON ( d.oid = x.fmterrtbl ) "
+					"LEFT JOIN pg_catalog.pg_namespace n ON ( n.oid = d.relnamespace ) "
+					"WHERE c.oid = '%u'::oid ",
+					tbinfo->dobj.catId.oid);
 		}
 		else if (g_fout->remoteVersion >= 80205)
 		{
 
 			appendPQExpBuffer(query,
-					   "SELECT x.location, "
-							  "CASE WHEN x.command <> '' THEN x.location "
-								   "ELSE '{ALL_SEGMENTS}' "
-							  "END AS execlocation, "
-							  "x.fmttype, x.fmtopts, x.command, "
-							  "x.rejectlimit, x.rejectlimittype, "
-						 "n.nspname AS errnspname, d.relname AS errtblname, "
-			  "pg_catalog.pg_encoding_to_char(x.encoding), null as writable "
-							  "FROM pg_catalog.pg_class c "
-					 "JOIN pg_catalog.pg_exttable x ON ( c.oid = x.reloid ) "
-				"LEFT JOIN pg_catalog.pg_class d ON ( d.oid = x.fmterrtbl ) "
-							  "LEFT JOIN pg_catalog.pg_namespace n ON ( n.oid = d.relnamespace ) "
-							  "WHERE c.oid = '%u'::oid ",
-							  tbinfo->dobj.catId.oid);
+					"SELECT x.location, "
+						   "CASE WHEN x.command <> '' THEN x.location "
+								"ELSE '{ALL_SEGMENTS}' "
+						   "END AS execlocation, "
+						   "x.fmttype, x.fmtopts, x.command, "
+						   "x.rejectlimit, x.rejectlimittype, "
+						   "n.nspname AS errnspname, d.relname AS errtblname, "
+						   "pg_catalog.pg_encoding_to_char(x.encoding), null as writable "
+					"FROM pg_catalog.pg_class c "
+					"JOIN pg_catalog.pg_exttable x ON ( c.oid = x.reloid ) "
+					"LEFT JOIN pg_catalog.pg_class d ON ( d.oid = x.fmterrtbl ) "
+					"LEFT JOIN pg_catalog.pg_namespace n ON ( n.oid = d.relnamespace ) "
+					"WHERE c.oid = '%u'::oid ",
+					tbinfo->dobj.catId.oid);
 		}
 		else
 		{
 			/* not SREH and encoding colums yet */
 			appendPQExpBuffer(query,
-					   "SELECT x.location, "
-							  "CASE WHEN x.command <> '' THEN x.location "
-								   "ELSE '{ALL_SEGMENTS}' "
-							  "END AS execlocation, "
-							  "x.fmttype, x.fmtopts, x.command, "
-							  "-1 as rejectlimit, null as rejectlimittype,"
-							  "null as errnspname, null as errtblname, "
-							  "null as encoding, null as writable "
-					  "FROM pg_catalog.pg_exttable x, pg_catalog.pg_class c "
-							  "WHERE x.reloid = c.oid AND c.oid = '%u'::oid",
-							  tbinfo->dobj.catId.oid);
+					"SELECT x.location, "
+						   "CASE WHEN x.command <> '' THEN x.location "
+								"ELSE '{ALL_SEGMENTS}' "
+						   "END AS execlocation, "
+						   "x.fmttype, x.fmtopts, x.command, "
+						   "-1 as rejectlimit, null as rejectlimittype,"
+						   "null as errnspname, null as errtblname, "
+						   "null as encoding, null as writable "
+					"FROM pg_catalog.pg_exttable x, pg_catalog.pg_class c "
+					"WHERE x.reloid = c.oid AND c.oid = '%u'::oid",
+					tbinfo->dobj.catId.oid);
 		}
 
 		res = PQexec(g_conn, query->data);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -9559,7 +9559,11 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 		else if (g_fout->remoteVersion >= 80214)
 		{
 			appendPQExpBuffer(query,
-					   "SELECT x.location, x.fmttype, x.fmtopts, x.command, "
+					   "SELECT x.location, "
+							  "CASE WHEN x.command <> '' THEN x.location "
+								   "ELSE '{ALL_SEGMENTS}' "
+							  "END AS execlocation, "
+							  "x.fmttype, x.fmtopts, x.command, "
 							  "x.rejectlimit, x.rejectlimittype, "
 						 "n.nspname AS errnspname, d.relname AS errtblname, "
 					"pg_catalog.pg_encoding_to_char(x.encoding), x.writable "
@@ -9574,7 +9578,11 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 		{
 
 			appendPQExpBuffer(query,
-					   "SELECT x.location, x.fmttype, x.fmtopts, x.command, "
+					   "SELECT x.location, "
+							  "CASE WHEN x.command <> '' THEN x.location "
+								   "ELSE '{ALL_SEGMENTS}' "
+							  "END AS execlocation, "
+							  "x.fmttype, x.fmtopts, x.command, "
 							  "x.rejectlimit, x.rejectlimittype, "
 						 "n.nspname AS errnspname, d.relname AS errtblname, "
 			  "pg_catalog.pg_encoding_to_char(x.encoding), null as writable "
@@ -9589,7 +9597,11 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 		{
 			/* not SREH and encoding colums yet */
 			appendPQExpBuffer(query,
-					   "SELECT x.location, x.fmttype, x.fmtopts, x.command, "
+					   "SELECT x.location, "
+							  "CASE WHEN x.command <> '' THEN x.location "
+								   "ELSE '{ALL_SEGMENTS}' "
+							  "END AS execlocation, "
+							  "x.fmttype, x.fmtopts, x.command, "
 							  "-1 as rejectlimit, null as rejectlimittype,"
 							  "null as errnspname, null as errtblname, "
 							  "null as encoding, null as writable "
@@ -9636,22 +9648,19 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 		else
 		{
 			urilocations = PQgetvalue(res, 0, 0);
-			fmttype = PQgetvalue(res, 0, 1);
-			fmtopts = PQgetvalue(res, 0, 2);
-			command = PQgetvalue(res, 0, 3);
-			rejlim = PQgetvalue(res, 0, 4);
-			rejlimtype = PQgetvalue(res, 0, 5);
-			errnspname = PQgetvalue(res, 0, 6);
-			errtblname = PQgetvalue(res, 0, 7);
-			extencoding = PQgetvalue(res, 0, 8);
-			writable = PQgetvalue(res, 0, 9);
-			execlocations = "";
+			execlocations = PQgetvalue(res, 0, 1);
+			fmttype = PQgetvalue(res, 0, 2);
+			fmtopts = PQgetvalue(res, 0, 3);
+			command = PQgetvalue(res, 0, 4);
+			rejlim = PQgetvalue(res, 0, 5);
+			rejlimtype = PQgetvalue(res, 0, 6);
+			errnspname = PQgetvalue(res, 0, 7);
+			errtblname = PQgetvalue(res, 0, 8);
+			extencoding = PQgetvalue(res, 0, 9);
+			writable = PQgetvalue(res, 0, 10);
 			options = "";
 
-			if (command && strlen(command) > 0)
-				on_clause = urilocations;
-			else
-				on_clause = NULL;
+			on_clause = execlocations;
 		}
 
 		if ((command && strlen(command) > 0) ||
@@ -9731,7 +9740,7 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 		 * ON clauses were up until 5.0 supported only on EXECUTE, in 5.0
 		 * and thereafter they are allowed on all external tables.
 		 */
-		if (!iswritable && on_clause)
+		if (!iswritable)
 		{
 			/* remove curly braces */
 			on_clause[strlen(on_clause) - 1] = '\0';
@@ -9799,7 +9808,7 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 			customfmt = NULL;
 		}
 
-		if (gpdb5OrLater)
+		if (options && options[0] != '\0')
 		{
 			appendPQExpBuffer(q, "OPTIONS (\n %s\n )\n", options);
 		}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -9649,7 +9649,7 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 			options = "";
 
 			if (command && strlen(command) > 0)
-				on_clause = command;
+				on_clause = urilocations;
 			else
 				on_clause = NULL;
 		}


### PR DESCRIPTION
This is a backport of PRs #4794 and #4682 to 5X_STABLE. These fix pg_dump's handling of `EXTERNAL TABLE` when dealing with older clusters, which is needed for upgrade tests.