### PR TITLE
Fix imtermittent failure dispatch test cases

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3353,7 +3353,6 @@ drop_unnamed_stmt(void)
 void
 quickdie(SIGNAL_ARGS)
 {
-	SIMPLE_FAULT_INJECTOR(QuickDie);
 	quickdie_impl();
 }
 

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -190,8 +190,6 @@ FI_IDENT(OptRelcacheTranslatorCatalogAccess, "opt_relcache_translator_catalog_ac
 FI_IDENT(SendQEDetailsInitBackend, "send_qe_details_init_backend")
 /* inject fault in ProcessStartupPacket() */
 FI_IDENT(ProcessStartupPacketFault, "process_startup_packet")
-/* inject fault in quickdie*/
-FI_IDENT(QuickDie, "quickdie")
 /* inject fault in cdbdisp_dispatchX*/
 FI_IDENT(AfterOneSliceDispatched, "after_one_slice_dispatched")
 /* inject fault in interconnect to skip sending the stop ack */

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -1,4 +1,6 @@
 -- Misc tests related to dispatching queries to segments.
+CREATE DATABASE dispatch_test_db;
+\c dispatch_test_db;
 
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 
@@ -73,7 +75,7 @@ CREATE TABLE "my table" (id integer);
 DROP TABLE "my table";
 
 -- Clean up
-\c regression
+\c dispatch_test_db
 DROP DATABASE "dispatch test db";
 
 -- Test gp_max_plan_size limit
@@ -91,12 +93,13 @@ select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 select gp_inject_fault('send_qe_details_init_backend', 'skip', 2);
 
 -- terminate exiting QEs first
-\c
+\c dispatch_test_db
 -- verify failure will be reported
 SELECT 1 FROM gp_dist_random('gp_id');
 
 -- reset fault injector
 select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
+
 
 --
 -- Test suit : test gang creation and commands dispatching 
@@ -143,13 +146,9 @@ set gp_gang_creation_retry_timer to 1000;
 
 select cleanupAllGangs();
 
--- trigger fault and put segment 0 into recovery mode
-select gp_inject_fault('process_startup_packet', 'segv', 2);
+-- trigger fault and report segment 0 in recovery for 5 times
+select gp_inject_fault('process_startup_packet', 'skip', '', 'dispatch_test_db', '', 1, 5, 0, 2::smallint);
 select cleanupAllGangs();
---start_ignore
-select 'trigger fault' from gp_dist_random('gp_id');
---end_ignore
-select pg_sleep(1); -- small delay to make sure the postmaster has noticed the child death.
 
 -- should success after retry
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
@@ -166,24 +165,19 @@ set gp_gang_creation_retry_timer to 200;
 select cleanupAllGangs();
 
 -- trigger fault and put segment 0 into recovery mode
-select gp_inject_fault('process_startup_packet', 'segv', 2);
-select gp_inject_fault('quickdie', 'sleep', '', '', '', 1, 1, 5, 2::smallint);
+select gp_inject_fault('process_startup_packet', 'skip', '', 'dispatch_test_db', '', 1, 5, 0, 2::smallint);
 select cleanupAllGangs();
---start_ignore
-select 'trigger fault' from gp_dist_random('gp_id');
---end_ignore
-select pg_sleep(1); -- small delay to make sure the postmaster has noticed the child death.
 
 -- should fail after 2 retries
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 
--- Wait for the quickdie() sleep to time out, and the server to restart.
-select pg_sleep(5);
+set gp_gang_creation_retry_count to 10;
+-- should success and process_startup_packet will be invalid after this query
+select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
+where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 
-set gp_gang_creation_retry_count to 100;
 select gp_inject_fault('process_startup_packet', 'reset', 2);
-select gp_inject_fault('quickdie', 'reset', 2);
 
 --start_ignore
 -- enlarge the retry count
@@ -249,7 +243,7 @@ select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 -- gp_segment_connect_timeout = 1 : wait 1 second
 
 set gp_segment_connect_timeout to 1;
-select gp_inject_fault('process_startup_packet', 'suspend', 2);
+select gp_inject_fault('process_startup_packet', 'suspend', '', 'dispatch_test_db', '', 1, 1, 0, 2::smallint);
 
 select cleanupAllGangs();
 
@@ -342,7 +336,7 @@ DROP TABLE foo_test;
 --
 -- Test dangling Gang would be destroyed if interrupted during the creation
 --
-\c
+select cleanupAllGangs();
 select gp_inject_fault('gang_created', 'reset', 1);
 select gp_inject_fault('gang_created', 'error', 1);
 select 1 from gp_dist_random('gp_id') limit 1;
@@ -379,3 +373,6 @@ end;
 select gp_inject_fault('fts_probe', 'reset', 1);
 -- resume GDD scan 
 select gp_inject_fault('gdd_probe', 'reset', 1);
+
+\c regression
+DROP DATABASE dispatch_test_db;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1,4 +1,6 @@
 -- Misc tests related to dispatching queries to segments.
+CREATE DATABASE dispatch_test_db;
+\c dispatch_test_db;
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- Mask out the whoami message
 -- start_matchsubs
@@ -106,7 +108,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP TABLE "my table";
 -- Clean up
-\c regression
+\c dispatch_test_db
 DROP DATABASE "dispatch test db";
 -- Test gp_max_plan_size limit
 set gp_max_plan_size='10 kB';
@@ -136,7 +138,7 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11034)
 (1 row)
 
 -- terminate exiting QEs first
