### PR TITLE
Allow tables to be distributed on a subset of segments

### DIFF
--- a/gpcontrib/gp_distribution_policy/gp_distribution_policy--1.0.sql
+++ b/gpcontrib/gp_distribution_policy/gp_distribution_policy--1.0.sql
@@ -6,7 +6,7 @@
 SET search_path = public;
 
 -- This function validates the data distribution in a heap table in a segment.
-CREATE OR REPLACE FUNCTION gp_distribution_policy_heap_table_check(oid, smallint[]) RETURNS boolean
+CREATE OR REPLACE FUNCTION gp_distribution_policy_heap_table_check(oid, smallint[], integer) RETURNS boolean
 AS '$libdir/gp_distribution_policy','gp_distribution_policy_heap_table_check'
 LANGUAGE C IMMUTABLE STRICT;
 
@@ -18,7 +18,8 @@ $$
 SELECT gp_execution_segment(),
         gp_distribution_policy_heap_table_check(
                 (SELECT oid FROM pg_class WHERE relname =$1 AND relkind = 'r'),
-                (SELECT attrnums FROM gp_distribution_policy WHERE localoid = (SELECT oid FROM pg_class WHERE relname =$1 AND relkind = 'r'))
+                (SELECT attrnums FROM gp_distribution_policy WHERE localoid = (SELECT oid FROM pg_class WHERE relname =$1 AND relkind = 'r')),
+                (SELECT numsegments FROM gp_distribution_policy WHERE localoid = (SELECT oid FROM pg_class WHERE relname =$1 AND relkind = 'r'))
         ) AS is_distribution_correct
 $$
 LANGUAGE SQL

--- a/gpcontrib/gp_distribution_policy/output/gp_distribution_policy.source
+++ b/gpcontrib/gp_distribution_policy/output/gp_distribution_policy.source
@@ -16,7 +16,7 @@ INSERT INTO APPENDONLY_TABLE (SELECT gen_id, gen_data from generate_series(1, 10
 INSERT INTO some_table (SELECT gen_id, gen_data from generate_series(100000, 20000) gen_id, generate_series(1, 10000) gen_data);
 -- Check that AO Tables throw error when checked
 SELECT gp_heap_distribution_check('appendonly_table');
-ERROR:  input relation is not a heap table (gp_distribution_policy.c:171)  (seg0 slice1 127.0.1.1:25432 pid=10683) (gp_distribution_policy.c:171)
+ERROR:  input relation is not a heap table (gp_distribution_policy.c:179)  (seg0 slice1 127.0.1.1:25432 pid=10683) (gp_distribution_policy.c:179)
 CONTEXT:  SQL function "gp_heap_distribution_check" statement 1
 -- Check partitioned table returns something
 SELECT gp_heap_distribution_check('some_table');

--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -23,6 +23,7 @@
 #include "catalog/pg_type.h"
 #include "cdb/cdbcat.h"
 #include "cdb/cdbrelsize.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"		/* Gp_role */
 #include "utils/array.h"
 #include "utils/builtins.h"
@@ -34,7 +35,7 @@
 static void extract_INT2OID_array(Datum array_datum, int *lenp, int16 **vecp);
 
 GpPolicy *
-makeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs)
+makeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs, int numsegments)
 {
 	GpPolicy *policy;
 	size_t	size;
@@ -45,12 +46,19 @@ makeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs)
 	size = sizeof(GpPolicy) + nattrs * sizeof(AttrNumber);
 	policy = MemoryContextAlloc(mcxt, size);
 	policy->type = T_GpPolicy;
+	policy->numsegments = numsegments;
 	policy->ptype = ptype; 
 	policy->nattrs = nattrs; 
 	if (nattrs > 0)
 		policy->attrs = (AttrNumber *) ((char*)policy + sizeof(GpPolicy));
 	else
 		policy->attrs = NULL;
+
+	Assert(numsegments > 0);
+	if (numsegments == __GP_POLICY_EVIL_NUMSEGMENTS)
+	{
+		Assert(!"what's the proper value of numsegments?");
+	}
 
 	return policy;
 }
@@ -59,9 +67,9 @@ makeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs)
  * createReplicatedGpPolicy-- Create a policy with replicated distribution
  */
 GpPolicy *
-createReplicatedGpPolicy(MemoryContext mcxt)
+createReplicatedGpPolicy(MemoryContext mcxt, int numsegments)
 {
-	return makeGpPolicy(mcxt, POLICYTYPE_REPLICATED, 0);
+	return makeGpPolicy(mcxt, POLICYTYPE_REPLICATED, 0, numsegments);
 }
 
 /*
@@ -69,9 +77,9 @@ createReplicatedGpPolicy(MemoryContext mcxt)
  * partitioned distribution
  */
 GpPolicy *
-createRandomPartitionedPolicy(MemoryContext mcxt)
+createRandomPartitionedPolicy(MemoryContext mcxt, int numsegments)
 {
-	return makeGpPolicy(mcxt, POLICYTYPE_PARTITIONED, 0);
+	return makeGpPolicy(mcxt, POLICYTYPE_PARTITIONED, 0, numsegments);
 }
 
 /*
@@ -79,7 +87,7 @@ createRandomPartitionedPolicy(MemoryContext mcxt)
  * partitioned by keys 
  */
 GpPolicy *
-createHashPartitionedPolicy(MemoryContext mcxt, List *keys)
+createHashPartitionedPolicy(MemoryContext mcxt, List *keys, int numsegments)
 {
 	GpPolicy	*policy;
 	ListCell 	*lc;
@@ -87,9 +95,9 @@ createHashPartitionedPolicy(MemoryContext mcxt, List *keys)
 	int 		len = list_length(keys);
 
 	if (len == 0)
-		return createRandomPartitionedPolicy(mcxt);
+		return createRandomPartitionedPolicy(mcxt, numsegments);
 
-	policy = makeGpPolicy(mcxt, POLICYTYPE_PARTITIONED, len);
+	policy = makeGpPolicy(mcxt, POLICYTYPE_PARTITIONED, len, numsegments);
 	foreach(lc, keys)
 	{
 		policy->attrs[idx++] = (AttrNumber)lfirst_int(lc);
@@ -112,7 +120,7 @@ GpPolicyCopy(MemoryContext mcxt, const GpPolicy *src)
 	if (!src)
 		return NULL;
 
-	tgt = makeGpPolicy(mcxt, src->ptype, src->nattrs);
+	tgt = makeGpPolicy(mcxt, src->ptype, src->nattrs, src->numsegments);
 
 	for (i = 0; i < src->nattrs; i++)
 		tgt->attrs[i] = src->attrs[i];
@@ -135,6 +143,9 @@ GpPolicyEqual(const GpPolicy *lft, const GpPolicy *rgt)
 		return false;
 
 	if (lft->ptype != rgt->ptype)
+		return false;
+
+	if (lft->numsegments != rgt->numsegments)
 		return false;
 
 	if (lft->nattrs != rgt->nattrs)
@@ -248,10 +259,12 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 
 			if (strcmp(on_clause, "MASTER_ONLY") == 0)
 			{
-				return makeGpPolicy(mcxt, POLICYTYPE_ENTRY, 0);
+				return makeGpPolicy(mcxt, POLICYTYPE_ENTRY,
+									0, GP_POLICY_ENTRY_NUMSEGMENTS);
 			}
 
-			return createRandomPartitionedPolicy(mcxt);
+			return createRandomPartitionedPolicy(mcxt,
+												 GP_POLICY_ALL_NUMSEGMENTS);
 		}
 	}
 
@@ -271,8 +284,18 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 		bool		isNull;
 		Datum		attr;
 		int			i,
+					numsegments,
 					nattrs = 0;
 		int16	   *attrnums = NULL;
+
+		attr = SysCacheGetAttr(GPPOLICYID, gp_policy_tuple,
+							   Anum_gp_policy_numsegments,
+							   &isNull);
+
+		if (isNull)
+			numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+		else
+			numsegments = DatumGetInt32(attr);
 
 		attr = SysCacheGetAttr(GPPOLICYID, gp_policy_tuple,
 							   Anum_gp_policy_type,
@@ -285,7 +308,7 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 		switch (ptype)
 		{
 			case SYM_POLICYTYPE_REPLICATED:
-				policy = createReplicatedGpPolicy(mcxt);
+				policy = createReplicatedGpPolicy(mcxt, numsegments);
 				break;
 			case SYM_POLICYTYPE_PARTITIONED:
 				/*
@@ -305,7 +328,8 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 				}
 
 				/* Create a GpPolicy object. */
-				policy = makeGpPolicy(mcxt, POLICYTYPE_PARTITIONED, nattrs);
+				policy = makeGpPolicy(mcxt, POLICYTYPE_PARTITIONED,
+									  nattrs, numsegments);
 
 				for (i = 0; i < nattrs; i++)
 				{
@@ -323,7 +347,8 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 	/* Interpret absence of a valid policy row as POLICYTYPE_ENTRY */
 	if (policy == NULL)
 	{
-		return makeGpPolicy(mcxt, POLICYTYPE_ENTRY, 0);
+		return makeGpPolicy(mcxt, POLICYTYPE_ENTRY,
+							0, GP_POLICY_ENTRY_NUMSEGMENTS);
 	}
 
 	return policy;
@@ -364,15 +389,17 @@ GpPolicyStore(Oid tbloid, const GpPolicy *policy)
 
 	ArrayType  *attrnums;
 
-	bool		nulls[3];
-	Datum		values[3];
+	bool		nulls[4];
+	Datum		values[4];
 
 	Insist(policy->ptype != POLICYTYPE_ENTRY);
 
 	nulls[0] = false;
 	nulls[1] = false;
 	nulls[2] = false;
+	nulls[3] = false;
 	values[0] = ObjectIdGetDatum(tbloid);
+	values[3] = Int32GetDatum(policy->numsegments);
 
 	/*
 	 * Open and lock the gp_distribution_policy catalog.
@@ -438,16 +465,18 @@ GpPolicyReplace(Oid tbloid, const GpPolicy *policy)
 	SysScanDesc scan;
 	ScanKeyData skey;
 	ArrayType  *attrnums;
-	bool		nulls[3];
-	Datum		values[3];
-	bool		repl[3];
+	bool		nulls[4];
+	Datum		values[4];
+	bool		repl[4];
 
 	Insist(!GpPolicyIsEntry(policy));
 
 	nulls[0] = false;
 	nulls[1] = false;
 	nulls[2] = false;
+	nulls[3] = false;
 	values[0] = ObjectIdGetDatum(tbloid);
+	values[3] = Int32GetDatum(policy->numsegments);
 
 	/*
 	 * Open and lock the gp_distribution_policy catalog.
@@ -491,6 +520,7 @@ GpPolicyReplace(Oid tbloid, const GpPolicy *policy)
 	repl[0] = false;
 	repl[1] = true;
 	repl[2] = true;
+	repl[3] = true;
 
 
 	/*
@@ -658,7 +688,8 @@ checkPolicyForUniqueIndex(Relation rel, AttrNumber *indattr, int nidxatts,
 		}
 
 		/* update policy since table is not populated yet. See MPP-101 */
-		GpPolicy *policy = makeGpPolicy(NULL, POLICYTYPE_PARTITIONED, nidxatts);
+		GpPolicy *policy = makeGpPolicy(NULL, POLICYTYPE_PARTITIONED, nidxatts,
+										rel->rd_cdbpolicy->numsegments);
 
 		for (i = 0; i < nidxatts; i++)
 			policy->attrs[i] = indattr[i];

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -128,7 +128,8 @@ cdbCopyStart(CdbCopy *c, CopyStmt *stmt, struct GpPolicy *policy)
 	}
 	else
 	{
-		stmt->policy = createRandomPartitionedPolicy(NULL);
+		stmt->policy = createRandomPartitionedPolicy(NULL,
+													 GP_POLICY_ALL_NUMSEGMENTS);
 	}
 
 	CdbDispatchCopyStart(c, (Node *)stmt,

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -65,6 +65,7 @@
 #include "cdb/cdbpath.h"
 #include "cdb/cdbplan.h"
 #include "cdb/cdbpullup.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbhash.h"		/* isGreenplumDbHashable() */
 
@@ -559,17 +560,20 @@ cdb_grouping_planner(PlannerInfo *root,
 				 * duplicates, but there is no key to hash on.
 				 */
 				plan_1p.group_prep = MPP_GRP_PREP_HASH_GROUPS;
-				CdbPathLocus_MakeGeneral(&plan_1p.output_locus);
+				CdbPathLocus_MakeGeneral(&plan_1p.output_locus,
+										 CdbPathLocus_NumSegments(plan_1p.input_locus));
 			}
 			else if (gp_hash_safe_grouping(root))
 			{
 				plan_1p.group_prep = MPP_GRP_PREP_HASH_GROUPS;
-				CdbPathLocus_MakeHashed(&plan_1p.output_locus, root->group_pathkeys);
+				CdbPathLocus_MakeHashed(&plan_1p.output_locus, root->group_pathkeys,
+										CdbPathLocus_NumSegments(plan_1p.input_locus));
 			}
 			else
 			{
 				plan_1p.group_prep = MPP_GRP_PREP_FOCUS_QE;
-				CdbPathLocus_MakeSingleQE(&plan_1p.output_locus);
+				CdbPathLocus_MakeSingleQE(&plan_1p.output_locus,
+										  CdbPathLocus_NumSegments(plan_1p.input_locus));
 			}
 		}
 	}
@@ -577,7 +581,8 @@ cdb_grouping_planner(PlannerInfo *root,
 								 * replicated  */
 	{
 		plan_1p.group_prep = MPP_GRP_PREP_FOCUS_QE;
-		CdbPathLocus_MakeSingleQE(&plan_1p.output_locus);
+		CdbPathLocus_MakeSingleQE(&plan_1p.output_locus,
+								  CdbPathLocus_NumSegments(plan_1p.input_locus));
 	}
 
 	/*
@@ -756,14 +761,17 @@ cdb_grouping_planner(PlannerInfo *root,
 		{
 			plan_2p.group_type = MPP_GRP_TYPE_GROUPED_2STAGE;
 			if (root->group_pathkeys == NIL)
-				CdbPathLocus_MakeGeneral(&plan_2p.output_locus);
+				CdbPathLocus_MakeGeneral(&plan_2p.output_locus,
+										 CdbPathLocus_NumSegments(plan_2p.input_locus));
 			else
-				CdbPathLocus_MakeHashed(&plan_2p.output_locus, root->group_pathkeys);
+				CdbPathLocus_MakeHashed(&plan_2p.output_locus, root->group_pathkeys,
+										CdbPathLocus_NumSegments(plan_2p.input_locus));
 		}
 		else
 		{
 			plan_2p.group_type = MPP_GRP_TYPE_PLAIN_2STAGE;
-			CdbPathLocus_MakeSingleQE(&plan_2p.output_locus);
+			CdbPathLocus_MakeSingleQE(&plan_2p.output_locus,
+									  CdbPathLocus_NumSegments(plan_2p.input_locus));
 		}
 
 		if (consider_agg & AGG_2PHASE_DQA)
@@ -784,7 +792,8 @@ cdb_grouping_planner(PlannerInfo *root,
 			if (!cdbpathlocus_collocates(root, plan_2p.input_locus, l, false /* exact_match */ ))
 			{
 				plan_2p.group_prep = MPP_GRP_PREP_HASH_DISTINCT;
-				CdbPathLocus_MakeHashed(&plan_2p.input_locus, l);
+				CdbPathLocus_MakeHashed(&plan_2p.input_locus, l,
+										CdbPathLocus_NumSegments(plan_2p.input_locus));
 			}
 			else
 			{
@@ -806,14 +815,17 @@ cdb_grouping_planner(PlannerInfo *root,
 		{
 			plan_3p.group_type = MPP_GRP_TYPE_GROUPED_DQA_2STAGE;
 			if (root->group_pathkeys == NIL)
-				CdbPathLocus_MakeGeneral(&plan_3p.output_locus);
+				CdbPathLocus_MakeGeneral(&plan_3p.output_locus,
+										 CdbPathLocus_NumSegments(plan_3p.input_locus));
 			else
-				CdbPathLocus_MakeHashed(&plan_3p.output_locus, root->group_pathkeys);
+				CdbPathLocus_MakeHashed(&plan_3p.output_locus, root->group_pathkeys,
+										CdbPathLocus_NumSegments(plan_3p.input_locus));
 		}
 		else
 		{
 			plan_3p.group_type = MPP_GRP_TYPE_PLAIN_DQA_2STAGE;
-			CdbPathLocus_MakeSingleQE(&plan_3p.output_locus);
+			CdbPathLocus_MakeSingleQE(&plan_3p.output_locus,
+									  CdbPathLocus_NumSegments(plan_3p.input_locus));
 		}
 	}
 
@@ -1429,7 +1441,7 @@ make_two_stage_agg_plan(PlannerInfo *root,
 										0,	/* rollup_gs_times */
 										result_plan);
 		/* May lose useful locus and sort. Unlikely, but could do better. */
-		mark_plan_strewn(result_plan);
+		mark_plan_strewn(result_plan, ctx->output_locus.numsegments);
 		current_pathkeys = NIL;
 	}
 
@@ -3039,7 +3051,7 @@ cdbpathlocus_from_flow(Flow *flow)
 {
 	CdbPathLocus locus;
 
-	CdbPathLocus_MakeNull(&locus);
+	CdbPathLocus_MakeNull(&locus, flow->numsegments);
 
 	if (!flow)
 		return locus;
@@ -3048,15 +3060,16 @@ cdbpathlocus_from_flow(Flow *flow)
 	{
 		case FLOW_SINGLETON:
 			if (flow->segindex == -1)
+				/* FIXME: should numsegments be set to flow->numsegments? */
 				CdbPathLocus_MakeEntry(&locus);
 			else
-				CdbPathLocus_MakeSingleQE(&locus);
+				CdbPathLocus_MakeSingleQE(&locus, flow->numsegments);
 			break;
 		case FLOW_REPLICATED:
-			CdbPathLocus_MakeReplicated(&locus);
+			CdbPathLocus_MakeReplicated(&locus, flow->numsegments);
 			break;
 		case FLOW_PARTITIONED:
-			CdbPathLocus_MakeStrewn(&locus);
+			CdbPathLocus_MakeStrewn(&locus, flow->numsegments);
 			break;
 		case FLOW_UNDEFINED:
 		default:
@@ -5368,11 +5381,11 @@ initAggPlanInfo(AggPlanInfo *info, Path *input_path, Plan *input_plan)
 	if (input_path != NULL)
 		info->input_locus = input_path->locus;
 	else
-		CdbPathLocus_MakeNull(&info->input_locus);
+		CdbPathLocus_MakeNull(&info->input_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
 
 	info->group_type = MPP_GRP_TYPE_BASEPLAN;
 	info->group_prep = MPP_GRP_PREP_NONE;
-	CdbPathLocus_MakeNull(&info->output_locus);
+	CdbPathLocus_MakeNull(&info->output_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
 	info->distinctkey_collocate = false;
 
 	info->valid = false;
@@ -5668,7 +5681,12 @@ add_motion_to_dqa_child(Plan *plan, PlannerInfo *root, bool *motion_added)
 
 	if (CdbPathLocus_IsPartitioned(locus) && NIL != plan->flow->hashExpr)
 	{
-		locus = cdbpathlocus_from_exprs(root, plan->flow->hashExpr);
+		/*
+		 * We want to create a locus to representing the exprs of the flow,
+		 * it must have the same numsegments with the flow.
+		 */
+		locus = cdbpathlocus_from_exprs(root, plan->flow->hashExpr,
+										plan->flow->numsegments);
 	}
 
 	if (!cdbpathlocus_collocates(root, locus, pathkeys, true /* exact_match */ ))

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -106,6 +106,11 @@ makeCdbHash(int numsegs)
 
 	Assert(MyDatabaseHashMethod != INVALID_HASH_METHOD);
 
+	if (numsegs == __GP_POLICY_EVIL_NUMSEGMENTS)
+	{
+		Assert(!"what's the proper value of numsegments?");
+	}
+
 	/* Create a pointer to a CdbHash that includes the hash properties */
 	h = palloc(sizeof(CdbHash));
 

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -75,7 +75,8 @@ static bool adjustPlanFlow(Plan *plan,
 			   bool stable,
 			   bool rescannable,
 			   Movement req_move,
-			   List *hashExpr);
+			   List *hashExpr,
+			   int numsegments);
 
 static void motion_sanity_check(PlannerInfo *root, Plan *plan);
 static bool loci_compatible(List *hashExpr1, List *hashExpr2);
@@ -571,7 +572,8 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		 */
 		if (ctx->movement == MOVEMENT_BROADCAST)
 		{
-			broadcastPlan(scanPlan, false /* stable */ , false /* rescannable */ );
+			broadcastPlan(scanPlan, false /* stable */ , false /* rescannable */,
+						  scanPlan->flow->numsegments /* numsegments */);
 		}
 		else
 		{
@@ -736,7 +738,8 @@ ParallelizeSubplan(SubPlan *spExpr, PlanProfile *context)
 
 		if (containingPlanDistributed)
 		{
-			broadcastPlan(newPlan, false /* stable */ , false /* rescannable */ );
+			broadcastPlan(newPlan, false /* stable */ , false /* rescannable */,
+						  context->currentPlanFlow->numsegments /* numsegments */);
 		}
 		else
 		{
@@ -915,13 +918,20 @@ prescan_walker(Node *node, PlanProfile *context)
  * Construct a new Flow in the current memory context.
  */
 Flow *
-makeFlow(FlowType flotype)
+makeFlow(FlowType flotype, int numsegments)
 {
 	Flow	   *flow = makeNode(Flow);
+
+	Assert(numsegments > 0);
+	if (numsegments == __GP_POLICY_EVIL_NUMSEGMENTS)
+	{
+		Assert(!"what's the proper value of numsegments?");
+	}
 
 	flow->flotype = flotype;
 	flow->req_move = MOVEMENT_NONE;
 	flow->locustype = CdbLocusType_Null;
+	flow->numsegments = numsegments;
 
 	return flow;
 }
@@ -963,7 +973,7 @@ pull_up_Flow(Plan *plan, Plan *subplan)
 	else
 		Assert(subplan == plan->lefttree);
 
-	new_flow = makeFlow(model_flow->flotype);
+	new_flow = makeFlow(model_flow->flotype, model_flow->numsegments);
 
 	if (model_flow->flotype == FLOW_SINGLETON)
 		new_flow->segindex = model_flow->segindex;
@@ -1034,23 +1044,29 @@ focusPlan(Plan *plan, bool stable, bool rescannable)
 		plan->flow->locustype != CdbLocusType_SegmentGeneral)
 		return true;
 
-	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_FOCUS, NIL);
+	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_FOCUS, NIL,
+						  plan->flow->numsegments);
 }
 
 /*
  * Function: broadcastPlan
  */
 bool
-broadcastPlan(Plan *plan, bool stable, bool rescannable)
+broadcastPlan(Plan *plan, bool stable, bool rescannable, int numsegments)
 {
 	Assert(plan->flow && plan->flow->flotype != FLOW_UNDEFINED);
 
-	/* Already focused and flow is CdbLocusType_SegmentGeneral, do nothing. */
+	/*
+	 * Already focused and flow is CdbLocusType_SegmentGeneral and data
+	 * is replicated on every segment of target, do nothing.
+	 */
 	if (plan->flow->flotype == FLOW_SINGLETON &&
-		plan->flow->locustype == CdbLocusType_SegmentGeneral)
+		plan->flow->locustype == CdbLocusType_SegmentGeneral &&
+		plan->flow->numsegments >= numsegments)
 		return true;
 
-	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_BROADCAST, NIL);
+	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_BROADCAST, NIL,
+						  numsegments);
 }
 
 
@@ -1089,14 +1105,15 @@ loci_compatible(List *hashExpr1, List *hashExpr2)
  * Function: repartitionPlan
  */
 bool
-repartitionPlan(Plan *plan, bool stable, bool rescannable, List *hashExpr)
+repartitionPlan(Plan *plan, bool stable, bool rescannable,
+				List *hashExpr, int numsegments)
 {
 	Assert(plan->flow);
 	Assert(plan->flow->flotype == FLOW_PARTITIONED ||
 		   plan->flow->flotype == FLOW_SINGLETON);
 
 	/* Already partitioned on the given hashExpr?  Do nothing. */
-	if (hashExpr)
+	if (hashExpr && plan->flow->numsegments == numsegments)
 	{
 		if (equal(hashExpr, plan->flow->hashExpr))
 			return true;
@@ -1110,7 +1127,8 @@ repartitionPlan(Plan *plan, bool stable, bool rescannable, List *hashExpr)
 			return true;
 	}
 
-	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_REPARTITION, hashExpr);
+	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_REPARTITION,
+						  hashExpr, numsegments);
 }
 
 /*
@@ -1128,7 +1146,8 @@ adjustPlanFlow(Plan *plan,
 			   bool stable,
 			   bool rescannable,
 			   Movement req_move,
-			   List *hashExpr)
+			   List *hashExpr,
+			   int numsegments)
 {
 	Flow	   *flow = plan->flow;
 	bool		disorder = false;
@@ -1138,6 +1157,12 @@ adjustPlanFlow(Plan *plan,
 	Assert(flow && flow->flotype != FLOW_UNDEFINED);
 	Assert(flow->req_move == MOVEMENT_NONE);
 	Assert(flow->flow_before_req_move == NULL);
+
+	Assert(numsegments > 0);
+	if (numsegments == __GP_POLICY_EVIL_NUMSEGMENTS)
+	{
+		Assert(!"what's the proper value of numsegments?");
+	}
 
 	switch (req_move)
 	{
@@ -1225,7 +1250,8 @@ adjustPlanFlow(Plan *plan,
 							stable && !reorder,
 							rescannable,
 							req_move,
-							hashExpr))
+							hashExpr,
+							numsegments))
 			return false;
 
 		/* After updating subplan, bubble new distribution back up the tree. */
@@ -1234,6 +1260,7 @@ adjustPlanFlow(Plan *plan,
 		flow->flotype = kidflow->flotype;
 		flow->segindex = kidflow->segindex;
 		flow->hashExpr = copyObject(kidflow->hashExpr);
+		flow->numsegments = kidflow->numsegments;
 		plan->dispatch = plan->lefttree->dispatch;
 
 		return true;			/* success */
@@ -1285,18 +1312,21 @@ adjustPlanFlow(Plan *plan,
 			/* Converge to a single QE (or QD; that choice is made later). */
 			flow->flotype = FLOW_SINGLETON;
 			flow->hashExpr = NIL;
+			flow->numsegments = numsegments;
 			flow->segindex = 0;
 			break;
 
 		case MOVEMENT_BROADCAST:
 			flow->flotype = FLOW_REPLICATED;
 			flow->hashExpr = NIL;
+			flow->numsegments = numsegments;
 			flow->segindex = 0;
 			break;
 
 		case MOVEMENT_REPARTITION:
 			flow->flotype = FLOW_PARTITIONED;
 			flow->hashExpr = copyObject(hashExpr);
+			flow->numsegments = numsegments;
 			flow->segindex = 0;
 			break;
 

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -150,7 +150,7 @@ directDispatchCalculateHash(Plan *plan, GpPolicy *targetPolicy)
 	ListCell   *cell = NULL;
 	bool		directDispatch;
 
-	h = makeCdbHash(GpIdentity.numsegments);
+	h = makeCdbHash(targetPolicy->numsegments);
 	cdbhashinit(h);
 
 	/*

--- a/src/backend/cdb/cdbpathtoplan.c
+++ b/src/backend/cdb/cdbpathtoplan.c
@@ -33,32 +33,32 @@ cdbpathtoplan_create_flow(PlannerInfo *root,
 	/* Distribution */
 	if (CdbPathLocus_IsEntry(locus))
 	{
-		flow = makeFlow(FLOW_SINGLETON);
+		flow = makeFlow(FLOW_SINGLETON, locus.numsegments);
 		flow->segindex = -1;
 	}
 	else if (CdbPathLocus_IsSingleQE(locus))
 	{
-		flow = makeFlow(FLOW_SINGLETON);
+		flow = makeFlow(FLOW_SINGLETON, locus.numsegments);
 		flow->segindex = 0;
 	}
 	else if (CdbPathLocus_IsGeneral(locus))
 	{
-		flow = makeFlow(FLOW_SINGLETON);
+		flow = makeFlow(FLOW_SINGLETON, locus.numsegments);
 		flow->segindex = 0;
 	}
 	else if (CdbPathLocus_IsSegmentGeneral(locus))
 	{
-		flow = makeFlow(FLOW_SINGLETON);
+		flow = makeFlow(FLOW_SINGLETON, locus.numsegments);
 		flow->segindex = 0;
 	}
 	else if (CdbPathLocus_IsReplicated(locus))
 	{
-		flow = makeFlow(FLOW_REPLICATED);
+		flow = makeFlow(FLOW_REPLICATED, locus.numsegments);
 	}
 	else if (CdbPathLocus_IsHashed(locus) ||
 			 CdbPathLocus_IsHashedOJ(locus))
 	{
-		flow = makeFlow(FLOW_PARTITIONED);
+		flow = makeFlow(FLOW_PARTITIONED, locus.numsegments);
 		flow->hashExpr = cdbpathlocus_get_partkey_exprs(locus,
 														relids,
 														plan->targetlist);
@@ -70,7 +70,7 @@ cdbpathtoplan_create_flow(PlannerInfo *root,
 		 */
 	}
 	else if (CdbPathLocus_IsStrewn(locus))
-		flow = makeFlow(FLOW_PARTITIONED);
+		flow = makeFlow(FLOW_PARTITIONED, locus.numsegments);
 	else
 		Insist(0);
 

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -357,6 +357,8 @@ make_motion_gather(PlannerInfo *root, Plan *subplan, int segindex, List *sortPat
 									   -1.0,
 									   false /* useExecutorVarFormat */ );
 
+		/* FIXME: numsegments */
+
 		motion = make_sorted_union_motion(root,
 										  subplan,
 										  sort->numCols,
@@ -365,17 +367,21 @@ make_motion_gather(PlannerInfo *root, Plan *subplan, int segindex, List *sortPat
 										  sort->collations,
 										  sort->nullsFirst,
 										  segindex,
-										  false /* useExecutorVarFormat */ );
+										  false /* useExecutorVarFormat */,
+										  subplan->flow->numsegments);
 
 		/* throw away the Sort */
 		pfree(sort);
 	}
 	else
 	{
+		/* FIXME: numsegments */
+
 		motion = make_union_motion(
 								   subplan,
 								   segindex,
-								   false /* useExecutorVarFormat */ );
+								   false /* useExecutorVarFormat */,
+								   subplan->flow->numsegments);
 	}
 
 	return motion;
@@ -412,7 +418,14 @@ make_motion_hash_all_targets(PlannerInfo *root, Plan *subplan)
 	}
 
 	if (hashexprs)
