### PR TITLE
Remove FIXME on function ExplainOneQuery

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -389,6 +389,7 @@ ExplainOneQuery(Query *query, IntoClause *into, ExplainState *es,
 		/* plan the query */
 		plan = pg_plan_query(query, 0, params);
 
+		/* run it (if needed) and produce output */
 		ExplainOnePlan(plan, into, es, queryString, params);
 	}
 }

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -389,13 +389,6 @@ ExplainOneQuery(Query *query, IntoClause *into, ExplainState *es,
 		/* plan the query */
 		plan = pg_plan_query(query, 0, params);
 
-		/*
-		 * GPDB_92_MERGE_FIXME: it really should be an optimizer's responsibility
-		 * to correctly set the into-clause and into-policy of the PlannedStmt.
-		 */
-		if (into != NULL)
-			plan->intoClause = copyObject(into);
-		/* run it (if needed) and produce output */
 		ExplainOnePlan(plan, into, es, queryString, params);
 	}
 }


### PR DESCRIPTION
The field 'intoClause' in struct PlannedStmt don't need to set in
this situation.

TODO:
The intoClause in PlannedStmt is complex to me, still not wholly 
figure out why does it needed and how to refactor it in a clean 
way.

```
 	/*
	 * GPDB: Used to keep target information for CTAS and it is needed
	 * to be dispatched to QEs.
	 */
	IntoClause *intoClause;
} PlannedStmt;
```
and there are other apperances of 
`plan->intoClause = copyObject(stmt->into);`

Test passed when runnint installcheck-good under the directory src/test/regress