### PR TITLE
Fix intermittent issue with appendonly regression test

### DIFF
--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -218,7 +218,7 @@ DROP TABLE tenk_ao3;
 DROP TABLE tenk_ao4;
 
 -- CTAS
-CREATE TABLE tenk_ao1 with(appendonly=true, checksum=true) AS SELECT * FROM tenk_heap;
+CREATE TABLE tenk_ao1 with(appendonly=true, checksum=true) AS SELECT * FROM tenk_heap DISTRIBUTED BY (unique1);
 -- Incase of CTAS also, gp_fastsequence entries must get created and use segfile 0
 
 -- With and without ORCA last_sequence fluctuates bit and hence using >= 3300 as

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -401,9 +401,7 @@ DROP TABLE tenk_ao2;
 DROP TABLE tenk_ao3;
 DROP TABLE tenk_ao4;
 -- CTAS
-CREATE TABLE tenk_ao1 with(appendonly=true, checksum=true) AS SELECT * FROM tenk_heap;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'unique1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE tenk_ao1 with(appendonly=true, checksum=true) AS SELECT * FROM tenk_heap DISTRIBUTED BY (unique1);
 -- Incase of CTAS also, gp_fastsequence entries must get created and use segfile 0
 -- With and without ORCA last_sequence fluctuates bit and hence using >= 3300 as
 -- inserting 10k tuples to 3 node system must atleast have last_sequence >= 3300


### PR DESCRIPTION
A `CREATE TABLE AS` without a `DISTRIBUTED BY` clause will create a
randomly distributed table, when optimized by ORCA. The plan for the
CTAS will have a redistribute motion (random) between the scan and the
insert. Depending on your data, this style of plan could be more even,
equally even, or less even than a hash distributed table (the kind of
distribution usually assumed by planner).

This commit changes the test to explicitly distribute by the same column
that planner would guess.

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>