-		return make_motion_hash(root, subplan, hashexprs);
+		/*
+		 * FIXME: ALL as numsegments is correct,
+		 *        but can we decide a better value?
+		 */
+		return make_hashed_motion(subplan,
+								  hashexprs,
+								  false /* useExecutorVarFormat */,
+								  GP_POLICY_ALL_NUMSEGMENTS);
 	else
 	{
 		/*
@@ -439,10 +452,13 @@ make_motion_hash(PlannerInfo *root __attribute__((unused)), Plan *subplan, List 
 
 	Assert(subplan->flow != NULL);
 
+	/* FIXME: numsegments */
+
 	motion = make_hashed_motion(
 								subplan,
 								hashexprs,
-								false /* useExecutorVarFormat */ );
+								false /* useExecutorVarFormat */,
+								subplan->flow->numsegments);
 
 	return motion;
 }

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -26,6 +26,7 @@
 #include "cdb/cdbllize.h"
 #include "cdb/cdbmutate.h"
 #include "cdb/cdbsetop.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbpullup.h"
 
@@ -273,7 +274,7 @@ copyFlow(Flow *model_flow, bool withExprs, bool withSort)
 	if (model_flow == NULL)
 		return NULL;
 
-	new_flow = makeFlow(model_flow->flotype);
+	new_flow = makeFlow(model_flow->flotype, model_flow->numsegments);
 	new_flow->locustype = model_flow->locustype;
 
 	if (model_flow->flotype == FLOW_PARTITIONED)
@@ -453,22 +454,27 @@ make_motion_hash(PlannerInfo *root __attribute__((unused)), Plan *subplan, List 
 void
 mark_append_locus(Plan *plan, GpSetOpType optype)
 {
+	/*
+	 * FIXME: for append we forcely collect data on all segments
+	 */
+	int			numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+
 	switch (optype)
 	{
 		case PSETOP_GENERAL:
-			mark_plan_general(plan);
+			mark_plan_general(plan, numsegments);
 			break;
 		case PSETOP_PARALLEL_PARTITIONED:
-			mark_plan_strewn(plan);
+			mark_plan_strewn(plan, numsegments);
 			break;
 		case PSETOP_PARALLEL_REPLICATED:
-			mark_plan_replicated(plan);
+			mark_plan_replicated(plan, numsegments);
 			break;
 		case PSETOP_SEQUENTIAL_QD:
 			mark_plan_entry(plan);
 			break;
 		case PSETOP_SEQUENTIAL_QE:
-			mark_plan_singleQE(plan);
+			mark_plan_singleQE(plan, numsegments);
 		case PSETOP_NONE:
 			break;
 	}
@@ -531,27 +537,27 @@ mark_sort_locus(Plan *plan)
 }
 
 void
-mark_plan_general(Plan *plan)
+mark_plan_general(Plan *plan, int numsegments)
 {
 	Assert(is_plan_node((Node *) plan) && plan->flow == NULL);
-	plan->flow = makeFlow(FLOW_SINGLETON);
+	plan->flow = makeFlow(FLOW_SINGLETON, numsegments);
 	plan->flow->segindex = 0;
 	plan->flow->locustype = CdbLocusType_General;
 }
 
 void
-mark_plan_strewn(Plan *plan)
+mark_plan_strewn(Plan *plan, int numsegments)
 {
 	Assert(is_plan_node((Node *) plan) && plan->flow == NULL);
-	plan->flow = makeFlow(FLOW_PARTITIONED);
+	plan->flow = makeFlow(FLOW_PARTITIONED, numsegments);
 	plan->flow->locustype = CdbLocusType_Strewn;
 }
 
 void
-mark_plan_replicated(Plan *plan)
+mark_plan_replicated(Plan *plan, int numsegments)
 {
 	Assert(is_plan_node((Node *) plan) && plan->flow == NULL);
-	plan->flow = makeFlow(FLOW_REPLICATED);
+	plan->flow = makeFlow(FLOW_REPLICATED, numsegments);
 	plan->flow->locustype = CdbLocusType_Replicated;
 }
 
@@ -559,25 +565,25 @@ void
 mark_plan_entry(Plan *plan)
 {
 	Assert(is_plan_node((Node *) plan) && plan->flow == NULL);
-	plan->flow = makeFlow(FLOW_SINGLETON);
+	plan->flow = makeFlow(FLOW_SINGLETON, GP_POLICY_ENTRY_NUMSEGMENTS);
 	plan->flow->segindex = -1;
 	plan->flow->locustype = CdbLocusType_Entry;
 }
 
 void
-mark_plan_singleQE(Plan *plan)
+mark_plan_singleQE(Plan *plan, int numsegments)
 {
 	Assert(is_plan_node((Node *) plan) && plan->flow == NULL);
-	plan->flow = makeFlow(FLOW_SINGLETON);
+	plan->flow = makeFlow(FLOW_SINGLETON, numsegments);
 	plan->flow->segindex = 0;
 	plan->flow->locustype = CdbLocusType_SingleQE;
 }
 
 void
-mark_plan_segment_general(Plan *plan)
+mark_plan_segment_general(Plan *plan, int numsegments)
 {
 	Assert(is_plan_node((Node *) plan) && plan->flow == NULL);
-	plan->flow = makeFlow(FLOW_SINGLETON);
+	plan->flow = makeFlow(FLOW_SINGLETON, numsegments);
 	plan->flow->segindex = 0;
 	plan->flow->locustype = CdbLocusType_SegmentGeneral;
 }

--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -278,9 +278,9 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 		}
 		else if (totalCombinations > 0 &&
 			/* don't bother for ones which will likely hash to many segments */
-				 totalCombinations < GpIdentity.numsegments * 3)
+				 totalCombinations < policy->numsegments * 3)
 		{
-			CdbHash    *h = makeCdbHash(GpIdentity.numsegments);
+			CdbHash    *h = makeCdbHash(policy->numsegments);
 			long		index = 0;
 
 			result.dd.isDirectDispatch = true;

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2197,8 +2197,8 @@ analyzeEstimateReltuplesRelpages(Oid relationOid, float4 *relTuples, float4 *rel
 
 		if (GpPolicyIsReplicated(policy))
 		{
-			*relTuples += DatumGetFloat4(values[0]) / getgpsegmentCount();
-			*relPages += DatumGetFloat4(values[1]) / getgpsegmentCount();
+			*relTuples += DatumGetFloat4(values[0]) / policy->numsegments;
+			*relPages += DatumGetFloat4(values[1]) / policy->numsegments;
 		}
 		else
 		{
@@ -2272,7 +2272,7 @@ analyzeEstimateIndexpages(Relation onerel, Relation indrel, BlockNumber *indexPa
     Assert(valuesLength == 2);
 
 	if (GpPolicyIsReplicated(policy))
-		*indexPages = DatumGetFloat4(values[1]) / getgpsegmentCount();
+		*indexPages = DatumGetFloat4(values[1]) / policy->numsegments;
 	else
 		*indexPages = DatumGetFloat4(values[1]);
 

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -6973,7 +6973,6 @@ InitDistributionData(CopyState cstate, Form_pg_attribute *attr,
 	CdbHash *cdbHash = NULL;
 	AttrNumber h_attnum; /* hash key attribute number */
 	int p_index;
-	int total_segs = getgpsegmentCount();
 	int i = 0;
 
 	if (!multi_dist_policy)
@@ -6985,7 +6984,7 @@ InitDistributionData(CopyState cstate, Form_pg_attribute *attr,
 		else
 			p_nattrs = 0;
 		/* Create hash API reference */
-		cdbHash = makeCdbHash(total_segs);
+		cdbHash = makeCdbHash(policy->numsegments);
 	}
 	else
 	{
@@ -7202,7 +7201,7 @@ GetDistributionPolicyForPartition(CopyState cstate, EState *estate,
 			 * iteration.
 			 */
 			d->relid = relid;
-			part_hash = d->cdbHash = makeCdbHash(cstate->cdbCopy->total_segs);
+			part_hash = d->cdbHash = makeCdbHash(rel->rd_cdbpolicy->numsegments);
 			part_policy = d->policy = GpPolicyCopy(cstate->copycontext, rel->rd_cdbpolicy);
 			part_p_nattrs = part_policy->nattrs;
 			heap_close(rel, NoLock);

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2017,7 +2017,8 @@ CopyDispatchOnSegment(CopyState cstate, const CopyStmt *stmt)
 	}
 	else
 	{
-		dispatchStmt->policy = createRandomPartitionedPolicy(NULL);
+		dispatchStmt->policy = createRandomPartitionedPolicy(NULL,
+															 GP_POLICY_ALL_NUMSEGMENTS);
 	}
 
 	CdbDispatchUtilityStatement((Node *) dispatchStmt,
@@ -7013,7 +7014,8 @@ InitDistributionData(CopyState cstate, Form_pg_attribute *attr,
 		                      &hash_ctl,
 		                      HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 		p_nattrs = list_length(cols);
-		policy = createHashPartitionedPolicy(NULL, cols);
+		policy = createHashPartitionedPolicy(NULL, cols,
+											 cstate->rel->rd_cdbpolicy->numsegments);
 	}
 
 	/*

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -187,7 +187,7 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 
 	if (into->distributedBy &&
 		((DistributedBy *)(into->distributedBy))->ptype == POLICYTYPE_REPLICATED)
-		queryDesc->es_processed /= getgpsegmentCount();
+		queryDesc->es_processed /= ((DistributedBy *)(into->distributedBy))->numsegments;
 
 	/* MPP-14001: Running auto_stats */
 	if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14110,6 +14110,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 	bool        is_aocs = false;
 	char        relstorage = RELSTORAGE_HEAP;
 	int         nattr; /* number of attributes */
+	int			numsegments;
 	bool useExistingColumnAttributes = true;
 	SetDistributionCmd *qe_data = NULL; 
 	bool save_optimizer_replicated_table_insert;
@@ -14142,6 +14143,15 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		ereport(ERROR,
 			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			 errmsg("SET DISTRIBUTED BY not supported in utility mode")));
+
+	/*
+	 * SET DISTRIBUTED BY only change the distribution policy, but should not
+	 * change numsegments, keep the old value.
+	 */
+	numsegments = rel->rd_cdbpolicy->numsegments;
+
+	if (Gp_role == GP_ROLE_DISPATCH && ldistro)
+		ldistro->numsegments = numsegments;
 
 	/* we only support partitioned/replicated tables */
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -14290,7 +14300,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 									 RelationGetRelationName(rel))));
 			}
 
-			policy = createRandomPartitionedPolicy(NULL);
+			policy = createRandomPartitionedPolicy(NULL, ldistro->numsegments);
 
 			/* always need to rebuild if changed from replicated policy */
 			if (!GpPolicyIsReplicated(rel->rd_cdbpolicy))
@@ -14325,7 +14335,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 						 errhint("Use ALTER TABLE \"%s\" SET WITH (REORGANIZE=TRUE) DISTRIBUTED REPLICATED to force a replicated redistribution.",
 								 RelationGetRelationName(rel))));
 
-			policy = createReplicatedGpPolicy(NULL);
+			policy = createReplicatedGpPolicy(NULL, ldistro->numsegments);
 
 			/* rebuild if have new storage options or policy changed */
 			if (!DatumGetPointer(newOptions) &&
@@ -14401,7 +14411,8 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 				} /* end foreach */
 
 				Assert(policykeys != NIL);
-				policy = createHashPartitionedPolicy(NULL, policykeys);
+				policy = createHashPartitionedPolicy(NULL, policykeys,
+													 ldistro->numsegments);
 
 				/*
 				 * See if the the old policy is the same as the new one but
@@ -14503,7 +14514,8 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			 * is same as the original one, the query optimizer will generate
 			 * redistribute plan.
 			 */
-			GpPolicy *random_policy = createRandomPartitionedPolicy(NULL);
+			GpPolicy *random_policy = createRandomPartitionedPolicy(NULL,
+																	ldistro->numsegments);
 
 			original_policy = rel->rd_cdbpolicy;
 			/*
@@ -16618,6 +16630,7 @@ make_dist_clause(Relation rel)
 	{
 		/* must be random distribution */
 		dist->ptype = POLICYTYPE_REPLICATED;
+		dist->numsegments = rel->rd_cdbpolicy->numsegments;
 		dist->keys = NIL;
 	}
 	else
@@ -16636,6 +16649,7 @@ make_dist_clause(Relation rel)
 		}
 
 		dist->ptype = POLICYTYPE_PARTITIONED;
+		dist->numsegments = rel->rd_cdbpolicy->numsegments;
 		dist->keys = distro;
 	}
 

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1427,9 +1427,9 @@ vac_update_relstats_from_list(List *updated_stats)
 
 		if (GpPolicyIsReplicated(rel->rd_cdbpolicy))
 		{
-			stats->rel_pages = stats->rel_pages / getgpsegmentCount();
-			stats->rel_tuples = stats->rel_tuples / getgpsegmentCount();
-			stats->relallvisible = stats->relallvisible / getgpsegmentCount();
+			stats->rel_pages = stats->rel_pages / rel->rd_cdbpolicy->numsegments;
+			stats->rel_tuples = stats->rel_tuples / rel->rd_cdbpolicy->numsegments;
+			stats->relallvisible = stats->relallvisible / rel->rd_cdbpolicy->numsegments;
 		}
 
 		/*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4737,6 +4737,7 @@ AdjustReplicatedTableCounts(EState *estate)
 	int i;
 	ResultRelInfo *resultRelInfo;
 	bool containReplicatedTable = false;
+	int			numsegments = getgpsegmentCount();
 
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
@@ -4750,7 +4751,10 @@ AdjustReplicatedTableCounts(EState *estate)
 			continue;
 
 		if (GpPolicyIsReplicated(resultRelInfo->ri_RelationDesc->rd_cdbpolicy))
+		{
 			containReplicatedTable = true;
+			numsegments = resultRelInfo->ri_RelationDesc->rd_cdbpolicy->numsegments;
+		}
 		else if (containReplicatedTable)
 		{
 			/*
@@ -4762,5 +4766,5 @@ AdjustReplicatedTableCounts(EState *estate)
 	}
 
 	if (containReplicatedTable)
-		estate->es_processed = estate->es_processed / getgpsegmentCount();
+		estate->es_processed = estate->es_processed / numsegments;
 }

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -3211,15 +3211,19 @@ gpdb::IsAbortRequested
 
 GpPolicy *
 gpdb::MakeGpPolicy
-       (
-               MemoryContext mcxt,
-               GpPolicyType ptype,
-               int nattrs
-       )
+		(
+			MemoryContext mcxt,
+			GpPolicyType ptype,
+			int nattrs,
+			int numsegments
+		)
 {
 	GP_WRAP_START;
 	{
-		return makeGpPolicy(mcxt, ptype, nattrs);
+		/*
+		 * FIXME_TABLE_EXPAND: it used by ORCA, help...
+		 */
+		return makeGpPolicy(mcxt, ptype, nattrs, numsegments);
 	}
 	GP_WRAP_END;
 }

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5175,7 +5175,10 @@ CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy
 		num_of_distr_cols_alloc = num_of_distr_cols;
 	}
 	
-	GpPolicy *distr_policy = gpdb::MakeGpPolicy(NULL, POLICYTYPE_PARTITIONED, num_of_distr_cols_alloc);
+	// always set numsegments to ALL for CTAS
+	GpPolicy *distr_policy = gpdb::MakeGpPolicy(NULL, POLICYTYPE_PARTITIONED,
+												num_of_distr_cols_alloc,
+												gpdb::GetGPSegmentCount());
 
 	GPOS_ASSERT(IMDRelation::EreldistrHash == dxlop->Ereldistrpolicy() ||
 				IMDRelation::EreldistrRandom == dxlop->Ereldistrpolicy());

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -565,6 +565,15 @@ CTranslatorRelcacheToDXL::RetrieveRel
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Foreign Data"));
 	}
 
+	if (NULL != rel->rd_cdbpolicy &&
+		gpdb::GetGPSegmentCount() != rel->rd_cdbpolicy->numsegments)
+	{
+		// GPORCA does not support partially distributed tables yet
+		gpdb::CloseRelation(rel);
+		GPOS_RAISE(gpdxl::ExmaMD,
+				   gpdxl::ExmiDXLInvalidAttributeValue,
+				   GPOS_WSZ_LIT("Partially Distributed Data"));
+	}
 
 	CMDName *mdname = NULL;
 	IMDRelation::Erelstoragetype rel_storage_type = IMDRelation::ErelstorageSentinel;

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2296,6 +2296,7 @@ _copyFlow(const Flow *from)
 	COPY_SCALAR_FIELD(req_move);
 	COPY_SCALAR_FIELD(locustype);
 	COPY_SCALAR_FIELD(segindex);
+	COPY_SCALAR_FIELD(numsegments);
 	COPY_NODE_FIELD(hashExpr);
 	COPY_NODE_FIELD(flow_before_req_move);
 
@@ -4895,6 +4896,7 @@ _copyGpPolicy(const GpPolicy *from)
 	GpPolicy *newnode = makeNode(GpPolicy);
 
 	COPY_SCALAR_FIELD(ptype);
+	COPY_SCALAR_FIELD(numsegments);
 	COPY_SCALAR_FIELD(nattrs);
 	COPY_POINTER_FIELD(attrs, from->nattrs * sizeof(AttrNumber));
 
@@ -4907,6 +4909,7 @@ _copyDistributedBy(const DistributedBy *from)
 	DistributedBy *newnode = makeNode(DistributedBy);
 
 	COPY_SCALAR_FIELD(ptype);
+	COPY_SCALAR_FIELD(numsegments);
 	COPY_NODE_FIELD(keys);
 
 	return newnode;

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -765,6 +765,7 @@ _equalFlow(const Flow *a, const Flow *b)
 	COMPARE_SCALAR_FIELD(req_move);
 	COMPARE_SCALAR_FIELD(locustype);
 	COMPARE_SCALAR_FIELD(segindex);
+	COMPARE_SCALAR_FIELD(numsegments);
 	COMPARE_NODE_FIELD(hashExpr);
 
 	return true;
@@ -2639,6 +2640,7 @@ static bool
 _equalDistributedBy(const DistributedBy *a, const DistributedBy *b)
 {
 	COMPARE_SCALAR_FIELD(ptype);
+	COMPARE_SCALAR_FIELD(numsegments);
 	COMPARE_NODE_FIELD(keys);
 
 	return true;

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1271,6 +1271,7 @@ _outGpPolicy(StringInfo str, GpPolicy *node)
 	WRITE_NODE_TYPE("GPPOLICY");
 
 	WRITE_ENUM_FIELD(ptype, GpPolicyType);
+	WRITE_INT_FIELD(numsegments);
 	WRITE_INT_FIELD(nattrs);
 	WRITE_INT_ARRAY(attrs, node->nattrs, AttrNumber);
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1912,6 +1912,7 @@ _outFlow(StringInfo str, const Flow *node)
 	WRITE_ENUM_FIELD(req_move, Movement);
 	WRITE_ENUM_FIELD(locustype, CdbLocusType);
 	WRITE_INT_FIELD(segindex);
+	WRITE_INT_FIELD(numsegments);
 
 	WRITE_NODE_FIELD(hashExpr);
 
@@ -2607,6 +2608,7 @@ _outDistributedBy(StringInfo str, const DistributedBy *node)
 	WRITE_NODE_TYPE("DISTRIBUTEDBY");
 
 	WRITE_ENUM_FIELD(ptype, GpPolicyType);
+	WRITE_INT_FIELD(numsegments);
 	WRITE_NODE_FIELD(keys);
 }
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2214,6 +2214,7 @@ _readFlow(void)
 	READ_ENUM_FIELD(req_move, Movement);
 	READ_ENUM_FIELD(locustype, CdbLocusType);
 	READ_INT_FIELD(segindex);
+	READ_INT_FIELD(numsegments);
 
 	READ_NODE_FIELD(hashExpr);
 	READ_NODE_FIELD(flow_before_req_move);
@@ -2752,6 +2753,7 @@ _readDistributedBy(void)
 	READ_LOCALS(DistributedBy);
 
 	READ_ENUM_FIELD(ptype, GpPolicyType);
+	READ_INT_FIELD(numsegments);
 	READ_NODE_FIELD(keys);
 
 	READ_DONE();
@@ -2941,6 +2943,8 @@ _readGpPolicy(void)
 	READ_LOCALS(GpPolicy);
 
 	READ_ENUM_FIELD(ptype, GpPolicyType);
+
+	READ_INT_FIELD(numsegments);
 
 	READ_INT_FIELD(nattrs);
 	READ_INT_ARRAY(attrs, local_node->nattrs, AttrNumber);

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1278,7 +1278,8 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 	subquery_path = create_subqueryscan_path(root, rel, pathkeys, required_outer);
 
 	if (forceDistRand)
-		CdbPathLocus_MakeStrewn(&subquery_path->locus);
+		CdbPathLocus_MakeStrewn(&subquery_path->locus,
+								CdbPathLocus_NumSegments(subquery_path->locus));
 
 	add_path(rel, subquery_path);
 

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -4578,12 +4578,14 @@ page_size(double tuples, int width)
  * need it in contexts in which root is not defined may call this function to
  * derive it.
  */
-int planner_segment_count(void)
+int planner_segment_count(GpPolicy *policy)
 {
 	if ( Gp_role != GP_ROLE_DISPATCH )
 		return 1;
 	else if ( gp_segments_for_planner > 0 )
 		return gp_segments_for_planner;
+	else if (policy)
+		return policy->numsegments;
 	else
 		return getgpsegmentCount();
 }
@@ -4604,7 +4606,7 @@ double global_work_mem(PlannerInfo *root)
 		segment_count = root->config->cdbpath_segments;
 	}
 	else
-		segment_count = planner_segment_count();
+		segment_count = planner_segment_count(NULL);
 
 	return (double) planner_work_mem * 1024L * segment_count;	
 }

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -4149,7 +4149,10 @@ cdb_transform_appendrel_var(PlannerInfo *root, RelOptInfo *rel, List **index_pat
 	 * can use cdbpathlocus_pull_above_projection() to do the
 	 * transformation.
 	 */
-	CdbPathLocus_MakeHashed(&notalocus, *index_pathkeys);
+	Assert(rel->cdbpolicy != NULL);
+	CdbPathLocus_MakeHashed(&notalocus, *index_pathkeys,
+							/* FIXME: rel or appendrel or other source? */
+							rel->cdbpolicy->numsegments);
 	notalocus =
 		cdbpathlocus_pull_above_projection(root,
 										   notalocus,

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6572,6 +6572,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 			   *lcp;
 	bool		all_subplans_entry = true,
 				all_subplans_replicated = true;
+	int			numsegments = -1;
 
 	if (node->operation == CMD_INSERT)
 	{
@@ -6589,10 +6590,34 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 			targetPolicy = GpPolicyFetch(CurrentMemoryContext, rte->relid);
 			targetPolicyType = targetPolicy->ptype;
 
+			if (numsegments >= 0)
+			{
+				/*
+				 * We require a table T's sub tables all have the same
+				 * numsegments with T
+				 */
+				Assert(numsegments == targetPolicy->numsegments);
+			}
+
+			numsegments = targetPolicy->numsegments;
+
 			if (targetPolicyType == POLICYTYPE_PARTITIONED)
 			{
 				all_subplans_entry = false;
 				all_subplans_replicated = false;
+
+				/*
+				 * A query to reach here: INSERT INTO t1 VALUES(1).
+				 * There is no need to add a motion from General, we could
+				 * simply put General on the same segments with target table.
+				 */
+				/* FIXME: also do this for other targetPolicyType? */
+				/* FIXME: also do this for all the subplans */
+				if (subplan->flow->locustype == CdbLocusType_General)
+				{
+					Assert(subplan->flow->numsegments >= numsegments);
+					subplan->flow->numsegments = numsegments;
+				}
 
 				if (gp_enable_fast_sri && IsA(subplan, Result))
 					sri_optimize_for_result(root, subplan, rte, &targetPolicy, &hashExpr);
@@ -6603,7 +6628,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 														 targetPolicy->attrs,
 														 false);
 
-				if (!repartitionPlan(subplan, false, false, hashExpr))
+				if (!repartitionPlan(subplan, false, false, hashExpr, numsegments))
 					ereport(ERROR, (errcode(ERRCODE_GP_FEATURE_NOT_YET),
 									errmsg("Cannot parallelize that INSERT yet")));
 			}
@@ -6622,6 +6647,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 					 * Ask for motion to a single QE.  Later, apply_motion
 					 * will override that to bring it to the QD instead.
 					 */
+					/* FIXME: why make below assertion? */
+					Assert(subplan->flow->numsegments == numsegments);
 					if (!focusPlan(subplan, false, false))
 						ereport(ERROR, (errcode(ERRCODE_GP_FEATURE_NOT_YET),
 										errmsg("Cannot parallelize that INSERT yet")));
@@ -6648,7 +6675,28 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 					subplan->flow->flotype == FLOW_SINGLETON &&
 					subplan->flow->locustype == CdbLocusType_SegmentGeneral &&
 					!contain_volatile_functions((Node *)subplan->targetlist))
-					break;
+				{
+					if (subplan->flow->numsegments >= numsegments)
+					{
+						/*
+						 * A query to reach here:
+						 *     INSERT INTO d1 SELECT * FROM d1;
+						 * There is no need to add a motion from General, we
+						 * could simply put General on the same segments with
+						 * target table.
+						 */
+						subplan->flow->numsegments = numsegments;
+						continue;
+					}
+
+					/*
+					 * Otherwise a broadcast motion is needed otherwise d2 will
+					 * only have data on segment 0.
+					 *
+					 * A query to reach here:
+					 *     INSERT INTO d2 SELECT * FROM d1;
+					 */
+				}
 
 				/* plan's data are available on all segment, no motion needed */
 				if (optimizer_replicated_table_insert &&
@@ -6657,10 +6705,24 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 					!contain_volatile_functions((Node *)subplan->targetlist))
 				{
 					subplan->dispatch = DISPATCH_PARALLEL;
-					break;
+					if (subplan->flow->numsegments >= numsegments)
+					{
+						/*
+						 * A query to reach here: INSERT INTO d1 VALUES(1).
+						 * There is no need to add a motion from General, we
+						 * could simply put General on the same segments with
+						 * target table.
+						 */
+						subplan->flow->numsegments = numsegments;
+					}
+					else
+					{
+						/* FIXME: is here reachable? */
+					}
+					continue;
 				}
 
-				if (!broadcastPlan(subplan, false, false))
+				if (!broadcastPlan(subplan, false, false, numsegments))
 					ereport(ERROR, (errcode(ERRCODE_GP_FEATURE_NOT_YET),
 								errmsg("Cannot parallelize that INSERT yet")));
 
@@ -6685,6 +6747,17 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 			targetPolicy = GpPolicyFetch(CurrentMemoryContext, rte->relid);
 			targetPolicyType = targetPolicy->ptype;
 
+			if (numsegments >= 0)
+			{
+				/*
+				 * We require a table T's sub tables all have the same
+				 * numsegments with T
+				 */
+				Assert(numsegments == targetPolicy->numsegments);
+			}
+
+			numsegments = targetPolicy->numsegments;
+
 			if (targetPolicyType == POLICYTYPE_PARTITIONED)
 			{
 				all_subplans_entry = false;
@@ -6708,7 +6781,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 														 targetPolicy->nattrs,
 														 targetPolicy->attrs,
 														 false);
-					if (!repartitionPlan(new_subplan, false, false, hashExpr))
+					if (!repartitionPlan(new_subplan, false, false, hashExpr,
+										 targetPolicy->numsegments))
 						ereport(ERROR, (errcode(ERRCODE_GP_FEATURE_NOT_YET),
 										errmsg("Cannot parallelize that UPDATE yet")));
 
@@ -6771,6 +6845,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 		}
 	}
 
+	Assert(numsegments >= 0);
+
 	/*
 	 * Set the distribution of the ModifyTable node itself. If there is only
 	 * one subplan, or all the subplans have a compatible distribution, then
@@ -6788,11 +6864,11 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node)
 	}
 	else if (all_subplans_replicated)
 	{
-		mark_plan_replicated((Plan *) node);
+		mark_plan_replicated((Plan *) node, numsegments);
 	}
 	else
 	{
-		mark_plan_strewn((Plan *) node);
+		mark_plan_strewn((Plan *) node, numsegments);
 
 		if (list_length(node->plans) == 1)
 		{

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -131,7 +131,8 @@ query_planner(PlannerInfo *root, List *tlist,
 			if (exec_location == PROEXECLOCATION_MASTER)
 				CdbPathLocus_MakeEntry(&(*cheapest_path)->locus);
 			else if (exec_location == PROEXECLOCATION_ALL_SEGMENTS)
-				CdbPathLocus_MakeStrewn(&(*cheapest_path)->locus);
+				CdbPathLocus_MakeStrewn(&(*cheapest_path)->locus,
+										GP_POLICY_ALL_NUMSEGMENTS);
 		}
 
 		return;

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -33,6 +33,7 @@
 
 #include "catalog/pg_proc.h"
 #include "cdb/cdbpath.h"        /* cdbpath_rows() */
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 
 static Bitmapset *distcols_in_groupclause(List *gc, Bitmapset *bms);
