### PR TITLE
5X: fix up checksum version checks in pg_upgrade

### DIFF
--- a/contrib/pg_upgrade/controldata.c
+++ b/contrib/pg_upgrade/controldata.c
@@ -127,11 +127,11 @@ get_control_data(migratorContext *ctx, ClusterInfo *cluster, bool live_check)
 	/*
 	 * In PostgreSQL, checksums were introduced in 9.3 so the test for checksum
 	 * version applies to <= 9.2. Greenplum backported checksums into 5.x which
-	 * is based on PostgreSQL 8.3 so this test need to go on <= 8.3 instead.
+	 * is based on PostgreSQL 8.3 so this test need to go on <= 8.2 instead.
 	 */
-	if (GET_MAJOR_VERSION(cluster->major_version) <= 803)
+	if (GET_MAJOR_VERSION(cluster->major_version) <= 802)
 	{
-		cluster->controldata.data_checksum_version = false;
+		cluster->controldata.data_checksum_version = 0;
 		got_data_checksums = true;
 	}
 

--- a/contrib/pg_upgrade/controldata.c
+++ b/contrib/pg_upgrade/controldata.c
@@ -124,10 +124,14 @@ get_control_data(migratorContext *ctx, ClusterInfo *cluster, bool live_check)
 		got_float8_pass_by_value = true;
 	}
 
-	/* Only in <= 9.2 */
-	if (GET_MAJOR_VERSION(cluster->major_version) <= 902)
+	/*
+	 * In PostgreSQL, checksums were introduced in 9.3 so the test for checksum
+	 * version applies to <= 9.2. Greenplum backported checksums into 5.x which
+	 * is based on PostgreSQL 8.3 so this test need to go on <= 8.3 instead.
+	 */
+	if (GET_MAJOR_VERSION(cluster->major_version) <= 803)
 	{
-		cluster->controldata.data_checksums = false;
+		cluster->controldata.data_checksum_version = false;
 		got_data_checksums = true;
 	}
 
@@ -368,7 +372,7 @@ get_control_data(migratorContext *ctx, ClusterInfo *cluster, bool live_check)
 			cluster->controldata.float8_pass_by_value = strstr(p, "by value") != NULL;
 			got_float8_pass_by_value = true;
 		}
-		else if ((p = strstr(bufin, "checksums")) != NULL)
+		else if ((p = strstr(bufin, "checksum")) != NULL)
 		{
 			p = strchr(p, ':');
 
@@ -377,7 +381,7 @@ get_control_data(migratorContext *ctx, ClusterInfo *cluster, bool live_check)
 
 			p++;				/* removing ':' char */
 			/* used later for contrib check */
-			cluster->controldata.data_checksums = strstr(p, "enabled") != NULL;
+			cluster->controldata.data_checksum_version = str2uint(p);
 			got_data_checksums = true;
 		}
 		/* In pre-8.4 only */
@@ -572,11 +576,17 @@ check_control_data(migratorContext *ctx, ControlData *oldctrl,
 			   "with those options.\n");
 	}
 
-	if (oldctrl->data_checksums != newctrl->data_checksums)
-	{
-		pg_log(ctx, PG_FATAL,
-			   "old and new pg_controldata checksums settings are invalid or do not match\n");
-	}
+	/*
+	 * Check for allowed combinations of data checksums
+	 */
+	if (oldctrl->data_checksum_version == 0 &&
+		newctrl->data_checksum_version != 0)
+		pg_log(ctx, PG_FATAL, "old cluster does not use data checksums but the new one does\n");
+	else if (oldctrl->data_checksum_version != 0 &&
+			 newctrl->data_checksum_version == 0)
+		pg_log(ctx, PG_FATAL, "old cluster uses data checksums but the new one does not\n");
+	else if (oldctrl->data_checksum_version != newctrl->data_checksum_version)
+		pg_log(ctx, PG_FATAL, "old and new cluster pg_controldata checksum versions do not match\n");
 }
 
 

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -240,7 +240,7 @@ typedef struct
 	uint32		toast;
 	bool		date_is_int;
 	bool		float8_pass_by_value;
-	bool		data_checksums;
+	bool		data_checksum_version;
 	char	   *lc_collate;
 	char	   *lc_ctype;
 	char	   *encoding;


### PR DESCRIPTION
This backports the checksum version fixes made as part of 719160503dee and its followup c687f53. It intentionally does *not* backport the `--add-`/`--remove-checksum` options that were added there; we just want the bugfixes for now.