### PR TITLE
cte: Remove limitation on duplicate column aliases in CTEs

### DIFF
--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -339,41 +339,6 @@ analyzeCTE(ParseState *pstate, CommonTableExpr *cte)
 }
 
 /*
- * reportDuplicateNames
- *    Report error when a given list of names (in String) contain duplicate values for a given
- * query name.
- */
-static void
-reportDuplicateNames(const char *queryName, List *names)
-{
-	if (names == NULL)
-		return;
-
-	ListCell *lc;
-	foreach (lc, names)
-	{
-		Value *string = (Value *)lfirst(lc);
-		Assert(IsA(string, String));
-
-		ListCell *rest;
-		for_each_cell(rest, lnext(lc))
-		{
-			Value *string2 = (Value *)lfirst(rest);
-			Assert(IsA(string, String));
-			
-			if (strcmp(strVal(string), strVal(string2)) == 0)
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("WITH query \"%s\" must not have duplicate column name: %s",
-								queryName, strVal(string)),
-						 errhint("Specify a column list without duplicate names")));
-			}
-		}
-	}
-}
-
-/*
  * Compute derived fields of a CTE, given the transformed output targetlist
  *
  * For a nonrecursive CTE, this is called after transforming the CTE's query.
@@ -456,8 +421,6 @@ analyzeCTETargetList(ParseState *pstate, CommonTableExpr *cte, List *tlist)
 				 errmsg("WITH query \"%s\" has %d columns available but %d columns specified",
 						cte->ctename, varattno, numaliases),
 				 parser_errposition(pstate, cte->location)));
-
-	reportDuplicateNames(cte->ctename, cte->ctecolnames);
 }
 
 

--- a/src/test/regress/expected/qp_with_clause.out
+++ b/src/test/regress/expected/qp_with_clause.out
@@ -811,27 +811,337 @@ select CITY12,POPULATION12 from
   7980230.000000000000 | Tokyo
 (14 rows)
 
---query1 having duplicates without specifying a column list. Should error out. 
+-- Tests for duplicate column aliases
 with capitals as 
 (select country.code,id,city.name,city.countrycode as code from city,country 
  where city.countrycode = country.code AND city.id = country.capital) 
-select * from capitals;
-ERROR:  WITH query "capitals" must not have duplicate column name: code
-HINT:  Specify a column list without duplicate names
--- query2
+select * from capitals where id < 100;
+ code | id |       name       | code 
+------+----+------------------+------
+ NLD  |  5 | Amsterdam        | NLD
+ ALB  | 34 | Tirana           | ALB
+ DZA  | 35 | Alger            | DZA
+ AND  | 55 | Andorra la Vella | AND
+ AIA  | 62 | The Valley       | AIA
+ ATG  | 63 | Saint Johns      | ATG
+ AFG  |  1 | Kabul            | AFG
+ ARE  | 65 | Abu Dhabi        | ARE
+ ARG  | 69 | Buenos Aires     | ARG
+ ANT  | 33 | Willemstad       | ANT
+ ASM  | 54 | Fagatogo         | ASM
+ AGO  | 56 | Luanda           | AGO
+(12 rows)
+
 with allofficiallanguages as 
 (select countrylanguage.countrycode,city.countrycode,language from
  city,countrylanguage where countrylanguage.countrycode = city.countrycode and isofficial = 'True')
-select * from allofficiallanguages;
-ERROR:  WITH query "allofficiallanguages" must not have duplicate column name: countrycode
-HINT:  Specify a column list without duplicate names
--- query3 specifying duplicates explicitly in the column list
+select * from allofficiallanguages where language like 'A%';
+ countrycode | countrycode |  language   
+-------------+-------------+-------------
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ ARM         | ARM         | Armenian
+ AZE         | AZE         | Azerbaijani
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ KWT         | KWT         | Arabic
+ KWT         | KWT         | Arabic
+ SOM         | SOM         | Arabic
+ DJI         | DJI         | Arabic
+ BHR         | BHR         | Arabic
+ JOR         | JOR         | Arabic
+ JOR         | JOR         | Arabic
+ JOR         | JOR         | Arabic
+ JOR         | JOR         | Arabic
+ OMN         | OMN         | Arabic
+ OMN         | OMN         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SDN         | SDN         | Arabic
+ SDN         | SDN         | Arabic
+ SDN         | SDN         | Arabic
+ TCD         | TCD         | Arabic
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ARE         | ARE         | Arabic
+ ARE         | ARE         | Arabic
+ ARE         | ARE         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ YEM         | YEM         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ SYR         | SYR         | Arabic
+ SYR         | SYR         | Arabic
+ SYR         | SYR         | Arabic
+ SYR         | SYR         | Arabic
+ TUN         | TUN         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ BOL         | BOL         | Aimara
+ BOL         | BOL         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ ARM         | ARM         | Armenian
+ IRQ         | IRQ         | Arabic
+ LBY         | LBY         | Arabic
+ LBY         | LBY         | Arabic
+ OMN         | OMN         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SDN         | SDN         | Arabic
+ SDN         | SDN         | Arabic
+ SDN         | SDN         | Arabic
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ALB         | ALB         | Albaniana
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ YEM         | YEM         | Arabic
+ YEM         | YEM         | Arabic
+ LBN         | LBN         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ SYR         | SYR         | Arabic
+ SYR         | SYR         | Arabic
+ SYR         | SYR         | Arabic
+ SYR         | SYR         | Arabic
+ TUN         | TUN         | Arabic
+ TUN         | TUN         | Arabic
+ TUN         | TUN         | Arabic
+ TUN         | TUN         | Arabic
+ TUN         | TUN         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ BOL         | BOL         | Aimara
+ BOL         | BOL         | Aimara
+ BOL         | BOL         | Aimara
+ BOL         | BOL         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ DZA         | DZA         | Arabic
+ ARM         | ARM         | Armenian
+ AZE         | AZE         | Azerbaijani
+ AZE         | AZE         | Azerbaijani
+ AZE         | AZE         | Azerbaijani
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ IRQ         | IRQ         | Arabic
+ KWT         | KWT         | Arabic
+ ESH         | ESH         | Arabic
+ SOM         | SOM         | Arabic
+ SOM         | SOM         | Arabic
+ JOR         | JOR         | Arabic
+ LBY         | LBY         | Arabic
+ LBY         | LBY         | Arabic
+ OMN         | OMN         | Arabic
+ OMN         | OMN         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SAU         | SAU         | Arabic
+ SDN         | SDN         | Arabic
+ SDN         | SDN         | Arabic
+ SDN         | SDN         | Arabic
+ SDN         | SDN         | Arabic
+ SDN         | SDN         | Arabic
+ SDN         | SDN         | Arabic
+ TCD         | TCD         | Arabic
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ZAF         | ZAF         | Afrikaans
+ ARE         | ARE         | Arabic
+ ARE         | ARE         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ EGY         | EGY         | Arabic
+ YEM         | YEM         | Arabic
+ YEM         | YEM         | Arabic
+ YEM         | YEM         | Arabic
+ LBN         | LBN         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ MAR         | MAR         | Arabic
+ QAT         | QAT         | Arabic
+ SYR         | SYR         | Arabic
+ SYR         | SYR         | Arabic
+ SYR         | SYR         | Arabic
+ TUN         | TUN         | Arabic
+ TUN         | TUN         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ ISR         | ISR         | Arabic
+ BOL         | BOL         | Aimara
+ BOL         | BOL         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+ PER         | PER         | Aimara
+(282 rows)
+
 with capitals(code,id,name,code) as 
 (select country.code,id,city.name,city.countrycode from city,country 
  where city.countrycode = country.code AND city.id = country.capital) 
-select * from capitals;
-ERROR:  WITH query "capitals" must not have duplicate column name: code
-HINT:  Specify a column list without duplicate names
+select * from capitals where id < 100;
+ code | id |       name       | code 
+------+----+------------------+------
+ NLD  |  5 | Amsterdam        | NLD
+ ALB  | 34 | Tirana           | ALB
+ DZA  | 35 | Alger            | DZA
+ AND  | 55 | Andorra la Vella | AND
+ AIA  | 62 | The Valley       | AIA
+ ATG  | 63 | Saint Johns      | ATG
+ AFG  |  1 | Kabul            | AFG
+ ARE  | 65 | Abu Dhabi        | ARE
+ ARG  | 69 | Buenos Aires     | ARG
+ ANT  | 33 | Willemstad       | ANT
+ ASM  | 54 | Fagatogo         | ASM
+ AGO  | 56 | Luanda           | AGO
+(12 rows)
+
 -- query1 CTE referencing itself
 with lang_total as
 ( select count(*) as lang_count,country.code,countrylanguage.countrycode

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -1352,46 +1352,6 @@ from my_sum;
 ERROR:  syntax error at or near "into"
 LINE 1: ..._sum(total) as (select sum(value) from with_test1 into total...
                                                              ^
--- alias columns mismatch
-with my_sum(group_total) as (select i, sum(value) from with_test1 group by i)
-select *
-from my_sum;
- group_total | sum 
--------------+-----
-           9 | 180
-           8 | 170
-           7 | 160
-           6 | 150
-           4 | 130
-           3 | 120
-           5 | 140
-           1 | 100
-           2 | 110
-           0 |  90
-(10 rows)
-
-with my_sum as (select i, sum(value) as i from with_test1 group by i)
-select *
-from my_sum;
-ERROR:  WITH query "my_sum" must not have duplicate column name: i
-HINT:  Specify a column list without duplicate names
-with my_sum(i, total) as (select i, sum(value) as i from with_test1 group by i)
-select *
-from my_sum; -- this works
- i | total 
----+-------
- 2 |   110
- 6 |   150
- 0 |    90
- 4 |   130
- 8 |   170
- 9 |   180
- 7 |   160
- 5 |   140
- 3 |   120
- 1 |   100
-(10 rows)
-
 -- name resolution
 select * from with_test1, my_max
 where value < (with my_max(maximum) as (select max(i) from with_test1)

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -1352,46 +1352,6 @@ from my_sum;
 ERROR:  syntax error at or near "into"
 LINE 1: ..._sum(total) as (select sum(value) from with_test1 into total...
                                                              ^
--- alias columns mismatch
-with my_sum(group_total) as (select i, sum(value) from with_test1 group by i)
-select *
-from my_sum;
- group_total | sum 
--------------+-----
-           9 | 180
-           8 | 170
-           7 | 160
-           6 | 150
-           4 | 130
-           3 | 120
-           5 | 140
-           1 | 100
-           2 | 110
-           0 |  90
-(10 rows)
-
-with my_sum as (select i, sum(value) as i from with_test1 group by i)
-select *
-from my_sum;
-ERROR:  WITH query "my_sum" must not have duplicate column name: i
-HINT:  Specify a column list without duplicate names
-with my_sum(i, total) as (select i, sum(value) as i from with_test1 group by i)
-select *
-from my_sum; -- this works
- i | total 
----+-------
- 2 |   110
- 6 |   150
- 0 |    90
- 4 |   130
- 8 |   170
- 9 |   180
- 7 |   160
- 5 |   140
- 3 |   120
- 1 |   100
-(10 rows)
-
 -- name resolution
 select * from with_test1, my_max
 where value < (with my_max(maximum) as (select max(i) from with_test1)

--- a/src/test/regress/sql/qp_with_clause.sql
+++ b/src/test/regress/sql/qp_with_clause.sql
@@ -5710,25 +5710,21 @@ select CITY12,POPULATION12 from
 ) FOO1
 ) FOO0 group by city12 order by city12;-- negative cases where queries have duplicate names in CTEs
 
---query1 having duplicates without specifying a column list. Should error out. 
+-- Tests for duplicate column aliases
 with capitals as 
 (select country.code,id,city.name,city.countrycode as code from city,country 
  where city.countrycode = country.code AND city.id = country.capital) 
+select * from capitals where id < 100;
 
-select * from capitals;
-
--- query2
 with allofficiallanguages as 
 (select countrylanguage.countrycode,city.countrycode,language from
  city,countrylanguage where countrylanguage.countrycode = city.countrycode and isofficial = 'True')
-select * from allofficiallanguages;
+select * from allofficiallanguages where language like 'A%';
 
--- query3 specifying duplicates explicitly in the column list
 with capitals(code,id,name,code) as 
 (select country.code,id,city.name,city.countrycode from city,country 
  where city.countrycode = country.code AND city.id = country.capital) 
-
-select * from capitals;
+select * from capitals where id < 100;
 
 -- query1 CTE referencing itself
 with lang_total as

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -218,19 +218,6 @@ with my_sum(total) as (select sum(value) from with_test1 into total_value)
 select *
 from my_sum;
 
--- alias columns mismatch
-with my_sum(group_total) as (select i, sum(value) from with_test1 group by i)
-select *
-from my_sum;
-
-with my_sum as (select i, sum(value) as i from with_test1 group by i)
-select *
-from my_sum;
-
-with my_sum(i, total) as (select i, sum(value) as i from with_test1 group by i)
-select *
-from my_sum; -- this works
-
 -- name resolution
 select * from with_test1, my_max
 where value < (with my_max(maximum) as (select max(i) from with_test1)


### PR DESCRIPTION
There is no restriction in the SQL specification (afaict) regarding duplicate column aliases in a CTE. Remove the Greenplum specific check and align us with how queries work in upstream PostgreSQL (and with the spec).