@@ -524,7 +525,7 @@ num_distcols_in_grouplist(List *gc)
 PlannerConfig *DefaultPlannerConfig(void)
 {
 	PlannerConfig *c1 = (PlannerConfig *) palloc(sizeof(PlannerConfig));
-	c1->cdbpath_segments = planner_segment_count();
+	c1->cdbpath_segments = planner_segment_count(NULL);
 	c1->enable_seqscan = enable_seqscan;
 	c1->enable_indexscan = enable_indexscan;
 	c1->enable_bitmapscan = enable_bitmapscan;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -568,7 +568,8 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	if (Gp_role == GP_ROLE_DISPATCH && gp_session_id > -1)
 	{
 		/* Choose a segdb to which our singleton gangs should be dispatched. */
-		gp_singleton_segindex = gp_session_id % getgpsegmentCount();
+		/* FIXME: do not hard code to 0 */
+		gp_singleton_segindex = 0;
 	}
 
 	root->hasRecursion = hasRecursion;
@@ -1083,6 +1084,8 @@ inheritance_planner(PlannerInfo *root)
 	List	   *returningLists = NIL;
 	List	   *rowMarks;
 	ListCell   *lc;
+	GpPolicy   *parentPolicy = NULL;
+	Oid			parentOid = InvalidOid;
 
 	/* MPP */
 	Plan	   *plan;
@@ -1114,6 +1117,17 @@ inheritance_planner(PlannerInfo *root)
 		/* append_rel_list contains all append rels; ignore others */
 		if (appinfo->parent_relid != parentRTindex)
 			continue;
+
+		if (!parentPolicy)
+		{
+			parentPolicy = GpPolicyFetch(NULL, appinfo->parent_reloid);
+			parentOid = appinfo->parent_reloid;
+
+			Assert(parentPolicy != NULL);
+			Assert(parentOid != InvalidOid);
+		}
+
+		Assert(parentOid == appinfo->parent_reloid);
 
 		/*
 		 * We need a working copy of the PlannerInfo so that we can control
@@ -1313,6 +1327,8 @@ inheritance_planner(PlannerInfo *root)
 									 subroot.parse->returningList);
 	}
 
+	Assert(parentPolicy != NULL);
+
 	/* Mark result as unordered (probably unnecessary) */
 	root->query_pathkeys = NIL;
 
@@ -1333,7 +1349,7 @@ inheritance_planner(PlannerInfo *root)
 									NULL);
 
 		if (Gp_role == GP_ROLE_DISPATCH)
-			mark_plan_general(plan);
+			mark_plan_general(plan, parentPolicy->numsegments);
 
 		return plan;
 	}
@@ -1498,7 +1514,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	gp_motion_cost_per_row :
 	2.0 * cpu_tuple_cost;
 
-	CdbPathLocus_MakeNull(&current_locus);
+	CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
 
 	/* Tweak caller-supplied tuple_fraction if have LIMIT/OFFSET */
 	if (parse->limitCount || parse->limitOffset)
@@ -1984,7 +2000,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 
 				/* Hashed aggregation produces randomly-ordered results */
 				current_pathkeys = NIL;
-				CdbPathLocus_MakeNull(&current_locus);
+				CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
 			}
 			else if (!grpext && (parse->hasAggs || parse->groupClause))
 			{
@@ -2049,7 +2065,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 												  0);
 				}
 
-				CdbPathLocus_MakeNull(&current_locus);
+				CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
 			}
 			else if (grpext && (parse->hasAggs || parse->groupClause))
 			{
@@ -2109,7 +2125,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 							make_pathkeys_for_sortclauses(root,
 														  parse->sortClause,
 														  result_plan->targetlist);
-					CdbPathLocus_MakeNull(&current_locus);
+					CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
 				}
 			}
 			else if (root->hasHavingQual)
@@ -2126,14 +2142,16 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				 * this routine to avoid having to generate the plan in the
 				 * first place.
 				 */
+				/* FIXME: numsegments, is policy needed? */
+
 				result_plan = (Plan *) make_result(root,
 												   tlist,
 												   parse->havingQual,
 												   NULL);
 				/* Result will be only one row anyway; no sort order */
 				current_pathkeys = NIL;
-				mark_plan_general(result_plan);
-				CdbPathLocus_MakeNull(&current_locus);
+				mark_plan_general(result_plan, GP_POLICY_ALL_NUMSEGMENTS);
+				CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
 			}
 		}						/* end of non-minmax-aggregate case */
 
@@ -2277,7 +2295,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 						 * Change current_locus based on the new distribution
 						 * pathkeys.
 						 */
-						CdbPathLocus_MakeHashed(&current_locus, partition_dist_keys);
+						CdbPathLocus_MakeHashed(&current_locus, partition_dist_keys,
+												CdbPathLocus_NumSegments(current_locus));
 						need_gather_for_partitioning = false;
 					}
 				}
@@ -2862,7 +2881,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		 * Repartition the subquery plan based on our distribution
 		 * requirements
 		 */
-		r = repartitionPlan(result_plan, false, false, exprList);
+		r = repartitionPlan(result_plan, false, false, exprList,
+							result_plan->flow->numsegments);
 		if (!r)
 		{
 			/*

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -38,6 +38,7 @@
 #include "utils/selfuncs.h"
 
 #include "cdb/cdbpath.h"        /* cdb_create_motion_path() etc */
+#include "cdb/cdbutil.h"		/* getgpsegmentCount() */
 
 typedef enum
 {
@@ -1403,7 +1404,9 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 	/* If no subpath, any worker can execute this Append.  Result has 0 rows. */
 	if (!subpaths)
 	{
-		CdbPathLocus_MakeGeneral(&pathnode->locus);
+		/* FIXME: do not hard code to ALL */
+		CdbPathLocus_MakeGeneral(&pathnode->locus,
+								 GP_POLICY_ALL_NUMSEGMENTS);
 		return;
 	}
 
@@ -1462,7 +1465,25 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 				if (!CdbPathLocus_IsSingleQE(subpath->locus))
 				{
 					CdbPathLocus    singleQE;
-					CdbPathLocus_MakeSingleQE(&singleQE);
+					/*
+					 * It's important to ensure that all the subpaths can be
+					 * gathered to the SAME segment, we must set the same
+					 * numsegments for all the SingleQE, there are many
+					 * options:
+					 *
+					 * 1. a constant 1;
+					 * 2. Min(numsegments of all subpaths);
+					 * 3. Max(numsegments of all subpaths);
+					 * 4. ALL;
+					 *
+					 * Options 2 & 3 need to decide the value with an extra
+					 * scan, option 1 puts all the SingleQE on segment 0
+					 * which makes segment 0 a bottle neck.  So we choose
+					 * option 4, ALL helps to balance the load on all the
+					 * segments and no extra scan is needed.
+					 */
+					int			numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+					CdbPathLocus_MakeSingleQE(&singleQE, numsegments);
 
 					subpath = cdbpath_create_motion_path(root, subpath, subpath->pathkeys, false, singleQE);
 				}
@@ -1511,7 +1532,8 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 		}
 		else if (CdbPathLocus_IsPartitioned(pathnode->locus) &&
 				 CdbPathLocus_IsPartitioned(projectedlocus))
-			CdbPathLocus_MakeStrewn(&pathnode->locus);
+			CdbPathLocus_MakeStrewn(&pathnode->locus,
+									CdbPathLocus_NumSegments(projectedlocus));
 		else
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg_internal("cannot append paths with incompatible distribution")));
@@ -1551,7 +1573,8 @@ create_result_path(List *quals)
 	pathnode->path.startup_cost = 0;
 	pathnode->path.total_cost = cpu_tuple_cost;
 
-	CdbPathLocus_MakeGeneral(&pathnode->path.locus);
+	/* Result can be on any segments */
+	CdbPathLocus_MakeGeneral(&pathnode->path.locus, GP_POLICY_ALL_NUMSEGMENTS);
 	pathnode->path.motionHazard = false;
 	pathnode->path.rescannable = true;
 
@@ -1793,7 +1816,8 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 	if (!CdbPathLocus_IsBottleneck(subpath->locus) &&
 		!cdbpathlocus_is_hashed_on_exprs(subpath->locus, uniq_exprs))
 	{
-        locus = cdbpathlocus_from_exprs(root, uniq_exprs);
+        locus = cdbpathlocus_from_exprs(root, uniq_exprs,
+										rel->cdbpolicy->numsegments);
         subpath = cdbpath_create_motion_path(root, subpath, NIL, false, locus);
 		/*
 		 * We probably add agg/sort node above the added motion node, but it is
@@ -2227,7 +2251,8 @@ create_unique_rowid_path(PlannerInfo *root,
         pathnode->must_repartition = true;
 
         /* Set a fake locus.  Repartitioning key won't be built until later. */
-        CdbPathLocus_MakeStrewn(&pathnode->path.locus);
+        CdbPathLocus_MakeStrewn(&pathnode->path.locus,
+								CdbPathLocus_NumSegments(subpath->locus));
 		pathnode->path.sameslice_relids = NULL;
 
         /* Estimate repartitioning cost. */
@@ -2522,7 +2547,8 @@ create_functionscan_path(PlannerInfo *root, RelOptInfo *rel,
 		switch (exec_location)
 		{
 			case PROEXECLOCATION_ANY:
-				CdbPathLocus_MakeGeneral(&pathnode->locus);
+				CdbPathLocus_MakeGeneral(&pathnode->locus,
+										 GP_POLICY_ALL_NUMSEGMENTS);
 
 				/*
 				 * If the function is ON ANY, we presumably could execute the
@@ -2534,13 +2560,15 @@ create_functionscan_path(PlannerInfo *root, RelOptInfo *rel,
 				if (contain_mutable_functions(rte->funcexpr))
 					CdbPathLocus_MakeEntry(&pathnode->locus);
 				else
-					CdbPathLocus_MakeGeneral(&pathnode->locus);
+					CdbPathLocus_MakeGeneral(&pathnode->locus,
+											 GP_POLICY_ALL_NUMSEGMENTS);
 				break;
 			case PROEXECLOCATION_MASTER:
 				CdbPathLocus_MakeEntry(&pathnode->locus);
 				break;
 			case PROEXECLOCATION_ALL_SEGMENTS:
-				CdbPathLocus_MakeStrewn(&pathnode->locus);
+				CdbPathLocus_MakeStrewn(&pathnode->locus,
+										GP_POLICY_ALL_NUMSEGMENTS);
 				break;
 			default:
 				elog(ERROR, "unrecognized proexeclocation '%c'", exec_location);
@@ -2556,7 +2584,8 @@ create_functionscan_path(PlannerInfo *root, RelOptInfo *rel,
 		if (contain_mutable_functions(rte->funcexpr))
 			CdbPathLocus_MakeEntry(&pathnode->locus);
 		else
-			CdbPathLocus_MakeGeneral(&pathnode->locus);
+			CdbPathLocus_MakeGeneral(&pathnode->locus,
+									 GP_POLICY_ALL_NUMSEGMENTS);
 	}
 
 	pathnode->motionHazard = false;
@@ -2605,7 +2634,8 @@ create_tablefunction_path(PlannerInfo *root, RelOptInfo *rel,
 
 	/* Mark the output as random if the input is partitioned */
 	if (CdbPathLocus_IsPartitioned(pathnode->locus))
-		CdbPathLocus_MakeStrewn(&pathnode->locus);
+		CdbPathLocus_MakeStrewn(&pathnode->locus,
+								CdbPathLocus_NumSegments(pathnode->locus));
 	pathnode->sameslice_relids = NULL;
 
 	cost_tablefunction(pathnode, root, rel, pathnode->param_info);
@@ -2639,7 +2669,10 @@ create_valuesscan_path(PlannerInfo *root, RelOptInfo *rel,
 	if (contain_mutable_functions((Node *)rte->values_lists))
 		CdbPathLocus_MakeEntry(&pathnode->locus);
 	else
-		CdbPathLocus_MakeGeneral(&pathnode->locus);
+		/*
+		 * ValuesScan can be on any segment.
+		 */
+		CdbPathLocus_MakeGeneral(&pathnode->locus, GP_POLICY_ALL_NUMSEGMENTS);
 
 	pathnode->motionHazard = false;
 	pathnode->rescannable = true;
@@ -2694,17 +2727,23 @@ create_worktablescan_path(PlannerInfo *root, RelOptInfo *rel,
 {
 	Path	   *pathnode = makeNode(Path);
 	CdbPathLocus result;
+	int			numsegments;
+
+	if (rel->cdbpolicy)
+		numsegments = rel->cdbpolicy->numsegments;
+	else
+		numsegments = GP_POLICY_ALL_NUMSEGMENTS; /* FIXME */
 
 	if (ctelocus == CdbLocusType_Entry)
 		CdbPathLocus_MakeEntry(&result);
 	else if (ctelocus == CdbLocusType_SingleQE)
-		CdbPathLocus_MakeSingleQE(&result);
+		CdbPathLocus_MakeSingleQE(&result, numsegments);
 	else if (ctelocus == CdbLocusType_General)
-		CdbPathLocus_MakeGeneral(&result);
+		CdbPathLocus_MakeGeneral(&result, numsegments);
 	else if (ctelocus == CdbLocusType_SegmentGeneral)
-		CdbPathLocus_MakeSegmentGeneral(&result);
+		CdbPathLocus_MakeSegmentGeneral(&result, numsegments);
 	else
-		CdbPathLocus_MakeStrewn(&result);
+		CdbPathLocus_MakeStrewn(&result, numsegments);
 
 	pathnode->pathtype = T_WorkTableScan;
 	pathnode->parent = rel;

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -158,7 +158,7 @@ build_simple_rel(PlannerInfo *root, int relid, RelOptKind reloptkind)
 															   origpolicy->numsegments);
 
 				/* Scribble the tuple number of rel to reflect the real size */
-				rel->tuples = rel->tuples * planner_segment_count();
+				rel->tuples = rel->tuples * planner_segment_count(rel->cdbpolicy);
 			}
 
 			if ((root->parse->commandType == CMD_UPDATE ||

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -152,7 +152,10 @@ build_simple_rel(PlannerInfo *root, int relid, RelOptKind reloptkind)
 			/* if we've been asked to, force the dist-policy to be partitioned-randomly. */
 			if (rte->forceDistRandom)
 			{
-				rel->cdbpolicy = createRandomPartitionedPolicy(NULL);
+				GpPolicy   *origpolicy = GpPolicyFetch(NULL, rte->relid);
+
+				rel->cdbpolicy = createRandomPartitionedPolicy(NULL,
+															   origpolicy->numsegments);
 
 				/* Scribble the tuple number of rel to reflect the real size */
 				rel->tuples = rel->tuples * planner_segment_count();

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3555,7 +3555,7 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 						MaxPolicyAttributeNumber)));
 
 	if (dist->ptype == POLICYTYPE_REPLICATED)
-		qry->intoPolicy = createReplicatedGpPolicy(NULL);
+		qry->intoPolicy = createReplicatedGpPolicy(NULL, dist->numsegments);
 	else
 	{
 		List	*policykeys = NIL;
@@ -3577,6 +3577,7 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 			policykeys = lappend_int(policykeys, keyindex);
 		}
 
-		qry->intoPolicy = createHashPartitionedPolicy(NULL, policykeys);
+		qry->intoPolicy = createHashPartitionedPolicy(NULL, policykeys,
+													  dist->numsegments);
 	}
 }

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -65,6 +65,7 @@
 #include "utils/datetime.h"
 #include "utils/numeric.h"
 #include "utils/xml.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 
 #include "utils/guc.h"
@@ -4611,6 +4612,7 @@ DistributedBy:   DISTRIBUTED BY  '(' columnListUnique ')'
 			{
 				DistributedBy *distributedBy = makeNode(DistributedBy);
 				distributedBy->ptype = POLICYTYPE_PARTITIONED;
+				distributedBy->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
 				distributedBy->keys = $4;
 				$$ = (Node *)distributedBy;
 			}
@@ -4618,6 +4620,7 @@ DistributedBy:   DISTRIBUTED BY  '(' columnListUnique ')'
 			{
 				DistributedBy *distributedBy = makeNode(DistributedBy);
 				distributedBy->ptype = POLICYTYPE_PARTITIONED;
+				distributedBy->numsegments = Max(1, getgpsegmentCount());
 				distributedBy->keys = NIL;
 				$$ = (Node *)distributedBy;
 			}
@@ -4625,6 +4628,7 @@ DistributedBy:   DISTRIBUTED BY  '(' columnListUnique ')'
 			{
 				DistributedBy *distributedBy = makeNode(DistributedBy);
 				distributedBy->ptype = POLICYTYPE_REPLICATED;
+				distributedBy->numsegments = Max(1, getgpsegmentCount());
 				distributedBy->keys = NIL;
 				$$ = (Node *)distributedBy;
 			}

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -33,21 +33,46 @@ CATALOG(gp_distribution_policy,5002) BKI_WITHOUT_OIDS
 	Oid			localoid;
 	int16		attrnums[1];
 	char		policytype; /* distribution policy type */
+	int32		numsegments;
 } FormData_gp_policy;
 
 /* GPDB added foreign key definitions for gpcheckcat. */
 FOREIGN_KEY(localoid REFERENCES pg_class(oid));
 
-#define Natts_gp_policy		3
+#define Natts_gp_policy		4
 #define Anum_gp_policy_localoid	1
 #define Anum_gp_policy_attrnums	2
 #define Anum_gp_policy_type	3
+#define Anum_gp_policy_numsegments	4
 
 /*
  * Symbolic values for Anum_gp_policy_type column
  */
 #define SYM_POLICYTYPE_PARTITIONED 'p'
 #define SYM_POLICYTYPE_REPLICATED 'r'
+
+/*
+ * A magic number, setting GpPolicy.numsegments to this value will cause a
+ * failed assertion at runtime, which allows developers to debug with gdb.
+ */
+#define __GP_POLICY_EVIL_NUMSEGMENTS		(666)
+
+/*
+ * All the segments.  getgpsegmentCount() should not be used directly as it
+ * will return 0 in utility mode, but a valid numsegments should always be
+ * greater than 0.
+ */
+#define GP_POLICY_ALL_NUMSEGMENTS			Max(1, getgpsegmentCount())
+
+/*
+ * The segments suitable for Entry locus, which include both master and all
+ * the segments.
+ *
+ * FIXME: in fact numsegments only describe a range of segments from 0 to
+ * `numsegments-1`, master is not described by it at all.  So far this does
+ * not matter.
+ */
+#define GP_POLICY_ENTRY_NUMSEGMENTS			GP_POLICY_ALL_NUMSEGMENTS
 
 /*
  * GpPolicyType represents a type of policy under which a relation's
@@ -72,6 +97,7 @@ typedef struct GpPolicy
 {
 	NodeTag         type;
 	GpPolicyType ptype;
+	int			numsegments;
 
 	/* These fields apply to POLICYTYPE_PARTITIONED. */
 	int			nattrs;
@@ -121,10 +147,10 @@ bool GpPolicyIsPartitioned(const GpPolicy *policy);
 bool GpPolicyIsReplicated(const GpPolicy *policy);
 bool GpPolicyIsEntry(const GpPolicy *policy);
 
-extern GpPolicy *makeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs);
-extern GpPolicy *createReplicatedGpPolicy(MemoryContext mcxt);
-extern GpPolicy *createRandomPartitionedPolicy(MemoryContext mcxt);
-extern GpPolicy *createHashPartitionedPolicy(MemoryContext mcxt, List *keys);
+extern GpPolicy *makeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs, int numsegments);
+extern GpPolicy *createReplicatedGpPolicy(MemoryContext mcxt, int numsegments);
+extern GpPolicy *createRandomPartitionedPolicy(MemoryContext mcxt, int numsegments);
+extern GpPolicy *createHashPartitionedPolicy(MemoryContext mcxt, List *keys, int numsegments);
 
 extern bool IsReplicatedTable(Oid relid);
 

--- a/src/include/cdb/cdbllize.h
+++ b/src/include/cdb/cdbllize.h
@@ -30,12 +30,14 @@ extern Plan *cdbparallelize(struct PlannerInfo *root, Plan *plan, Query *query,
 
 extern bool is_plan_node(Node *node);
 
-extern Flow *makeFlow(FlowType flotype);
+extern Flow *makeFlow(FlowType flotype, int numsegments);
 
 extern Flow *pull_up_Flow(Plan *plan, Plan *subplan);
 
 extern bool focusPlan(Plan *plan, bool stable, bool rescannable);
-extern bool repartitionPlan(Plan *plan, bool stable, bool rescannable, List *hashExpr);
-extern bool broadcastPlan(Plan *plan, bool stable, bool rescannable);
+extern bool repartitionPlan(Plan *plan, bool stable, bool rescannable,
+							List *hashExpr, int numsegments);
+extern bool broadcastPlan(Plan *plan, bool stable, bool rescannable,
+						  int numsegments);
 
 #endif   /* CDBLLIZE_H */

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -24,17 +24,23 @@
 extern Plan *apply_motion(struct PlannerInfo *root, Plan *plan, Query *query);
 
 extern Motion *make_union_motion(Plan *lefttree,
-		                                int destSegIndex, bool useExecutorVarFormat);
+								 int destSegIndex, bool useExecutorVarFormat,
+								 int numsegments);
 extern Motion *make_sorted_union_motion(PlannerInfo *root,
-						 Plan *lefttree,
-						 int numSortCols, AttrNumber *sortColIdx,
-						 Oid *sortOperators, Oid *collations, bool *nullsFirst,
-						 int destSegIndex,
-						 bool useExecutorVarFormat);
+										Plan *lefttree,
+										int numSortCols, AttrNumber *sortColIdx,
+										Oid *sortOperators, Oid *collations, bool *nullsFirst,
+										int destSegIndex,
+										bool useExecutorVarFormat,
+										int numsegments);
 extern Motion *make_hashed_motion(Plan *lefttree,
-				    List *hashExpr, bool useExecutorVarFormat);
+								  List *hashExpr,
+								  bool useExecutorVarFormat,
+								  int numsegments);
 
-extern Motion *make_broadcast_motion(Plan *lefttree, bool useExecutorVarFormat);
+extern Motion *make_broadcast_motion(Plan *lefttree,
+									 bool useExecutorVarFormat,
+									 int numsegments);
 
 extern Motion *make_explicit_motion(Plan *lefttree, AttrNumber segidColIdx, bool useExecutorVarFormat);
 

--- a/src/include/cdb/cdbsetop.h
+++ b/src/include/cdb/cdbsetop.h
@@ -90,21 +90,21 @@ extern
 void mark_sort_locus(Plan *plan);
 
 extern
-void mark_plan_general(Plan* plan);
+void mark_plan_general(Plan* plan, int numsegments);
 
 extern
-void mark_plan_strewn(Plan* plan);
+void mark_plan_strewn(Plan* plan, int numsegments);
 
 extern
-void mark_plan_replicated(Plan* plan);
+void mark_plan_replicated(Plan* plan, int numsegments);
 
 extern
 void mark_plan_entry(Plan* plan);
 
 extern
-void mark_plan_singleQE(Plan* plan);
+void mark_plan_singleQE(Plan* plan, int numsegments);
 
 extern
-void mark_plan_segment_general(Plan* plan);
+void mark_plan_segment_general(Plan* plan, int numsegments);
 
 #endif   /* CDBSETOP_H */

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -650,7 +650,8 @@ namespace gpdb {
 	// returns true if a query cancel is requested in GPDB
 	bool IsAbortRequested(void);
 
-	GpPolicy *MakeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs);
+	GpPolicy *MakeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs,
+						   int numsegments);
 
 } //namespace gpdb
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1142,6 +1142,7 @@ typedef struct DistributedBy
 {
 	NodeTag		type;
 	GpPolicyType ptype;
+	int			numsegments;
 	List	   *keys; /* valid when ptype is POLICYTYPE_PARTITIONED */
 } DistributedBy;
 

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1453,6 +1453,7 @@ typedef struct Flow
 	 * the desired segment for the resulting singleton flow.
 	 */
 	int			segindex;		/* Segment index of singleton flow. */
+	int         numsegments;
 
 	/* If req_move is MOVEMENT_REPARTITION, these express the desired
      * partitioning for a hash motion.  Else if flotype is FLOW_PARTITIONED,

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -234,7 +234,7 @@ extern Selectivity clause_selectivity(PlannerInfo *root,
 				   JoinType jointype,
 				   SpecialJoinInfo *sjinfo,
 				   bool use_damping);
-extern int planner_segment_count(void);
+extern int planner_segment_count(GpPolicy *policy);
 extern double global_work_mem(PlannerInfo *root);
 
 #endif   /* COST_H */

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -88,7 +88,7 @@ set enable_seqscan to off;
 explain select * from atsdb where i = 1;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1)  (cost=0.00..200.27 rows=1 width=6)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=6)
    ->  Index Scan using atsdb_i_idx on atsdb  (cost=0.00..200.27 rows=1 width=6)
          Index Cond: i = 1
  Settings:  enable_seqscan=off
@@ -104,7 +104,7 @@ alter table atsdb set distributed by (i);
 explain select * from atsdb where i = 1;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1)  (cost=0.00..200.27 rows=1 width=6)
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..200.27 rows=1 width=6)
    ->  Index Scan using atsdb_i_idx on atsdb  (cost=0.00..200.27 rows=1 width=6)
          Index Cond: i = 1
  Settings:  enable_seqscan=off

--- a/src/test/regress/expected/arrays.out
+++ b/src/test/regress/expected/arrays.out
@@ -337,7 +337,7 @@ EXPLAIN SELECT ARRAY(select f2 from arrtest_f) AS "ARRAY";
 ------------------------------------------------------------------------------------
  Result  (cost=1.01..1.02 rows=1 width=0)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.01 rows=1 width=8)
+     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=8)
            ->  Seq Scan on arrtest_f  (cost=0.00..1.01 rows=1 width=8)
 (4 rows)
 

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1578,12 +1578,12 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 explain select string_agg(a, '') from mpp14125 group by b;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=8.32..9.20 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=8.32..9.20 rows=5 width=36)
    ->  GroupAggregate  (cost=8.32..9.20 rows=5 width=36)
          Group By: b
          ->  Sort  (cost=8.32..8.57 rows=50 width=55)
                Sort Key: b
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..5.00 rows=50 width=55)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..5.00 rows=50 width=55)
                      Hash Key: b
                      ->  Seq Scan on mpp14125  (cost=0.00..3.00 rows=50 width=55)
 (8 rows)

--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -1312,14 +1312,20 @@ NOTICE:  CREATE TABLE will create partition "r_co_1_prt_6" for table "r_co"
 NOTICE:  CREATE TABLE will create partition "r_co_1_prt_7" for table "r_co"
 NOTICE:  CREATE TABLE will create partition "r_co_1_prt_8" for table "r_co"
 NOTICE:  CREATE TABLE will create partition "r_co_1_prt_9" for table "r_co"
-insert into r_part values (1,1), (2,2), (3,3);
-select * from r_part order by a,b;
- a | b 
----+---
- 1 | 1
- 2 | 2
- 3 | 3
-(3 rows)
+insert into r_part values (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8);
+-- following tests rely on the data distribution, verify them
+select gp_segment_id, * from r_part order by a,b;
+ gp_segment_id | a | b 
+---------------+---+---
+             2 | 1 | 1
+             1 | 2 | 2
+             2 | 3 | 3
+             0 | 4 | 4
+             1 | 5 | 5
+             1 | 6 | 6
+             0 | 7 | 7
+             0 | 8 | 8
+(8 rows)
 
 analyze r_part;
 explain select * from r_part r1, r_part r2 where r1.a=1; -- should eliminate partitions in the r1 copy of r_part
@@ -1345,15 +1351,16 @@ explain select * from r_part r1, r_part r2 where r1.a=1; -- should eliminate par
  Optimizer: legacy query optimizer
 (18 rows)
 
-explain select * from r_part where a in (1,2); -- should eliminate partitions
+-- the numbers in the filter should be both on segment 0
+explain select * from r_part where a in (7,8); -- should eliminate partitions
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.02 rows=2 width=8)
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..2.02 rows=2 width=8)
    ->  Append  (cost=0.00..2.02 rows=1 width=8)
-         ->  Seq Scan on r_part_1_prt_1  (cost=0.00..1.01 rows=1 width=8)
-               Filter: a = ANY ('{1,2}'::integer[])
-         ->  Seq Scan on r_part_1_prt_2  (cost=0.00..1.01 rows=1 width=8)
-               Filter: a = ANY ('{1,2}'::integer[])
+         ->  Seq Scan on r_part_1_prt_7  (cost=0.00..1.01 rows=1 width=8)
+               Filter: a = ANY ('{7,8}'::integer[])
+         ->  Seq Scan on r_part_1_prt_8  (cost=0.00..1.01 rows=1 width=8)
+               Filter: a = ANY ('{7,8}'::integer[])
  Optimizer: legacy query optimizer
 (7 rows)
 

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -1313,14 +1313,20 @@ NOTICE:  CREATE TABLE will create partition "r_co_1_prt_6" for table "r_co"
 NOTICE:  CREATE TABLE will create partition "r_co_1_prt_7" for table "r_co"
 NOTICE:  CREATE TABLE will create partition "r_co_1_prt_8" for table "r_co"
 NOTICE:  CREATE TABLE will create partition "r_co_1_prt_9" for table "r_co"
-insert into r_part values (1,1), (2,2), (3,3);
-select * from r_part order by a,b;
- a | b 
----+---
- 1 | 1
- 2 | 2
- 3 | 3
-(3 rows)
+insert into r_part values (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8);
+-- following tests rely on the data distribution, verify them
+select gp_segment_id, * from r_part order by a,b;
+ gp_segment_id | a | b 
+---------------+---+---
+             2 | 1 | 1
+             1 | 2 | 2
+             2 | 3 | 3
+             0 | 4 | 4
+             1 | 5 | 5
+             1 | 6 | 6
+             0 | 7 | 7
+             0 | 8 | 8
+(8 rows)
 
 analyze r_part;
 explain select * from r_part r1, r_part r2 where r1.a=1; -- should eliminate partitions in the r1 copy of r_part
@@ -1343,19 +1349,18 @@ explain select * from r_part r1, r_part r2 where r1.a=1; -- should eliminate par
  Optimizer: PQO version 2.74.0
 (15 rows)
 
