### PR TITLE
5X: dump and upgrade fixes for partitioned tables

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -21,6 +21,7 @@ static void check_for_reg_data_type_usage(migratorContext *ctx, Cluster whichClu
 static void check_external_partition(migratorContext *ctx);
 static void check_fts_fault_strategy(migratorContext *ctx);
 static void check_covering_aoindex(migratorContext *ctx);
+static void check_hash_partition_usage(migratorContext *ctx, Cluster whichCluster);
 
 
 /*
@@ -105,6 +106,7 @@ check_old_cluster(migratorContext *ctx, bool live_check,
 	check_external_partition(ctx);
 	check_fts_fault_strategy(ctx);
 	check_covering_aoindex(ctx);
+	check_hash_partition_usage(ctx, CLUSTER_OLD);
 
 	/* old = PG 8.3 checks? */
 	/*
@@ -1054,4 +1056,87 @@ check_covering_aoindex(migratorContext *ctx)
 	{
 		check_ok(ctx);
 	}
+}
+
+/*
+ *	check_hash_partition_usage()
+ *	8.3 -> 8.4
+ *	The hash algorithm was changed in 8.4, so upgrading is impossible. This
+ *	is basically the same problem as with hash indexes in PostgreSQL. Hash
+ *	partitioning was not officially supported in GPDB5, but better check just
+ *	in case someone has found the hidden GUC and used them anyway.
+ *
+ *	XXX: Actually, pg_dump outright fails on hash partitioned tables, so we
+ *	cannot support hash partitioned tables even on a same-version upgrade.
+ */
+void
+check_hash_partition_usage(migratorContext *ctx, Cluster whichCluster)
+{
+	ClusterInfo *active_cluster = (whichCluster == CLUSTER_OLD) ?
+	&ctx->old : &ctx->new;
+	int			dbnum;
+	FILE	   *script = NULL;
+	bool		found = false;
+	char		output_path[MAXPGPATH];
+
+	prep_status(ctx, "Checking for hash partitioned tables");
+
+	snprintf(output_path, sizeof(output_path), "%s/hash_partitioned_tables.txt",
+			 ctx->cwd);
+
+	for (dbnum = 0; dbnum < active_cluster->dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		bool		db_used = false;
+		int			ntups;
+		int			rowno;
+		int			i_nspname,
+					i_relname;
+		DbInfo	   *active_db = &active_cluster->dbarr.dbs[dbnum];
+		PGconn	   *conn = connectToServer(ctx, active_db->db_name, whichCluster);
+
+		res = executeQueryOrDie(ctx, conn,
+								"SELECT n.nspname, c.relname "
+								"FROM pg_catalog.pg_partition p, pg_catalog.pg_class c, pg_catalog.pg_namespace n "
+								"WHERE p.parrelid = c.oid AND c.relnamespace = n.oid "
+								"AND parkind = 'h'");
+
+		ntups = PQntuples(res);
+		i_nspname = PQfnumber(res, "nspname");
+		i_relname = PQfnumber(res, "relname");
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			found = true;
+			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
+				pg_log(ctx, PG_FATAL, "Could not create necessary file:  %s\n", output_path);
+			if (!db_used)
+			{
+				fprintf(script, "Database:  %s\n", active_db->db_name);
+				db_used = true;
+			}
+			fprintf(script, "  %s.%s\n",
+					PQgetvalue(res, rowno, i_nspname),
+					PQgetvalue(res, rowno, i_relname));
+		}
+
+		PQclear(res);
+
+		PQfinish(conn);
+	}
+
+	if (found)
+	{
+		fclose(script);
+		pg_log(ctx, PG_REPORT, "fatal\n");
+		pg_log(ctx, PG_FATAL,
+			   "| Your installation contains hash partitioned tables.\n"
+			   "| Upgrading hash partitioned tables is not supported,\n"
+			   "| so this cluster cannot currently be upgraded.  You\n"
+			   "| can remove the problem tables and restart the\n"
+			   "| migration.  A list of the problem tables is in the\n"
+			   "| file:\n"
+			   "| \t%s\n\n", output_path);
+	}
+	else
+		check_ok(ctx);
 }

--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -22,6 +22,7 @@ static void check_external_partition(migratorContext *ctx);
 static void check_fts_fault_strategy(migratorContext *ctx);
 static void check_covering_aoindex(migratorContext *ctx);
 static void check_hash_partition_usage(migratorContext *ctx);
