### PR TITLE
Set TLSv1.1+ as preferred in external web tables

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -113,7 +113,7 @@ typedef struct
  * SSL support GUCs - should be added soon. Until then we will use stubs
  *
  *  SSL Params
- *	extssl_protocol  CURL_SSLVERSION_TLSv1 				
+ *	extssl_protocol  CURL_SSLVERSION_TLSv1_1
  *  extssl_cipher 	 TLS_RSA_WITH_AES_128_CBC_SHA
  *  extssl_verifycert 	1
  *  extssl_verifyhost 	2
@@ -127,7 +127,7 @@ typedef struct
  *  extssl_libcurldebug 1 	
  */
 
-const static int extssl_protocol  = CURL_SSLVERSION_TLSv1;
+const static int extssl_protocol  = CURL_SSLVERSION_TLSv1_1;
 const char* extssl_cipher = "AES128-SHA";
 const static int extssl_verifycert = 1;
 const static int extssl_verifyhost = 2;


### PR DESCRIPTION
The previous setting was using a legacy curl macro for specifying "TLSv1.0 or higher" for connections. Use of TLSv1.0 is discouraged so bump the minimum version to TLSv1.1 with the newer curl macros (shipped in 7.34.0 which was released in 2013).

This might be somewhat of a discussion piece, but is there really any real use case for allowing TLSv1.0?