-explain select * from r_part where a in (1,2); -- should eliminate partitions
+-- the numbers in the filter should be both on segment 0
+explain select * from r_part where a in (7,8); -- should eliminate partitions
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=2 width=8)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
          ->  Partition Selector for r_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-               Filter: a = 1 OR a = 2
                Partitions selected: 2 (out of 9)
          ->  Dynamic Table Scan on r_part (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
-               Filter: a = ANY ('{1,2}'::integer[])
- Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
-(9 rows)
+               Filter: a = ANY ('{7,8}'::integer[])
+ Optimizer: PQO version 2.71.0
+(7 rows)
 
 -- Test partition elimination in prepared statements
 prepare f1(int) as select * from r_part where a = 1 order by a,b; 

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -433,7 +433,7 @@ set optimizer_enable_bitmapscan=off;
 explain select * from bm_test where j = 1;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..400.28 rows=1 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..400.28 rows=1 width=8)
    ->  Index Scan using bm_test_j on bm_test  (cost=0.00..400.28 rows=1 width=8)
          Index Cond: j = 1
  Settings:  enable_bitmapscan=off; enable_indexscan=on; enable_seqscan=off

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -433,7 +433,7 @@ set optimizer_enable_bitmapscan=off;
 explain select * from bm_test where j = 1;
                                    QUERY PLAN                                    
 -----------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2.03 rows=1 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.03 rows=1 width=8)
    ->  Table Scan on bm_test  (cost=0.00..1.03 rows=1 width=8)
          Filter: j = 1
  Settings:  enable_bitmapscan=off; enable_indexscan=on; enable_seqscan=off; optimizer=on

--- a/src/test/regress/expected/co_nestloop_idxscan.out
+++ b/src/test/regress/expected/co_nestloop_idxscan.out
@@ -13,7 +13,7 @@ create index foo_id_idx on co_nestloop_idxscan.foo(id);
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=1.02..32.07 rows=2 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..32.07 rows=2 width=8)
    ->  Hash Join  (cost=1.02..32.07 rows=2 width=8)
          Hash Cond: f.id = b.id
          ->  Append-only Columnar Scan on foo f  (cost=0.00..31.01 rows=1 width=8)
@@ -34,7 +34,7 @@ set enable_nestloop=on;
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..32.03 rows=2 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..32.03 rows=2 width=8)
    ->  Nested Loop  (cost=0.00..32.03 rows=2 width=8)
          Join Filter: f.id = b.id
          ->  Append-only Columnar Scan on foo f  (cost=0.00..31.01 rows=1 width=8)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -8112,7 +8112,7 @@ select * from orca.t order by 1,2;
 explain select * from orca.t order by 1,2;
                                              QUERY PLAN
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=32)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=32)
    Merge Key: timest, user_id
    ->  Sequence  (cost=0.00..431.00 rows=1 width=32)
          ->  Partition Selector for t (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
@@ -9492,17 +9492,17 @@ where c.cid = s.cid and s.date_sk = d.date_sk and
       ((d.year = 2001 and lower(s.type) = 't1' and plusone(d.moy) = 5) or (d.moy = 4 and upper(s.type) = 'T2'));
                                                                                       QUERY PLAN
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..1293.00 rows=1 width=24)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=24)
    ->  Hash Join  (cost=0.00..1293.00 rows=1 width=24)
          Hash Cond: cust.cid = sales.cid
          ->  Table Scan on cust  (cost=0.00..431.00 rows=1 width=20)
          ->  Hash  (cost=862.00..862.00 rows=1 width=8)
-               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..862.00 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
                      Hash Key: sales.cid
                      ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
                            Hash Cond: sales.date_sk = datedim.date_sk
                            Join Filter: (datedim.year = 2001 AND lower(sales.type) = 't1'::text AND plusone(datedim.moy) = 5) OR (datedim.moy = 4 AND upper(sales.type) = 'T2'::text)
-                           ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=16)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
                                  Hash Key: sales.date_sk
                                  ->  Table Scan on sales  (cost=0.00..431.00 rows=1 width=16)
                                        Filter: lower(type) = 't1'::text OR upper(type) = 'T2'::text

--- a/src/test/regress/expected/indexjoin.out
+++ b/src/test/regress/expected/indexjoin.out
@@ -92,19 +92,19 @@ GROUP BY 1
 ORDER BY 1 asc ;
                                                                    QUERY PLAN                                                                   
 ------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=13720.17..13721.20 rows=206 width=16)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=13720.17..13721.20 rows=206 width=16)
    Merge Key: fivemin
    ->  Sort  (cost=13720.17..13721.20 rows=206 width=16)
          Sort Key: partial_aggregation.unnamed_attr_1
          ->  HashAggregate  (cost=13697.13..13702.28 rows=206 width=16)
                Group By: "?column1?"
-               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=13679.62..13690.95 rows=206 width=16)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=13679.62..13690.95 rows=206 width=16)
                      Hash Key: unnamed_attr_1
                      ->  HashAggregate  (cost=13679.62..13682.71 rows=206 width=16)
                            Group By: tt.event_ts / 100000 / 5 * 5
                            ->  Nested Loop  (cost=0.00..13452.65 rows=22697 width=8)
                                  Join Filter: tq.sym::bpchar = tt.symbol
-                                 ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..17.80 rows=420 width=25)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..17.80 rows=420 width=25)
                                        ->  Seq Scan on my_tt_agg_small tt  (cost=0.00..5.20 rows=210 width=25)
                                  ->  Index Scan using my_tq_agg_small_ets_end_ts_ix on my_tq_agg_small tq  (cost=0.00..11.65 rows=113 width=20)
                                        Index Cond: tt.event_ts >= tq.ets AND tt.event_ts < tq.end_ts

--- a/src/test/regress/expected/indexjoin_1.out
+++ b/src/test/regress/expected/indexjoin_1.out
@@ -29,13 +29,13 @@ GROUP BY 1
 ORDER BY 1 asc ;
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=7250.73..7251.76 rows=412 width=16)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=7250.73..7251.76 rows=412 width=16)
    Merge Key: fivemin
    ->  Sort  (cost=7250.73..7251.76 rows=206 width=16)
          Sort Key: partial_aggregation.unnamed_attr_1
          ->  HashAggregate  (cost=7227.69..7232.84 rows=206 width=16)
                Group By: "?column1?"
-               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=7210.18..7221.51 rows=206 width=16)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=7210.18..7221.51 rows=206 width=16)
                      Hash Key: unnamed_attr_1
                      ->  HashAggregate  (cost=7210.18..7213.27 rows=206 width=16)
                            Group By: tt.event_ts / 100000 / 5 * 5
@@ -44,7 +44,7 @@ ORDER BY 1 asc ;
                                  Join Filter: tt.event_ts >= tq.ets AND tt.event_ts < tq.end_ts
                                  ->  Seq Scan on my_tq_agg_small tq  (cost=0.00..26.27 rows=1014 width=20)
                                  ->  Hash  (cost=18.80..18.80 rows=420 width=25)
-                                       ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..18.80 rows=420 width=25)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.80 rows=420 width=25)
                                              ->  Seq Scan on my_tt_agg_small tt  (cost=0.00..6.20 rows=210 width=25)
 (17 rows)
 
@@ -90,19 +90,19 @@ GROUP BY 1
 ORDER BY 1 asc ;
                                                                    QUERY PLAN                                                                   
 ------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=13721.17..13722.20 rows=412 width=16)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=13721.17..13722.20 rows=412 width=16)
    Merge Key: fivemin
    ->  Sort  (cost=13721.17..13722.20 rows=206 width=16)
          Sort Key: partial_aggregation.unnamed_attr_1
          ->  HashAggregate  (cost=13698.13..13703.28 rows=206 width=16)
                Group By: "?column1?"
-               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=13680.62..13691.95 rows=206 width=16)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=13680.62..13691.95 rows=206 width=16)
                      Hash Key: unnamed_attr_1
                      ->  HashAggregate  (cost=13680.62..13683.71 rows=206 width=16)
                            Group By: tt.event_ts / 100000 / 5 * 5
                            ->  Nested Loop  (cost=0.00..13453.65 rows=22697 width=8)
                                  Join Filter: tq.sym::bpchar = tt.symbol
-                                 ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..18.80 rows=420 width=25)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.80 rows=420 width=25)
                                        ->  Seq Scan on my_tt_agg_small tt  (cost=0.00..6.20 rows=210 width=25)
                                  ->  Index Scan using my_tq_agg_small_ets_end_ts_ix on my_tq_agg_small tq  (cost=0.00..11.65 rows=113 width=20)
                                        Index Cond: tt.event_ts >= tq.ets AND tt.event_ts < tq.end_ts

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -8,7 +8,7 @@ insert into nhtest values(300000.19);
 explain select * from nhtest a join nhtest b using (i);
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=1.02..2.07 rows=2 width=11)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..2.07 rows=2 width=11)
    ->  Hash Join  (cost=1.02..2.07 rows=2 width=11)
          Hash Cond: (a.i = b.i)
          ->  Seq Scan on nhtest a  (cost=0.00..1.01 rows=1 width=11)
@@ -96,10 +96,10 @@ explain select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Aggregate  (cost=6.60..6.61 rows=1 width=8)
-   ->  Gather Motion 2:1  (slice2; segments: 2)  (cost=6.54..6.58 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=6.54..6.58 rows=1 width=8)
          ->  Aggregate  (cost=6.54..6.55 rows=1 width=8)
                ->  Nested Loop  (cost=0.00..6.53 rows=2 width=0)
-                     ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..3.27 rows=1 width=4)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.27 rows=1 width=4)
                            Hash Key: t1.x
                            ->  Seq Scan on t1  (cost=0.00..3.25 rows=1 width=4)
                                  Filter: (x = 100)
@@ -120,13 +120,13 @@ select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
 explain select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=3.28..6.58 rows=2 width=24)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=3.28..6.58 rows=2 width=24)
    ->  Nested Loop  (cost=3.28..6.58 rows=2 width=24)
          Join Filter: (t2.x >= t1.x)
          ->  Seq Scan on t1  (cost=0.00..3.25 rows=1 width=12)
                Filter: (x = 100)
          ->  Materialize  (cost=3.28..3.30 rows=1 width=12)
-               ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..3.28 rows=1 width=12)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.28 rows=1 width=12)
                      ->  Seq Scan on t2  (cost=0.00..3.25 rows=1 width=12)
                            Filter: (x >= 100)
  Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off

--- a/src/test/regress/expected/olap_window.out
+++ b/src/test/regress/expected/olap_window.out
@@ -1596,7 +1596,7 @@ from sale_ord;
 -----------------------------------------------------------------------------------
  Window  (cost=2.34..2.67 rows=12 width=12)
    Order By: ord, cn
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.34..2.61 rows=6 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.34..2.61 rows=6 width=12)
          Merge Key: ord, cn
          ->  Sort  (cost=2.34..2.37 rows=6 width=12)
                Sort Key: ord, cn

--- a/src/test/regress/expected/olap_window_optimizer.out
+++ b/src/test/regress/expected/olap_window_optimizer.out
@@ -1597,7 +1597,7 @@ from sale_ord;
  Result  (cost=0.00..8.07 rows=6 width=24)
    ->  Window  (cost=0.00..8.07 rows=6 width=24)
          Order By: ord, cn
-         ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..6.50 rows=6 width=12)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.50 rows=6 width=12)
                Merge Key: ord, cn
                ->  Sort  (cost=0.00..5.43 rows=6 width=12)
                      Sort Key: ord, cn

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -1610,7 +1610,7 @@ from sale_ord;
 ---------------------------------------------------------------------------
  WindowAgg  (cost=2.34..2.67 rows=12 width=12)
    Order By: ord, cn
-   ->  Gather Motion 2:1  (slice1)  (cost=2.34..2.61 rows=12 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.34..2.61 rows=12 width=12)
          Merge Key: ord, cn
          ->  Sort  (cost=2.34..2.37 rows=6 width=12)
                Sort Key: ord, cn
@@ -8099,7 +8099,7 @@ select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, bar wher
 explain select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, bar where foo.a = bar.a;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=3.46..3.50 rows=5 width=12)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=3.46..3.50 rows=5 width=12)
    ->  WindowAgg  (cost=3.46..3.50 rows=3 width=12)
          Partition By: bar.a
          Order By: bar.b
@@ -8109,7 +8109,7 @@ explain select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, 
                      Hash Cond: foo.a = bar.a
                      ->  Seq Scan on foo  (cost=0.00..2.10 rows=5 width=4)
                      ->  Hash  (cost=1.15..1.15 rows=3 width=8)
-                           ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..1.15 rows=3 width=8)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.15 rows=3 width=8)
                                  Hash Key: bar.a
                                  ->  Seq Scan on bar  (cost=0.00..1.05 rows=3 width=8)
 (14 rows)

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -1611,7 +1611,7 @@ from sale_ord;
  Result  (cost=0.00..431.00 rows=6 width=24)
    ->  WindowAgg  (cost=0.00..431.00 rows=6 width=24)
          Order By: ord, cn
-         ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=12 width=12)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=12 width=12)
                Merge Key: ord, cn
                ->  Sort  (cost=0.00..431.00 rows=6 width=12)
                      Sort Key: ord, cn
@@ -8105,7 +8105,7 @@ select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, bar wher
 explain select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, bar where foo.a = bar.a;
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..862.00 rows=6 width=12)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=6 width=12)
    ->  Result  (cost=0.00..862.00 rows=3 width=12)
          ->  WindowAgg  (cost=0.00..862.00 rows=3 width=12)
                Partition By: bar.a
@@ -8114,7 +8114,7 @@ explain select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, 
                      Sort Key: bar.a, bar.b
                      ->  Hash Join  (cost=0.00..862.00 rows=3 width=12)
                            Hash Cond: bar.a = foo.a
-                           ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=3 width=8)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=8)
                                  Hash Key: bar.a
                                  ->  Table Scan on bar  (cost=0.00..431.00 rows=3 width=8)
                            ->  Hash  (cost=431.00..431.00 rows=5 width=4)

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -8241,7 +8241,7 @@ explain insert into window_preds select k from ( select row_number() over()+2 as
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Insert  (cost=0.00..862.04 rows=1 width=4)
-   ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..862.00 rows=2 width=16)
+   ->  Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..862.00 rows=2 width=16)
          Hash Key: (((row_number() OVER (?)) + 2)::integer)
          ->  Result  (cost=0.00..862.00 rows=1 width=16)
                ->  Append  (cost=0.00..862.00 rows=1 width=8)
