### PR TITLE
pg_upgrade: diff schema during smoke test

### DIFF
--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -118,10 +118,20 @@ DROP TABLE IF EXISTS stat_heap6.stat_part_heap_t6 CASCADE;
 --    No match found in old cluster for new relation with OID 556718 in database "regression": "public.newpart_pkey" which is an index on "public.newpart"
 DROP TABLE IF EXISTS public.newpart CASCADE;
 
+-- This view definition changes after upgrade.
+DROP VIEW IF EXISTS v_xpect_triangle_de CASCADE;
+
+-- The dump location for this protocol changes sporadically and causes a false
+-- negative. This may indicate a bug in pg_dump's sort priority for PROTOCOLs.
+DROP PROTOCOL IF EXISTS demoprot_untrusted;
+
 \c dsp1;
 
 -- drop all AO tables
 \ir pre_drop_ao.sql
+
+-- h1 seems to switch AO storage options after upgrade.
+DROP TABLE IF EXISTS public.h1 CASCADE;
 
 \c dsp2;
 

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -1904,7 +1904,7 @@ dumpDbRoleConfig(PGconn *conn)
 	/* Need "ORDER BY" here to keep order consistency cross pg_dump call */
 	printfPQExpBuffer(buf, "SELECT rolname, datname, unnest(setconfig) "
 					  "FROM pg_db_role_setting, pg_authid, pg_database "
-		  "WHERE setrole = pg_authid.oid AND setdatabase = pg_database.oid ORDER BY 1,2");
+		  "WHERE setrole = pg_authid.oid AND setdatabase = pg_database.oid ORDER BY 1,2,3");
 	res = executeQuery(conn, buf->data);
 
 	if (PQntuples(res) > 0)


### PR DESCRIPTION
We don't upgrade the segments during the ICW smoke test, but we can still connect to the master and dump the schema to make sure everything's okay. This will let us put some basic pg_dump regression cases into ICW.

This has already found a few new dump/upgrade failures. I was able to fix one outright with the first commit; the other three failing objects have been dropped in `test_gpdb_pre.sh` so we can fix them as we go.