### PR TITLE
ci: fix race condition in ccp multi-cluster gptransfer test

### DIFF
--- a/concourse/pipelines/gpdb_master-generated.yml
+++ b/concourse/pipelines/gpdb_master-generated.yml
@@ -2107,6 +2107,8 @@ jobs:
         output_mapping:
           cluster_env_files: cluster_env_files2
       - task: gpinitsystem
+        input_mapping:
+          terraform: terraform2
         config:
           platform: linux
           image_resource:

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -2153,6 +2153,8 @@ jobs:
         output_mapping:
           cluster_env_files: cluster_env_files2
       - task: gpinitsystem
+        input_mapping:
+          terraform: terraform2
         config:
           platform: linux
           image_resource:


### PR DESCRIPTION
The below is based on gpdb5 but is identical in the error, fix, and validation.
https://github.com/greenplum-db/gpdb/pull/5717

This relates to these errors that occasionally occurred due to a race condition explained below:
https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/5X_STABLE/jobs/gptransfer-43x-to-5x/builds/74
https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/5X_STABLE/jobs/gptransfer-43x-to-5x/builds/72
https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/5X_STABLE/jobs/gptransfer-43x-to-5x/builds/70

A race condition was occurring because the set of concourse tasks that
create the second of two CCP clusters was expecting to find and use the
terraform volume. The terraform volume is expected to only be created
and used in the first set of tasks for the first CCP cluster. If the
first set of tasks did not complete before the second set then there was
the potential for the terraform volume to not exist yet. This causes
the job to error in concourse.

The fix is to correct the mistake of the second set of tasks using the
wrong volume. They should only be using the terraform2 volume. This
completely removes the potential for the race condition.

Dev pipeline for proof of the fix being correct:
https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/dev:fix-gptransfer-race-condition-kmacoskey

It's hard to replicate the race condition happening, so the dev pipeline doesn't show exactly what would happen under those conditions, but it does show that the jobs run successfully after the input mapping changes for terraform2 in the second CCP cluster.