@@ -8371,7 +8371,7 @@ explain insert into window_preds select k from ( select k from (select row_numbe
                                                        QUERY PLAN                                                        
 -------------------------------------------------------------------------------------------------------------------------
  Insert  (cost=0.00..862.04 rows=1 width=4)
-   ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..862.00 rows=2 width=16)
+   ->  Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..862.00 rows=2 width=16)
          Hash Key: ((row_number() OVER (?))::integer)
          ->  Result  (cost=0.00..862.00 rows=1 width=16)
                ->  Append  (cost=0.00..862.00 rows=1 width=8)

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -1,0 +1,3655 @@
+-- TODO: inherit tables
+-- TODO: partition tables
+-- TODO: ao tables
+-- TODO: tables and temp tables
+\set explain 'explain analyze'
+set allow_system_table_mods to true;
+--
+-- prepare kinds of tables
+--
+create temp table t1 (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+create temp table d1 (c1 int, c2 int, c3 int, c4 int) distributed replicated;
+create temp table r1 (c1 int, c2 int, c3 int, c4 int) distributed randomly;
+create temp table t2 (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+create temp table d2 (c1 int, c2 int, c3 int, c4 int) distributed replicated;
+create temp table r2 (c1 int, c2 int, c3 int, c4 int) distributed randomly;
+update gp_distribution_policy set numsegments=1
+	where localoid in ('t1'::regclass, 'd1'::regclass, 'r1'::regclass);
+update gp_distribution_policy set numsegments=2
+	where localoid in ('t2'::regclass, 'd2'::regclass, 'r2'::regclass);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in (
+		't1'::regclass, 'd1'::regclass, 'r1'::regclass,
+		't2'::regclass, 'd2'::regclass, 'r2'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t1       | {1,2}    | p          |           1
+ d1       |          | r          |           1
+ r1       |          | p          |           1
+ t2       | {1,2}    | p          |           2
+ d2       |          | r          |           2
+ r2       |          | p          |           2
+(6 rows)
+
+--
+-- create table
+--
+create temp table t (like t1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           1
+(1 row)
+
+drop table t;
+create temp table t as table t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1, c2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           3
+(1 row)
+
+drop table t;
+create temp table t as select * from t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1, c2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           3
+(1 row)
+
+drop table t;
+create temp table t as select * from t1 distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           3
+(1 row)
+
+drop table t;
+create temp table t as select * from t1 distributed replicated;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | r          |           3
+(1 row)
+
+drop table t;
+create temp table t as select * from t1 distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           3
+(1 row)
+
+drop table t;
+select * into temp table t from t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1, c2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           3
+(1 row)
+
+drop table t;
+--
+-- alter table
+--
+create table t (like t1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           1
+(1 row)
+
+alter table t set distributed replicated;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | r          |           1
+(1 row)
+
+alter table t set distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           1
+(1 row)
+
+alter table t set distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           1
+(1 row)
+
+alter table t add column c10 int;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           1
+(1 row)
+
+alter table t alter column c10 type text;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           1
+(1 row)
+
+drop table t;
+-- below join cases cover all the combinations of
+--
+--     select * from {t,d,r}{1,2} a
+--      {left,} join {t,d,r}{1,2} b
+--      using (c1{',c2',});
+--
+-- there might be some duplicated ones, like 't1 join d1' and 'd1 join t1',
+-- or 'd1 join r1 using (c1)' and 'd1 join r1 using (c1, c2)', this is because
+-- we generate them via scripts and do not clean them up manually.
+--
+-- please do not remove the duplicated ones as we care about the motion
+-- direction of different join orders, e.g. 't2 join t1' and 't1 join t2'
+-- should both distribute t2 to t1.
+--
+-- JOIN
+--
+-- x1 join y1
+:explain select * from t1 a join t1 b using (c1);
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=6321.25..1953565.85 rows=5055210 width=28) (actual time=2.618..2.618 rows=0 loops=2)
+   ->  Hash Join  (cost=6321.25..1953565.85 rows=1685070 width=28) (actual time=0.000..4.353 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+         ->  Hash  (cost=3655.00..3655.00 rows=71100 width=16) (actual time=0.000..0.007 rows=0 loops=1)
+               ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (actual time=0.000..0.006 rows=0 loops=1)
+                     ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 6.541 ms
+(13 rows)
+
+:explain select * from t1 a join t1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.247..0.247 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes avg x 3 workers, 78K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.148 ms
+(11 rows)
+
+:explain select * from t1 a join d1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.239..0.239 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.205 ms
+(11 rows)
+
+:explain select * from t1 a join d1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.179..0.179 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.016 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.027 ms
+(11 rows)
+
+:explain select * from t1 a join r1 b using (c1);
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=6321.25..1953565.85 rows=5055210 width=28) (actual time=2.035..2.035 rows=0 loops=2)
+   ->  Hash Join  (cost=6321.25..1953565.85 rows=1685070 width=28) (actual time=0.000..3.162 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+         ->  Hash  (cost=3655.00..3655.00 rows=71100 width=16) (actual time=0.000..0.644 rows=0 loops=1)
+               ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (actual time=0.000..0.644 rows=0 loops=1)
+                     ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.919 ms
+(13 rows)
+
+:explain select * from t1 a join r1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.638..1.638 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.303 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.034 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.182 ms
+(14 rows)
+
+:explain select * from d1 a join t1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.205..0.205 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.103 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.103 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.165 ms
+(11 rows)
+
+:explain select * from d1 a join t1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.181..0.181 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.223 ms
+(11 rows)
+
+:explain select * from d1 a join d1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.197..0.197 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.015 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.053 ms
+(11 rows)
+
+:explain select * from d1 a join d1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.198..0.198 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.015 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.028 ms
+(11 rows)
+
+:explain select * from d1 a join r1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.233..0.233 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.135 ms
+(11 rows)
+
+:explain select * from d1 a join r1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.179..0.179 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.070 ms
+(11 rows)
+
+:explain select * from r1 a join t1 b using (c1);
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=6321.25..1953565.85 rows=5055210 width=28) (actual time=2.547..2.547 rows=0 loops=2)
+   ->  Hash Join  (cost=6321.25..1953565.85 rows=1685070 width=28) (actual time=0.000..4.806 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+         ->  Hash  (cost=3655.00..3655.00 rows=71100 width=16) (actual time=0.000..2.952 rows=0 loops=1)
+               ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (actual time=0.000..2.951 rows=0 loops=1)
+                     ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 6.008 ms
+(13 rows)
+
+:explain select * from r1 a join t1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.854..1.854 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.481 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.028 rows=0 loops=1)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.638 ms
+(14 rows)
+
+:explain select * from r1 a join d1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.200..0.200 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.094 ms
+(11 rows)
+
+:explain select * from r1 a join d1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.200..0.200 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.032 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.031 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.085 ms
+(11 rows)
+
+:explain select * from r1 a join r1 b using (c1);
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=6321.25..1953565.85 rows=5055210 width=28) (actual time=1.854..1.854 rows=0 loops=2)
+   ->  Hash Join  (cost=6321.25..1953565.85 rows=1685070 width=28) (actual time=0.000..3.374 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+         ->  Hash  (cost=3655.00..3655.00 rows=71100 width=16) (actual time=0.000..1.479 rows=0 loops=1)
+               ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (actual time=0.000..1.478 rows=0 loops=1)
+                     ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.583 ms
+(13 rows)
+
+:explain select * from r1 a join r1 b using (c1, c2);
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=6854.50..3799479.05 rows=5056 width=24) (actual time=1.801..1.801 rows=0 loops=2)
+   ->  Hash Join  (cost=6854.50..3799479.05 rows=1686 width=24) (actual time=0.000..3.319 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+         ->  Hash  (cost=3655.00..3655.00 rows=71100 width=16) (actual time=0.000..1.441 rows=0 loops=1)
+               ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (actual time=0.000..1.440 rows=0 loops=1)
+                     ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.447 ms
+(13 rows)
+
+-- x1 join y2
+:explain select * from t1 a join t2 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.482..1.482 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.550 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.055 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.053 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.039 ms
+(13 rows)
+
+:explain select * from t1 a join t2 b using (c1, c2);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=3299.50..1268319.05 rows=5056 width=24) (actual time=2.173..2.173 rows=0 loops=2)
+   ->  Hash Join  (cost=3299.50..1268319.05 rows=1686 width=24) (actual time=0.000..4.084 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..2.287 rows=0 loops=1)
+               ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..2.286 rows=0 loops=1)
+                     Hash Key: b.c1, b.c2
+                     ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 5.340 ms
+(14 rows)
+
+:explain select * from t1 a join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.314..0.314 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.370 ms
+(11 rows)
+
+:explain select * from t1 a join d2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.190..0.190 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.071 ms
+(11 rows)
+
+:explain select * from t1 a join r2 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.824..1.824 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.478 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.028 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.588 ms
+(13 rows)
+
+:explain select * from t1 a join r2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=2.078..2.078 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.362 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.042 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.040 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.038 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 5.159 ms
+(14 rows)
+
+:explain select * from d1 a join t2 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.488..1.488 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.058 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.004..0.004 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.003..0.003 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.018 ms
+(16 rows)
+
+:explain select * from d1 a join t2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=0.795..0.795 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.185 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.031 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.030 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.289 ms
+(14 rows)
+
+:explain select * from d1 a join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.214..0.214 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.036 ms
+(11 rows)
+
+:explain select * from d1 a join d2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.209..0.209 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.005 ms
+(11 rows)
+
+:explain select * from d1 a join r2 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.544..1.544 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.324..0.324 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.323..0.323 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.589 ms
+(16 rows)
+
+:explain select * from d1 a join r2 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=0.919..0.919 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.003..0.003 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 2.643 ms
+(16 rows)
+
+:explain select * from r1 a join t2 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.801..1.801 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.489 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.025 rows=0 loops=1)
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.024 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.490 ms
+(13 rows)
+
+:explain select * from r1 a join t2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.266..1.266 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.969 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.029 rows=0 loops=1)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.184 ms
+(14 rows)
+
+:explain select * from r1 a join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.294..0.294 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.073 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.073 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.169 ms
+(11 rows)
+
+:explain select * from r1 a join d2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.199..0.199 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.019 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.995 ms
+(11 rows)
+
+:explain select * from r1 a join r2 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.734..1.734 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.483 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.364 ms
+(13 rows)
+
+:explain select * from r1 a join r2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..3798057.05 rows=5056 width=24) (actual time=1.571..1.571 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..3798057.05 rows=1686 width=24) (actual time=0.000..2.437 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.029 rows=0 loops=1)
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.028 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.899 ms
+(13 rows)
+
+-- x2 join y1
+:explain select * from t2 a join t1 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.211..1.211 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.031 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.025 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.164 ms
+(13 rows)
+
+:explain select * from t2 a join t1 b using (c1, c2);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=3299.50..1268319.05 rows=5056 width=24) (actual time=1.479..1.479 rows=0 loops=2)
+   ->  Hash Join  (cost=3299.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.556 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..0.635 rows=0 loops=1)
+               ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.633 rows=0 loops=1)
+                     Hash Key: b.c1, b.c2
+                     ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.722 ms
+(14 rows)
+
+:explain select * from t2 a join d1 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.470..1.470 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.613..0.613 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.612..0.612 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.343 ms
+(16 rows)
+
+:explain select * from t2 a join d1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.815..1.815 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.410 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.008 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.025 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.357 ms
+(14 rows)
+
+:explain select * from t2 a join r1 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.463..1.463 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.380 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.008 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.030 rows=0 loops=1)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.029 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.651 ms
+(13 rows)
+
+:explain select * from t2 a join r1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.357..1.357 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.370 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.012 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.034 rows=0 loops=1)
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.546 ms
+(14 rows)
+
+:explain select * from d2 a join t1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.283..0.283 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.190 ms
+(11 rows)
+
+:explain select * from d2 a join t1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.196..0.196 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.016 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.001 ms
+(11 rows)
+
+:explain select * from d2 a join d1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.192..0.192 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.015 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.951 ms
+(11 rows)
+
+:explain select * from d2 a join d1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.202..0.202 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.014 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.969 ms
+(11 rows)
+
+:explain select * from d2 a join r1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.200..0.200 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.075 ms
+(11 rows)
+
+:explain select * from d2 a join r1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.198..0.198 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.016 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.028 ms
+(11 rows)
+
+:explain select * from r2 a join t1 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.407..1.407 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.410 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.647 ms
+(13 rows)
+
+:explain select * from r2 a join t1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.370..1.370 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.408 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.034 rows=0 loops=1)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.610 ms
+(14 rows)
+
+:explain select * from r2 a join d1 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.540..1.540 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.636..0.636 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.635..0.635 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.470 ms
+(16 rows)
+
+:explain select * from r2 a join d1 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.428..1.428 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.023 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.648..0.648 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.647..0.647 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.332 ms
+(16 rows)
+
+:explain select * from r2 a join r1 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.328..1.328 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.378 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.497 ms
+(13 rows)
+
+:explain select * from r2 a join r1 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..3798057.05 rows=5056 width=24) (actual time=1.363..1.363 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..3798057.05 rows=1686 width=24) (actual time=0.000..2.437 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.035 rows=0 loops=1)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.561 ms
+(13 rows)
+
+-- x2 join y2
+:explain select * from t2 a join t2 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=2.625..2.625 rows=0 loops=2)
+   ->  Hash Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..4.832 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: a.c1
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.012 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..3.169 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..3.167 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.024 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 12.201 ms
+(17 rows)
+
+:explain select * from t2 a join t2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.189..0.189 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes avg x 3 workers, 78K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.957 ms
+(11 rows)
+
+:explain select * from t2 a join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.287..0.287 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.908 ms
+(11 rows)
+
+:explain select * from t2 a join d2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.312..0.312 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.960 ms
+(11 rows)
+
+:explain select * from t2 a join r2 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=1.421..1.421 rows=0 loops=2)
+   ->  Hash Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..3.165 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: a.c1
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.204 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.203 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.328 ms
+(17 rows)
+
+:explain select * from t2 a join r2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.399..1.399 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.266 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.556 ms
+(14 rows)
+
+:explain select * from d2 a join t2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.185..0.185 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.972 ms
+(11 rows)
+
+:explain select * from d2 a join t2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.197..0.197 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.972 ms
+(11 rows)
+
+:explain select * from d2 a join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.196..0.196 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.015 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.893 ms
+(11 rows)
+
+:explain select * from d2 a join d2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.189..0.189 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.013 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.869 ms
+(11 rows)
+
+:explain select * from d2 a join r2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.201..0.201 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.103 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.103 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.087 ms
+(11 rows)
+
+:explain select * from d2 a join r2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.216..0.216 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.019 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.019 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.045 ms
+(11 rows)
+
+:explain select * from r2 a join t2 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=1.552..1.552 rows=0 loops=2)
+   ->  Hash Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..3.164 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: a.c1
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.273 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.271 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.302 ms
+(17 rows)
+
+:explain select * from r2 a join t2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.061..1.061 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1268319.05 rows=1686 width=24) (actual time=0.000..2.453 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.039 rows=0 loops=1)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.037 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.654 ms
+(14 rows)
+
+:explain select * from r2 a join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.245..0.245 rows=0 loops=2)
+   ->  Hash Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.075 ms
+(11 rows)
+
+:explain select * from r2 a join d2 b using (c1, c2);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1877.50..1266897.05 rows=5056 width=24) (actual time=0.180..0.180 rows=0 loops=2)
+   ->  Hash Join  (cost=1877.50..1266897.05 rows=1686 width=24) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.943 ms
+(11 rows)
+
+:explain select * from r2 a join r2 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=1.821..1.821 rows=0 loops=2)
+   ->  Hash Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..3.395 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: a.c1
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.527 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.526 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.498 ms
+(17 rows)
+
+:explain select * from r2 a join r2 b using (c1, c2);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3299.50..1269741.05 rows=5056 width=24) (actual time=2.001..2.001 rows=0 loops=2)
+   ->  Hash Join  (cost=3299.50..1269741.05 rows=1686 width=24) (actual time=0.000..3.243 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.378 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.377 rows=0 loops=1)
+                     Hash Key: b.c1, b.c2
+                     ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.819 ms
+(17 rows)
+
+-- x1 left join y1
+:explain select * from t1 a left join t1 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.423..1.423 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.392 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.025 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.543 ms
+(13 rows)
+
+:explain select * from t1 a left join t1 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.172..0.172 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes avg x 3 workers, 78K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.907 ms
+(11 rows)
+
+:explain select * from t1 a left join d1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.200..0.200 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.952 ms
+(11 rows)
+
+:explain select * from t1 a left join d1 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.183..0.183 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.077 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.076 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.982 ms
+(11 rows)
+
+:explain select * from t1 a left join r1 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.372..1.372 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.421 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.021 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.448 ms
+(13 rows)
+
+:explain select * from t1 a left join r1 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.411..1.411 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1877.50..1268979.50 rows=23700 width=24) (actual time=0.000..2.367 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.021 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.552 ms
+(14 rows)
+
+:explain select * from d1 a left join t1 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.584..1.584 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.676..0.676 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.675..0.675 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.561 ms
+(16 rows)
+
+:explain select * from d1 a left join t1 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=0.991..0.991 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.200..0.200 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.200..0.200 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.008 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 2.434 ms
+(16 rows)
+
+:explain select * from d1 a left join d1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.205..0.205 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.985 ms
+(11 rows)
+
+:explain select * from d1 a left join d1 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.200..0.200 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.015 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.906 ms
+(11 rows)
+
+:explain select * from d1 a left join r1 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.578..1.578 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.702..0.702 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.700..0.700 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.536 ms
+(16 rows)
+
+:explain select * from d1 a left join r1 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.507..1.507 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.663..0.663 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.663..0.663 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.429 ms
+(16 rows)
+
+:explain select * from r1 a left join t1 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.381..1.381 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.252 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.023 rows=0 loops=1)
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.021 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.601 ms
+(13 rows)
+
+:explain select * from r1 a left join t1 b using (c1, c2);
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.681..1.681 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1268979.50 rows=23700 width=24) (actual time=0.000..2.901 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.138 rows=0 loops=1)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.057 rows=0 loops=1)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.055 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.023 ms
+(14 rows)
+
+:explain select * from r1 a left join d1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.230..0.230 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.015 ms
+(11 rows)
+
+:explain select * from r1 a left join d1 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.194..0.194 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.101 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.101 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.979 ms
+(11 rows)
+
+:explain select * from r1 a left join r1 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.393..1.393 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.391 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.021 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.549 ms
+(13 rows)
+
+:explain select * from r1 a left join r1 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..3798717.50 rows=71100 width=24) (actual time=1.401..1.401 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1877.50..3798717.50 rows=23700 width=24) (actual time=0.000..2.158 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Broadcast Motion 1:1  (slice1; segments: 1)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.025 rows=0 loops=1)
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.023 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.448 ms
+(13 rows)
+
+-- x1 left join y2
+:explain select * from t1 a left join t2 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.409..1.409 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.453 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.737 ms
+(13 rows)
+
+:explain select * from t1 a left join t2 b using (c1, c2);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=3299.50..1268979.50 rows=71100 width=24) (actual time=1.793..1.793 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3299.50..1268979.50 rows=23700 width=24) (actual time=0.000..3.120 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.196 rows=0 loops=1)
+               ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.195 rows=0 loops=1)
+                     Hash Key: b.c1, b.c2
+                     ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.268 ms
+(14 rows)
+
+:explain select * from t1 a left join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.201..0.201 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.105 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.104 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.996 ms
+(11 rows)
+
+:explain select * from t1 a left join d2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.192..0.192 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.024 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.024 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.024 ms
+(11 rows)
+
+:explain select * from t1 a left join r2 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.427..1.427 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.190 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.057 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.056 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.685 ms
+(13 rows)
+
+:explain select * from t1 a left join r2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.449..1.449 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1877.50..1268979.50 rows=23700 width=24) (actual time=0.000..2.436 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.024 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.813 ms
+(14 rows)
+
+:explain select * from d1 a left join t2 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.573..1.573 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.674..0.674 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.674..0.674 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.531 ms
+(16 rows)
+
+:explain select * from d1 a left join t2 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.542..1.542 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.021 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.700..0.700 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.699..0.699 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.583 ms
+(16 rows)
+
+:explain select * from d1 a left join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.230..0.230 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.013 ms
+(11 rows)
+
+:explain select * from d1 a left join d2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.226..0.226 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.015 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.973 ms
+(11 rows)
+
+:explain select * from d1 a left join r2 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.550..1.550 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.690..0.690 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.689..0.689 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.479 ms
+(16 rows)
+
+:explain select * from d1 a left join r2 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.553..1.553 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.710..0.710 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.709..0.709 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.539 ms
+(16 rows)
+
+:explain select * from r1 a left join t2 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.381..1.381 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.357 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.050 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.531 ms
+(13 rows)
+
+:explain select * from r1 a left join t2 b using (c1, c2);
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.752..1.752 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1268979.50 rows=23700 width=24) (actual time=0.000..2.998 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.113 rows=0 loops=1)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.034 rows=0 loops=1)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.228 ms
+(14 rows)
+
+:explain select * from r1 a left join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.175..0.175 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.921 ms
+(11 rows)
+
+:explain select * from r1 a left join d2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.202..0.202 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.033 ms
+(11 rows)
+
+:explain select * from r1 a left join r2 b using (c1);
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1699.75..1952143.85 rows=5055210 width=28) (actual time=1.422..1.422 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1699.75..1952143.85 rows=1685070 width=28) (actual time=0.000..2.366 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.037 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.028 rows=0 loops=1)
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.668 ms
+(13 rows)
+
+:explain select * from r1 a left join r2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..3798717.50 rows=71100 width=24) (actual time=1.442..1.442 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1877.50..3798717.50 rows=23700 width=24) (actual time=0.000..2.549 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..3655.00 rows=71100 width=16) (never executed)
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
+               ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.031 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.610 ms
+(13 rows)
+
+-- x2 left join y1
+:explain select * from t2 a left join t1 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=2.356..2.356 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..3.760 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.003 rows=0 loops=1)
+               Hash Key: a.c1
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..2.152 rows=0 loops=1)
+               ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..2.151 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 5.593 ms
+(17 rows)
+
+:explain select * from t2 a left join t1 b using (c1, c2);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=3299.50..1268979.50 rows=71100 width=24) (actual time=1.287..1.287 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3299.50..1268979.50 rows=23700 width=24) (actual time=0.000..2.759 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..0.943 rows=0 loops=1)
+               ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.942 rows=0 loops=1)
+                     Hash Key: b.c1, b.c2
+                     ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.922 ms
+(14 rows)
+
+:explain select * from t2 a left join d1 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=0.920..0.920 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.577 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.003..0.003 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4238K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 2.487 ms
+(16 rows)
+
+:explain select * from t2 a left join d1 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=0.002..0.002 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1877.50..1268979.50 rows=23700 width=24) (actual time=0.000..1.866 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.036 rows=0 loops=1)
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.034 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.554 ms
+(14 rows)
+
+:explain select * from t2 a left join r1 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=1.841..1.841 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..4.616 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.003 rows=0 loops=1)
+               Hash Key: a.c1
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..2.932 rows=0 loops=1)
+               ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..2.930 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.019 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 5.554 ms
+(17 rows)
+
+:explain select * from t2 a left join r1 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.105..1.105 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1877.50..1268979.50 rows=23700 width=24) (actual time=0.000..1.888 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.969 ms
+(14 rows)
+
+:explain select * from d2 a left join t1 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.737..1.737 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.887..0.887 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.886..0.886 rows=0 loops=2)
+               ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.870 ms
+(16 rows)
+
+:explain select * from d2 a left join t1 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.373..1.373 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.606..0.606 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.605..0.605 rows=0 loops=2)
+               ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.182 ms
+(16 rows)
+
+:explain select * from d2 a left join d1 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.214..0.214 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.074 ms
+(11 rows)
+
+:explain select * from d2 a left join d1 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.184..0.184 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.015 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.981 ms
+(11 rows)
+
+:explain select * from d2 a left join r1 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=0.832..0.832 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.002..0.002 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
+               ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 2.081 ms
+(16 rows)
+
+:explain select * from d2 a left join r1 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.465..1.465 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.595..0.595 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.594..0.594 rows=0 loops=2)
+               ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.325 ms
+(16 rows)
+
+:explain select * from r2 a left join t1 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=2.688..2.688 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..3.979 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.906 rows=0 loops=1)
+               Hash Key: a.c1
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.287 rows=0 loops=1)
+               ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.285 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 6.261 ms
+(17 rows)
+
+:explain select * from r2 a left join t1 b using (c1, c2);
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.612..1.612 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1268979.50 rows=23700 width=24) (actual time=0.000..2.797 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.923 rows=0 loops=1)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
+               ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.031 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.018 ms
+(14 rows)
+
+:explain select * from r2 a left join d1 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.099..1.099 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (actual time=0.198..0.198 rows=0 loops=2)
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.087..0.087 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.086..0.086 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4238K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 2.591 ms
+(16 rows)
+
+:explain select * from r2 a left join d1 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.158..1.158 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (actual time=0.258..0.258 rows=0 loops=2)
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.138..0.138 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.137..0.137 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
+   (slice0)    Executor memory: 4238K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 2.802 ms
+(16 rows)
+
+:explain select * from r2 a left join r1 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=1.945..1.945 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..3.466 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.003 rows=0 loops=1)
+               Hash Key: a.c1
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.634 rows=0 loops=1)
+               ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.634 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.749 ms
+(17 rows)
+
+:explain select * from r2 a left join r1 b using (c1, c2);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)  (cost=3299.50..1270401.50 rows=71100 width=24) (actual time=2.230..2.230 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3299.50..1270401.50 rows=23700 width=24) (actual time=0.000..3.825 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.693 rows=0 loops=1)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..0.810 rows=0 loops=1)
+               ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.808 rows=0 loops=1)
+                     Hash Key: b.c1, b.c2
+                     ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.073 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 5.359 ms
+(17 rows)
+
+-- x2 left join y2
+:explain select * from t2 a left join t2 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=1.972..1.972 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..3.288 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.003 rows=0 loops=1)
+               Hash Key: a.c1
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.506 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.505 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.784 ms
+(17 rows)
+
+:explain select * from t2 a left join t2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.167..0.167 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.018 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes avg x 3 workers, 78K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.954 ms
+(11 rows)
+
+:explain select * from t2 a left join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.216..0.216 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.063 ms
+(11 rows)
+
+:explain select * from t2 a left join d2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.196..0.196 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.016 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.968 ms
+(11 rows)
+
+:explain select * from t2 a left join r2 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=2.635..2.635 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..4.959 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.997 rows=0 loops=1)
+               Hash Key: a.c1
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.019 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.252 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.251 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 6.142 ms
+(17 rows)
+
+:explain select * from t2 a left join r2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.633..1.633 rows=0 loops=2)
+   ->  Hash Right Join  (cost=1877.50..1268979.50 rows=23700 width=24) (actual time=0.000..2.559 rows=0 loops=1)
+         Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (never executed)
+               Hash Key: b.c1, b.c2
+               ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
+               ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.862 ms
+(14 rows)
+
+:explain select * from d2 a left join t2 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.438..1.438 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.617..0.617 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.617..0.617 rows=0 loops=2)
+               ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.285 ms
+(16 rows)
+
+:explain select * from d2 a left join t2 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.335..1.335 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.561..0.561 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.560..0.560 rows=0 loops=2)
+               ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.063 ms
+(16 rows)
+
+:explain select * from d2 a left join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.206..0.206 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.946 ms
+(11 rows)
+
+:explain select * from d2 a left join d2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.192..0.192 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.014 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 78K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.883 ms
+(11 rows)
+
+:explain select * from d2 a left join r2 b using (c1);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.487..1.487 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.662..0.662 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.662..0.662 rows=0 loops=2)
+               ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.353 ms
+(16 rows)
+
+:explain select * from d2 a left join r2 b using (c1, c2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Right Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.478..1.478 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.662..0.662 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.662..0.662 rows=0 loops=2)
+               ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 3.353 ms
+(16 rows)
+
+:explain select * from r2 a left join t2 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=2.192..2.192 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..4.022 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.003 rows=0 loops=1)
+               Hash Key: a.c1
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..2.100 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..2.099 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 5.253 ms
+(17 rows)
+
+:explain select * from r2 a left join t2 b using (c1, c2);
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice2; segments: 2)  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.683..1.683 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1268979.50 rows=23700 width=24) (actual time=0.000..2.974 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.021 rows=0 loops=1)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
+               ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.098 ms
+(14 rows)
+
+:explain select * from r2 a left join d2 b using (c1);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1699.75..685141.85 rows=5055210 width=28) (actual time=0.237..0.237 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1699.75..685141.85 rows=1685070 width=28) (actual time=0.000..0.103 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.022 ms
+(11 rows)
+
+:explain select * from r2 a left join d2 b using (c1, c2);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1877.50..1267557.50 rows=71100 width=24) (actual time=0.171..0.171 rows=0 loops=2)
+   ->  Hash Left Join  (cost=1877.50..1267557.50 rows=23700 width=24) (actual time=0.000..0.017 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+         ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
+               ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 0.923 ms
+(11 rows)
+
+:explain select * from r2 a left join r2 b using (c1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3121.75..687985.85 rows=5055210 width=28) (actual time=2.649..2.649 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3121.75..687985.85 rows=1685070 width=28) (actual time=0.000..4.693 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.019 rows=0 loops=1)
+               Hash Key: a.c1
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.019 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..3.142 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..3.141 rows=0 loops=1)
+                     Hash Key: b.c1
+                     ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.012 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 6.083 ms
+(17 rows)
+
+:explain select * from r2 a left join r2 b using (c1, c2);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3299.50..1270401.50 rows=71100 width=24) (actual time=2.026..2.026 rows=0 loops=2)
+   ->  Hash Left Join  (cost=3299.50..1270401.50 rows=23700 width=24) (actual time=0.000..3.432 rows=0 loops=1)
+         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.607 rows=0 loops=1)
+               Hash Key: a.c1, a.c2
+               ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
+         ->  Hash  (cost=2233.00..2233.00 rows=23700 width=16) (actual time=0.000..1.445 rows=0 loops=1)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.444 rows=0 loops=1)
+                     Hash Key: b.c1, b.c2
+                     ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 390K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 4.955 ms
+(17 rows)
+
+--
+-- insert
+--
+insert into t1 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into t2 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  4 |   
+  5 |   
+(6 rows)
+
+insert into d1 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into d2 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into r1 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into r2 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  2 |   
+(6 rows)
+
+begin;
+insert into t1 (c1) values (1) returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+(1 row)
+
+insert into d1 (c1) values (1) returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+(1 row)
+
+insert into r1 (c1) values (1) returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+(1 row)
+
+insert into t2 (c1) values (1) returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+(1 row)
+
+insert into d2 (c1) values (1) returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+(1 row)
+
+insert into r2 (c1) values (1) returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+(1 row)
+
+rollback;
+begin;
+insert into t1 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  7 |   
+  8 |   
+  9 |   
+ 10 |   
+ 11 |   
+ 12 |   
+ 13 |   
+ 14 |   
+ 15 |   
+ 16 |   
+ 17 |   
+ 18 |   
+ 19 |   
+ 20 |   
+(20 rows)
+
+insert into d1 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  7 |   
+  8 |   
+  9 |   
+ 10 |   
+ 11 |   
+ 12 |   
+ 13 |   
+ 14 |   
+ 15 |   
+ 16 |   
+ 17 |   
+ 18 |   
+ 19 |   
+ 20 |   
+(20 rows)
+
+insert into r1 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  7 |   
+  8 |   
+  9 |   
+ 10 |   
+ 11 |   
+ 12 |   
+ 13 |   
+ 14 |   
+ 15 |   
+ 16 |   
+ 17 |   
+ 18 |   
+ 19 |   
+ 20 |   
+(20 rows)
+
+insert into t2 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+ c1 | c2 
+----+----
+  4 |   
+  5 |   
+ 11 |   
+ 12 |   
+ 13 |   
+ 14 |   
+ 19 |   
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  7 |   
+  8 |   
+  9 |   
+ 10 |   
+ 15 |   
+ 16 |   
+ 17 |   
+ 18 |   
+ 20 |   
+(20 rows)
+
+insert into d2 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  7 |   
+  8 |   
+  9 |   
+ 10 |   
+ 11 |   
+ 12 |   
+ 13 |   
+ 14 |   
+ 15 |   
+ 16 |   
+ 17 |   
+ 18 |   
+ 19 |   
+ 20 |   
+(20 rows)
+
+insert into r2 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+ c1 | c2 
+----+----
+  4 |   
+  6 |   
+ 14 |   
+ 15 |   
+ 16 |   
+ 18 |   
+ 19 |   
+  1 |   
+  2 |   
+  3 |   
+  5 |   
+  7 |   
+  8 |   
+  9 |   
+ 10 |   
+ 11 |   
+ 12 |   
+ 13 |   
+ 17 |   
+ 20 |   
+(20 rows)
+
+rollback;
+begin;
+insert into t1 (c1, c2) select c1, c2 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into t1 (c1, c2) select c2, c1 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+    |  1
+    |  2
+    |  3
+    |  4
+    |  5
+    |  6
+    |  1
+    |  2
+    |  3
+    |  4
+    |  5
+    |  6
+(12 rows)
+
+insert into t1 (c1, c2) select c1, c2 from t2 returning c1, c2;
+ c1 | c2 
+----+----
+  4 |   
+  5 |   
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+(6 rows)
+
+insert into t1 (c1, c2) select c2, c1 from t2 returning c1, c2;
+ c1 | c2 
+----+----
+    |  1
+    |  2
+    |  3
+    |  6
+    |  4
+    |  5
+(6 rows)
+
+insert into t1 (c1, c2) select c1, c2 from d1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into t1 (c1, c2) select c1, c2 from d2 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into t1 (c1, c2) select c1, c2 from r1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into t1 (c1, c2) select c1, c2 from r2 returning c1, c2;
+ c1 | c2 
+----+----
+  2 |   
+  1 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+rollback;
+begin;
+insert into t2 (c1, c2) select c1, c2 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  4 |   
+  5 |   
+(6 rows)
+
+insert into t2 (c1, c2) select c2, c1 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+    |  2
+    |  4
+    |  6
+    |  1
+    |  3
+    |  5
+(6 rows)
+
+insert into t2 (c1, c2) select c1, c2 from d1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  4 |   
+  5 |   
+(6 rows)
+
+insert into t2 (c1, c2) select c1, c2 from d2 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  4 |   
+  5 |   
+(6 rows)
+
+insert into t2 (c1, c2) select c1, c2 from r1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  4 |   
+  5 |   
+(6 rows)
+
+insert into t2 (c1, c2) select c1, c2 from r2 returning c1, c2;
+ c1 | c2 
+----+----
+  4 |   
+  5 |   
+  2 |   
+  1 |   
+  3 |   
+  6 |   
+(6 rows)
+
+rollback;
+begin;
+insert into d1 (c1, c2) select c1, c2 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into d1 (c1, c2) select c2, c1 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+    |  1
+    |  2
+    |  3
+    |  4
+    |  5
+    |  6
+(6 rows)
+
+insert into d1 (c1, c2) select c1, c2 from t2 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  4 |   
+  5 |   
+(6 rows)
+
+insert into d1 (c1, c2) select c2, c1 from t2 returning c1, c2;
+ c1 | c2 
+----+----
+    |  1
+    |  2
+    |  3
+    |  6
+    |  4
+    |  5
+(6 rows)
+
+insert into d1 (c1, c2) select c1, c2 from d1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+    |  1
+    |  2
+    |  3
+    |  4
+    |  5
+    |  6
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  4 |   
+  5 |   
+    |  1
+    |  2
+    |  3
+    |  6
+    |  4
+    |  5
+(30 rows)
+
+insert into d1 (c1, c2) select c1, c2 from d2 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into d1 (c1, c2) select c1, c2 from r1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into d1 (c1, c2) select c1, c2 from r2 returning c1, c2;
+ c1 | c2 
+----+----
+  2 |   
+  1 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+rollback;
+begin;
+insert into d2 (c1, c2) select c1, c2 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into d2 (c1, c2) select c2, c1 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+    |  1
+    |  2
+    |  3
+    |  4
+    |  5
+    |  6
+(6 rows)
+
+insert into d2 (c1, c2) select c1, c2 from d1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into d2 (c1, c2) select c1, c2 from d2 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+    |  1
+    |  2
+    |  3
+    |  4
+    |  5
+    |  6
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(24 rows)
+
+insert into d2 (c1, c2) select c1, c2 from r1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into d2 (c1, c2) select c1, c2 from r2 returning c1, c2;
+ c1 | c2 
+----+----
+  2 |   
+  1 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+rollback;
+begin;
+insert into r1 (c1, c2) select c1, c2 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into r1 (c1, c2) select c2, c1 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+    |  1
+    |  2
+    |  3
+    |  4
+    |  5
+    |  6
+(6 rows)
+
+insert into r1 (c1, c2) select c1, c2 from t2 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  4 |   
+  5 |   
+(6 rows)
+
+insert into r1 (c1, c2) select c2, c1 from t2 returning c1, c2;
+ c1 | c2 
+----+----
+    |  1
+    |  2
+    |  3
+    |  6
+    |  4
+    |  5
+(6 rows)
+
+insert into r1 (c1, c2) select c1, c2 from d1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into r1 (c1, c2) select c1, c2 from d2 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into r1 (c1, c2) select c1, c2 from r1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+    |  1
+    |  2
+    |  3
+    |  4
+    |  5
+    |  6
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  4 |   
+  5 |   
+    |  1
+    |  2
+    |  3
+    |  6
+    |  4
+    |  5
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(42 rows)
+
+insert into r1 (c1, c2) select c1, c2 from r2 returning c1, c2;
+ c1 | c2 
+----+----
+  2 |   
+  1 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+rollback;
+begin;
+insert into r2 (c1, c2) select c1, c2 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+(6 rows)
+
+insert into r2 (c1, c2) select c2, c1 from t1 returning c1, c2;
+ c1 | c2 
+----+----
+    |  1
+    |  2
+    |  4
+    |  5
+    |  6
+    |  3
+(6 rows)
+
+insert into r2 (c1, c2) select c1, c2 from d1 returning c1, c2;
+ c1 | c2 
+----+----
+  4 |   
+  5 |   
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+(6 rows)
+
+insert into r2 (c1, c2) select c1, c2 from d2 returning c1, c2;
+ c1 | c2 
+----+----
+  4 |   
+  5 |   
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+(6 rows)
+
+insert into r2 (c1, c2) select c1, c2 from r1 returning c1, c2;
+ c1 | c2 
+----+----
+  3 |   
+  4 |   
+  6 |   
+  1 |   
+  2 |   
+  5 |   
+(6 rows)
+
+insert into r2 (c1, c2) select c1, c2 from r2 returning c1, c2;
+ c1 | c2 
+----+----
+  2 |   
+  1 |   
+  6 |   
+    |  5
+  5 |   
+  4 |   
+  5 |   
+  4 |   
+  6 |   
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  1 |   
+  2 |   
+  3 |   
+  6 |   
+  3 |   
+  4 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+    |  1
+    |  2
+    |  4
+    |  6
+  4 |   
+  5 |   
+  1 |   
+  2 |   
+  1 |   
+  3 |   
+  5 |   
+    |  3
+  6 |   
+(36 rows)
+
+rollback;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -1489,7 +1489,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 = 35 ORDER BY col2,col3 LIMIT 5;
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..431.00 rows=1 width=14)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=14)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=14)
          Merge Key: col2, col3
          ->  Sort  (cost=0.00..431.00 rows=1 width=14)
                Sort Key: col2, col3
@@ -1524,7 +1524,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 > 15 ORDER BY col2,col3 LIMIT 5;
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..431.01 rows=3 width=14)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.01 rows=5 width=14)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=5 width=14)
          Merge Key: col2, col3
          ->  Limit  (cost=0.00..431.01 rows=3 width=14)
                ->  Sort  (cost=0.00..431.01 rows=23 width=14)
@@ -1784,7 +1784,7 @@ NOTICE:  CREATE TABLE will create partition "ds_4_1_prt_p200803" for table "ds_4
 explain select * from ds_4 where month_id = '200800';
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
          ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
                Filter: month_id::text = '200800'::text
@@ -1800,7 +1800,7 @@ explain select * from ds_4 where month_id = '200800';
 explain select * from ds_4 where month_id::int = 200800;
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
          ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
          ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
@@ -1815,7 +1815,7 @@ explain select * from ds_4 where month_id::int = 200800;
 explain select * from ds_4 where month_id::int - 801 < 200000;
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
          ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
          ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
@@ -1827,7 +1827,7 @@ explain select * from ds_4 where month_id::int - 801 < 200000;
 explain select * from ds_4 where month_id::int - 801 < 200000 OR count_vas > 10;
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
          ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
          ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
@@ -1842,7 +1842,7 @@ explain select * from ds_4 where month_id::int - 801 < 200000 OR count_vas > 10;
 explain select * from ds_4 where month_id::int - 801 < 200000 AND count_vas > 10;
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
          ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
          ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
@@ -1857,7 +1857,7 @@ explain select * from ds_4 where month_id::int - 801 < 200000 AND count_vas > 10
 explain select * from ds_4 where case when month_id = '200800' then 100 else 2 end = 100;
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
          ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
          ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
@@ -1872,7 +1872,7 @@ explain select * from ds_4 where case when month_id = '200800' then 100 else 2 e
 explain select * from ds_4 where case when month_id = '200800' then NULL else 2 end IS NULL;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
          ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
          ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
@@ -1887,7 +1887,7 @@ explain select * from ds_4 where case when month_id = '200800' then NULL else 2 
 explain select * from ds_4 where case when month_id::int = 200800 then count_vas else 2 end IS NULL;
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
          ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
          ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
@@ -1902,7 +1902,7 @@ explain select * from ds_4 where case when month_id::int = 200800 then count_vas
 explain select * from ds_4 where month_id::int in (200801, 1,55,6,6,6,6,66,565,65,65,200803);
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
          ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
          ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
@@ -1973,7 +1973,7 @@ set optimizer_segments=2;
 explain select * from ds_2 where month_id::int in (200808, 1315) order by month_id;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    Merge Key: month_id
    ->  Sort  (cost=0.00..431.00 rows=1 width=80)
          Sort Key: month_id
@@ -1990,7 +1990,7 @@ explain select * from ds_2 where month_id::int in (200808, 1315) order by month_
 explain  select * from ds_2 where month_id::int in (200808, 200801, 2008010) order by month_id;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=80)
    Merge Key: month_id
    ->  Sort  (cost=0.00..431.00 rows=1 width=80)
          Sort Key: month_id
@@ -2848,7 +2848,7 @@ NOTICE:  building index for child partition "sales_1_prt_5_2_prt_other_regions"
 explain select * from sales where date = '2011-01-01' and region = 'usa';
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..3.00 rows=1 width=24)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.00 rows=1 width=24)
    ->  Sequence  (cost=0.00..3.00 rows=1 width=24)
          ->  Partition Selector for sales (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
                Filter: date = '01-01-2011'::date AND region = 'usa'::text

--- a/src/test/regress/expected/tpch500GB.out
+++ b/src/test/regress/expected/tpch500GB.out
@@ -1768,13 +1768,13 @@ order by
 	l_linestatus;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=120573745.63..120573745.64 rows=3 width=248)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=120573745.63..120573745.64 rows=3 width=248)
    Merge Key: l_returnflag, l_linestatus
    ->  Sort  (cost=120573745.63..120573745.64 rows=3 width=248)
          Sort Key: partial_aggregation.l_returnflag, partial_aggregation.l_linestatus
          ->  HashAggregate  (cost=120573745.37..120573745.55 rows=3 width=248)
                Group By: lineitem.l_returnflag, lineitem.l_linestatus
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=120573744.95..120573745.16 rows=3 width=248)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=120573744.95..120573745.16 rows=3 width=248)
                      Hash Key: lineitem.l_returnflag, lineitem.l_linestatus
                      ->  HashAggregate  (cost=120573744.95..120573745.04 rows=3 width=248)
                            Group By: lineitem.l_returnflag, lineitem.l_linestatus
@@ -1842,14 +1842,14 @@ LIMIT 100;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=23224951.08..23224951.20 rows=6 width=194)
-   ->  Gather Motion 2:1  (slice7; segments: 2)  (cost=23224951.08..23224951.20 rows=3 width=194)
+   ->  Gather Motion 3:1  (slice7; segments: 3)  (cost=23224951.08..23224951.20 rows=3 width=194)
          Merge Key: tpch500gb.supplier.s_acctbal, tpch500gb.nation.n_name, tpch500gb.supplier.s_name, part.p_partkey
          ->  Limit  (cost=23224951.08..23224951.10 rows=3 width=194)
                ->  Sort  (cost=23224951.08..23224951.10 rows=3 width=194)
                      Sort Key (Limit): tpch500gb.supplier.s_acctbal, tpch500gb.nation.n_name, tpch500gb.supplier.s_name, part.p_partkey
                      ->  Hash Join  (cost=21035046.61..23224951.02 rows=3 width=194)
                            Hash Cond: tpch500gb.partsupp.ps_suppkey = tpch500gb.supplier.s_suppkey
-                           ->  Redistribute Motion 2:2  (slice4; segments: 2)  (cost=20884242.76..23074147.05 rows=15 width=34)
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=20884242.76..23074147.05 rows=15 width=34)
                                  Hash Key: tpch500gb.partsupp.ps_suppkey
                                  ->  Hash Join  (cost=20884242.76..23074146.48 rows=15 width=34)
                                        Hash Cond: "Expr_SUBQUERY".csq_c0 = part.p_partkey AND "Expr_SUBQUERY".csq_c1 = tpch500gb.partsupp.ps_supplycost