+static void check_partition_indexes(migratorContext *ctx);
 
 
 /*
@@ -107,6 +108,7 @@ check_old_cluster(migratorContext *ctx, bool live_check,
 	check_fts_fault_strategy(ctx);
 	check_covering_aoindex(ctx);
 	check_hash_partition_usage(ctx);
+	check_partition_indexes(ctx);
 
 	/* old = PG 8.3 checks? */
 	/*
@@ -1134,6 +1136,103 @@ check_hash_partition_usage(migratorContext *ctx)
 			   "| can remove the problem tables and restart the\n"
 			   "| migration.  A list of the problem tables is in the\n"
 			   "| file:\n"
+			   "| \t%s\n\n", output_path);
+	}
+	else
+		check_ok(ctx);
+}
+
+/*
+ *	check_partition_indexes
+ *
+ *	There are numerous pitfalls surrounding indexes on partition hierarchies,
+ *	so rather than trying to cover all the cornercases we disallow indexes on
+ *	partitioned tables altogether during the upgrade.  Since we in any case
+ *	invalidate the indexes forcing a REINDEX, there is little to be gained by
+ *	handling them for the end-user.
+ */
+static void
+check_partition_indexes(migratorContext *ctx)
+{
+	ClusterInfo	   *old_cluster = &ctx->old;
+	int				dbnum;
+	FILE		   *script = NULL;
+	bool			found = false;
+	char			output_path[MAXPGPATH];
+
+	prep_status(ctx, "Checking for indexes on partitioned tables");
+
+	snprintf(output_path, sizeof(output_path), "%s/partitioned_tables_indexes.txt",
+			 ctx->cwd);
+
+	for (dbnum = 0; dbnum < old_cluster->dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		bool		db_used = false;
+		int			ntups;
+		int			rowno;
+		int			i_nspname;
+		int			i_relname;
+		int			i_indexes;
+		DbInfo	   *active_db = &old_cluster->dbarr.dbs[dbnum];
+		PGconn	   *conn = connectToServer(ctx, active_db->db_name, CLUSTER_OLD);
+
+		res = executeQueryOrDie(ctx, conn,
+								"WITH partitions AS ("
+								"    SELECT DISTINCT n.nspname, "
+								"           c.relname "
+								"    FROM pg_catalog.pg_partition p "
+								"         JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid) "
+								"         JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace) "
+								"    UNION "
+								"    SELECT n.nspname, "
+								"           partitiontablename AS relname "
+								"    FROM pg_catalog.pg_partitions p "
+								"         JOIN pg_catalog.pg_class c ON (p.partitiontablename = c.relname) "
+								"         JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace) "
+								") "
+								"SELECT nspname, "
+								"       relname, "
+								"       count(indexname) AS indexes "
+								"FROM partitions "
+								"     JOIN pg_catalog.pg_indexes ON (relname = tablename AND "
+								"                                    nspname = schemaname) "
+								"GROUP BY nspname, relname "
+								"ORDER BY relname");
+
+		ntups = PQntuples(res);
+		i_nspname = PQfnumber(res, "nspname");
+		i_relname = PQfnumber(res, "relname");
+		i_indexes = PQfnumber(res, "indexes");
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			found = true;
+			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
+				pg_log(ctx, PG_FATAL, "Could not create necessary file:  %s\n", output_path);
+			if (!db_used)
+			{
+				fprintf(script, "Database:  %s\n", active_db->db_name);
+				db_used = true;
+			}
+			fprintf(script, "  %s.%s has %s index(es)\n",
+					PQgetvalue(res, rowno, i_nspname),
+					PQgetvalue(res, rowno, i_relname),
+					PQgetvalue(res, rowno, i_indexes));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (found)
+	{
+		fclose(script);
+		pg_log(ctx, PG_REPORT, "fatal\n");
+		pg_log(ctx, PG_FATAL,
+			   "| Your installation contains partitioned tables with\n"
+			   "| indexes defined on them.  Indexes on partition parents,\n"
+			   "| as well as children, must be dropped before upgrade.\n"
+			   "| A list of the problem tables is in the file:\n"
 			   "| \t%s\n\n", output_path);
 	}
 	else

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -151,6 +151,7 @@ gpstart -a
 # Run any pre-upgrade tasks to prep the cluster
 if [ -f "test_gpdb_pre.sql" ]; then
 	psql -f test_gpdb_pre.sql regression
+	psql -f test_gpdb_pre.sql isolation2test
 fi
 
 # Ensure that the catalog is sane before attempting an upgrade. While there is

--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -11,23 +11,39 @@ DROP TABLE IF EXISTS constraint_pt2 CASCADE;
 DROP TABLE IF EXISTS constraint_pt3 CASCADE;
 DROP TABLE IF EXISTS contest_inherit CASCADE;
 
--- The indexes on mpp3033a partitions don't have their default names,
--- presumably because the default names are taken when the tests
--- are run. That's a problem, because in QD, pg_dump and restore will
--- create them with new, defalt, names, as part of the CREATE INDEX
--- command on the parent table. But when we do pg_dump and restore
--- on a QE node, it doesn't have the partition hierarchy available,
--- and will dump restore each index separately, with the original name.
-DROP TABLE IF EXISTS mpp3033a CASCADE;
-DROP TABLE IF EXISTS mpp3033b CASCADE;
+-- Greenplum pg_upgrade doesn't support indexes on partitions since they can't
+-- be reliably dump/restored in all situations. Drop all such indexes before
+-- attempting the upgrade.
+CREATE OR REPLACE FUNCTION drop_indexes() RETURNS void AS $$
+DECLARE
+	part_indexes RECORD;
+BEGIN
+	FOR part_indexes IN
+	WITH partitions AS (
+	    SELECT DISTINCT n.nspname,
+	           c.relname
+	    FROM pg_catalog.pg_partition p
+	         JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid)
+	         JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+	    UNION
+	    SELECT n.nspname,
+	           partitiontablename AS relname
+	    FROM pg_catalog.pg_partitions p
+	         JOIN pg_catalog.pg_class c ON (p.partitiontablename = c.relname)
+	         JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+	)
+	SELECT nspname,
+	       relname,
+	       indexname
+	FROM partitions
+	     JOIN pg_catalog.pg_indexes ON (relname = tablename
+										AND nspname = schemaname)
+	LOOP
+		EXECUTE 'DROP INDEX IF EXISTS ' || quote_ident(part_indexes.nspname) || '.' || quote_ident(part_indexes.indexname);
+	END LOOP;
+	RETURN;
+END;
+$$ LANGUAGE plpgsql;
 
-DROP TABLE IF EXISTS mpp17707 CASCADE;
-
--- These partitioned tables have different indexes on different
--- partitions. pg_dump cannot currently reconstruct that situation
--- correctly.
-DROP TABLE IF EXISTS mpp7635_aoi_table2 CASCADE;
-DROP TABLE IF EXISTS partition_pruning.pt_lt_tab CASCADE;
-DROP TABLE IF EXISTS dcl_messaging_test CASCADE;
-DROP TABLE IF EXISTS my_tq_agg_opt_part CASCADE;
-DROP TABLE IF EXISTS pt_indx_tab CASCADE;
+SELECT drop_indexes();
+DROP FUNCTION drop_indexes();

--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -31,12 +31,3 @@ DROP TABLE IF EXISTS partition_pruning.pt_lt_tab CASCADE;
 DROP TABLE IF EXISTS dcl_messaging_test CASCADE;
 DROP TABLE IF EXISTS my_tq_agg_opt_part CASCADE;
 DROP TABLE IF EXISTS pt_indx_tab CASCADE;
-
--- Thes partitioned tables have a SERIAL column. That's also not
--- not reconstructed by pg_dump + restore correctly.
-DROP TABLE IF EXISTS ao_wt_sub_partzlib8192_5_2_uncompr CASCADE;
-DROP TABLE IF EXISTS ao_wt_sub_partzlib8192_5_uncompr CASCADE;
-DROP TABLE IF EXISTS co_cr_sub_partzlib8192_1_2_uncompr CASCADE;
-DROP TABLE IF EXISTS co_cr_sub_partzlib8192_1_uncompr CASCADE;
-DROP TABLE IF EXISTS co_wt_sub_partrle_type8192_1_2_uncompr CASCADE;
-DROP TABLE IF EXISTS co_wt_sub_partrle_type8192_1_uncompr CASCADE;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -12499,8 +12499,7 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 	PartitionElem *pelem;
 	List	   *colencs = NIL;
 
-	/* This whole function is QD only. */
-	if (Gp_role != GP_ROLE_DISPATCH)
+	if (!(Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade))
 		return;
 
 	if (att == AT_PartAddForSplit)
@@ -12707,7 +12706,8 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	if (!(atc->subtype == AT_PartExchange ||
 		  atc->subtype == AT_PartSplit ||
 		  atc->subtype == AT_SetDistributedBy) &&
-		Gp_role != GP_ROLE_DISPATCH)
+		  Gp_role != GP_ROLE_DISPATCH &&
+		  !IsBinaryUpgrade)
 		return;
 
 	switch (atc->subtype)