-\c
+\c dispatch_test_db
 -- verify failure will be reported
 SELECT 1 FROM gp_dist_random('gp_id');
 ERROR:  failed to acquire resources on one or more segments
@@ -202,9 +204,9 @@ select cleanupAllGangs();
  t
 (1 row)
 
--- trigger fault and put segment 0 into recovery mode
-select gp_inject_fault('process_startup_packet', 'segv', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11062)
+-- trigger fault and report segment 0 in recovery for 5 times
+select gp_inject_fault('process_startup_packet', 'skip', '', 'dispatch_test_db', '', 1, 5, 0, 2::smallint);
+NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=373785)
  gp_inject_fault 
 -----------------
  t
@@ -214,20 +216,6 @@ select cleanupAllGangs();
  cleanupallgangs 
 -----------------
  t
-(1 row)
-
---start_ignore
-select 'trigger fault' from gp_dist_random('gp_id');
-ERROR:  failed to acquire resources on one or more segments
-DETAIL:  server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
- (seg0 127.0.0.1:40000)
---end_ignore
-select pg_sleep(1); -- small delay to make sure the postmaster has noticed the child death.
- pg_sleep 
-----------
- 
 (1 row)
 
 -- should success after retry
@@ -258,15 +246,8 @@ select cleanupAllGangs();
 (1 row)
 
 -- trigger fault and put segment 0 into recovery mode
-select gp_inject_fault('process_startup_packet', 'segv', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11116)
- gp_inject_fault 
------------------
- t
-(1 row)
-
-select gp_inject_fault('quickdie', 'sleep', '', '', '', 1, 1, 5, 2::smallint);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11116)
+select gp_inject_fault('process_startup_packet', 'skip', '', 'dispatch_test_db', '', 1, 5, 0, 2::smallint);
+NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=373867)
  gp_inject_fault 
 -----------------
  t
@@ -278,42 +259,22 @@ select cleanupAllGangs();
  t
 (1 row)
 
---start_ignore
-select 'trigger fault' from gp_dist_random('gp_id');
-ERROR:  failed to acquire resources on one or more segments
-DETAIL:  server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
- (seg0 127.0.0.1:40000)
---end_ignore
-select pg_sleep(1); -- small delay to make sure the postmaster has noticed the child death.
- pg_sleep 
-----------
- 
-(1 row)
-
 -- should fail after 2 retries
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 ERROR:  failed to acquire resources on one or more segments
 DETAIL:  Segments are in recovery mode.
--- Wait for the quickdie() sleep to time out, and the server to restart.
-select pg_sleep(5);
- pg_sleep 
-----------
- 
+set gp_gang_creation_retry_count to 10;
+-- should success and process_startup_packet will be invalid after this query
+select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
+where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
+ c1 | c2 | c3 | c1 | c2 | c3 | c1 | c2 | c3 
+----+----+----+----+----+----+----+----+----
+  1 |  1 |  2 |  2 |  1 |  2 |  3 |  1 |  2
 (1 row)
 
-set gp_gang_creation_retry_count to 100;
 select gp_inject_fault('process_startup_packet', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11186)
- gp_inject_fault 
------------------
- t
-(1 row)
-
-select gp_inject_fault('quickdie', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11186)
+NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=373925)
  gp_inject_fault 
 -----------------
  t
@@ -459,8 +420,8 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11284)
 -- gp_segment_connect_timeout = 0 : wait forever
 -- gp_segment_connect_timeout = 1 : wait 1 second
 set gp_segment_connect_timeout to 1;
-select gp_inject_fault('process_startup_packet', 'suspend', 2);
-NOTICE:  Success:
+select gp_inject_fault('process_startup_packet', 'suspend', '', 'dispatch_test_db', '', 1, 1, 0, 2::smallint);
+NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=374053)
  gp_inject_fault 
 -----------------
  t
@@ -613,7 +574,12 @@ DROP TABLE foo_test;
 --
 -- Test dangling Gang would be destroyed if interrupted during the creation
 --
-\c
+select cleanupAllGangs();
+ cleanupallgangs 
+-----------------
+ t
+(1 row)
+
 select gp_inject_fault('gang_created', 'reset', 1);
 NOTICE:  Success:
  gp_inject_fault 
@@ -700,3 +666,5 @@ NOTICE:  Success:
  t
 (1 row)
 
+\c regression
+DROP DATABASE dispatch_test_db;


### PR DESCRIPTION
In dispatch test cases, we need a way to put a segment to in-recovery
status to test gang recreating logic of dispatcher.

We used to trigger a panic fault on a segment and suspend the quickdie()
to simulate in-recovery status. To avoid segment staying in recovery mode
for a long time, we used a 'sleep' fault instead of 'suspend' in quickdie(),
so segment can accept new connections after 5 seconds. 5 seconds works
fine most of time, but still not stable enough, so we decide to use more
straight-forward mean to simulate in-recovery mode which reports a
POSTMASTER_IN_RECOVERY_MSG directly in ProcessStartupPacket(). To not
affecting other backends, we create a new database so fault injectors
only affect dispatch test cases.