@@ -1859,17 +1859,17 @@ LIMIT 100;
                                                    Hash Cond: tpch500gb.partsupp.ps_suppkey = tpch500gb.supplier.s_suppkey
                                                    ->  Seq Scan on partsupp  (cost=0.00..6122355.01 rows=195954001 width=16)
                                                    ->  Hash  (cost=305737.21..305737.21 rows=7869632 width=4)
-                                                         ->  Broadcast Motion 2:2  (slice3; segments: 2)  (cost=31.85..305737.21 rows=7869632 width=4)
+                                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=31.85..305737.21 rows=7869632 width=4)
                                                                ->  Hash Join  (cost=31.85..138507.54 rows=491852 width=4)
                                                                      Hash Cond: tpch500gb.supplier.s_nationkey = tpch500gb.nation.n_nationkey
                                                                      ->  Seq Scan on supplier  (cost=0.00..76994.20 rows=2459260 width=8)
                                                                      ->  Hash  (cost=30.85..30.85 rows=41 width=4)
-                                                                           ->  Broadcast Motion 2:2  (slice2; segments: 2)  (cost=5.43..30.85 rows=41 width=4)
+                                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=5.43..30.85 rows=41 width=4)
                                                                                  ->  Hash Join  (cost=5.43..30.00 rows=3 width=4)
                                                                                        Hash Cond: tpch500gb.nation.n_regionkey = tpch500gb.region.r_regionkey
                                                                                        ->  Seq Scan on nation  (cost=0.00..24.25 rows=13 width=8)
                                                                                        ->  Hash  (cost=5.23..5.23 rows=9 width=4)
-                                                                                             ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..5.23 rows=9 width=4)
+                                                                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..5.23 rows=9 width=4)
                                                                                                    ->  Seq Scan on region  (cost=0.00..5.06 rows=1 width=4)
                                                                                                          Filter: r_name = 'EUROPE'::bpchar
                                        ->  Hash  (cost=9132243.60..9132243.60 rows=1381832 width=46)
@@ -1884,12 +1884,12 @@ LIMIT 100;
                                        Hash Cond: tpch500gb.supplier.s_nationkey = tpch500gb.nation.n_nationkey
                                        ->  Seq Scan on supplier  (cost=0.00..76994.20 rows=2459260 width=146)
                                        ->  Hash  (cost=30.85..30.85 rows=41 width=30)
-                                             ->  Broadcast Motion 2:2  (slice6; segments: 2)  (cost=5.43..30.85 rows=41 width=30)
+                                             ->  Broadcast Motion 3:3  (slice6; segments: 3)  (cost=5.43..30.85 rows=41 width=30)
                                                    ->  Hash Join  (cost=5.43..30.00 rows=3 width=30)
                                                          Hash Cond: tpch500gb.nation.n_regionkey = tpch500gb.region.r_regionkey
                                                          ->  Seq Scan on nation  (cost=0.00..24.25 rows=13 width=34)
                                                          ->  Hash  (cost=5.23..5.23 rows=9 width=4)
-                                                               ->  Broadcast Motion 2:2  (slice5; segments: 2)  (cost=0.00..5.23 rows=9 width=4)
+                                                               ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..5.23 rows=9 width=4)
                                                                      ->  Seq Scan on region  (cost=0.00..5.06 rows=1 width=4)
                                                                            Filter: r_name = 'EUROPE'::bpchar
  Settings:  enable_mergejoin=on; enable_nestloop=on; gp_enable_agg_distinct=off; gp_segments_for_planner=16; gp_selectivity_damping_for_joins=off; gp_selectivity_damping_for_scans=off
@@ -1933,7 +1933,7 @@ LIMIT 10;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=136238292.45..136238292.68 rows=10 width=48)
-   ->  Gather Motion 2:1  (slice2; segments: 2)  (cost=136238292.45..136238292.68 rows=5 width=48)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=136238292.45..136238292.68 rows=5 width=48)
          Merge Key: revenue, orders.o_orderdate
          ->  Limit  (cost=136238292.45..136238292.48 rows=5 width=48)
                ->  Sort  (cost=136238292.45..136637393.84 rows=79820278 width=48)
@@ -1950,7 +1950,7 @@ LIMIT 10;
                                              ->  Seq Scan on orders  (cost=0.00..12613430.80 rows=179773405 width=20)
                                                    Filter: o_orderdate < '03-22-1995'::date
                                              ->  Hash  (cost=3854360.45..3854360.45 rows=117034883 width=4)
-                                                   ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..3854360.45 rows=117034883 width=4)
+                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3854360.45 rows=117034883 width=4)
                                                          ->  Seq Scan on customer  (cost=0.00..1367369.20 rows=7314681 width=4)
                                                                Filter: c_mktsegment = 'AUTOMOBILE'::bpchar
  Settings:  enable_mergejoin=on; enable_nestloop=on; gp_enable_agg_distinct=off; gp_segments_for_planner=16; gp_selectivity_damping_for_joins=off; gp_selectivity_damping_for_scans=off
@@ -1991,13 +1991,13 @@ order by
         o_orderpriority;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=79166496.69..79166496.69 rows=1 width=72)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=79166496.69..79166496.69 rows=1 width=72)
    Merge Key: o_orderpriority
    ->  Sort  (cost=79166496.69..79166496.69 rows=1 width=72)
          Sort Key: partial_aggregation.o_orderpriority
          ->  HashAggregate  (cost=79166496.66..79166496.68 rows=1 width=72)
                Group By: orders.o_orderpriority
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=79166496.63..79166496.65 rows=1 width=72)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=79166496.63..79166496.65 rows=1 width=72)
                      Hash Key: orders.o_orderpriority
                      ->  HashAggregate  (cost=79166496.63..79166496.63 rows=1 width=72)
                            Group By: orders.o_orderpriority
@@ -2057,7 +2057,7 @@ where
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=82836950.11..82836950.12 rows=1 width=8)
-   ->  Gather Motion 2:1  (slice6; segments: 2)  (cost=82836949.91..82836950.09 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=82836949.91..82836950.09 rows=1 width=8)
          ->  Aggregate  (cost=82836949.91..82836949.92 rows=1 width=8)
                ->  Hash Join  (cost=22440953.76..82828342.64 rows=1721454 width=0)
                      Hash Cond: customer.c_nationkey = supplier.s_nationkey AND lineitem.l_suppkey = supplier.s_suppkey
@@ -2065,11 +2065,11 @@ where
                            Hash Cond: lineitem.l_orderkey = orders.o_orderkey
                            ->  Seq Scan on lineitem  (cost=0.00..44422937.88 rows=1468914944 width=12)
                            ->  Hash  (cost=19965159.90..19965159.90 rows=11127499 width=16)
-                                 ->  Redistribute Motion 2:2  (slice4; segments: 2)  (cost=2285832.40..19965159.90 rows=11127499 width=16)
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=2285832.40..19965159.90 rows=11127499 width=16)
                                        Hash Key: orders.o_orderkey
                                        ->  Hash Join  (cost=2285832.40..19520059.96 rows=11127499 width=16)
                                              Hash Cond: orders.o_custkey = customer.c_custkey
-                                             ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..16677852.68 rows=55637484 width=12)
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..16677852.68 rows=55637484 width=12)
                                                    Hash Key: orders.o_custkey
                                                    ->  Seq Scan on orders  (cost=0.00..14452353.36 rows=55637484 width=12)
                                                          Filter: o_orderdate >= '01-01-1993'::date AND o_orderdate < 'Sat Jan 01 00:00:00 1994'::timestamp without time zone
@@ -2078,16 +2078,16 @@ where
                                                          Hash Cond: customer.c_nationkey = nation.n_nationkey
                                                          ->  Seq Scan on customer  (cost=0.00..1183682.96 rows=36737248 width=8)
                                                          ->  Hash  (cost=30.85..30.85 rows=41 width=4)
-                                                               ->  Broadcast Motion 2:2  (slice3; segments: 2)  (cost=5.43..30.85 rows=41 width=4)
+                                                               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=5.43..30.85 rows=41 width=4)
                                                                      ->  Hash Join  (cost=5.43..30.00 rows=3 width=4)
                                                                            Hash Cond: nation.n_regionkey = region.r_regionkey
                                                                            ->  Seq Scan on nation  (cost=0.00..24.25 rows=13 width=8)
                                                                            ->  Hash  (cost=5.23..5.23 rows=9 width=4)
-                                                                                 ->  Broadcast Motion 2:2  (slice2; segments: 2)  (cost=0.00..5.23 rows=9 width=4)
+                                                                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..5.23 rows=9 width=4)
                                                                                        ->  Seq Scan on region  (cost=0.00..5.06 rows=1 width=4)
                                                                                              Filter: r_name = 'ASIA'::bpchar
                      ->  Hash  (cost=913142.60..913142.60 rows=39348160 width=8)
-                           ->  Broadcast Motion 2:2  (slice5; segments: 2)  (cost=0.00..913142.60 rows=39348160 width=8)
+                           ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..913142.60 rows=39348160 width=8)
                                  ->  Seq Scan on supplier  (cost=0.00..76994.20 rows=2459260 width=8)
  Settings:  enable_mergejoin=on; enable_nestloop=on; gp_enable_agg_distinct=off; gp_segments_for_planner=16; gp_selectivity_damping_for_joins=off; gp_selectivity_damping_for_scans=off
 (34 rows)
@@ -2116,7 +2116,7 @@ where
                                                                                                     QUERY PLAN                                                                                                    
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=81285244.19..81285244.20 rows=1 width=32)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=81285243.99..81285244.18 rows=1 width=32)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=81285243.99..81285244.18 rows=1 width=32)
          ->  Aggregate  (cost=81285243.99..81285244.01 rows=1 width=32)
                ->  Seq Scan on lineitem  (cost=0.00..81145811.48 rows=27886503 width=16)
                      Filter: l_shipdate >= '01-01-1993'::date AND l_shipdate < 'Sat Jan 01 00:00:00 1994'::timestamp without time zone AND l_discount >= 0.01 AND l_discount <= 0.03 AND l_quantity < 25::numeric
@@ -2176,19 +2176,19 @@ order by
 	l_year;
                                                                                                                    QUERY PLAN                                                                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice6; segments: 2)  (cost=85867195.23..85868345.74 rows=230102 width=248)
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=85867195.23..85868345.74 rows=230102 width=248)
    Merge Key: supp_nation, cust_nation, l_year
    ->  Sort  (cost=85867195.23..85868345.74 rows=230102 width=248)
          Sort Key: partial_aggregation.supp_nation, partial_aggregation.cust_nation, partial_aggregation.unnamed_attr_3
          ->  HashAggregate  (cost=85818156.09..85823908.64 rows=230102 width=248)
                Group By: n1.n_name, n2.n_name, "?column3?"
-               ->  Redistribute Motion 2:2  (slice5; segments: 2)  (cost=85795145.89..85808952.01 rows=230102 width=248)
+               ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=85795145.89..85808952.01 rows=230102 width=248)
                      Hash Key: n1.n_name, n2.n_name, unnamed_attr_3
                      ->  HashAggregate  (cost=85795145.89..85799747.93 rows=230102 width=248)
                            Group By: n1.n_name, n2.n_name, date_part('year'::text, lineitem.l_shipdate::timestamp without time zone)
                            ->  Hash Join  (cost=68275249.57..85768515.92 rows=1331499 width=72)
                                  Hash Cond: n2.n_nationkey = customer.c_nationkey AND orders.o_custkey = customer.c_custkey
-                                 ->  Redistribute Motion 2:2  (slice4; segments: 2)  (cost=65917696.17..82530478.96 rows=33287462 width=80)
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=65917696.17..82530478.96 rows=33287462 width=80)
                                        Hash Key: orders.o_custkey
                                        ->  Hash Join  (cost=65917696.17..81198980.50 rows=33287462 width=80)
                                              Hash Cond: orders.o_orderkey = lineitem.l_orderkey
@@ -2199,17 +2199,17 @@ order by
                                                          ->  Seq Scan on lineitem  (cost=0.00..59112087.32 rows=429931399 width=32)
                                                                Filter: l_shipdate >= '01-01-1995'::date AND l_shipdate <= '12-31-1996'::date
                                                          ->  Hash  (cost=196960.82..196960.82 rows=3145334 width=60)
-                                                               ->  Broadcast Motion 2:2  (slice3; segments: 2)  (cost=354.87..196960.82 rows=3145334 width=60)
+                                                               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=354.87..196960.82 rows=3145334 width=60)
                                                                      ->  Hash Join  (cost=354.87..130122.47 rows=196584 width=60)
                                                                            Hash Cond: supplier.s_nationkey = n1.n_nationkey
                                                                            ->  Seq Scan on supplier  (cost=0.00..76994.20 rows=2459260 width=8)
                                                                            ->  Hash  (cost=353.94..353.94 rows=38 width=60)
-                                                                                 ->  Broadcast Motion 2:2  (slice2; segments: 2)  (cost=28.90..353.94 rows=38 width=60)
+                                                                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=28.90..353.94 rows=38 width=60)
                                                                                        ->  Nested Loop  (cost=28.90..353.15 rows=3 width=60)
                                                                                              Join Filter: (n1.n_name = 'ALGERIA'::bpchar AND n2.n_name = 'ROMANIA'::bpchar) OR (n1.n_name = 'ROMANIA'::bpchar AND n2.n_name = 'ALGERIA'::bpchar)
                                                                                              ->  Seq Scan on nation n1  (cost=0.00..24.25 rows=13 width=30)
                                                                                              ->  Materialize  (cost=28.90..32.90 rows=200 width=30)
-                                                                                                   ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..28.50 rows=200 width=30)
+                                                                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..28.50 rows=200 width=30)
                                                                                                          ->  Seq Scan on nation n2  (cost=0.00..24.25 rows=13 width=30)
                                  ->  Hash  (cost=1183682.96..1183682.96 rows=36737248 width=8)
                                        ->  Seq Scan on customer  (cost=0.00..1183682.96 rows=36737248 width=8)
@@ -2268,13 +2268,13 @@ order by
 	o_year;
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice8; segments: 2)  (cost=72596753.00..72596754.83 rows=367 width=40)
+ Gather Motion 3:1  (slice8; segments: 3)  (cost=72596753.00..72596754.83 rows=367 width=40)
    Merge Key: o_year
    ->  Sort  (cost=72596753.00..72596754.83 rows=367 width=40)
          Sort Key: partial_aggregation.unnamed_attr_1
          ->  HashAggregate  (cost=72596705.29..72596718.11 rows=367 width=40)
                Group By: "?column1?"
-               ->  Redistribute Motion 2:2  (slice7; segments: 2)  (cost=72596664.97..72596692.46 rows=367 width=72)
+               ->  Redistribute Motion 3:3  (slice7; segments: 3)  (cost=72596664.97..72596692.46 rows=367 width=72)
                      Hash Key: unnamed_attr_1
                      ->  HashAggregate  (cost=72596664.97..72596677.80 rows=367 width=72)
                            Group By: date_part('year'::text, orders.o_orderdate::timestamp without time zone)
@@ -2282,7 +2282,7 @@ order by
                                  Hash Cond: supplier.s_nationkey = n2.n_nationkey
                                  ->  Hash Join  (cost=70968900.95..72522981.77 rows=566537 width=24)
                                        Hash Cond: lineitem.l_suppkey = supplier.s_suppkey
-                                       ->  Redistribute Motion 2:2  (slice5; segments: 2)  (cost=70830425.25..72367418.12 rows=584910 width=24)
+                                       ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=70830425.25..72367418.12 rows=584910 width=24)
                                              Hash Key: lineitem.l_suppkey
                                              ->  Hash Join  (cost=70830425.25..72344021.75 rows=584910 width=24)
                                                    Hash Cond: customer.c_nationkey = n1.n_nationkey
@@ -2290,7 +2290,7 @@ order by
                                                          Hash Cond: customer.c_custkey = orders.o_custkey
                                                          ->  Seq Scan on customer  (cost=0.00..1183682.96 rows=36737248 width=8)
                                                          ->  Hash  (cost=70757279.76..70757279.76 rows=2924546 width=28)
-                                                               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=54977627.99..70757279.76 rows=2924546 width=28)
+                                                               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=54977627.99..70757279.76 rows=2924546 width=28)
                                                                      Hash Key: orders.o_custkey
                                                                      ->  Hash Join  (cost=54977627.99..70640297.93 rows=2924546 width=28)
                                                                            Hash Cond: orders.o_orderkey = lineitem.l_orderkey
@@ -2301,22 +2301,22 @@ order by
                                                                                        Hash Cond: lineitem.l_partkey = part.p_partkey
                                                                                        ->  Seq Scan on lineitem  (cost=0.00..44422937.88 rows=1468914944 width=32)
                                                                                        ->  Hash  (cost=1850673.92..1850673.92 rows=5133418 width=4)
-                                                                                             ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..1850673.92 rows=5133418 width=4)
+                                                                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1850673.92 rows=5133418 width=4)
                                                                                                    ->  Seq Scan on part  (cost=0.00..1741588.80 rows=320839 width=4)
                                                                                                          Filter: p_type::text = 'ECONOMY BRUSHED COPPER'::text
                                                    ->  Hash  (cost=30.85..30.85 rows=41 width=4)
-                                                         ->  Broadcast Motion 2:2  (slice4; segments: 2)  (cost=5.43..30.85 rows=41 width=4)
+                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=5.43..30.85 rows=41 width=4)
                                                                ->  Hash Join  (cost=5.43..30.00 rows=3 width=4)
                                                                      Hash Cond: n1.n_regionkey = region.r_regionkey
                                                                      ->  Seq Scan on nation n1  (cost=0.00..24.25 rows=13 width=8)
                                                                      ->  Hash  (cost=5.23..5.23 rows=9 width=4)
-                                                                           ->  Broadcast Motion 2:2  (slice3; segments: 2)  (cost=0.00..5.23 rows=9 width=4)
+                                                                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..5.23 rows=9 width=4)
                                                                                  ->  Seq Scan on region  (cost=0.00..5.06 rows=1 width=4)
                                                                                        Filter: r_name = 'EUROPE'::bpchar
                                        ->  Hash  (cost=76994.20..76994.20 rows=2459260 width=8)
                                              ->  Seq Scan on supplier  (cost=0.00..76994.20 rows=2459260 width=8)
                                  ->  Hash  (cost=28.50..28.50 rows=200 width=30)
-                                       ->  Broadcast Motion 2:2  (slice6; segments: 2)  (cost=0.00..28.50 rows=200 width=30)
+                                       ->  Broadcast Motion 3:3  (slice6; segments: 3)  (cost=0.00..28.50 rows=200 width=30)
                                              ->  Seq Scan on nation n2  (cost=0.00..24.25 rows=13 width=30)
  Settings:  enable_mergejoin=on; enable_nestloop=on; gp_enable_agg_distinct=off; gp_segments_for_planner=16; gp_selectivity_damping_for_joins=off; gp_selectivity_damping_for_scans=off
 (51 rows)
@@ -2368,13 +2368,13 @@ order by
 	o_year desc;
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice7; segments: 2)  (cost=74955700.97..74955701.85 rows=14 width=144)
+ Gather Motion 3:1  (slice7; segments: 3)  (cost=74955700.97..74955701.85 rows=14 width=144)
    Merge Key: nation, o_year
    ->  GroupAggregate  (cost=74955700.97..74955701.85 rows=14 width=144)
          Group By: nation.n_name, "?column2?"
          ->  Sort  (cost=74955700.97..74955701.04 rows=14 width=144)
                Sort Key: nation.n_name, unnamed_attr_2
-               ->  Redistribute Motion 2:2  (slice6; segments: 2)  (cost=74955698.77..74955700.33 rows=14 width=144)
+               ->  Redistribute Motion 3:3  (slice6; segments: 3)  (cost=74955698.77..74955700.33 rows=14 width=144)
                      Hash Key: nation.n_name, "?column2?"
                      ->  GroupAggregate  (cost=74955698.77..74955699.79 rows=14 width=144)
                            Group By: nation.n_name, "?column7?"
@@ -2384,27 +2384,27 @@ order by
                                        Hash Cond: orders.o_orderkey = lineitem.l_orderkey
                                        ->  Seq Scan on orders  (cost=0.00..10774508.24 rows=367784512 width=12)
                                        ->  Hash  (cost=62342266.46..62342266.46 rows=14 width=65)
-                                             ->  Redistribute Motion 2:2  (slice5; segments: 2)  (cost=54260368.51..62342266.46 rows=14 width=65)
+                                             ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=54260368.51..62342266.46 rows=14 width=65)
                                                    Hash Key: lineitem.l_orderkey
                                                    ->  Hash Join  (cost=54260368.51..62342265.90 rows=14 width=65)
                                                          Hash Cond: supplier.s_nationkey = nation.n_nationkey
-                                                         ->  Redistribute Motion 2:2  (slice4; segments: 2)  (cost=54260343.95..62342240.92 rows=14 width=43)
+                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=54260343.95..62342240.92 rows=14 width=43)
                                                                Hash Key: supplier.s_nationkey
                                                                ->  Hash Join  (cost=54260343.95..62342240.36 rows=14 width=43)
                                                                      Hash Cond: partsupp.ps_suppkey = supplier.s_suppkey
-                                                                     ->  Redistribute Motion 2:2  (slice3; segments: 2)  (cost=54121868.25..62203764.23 rows=16 width=47)
+                                                                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=54121868.25..62203764.23 rows=16 width=47)
                                                                            Hash Key: lineitem.l_suppkey
                                                                            ->  Hash Join  (cost=54121868.25..62203763.60 rows=16 width=47)
                                                                                  Hash Cond: partsupp.ps_partkey = part.p_partkey AND partsupp.ps_suppkey = lineitem.l_suppkey
                                                                                  ->  Seq Scan on partsupp  (cost=0.00..6122355.01 rows=195954001 width=16)
                                                                                  ->  Hash  (cost=54027460.15..54027460.15 rows=3146937 width=43)
-                                                                                       ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=1819376.40..54027460.15 rows=3146937 width=43)
+                                                                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1819376.40..54027460.15 rows=3146937 width=43)
                                                                                              Hash Key: lineitem.l_partkey
                                                                                              ->  Hash Join  (cost=1819376.40..53901582.68 rows=3146937 width=43)
                                                                                                    Hash Cond: lineitem.l_partkey = part.p_partkey
                                                                                                    ->  Seq Scan on lineitem  (cost=0.00..44422937.88 rows=1468914944 width=39)
                                                                                                    ->  Hash  (cost=1777329.05..1777329.05 rows=1681895 width=4)
-                                                                                                         ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..1777329.05 rows=1681895 width=4)
+                                                                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1777329.05 rows=1681895 width=4)
                                                                                                                ->  Seq Scan on part  (cost=0.00..1741588.80 rows=105119 width=4)
                                                                                                                      Filter: p_name::text ~~ '%seashell%'::text
                                                                      ->  Hash  (cost=76994.20..76994.20 rows=2459260 width=8)
@@ -2461,7 +2461,7 @@ LIMIT 20;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=111294577.28..111294577.73 rows=20 width=638)
-   ->  Gather Motion 2:1  (slice3; segments: 2)  (cost=111294577.28..111294577.73 rows=10 width=638)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=111294577.28..111294577.73 rows=10 width=638)
          Merge Key: revenue
          ->  Limit  (cost=111294577.28..111294577.33 rows=10 width=638)
                ->  Sort  (cost=111294577.28..111362281.64 rows=13540873 width=638)
@@ -2472,7 +2472,7 @@ LIMIT 20;
                                  Hash Cond: customer.c_nationkey = nation.n_nationkey
                                  ->  Hash Join  (cost=17325704.71..74783041.55 rows=13540872 width=166)
                                        Hash Cond: orders.o_custkey = customer.c_custkey
-                                       ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=14828951.55..71412693.23 rows=13540872 width=20)
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=14828951.55..71412693.23 rows=13540872 width=20)
                                              Hash Key: orders.o_custkey
                                              ->  Hash Join  (cost=14828951.55..70871058.36 rows=13540872 width=20)
                                                    Hash Cond: lineitem.l_orderkey = orders.o_orderkey
@@ -2484,7 +2484,7 @@ LIMIT 20;
                                        ->  Hash  (cost=1183682.96..1183682.96 rows=36737248 width=150)
                                              ->  Seq Scan on customer  (cost=0.00..1183682.96 rows=36737248 width=150)
                                  ->  Hash  (cost=28.50..28.50 rows=200 width=30)
-                                       ->  Broadcast Motion 2:2  (slice2; segments: 2)  (cost=0.00..28.50 rows=200 width=30)
+                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..28.50 rows=200 width=30)
                                              ->  Seq Scan on nation  (cost=0.00..24.25 rows=13 width=30)
  Settings:  enable_mergejoin=on; enable_nestloop=on; gp_enable_agg_distinct=off; gp_segments_for_planner=16; gp_selectivity_damping_for_joins=off; gp_selectivity_damping_for_scans=off
 (27 rows)
@@ -2530,24 +2530,24 @@ order by
 	value desc;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice6; segments: 2)  (cost=19599154.59..19633991.64 rows=6967410 width=36)
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=19599154.59..19633991.64 rows=6967410 width=36)
    Merge Key: value
    ->  Sort  (cost=19599154.59..19633991.64 rows=6967410 width=36)
          Sort Key: value
          InitPlan  (slice7)
            ->  Aggregate  (cost=8005649.55..8005649.56 rows=1 width=32)
-                 ->  Gather Motion 2:1  (slice5; segments: 2)  (cost=8005649.35..8005649.54 rows=1 width=32)
+                 ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=8005649.35..8005649.54 rows=1 width=32)
                        ->  Aggregate  (cost=8005649.35..8005649.37 rows=1 width=32)
                              ->  Hash Join  (cost=171946.31..7970812.30 rows=6967410 width=12)
                                    Hash Cond: tpch500gb.partsupp.ps_suppkey = tpch500gb.supplier.s_suppkey
                                    ->  Seq Scan on partsupp  (cost=0.00..6122355.01 rows=195954001 width=16)
                                    ->  Hash  (cost=132598.15..132598.15 rows=1573927 width=4)
-                                         ->  Broadcast Motion 2:2  (slice4; segments: 2)  (cost=24.68..132598.15 rows=1573927 width=4)
+                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=24.68..132598.15 rows=1573927 width=4)
                                                ->  Hash Join  (cost=24.68..99152.22 rows=98371 width=4)
                                                      Hash Cond: tpch500gb.supplier.s_nationkey = tpch500gb.nation.n_nationkey
                                                      ->  Seq Scan on supplier  (cost=0.00..76994.20 rows=2459260 width=8)
                                                      ->  Hash  (cost=24.48..24.48 rows=8 width=4)
-                                                           ->  Broadcast Motion 2:2  (slice3; segments: 2)  (cost=0.00..24.48 rows=8 width=4)
+                                                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..24.48 rows=8 width=4)
                                                                  ->  Seq Scan on nation  (cost=0.00..24.31 rows=1 width=4)
                                                                        Filter: n_name = 'INDIA'::bpchar
          ->  HashAggregate  (cost=8159014.01..8625912.10 rows=6967410 width=36)
@@ -2557,12 +2557,12 @@ order by
                      Hash Cond: tpch500gb.partsupp.ps_suppkey = tpch500gb.supplier.s_suppkey
                      ->  Seq Scan on partsupp  (cost=0.00..6122355.01 rows=195954001 width=20)
                      ->  Hash  (cost=132598.15..132598.15 rows=1573927 width=4)
-                           ->  Broadcast Motion 2:2  (slice2; segments: 2)  (cost=24.68..132598.15 rows=1573927 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=24.68..132598.15 rows=1573927 width=4)
                                  ->  Hash Join  (cost=24.68..99152.22 rows=98371 width=4)
                                        Hash Cond: tpch500gb.supplier.s_nationkey = tpch500gb.nation.n_nationkey
                                        ->  Seq Scan on supplier  (cost=0.00..76994.20 rows=2459260 width=8)
                                        ->  Hash  (cost=24.48..24.48 rows=8 width=4)
-                                             ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..24.48 rows=8 width=4)
+                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..24.48 rows=8 width=4)
                                                    ->  Seq Scan on nation  (cost=0.00..24.31 rows=1 width=4)
                                                          Filter: n_name = 'INDIA'::bpchar
  Settings:  enable_mergejoin=on; enable_nestloop=on; gp_enable_agg_distinct=off; gp_segments_for_planner=16; gp_selectivity_damping_for_joins=off; gp_selectivity_damping_for_scans=off
@@ -2610,13 +2610,13 @@ order by
 	l_shipmode;
                                                                                                                                      QUERY PLAN                                                                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=94177104.73..94177104.74 rows=1 width=60)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=94177104.73..94177104.74 rows=1 width=60)
    Merge Key: l_shipmode
    ->  Sort  (cost=94177104.73..94177104.74 rows=1 width=60)
          Sort Key: partial_aggregation.l_shipmode
          ->  HashAggregate  (cost=94177104.71..94177104.72 rows=1 width=60)
                Group By: lineitem.l_shipmode
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=94177104.66..94177104.69 rows=1 width=60)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=94177104.66..94177104.69 rows=1 width=60)
                      Hash Key: lineitem.l_shipmode
                      ->  HashAggregate  (cost=94177104.66..94177104.67 rows=1 width=60)
                            Group By: lineitem.l_shipmode
@@ -2663,20 +2663,20 @@ order by
 	c_count desc;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice4; segments: 2)  (cost=62485181.31..62485183.81 rows=500 width=16)
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=62485181.31..62485183.81 rows=500 width=16)
    Merge Key: custdist, c_count
    ->  Sort  (cost=62485181.31..62485183.81 rows=500 width=16)
          Sort Key: custdist, partial_aggregation.c_count
          ->  HashAggregate  (cost=62485118.98..62485131.48 rows=500 width=16)
                Group By: c_orders.c_count
-               ->  Redistribute Motion 2:2  (slice3; segments: 2)  (cost=62485083.98..62485103.98 rows=500 width=16)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=62485083.98..62485103.98 rows=500 width=16)
                      Hash Key: c_orders.c_count
                      ->  HashAggregate  (cost=62485083.98..62485083.98 rows=500 width=16)
                            Group By: c_orders.c_count
                            ->  Subquery Scan on c_orders  (cost=60283360.43..62117711.50 rows=36737248 width=8)
                                  ->  HashAggregate  (cost=60283360.43..61382966.54 rows=36737248 width=12)
                                        Group By: customer.c_custkey