@@ -12753,7 +12753,7 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation rel,
 							RelationGetRelationName(rel))));
 	}
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade)
 	{
 		pid2->idtype = AT_AP_IDList;
 		pid2->partiddef = (Node *)pidlst;
@@ -13882,7 +13882,7 @@ ATPExecPartSetTemplate(AlteredTableInfo *tab,
 	PgPartRule			*prule = NULL;
 	int					 lvl   = 1;
 
-	if (Gp_role != GP_ROLE_DISPATCH)
+	if (!(Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade))
 		return;
 
 	/* set template for top level table */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -3403,7 +3403,7 @@ getTables(int *numTables)
 					  "(SELECT spcname FROM pg_tablespace t WHERE t.oid = c.reltablespace) AS reltablespace, "
 					  "array_to_string(c.reloptions, ', ') as reloptions, "
 					  "p.parrelid as parrelid, "
-					  "p.parlevel as parlevel "
+					  "pl.parlevel as parlevel "
 					  "from pg_class c "
 					  "left join pg_depend d on "
 					  "(c.relkind = '%c' and "

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -3362,6 +3362,7 @@ getTables(int *numTables)
 	int			i_reltablespace;
 	int			i_reloptions;
 	int			i_parrelid;
+	int			i_parlevel;
 
 	/* Make sure we are in proper schema */
 	selectSourceSchema("pg_catalog");
@@ -3401,7 +3402,8 @@ getTables(int *numTables)
 					  "d.refobjsubid as owning_col, "
 					  "(SELECT spcname FROM pg_tablespace t WHERE t.oid = c.reltablespace) AS reltablespace, "
 					  "array_to_string(c.reloptions, ', ') as reloptions, "
-					  "p.parrelid as parrelid "
+					  "p.parrelid as parrelid, "
+					  "p.parlevel as parlevel "
 					  "from pg_class c "
 					  "left join pg_depend d on "
 					  "(c.relkind = '%c' and "
@@ -3410,6 +3412,7 @@ getTables(int *numTables)
 					  "d.refclassid = c.tableoid and d.deptype = 'a') "
 					  "left join pg_partition_rule pr on c.oid = pr.parchildrelid "
 					  "left join pg_partition p on pr.paroid = p.oid "
+					  "left join pg_partition pl on (c.oid = pl.parrelid and pl.parlevel = 0) "
 					  "where relkind in ('%c', '%c', '%c', '%c') %s"
 					  "order by c.oid",
 					  username_subquery,
@@ -3457,6 +3460,7 @@ getTables(int *numTables)
 	i_reltablespace = PQfnumber(res, "reltablespace");
 	i_reloptions = PQfnumber(res, "reloptions");
 	i_parrelid = PQfnumber(res, "parrelid");
+	i_parlevel = PQfnumber(res, "parlevel");
 
 	for (i = 0; i < ntups; i++)
 	{
@@ -3500,6 +3504,11 @@ getTables(int *numTables)
 			snprintf(tmpStr, sizeof(tmpStr), "%s%s", tblinfo[i].dobj.name, EXT_PARTITION_NAME_POSTFIX);
 			tblinfo[i].dobj.name = strdup(tmpStr);
 		}
+		if (PQgetisnull(res, i, i_parlevel) ||
+			atoi(PQgetvalue(res, i, i_parlevel)) > 0)
+			tblinfo[i].parparent = false;
+		else
+			tblinfo[i].parparent = true;
 
 		/* other fields were zeroed above */
 
@@ -10474,7 +10483,12 @@ dumpAttrDef(Archive *fout, AttrDefInfo *adinfo)
 	q = createPQExpBuffer();
 	delq = createPQExpBuffer();
 
-	appendPQExpBuffer(q, "ALTER TABLE ONLY %s ",
+	/*
+	 * If the table is the parent of a partitioning hierarchy, the default
+	 * constraint must be applied to all children as well.
+	 */
+	appendPQExpBuffer(q, "ALTER TABLE %s %s ",
+					  tbinfo->parparent ? "" : "ONLY",
 					  fmtId(tbinfo->dobj.name));
 	appendPQExpBuffer(q, "ALTER COLUMN %s SET DEFAULT %s;\n",
 					  fmtId(tbinfo->attnames[adnum - 1]),

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -337,6 +337,7 @@ typedef struct _tableInfo
 	struct _tableInfo **parents;	/* TableInfos of immediate parents */
 	struct _tableDataInfo *dataObj;		/* TableDataInfo, if dumping its data */
 	Oid			parrelid;			/* external partition's parent oid */
+	bool		parparent;		/* true if the table is partition parent */
 } TableInfo;
 
 typedef struct _attrDefInfo


### PR DESCRIPTION
This is a backport of the following commits/PRs to 5X_STABLE:
- 68877c3
- #3302
- 25c1c95
- 404b199
- #4750
- #4774

Each provides a separate fix for pg_dump's and pg_upgrade's handling of partitioned tables.