### PR TITLE
Explicitly select the correct side in restrictinfo for copathkey gene…

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -325,6 +325,7 @@ typedef struct
 {
 	PlannerInfo *root;
 	List	   *mergeclause_list;
+	Path       *path;
 	CdbPathLocus locus;
 	CdbPathLocus *colocus;
 	bool		colocus_eq_locus;
@@ -401,20 +402,32 @@ cdbpath_match_preds_to_partkey_tail(CdbpathMatchPredsContext *ctx,
 	{
 		foreach(rcell, ctx->mergeclause_list)
 		{
+			EquivalenceClass *a_ec; /* Corresponding to ctx->path. */
+			EquivalenceClass *b_ec;
 			ListCell   *i;
 			RestrictInfo *rinfo = (RestrictInfo *) lfirst(rcell);
 
 			if (!rinfo->left_ec)
 				update_mergeclause_eclasses(ctx->root, rinfo);
 
+			if (bms_is_subset(rinfo->right_relids, ctx->path->parent->relids))
+			{
+				a_ec = rinfo->right_ec;
+				b_ec = rinfo->left_ec;
+			}
+			else
+			{
+				a_ec = rinfo->left_ec;
+				b_ec = rinfo->right_ec;
+				Assert(bms_is_subset(rinfo->left_relids, ctx->path->parent->relids));
+			}
+
 			if (CdbPathLocus_IsHashed(ctx->locus))
 			{
 				PathKey    *pathkey = (PathKey *) lfirst(partkeycell);
 
-				if (pathkey->pk_eclass == rinfo->left_ec)
-					copathkey = makePathKeyForEC(rinfo->right_ec);
-				else if (pathkey->pk_eclass == rinfo->right_ec)
-					copathkey = makePathKeyForEC(rinfo->left_ec);
+				if (pathkey->pk_eclass == a_ec)
+					copathkey = makePathKeyForEC(b_ec);
 			}
 			else if (CdbPathLocus_IsHashedOJ(ctx->locus))
 			{
@@ -424,10 +437,8 @@ cdbpath_match_preds_to_partkey_tail(CdbpathMatchPredsContext *ctx,
 				{
 					PathKey    *pathkey = (PathKey *) lfirst(i);
 
-					if (pathkey->pk_eclass == rinfo->left_ec)
-						copathkey = makePathKeyForEC(rinfo->right_ec);
-					else if (pathkey->pk_eclass == rinfo->right_ec)
-						copathkey = makePathKeyForEC(rinfo->left_ec);
+					if (pathkey->pk_eclass == a_ec)
+						copathkey = makePathKeyForEC(b_ec); /* break earlier? */
 				}
 			}
 
@@ -491,6 +502,7 @@ cdbpath_match_preds_to_partkey_tail(CdbpathMatchPredsContext *ctx,
 static bool
 cdbpath_match_preds_to_partkey(PlannerInfo *root,
 							   List *mergeclause_list,
+							   Path *path,
 							   CdbPathLocus locus,
 							   CdbPathLocus *colocus)	/* OUT */
 {
@@ -504,6 +516,7 @@ cdbpath_match_preds_to_partkey(PlannerInfo *root,
 
 	ctx.root = root;
 	ctx.mergeclause_list = mergeclause_list;
+	ctx.path = path;
 	ctx.locus = locus;
 	ctx.colocus = colocus;
 	ctx.colocus_eq_locus = true;
@@ -1071,6 +1084,7 @@ cdbpath_motion_for_join(PlannerInfo *root,
 		/* Redistribute single rel if joining on other rel's partitioning key */
 		else if (cdbpath_match_preds_to_partkey(root,
 												redistribution_clauses,
+												other->path,
 												other->locus,
 												&single->move_to))	/* OUT */
 		{
@@ -1131,6 +1145,7 @@ cdbpath_motion_for_join(PlannerInfo *root,
 		if (!small->require_existing_order &&
 			cdbpath_match_preds_to_partkey(root,
 										   redistribution_clauses,
+										   large->path,
 										   large->locus,
 										   &small->move_to))	/* OUT */
 		{
@@ -1149,6 +1164,7 @@ cdbpath_motion_for_join(PlannerInfo *root,
 		else if (!large->require_existing_order &&
 				 cdbpath_match_preds_to_partkey(root,
 												redistribution_clauses,
+												small->path,
 												small->locus,
 												&large->move_to))	/* OUT */
 		{


### PR DESCRIPTION
…ration in cdbpath_match_preds_to_partkey_tail().

Just like what we do in cdbpath_partkeys_from_preds(). This is more
friendly for code reading and also is better for code maintenance.
Previous code could potentially introduce bugs since it's relids, not
equivalenceclass, that could determine the side for comparison accurately.

I could not create a test case for this unfortunately.