-                                       ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=52476943.84..59000068.09 rows=36737248 width=12)
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=52476943.84..59000068.09 rows=36737248 width=12)
                                              Hash Key: customer.c_custkey
                                              ->  HashAggregate  (cost=52476943.84..57530578.17 rows=36737248 width=12)
                                                    Group By: customer.c_custkey
@@ -2684,7 +2684,7 @@ order by
                                                          Hash Cond: customer.c_custkey = orders.o_custkey
                                                          ->  Seq Scan on customer  (cost=0.00..1183682.96 rows=36737248 width=4)
                                                          ->  Hash  (cost=27315570.74..27315570.74 rows=367553499 width=12)
-                                                               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..27315570.74 rows=367553499 width=12)
+                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..27315570.74 rows=367553499 width=12)
                                                                      Hash Key: orders.o_custkey
                                                                      ->  Seq Scan on orders  (cost=0.00..12613430.80 rows=367553499 width=12)
                                                                            Filter: o_comment::text !~~ '%unusual%deposits%'::text
@@ -2719,11 +2719,11 @@ where
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=63693203.44..63693203.46 rows=1 width=32)
-   ->  Gather Motion 2:1  (slice2; segments: 2)  (cost=63693203.23..63693203.42 rows=1 width=64)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=63693203.23..63693203.42 rows=1 width=64)
          ->  Aggregate  (cost=63693203.23..63693203.25 rows=1 width=64)
                ->  Hash Join  (cost=2878653.84..63512025.97 rows=18117726 width=37)
                      Hash Cond: lineitem.l_partkey = part.p_partkey
-                     ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..59836796.35 rows=18117726 width=20)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..59836796.35 rows=18117726 width=20)
                            Hash Key: lineitem.l_partkey
                            ->  Seq Scan on lineitem  (cost=0.00..59112087.32 rows=18117726 width=20)
                                  Filter: l_shipdate >= '08-01-1997'::date AND l_shipdate < 'Mon Sep 01 00:00:00 1997'::timestamp without time zone
@@ -2777,18 +2777,18 @@ order by
 	s_suppkey;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice4; segments: 2)  (cost=119640040.92..119640484.36 rows=88688 width=103)
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=119640040.92..119640484.36 rows=88688 width=103)
    Merge Key: s_suppkey
    ->  Sort  (cost=119640040.92..119640484.36 rows=88688 width=103)
          Sort Key: supplier.s_suppkey
          InitPlan  (slice5)
            ->  Aggregate  (cost=59636709.51..59636709.52 rows=1 width=32)
-                 ->  Gather Motion 2:1  (slice3; segments: 2)  (cost=59636709.31..59636709.49 rows=1 width=32)
+                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=59636709.31..59636709.49 rows=1 width=32)
                        ->  Aggregate  (cost=59636709.31..59636709.32 rows=1 width=32)
                              ->  Subquery Scan on revenue0  (cost=59632274.91..59636265.87 rows=88688 width=32)
                                    ->  HashAggregate  (cost=59632274.91..59634492.11 rows=88688 width=36)
                                          Group By: tpch500gb.lineitem.l_suppkey
-                                         ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=59625179.87..59629614.27 rows=88688 width=36)
+                                         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=59625179.87..59629614.27 rows=88688 width=36)
                                                Hash Key: tpch500gb.lineitem.l_suppkey
                                                ->  HashAggregate  (cost=59625179.87..59626066.75 rows=88688 width=36)
                                                      Group By: tpch500gb.lineitem.l_suppkey
@@ -2802,7 +2802,7 @@ order by
                            ->  HashAggregate  (cost=59889264.62..59892368.70 rows=88688 width=36)
                                  Filter: sum(partial_aggregation.unnamed_attr_2) = $0
                                  Group By: tpch500gb.lineitem.l_suppkey
-                                 ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=59881726.14..59886160.54 rows=88688 width=36)
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=59881726.14..59886160.54 rows=88688 width=36)
                                        Hash Key: tpch500gb.lineitem.l_suppkey
                                        ->  HashAggregate  (cost=59881726.14..59882613.02 rows=88688 width=36)
                                              Group By: tpch500gb.lineitem.l_suppkey
@@ -2856,7 +2856,7 @@ order by
 	p_size;
                                                                                              QUERY PLAN                                                                                             
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=18321628.07..18321690.94 rows=12575 width=124)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=18321628.07..18321690.94 rows=12575 width=124)
    Merge Key: supplier_cnt, p_brand, p_type, p_size
    ->  Sort  (cost=18321628.07..18321690.94 rows=12575 width=124)
          Sort Key: supplier_cnt, partial_aggregation.p_brand, partial_aggregation.p_type, partial_aggregation.p_size
@@ -2864,7 +2864,7 @@ order by
                Group By: partial_aggregation.p_brand, partial_aggregation.p_type, partial_aggregation.p_size
                ->  HashAggregate  (cost=16308198.92..17268149.68 rows=26283144 width=120)
                      Group By: part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey
-                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=13114180.91..14822585.27 rows=26283144 width=120)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=13114180.91..14822585.27 rows=26283144 width=120)
                            Hash Key: part.p_brand, part.p_type, part.p_size
                            ->  HashAggregate  (cost=13114180.91..13771259.51 rows=26283144 width=120)
                                  Group By: part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey
@@ -2878,7 +2878,7 @@ order by
                                                    ->  Seq Scan on part  (cost=0.00..2968257.60 rows=6581284 width=40)
                                                          Filter: p_brand <> 'Brand#15'::bpchar AND p_type::text !~~ 'LARGE BRUSHED%'::text AND (p_size = ANY ('{4,41,17,9,15,2,25,34}'::integer[]))
                                        ->  Hash  (cost=89734.75..89734.75 rows=19745 width=4)
-                                             ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..89734.75 rows=19745 width=4)
+                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..89734.75 rows=19745 width=4)
                                                    ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=0.00..89315.18 rows=1235 width=4)
                                                          ->  Seq Scan on supplier  (cost=0.00..89290.50 rows=1235 width=4)
                                                                Filter: s_comment::text ~~ '%Customer%Complaints%'::text
@@ -2917,19 +2917,19 @@ where
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=135605249.61..135605249.63 rows=1 width=32)
-   ->  Gather Motion 2:1  (slice3; segments: 2)  (cost=135605249.42..135605249.60 rows=1 width=32)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=135605249.42..135605249.60 rows=1 width=32)
          ->  Aggregate  (cost=135605249.42..135605249.43 rows=1 width=32)
                ->  Hash Join  (cost=83692089.41..135602741.30 rows=501624 width=10)
                      Hash Cond: tpch500gb.lineitem.l_partkey = part.p_partkey
                      Join Filter: tpch500gb.lineitem.l_quantity < "Expr_SUBQUERY".csq_c1
                      ->  Seq Scan on lineitem  (cost=0.00..44422937.88 rows=1468914944 width=21)
                      ->  Hash  (cost=83680973.86..83680973.86 rows=444622 width=40)
-                           ->  Broadcast Motion 2:2  (slice2; segments: 2)  (cost=81939234.53..83680973.86 rows=444622 width=40)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=81939234.53..83680973.86 rows=444622 width=40)
                                  ->  Hash Join  (cost=81939234.53..83671525.65 rows=27789 width=40)
                                        Hash Cond: "Expr_SUBQUERY".csq_c0 = part.p_partkey
                                        ->  HashAggregate  (cost=79951055.27..81004529.17 rows=27124900 width=36)
                                              Group By: tpch500gb.lineitem.l_partkey
-                                             ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=59112087.32..78897581.37 rows=27124900 width=36)
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=59112087.32..78897581.37 rows=27124900 width=36)
                                                    Hash Key: tpch500gb.lineitem.l_partkey
                                                    ->  HashAggregate  (cost=59112087.32..77812585.37 rows=27124900 width=36)
                                                          Group By: tpch500gb.lineitem.l_partkey
@@ -2988,7 +2988,7 @@ LIMIT 100;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=510594737.04..510594742.04 rows=100 width=132)
-   ->  Gather Motion 2:1  (slice3; segments: 2)  (cost=510594737.04..510594742.04 rows=50 width=132)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=510594737.04..510594742.04 rows=50 width=132)
          Merge Key: orders.o_totalprice, orders.o_orderdate, customer.c_name, customer.c_custkey, orders.o_orderkey
          ->  Limit  (cost=510594737.04..510594740.04 rows=50 width=132)
                ->  GroupAggregate  (cost=510594737.04..544516358.94 rows=565360365 width=132)
@@ -2999,11 +2999,11 @@ LIMIT 100;
                                  Hash Cond: tpch500gb.lineitem.l_orderkey = orders.o_orderkey
                                  ->  Seq Scan on lineitem  (cost=0.00..44422937.88 rows=1468914944 width=15)
                                  ->  Hash  (cost=127509837.36..127509837.36 rows=141554000 width=53)
-                                       ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=92031170.56..127509837.36 rows=141554000 width=53)
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=92031170.56..127509837.36 rows=141554000 width=53)
                                              Hash Key: orders.o_orderkey
                                              ->  Hash Join  (cost=92031170.56..121847677.36 rows=141554000 width=53)
                                                    Hash Cond: orders.o_custkey = customer.c_custkey
-                                                   ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=89821427.40..114246911.20 rows=141554000 width=34)
+                                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=89821427.40..114246911.20 rows=141554000 width=34)
                                                          Hash Key: orders.o_custkey
                                                          ->  Hash Join  (cost=89821427.40..108584751.20 rows=141554000 width=34)
                                                                Hash Cond: orders.o_orderkey = "IN_subquery".l_orderkey
@@ -3068,12 +3068,12 @@ where
                                                                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                                                                        
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=70109084.82..70109084.83 rows=1 width=32)
-   ->  Gather Motion 2:1  (slice2; segments: 2)  (cost=70109084.62..70109084.81 rows=1 width=32)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=70109084.62..70109084.81 rows=1 width=32)
          ->  Aggregate  (cost=70109084.62..70109084.64 rows=1 width=32)
                ->  Hash Join  (cost=3135899.13..70108968.54 rows=23215 width=16)
                      Hash Cond: lineitem.l_partkey = part.p_partkey
                      Join Filter: (part.p_brand = 'Brand#11'::bpchar AND (part.p_container = ANY ('{"SM CASE","SM BOX","SM PACK","SM PKG"}'::bpchar[])) AND lineitem.l_quantity >= 9::numeric AND lineitem.l_quantity <= 19::numeric AND part.p_size <= 5) OR (part.p_brand = 'Brand#51'::bpchar AND (part.p_container = ANY ('{"MED BAG","MED BOX","MED PKG","MED PACK"}'::bpchar[])) AND lineitem.l_quantity >= 10::numeric AND lineitem.l_quantity <= 20::numeric AND part.p_size <= 10) OR (part.p_brand = 'Brand#23'::bpchar AND (part.p_container = ANY ('{"LG CASE","LG BOX","LG PACK","LG PKG"}'::bpchar[])) AND lineitem.l_quantity >= 22::numeric AND lineitem.l_quantity <= 32::numeric AND part.p_size <= 15)
-                     ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..61214767.57 rows=52567007 width=27)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..61214767.57 rows=52567007 width=27)
                            Hash Key: lineitem.l_partkey
                            ->  Seq Scan on lineitem  (cost=0.00..59112087.32 rows=52567007 width=27)
                                  Filter: (l_shipmode = ANY ('{AIR,"AIR REG"}'::bpchar[])) AND l_shipinstruct = 'DELIVER IN PERSON'::bpchar
@@ -3134,19 +3134,19 @@ order by
 	s_name;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice6; segments: 2)  (cost=77572610.05..77572610.06 rows=3 width=222)
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=77572610.05..77572610.06 rows=3 width=222)
    Merge Key: s_name
    ->  Sort  (cost=77572610.05..77572610.06 rows=3 width=222)
          Sort Key: supplier.s_name
          ->  HashAggregate  (cost=77572609.95..77572609.99 rows=3 width=222)
                Group By: supplier.ctid::bigint, nation.ctid::bigint, supplier.gp_segment_id, nation.gp_segment_id
                ->  Result  (cost=70397001.99..77572609.91 rows=3 width=71)
-                     ->  Redistribute Motion 2:2  (slice5; segments: 2)  (cost=70397001.99..77572609.91 rows=3 width=71)
+                     ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=70397001.99..77572609.91 rows=3 width=71)
                            Hash Key: supplier.ctid, nation.ctid
                            ->  Hash Join  (cost=70397001.99..77572609.81 rows=3 width=71)
                                  Hash Cond: partsupp.ps_partkey = "Expr_SUBQUERY".csq_c0 AND partsupp.ps_suppkey = "Expr_SUBQUERY".csq_c1
                                  Join Filter: partsupp.ps_availqty::numeric > "Expr_SUBQUERY".csq_c2
-                                 ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=1747722.14..8913532.21 rows=979771 width=16)
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1747722.14..8913532.21 rows=979771 width=16)
                                        Hash Key: partsupp.ps_partkey, partsupp.ps_suppkey
                                        ->  Hash Join  (cost=1747722.14..8874341.41 rows=979771 width=16)
                                              Hash Cond: partsupp.ps_partkey = part.p_partkey
@@ -3159,19 +3159,19 @@ order by
                                              Hash Cond: "Expr_SUBQUERY".csq_c1 = supplier.s_suppkey
                                              ->  HashAggregate  (cost=67019868.07..67832942.14 rows=21337464 width=40)
                                                    Group By: lineitem.l_partkey, lineitem.l_suppkey
-                                                   ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=62312706.87..66100106.68 rows=21337464 width=40)
+                                                   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=62312706.87..66100106.68 rows=21337464 width=40)
                                                          Hash Key: lineitem.l_partkey, lineitem.l_suppkey
                                                          ->  HashAggregate  (cost=62312706.87..65246608.12 rows=21337464 width=40)
                                                                Group By: lineitem.l_partkey, lineitem.l_suppkey
                                                                ->  Seq Scan on lineitem  (cost=0.00..59112087.32 rows=213374637 width=15)
                                                                      Filter: l_shipdate >= '01-01-1997'::date AND l_shipdate < 'Thu Jan 01 00:00:00 1998'::timestamp without time zone
                                              ->  Hash  (cost=132598.15..132598.15 rows=1573927 width=75)
-                                                   ->  Broadcast Motion 2:2  (slice4; segments: 2)  (cost=24.68..132598.15 rows=1573927 width=75)
+                                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=24.68..132598.15 rows=1573927 width=75)
                                                          ->  Hash Join  (cost=24.68..99152.22 rows=98371 width=75)
                                                                Hash Cond: supplier.s_nationkey = nation.n_nationkey
                                                                ->  Seq Scan on supplier  (cost=0.00..76994.20 rows=2459260 width=69)
                                                                ->  Hash  (cost=24.48..24.48 rows=8 width=14)
-                                                                     ->  Broadcast Motion 2:2  (slice3; segments: 2)  (cost=0.00..24.48 rows=8 width=14)
+                                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..24.48 rows=8 width=14)
                                                                            ->  Seq Scan on nation  (cost=0.00..24.31 rows=1 width=14)
                                                                                  Filter: n_name = 'ALGERIA'::bpchar
  Settings:  enable_mergejoin=on; enable_nestloop=on; gp_enable_agg_distinct=off; gp_segments_for_planner=16; gp_selectivity_damping_for_joins=off; gp_selectivity_damping_for_scans=off
@@ -3232,14 +3232,14 @@ LIMIT 100;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=255819983.00..255819985.25 rows=100 width=112)
-   ->  Gather Motion 2:1  (slice4; segments: 2)  (cost=255819983.00..255819985.25 rows=50 width=112)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=255819983.00..255819985.25 rows=50 width=112)
          Merge Key: numwait, partial_aggregation.s_name
          ->  Limit  (cost=255819983.00..255819983.25 rows=50 width=112)
                ->  Sort  (cost=255819983.00..255832279.30 rows=2459260 width=112)
                      Sort Key (Limit): numwait, partial_aggregation.s_name
                      ->  HashAggregate  (cost=254133353.78..254221973.59 rows=2459260 width=112)
                            Group By: supplier.s_name
-                           ->  Redistribute Motion 2:2  (slice3; segments: 2)  (cost=246567523.24..254032437.66 rows=2459260 width=112)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=246567523.24..254032437.66 rows=2459260 width=112)
                                  Hash Key: supplier.s_name
                                  ->  HashAggregate  (cost=246567523.24..253934067.26 rows=2459260 width=112)
                                        Group By: supplier.s_name
@@ -3259,12 +3259,12 @@ LIMIT 100;
                                                                      ->  Seq Scan on lineitem l1  (cost=0.00..51767512.60 rows=489638315 width=12)
                                                                            Filter: l_receiptdate > l_commitdate
                                                                      ->  Hash  (cost=132598.15..132598.15 rows=1573927 width=30)
-                                                                           ->  Broadcast Motion 2:2  (slice2; segments: 2)  (cost=24.68..132598.15 rows=1573927 width=30)
+                                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=24.68..132598.15 rows=1573927 width=30)
                                                                                  ->  Hash Join  (cost=24.68..99152.22 rows=98371 width=30)
                                                                                        Hash Cond: supplier.s_nationkey = nation.n_nationkey
                                                                                        ->  Seq Scan on supplier  (cost=0.00..76994.20 rows=2459260 width=34)
                                                                                        ->  Hash  (cost=24.48..24.48 rows=8 width=4)
-                                                                                             ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..24.48 rows=8 width=4)
+                                                                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..24.48 rows=8 width=4)
                                                                                                    ->  Seq Scan on nation  (cost=0.00..24.31 rows=1 width=4)
                                                                                                          Filter: n_name = 'SAUDI ARABIA'::bpchar
                                                    ->  Hash  (cost=51767512.60..51767512.60 rows=489638315 width=12)
@@ -3326,19 +3326,19 @@ order by
 	cntrycode;
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice4; segments: 2)  (cost=40740110.94..40746093.38 rows=85464 width=72)
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=40740110.94..40746093.38 rows=85464 width=72)
    Merge Key: cntrycode
    ->  GroupAggregate  (cost=40740110.94..40746093.38 rows=85464 width=72)
          Group By: "?column1?"
          InitPlan  (slice5)
            ->  Aggregate  (cost=2378818.07..2378818.08 rows=1 width=32)
-                 ->  Gather Motion 2:1  (slice3; segments: 2)  (cost=2378817.87..2378818.05 rows=1 width=32)
+                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=2378817.87..2378818.05 rows=1 width=32)
                        ->  Aggregate  (cost=2378817.87..2378817.88 rows=1 width=32)
                              ->  Seq Scan on customer  (cost=0.00..2377643.52 rows=234871 width=8)
                                    Filter: c_acctbal > 0.00 AND ("substring"(c_phone::text, 1, 2) = ANY ('{10,28,11,15,18,16,19}'::text[]))
          ->  Sort  (cost=38361292.86..38361720.18 rows=85464 width=72)
                Sort Key: unnamed_attr_1
-               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=38337890.37..38346436.72 rows=85464 width=72)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=38337890.37..38346436.72 rows=85464 width=72)
                      Hash Key: "?column1?"
                      ->  GroupAggregate  (cost=38337890.37..38343018.18 rows=85464 width=72)
                            Group By: "?column3?"
@@ -3349,7 +3349,7 @@ order by
                                        ->  Seq Scan on customer  (cost=0.00..2377643.52 rows=85464 width=28)
                                              Filter: ("substring"(c_phone::text, 1, 2) = ANY ('{10,28,11,15,18,16,19}'::text[])) AND c_acctbal > $0
                                        ->  Hash  (cost=25485888.72..25485888.72 rows=367784512 width=4)
-                                             ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..25485888.72 rows=367784512 width=4)
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..25485888.72 rows=367784512 width=4)
                                                    Hash Key: orders.o_custkey
                                                    ->  Seq Scan on orders  (cost=0.00..10774508.24 rows=367784512 width=4)
                                                          Filter: o_custkey IS NOT NULL

--- a/src/test/regress/explain.pm
+++ b/src/test/regress/explain.pm
@@ -1385,6 +1385,12 @@ sub prune_heavily
     return
         unless (exists($node->{short}));
 
+    # example: (slice1; segments: 3)
+    if ($node->{short} =~ m/.*\(.*segment.*:\s+(\d+).*\).*/)
+    {
+        $node->{segments} = int($1);
+    }
+
     if ($node->{short} =~ m/Delete\s*\(slice.*segment.*\)\s*\(row.*width.*\)/)
     {
         # QA-1309: fix strange DELETE operator formatting
@@ -1395,10 +1401,13 @@ sub prune_heavily
                 # QA-1309: fix strange UPDATE operator formatting
                 $node->{short} = "Update";
         }
-    elsif ($node->{short} =~ m/\d+\:\d+/)
+    elsif ($node->{short} =~ m/(\d+)\:(\d+)/)
     {
 
         # example: Gather Motion 8:1 (slice4);
+
+        $node->{sendsize} = int($1);
+        $node->{recvsize} = int($2);
 
         # strip the number of nodes and slice information
         $node->{short} =~ s/\s+\d+\:\d+.*//;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -32,6 +32,9 @@ test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules
 # dispatch should always run seperately from other cases.
 test: dispatch
 
+# test partially distributed tables
+test: partial_table
+
 # deadlock tests run separately - because we don't know which one gets stuck.
 test: deadlock
 

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -1560,9 +1560,9 @@ explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id) );
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id SCATTER BY dbid) );
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1.11 rows=4 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.11 rows=4 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..1.11 rows=4 width=36)
-         ->  Redistribute Motion 1:2  (slice1)  (cost=0.00..1.01 rows=8 width=66)
+         ->  Redistribute Motion 1:3  (slice1)  (cost=0.00..1.01 rows=8 width=66)
                Hash Key: gp_id.dbid
                ->  Seq Scan on gp_id  (cost=0.00..1.01 rows=8 width=66)
  Settings:  gp_segments_for_planner=8
@@ -1571,9 +1571,9 @@ explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id SCATTER 
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id SCATTER RANDOMLY) );
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1.11 rows=4 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.11 rows=4 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..1.11 rows=4 width=36)
-         ->  Redistribute Motion 1:2  (slice1)  (cost=0.00..1.01 rows=8 width=66)
+         ->  Redistribute Motion 1:3  (slice1)  (cost=0.00..1.01 rows=8 width=66)
                ->  Seq Scan on gp_id  (cost=0.00..1.01 rows=8 width=66)
  Settings:  gp_segments_for_planner=8
 (5 rows)
@@ -1581,7 +1581,7 @@ explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id SCATTER 
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
          ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1592,7 +1592,7 @@ explain SELECT * from multiset_5( TABLE (SELECT * FROM example ORDER BY a limit 
 -----------------------------------------------------------------------------------------
  Table Function Scan on multiset_5  (cost=2.27..2.62 rows=80 width=36)
    ->  Limit  (cost=2.27..2.49 rows=10 width=16)
-         ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.49 rows=5 width=16)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.49 rows=5 width=16)
                Merge Key: example.a
                ->  Limit  (cost=2.27..2.29 rows=5 width=16)
                      ->  Sort  (cost=2.27..2.29 rows=5 width=16)
@@ -1604,7 +1604,7 @@ explain SELECT * from multiset_5( TABLE (SELECT * FROM example ORDER BY a limit 
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER BY a) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
          ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1613,9 +1613,9 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER BY a) );
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER BY b) );
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
-         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                Hash Key: example.b
                ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1624,9 +1624,9 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER BY b) );
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER RANDOMLY) );
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
-         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
 (5 rows)
@@ -1634,7 +1634,7 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER RANDOMLY)
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.42 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
          ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                Sort Key: example.a, example.b
@@ -1645,7 +1645,7 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b) );
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b SCATTER BY a) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.42 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
          ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                Sort Key: example.a, example.b
@@ -1656,11 +1656,11 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b SCA
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCATTER BY b) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.27..2.42 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
          ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                Sort Key: example.b, example.a
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                      Hash Key: example.b
                      ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1669,11 +1669,11 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCA
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCATTER RANDOMLY) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.27..2.42 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
          ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                Sort Key: example.b, example.a
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                      ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
 (7 rows)
@@ -1681,12 +1681,12 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCA
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b LIMIT 10 SCATTER BY a) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=2.27..2.62 rows=5 width=36)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.62 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.62 rows=5 width=36)
-         ->  Redistribute Motion 1:2  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
                Hash Key: example.a
                ->  Limit  (cost=2.27..2.49 rows=10 width=16)
-                     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.49 rows=5 width=16)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.49 rows=5 width=16)
                            Merge Key: example.a, example.b
                            ->  Limit  (cost=2.27..2.29 rows=5 width=16)
                                  ->  Sort  (cost=2.27..2.29 rows=5 width=16)
@@ -1698,12 +1698,12 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b LIM
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a LIMIT 10 SCATTER BY b) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=2.27..2.62 rows=5 width=36)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.62 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.62 rows=5 width=36)
-         ->  Redistribute Motion 1:2  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
                Hash Key: example.b
                ->  Limit  (cost=2.27..2.49 rows=10 width=16)
-                     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.49 rows=5 width=16)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.49 rows=5 width=16)
                            Merge Key: example.b, example.a
                            ->  Limit  (cost=2.27..2.29 rows=5 width=16)
                                  ->  Sort  (cost=2.27..2.29 rows=5 width=16)
@@ -1715,11 +1715,11 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a LIM
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a LIMIT 10 SCATTER RANDOMLY) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=2.27..2.62 rows=5 width=36)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.62 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.62 rows=5 width=36)
-         ->  Redistribute Motion 1:2  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
                ->  Limit  (cost=2.27..2.49 rows=10 width=16)
-                     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.49 rows=5 width=16)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.49 rows=5 width=16)
                            Merge Key: example.b, example.a
                            ->  Limit  (cost=2.27..2.29 rows=5 width=16)
                                  ->  Sort  (cost=2.27..2.29 rows=5 width=16)
@@ -1733,7 +1733,7 @@ explain SELECT ARRAY(SELECT a FROM multiset_5( TABLE ( SELECT a, b from example)
 -----------------------------------------------------------------------------------------
  Result  (cost=2.42..2.43 rows=1 width=0)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.39..2.42 rows=5 width=4)
+     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.39..2.42 rows=5 width=4)
            Merge Key: a
            ->  Sort  (cost=2.39..2.42 rows=5 width=4)
                  Sort Key: multiset_5.a
@@ -1747,7 +1747,7 @@ explain SELECT ARRAY(SELECT a FROM multiset_5( TABLE ( SELECT a, b from example 
 ------------------------------------------------------------------------------------
  Result  (cost=2.42..2.43 rows=1 width=0)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.42 rows=5 width=4)
+     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.42 rows=5 width=4)
            ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=4)
                  ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                        Sort Key: example.a
@@ -1822,7 +1822,7 @@ explain SELECT * FROM multiset_5( TABLE(SELECT a, b from example scatter by b)) 
 explain SELECT * FROM multiset_5( TABLE( SELECT * from example_r) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
          ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1853,9 +1853,9 @@ explain SELECT * FROM multiset_5( TABLE( SELECT * FROM example_r SCATTER by b, a
 explain SELECT * FROM multiset_5( TABLE( SELECT * FROM example_r SCATTER RANDOMLY) );
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
-         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
 (5 rows)
@@ -1865,7 +1865,7 @@ explain SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hello'::text
 ----------------------------------------------------------------------------------------
  Table Function Scan on multiset_5  (cost=2.24..2.27 rows=8 width=36)
    ->  Aggregate  (cost=2.24..2.25 rows=1 width=36)
-         ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.13..2.23 rows=1 width=8)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.13..2.23 rows=1 width=8)
                ->  Aggregate  (cost=2.13..2.14 rows=1 width=8)
                      ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=0)
  Settings:  gp_segments_for_planner=8
@@ -1892,7 +1892,7 @@ explain SELECT * FROM example_r WHERE (10, 'hello') in (SELECT * FROM multiset_5
 explain SELECT * FROM multiset_5( TABLE( SELECT * from example_v) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
          ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1916,7 +1916,7 @@ explain SELECT * FROM multiset_5( TABLE( SELECT * FROM example WHERE a >= (SELEC
 explain WITH cte AS (SELECT * FROM example) SELECT * FROM multiset_5( TABLE ( SELECT * FROM cte ) )  order by a, b;
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=2.39..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.39..2.42 rows=5 width=36)
    Merge Key: a, b
    ->  Sort  (cost=2.39..2.42 rows=5 width=36)
          Sort Key: multiset_5.a, multiset_5.b
@@ -2009,15 +2009,15 @@ explain SELECT x.* FROM multiset_5( TABLE ( SELECT 1 ) ) x right join (SELECT 1)
 explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hello'::text from example_r scatter randomly) );
                                                                               QUERY PLAN                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=2.24..2.27 rows=1 width=36)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.24..2.27 rows=1 width=36)
    Rows out:  1 rows at destination with 2.808 ms to first row, 3.303 ms to end, start offset by 1.517 ms.
    ->  Table Function Scan on multiset_5  (cost=2.24..2.27 rows=1 width=36)
          Rows out:  1 rows (seg1) with 0.093 ms to first row, 0.096 ms to end, start offset by 4.177 ms.
-         ->  Redistribute Motion 1:2  (slice2; segments: 1)  (cost=2.24..2.25 rows=1 width=36)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.24..2.25 rows=1 width=36)
                Rows out:  1 rows at destination (seg1) with 0.078 ms to first row, 0.079 ms to end, start offset by 4.183 ms.
                ->  Aggregate  (cost=2.24..2.25 rows=1 width=36)
                      Rows out:  1 rows with 0.060 ms to end, start offset by 4.070 ms.
-                     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.13..2.23 rows=1 width=8)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.13..2.23 rows=1 width=8)
                            Rows out:  2 rows at destination with 0.031 ms to first row, 0.051 ms to end, start offset by 4.071 ms.
                            ->  Aggregate  (cost=2.13..2.14 rows=1 width=8)
                                  Rows out:  Avg 1.0 rows x 2 workers.  Max 1 rows (seg0) with 0.687 ms to end, start offset by 2.106 ms.
@@ -2283,7 +2283,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a'
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..0.02 rows=8 width=36)
+ Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.02 rows=8 width=36)
    Hash Key: a
    ->  Table Function Scan on multi_args  (cost=0.00..0.02 rows=8 width=36)
          ->  Result  (cost=0.00..0.01 rows=1 width=0)

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -1561,9 +1561,9 @@ explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id) );
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id SCATTER BY dbid) );
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1.11 rows=4 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.11 rows=4 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..1.11 rows=4 width=36)
-         ->  Redistribute Motion 1:2  (slice1)  (cost=0.00..1.01 rows=8 width=66)
+         ->  Redistribute Motion 1:3  (slice1)  (cost=0.00..1.01 rows=8 width=66)
                Hash Key: gp_id.dbid
                ->  Seq Scan on gp_id  (cost=0.00..1.01 rows=8 width=66)
  Settings:  gp_segments_for_planner=8
@@ -1572,9 +1572,9 @@ explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id SCATTER 
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id SCATTER RANDOMLY) );
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1.11 rows=4 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.11 rows=4 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..1.11 rows=4 width=36)
-         ->  Redistribute Motion 1:2  (slice1)  (cost=0.00..1.01 rows=8 width=66)
+         ->  Redistribute Motion 1:3  (slice1)  (cost=0.00..1.01 rows=8 width=66)
                ->  Seq Scan on gp_id  (cost=0.00..1.01 rows=8 width=66)
  Settings:  gp_segments_for_planner=8
 (5 rows)
@@ -1582,7 +1582,7 @@ explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id SCATTER 
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
          ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1593,7 +1593,7 @@ explain SELECT * from multiset_5( TABLE (SELECT * FROM example ORDER BY a limit 
 -----------------------------------------------------------------------------------------
  Table Function Scan on multiset_5  (cost=2.27..2.62 rows=80 width=36)
    ->  Limit  (cost=2.27..2.49 rows=10 width=16)
-         ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.49 rows=5 width=16)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.49 rows=5 width=16)
                Merge Key: example.a
                ->  Limit  (cost=2.27..2.29 rows=5 width=16)
                      ->  Sort  (cost=2.27..2.29 rows=5 width=16)
@@ -1605,7 +1605,7 @@ explain SELECT * from multiset_5( TABLE (SELECT * FROM example ORDER BY a limit 
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER BY a) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
          ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1614,9 +1614,9 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER BY a) );
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER BY b) );
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
-         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                Hash Key: example.b
                ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1625,9 +1625,9 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER BY b) );
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER RANDOMLY) );
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
-         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
 (5 rows)
@@ -1635,7 +1635,7 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER RANDOMLY)
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.42 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
          ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                Sort Key: example.a, example.b
@@ -1646,7 +1646,7 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b) );
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b SCATTER BY a) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.42 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
          ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                Sort Key: example.a, example.b
@@ -1657,11 +1657,11 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b SCA
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCATTER BY b) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.27..2.42 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
          ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                Sort Key: example.b, example.a
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                      Hash Key: example.b
                      ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1670,11 +1670,11 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCA
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCATTER RANDOMLY) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.27..2.42 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
          ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                Sort Key: example.b, example.a
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                      ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
 (7 rows)
@@ -1682,12 +1682,12 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCA
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b LIMIT 10 SCATTER BY a) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=2.27..2.62 rows=5 width=36)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.62 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.62 rows=5 width=36)
-         ->  Redistribute Motion 1:2  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
                Hash Key: example.a
                ->  Limit  (cost=2.27..2.49 rows=10 width=16)
-                     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.49 rows=5 width=16)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.49 rows=5 width=16)
                            Merge Key: example.a, example.b
                            ->  Limit  (cost=2.27..2.29 rows=5 width=16)
                                  ->  Sort  (cost=2.27..2.29 rows=5 width=16)
@@ -1699,12 +1699,12 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b LIM
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a LIMIT 10 SCATTER BY b) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=2.27..2.62 rows=5 width=36)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.62 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.62 rows=5 width=36)
-         ->  Redistribute Motion 1:2  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
                Hash Key: example.b
                ->  Limit  (cost=2.27..2.49 rows=10 width=16)
-                     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.49 rows=5 width=16)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.49 rows=5 width=16)
                            Merge Key: example.b, example.a
                            ->  Limit  (cost=2.27..2.29 rows=5 width=16)
                                  ->  Sort  (cost=2.27..2.29 rows=5 width=16)
@@ -1716,11 +1716,11 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a LIM
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a LIMIT 10 SCATTER RANDOMLY) );
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=2.27..2.62 rows=5 width=36)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.62 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=2.27..2.62 rows=5 width=36)
-         ->  Redistribute Motion 1:2  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.49 rows=10 width=16)
                ->  Limit  (cost=2.27..2.49 rows=10 width=16)
-                     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.49 rows=5 width=16)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.49 rows=5 width=16)
                            Merge Key: example.b, example.a
                            ->  Limit  (cost=2.27..2.29 rows=5 width=16)
                                  ->  Sort  (cost=2.27..2.29 rows=5 width=16)
@@ -1734,7 +1734,7 @@ explain SELECT ARRAY(SELECT a FROM multiset_5( TABLE ( SELECT a, b from example)
 -----------------------------------------------------------------------------------------
  Result  (cost=2.42..2.43 rows=1 width=0)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.39..2.42 rows=5 width=4)
+     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.39..2.42 rows=5 width=4)
            Merge Key: a
            ->  Sort  (cost=2.39..2.42 rows=5 width=4)
                  Sort Key: multiset_5.a
@@ -1748,7 +1748,7 @@ explain SELECT ARRAY(SELECT a FROM multiset_5( TABLE ( SELECT a, b from example 
 ------------------------------------------------------------------------------------
  Result  (cost=2.42..2.43 rows=1 width=0)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.42 rows=5 width=4)
+     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.42 rows=5 width=4)
            ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=4)
                  ->  Sort  (cost=2.27..2.29 rows=5 width=16)
                        Sort Key: example.a
@@ -1823,7 +1823,7 @@ explain SELECT * FROM multiset_5( TABLE(SELECT a, b from example scatter by b)) 
 explain SELECT * FROM multiset_5( TABLE( SELECT * from example_r) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
          ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1854,9 +1854,9 @@ explain SELECT * FROM multiset_5( TABLE( SELECT * FROM example_r SCATTER by b, a
 explain SELECT * FROM multiset_5( TABLE( SELECT * FROM example_r SCATTER RANDOMLY) );
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
-         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=5 width=16)
                ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
 (5 rows)
@@ -1866,7 +1866,7 @@ explain SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hello'::text
 ----------------------------------------------------------------------------------------
  Table Function Scan on multiset_5  (cost=2.24..2.27 rows=8 width=36)
    ->  Aggregate  (cost=2.24..2.25 rows=1 width=36)
-         ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.13..2.23 rows=1 width=8)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.13..2.23 rows=1 width=8)
                ->  Aggregate  (cost=2.13..2.14 rows=1 width=8)
                      ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=0)
  Settings:  gp_segments_for_planner=8
@@ -1893,7 +1893,7 @@ explain SELECT * FROM example_r WHERE (10, 'hello') in (SELECT * FROM multiset_5
 explain SELECT * FROM multiset_5( TABLE( SELECT * from example_v) );
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2.23 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.23 rows=5 width=36)
    ->  Table Function Scan on multiset_5  (cost=0.00..2.23 rows=5 width=36)
          ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
  Settings:  gp_segments_for_planner=8
@@ -1917,7 +1917,7 @@ explain SELECT * FROM multiset_5( TABLE( SELECT * FROM example WHERE a >= (SELEC
 explain WITH cte AS (SELECT * FROM example) SELECT * FROM multiset_5( TABLE ( SELECT * FROM cte ) )  order by a, b;
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=2.39..2.42 rows=5 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.39..2.42 rows=5 width=36)
    Merge Key: a, b
    ->  Sort  (cost=2.39..2.42 rows=5 width=36)
          Sort Key: multiset_5.a, multiset_5.b
@@ -2010,15 +2010,15 @@ explain SELECT x.* FROM multiset_5( TABLE ( SELECT 1 ) ) x right join (SELECT 1)
 explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hello'::text from example_r scatter randomly) );
                                                                               QUERY PLAN                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=2.24..2.27 rows=1 width=36)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.24..2.27 rows=1 width=36)
    Rows out:  1 rows at destination with 2.808 ms to first row, 3.303 ms to end, start offset by 1.517 ms.
    ->  Table Function Scan on multiset_5  (cost=2.24..2.27 rows=1 width=36)
          Rows out:  1 rows (seg1) with 0.093 ms to first row, 0.096 ms to end, start offset by 4.177 ms.
-         ->  Redistribute Motion 1:2  (slice2; segments: 1)  (cost=2.24..2.25 rows=1 width=36)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.24..2.25 rows=1 width=36)
                Rows out:  1 rows at destination (seg1) with 0.078 ms to first row, 0.079 ms to end, start offset by 4.183 ms.
                ->  Aggregate  (cost=2.24..2.25 rows=1 width=36)
                      Rows out:  1 rows with 0.060 ms to end, start offset by 4.070 ms.
-                     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.13..2.23 rows=1 width=8)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.13..2.23 rows=1 width=8)
                            Rows out:  2 rows at destination with 0.031 ms to first row, 0.051 ms to end, start offset by 4.071 ms.
                            ->  Aggregate  (cost=2.13..2.14 rows=1 width=8)
                                  Rows out:  Avg 1.0 rows x 2 workers.  Max 1 rows (seg0) with 0.687 ms to end, start offset by 2.106 ms.
@@ -2284,7 +2284,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a'
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..0.02 rows=8 width=36)
+ Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.02 rows=8 width=36)
    Hash Key: a
    ->  Table Function Scan on multi_args  (cost=0.00..0.02 rows=8 width=36)
          ->  Result  (cost=0.00..0.01 rows=1 width=0)

--- a/src/test/regress/sql/bfv_partition_plans.sql
+++ b/src/test/regress/sql/bfv_partition_plans.sql
@@ -534,15 +534,17 @@ deallocate f3;
 create table r_part(a int, b int) partition by range(a) (start (1) end(10) every(1));
 create table r_co(a int, b int) with (orientation=column, appendonly=true) partition by range(a) (start (1) end(10) every(1)) ;
 
-insert into r_part values (1,1), (2,2), (3,3);
+insert into r_part values (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8);
 
-select * from r_part order by a,b;
+-- following tests rely on the data distribution, verify them
+select gp_segment_id, * from r_part order by a,b;
 
 analyze r_part;
 
 explain select * from r_part r1, r_part r2 where r1.a=1; -- should eliminate partitions in the r1 copy of r_part
 
-explain select * from r_part where a in (1,2); -- should eliminate partitions
+-- the numbers in the filter should be both on segment 0
+explain select * from r_part where a in (7,8); -- should eliminate partitions
 
 -- Test partition elimination in prepared statements
 prepare f1(int) as select * from r_part where a = 1 order by a,b; 

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -1,0 +1,381 @@
+-- TODO: inherit tables
+-- TODO: partition tables
+-- TODO: ao tables
+-- TODO: tables and temp tables
+
+\set explain 'explain analyze'
+
+set allow_system_table_mods to true;
+
+--
+-- prepare kinds of tables
+--
+
+create temp table t1 (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+create temp table d1 (c1 int, c2 int, c3 int, c4 int) distributed replicated;
+create temp table r1 (c1 int, c2 int, c3 int, c4 int) distributed randomly;
+
+create temp table t2 (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+create temp table d2 (c1 int, c2 int, c3 int, c4 int) distributed replicated;
+create temp table r2 (c1 int, c2 int, c3 int, c4 int) distributed randomly;
+
+update gp_distribution_policy set numsegments=1
+	where localoid in ('t1'::regclass, 'd1'::regclass, 'r1'::regclass);
+
+update gp_distribution_policy set numsegments=2
+	where localoid in ('t2'::regclass, 'd2'::regclass, 'r2'::regclass);
+
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in (
+		't1'::regclass, 'd1'::regclass, 'r1'::regclass,
+		't2'::regclass, 'd2'::regclass, 'r2'::regclass);
+
+--
+-- create table
+--
+
+create temp table t (like t1);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+create temp table t as table t1;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+create temp table t as select * from t1;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+create temp table t as select * from t1 distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+create temp table t as select * from t1 distributed replicated;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+create temp table t as select * from t1 distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+select * into temp table t from t1;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+--
+-- alter table
+--
+
+create table t (like t1);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+
+alter table t set distributed replicated;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+
+alter table t set distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+
+alter table t set distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+
+alter table t add column c10 int;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+
+alter table t alter column c10 type text;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+
+drop table t;
+
+-- below join cases cover all the combinations of
+--
+--     select * from {t,d,r}{1,2} a
+--      {left,} join {t,d,r}{1,2} b
+--      using (c1{',c2',});
+--
+-- there might be some duplicated ones, like 't1 join d1' and 'd1 join t1',
+-- or 'd1 join r1 using (c1)' and 'd1 join r1 using (c1, c2)', this is because
+-- we generate them via scripts and do not clean them up manually.
+--
+-- please do not remove the duplicated ones as we care about the motion
+-- direction of different join orders, e.g. 't2 join t1' and 't1 join t2'
+-- should both distribute t2 to t1.
+
+--
+-- JOIN
+--
+
+-- x1 join y1
+:explain select * from t1 a join t1 b using (c1);
+:explain select * from t1 a join t1 b using (c1, c2);
+:explain select * from t1 a join d1 b using (c1);
+:explain select * from t1 a join d1 b using (c1, c2);
+:explain select * from t1 a join r1 b using (c1);
+:explain select * from t1 a join r1 b using (c1, c2);
+:explain select * from d1 a join t1 b using (c1);
+:explain select * from d1 a join t1 b using (c1, c2);
+:explain select * from d1 a join d1 b using (c1);
+:explain select * from d1 a join d1 b using (c1, c2);
+:explain select * from d1 a join r1 b using (c1);
+:explain select * from d1 a join r1 b using (c1, c2);
+:explain select * from r1 a join t1 b using (c1);
+:explain select * from r1 a join t1 b using (c1, c2);
+:explain select * from r1 a join d1 b using (c1);
+:explain select * from r1 a join d1 b using (c1, c2);
+:explain select * from r1 a join r1 b using (c1);
+:explain select * from r1 a join r1 b using (c1, c2);
+
+-- x1 join y2
+:explain select * from t1 a join t2 b using (c1);
+:explain select * from t1 a join t2 b using (c1, c2);
+:explain select * from t1 a join d2 b using (c1);
+:explain select * from t1 a join d2 b using (c1, c2);
+:explain select * from t1 a join r2 b using (c1);
+:explain select * from t1 a join r2 b using (c1, c2);
+:explain select * from d1 a join t2 b using (c1);
+:explain select * from d1 a join t2 b using (c1, c2);
+:explain select * from d1 a join d2 b using (c1);
+:explain select * from d1 a join d2 b using (c1, c2);
+:explain select * from d1 a join r2 b using (c1);
+:explain select * from d1 a join r2 b using (c1, c2);
+:explain select * from r1 a join t2 b using (c1);
+:explain select * from r1 a join t2 b using (c1, c2);
+:explain select * from r1 a join d2 b using (c1);
+:explain select * from r1 a join d2 b using (c1, c2);
+:explain select * from r1 a join r2 b using (c1);
+:explain select * from r1 a join r2 b using (c1, c2);
+
+-- x2 join y1
+:explain select * from t2 a join t1 b using (c1);
+:explain select * from t2 a join t1 b using (c1, c2);
+:explain select * from t2 a join d1 b using (c1);
+:explain select * from t2 a join d1 b using (c1, c2);
+:explain select * from t2 a join r1 b using (c1);
+:explain select * from t2 a join r1 b using (c1, c2);
+:explain select * from d2 a join t1 b using (c1);
+:explain select * from d2 a join t1 b using (c1, c2);
+:explain select * from d2 a join d1 b using (c1);
+:explain select * from d2 a join d1 b using (c1, c2);
+:explain select * from d2 a join r1 b using (c1);
+:explain select * from d2 a join r1 b using (c1, c2);
+:explain select * from r2 a join t1 b using (c1);
+:explain select * from r2 a join t1 b using (c1, c2);
+:explain select * from r2 a join d1 b using (c1);
+:explain select * from r2 a join d1 b using (c1, c2);
+:explain select * from r2 a join r1 b using (c1);
+:explain select * from r2 a join r1 b using (c1, c2);
+
+-- x2 join y2
+:explain select * from t2 a join t2 b using (c1);
+:explain select * from t2 a join t2 b using (c1, c2);
+:explain select * from t2 a join d2 b using (c1);
+:explain select * from t2 a join d2 b using (c1, c2);
+:explain select * from t2 a join r2 b using (c1);
+:explain select * from t2 a join r2 b using (c1, c2);
+:explain select * from d2 a join t2 b using (c1);
+:explain select * from d2 a join t2 b using (c1, c2);
+:explain select * from d2 a join d2 b using (c1);
+:explain select * from d2 a join d2 b using (c1, c2);
+:explain select * from d2 a join r2 b using (c1);
+:explain select * from d2 a join r2 b using (c1, c2);
+:explain select * from r2 a join t2 b using (c1);
+:explain select * from r2 a join t2 b using (c1, c2);
+:explain select * from r2 a join d2 b using (c1);
+:explain select * from r2 a join d2 b using (c1, c2);
+:explain select * from r2 a join r2 b using (c1);
+:explain select * from r2 a join r2 b using (c1, c2);
+
+-- x1 left join y1
+:explain select * from t1 a left join t1 b using (c1);
+:explain select * from t1 a left join t1 b using (c1, c2);
+:explain select * from t1 a left join d1 b using (c1);
+:explain select * from t1 a left join d1 b using (c1, c2);
+:explain select * from t1 a left join r1 b using (c1);
+:explain select * from t1 a left join r1 b using (c1, c2);
+:explain select * from d1 a left join t1 b using (c1);
+:explain select * from d1 a left join t1 b using (c1, c2);
+:explain select * from d1 a left join d1 b using (c1);
+:explain select * from d1 a left join d1 b using (c1, c2);
+:explain select * from d1 a left join r1 b using (c1);
+:explain select * from d1 a left join r1 b using (c1, c2);
+:explain select * from r1 a left join t1 b using (c1);
+:explain select * from r1 a left join t1 b using (c1, c2);
+:explain select * from r1 a left join d1 b using (c1);
+:explain select * from r1 a left join d1 b using (c1, c2);
+:explain select * from r1 a left join r1 b using (c1);
+:explain select * from r1 a left join r1 b using (c1, c2);
+
+-- x1 left join y2
+:explain select * from t1 a left join t2 b using (c1);
+:explain select * from t1 a left join t2 b using (c1, c2);
+:explain select * from t1 a left join d2 b using (c1);
+:explain select * from t1 a left join d2 b using (c1, c2);
+:explain select * from t1 a left join r2 b using (c1);
+:explain select * from t1 a left join r2 b using (c1, c2);
+:explain select * from d1 a left join t2 b using (c1);
+:explain select * from d1 a left join t2 b using (c1, c2);
+:explain select * from d1 a left join d2 b using (c1);
+:explain select * from d1 a left join d2 b using (c1, c2);
+:explain select * from d1 a left join r2 b using (c1);
+:explain select * from d1 a left join r2 b using (c1, c2);
+:explain select * from r1 a left join t2 b using (c1);
+:explain select * from r1 a left join t2 b using (c1, c2);
+:explain select * from r1 a left join d2 b using (c1);
+:explain select * from r1 a left join d2 b using (c1, c2);
+:explain select * from r1 a left join r2 b using (c1);
+:explain select * from r1 a left join r2 b using (c1, c2);
+
+-- x2 left join y1
+:explain select * from t2 a left join t1 b using (c1);
+:explain select * from t2 a left join t1 b using (c1, c2);
+:explain select * from t2 a left join d1 b using (c1);
+:explain select * from t2 a left join d1 b using (c1, c2);
+:explain select * from t2 a left join r1 b using (c1);
+:explain select * from t2 a left join r1 b using (c1, c2);
+:explain select * from d2 a left join t1 b using (c1);
+:explain select * from d2 a left join t1 b using (c1, c2);
+:explain select * from d2 a left join d1 b using (c1);
+:explain select * from d2 a left join d1 b using (c1, c2);
+:explain select * from d2 a left join r1 b using (c1);
+:explain select * from d2 a left join r1 b using (c1, c2);
+:explain select * from r2 a left join t1 b using (c1);
+:explain select * from r2 a left join t1 b using (c1, c2);
+:explain select * from r2 a left join d1 b using (c1);
+:explain select * from r2 a left join d1 b using (c1, c2);
+:explain select * from r2 a left join r1 b using (c1);
+:explain select * from r2 a left join r1 b using (c1, c2);
+
+-- x2 left join y2
+:explain select * from t2 a left join t2 b using (c1);
+:explain select * from t2 a left join t2 b using (c1, c2);
+:explain select * from t2 a left join d2 b using (c1);
+:explain select * from t2 a left join d2 b using (c1, c2);
+:explain select * from t2 a left join r2 b using (c1);
+:explain select * from t2 a left join r2 b using (c1, c2);
+:explain select * from d2 a left join t2 b using (c1);
+:explain select * from d2 a left join t2 b using (c1, c2);
+:explain select * from d2 a left join d2 b using (c1);
+:explain select * from d2 a left join d2 b using (c1, c2);
+:explain select * from d2 a left join r2 b using (c1);
+:explain select * from d2 a left join r2 b using (c1, c2);
+:explain select * from r2 a left join t2 b using (c1);
+:explain select * from r2 a left join t2 b using (c1, c2);
+:explain select * from r2 a left join d2 b using (c1);
+:explain select * from r2 a left join d2 b using (c1, c2);
+:explain select * from r2 a left join r2 b using (c1);
+:explain select * from r2 a left join r2 b using (c1, c2);
+
+--
+-- insert
+--
+
+insert into t1 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+insert into t2 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+
+insert into d1 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+insert into d2 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+
+insert into r1 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+insert into r2 (c1) values (1), (2), (3), (4), (5), (6)
+	returning c1, c2;
+
+begin;
+insert into t1 (c1) values (1) returning c1, c2;
+insert into d1 (c1) values (1) returning c1, c2;
+insert into r1 (c1) values (1) returning c1, c2;
+insert into t2 (c1) values (1) returning c1, c2;
+insert into d2 (c1) values (1) returning c1, c2;
+insert into r2 (c1) values (1) returning c1, c2;
+rollback;
+
+begin;
+insert into t1 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+insert into d1 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+insert into r1 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+insert into t2 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+insert into d2 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+insert into r2 (c1) select i from generate_series(1, 20) i
+	returning c1, c2;
+rollback;
+
+begin;
+insert into t1 (c1, c2) select c1, c2 from t1 returning c1, c2;
+insert into t1 (c1, c2) select c2, c1 from t1 returning c1, c2;
+insert into t1 (c1, c2) select c1, c2 from t2 returning c1, c2;
+insert into t1 (c1, c2) select c2, c1 from t2 returning c1, c2;
+insert into t1 (c1, c2) select c1, c2 from d1 returning c1, c2;
+insert into t1 (c1, c2) select c1, c2 from d2 returning c1, c2;
+insert into t1 (c1, c2) select c1, c2 from r1 returning c1, c2;
+insert into t1 (c1, c2) select c1, c2 from r2 returning c1, c2;
+rollback;
+
+begin;
+insert into t2 (c1, c2) select c1, c2 from t1 returning c1, c2;
+insert into t2 (c1, c2) select c2, c1 from t1 returning c1, c2;
+insert into t2 (c1, c2) select c1, c2 from d1 returning c1, c2;
+insert into t2 (c1, c2) select c1, c2 from d2 returning c1, c2;
+insert into t2 (c1, c2) select c1, c2 from r1 returning c1, c2;
+insert into t2 (c1, c2) select c1, c2 from r2 returning c1, c2;
+rollback;
+
+begin;
+insert into d1 (c1, c2) select c1, c2 from t1 returning c1, c2;
+insert into d1 (c1, c2) select c2, c1 from t1 returning c1, c2;
+insert into d1 (c1, c2) select c1, c2 from t2 returning c1, c2;
+insert into d1 (c1, c2) select c2, c1 from t2 returning c1, c2;
+insert into d1 (c1, c2) select c1, c2 from d1 returning c1, c2;
+insert into d1 (c1, c2) select c1, c2 from d2 returning c1, c2;
+insert into d1 (c1, c2) select c1, c2 from r1 returning c1, c2;
+insert into d1 (c1, c2) select c1, c2 from r2 returning c1, c2;
+rollback;
+
+begin;
+insert into d2 (c1, c2) select c1, c2 from t1 returning c1, c2;
+insert into d2 (c1, c2) select c2, c1 from t1 returning c1, c2;
+insert into d2 (c1, c2) select c1, c2 from d1 returning c1, c2;
+insert into d2 (c1, c2) select c1, c2 from d2 returning c1, c2;
+insert into d2 (c1, c2) select c1, c2 from r1 returning c1, c2;
+insert into d2 (c1, c2) select c1, c2 from r2 returning c1, c2;
+rollback;
+
+begin;
+insert into r1 (c1, c2) select c1, c2 from t1 returning c1, c2;
+insert into r1 (c1, c2) select c2, c1 from t1 returning c1, c2;
+insert into r1 (c1, c2) select c1, c2 from t2 returning c1, c2;
+insert into r1 (c1, c2) select c2, c1 from t2 returning c1, c2;
+insert into r1 (c1, c2) select c1, c2 from d1 returning c1, c2;
+insert into r1 (c1, c2) select c1, c2 from d2 returning c1, c2;
+insert into r1 (c1, c2) select c1, c2 from r1 returning c1, c2;
+insert into r1 (c1, c2) select c1, c2 from r2 returning c1, c2;
+rollback;
+
+begin;
+insert into r2 (c1, c2) select c1, c2 from t1 returning c1, c2;
+insert into r2 (c1, c2) select c2, c1 from t1 returning c1, c2;
+insert into r2 (c1, c2) select c1, c2 from d1 returning c1, c2;
+insert into r2 (c1, c2) select c1, c2 from d2 returning c1, c2;
+insert into r2 (c1, c2) select c1, c2 from r1 returning c1, c2;
+insert into r2 (c1, c2) select c1, c2 from r2 returning c1, c2;
+rollback;


### PR DESCRIPTION
This is a follow up of https://github.com/greenplum-db/gpdb/pull/5679, in that PR we mentioned that we want to improve gpexpand in some points:

1. gpexpand used to stop the cluster during expansion;
2. gpexpand has to alter all the tables to randomly distributed for them to be immediately useable after expansion, however performance on randomly distributed tables are bad;
3. gpexpand could alter the tables back to their original distribution policies, but the process is very slow and causes heavy IO and network loads, which makes the performance even worse;

Point 1 is covered by https://github.com/greenplum-db/gpdb/pull/5679; point 2 is covered by current PR.  What we focus on is:

- Added a new column `numsegments` in `gp_distribution_policy` to track how many segments a table is distributed on;
- Allow a N table to exist on a M cluster;
- Allow DMLs on N tables;
- Support DMLs on N tables to join with M tables;

In details, this PR adds a new column ’numsegments’ for each table in gp_distribution_policy, it indicate how many segments a table is distributed on, if a table has numsegments=3 then all its data will be stored and scanned on segment 0\~2, for another example, if a table has numsegmnets=2, although there are 3 segments(0\~2) in cluster, the data of this table can only be stored on the segment 0~1, this is to say the table data distributed on the first N segments. By adding this column, we do not need to change the table distribution to be random, because we know that the table data is distributed correctly on the first N segments with the original distributed keys.

With this new column we could allow a N table to exist on a M cluster (N table: a table with numsegments=N; M cluster: a cluster with M primary segments; N<M), it can be used (select/insert/update/delete) directly without having to be altered to randomly, the performance is just the same before and after online expansion.

To support this we have to consider this new attribute in the planner to generate correct plan, for cases like a N table join M table motions are added to collocate the data. It can be better explained with some plans:

```
-- t1 and t2 are both distributed on (c1, c2), one on 1 segments, the other on 2 segments
select localoid::regclass, attrnums, policytype, numsegments from gp_distribution_policy;
 localoid | attrnums | policytype | numsegments
----------+----------+------------+-------------
 t1       | {1,2}    | p          |           1
 t2       | {1,2}    | p          |           2
(2 rows)

-- t1 and t1 have exactly the same distribution policy, join locally
explain select * from t1 a join t1 b using (c1, c2);
                                                            QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice1; segments: 1)
   ->  Hash Join
         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
         ->  Seq Scan on t1 a
         ->  Hash
               ->  Seq Scan on t1 b
 Optimizer: legacy query optimizer

-- t1 and t1 both have numsegments=1 but join with non-distribute column
-- please notice the broadcast motion size is 1:1
select * from t1 a join t1 b using (c1);
                                                              QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice2; segments: 1)
   ->  Hash Join
         Hash Cond: a.c1 = b.c1
         ->  Seq Scan on t1 a
         ->  Hash
               ->  Broadcast Motion 1:1  (slice1; segments: 1)
                     ->  Seq Scan on t1 b
 Optimizer: legacy query optimizer

-- t1 and t2 are both distributed on (c1, c2), but as they have different numsegments,
-- one has to be redistributed
explain select * from t1 a join t2 b using (c1, c2);
                                                            QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice2; segments: 1)
   ->  Hash Join
         Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
         ->  Seq Scan on t1 a
         ->  Hash
               ->  Redistribute Motion 2:1  (slice1; segments: 2)
                     Hash Key: b.c1, b.c2
                     ->  Seq Scan on t2 b
 Optimizer: legacy query optimizer
```
Not only JOIN, `numsegments` has to be considered also in UNION, INTERSECT, SUBQUERY, CTE, etc..

This PR is still WIP, there are some known issues/TODOs:
1.  ORCA support;
2. In some cases, we can not get the proper `numsegments` yet;
3. More test cases are needed;

Please kindly help to review, any comments are welcome, thanks in advance.