### PR TITLE
Update default value of optimizer_force_XXX gucs

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2601,7 +2601,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_multistage_agg,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 
@@ -2623,7 +2623,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_expanded_distinct_aggs,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 
@@ -2904,7 +2904,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_three_stage_scalar_dqa,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
@@ -225,18 +225,14 @@ INFO:  Dispatch command to SINGLE content
 
 -- group by and sort
 select a, count(*) from dd_multicol_1 where a=1 and b=1 group by a,b;
-INFO:  Dispatch command to ALL contents
-INFO:  Dispatch command to ALL contents
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | count 
 ---+-------
  1 |     1
 (1 row)
 
 select a, count(*) from dd_multicol_1 where a=1 and b=1 group by a,b  order by a,b;
-INFO:  Dispatch command to ALL contents
-INFO:  Dispatch command to ALL contents
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | count 
 ---+-------
  1 |     1

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -150,29 +150,28 @@ explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                                         QUERY PLAN                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1293.00 rows=2 width=1)
-                     Hash Cond: bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id
-                     ->  Table Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
-                     ->  Hash  (cost=862.00..862.00 rows=3 width=2)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=3 width=2)
-                                 Hash Key: bfv_tab2_facttable1.wk_id
-                                 ->  Hash Join  (cost=0.00..862.00 rows=3 width=2)
-                                       Hash Cond: bfv_tab2_facttable1.id = bfv_tab2_dimtabl1.id
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=6)
-                                             Hash Key: bfv_tab2_facttable1.id
-                                             ->  Sequence  (cost=0.00..431.00 rows=7 width=6)
-                                                   ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                                         Partitions selected: 20 (out of 20)
-                                                   ->  Dynamic Table Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=7 width=6)
-                                       ->  Hash  (cost=431.00..431.00 rows=3 width=4)
-                                             ->  Table Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.55.21
-(20 rows)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=4 width=1)
+         ->  Hash Join  (cost=0.00..1293.00 rows=2 width=1)
+               Hash Cond: bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id
+               ->  Table Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+               ->  Hash  (cost=862.00..862.00 rows=3 width=2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=3 width=2)
+                           Hash Key: bfv_tab2_facttable1.wk_id
+                           ->  Hash Join  (cost=0.00..862.00 rows=3 width=2)
+                                 Hash Cond: bfv_tab2_facttable1.id = bfv_tab2_dimtabl1.id
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=6)
+                                       Hash Key: bfv_tab2_facttable1.id
+                                       ->  Sequence  (cost=0.00..431.00 rows=7 width=6)
+                                             ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                                   Partitions selected: 20 (out of 20)
+                                             ->  Dynamic Table Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=7 width=6)
+                                 ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                                       ->  Table Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: PQO version 2.72.0
+(19 rows)
 
 -- start_ignore
 create language plpythonu;

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -548,7 +548,7 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
 --------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 <@ '(100,100),(0,0)'::box
                      Filter: f1 <@ '(100,100),(0,0)'::box
@@ -567,7 +567,7 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
 --------------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon
                      Filter: f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon
@@ -586,7 +586,7 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
 --------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 <@ '<(50,50),50>'::circle
                      Filter: f1 <@ '<(50,50),50>'::circle
@@ -605,7 +605,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 << '(0,0)'::point
                      Filter: f1 << '(0,0)'::point
@@ -624,7 +624,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 >> '(0,0)'::point
                      Filter: f1 >> '(0,0)'::point
@@ -643,7 +643,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 <^ '(0,0)'::point
                      Filter: f1 <^ '(0,0)'::point
@@ -662,7 +662,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 >^ '(0,0)'::point
                      Filter: f1 >^ '(0,0)'::point
@@ -681,7 +681,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 ~= '(-5,-12)'::point
                      Filter: f1 ~= '(-5,-12)'::point

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -529,11 +529,11 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
 --------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: f1 <@ '(100,100),(0,0)'::box
                      Filter: f1 <@ '(100,100),(0,0)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: PQO version 2.74.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
@@ -2956,15 +2956,15 @@ SELECT * FROM tenk1
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using tenk1_hundred on tenk1
                      Index Cond: hundred = 42
                      Filter: thousand = 42 OR thousand = 99
- Optimizer: PQO version 2.64.0
+ Optimizer: PQO version 2.74.0
 (7 rows)
 
 SELECT count(*) FROM tenk1

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -1623,32 +1623,27 @@ select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) and fact1.code = 'OH
 --
 set gp_dynamic_partition_pruning=off;
 explain select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
-                                                                                                                QUERY PLAN                                                                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
    Merge Key: fact1.code
-   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-         Group Key: fact1.code
-         ->  Sort  (cost=0.00..862.00 rows=1 width=16)
-               Sort Key: fact1.code
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
-                     Hash Key: fact1.code
-                     ->  Result  (cost=0.00..862.00 rows=1 width=16)
-                           ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-                                 Group Key: fact1.code
-                                 ->  Sort  (cost=0.00..862.00 rows=1 width=8)
-                                       Sort Key: fact1.code
-                                       ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
-                                             Hash Cond: fact1.pid = dim1.pid
-                                             ->  Dynamic Table Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
-                                             ->  Hash  (cost=100.00..100.00 rows=34 width=4)
-                                                   ->  Partition Selector for fact1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                                         Filter: fact1.dist = dim1.pid
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                               ->  Table Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=off; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
-(23 rows)
+   ->  Sort  (cost=0.00..862.00 rows=1 width=16)
+         Sort Key: fact1.code
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
+               Group Key: fact1.code
+               ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+                     Sort Key: fact1.code
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                           Hash Key: fact1.code
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                                 Hash Cond: fact1.pid = dim1.pid
+                                 ->  Dynamic Table Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                       ->  Partition Selector for fact1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                   ->  Table Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.74.0
+(18 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
  code | count 
@@ -1659,32 +1654,27 @@ select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) g
 
 set gp_dynamic_partition_pruning=on;
 explain select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
-                                                                                                                QUERY PLAN                                                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
    Merge Key: fact1.code
-   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-         Group Key: fact1.code
-         ->  Sort  (cost=0.00..862.00 rows=1 width=16)
-               Sort Key: fact1.code
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
-                     Hash Key: fact1.code
-                     ->  Result  (cost=0.00..862.00 rows=1 width=16)
-                           ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-                                 Group Key: fact1.code
-                                 ->  Sort  (cost=0.00..862.00 rows=1 width=8)
-                                       Sort Key: fact1.code
-                                       ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
-                                             Hash Cond: fact1.pid = dim1.pid
-                                             ->  Dynamic Table Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
-                                             ->  Hash  (cost=100.00..100.00 rows=34 width=4)
-                                                   ->  Partition Selector for fact1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                                         Filter: fact1.dist = dim1.pid
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                               ->  Table Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
-(23 rows)
+   ->  Sort  (cost=0.00..862.00 rows=1 width=16)
+         Sort Key: fact1.code
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
+               Group Key: fact1.code
+               ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+                     Sort Key: fact1.code
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                           Hash Key: fact1.code
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                                 Hash Cond: fact1.pid = dim1.pid
+                                 ->  Dynamic Table Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                       ->  Partition Selector for fact1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                   ->  Table Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.74.0
+(18 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
  code | count 

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -41,28 +41,24 @@ select d, count(*) from smallt group by d;
 (20 rows)
 
 explain analyze select d, count(*) from smallt group by d;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=2.560..2.577 rows=20 loops=1)
-   ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=2.007..2.039 rows=11 loops=1)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=1.126..1.189 rows=10 loops=2)
+   ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.952..0.980 rows=6 loops=2)
          Group Key: d
-         (seg1)   Hash chain length 1.4 avg, 3 max, using 8 of 32 buckets; total 0 expansions.
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=1.963..1.976 rows=11 loops=1)
-               Hash Key: d
-               ->  Result  (cost=0.00..431.01 rows=7 width=12) (actual time=0.081..0.108 rows=8 loops=1)
-                     ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.080..0.105 rows=8 loops=1)
-                           Group Key: d
-                           ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.073..0.080 rows=40 loops=1)
-                                 Sort Key: d
-                                 Sort Method:  quicksort  Memory: 99kB
-                                 ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.018..0.033 rows=40 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 110K bytes avg x 3 workers, 110K bytes max (seg0).  Work_mem: 33K bytes max.
-   (slice2)    Executor memory: 138K bytes avg x 3 workers, 138K bytes max (seg0).
+         ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.945..0.955 rows=28 loops=2)
+               Sort Key: d
+               Sort Method:  quicksort  Memory: 99kB
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.479..0.868 rows=28 loops=2)
+                     Hash Key: d
+                     ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.025..0.038 rows=20 loops=2)
+   (slice0)    Executor memory: 322K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 115K bytes avg x 3 workers, 118K bytes max (seg1).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
- Total runtime: 3.718 ms
-(19 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 4.805 ms
+(15 rows
 
 set statement_mem=2560;
 select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
@@ -74,21 +70,22 @@ select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
 explain analyze select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
                                                               QUERY PLAN                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..571.36 rows=1 width=8) (actual time=362.957..362.957 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..571.36 rows=1 width=8) (actual time=265.826..362.941 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..571.36 rows=1 width=8) (actual time=265.338..265.338 rows=1 loops=1)
-               ->  HashAggregate  (cost=0.00..571.36 rows=333580 width=1) (actual time=338.390..356.986 rows=44572 loops=1)
+ Aggregate  (cost=0.00..571.36 rows=1 width=8) (actual time=496.792..496.792 rows=0 loops=2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..571.36 rows=1 width=8) (actual time=476.548..496.785 rows=2 loops=2)
+         ->  Aggregate  (cost=0.00..571.36 rows=1 width=8) (actual time=476.200..476.200 rows=0 loops=2)
+               ->  HashAggregate  (cost=0.00..571.36 rows=333580 width=1) (actual time=438.763..467.339 rows=22286 loops=2)
                      Group Key: i, t, d
-                     (seg0)   44435 groups total in 32 batches; 1 overflows; 44435 spill groups.
-                     (seg0)   Hash chain length 2.8 avg, 10 max, using 30315 of 32768 buckets; total 9 expansions.
-                     ->  Table Scan on bigt  (cost=0.00..439.81 rows=333580 width=18) (actual time=0.026..49.692 rows=333530 loops=1)
+                     Extra Text: (seg0)   44435 groups total in 32 batches; 1 overflows; 44435 spill groups.
+ (seg0)   Hash chain length 2.8 avg, 10 max, using 30315 of 32768 buckets; total 9 expansions.
+ 
+                     ->  Table Scan on bigt  (cost=0.00..439.81 rows=333580 width=18) (actual time=0.038..51.381 rows=166765 loops=2)
    (slice0)    Executor memory: 386K bytes.
-   (slice1)  * Executor memory: 3180K bytes avg x 3 workers, 3180K bytes max (seg0).  Work_mem: 2461K bytes max, 4866K bytes wanted.
+ * (slice1)    Executor memory: 3180K bytes avg x 3 workers, 3180K bytes max (seg0).  Work_mem: 2461K bytes max, 4866K bytes wanted.
  Memory used:  2560kB
  Memory wanted:  5265kB
- Optimizer: PQO version 2.67.0
- Total runtime: 363.922 ms
-(14 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 994.811 ms
+(15 rows)
 
 set statement_mem=128000;
 -- DQA
@@ -101,30 +98,21 @@ select count(distinct d) from smallt;
 (1 row)
 
 explain analyze select count(distinct d) from smallt;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.01 rows=1 width=8) (actual time=2.016..2.016 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=4) (actual time=1.988..2.001 rows=20 loops=1)
-         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=1.551..1.561 rows=11 loops=1)
-               Group Key: d
-               ->  Sort  (cost=0.00..431.01 rows=7 width=4) (actual time=1.547..1.554 rows=11 loops=1)
-                     Sort Key: d
-                     Sort Method:  quicksort  Memory: 99kB
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=7 width=4) (actual time=0.543..1.519 rows=11 loops=1)
-                           Hash Key: d
-                           ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=0.076..0.092 rows=8 loops=1)
-                                 Group Key: d
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.072..0.079 rows=40 loops=1)
-                                       Sort Key: d
-                                       Sort Method:  quicksort  Memory: 99kB
-                                       ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.021..0.032 rows=40 loops=1)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.167..1.167 rows=0 loops=2)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=1.158..1.161 rows=2 loops=2)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.911..0.911 rows=0 loops=2)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.367..0.922 rows=28 loops=2)
+                     Hash Key: d
+                     ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.024..0.034 rows=20 loops=2)
    (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 110K bytes avg x 3 workers, 110K bytes max (seg0).  Work_mem: 33K bytes max.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
    (slice2)    Executor memory: 82K bytes avg x 3 workers, 82K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
- Total runtime: 3.325 ms
-(21 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 3.362 ms
+(12 rows)
 
 set statement_mem=2560;
 select count(distinct d) from bigt;
@@ -136,24 +124,20 @@ select count(distinct d) from bigt;
 explain analyze select count(distinct d) from bigt;
                                                                          QUERY PLAN                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..485.83 rows=1 width=8) (actual time=396.987..396.987 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.81 rows=49168 width=4) (actual time=352.946..386.854 rows=50000 loops=1)
-         ->  HashAggregate  (cost=0.00..485.08 rows=16390 width=4) (actual time=354.021..357.076 rows=16675 loops=1)
-               Group Key: d
-               (seg1)   Hash chain length 4.1 avg, 13 max, using 4021 of 4096 buckets; total 7 expansions.
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..483.07 rows=16390 width=4) (actual time=283.881..341.500 rows=27950 loops=1)
+ Aggregate  (cost=0.00..446.61 rows=1 width=8) (actual time=1742.497..1742.497 rows=0 loops=2)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..446.61 rows=1 width=8) (actual time=1669.266..1742.487 rows=2 loops=2)
+         ->  Aggregate  (cost=0.00..446.61 rows=1 width=8) (actual time=1666.418..1666.418 rows=0 loops=2)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..446.46 rows=333580 width=4) (actual time=1.528..563.716 rows=166750 loops=2)
                      Hash Key: d
-                     ->  HashAggregate  (cost=0.00..482.86 rows=16390 width=4) (actual time=280.096..286.016 rows=28117 loops=1)
-                           Group Key: d
-                           (seg2)   Hash chain length 3.5 avg, 14 max, using 7925 of 8192 buckets; total 8 expansions.
-                           ->  Table Scan on bigt  (cost=0.00..439.81 rows=333580 width=4) (actual time=0.024..168.014 rows=333530 loops=1)
+                     ->  Table Scan on bigt  (cost=0.00..439.81 rows=333580 width=4) (actual time=0.022..104.724 rows=166765 loops=2)
    (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 1171K bytes avg x 3 workers, 1171K bytes max (seg0).
-   (slice2)    Executor memory: 1006K bytes avg x 3 workers, 1006K bytes max (seg0).
+   (slice1)    Executor memory: 86K bytes avg x 3 workers, 86K bytes max (seg0).
+ * (slice2)    Executor memory: 2934K bytes avg x 3 workers, 2934K bytes max (seg0).  Work_mem: 2649K bytes max, 7843K bytes wanted.
  Memory used:  2560kB
- Optimizer: PQO version 2.67.0
- Total runtime: 397.691 ms
-(17 rows)
+ Memory wanted:  8242kB
+ Optimizer: PQO version 2.72.0
+ Total runtime: 3486.016 ms
+(13 rows)
 
 set statement_mem=128000;
 set gp_enable_agg_distinct=on;
@@ -196,41 +180,35 @@ explain analyze select t1.*, t2.* from
 where t1.d = t2.d;
                                                                        QUERY PLAN                                                                       
 --------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=2.690..3.081 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=1.575..2.074 rows=11 loops=1)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=2.596..2.792 rows=10 loops=2)
+   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=1.177..2.006 rows=6 loops=2)
          Hash Cond: public.smallt.d = public.smallt.d
-         (seg1)   Hash chain length 1.0 avg, 1 max, using 11 of 131072 buckets.
-         ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.263..0.277 rows=11 loops=1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 11 of 131072 buckets.
+ 
+         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.143..0.219 rows=6 loops=2)
                Group Key: public.smallt.d
-               (seg1)   Hash chain length 1.4 avg, 3 max, using 8 of 32 buckets; total 0 expansions.
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=0.008..0.235 rows=11 loops=1)
-                     Hash Key: public.smallt.d
-                     ->  Result  (cost=0.00..431.01 rows=7 width=12) (actual time=0.077..0.100 rows=8 loops=1)
-                           ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.077..0.096 rows=8 loops=1)
-                                 Group Key: public.smallt.d
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.069..0.075 rows=40 loops=1)
-                                       Sort Key: public.smallt.d
-                                       Sort Method:  quicksort  Memory: 99kB
-                                       ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.015..0.026 rows=40 loops=1)
-         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=1.184..1.184 rows=11 loops=1)
-               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.159..1.173 rows=11 loops=1)
-                     Group Key: public.smallt.d
-                     (seg1)   Hash chain length 1.4 avg, 3 max, using 8 of 32 buckets; total 0 expansions.
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=0.564..1.128 rows=11 loops=1)
+               ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.137..0.148 rows=28 loops=2)
+                     Sort Key: public.smallt.d
+                     Sort Method:  quicksort  Memory: 99kB
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.025..0.049 rows=28 loops=2)
                            Hash Key: public.smallt.d
-                           ->  Result  (cost=0.00..431.01 rows=7 width=12) (actual time=0.051..0.134 rows=8 loops=1)
-                                 ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.050..0.132 rows=8 loops=1)
-                                       Group Key: public.smallt.d
-                                       (seg0)   Hash chain length 1.3 avg, 3 max, using 6 of 32 buckets; total 0 expansions.
-                                       ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=8) (actual time=0.013..0.021 rows=40 loops=1)
-   (slice0)    Executor memory: 514K bytes.
-   (slice1)    Executor memory: 110K bytes avg x 3 workers, 110K bytes max (seg0).  Work_mem: 33K bytes max.
-   (slice2)    Executor memory: 166K bytes avg x 3 workers, 166K bytes max (seg0).
-   (slice3)    Executor memory: 1290K bytes avg x 3 workers, 1290K bytes max (seg0).  Work_mem: 1K bytes max.
+                           ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.030..0.043 rows=20 loops=2)
+         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=0.902..0.902 rows=6 loops=2)
+               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.866..0.894 rows=6 loops=2)
+                     Group Key: public.smallt.d
+                     Extra Text: (seg1)   Hash chain length 1.4 avg, 3 max, using 8 of 32 buckets; total 0 expansions.
+ 
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=8) (actual time=0.702..0.818 rows=28 loops=2)
+                           Hash Key: public.smallt.d
+                           ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=8) (actual time=0.022..0.034 rows=20 loops=2)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 1235K bytes avg x 3 workers, 1238K bytes max (seg1).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
- Total runtime: 4.439 ms
-(34 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 6.985 ms
+(28 rows)
 
 set enable_nestloop=off;
 set enable_hashjoin=on;
@@ -262,29 +240,30 @@ explain analyze select t1.*, t2.* from
 where t1.i = t2.i;
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=10 width=24) (actual time=1.082..1.099 rows=10 loops=1)
-   ->  Hash Join  (cost=0.00..862.01 rows=4 width=24) (actual time=0.295..0.609 rows=4 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=10 width=24) (actual time=0.831..0.931 rows=5 loops=2)
+   ->  Hash Join  (cost=0.00..862.01 rows=4 width=24) (actual time=0.266..0.600 rows=2 loops=2)
          Hash Cond: public.smallt.i = public.smallt.i
-         (seg0)   Hash chain length 1.0 avg, 1 max, using 4 of 131072 buckets.
-         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.049..0.064 rows=4 loops=1)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 4 of 131072 buckets.
+ 
+         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.053..0.071 rows=2 loops=2)
                Group Key: public.smallt.i
-               ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.041..0.048 rows=40 loops=1)
+               ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.047..0.053 rows=20 loops=2)
                      Sort Key: public.smallt.i
                      Sort Method:  quicksort  Memory: 99kB
-                     ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.014 rows=40 loops=1)
-         ->  Hash  (cost=431.01..431.01 rows=4 width=12) (actual time=0.103..0.103 rows=4 loops=1)
-               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.083..0.100 rows=4 loops=1)
+                     ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.006..0.016 rows=20 loops=2)
+         ->  Hash  (cost=431.01..431.01 rows=4 width=12) (actual time=0.103..0.103 rows=2 loops=2)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.080..0.100 rows=2 loops=2)
                      Group Key: public.smallt.i
-                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.074..0.081 rows=40 loops=1)
+                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.071..0.076 rows=20 loops=2)
                            Sort Key: public.smallt.i
                            Sort Method:  quicksort  Memory: 99kB
-                           ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.021..0.033 rows=40 loops=1)
+                           ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.025..0.040 rows=20 loops=2)
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 1238K bytes avg x 3 workers, 1238K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
- Total runtime: 2.287 ms
-(22 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 2.761 ms
+(23 rows)
 
 set enable_nestloop=off;
 set enable_hashjoin=on;
@@ -300,29 +279,26 @@ select d, count(*) from smallt group by d limit 5; --ignore
 (5 rows)
 
 explain analyze select d, count(*) from smallt group by d limit 5;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=2.452..2.455 rows=5 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=2.449..2.450 rows=5 loops=1)
-         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=2.021..2.025 rows=5 loops=1)
-               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=2.021..2.024 rows=5 loops=1)
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.116..1.162 rows=2 loops=2)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=1.115..1.161 rows=2 loops=2)
+         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=0.912..0.924 rows=2 loops=2)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.912..0.922 rows=2 loops=2)
                      Group Key: d
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=1.063..1.985 rows=11 loops=1)
-                           Hash Key: d
-                           ->  Result  (cost=0.00..431.01 rows=7 width=12) (actual time=0.422..0.448 rows=8 loops=1)
-                                 ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.421..0.445 rows=8 loops=1)
-                                       Group Key: d
-                                       ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.415..0.421 rows=40 loops=1)
-                                             Sort Key: d
-                                             Sort Method:  quicksort  Memory: 131kB
-                                             ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.015..0.028 rows=40 loops=1)
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.906..0.910 rows=13 loops=2)
+                           Sort Key: d
+                           Sort Method:  quicksort  Memory: 99kB
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.387..0.824 rows=28 loops=2)
+                                 Hash Key: d
+                                 ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.025..0.037 rows=20 loops=2)
    (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).  Work_mem: 65K bytes max.
-   (slice2)    Executor memory: 170K bytes avg x 3 workers, 170K bytes max (seg0).
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 115K bytes avg x 3 workers, 118K bytes max (seg1).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
- Total runtime: 4.148 ms
-(20 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 3.849 ms
+(17 rows)
 
 -- HashJoin
 select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i order by 1,2,3;
@@ -1641,21 +1617,22 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=200 width=15) (actual time=2.546..2.645 rows=200 loops=1)
-   ->  Hash Join  (cost=0.00..862.01 rows=67 width=15) (actual time=0.449..2.208 rows=100 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=200 width=15) (actual time=2.401..2.506 rows=100 loops=2)
+   ->  Hash Join  (cost=0.00..862.01 rows=67 width=15) (actual time=0.227..2.024 rows=50 loops=2)
          Hash Cond: public.smallt.i = public.smallt.i
-         (seg0)   Hash chain length 10.0 avg, 10 max, using 1 of 524288 buckets.
-         ->  Table Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.005..0.016 rows=10 loops=1)
+         Extra Text: (seg0)   Hash chain length 10.0 avg, 10 max, using 1 of 524288 buckets.
+ 
+         ->  Table Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.008..0.022 rows=5 loops=2)
                Filter: i < 2
-         ->  Hash  (cost=431.00..431.00 rows=7 width=4) (actual time=0.052..0.052 rows=10 loops=1)
-               ->  Table Scan on smallt  (cost=0.00..431.00 rows=7 width=4) (actual time=0.033..0.045 rows=10 loops=1)
+         ->  Hash  (cost=431.00..431.00 rows=7 width=4) (actual time=0.064..0.064 rows=5 loops=2)
+               ->  Table Scan on smallt  (cost=0.00..431.00 rows=7 width=4) (actual time=0.043..0.055 rows=5 loops=2)
                      Filter: i < 2
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
- Total runtime: 3.595 ms
-(14 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 5.981 ms
+(15 rows)
 
 select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
  i |    t    |     d      
@@ -1766,26 +1743,27 @@ select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
                                                                     QUERY PLAN                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=100 width=15) (actual time=3.786..4.275 rows=100 loops=1)
-   ->  Hash Join  (cost=0.00..862.01 rows=34 width=15) (actual time=1.541..3.140 rows=50 loops=1)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=100 width=15) (actual time=2.389..2.484 rows=50 loops=2)
+   ->  Hash Join  (cost=0.00..862.01 rows=34 width=15) (actual time=1.065..2.100 rows=25 loops=2)
          Hash Cond: public.smallt.d = public.smallt.d
-         (seg1)   Hash chain length 5.0 avg, 5 max, using 11 of 524288 buckets.
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=15) (actual time=0.005..0.013 rows=10 loops=1)
+         Extra Text: (seg1)   Hash chain length 5.0 avg, 5 max, using 11 of 524288 buckets.
+ 
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=15) (actual time=0.005..0.011 rows=5 loops=2)
                Hash Key: public.smallt.d
-               ->  Table Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.017..0.028 rows=10 loops=1)
+               ->  Table Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.024..0.034 rows=5 loops=2)
                      Filter: i < 2
-         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=1.305..1.305 rows=55 loops=1)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.032..1.281 rows=55 loops=1)
+         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.864..0.864 rows=28 loops=2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.460..0.835 rows=28 loops=2)
                      Hash Key: public.smallt.d
-                     ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.020..0.034 rows=40 loops=1)
+                     ->  Table Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.018..0.030 rows=20 loops=2)
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
    (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
    (slice3)    Executor memory: 4187K bytes avg x 3 workers, 4190K bytes max (seg1).  Work_mem: 2K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
- Total runtime: 5.448 ms
-(19 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 5.930 ms
+(20 rows)
 
 --end_ignore
 set enable_hashjoin=on;
@@ -1837,21 +1815,22 @@ explain analyze select smallt.* from smallt, smallt2 where smallt.i = smallt2.i 
 and smallt.d = '2011-01-04'::date;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..17.99 rows=2 width=15) (actual time=2.338..2.341 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..17.99 rows=1 width=15) (actual time=0.464..1.817 rows=20 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=2 width=15) (actual time=1.803..1.808 rows=10 loops=2)
+   ->  Hash Join  (cost=0.00..12.00 rows=1 width=15) (actual time=0.283..1.468 rows=10 loops=2)
          Hash Cond: smallt.i = smallt2.i
-         (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
-         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..9.99 rows=2 width=15) (actual time=0.005..0.007 rows=5 loops=1)
+         Extra Text: (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
+ 
+         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..6.00 rows=2 width=15) (actual time=0.004..0.006 rows=2 loops=2)
                Index Cond: d = '01-04-2011'::date
-         ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.034..0.034 rows=4 loops=1)
-               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.023..0.027 rows=4 loops=1)
+         ->  Hash  (cost=6.00..6.00 rows=2 width=4) (actual time=0.016..0.016 rows=2 loops=2)
+               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..6.00 rows=2 width=4) (actual time=0.009..0.013 rows=2 loops=2)
                      Index Cond: d = '01-04-2011'::date
    (slice0)    Executor memory: 450K bytes.
    (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
- Total runtime: 3.325 ms
-(14 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 4.405 ms
+(15 rows)
 
 -- IndexOnlyScan
 explain analyze select *, exists(select 1 from pg_class where oid = c.oid) as dummy from pg_class c;
@@ -1908,21 +1887,22 @@ explain analyze select smallt.* from smallt, smallt2 where smallt.i = smallt2.i 
 and smallt.d = '2011-01-04'::date;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..17.99 rows=2 width=15) (actual time=3.960..3.964 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..17.99 rows=1 width=15) (actual time=0.267..1.566 rows=20 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=2 width=15) (actual time=1.430..1.435 rows=10 loops=2)
+   ->  Hash Join  (cost=0.00..12.00 rows=1 width=15) (actual time=0.255..1.088 rows=10 loops=2)
          Hash Cond: smallt.i = smallt2.i
-         (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
-         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..9.99 rows=2 width=15) (actual time=0.005..0.007 rows=5 loops=1)
+         Extra Text: (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
+ 
+         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..6.00 rows=2 width=15) (actual time=0.003..0.005 rows=2 loops=2)
                Index Cond: d = '01-04-2011'::date
-         ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.031..0.031 rows=4 loops=1)
-               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.020..0.024 rows=4 loops=1)
+         ->  Hash  (cost=6.00..6.00 rows=2 width=4) (actual time=0.013..0.013 rows=2 loops=2)
+               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..6.00 rows=2 width=4) (actual time=0.008..0.010 rows=2 loops=2)
                      Index Cond: d = '01-04-2011'::date
    (slice0)    Executor memory: 450K bytes.
    (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
- Total runtime: 5.131 ms
-(14 rows)
+ Optimizer: PQO version 2.72.0
+ Total runtime: 3.720 ms
+(15 rows)
 
 set enable_hashjoin=on;
 set enable_nestloop=off;

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -58,7 +58,7 @@ explain analyze select d, count(*) from smallt group by d;
  Memory used:  128000kB
  Optimizer: PQO version 2.72.0
  Total runtime: 4.805 ms
-(15 rows
+(15 rows)
 
 set statement_mem=2560;
 select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;

--- a/src/test/regress/expected/gp_aggregates_optimizer.out
+++ b/src/test/regress/expected/gp_aggregates_optimizer.out
@@ -308,7 +308,6 @@ create aggregate mysum_prefunc(int4) (
   prefunc=int8pl_with_notice
 );
 select mysum_prefunc(a::int4) from aggtest;
-NOTICE:  combinefunc called
  mysum_prefunc 
 ---------------
            198

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -29,9 +29,10 @@ explain (costs off) select count(distinct d) from dqa_t1;
 ------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Table Scan on dqa_t1
- Optimizer: PQO version 2.70.0
-(4 rows)
+         ->  Aggregate
+               ->  Table Scan on dqa_t1
+ Optimizer: PQO version 2.72.0
+(5 rows)
 
 select count(distinct d) from dqa_t1 group by i;
  count 
@@ -242,17 +243,18 @@ select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d;
 (1 row)
 
 explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d;
-                   QUERY PLAN                   
-------------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Hash Join
-               Hash Cond: dqa_t1.d = dqa_t2.d
-               ->  Table Scan on dqa_t1
-               ->  Hash
-                     ->  Table Scan on dqa_t2
- Optimizer: PQO version 2.70.0
-(8 rows)
+         ->  Aggregate
+               ->  Hash Join
+                     Hash Cond: dqa_t1.d = dqa_t2.d
+                     ->  Table Scan on dqa_t1
+                     ->  Hash
+                           ->  Table Scan on dqa_t2
+ Optimizer: PQO version 2.72.0
+(9 rows)
 
 select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d group by dqa_t2.dt;
  count 
@@ -316,26 +318,23 @@ select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d gr
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d group by dqa_t2.dt;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Result
-         ->  HashAggregate
+         ->  GroupAggregate
                Group Key: dqa_t2.dt
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: dqa_t2.dt
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: dqa_t2.dt
-                                 ->  Sort
-                                       Sort Key: dqa_t2.dt
-                                       ->  Hash Join
-                                             Hash Cond: dqa_t2.d = dqa_t1.d
-                                             ->  Table Scan on dqa_t2
-                                             ->  Hash
-                                                   ->  Table Scan on dqa_t1
- Optimizer: PQO version 2.70.0
-(17 rows)
+               ->  Sort
+                     Sort Key: dqa_t2.dt
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: dqa_t2.dt
+                           ->  Hash Join
+                                 Hash Cond: dqa_t2.d = dqa_t1.d
+                                 ->  Table Scan on dqa_t2
+                                 ->  Hash
+                                       ->  Table Scan on dqa_t1
+ Optimizer: PQO version 2.72.0
+(14 rows)
 
 -- Distinct keys are not distribution keys
 select count(distinct c) from dqa_t1;
@@ -345,23 +344,16 @@ select count(distinct c) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct c) from dqa_t1;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice2; segments: 3)
-         ->  GroupAggregate
-               Group Key: c
-               ->  Sort
-                     Sort Key: c
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: c
-                           ->  GroupAggregate
-                                 Group Key: c
-                                 ->  Sort
-                                       Sort Key: c
-                                       ->  Table Scan on dqa_t1
- Optimizer: PQO version 2.70.0
-(14 rows)
+         ->  Aggregate
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: c
+                     ->  Table Scan on dqa_t1
+ Optimizer: PQO version 2.72.0
+(7 rows)
 
 select count(distinct c) from dqa_t1 group by dt;
  count 
@@ -403,24 +395,19 @@ select count(distinct c) from dqa_t1 group by dt;
 (34 rows)
 
 explain (costs off) select count(distinct c) from dqa_t1 group by dt;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
    ->  Result
-         ->  HashAggregate
+         ->  GroupAggregate
                Group Key: dt
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: dt
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: dt
-                                 ->  Sort
-                                       Sort Key: dt, c
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                             Hash Key: c
-                                             ->  Table Scan on dqa_t1
- Optimizer: PQO version 2.70.0
-(15 rows)
+               ->  Sort
+                     Sort Key: dt
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: dt
+                           ->  Table Scan on dqa_t1
+ Optimizer: PQO version 2.72.0
+(10 rows)
 
 select count(distinct c) from dqa_t1 group by d;
  count 
@@ -451,24 +438,17 @@ select count(distinct c) from dqa_t1 group by d;
 (23 rows)
 
 explain (costs off) select count(distinct c) from dqa_t1 group by d;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Result
-         ->  HashAggregate
+         ->  GroupAggregate
                Group Key: d
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: d
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: d
-                                 ->  Sort
-                                       Sort Key: d, c
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                             Hash Key: c
-                                             ->  Table Scan on dqa_t1
- Optimizer: PQO version 2.70.0
-(15 rows)
+               ->  Sort
+                     Sort Key: d
+                     ->  Table Scan on dqa_t1
+ Optimizer: PQO version 2.72.0
+(8 rows)
 
 select count(distinct c), count(distinct dt) from dqa_t1;
  count | count 
@@ -611,29 +591,24 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
 (1 row)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice4; segments: 3)
-         ->  GroupAggregate
-               Group Key: dqa_t1.dt
-               ->  Sort
-                     Sort Key: dqa_t1.dt
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: dqa_t1.dt
-                           ->  HashAggregate
-                                 Group Key: dqa_t1.dt
-                                 ->  Hash Join
-                                       Hash Cond: dqa_t1.c = dqa_t2.c
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                             Hash Key: dqa_t1.c
-                                             ->  Table Scan on dqa_t1
-                                       ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                                   Hash Key: dqa_t2.c
-                                                   ->  Table Scan on dqa_t2
- Optimizer: PQO version 2.70.0
-(20 rows)
+         ->  Aggregate
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: dqa_t1.dt
+                     ->  Hash Join
+                           Hash Cond: dqa_t1.c = dqa_t2.c
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: dqa_t1.c
+                                 ->  Table Scan on dqa_t1
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: dqa_t2.c
+                                       ->  Table Scan on dqa_t2
+ Optimizer: PQO version 2.72.0
+(15 rows)
 
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
  count 
@@ -697,32 +672,27 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c g
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
    ->  Result
-         ->  HashAggregate
+         ->  GroupAggregate
                Group Key: dqa_t2.dt
-               ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                     Hash Key: dqa_t2.dt
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: dqa_t2.dt
-                                 ->  Sort
-                                       Sort Key: dqa_t2.dt
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                             Hash Key: dqa_t1.dt
-                                             ->  Hash Join
-                                                   Hash Cond: dqa_t1.c = dqa_t2.c
-                                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                                         Hash Key: dqa_t1.c
-                                                         ->  Table Scan on dqa_t1
-                                                   ->  Hash
-                                                         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                                               Hash Key: dqa_t2.c
-                                                               ->  Table Scan on dqa_t2
- Optimizer: PQO version 2.70.0
-(23 rows)
+               ->  Sort
+                     Sort Key: dqa_t2.dt
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: dqa_t2.dt
+                           ->  Hash Join
+                                 Hash Cond: dqa_t1.c = dqa_t2.c
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                       Hash Key: dqa_t1.c
+                                       ->  Table Scan on dqa_t1
+                                 ->  Hash
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                             Hash Key: dqa_t2.c
+                                             ->  Table Scan on dqa_t2
+ Optimizer: PQO version 2.72.0
+(18 rows)
 
 -- MPP-19037
 drop table if exists fact_route_aggregation;

--- a/src/test/regress/expected/gpdiffcheck_optimizer.out
+++ b/src/test/regress/expected/gpdiffcheck_optimizer.out
@@ -251,7 +251,6 @@ select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
 (16 rows)
 
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
-explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1724.00 rows=1 width=12) (actual time=4.362..4.367 rows=8 loops=2)

--- a/src/test/regress/expected/gpdiffcheck_optimizer.out
+++ b/src/test/regress/expected/gpdiffcheck_optimizer.out
@@ -138,69 +138,51 @@ set optimizer_segments=4;
 set gp_cost_hashjoin_chainwalk=on;
 set optimizer_nestloop_factor = 1.0;
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
-                                                                              QUERY PLAN                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..1724.00 rows=1 width=16)
-   Hash Cond: public.gpd1.c1 = "inner".max
-   Rows out:  16 rows with 32 ms to first row, 33 ms to end, start offset by 42 ms.
-   Executor memory:  1K bytes.
-   Work_mem used:  1K bytes. Workfile: (0 spilling, 0 reused)
-   Hash chain length 1.0 avg, 1 max, using 1 of 262151 buckets.
-   ->  Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1293.00 rows=1 width=18)
-         Rows out:  64 rows at destination with 0.037 ms to first row, 0.092 ms to end, start offset by 74 ms.
-         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=18)
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=3.205..3.914 rows=8 loops=2)
+   Hash Cond: public.gpd1.c1 = (max(public.gpd1.c1))
+   Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
+ 
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.225..0.465 rows=32 loops=2)
+         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=1.792..2.655 rows=16 loops=2)
                Join Filter: true
-               Rows out:  Avg 32.0 rows x 2 workers.  Max 32 rows (seg0) with 1.401 ms to first row, 1.511 ms to end, start offset by 66 ms.
-               ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=16)
-                     Rows out:  Avg 4.0 rows x 2 workers.  Max 4 rows (seg0) with 0.053 ms to first row, 0.057 ms to end, start offset by 67 ms.
-               ->  Materialize  (cost=0.00..431.00 rows=2 width=2)
-                     Rows out:  Avg 33.0 rows x 2 workers.  Max 33 rows (seg0) with 1.338 ms to first row, 1.348 ms to end of 5 scans, start offset by 67 ms.
-                     ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=2 width=2)
-                           Rows out:  Avg 8.0 rows x 2 workers at destination.  Max 8 rows (seg0) with 0.062 ms to first row, 1.210 ms to end, start offset by 66 ms.
-                           ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
-                                 Rows out:  Avg 4.0 rows x 2 workers.  Max 4 rows (seg0) with 0.099 ms to first row, 0.102 ms to end, start offset by 67 ms.
-   ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-         Rows in:  1 rows with 32 ms to end, start offset by 42 ms.
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               Rows out:  1 rows with 32 ms to end, start offset by 42 ms.
-               Executor memory:  8K bytes.
-               ->  Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..431.00 rows=1 width=8)
-                     Rows out:  2 rows at destination with 21 ms to first row, 32 ms to end, start offset by 42 ms.
-                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                           Rows out:  Avg 1.0 rows x 2 workers.  Max 1 rows (seg0) with 0.074 ms to end, start offset by 63 ms.
-                           Executor memory:  8K bytes avg, 8K bytes max (seg0).
-                           ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
-                                 Rows out:  Avg 4.0 rows x 2 workers.  Max 4 rows (seg0) with 0.028 ms to first row, 0.034 ms to end, start offset by 63 ms.
- Slice statistics:
-   (slice0)    Executor memory: 4355K bytes.  Work_mem: 1K bytes max.
-   (slice1)    Executor memory: 255K bytes avg x 2 workers, 255K bytes max (seg0).
-   (slice2)    Executor memory: 247K bytes avg x 2 workers, 247K bytes max (seg0).
-   (slice3)    Executor memory: 239K bytes avg x 2 workers, 239K bytes max (seg0).
- Statement statistics:
-   Memory used: 128000K bytes
- Settings:  gp_cost_hashjoin_chainwalk=on; gp_segments_for_planner=4; optimizer=on; optimizer_segments=4
- Total runtime: 75.143 ms
-(40 rows)
+               ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.030..0.032 rows=2 loops=2)
+               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.579..0.831 rows=6 loops=6)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=1.555..2.303 rows=4 loops=2)
+                           ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.112..0.116 rows=2 loops=2)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=2.896..2.896 rows=0 loops=2)
+         Buckets: 262144  Batches: 1  Memory Usage: 1kB
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=2.890..2.890 rows=0 loops=2)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2) (actual time=1.869..2.855 rows=4 loops=2)
+                     ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.036..0.039 rows=2 loops=2)
+   (slice0)    Executor memory: 2218K bytes.  Work_mem: 1K bytes max.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 126K bytes avg x 3 workers, 126K bytes max (seg0).
+   (slice3)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: PQO version 2.72.0
+ Total runtime: 39.299 ms
+(23 rows)
 
 explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..1724.00 rows=1 width=16)
-   Hash Cond: public.gpd1.c1 = "inner".max
-   ->  Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1293.00 rows=1 width=18)
-         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=18)
+ Hash Join  (cost=0.00..1724.00 rows=1 width=12)
+   Hash Cond: public.gpd1.c1 = (max(public.gpd1.c1))
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=14)
+         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14)
                Join Filter: true
-               ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=16)
+               ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=12)
                ->  Materialize  (cost=0.00..431.00 rows=2 width=2)
-                     ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=2 width=2)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=2)
                            ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
    ->  Hash  (cost=431.00..431.00 rows=1 width=8)
          ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
- Settings:  gp_cost_hashjoin_chainwalk=on; gp_segments_for_planner=4; optimizer=on; optimizer_segments=4
-(15 rows)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2)
+                     ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
+ Optimizer: PQO version 2.72.0
+(14 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
  c1 | c2 | c3 
@@ -269,51 +251,35 @@ select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
 (16 rows)
 
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
-                                                                              QUERY PLAN                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice4; segments: 2)  (cost=0.00..1724.00 rows=1 width=16)
-   Rows out:  16 rows at destination with 37 ms to end, start offset by 2.113 ms.
-   ->  Hash Join  (cost=0.00..1724.00 rows=1 width=16)
-         Hash Cond: "outer".max = public.gpd1.c1
-         Rows out:  16 rows (seg1) with 4.823 ms to first row, 6.909 ms to end, start offset by 32 ms.
-         Executor memory:  2K bytes avg, 2K bytes max (seg0).
-         Work_mem used:  2K bytes avg, 2K bytes max (seg0). Workfile: (0 spilling, 0 reused)
-         (seg1)   Hash chain length 16.0 avg, 16 max, using 2 of 524341 buckets.
-         ->  Redistribute Motion 1:2  (slice2)  (cost=0.00..431.00 rows=1 width=8)
-               Hash Key: max
-               Rows out:  1 rows at destination (seg1) with 0.011 ms to end, start offset by 37 ms.
-               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                     Rows out:  1 rows with 3.101 ms to end, start offset by 21 ms.
-                     Executor memory:  8K bytes.
-                     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=8)
-                           Rows out:  2 rows at destination with 0.013 ms to first row, 3.088 ms to end, start offset by 21 ms.
-                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                 Rows out:  Avg 1.0 rows x 2 workers.  Max 1 rows (seg0) with 0.036 ms to end, start offset by 24 ms.
-                                 Executor memory:  8K bytes avg, 8K bytes max (seg0).
-                                 ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
-                                       Rows out:  Avg 4.0 rows x 2 workers.  Max 4 rows (seg0) with 0.021 ms to first row, 0.024 ms to end, start offset by 24 ms.
-         ->  Hash  (cost=1293.00..1293.00 rows=1 width=18)
-               Rows in:  Avg 32.0 rows x 2 workers.  Max 32 rows (seg0) with 7.497 ms to end, start offset by 30 ms.
-               ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=18)
+explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1724.00 rows=1 width=12) (actual time=4.362..4.367 rows=8 loops=2)
+   ->  Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=1.658..2.804 rows=8 loops=2)
+         Hash Cond: (max((max(public.gpd1.c1)))) = public.gpd1.c1
+         Extra Text: (seg0)   Hash chain length 16.0 avg, 16 max, using 2 of 524288 buckets.
+ 
+         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.003..0.003 rows=0 loops=2)
+               Hash Key: (max((max(public.gpd1.c1))))
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.042..0.042 rows=0 loops=2)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.023..0.027 rows=2 loops=2)
+                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.064..0.064 rows=0 loops=2)
+                                 ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.016..0.019 rows=2 loops=2)
+         ->  Hash  (cost=1293.00..1293.00 rows=1 width=14) (actual time=1.819..1.819 rows=16 loops=2)
+               ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.865..1.786 rows=16 loops=2)
                      Join Filter: true
-                     Rows out:  Avg 32.0 rows x 2 workers.  Max 32 rows (seg0) with 0.045 ms to first row, 7.467 ms to end, start offset by 30 ms.
-                     ->  Broadcast Motion 2:2  (slice3; segments: 2)  (cost=0.00..431.00 rows=20 width=16)
-                           Rows out:  Avg 8.0 rows x 2 workers at destination.  Max 8 rows (seg0) with 0.013 ms to first row, 7.370 ms to end, start offset by 30 ms.
-                           ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=16)
-                                 Rows out:  Avg 4.0 rows x 2 workers.  Max 4 rows (seg0) with 0.020 ms to first row, 0.023 ms to end, start offset by 27 ms.
-                     ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
-                           Rows out:  Avg 33.0 rows x 2 workers.  Max 33 rows (seg0) with 0.019 ms to first row, 0.061 ms to end of 9 scans, start offset by 37 ms.
- Slice statistics:
-   (slice0)    Executor memory: 235K bytes.
-   (slice1)    Executor memory: 239K bytes avg x 2 workers, 239K bytes max (seg0).
-   (slice2)    Executor memory: 259K bytes (entry db).
-   (slice3)    Executor memory: 255K bytes avg x 2 workers, 255K bytes max (seg0).
-   (slice4)    Executor memory: 8456K bytes avg x 2 workers, 8456K bytes max (seg0).  Work_mem: 2K bytes max.
- Statement statistics:
-   Memory used: 128000K bytes
- Settings:  gp_cost_hashjoin_chainwalk=on; gp_segments_for_planner=40; optimizer=on; optimizer_segments=40
- Total runtime: 39.966 ms
-(42 rows)
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=14 width=12) (actual time=0.835..1.711 rows=4 loops=2)
+                           ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.015..0.017 rows=2 loops=2)
+                     ->  Table Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.004..0.009 rows=3 loops=10)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 81K bytes avg x 3 workers, 81K bytes max (seg0).
+   (slice2)    Executor memory: 161K bytes (entry db).
+   (slice3)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice4)    Executor memory: 4198K bytes avg x 3 workers, 4198K bytes max (seg0).  Work_mem: 2K bytes max.
+ Memory used:  128000kB
+ Optimizer: PQO version 2.72.0
+ Total runtime: 10.471 ms
+(25 rows)
 
 --
 -- Clean up

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10612,7 +10612,7 @@ explain (costs off) select count(*), t2.c from input_tab1 t1 left join input_tab
                                              ->  Table Scan on input_tab1
                                              ->  Hash
                                                    ->  Table Scan on input_tab2
- Optimizer: PQO version 2.70.1
+ Optimizer: PQO version 2.74.0
 (18 rows)
 
 select count(*), t2.c from input_tab1 t1 left join input_tab2 t2 on t1.a = t2.c group by t2.c;
@@ -10654,8 +10654,8 @@ FROM   (SELECT *
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=4 width=1)
+         ->  Result  (cost=0.00..1293.00 rows=2 width=1)
                ->  Append  (cost=0.00..1293.00 rows=2 width=1)
                      ->  Result  (cost=0.00..862.00 rows=1 width=11)
                            ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
@@ -10669,7 +10669,7 @@ FROM   (SELECT *
                                              ->  Table Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
                      ->  Result  (cost=0.00..431.00 rows=1 width=16)
                            ->  Table Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 2.70.2
+ Optimizer: PQO version 2.74.0
 (17 rows)
 
 SELECT Count(*)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10022,43 +10022,41 @@ WHERE tq.sym = tt.symbol AND
       tt.event_ts <  tq.end_ts
 GROUP BY 1
 ORDER BY 1 asc ;
-                                                                                           QUERY PLAN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate  (cost=0.00..1305.01 rows=1 width=16)
-   Group Key: (share0_ref2.event_ts / 100000 / 5 * 5)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1305.01 rows=1 width=16)
-         Merge Key: (share0_ref2.event_ts / 100000 / 5 * 5)
-         ->  Result  (cost=0.00..1305.01 rows=1 width=16)
-               ->  GroupAggregate  (cost=0.00..1305.01 rows=1 width=16)
-                     Group Key: (share0_ref2.event_ts / 100000 / 5 * 5)
-                     ->  Sort  (cost=0.00..1305.01 rows=1 width=8)
-                           Sort Key: (share0_ref2.event_ts / 100000 / 5 * 5)
-                           ->  Result  (cost=0.00..1305.01 rows=1 width=8)
-                                 ->  Sequence  (cost=0.00..1305.01 rows=1 width=8)
-                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=1)
-                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-                                                   ->  Table Scan on my_tt_agg_opt  (cost=0.00..431.00 rows=1 width=62)
-                                       ->  Sequence  (cost=0.00..874.01 rows=1 width=8)
-                                             ->  Partition Selector for my_tq_agg_opt_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                                   Partitions selected: 2 (out of 2)
-                                             ->  Result  (cost=0.00..874.01 rows=1 width=8)
-                                                   ->  Append  (cost=0.00..874.01 rows=1 width=8)
-                                                         ->  Nested Loop  (cost=0.00..437.00 rows=1 width=132)
-                                                               Join Filter: true
-                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=62)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=62)
-                                                               ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=70)
-                                                                     Index Cond: ets <= share0_ref2.event_ts AND end_ts > share0_ref2.event_ts
-                                                                     Filter: sym::bpchar = share0_ref2.symbol AND plusone(bid_price) < share0_ref2.trade_price
-                                                         ->  Nested Loop  (cost=0.00..437.00 rows=1 width=132)
-                                                               Join Filter: true
-                                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=62)
-                                                                     ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=62)
-                                                               ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=70)
-                                                                     Index Cond: ets <= share0_ref3.event_ts
-                                                                     Filter: sym::bpchar = share0_ref3.symbol AND plusone(bid_price) < share0_ref3.trade_price AND share0_ref3.event_ts < end_ts
- Optimizer: PQO version 2.64.0
-(34 rows)
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=0.00..1305.01 rows=1 width=16)
+   Sort Key: (share0_ref2.event_ts / 100000 / 5 * 5)
+   ->  GroupAggregate  (cost=0.00..1305.01 rows=1 width=16)
+         Group Key: (share0_ref2.event_ts / 100000 / 5 * 5)
+         ->  Sort  (cost=0.00..1305.01 rows=1 width=8)
+               Sort Key: (share0_ref2.event_ts / 100000 / 5 * 5)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1305.01 rows=1 width=8)
+                     ->  Result  (cost=0.00..1305.01 rows=1 width=8)
+                           ->  Sequence  (cost=0.00..1305.01 rows=1 width=8)
+                                 ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=1)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Table Scan on my_tt_agg_opt  (cost=0.00..431.00 rows=1 width=62)
+                                 ->  Sequence  (cost=0.00..874.01 rows=1 width=8)
+                                       ->  Partition Selector for my_tq_agg_opt_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                             Partitions selected: 2 (out of 2)
+                                       ->  Result  (cost=0.00..874.01 rows=1 width=8)
+                                             ->  Append  (cost=0.00..874.01 rows=1 width=8)
+                                                   ->  Nested Loop  (cost=0.00..437.00 rows=1 width=132)
+                                                         Join Filter: true
+                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=62)
+                                                               ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=62)
+                                                         ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=70)
+                                                               Index Cond: ets <= share0_ref2.event_ts AND end_ts > share0_ref2.event_ts
+                                                               Filter: sym::bpchar = share0_ref2.symbol AND plusone(bid_price) < share0_ref2.trade_price
+                                                   ->  Nested Loop  (cost=0.00..437.00 rows=1 width=132)
+                                                         Join Filter: true
+                                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=62)
+                                                               ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=62)
+                                                         ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=70)
+                                                               Index Cond: ets <= share0_ref3.event_ts
+                                                               Filter: sym::bpchar = share0_ref3.symbol AND plusone(bid_price) < share0_ref3.trade_price AND share0_ref3.event_ts < end_ts
+ Optimizer: PQO version 2.72.0
+(32 rows)
 
 reset optimizer_segments;
 reset optimizer_enable_constant_expression_evaluation;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -96,23 +96,21 @@ analyze t2;
 -- infer over equalities
 --
 explain select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..862.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1)
-                     Hash Cond: t1.x = t2.x
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           Hash Key: t1.x
-                           ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=4)
-                                 Filter: x = 100
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
-                                 Filter: x = 100
- Settings:  optimizer=on
- Optimizer status: PQO version 2.39.2
-(14 rows)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=1)
+         ->  Hash Join  (cost=0.00..862.00 rows=1 width=1)
+               Hash Cond: t1.x = t2.x
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     Hash Key: t1.x
+                     ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+                           Filter: x = 100
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                           Filter: x = 100
+ Optimizer: PQO version 2.72.0
+(12 rows)
 
 select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
  count 

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7711,18 +7711,16 @@ order by 1,2,3;
 -- Once upon a time, there was a bug in deparsing a WindowAgg node with EXPLAIN
 -- that this query triggered (MPP-4840)
 explain select n from ( select row_number() over () from (values (0)) as t(x) ) as r(n) group by n;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
-   Group By: row_number
-   ->  GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
-         Group By: row_number
-         ->  Sort  (cost=0.00..0.00 rows=1 width=8)
-               Sort Key: row_number
-               ->  WindowAgg  (cost=0.00..0.00 rows=1 width=8)
-                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on; optimizer_segments=3
-(9 rows)
+   Group Key: (row_number() OVER (?))
+   ->  Sort  (cost=0.00..0.00 rows=1 width=8)
+         Sort Key: (row_number() OVER (?))
+         ->  WindowAgg  (cost=0.00..0.00 rows=1 width=8)
+               ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: PQO version 2.72.0
+(7 rows)
 
 -- Test for MPP-11645
 create table olap_window_r (a int, b int, x int,  y int,  z int ) distributed by (b);

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -1,13 +1,9 @@
--- ----------------------------------------------------------------------
 -- Test: setup.sql
--- ----------------------------------------------------------------------
 -- start_ignore
 create schema qp_correlated_query;
 set search_path to qp_correlated_query;
 -- end_ignore
--- ----------------------------------------------------------------------
 -- Test: csq_heap_in.sql (Correlated Subquery: CSQ using IN clause (Heap))
--- ----------------------------------------------------------------------
 -- start_ignore
 create table qp_csq_t1(a int, b int) distributed by (a);
 insert into qp_csq_t1 values (1,2);
@@ -71,9 +67,7 @@ insert into E values(99,7);
 insert into E values(78,62);
 analyze E;
 -- end_ignore
--- -- -- --
 -- Basic queries with IN clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a in (select x);
  a | x 
 ---+---
@@ -192,9 +186,7 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
  1 | 1
 (2 rows)
 
--- -- -- --
 -- Basic queries with NOT IN clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a not in (select x) order by a,x;
  a | x 
 ---+---
@@ -442,12 +434,8 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
  -1
 (10 rows)
 
--- ----------------------------------------------------------------------
 -- Test: csq_heap_any.sql - Correlated Subquery: CSQ using ANY clause (Heap)
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries with ANY clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x);
  a | x 
 ---+---
@@ -664,12 +652,8 @@ select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j =
 ---+---+---
 (0 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using ALL clause (Heap)
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries with ALL clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = all (select x) order by a;
  a | x 
 ---+---
@@ -856,12 +840,8 @@ select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j =
  1 | -1 | 62
 (10 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using EXISTS clause (Heap)
--- ----------------------------------------------------------------------
--- -- -- -- 
 -- Basic queries with EXISTS clause
--- -- -- --
 select b from qp_csq_t1 where exists(select * from qp_csq_t2 where y=a);
  b 
 ---
@@ -1005,9 +985,7 @@ select * from A,B,C where C.i = A.i and exists (select C.j where C.j = B.j and A
  78 | -1 | -1 | 62 | 78 | 62
 (1 row)
 
--- -- -- --
 -- Basic queries with NOT EXISTS clause
--- -- -- --
 select b from qp_csq_t1 where not exists(select * from qp_csq_t2 where y=a);
  b 
 ---
@@ -1334,9 +1312,7 @@ select * from A where not exists (select sum(c.i) from C where C.i = A.i group b
   1 | 1
 (3 rows)
 
--- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
--- ----------------------------------------------------------------------
 -- start_ignore
 drop table if exists qp_csq_t4;
 NOTICE:  table "qp_csq_t4" does not exist, skipping
@@ -1347,9 +1323,7 @@ insert into qp_csq_t4 values (5,6);
 insert into qp_csq_t4 values (7,8);
 analyze qp_csq_t4;
 -- end_ignore
--- -- -- --
 -- Basic CSQ with UPDATE statements
--- -- -- --
 select * from qp_csq_t4 order by a;
  a | b 
 ---+---
@@ -1431,9 +1405,7 @@ select * from D;
  22222 | 62
 (5 rows)
 
--- -- -- --
 -- Basic CSQ with DELETE statements
--- -- -- --
 select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
@@ -1496,12 +1468,8 @@ select * from D order by D.i;
 ---+---
 (0 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using WHERE clause (Heap)
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries with WHERE clause
--- -- -- --
 select a, (select y from qp_csq_t2 where x=a) from qp_csq_t1 where b < 8 order by a;
  a | y  
 ---+----
@@ -1539,12 +1507,8 @@ SELECT a, (SELECT d FROM qp_csq_t3 WHERE a=c) FROM qp_csq_t1 GROUP BY a order by
 -- Planner should fail due to skip-level correlation not supported. ORCA should pass
 SELECT a, (SELECT (SELECT d FROM qp_csq_t3 WHERE a=c)) FROM qp_csq_t1 GROUP BY a order by a;
 ERROR:  correlated subquery with skip-level correlations is not supported
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ in select list (Heap) 
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries in SELECT list
--- -- -- --
 select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
  i  | c_j 
 ----+-----
@@ -1569,9 +1533,7 @@ select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select 
  4.0000000000000000
 (4 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)
--- ----------------------------------------------------------------------
 select A.i, B.i from A, B where (A.i,A.j) = (select min(B.i),min(B.j) from B where B.i = A.i) order by A.i, B.i;
  i | i  
 ---+----
@@ -1937,12 +1899,8 @@ select A.i as A_i, B.i as B_i,C.i as C_i from A, B, C where (A.i,B.i) = (select 
    1 |   1 |   1
 (4 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using HAVING clause (Heap) 
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries with HAVING clause
--- -- -- -- 
 select A.i from A group by A.i having min(A.i) not in (select B.i from B where A.i = B.i) order by A.i;
  i  
 ----
@@ -1999,9 +1957,7 @@ SELECT name, department, salary FROM csq_emp ea group by name, department,salary
 ------+------------+--------
 (0 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multi-row subqueries (Heap)
--- ----------------------------------------------------------------------
 -- start_ignore
 drop table if exists Employee;
 NOTICE:  table "employee" does not exist, skipping
@@ -2272,9 +2228,7 @@ SELECT id, first_name, salary from employee
  08 | James      | 1232.78
 (8 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Misc Queries
--- ----------------------------------------------------------------------
 -- start_ignore
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
@@ -3628,9 +3582,7 @@ SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS 
 ---
 (0 rows)
 
--- ----------------------------------------------------------------------
 -- Test: teardown.sql
--- ----------------------------------------------------------------------
 -- start_ignore
 drop schema qp_correlated_query cascade;
 NOTICE:  drop cascades to table qp_tjoin4

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1,13 +1,9 @@
--- ----------------------------------------------------------------------
 -- Test: setup.sql
--- ----------------------------------------------------------------------
 -- start_ignore
 create schema qp_correlated_query;
 set search_path to qp_correlated_query;
 -- end_ignore
--- ----------------------------------------------------------------------
 -- Test: csq_heap_in.sql (Correlated Subquery: CSQ using IN clause (Heap))
--- ----------------------------------------------------------------------
 -- start_ignore
 create table qp_csq_t1(a int, b int) distributed by (a);
 insert into qp_csq_t1 values (1,2);
@@ -71,9 +67,7 @@ insert into E values(99,7);
 insert into E values(78,62);
 analyze E;
 -- end_ignore
--- -- -- --
 -- Basic queries with IN clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a in (select x);
  a | x 
 ---+---
@@ -186,7 +180,7 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
                                  ->  Table Scan on c
                                  ->  Hash
                                        ->  Table Scan on b
- Optimizer: PQO version 2.70.0
+ Optimizer: PQO version 2.74.0
 (15 rows)
 
 select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
@@ -196,9 +190,7 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
  1 | 1
 (2 rows)
 
--- -- -- --
 -- Basic queries with NOT IN clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a not in (select x) order by a,x;
  a | x 
 ---+---
@@ -462,12 +454,8 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
  -1
 (10 rows)
 
--- ----------------------------------------------------------------------
 -- Test: csq_heap_any.sql - Correlated Subquery: CSQ using ANY clause (Heap)
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries with ANY clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x);
  a | x 
 ---+---
@@ -698,12 +686,8 @@ select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j =
 ---+---+---
 (0 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using ALL clause (Heap)
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries with ALL clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = all (select x) order by a;
  a | x 
 ---+---
@@ -756,58 +740,53 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
 (4 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..1389709666335.39 rows=4 width=12)
-   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1389709666335.39 rows=10 width=12)
+                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1389709665858.46 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1389709665858.46 rows=10 width=12)
          Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-         ->  Limit  (cost=0.00..1389709666335.39 rows=4 width=12)
-               ->  Sort  (cost=0.00..1389709666335.39 rows=90 width=12)
+         ->  Limit  (cost=0.00..1389709665858.46 rows=4 width=12)
+               ->  Sort  (cost=0.00..1389709665858.46 rows=90 width=12)
                      Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-                     ->  Nested Loop  (cost=0.00..1389709666335.35 rows=90 width=12)
+                     ->  Nested Loop  (cost=0.00..1389709665858.42 rows=90 width=12)
                            Join Filter: true
-                           ->  Nested Loop  (cost=0.00..1357137484.03 rows=10 width=8)
+                           ->  Nested Loop  (cost=0.00..1357137483.56 rows=10 width=8)
                                  Join Filter: true
                                  ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324467.57 rows=5 width=4)
                                        ->  Hash Join  (cost=0.00..1324467.57 rows=2 width=4)
-                                             Hash Cond: (pg_catalog.sum((sum(qp_correlated_query.c.j)))) = a.j::bigint AND qp_correlated_query.c.j = a.j
+                                             Hash Cond: (sum(qp_correlated_query.c.j)) = a.j::bigint AND qp_correlated_query.c.j = a.j
                                              ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
                                                    Group Key: qp_correlated_query.c.j
-                                                   ->  Sort  (cost=0.00..1324036.57 rows=3 width=12)
+                                                   ->  Sort  (cost=0.00..1324036.57 rows=3 width=4)
                                                          Sort Key: qp_correlated_query.c.j
-                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.57 rows=3 width=12)
+                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.57 rows=3 width=4)
                                                                Hash Key: qp_correlated_query.c.j
-                                                               ->  Result  (cost=0.00..1324036.57 rows=3 width=12)
-                                                                     ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
-                                                                           Group Key: qp_correlated_query.c.j
-                                                                           ->  Sort  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                                 Sort Key: qp_correlated_query.c.j
-                                                                                 ->  Table Scan on c  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                                       Filter: (SubPlan 1)
-                                                                                       SubPlan 1  (slice3; segments: 3)
+                                                               ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                     ->  Table Scan on c  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                           Filter: (SubPlan 1)
+                                                                           SubPlan 1  (slice3; segments: 3)
+                                                                             ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                         Filter: (CASE WHEN (sum((CASE WHEN qp_correlated_query.c.i <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN qp_correlated_query.c.i IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN qp_correlated_query.c.i <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
                                                                                          ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                               Filter: (CASE WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
-                                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                                     Filter: (CASE WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
-                                                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                                                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                                                                                             Filter: $0 = qp_correlated_query.b.i
-                                                                                                                             ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                                         ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
-                                                                                                                                               Filter: i <> 10
+                                                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                                                 Filter: qp_correlated_query.c.i = qp_correlated_query.b.i
+                                                                                                                 ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                             ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                                                   Filter: i <> 10
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=8)
-                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
+                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
                                                          Hash Key: a.j
                                                          ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=8)
                                  ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.55.13
-(48 rows)
+ Optimizer: PQO version 2.74.0
+(44 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
@@ -917,12 +896,8 @@ select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j =
  1 | -1 | 62
 (10 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using EXISTS clause (Heap)
--- ----------------------------------------------------------------------
--- -- -- -- 
 -- Basic queries with EXISTS clause
--- -- -- --
 select b from qp_csq_t1 where exists(select * from qp_csq_t2 where y=a);
  b 
 ---
@@ -1100,9 +1075,7 @@ select * from A,B,C where C.i = A.i and exists (select C.j where C.j = B.j and A
  78 | -1 | -1 | 62 | 78 | 62
 (1 row)
 
--- -- -- --
 -- Basic queries with NOT EXISTS clause
--- -- -- --
 select b from qp_csq_t1 where not exists(select * from qp_csq_t2 where y=a);
  b 
 ---
@@ -1499,9 +1472,7 @@ select * from A where not exists (select sum(c.i) from C where C.i = A.i group b
  19 | 5
 (3 rows)
 
--- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
--- ----------------------------------------------------------------------
 -- start_ignore
 drop table if exists qp_csq_t4;
 NOTICE:  table "qp_csq_t4" does not exist, skipping
@@ -1512,9 +1483,7 @@ insert into qp_csq_t4 values (5,6);
 insert into qp_csq_t4 values (7,8);
 analyze qp_csq_t4;
 -- end_ignore
--- -- -- --
 -- Basic CSQ with UPDATE statements
--- -- -- --
 select * from qp_csq_t4 order by a;
  a | b 
 ---+---
@@ -1596,9 +1565,7 @@ select * from D;
  11111 |  1
 (5 rows)
 
--- -- -- --
 -- Basic CSQ with DELETE statements
--- -- -- --
 select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
@@ -1661,12 +1628,8 @@ select * from D order by D.i;
 ---+---
 (0 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using WHERE clause (Heap)
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries with WHERE clause
--- -- -- --
 select a, (select y from qp_csq_t2 where x=a) from qp_csq_t1 where b < 8 order by a;
  a | y  
 ---+----
@@ -1711,12 +1674,8 @@ SELECT a, (SELECT (SELECT d FROM qp_csq_t3 WHERE a=c)) FROM qp_csq_t1 GROUP BY a
  7 | seven
 (4 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ in select list (Heap) 
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries in SELECT list
--- -- -- --
 select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
  i  | c_j 
 ----+-----
@@ -1741,9 +1700,7 @@ select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select 
  4.0000000000000000
 (4 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)
--- ----------------------------------------------------------------------
 select A.i, B.i from A, B where (A.i,A.j) = (select min(B.i),min(B.j) from B where B.i = A.i) order by A.i, B.i;
  i | i  
 ---+----
@@ -2109,12 +2066,8 @@ select A.i as A_i, B.i as B_i,C.i as C_i from A, B, C where (A.i,B.i) = (select 
    1 |   1 |   1
 (4 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using HAVING clause (Heap) 
--- ----------------------------------------------------------------------
--- -- -- --
 -- Basic queries with HAVING clause
--- -- -- -- 
 select A.i from A group by A.i having min(A.i) not in (select B.i from B where A.i = B.i) order by A.i;
  i  
 ----
@@ -2171,9 +2124,7 @@ SELECT name, department, salary FROM csq_emp ea group by name, department,salary
 ------+------------+--------
 (0 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multi-row subqueries (Heap)
--- ----------------------------------------------------------------------
 -- start_ignore
 drop table if exists Employee;
 NOTICE:  table "employee" does not exist, skipping
@@ -2444,9 +2395,7 @@ SELECT id, first_name, salary from employee
  08 | James      | 1232.78
 (8 rows)
 
--- ----------------------------------------------------------------------
 -- Test: Misc Queries
--- ----------------------------------------------------------------------
 -- start_ignore
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
@@ -3811,9 +3760,7 @@ SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS 
 ---
 (0 rows)
 
--- ----------------------------------------------------------------------
 -- Test: teardown.sql
--- ----------------------------------------------------------------------
 -- start_ignore
 drop schema qp_correlated_query cascade;
 NOTICE:  drop cascades to table qp_tjoin4

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -2418,8 +2418,8 @@ select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a
 (2 rows)
 
 explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
-                                                                                            QUERY PLAN                                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=4)
    ->  Sequence  (cost=0.00..1293.00 rows=1 width=4)
          ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=1)
@@ -2427,30 +2427,21 @@ explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping 
                      ->  Table Scan on tbl7553_test  (cost=0.00..431.00 rows=1 width=4)
          ->  Append  (cost=0.00..862.00 rows=1 width=4)
                ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                     Group By: share0_ref2.j
+                     Group Key: share0_ref2.j
                      ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                            Sort Key: share0_ref2.j
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                  Hash Key: share0_ref2.j
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                       Group By: share0_ref2.j
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                             Sort Key: share0_ref2.j
-                                             ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
                ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                     Group By: share0_ref3.j, share0_ref3.j
+                     Group Key: share0_ref3.j, share0_ref3.j
                      ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                            Sort Key: share0_ref3.j, share0_ref3.j
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                  Hash Key: share0_ref3.j, share0_ref3.j
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                       Group By: share0_ref3.j, share0_ref3.j
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                             Sort Key: share0_ref3.j, share0_ref3.j
-                                             ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; gp_enable_agg_distinct=off; gp_enable_agg_distinct_pruning=off; optimizer=on; optimizer_force_three_stage_scalar_dqa=off
- Optimizer status: PQO version 2.51.0
-(30 rows)
+                                 ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.74.0
+(21 rows)
 
 select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
  a | b 
@@ -3046,112 +3037,84 @@ reset gp_enable_agg_distinct_pruning;
 set enable_groupagg=off;
 -- both queries should use hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..862.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-               Group By: qp_misc_jiras.tbl5994_test.j
-               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                     Group By: qp_misc_jiras.tbl5994_test.j
-                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                           Sort Key: qp_misc_jiras.tbl5994_test.j
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Key: qp_misc_jiras.tbl5994_test.j
-                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                       Group By: qp_misc_jiras.tbl5994_test.j
-                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                                             Sort Key: qp_misc_jiras.tbl5994_test.j
-                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: qp_misc_jiras.tbl5994_test.j = qp_misc_jiras.tbl5994_test.j
-                                                   ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                               ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_groupagg=off; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
- Optimizer status: PQO version 2.51.1
-(22 rows)
+               Group Key: qp_misc_jiras.tbl5994_test.j
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: qp_misc_jiras.tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: qp_misc_jiras.tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: qp_misc_jiras.tbl5994_test.j = qp_misc_jiras.tbl5994_test.j
+                                 ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.74.0
+(15 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..862.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-               Group By: qp_misc_jiras.tbl5994_test.j
-               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                     Group By: qp_misc_jiras.tbl5994_test.j
-                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                           Sort Key: qp_misc_jiras.tbl5994_test.j
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Key: qp_misc_jiras.tbl5994_test.j
-                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                       Group By: qp_misc_jiras.tbl5994_test.j
-                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                                             Sort Key: qp_misc_jiras.tbl5994_test.j
-                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: qp_misc_jiras.tbl5994_test.i = qp_misc_jiras.tbl5994_test.i
-                                                   ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                                         ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_groupagg=off; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
- Optimizer status: PQO version 2.51.1
-(21 rows)
+               Group Key: qp_misc_jiras.tbl5994_test.j
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: qp_misc_jiras.tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: qp_misc_jiras.tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: qp_misc_jiras.tbl5994_test.i = qp_misc_jiras.tbl5994_test.i
+                                 ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.74.0
+(14 rows)
 
 set enable_groupagg=on;
 -- first query should use groupagg, and second one - hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..862.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-               Group By: qp_misc_jiras.tbl5994_test.j
-               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                     Group By: qp_misc_jiras.tbl5994_test.j
-                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                           Sort Key: qp_misc_jiras.tbl5994_test.j
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Key: qp_misc_jiras.tbl5994_test.j
-                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                       Group By: qp_misc_jiras.tbl5994_test.j
-                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                                             Sort Key: qp_misc_jiras.tbl5994_test.j
-                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: qp_misc_jiras.tbl5994_test.j = qp_misc_jiras.tbl5994_test.j
-                                                   ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                               ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_groupagg=on; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
- Optimizer status: PQO version 2.51.1
-(22 rows)
+               Group Key: qp_misc_jiras.tbl5994_test.j
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: qp_misc_jiras.tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: qp_misc_jiras.tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: qp_misc_jiras.tbl5994_test.j = qp_misc_jiras.tbl5994_test.j
+                                 ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.74.0
+(15 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..862.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-               Group By: qp_misc_jiras.tbl5994_test.j
-               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                     Group By: qp_misc_jiras.tbl5994_test.j
-                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                           Sort Key: qp_misc_jiras.tbl5994_test.j
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Key: qp_misc_jiras.tbl5994_test.j
-                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                       Group By: qp_misc_jiras.tbl5994_test.j
-                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                                             Sort Key: qp_misc_jiras.tbl5994_test.j
-                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: qp_misc_jiras.tbl5994_test.i = qp_misc_jiras.tbl5994_test.i
-                                                   ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                                         ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_groupagg=on; optimizer_force_three_stage_scalar_dqa=off; optimizer_segments=3
- Optimizer status: PQO version 2.51.1
-(21 rows)
+               Group Key: qp_misc_jiras.tbl5994_test.j
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: qp_misc_jiras.tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: qp_misc_jiras.tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: qp_misc_jiras.tbl5994_test.i = qp_misc_jiras.tbl5994_test.i
+                                 ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Table Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.74.0
+(14 rows)
 
 drop table qp_misc_jiras.tbl5994_test;
 CREATE TABLE qp_misc_jiras.tbl_8205 (
@@ -3883,27 +3846,18 @@ select  * from qp_misc_jiras.test_co where ctid='(33554432,32769)' and gp_segmen
 set gp_enable_explain_allstat=on;
 insert into qp_misc_jiras.test_heap select i, i from generate_series(0, 99999) i;
 explain analyze select count(*) from qp_misc_jiras.test_heap;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   Rows out:  1 rows with 10 ms to end, start offset by 0.342 ms.
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         Rows out:  3 rows at destination with 10 ms to end, start offset by 0.343 ms.
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 10 ms to end, start offset by 0.638 ms.
-               allstat: seg_firststart_total_ntuples/seg0_0.638 ms_10 ms_1/seg1_0.636 ms_10 ms_1/seg2_0.637 ms_10 ms_1//end
-               ->  Table Scan on test_heap  (cost=0.00..431.00 rows=1 width=1)
-                     Rows out:  Avg 33333.7 rows x 3 workers.  Max 33350 rows (seg0) with 0.039 ms to first row, 5.346 ms to end, start offset by 0.638 ms.
-                     allstat: seg_firststart_total_ntuples/seg0_0.638 ms_5.346 ms_33350/seg1_0.636 ms_5.368 ms_33336/seg2_0.637 ms_5.264 ms_33315//end
- Slice statistics:
-   (slice0)    Executor memory: 382K bytes.
-   (slice1)    Executor memory: 163K bytes avg x 3 workers, 163K bytes max (seg0).
- Statement statistics:
-   Memory used: 128000K bytes
- Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.684
- Total runtime: 10.892 ms
-(18 rows)
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=51.450..51.450 rows=0 loops=2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1) (actual time=1.677..40.539 rows=50000 loops=2)
+         ->  Table Scan on test_heap  (cost=0.00..431.00 rows=1 width=1) (actual time=0.034..5.955 rows=16676 loops=2)
+               allstat: seg_firststart_total_ntuples//end
+   (slice0)    Executor memory: 1085K bytes.
+   (slice1)    Executor memory: 70K bytes avg x 3 workers, 70K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: PQO version 2.74.0
+ Total runtime: 103.438 ms
+(9 rows)
 
 -- start_ignore
 -- This is to verify MPP-8946
@@ -4017,40 +3971,30 @@ explain select * from qp_misc_jiras.r;
 (4 rows)
 
 explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.26 rows=1000 width=16)
-   Rows out:  1000 rows at destination with 60 ms to first row, 87 ms to end, start offset by 0.252 ms.
-   ->  Hash Join  (cost=0.00..862.20 rows=334 width=16)
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.26 rows=1000 width=16) (actual time=21.749..39.838 rows=500 loops=2)
+   ->  Hash Join  (cost=0.00..862.20 rows=334 width=16) (actual time=21.471..39.470 rows=174 loops=2)
          Hash Cond: r.a = s.b
-         Rows out:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 60 ms to first row, 86 ms to end, start offset by 0.527 ms.
-         Executor memory:  11K bytes avg, 11K bytes max (seg1).
-         Work_mem used:  11K bytes avg, 11K bytes max (seg1). Workfile: (0 spilling, 0 reused)
-         (seg1)   Hash chain length 1.0 avg, 1 max, using 342 of 8388619 buckets.
-         allstat: seg_firststart_total_ntuples/seg0_0.559 ms_86 ms_321/seg1_0.527 ms_86 ms_342/seg2_0.576 ms_86 ms_337//end
-         ->  Table Scan on r  (cost=0.00..431.01 rows=334 width=8)
-               Rows out:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 0.019 ms to first row, 0.037 ms to end, start offset by 60 ms.
-               allstat: seg_firststart_total_ntuples/seg0_61 ms_0.041 ms_321/seg1_60 ms_0.037 ms_342/seg2_61 ms_0.036 ms_337//end
-         ->  Hash  (cost=431.02..431.02 rows=334 width=8)
-               Rows in:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 0.131 ms to end, start offset by 60 ms.
-               allstat: seg_firststart_total_ntuples/seg0_61 ms_0.135 ms_321/seg1_60 ms_0.131 ms_342/seg2_61 ms_0.176 ms_337//end
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.02 rows=334 width=8)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 347 of 8388608 buckets.
+ 
+         allstat: seg_firststart_total_ntuples//end
+         ->  Table Scan on r  (cost=0.00..431.01 rows=334 width=8) (actual time=0.032..0.062 rows=174 loops=2)
+               allstat: seg_firststart_total_ntuples//end
+         ->  Hash  (cost=431.02..431.02 rows=334 width=8) (actual time=0.309..0.309 rows=174 loops=2)
+               allstat: seg_firststart_total_ntuples//end
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.02 rows=334 width=8) (actual time=0.123..0.183 rows=174 loops=2)
                      Hash Key: s.b
-                     Rows out:  Avg 333.3 rows x 3 workers at destination.  Max 342 rows (seg1) with 0.048 ms to first row, 0.081 ms to end, start offset by 60 ms.
-                     allstat: seg_firststart_total_ntuples/seg0_61 ms_0.076 ms_321/seg1_60 ms_0.081 ms_342/seg2_61 ms_0.117 ms_337//end
-                     ->  Table Scan on s  (cost=0.00..431.01 rows=334 width=8)
-                           Rows out:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 2.039 ms to first row, 2.069 ms to end, start offset by 2.265 ms.
-                           allstat: seg_firststart_total_ntuples/seg0_2.222 ms_2.232 ms_321/seg1_2.265 ms_2.069 ms_342/seg2_2.286 ms_1.974 ms_337//end
- Slice statistics:
-   (slice0)    Executor memory: 267K bytes.
-   (slice1)    Executor memory: 193K bytes avg x 3 workers, 193K bytes max (seg0).
-   (slice2)    Executor memory: 131378K bytes avg x 3 workers, 131399K bytes max (seg1).  Work_mem: 11K bytes max.
- Statement statistics:
-   Memory used: 1945600K bytes
- Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
- Total runtime: 87.064 ms
-(31 rows)
+                     allstat: seg_firststart_total_ntuples//end
+                     ->  Table Scan on s  (cost=0.00..431.01 rows=334 width=8) (actual time=0.018..0.040 rows=174 loops=2)
+                           allstat: seg_firststart_total_ntuples//end
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 65802K bytes avg x 3 workers, 65802K bytes max (seg0).  Work_mem: 11K bytes max.
+ Memory used:  1945600kB
+ Optimizer: PQO version 2.74.0
+ Total runtime: 81.049 ms
+(21 rows)
 
 drop table qp_misc_jiras.r;
 drop table qp_misc_jiras.s;

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -3568,25 +3568,20 @@ then 'MO' else 'foo' end
 case when ir_call_type_group_code in ('H', 'VH', 'PCB') then 'Thailland'
 else 'Unidentify' end
 ;
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
    ->  Result  (cost=0.00..431.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
-               Group By: "?column?", "?column?"
+               Group Key: (CASE WHEN ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[]) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ir_call_type_group_code::text = ANY ('{H,VH,PCB}'::text[]) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
                ->  Sort  (cost=0.00..431.00 rows=1 width=16)
-                     Sort Key: "?column?", "?column?"
+                     Sort Key: (CASE WHEN ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[]) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ir_call_type_group_code::text = ANY ('{H,VH,PCB}'::text[]) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-                           Hash Key: "?column?", "?column?"
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                                 Group By: "?column?", "?column?"
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=16)
-                                       Sort Key: "?column?", "?column?"
-                                       ->  Result  (cost=0.00..431.00 rows=1 width=16)
-                                             ->  Table Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
- Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
-(16 rows)
+                           Hash Key: (CASE WHEN ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[]) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ir_call_type_group_code::text = ANY ('{H,VH,PCB}'::text[]) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=16)
+                                 ->  Table Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
+ Optimizer: PQO version 2.74.0
+(11 rows)
 
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
 create table qp_misc_jiras.r

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -730,16 +730,15 @@ explain select count(*) from mpp7638 where a =1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Result  (cost=0.00..431.00 rows=1 width=1)
                ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
                      ->  Partition Selector for mpp7638 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                           Partitions selected:  9 (out of 9)
+                           Partitions selected: 9 (out of 9)
                      ->  Dynamic Table Scan on mpp7638 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
                            Filter: a = 1
- Settings:  optimizer=on
- Optimizer status: PQO version 1.624
-(10 rows)
+ Optimizer: PQO version 2.74.0
+(9 rows)
 
 alter table mpp7638 set distributed by (a, b, c);
 INFO:  Dispatch command to ALL contents
@@ -1044,18 +1043,16 @@ explain select a0 from table_a where a0 in (select max(a1) from table_a);
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: "outer".max = public.table_a.a0
+         Hash Cond: (max(public.table_a.a1)) = public.table_a.a0
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
-               Hash Key: max
+               Hash Key: (max(public.table_a.a1))
                ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: PQO version 1.624
-(13 rows)
+ Optimizer: PQO version 2.74.0
+(11 rows)
 
 select a0 from table_a where a0 in (select max(a1) from table_a);
 INFO:  Dispatch command to ALL contents
@@ -1084,19 +1081,17 @@ explain select a0 from table_a where a0 in (select max(a1) from table_a where a0
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: "outer".max = public.table_a.a0
+         Hash Cond: (max(public.table_a.a1)) = public.table_a.a0
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
-               Hash Key: max
+               Hash Key: (max(public.table_a.a1))
                ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
-                                       Filter: a0 = 1
+                           ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: a0 = 1
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: PQO version 1.624
-(14 rows)
+ Optimizer: PQO version 2.74.0
+(12 rows)
 
 --start_ignore
 drop table table_a cascade;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -112,8 +112,8 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
                                                            ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
                                                                  Partitions selected: 4 (out of 4)
                                                            ->  Dynamic Table Scan on csq_t2 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 2.55.21
-(26 rows)
+ Optimizer: PQO version 2.74.0
+(25 rows)
 
 select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
  x | y 
@@ -146,8 +146,8 @@ explain select * from mrs_t1 where exists (select x from mrs_t1 where x < -1);
                                  ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=1 width=1)
                                        Filter: x < (-1)
  Settings:  optimizer_nestloop_factor=1; optimizer_segments=3
- Optimizer status: PQO version 2.35.1
-(12 rows)
+ Optimizer: PQO version 2.74.0
+(11 rows)
 
 select * from mrs_t1 where exists (select x from mrs_t1 where x < -1) order by 1;
  x 
@@ -168,8 +168,8 @@ explain select * from mrs_t1 where exists (select x from mrs_t1 where x = 1);
                                  ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=1 width=1)
                                        Filter: x = 1
  Settings:  optimizer_nestloop_factor=1; optimizer_segments=3
- Optimizer status: PQO version 2.35.1
-(12 rows)
+ Optimizer: PQO version 2.74.0
+(11 rows)
 
 select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
  x  
@@ -214,7 +214,7 @@ explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
                                        ->  Result  (cost=0.00..431.00 rows=7 width=4)
                                              ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
- Optimizer: PQO version 2.72.0
+ Optimizer: PQO version 2.74.0
 (16 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
@@ -290,8 +290,8 @@ explain select array(select x from csq_d1); -- initplan
      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
            ->  Seq Scan on csq_d1  (cost=0.00..1.01 rows=1 width=4)
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: legacy query optimizer
-(6 rows)
+ Optimizer: legacy query optimizer
+(5 rows)
 
 select array(select x from csq_d1); -- {1}
  array 
@@ -413,8 +413,8 @@ explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; 
                            ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                                  ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=3 width=4)
                                        ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.72.0
-(15 rows
+ Optimizer: PQO version 2.74.0
+(15 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
  x 

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -197,32 +197,25 @@ select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
 (20 rows)
 
 explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
-                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.03 rows=20 width=4)
+                                                                                                                                                                         QUERY PLAN                                                                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.03 rows=20 width=4)
    ->  Result  (cost=0.00..1293.03 rows=7 width=4)
-         Filter: CASE WHEN NOT subselect_gp.mrs_t1.x IS NULL THEN CASE WHEN (pg_catalog.sum((sum((CASE WHEN (subselect_gp.mrs_t1.x - 95) IS NULL THEN 1 ELSE 0 END))))) = (count((count()))) THEN NULL::boolean WHEN NOT (pg_catalog.sum((sum((CASE WHEN (subselect_gp.mrs_t1.x - 95) IS NULL THEN 1 ELSE 0 END))))) IS NULL THEN true ELSE false END ELSE NULL::boolean END OR subselect_gp.mrs_t1.x < 5
+         Filter: CASE WHEN NOT subselect_gp.mrs_t1.x IS NULL THEN CASE WHEN (sum((CASE WHEN (subselect_gp.mrs_t1.x - 95) IS NULL THEN 1 ELSE 0 END))) = (count()) THEN NULL::boolean WHEN NOT (sum((CASE WHEN (subselect_gp.mrs_t1.x - 95) IS NULL THEN 1 ELSE 0 END))) IS NULL THEN true ELSE false END ELSE NULL::boolean END OR subselect_gp.mrs_t1.x < 5
          ->  GroupAggregate  (cost=0.00..1293.03 rows=7 width=20)
                Group Key: subselect_gp.mrs_t1.x, subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
-               ->  Sort  (cost=0.00..1293.03 rows=7 width=30)
-                     Sort Key: subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.03 rows=7 width=30)
-                           Hash Key: subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
-                           ->  Result  (cost=0.00..1293.03 rows=7 width=30)
-                                 ->  GroupAggregate  (cost=0.00..1293.03 rows=7 width=30)
-                                       Group Key: subselect_gp.mrs_t1.x, subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
-                                       ->  Nested Loop Left Join  (cost=0.00..1293.03 rows=140 width=18)
-                                             Join Filter: subselect_gp.mrs_t1.x = (subselect_gp.mrs_t1.x - 95) OR (subselect_gp.mrs_t1.x - 95) IS NULL
-                                             ->  Sort  (cost=0.00..431.00 rows=7 width=14)
-                                                   Sort Key: subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
-                                                   ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=14)
-                                             ->  Result  (cost=0.00..431.00 rows=20 width=8)
-                                                   ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
-                                                               ->  Result  (cost=0.00..431.00 rows=7 width=4)
-                                                                     ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
- Optimizer: PQO version 2.55.21
-(23 rows)
+               ->  Nested Loop Left Join  (cost=0.00..1293.03 rows=140 width=18)
+                     Join Filter: subselect_gp.mrs_t1.x = (subselect_gp.mrs_t1.x - 95) OR (subselect_gp.mrs_t1.x - 95) IS NULL
+                     ->  Sort  (cost=0.00..431.00 rows=7 width=14)
+                           Sort Key: subselect_gp.mrs_t1.x, subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
+                           ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=14)
+                     ->  Result  (cost=0.00..431.00 rows=20 width=8)
+                           ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
+                                       ->  Result  (cost=0.00..431.00 rows=7 width=4)
+                                             ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
+ Optimizer: PQO version 2.72.0
+(16 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
  x 
@@ -382,18 +375,17 @@ explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; 
    Filter: CASE WHEN NOT csq_m1.x IS NULL THEN CASE WHEN (sum((CASE WHEN csq_d1.x IS NULL THEN 1 ELSE 0 END))) = (count()) THEN NULL::boolean WHEN NOT (sum((CASE WHEN csq_d1.x IS NULL THEN 1 ELSE 0 END))) IS NULL THEN false ELSE true END ELSE NULL::boolean END OR csq_m1.x < (-100)
    ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
          Group Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-         ->  Sort  (cost=0.00..1293.00 rows=1 width=18)
-               Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-               ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=1 width=18)
-                     Join Filter: csq_m1.x = csq_d1.x OR csq_d1.x IS NULL
+         ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=1 width=18)
+               Join Filter: csq_m1.x = csq_d1.x OR csq_d1.x IS NULL
+               ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+                     Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
                      ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=1 width=14)
-                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                       ->  Table Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
-(15 rows)
+               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                 ->  Table Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.72.0
+(14 rows)
 
 select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
  x 
@@ -405,31 +397,24 @@ select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
 -- outer plan node is master-only and CSQ has distributed relation
 --
 explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- broadcast motion
-                                                                                                                                                                 QUERY PLAN                                                                                                                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
-         Filter: CASE WHEN NOT csq_d1.x IS NULL THEN CASE WHEN (pg_catalog.sum((sum((CASE WHEN csq_m1.x IS NULL THEN 1 ELSE 0 END))))) = (count((count()))) THEN NULL::boolean WHEN NOT (pg_catalog.sum((sum((CASE WHEN csq_m1.x IS NULL THEN 1 ELSE 0 END))))) IS NULL THEN false ELSE true END ELSE NULL::boolean END OR csq_d1.x < (-100)
+         Filter: CASE WHEN NOT csq_d1.x IS NULL THEN CASE WHEN (sum((CASE WHEN csq_m1.x IS NULL THEN 1 ELSE 0 END))) = (count()) THEN NULL::boolean WHEN NOT (sum((CASE WHEN csq_m1.x IS NULL THEN 1 ELSE 0 END))) IS NULL THEN false ELSE true END ELSE NULL::boolean END OR csq_d1.x < (-100)
          ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-               ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
-                     Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
-                           Hash Key: csq_d1.ctid, csq_d1.gp_segment_id
-                           ->  Result  (cost=0.00..1293.00 rows=1 width=30)
-                                 ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
-                                       Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-                                       ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=18)
-                                             Join Filter: csq_d1.x = csq_m1.x OR csq_m1.x IS NULL
-                                             ->  Sort  (cost=0.00..431.00 rows=1 width=14)
-                                                   Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                                                   ->  Table Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                                         ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=3 width=4)
-                                                               ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.64.0
-(22 rows)
+               ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=18)
+                     Join Filter: csq_d1.x = csq_m1.x OR csq_m1.x IS NULL
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+                           Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
+                           ->  Table Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=3 width=4)
+                                       ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.72.0
+(15 rows
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
  x 
@@ -671,11 +656,11 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 -- text, varchar
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: 1 = COALESCE((count((count()))), 0::bigint)
+         Filter: 1 = COALESCE((count()), 0::bigint)
          ->  Result  (cost=0.00..862.00 rows=1 width=36)
                ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
                      Hash Cond: subselect_gp.csq_pullup.t = subselect_gp.csq_pullup.v::text
@@ -683,18 +668,13 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                      ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                            ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                                  Group Key: subselect_gp.csq_pullup.v
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                                        Sort Key: subselect_gp.csq_pullup.v
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                              Hash Key: subselect_gp.csq_pullup.v
-                                             ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                                                   ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                                         Group Key: subselect_gp.csq_pullup.v
-                                                         ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                                               Sort Key: subselect_gp.csq_pullup.v
-                                                               ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.55.21
-(21 rows)
+                                             ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.72.0
+(16 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
   t  | n | i |  v  
@@ -708,11 +688,11 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 -- numeric, numeric
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: 1 = COALESCE((count((count()))), 0::bigint)
+         Filter: 1 = COALESCE((count()), 0::bigint)
          ->  Result  (cost=0.00..862.00 rows=1 width=36)
                ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
                      Hash Cond: subselect_gp.csq_pullup.n = subselect_gp.csq_pullup.n
@@ -722,18 +702,13 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                      ->  Hash  (cost=431.00..431.00 rows=1 width=13)
                            ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
                                  Group Key: subselect_gp.csq_pullup.n
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=13)
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=5)
                                        Sort Key: subselect_gp.csq_pullup.n
-                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
                                              Hash Key: subselect_gp.csq_pullup.n
-                                             ->  Result  (cost=0.00..431.00 rows=1 width=13)
-                                                   ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
-                                                         Group Key: subselect_gp.csq_pullup.n
-                                                         ->  Sort  (cost=0.00..431.00 rows=1 width=5)
-                                                               Sort Key: subselect_gp.csq_pullup.n
-                                                               ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: PQO version 2.55.21
-(23 rows)
+                                             ->  Table Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=5)
+ Optimizer: PQO version 2.72.0
+(18 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
   t  | n | i |  v  
@@ -914,18 +889,17 @@ select * from subselect_t1 where x in (select y from subselect_t2 union all sele
 (2 rows)
 
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2);
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..862.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
-               ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
-                     Hash Cond: subselect_t1.x = subselect_t2.y
-                     ->  Table Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.64.0
-(9 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
+               Hash Cond: subselect_t1.x = subselect_t2.y
+               ->  Table Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.72.0
+(8 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2);
  count 
@@ -937,25 +911,23 @@ select count(*) from subselect_t1 where x in (select y from subselect_t2);
 -- Known_opt_diff: MPP-21351
 -- end_ignore
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
-                     Hash Cond: subselect_gp.subselect_t2.y = subselect_t1.x
-                     ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
-                           Group Key: subselect_gp.subselect_t2.y
-                           ->  Sort  (cost=0.00..862.00 rows=2 width=4)
-                                 Sort Key: subselect_gp.subselect_t2.y
-                                 ->  Append  (cost=0.00..862.00 rows=2 width=4)
-                                       ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Table Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
-(16 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=1)
+         ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
+               Hash Cond: subselect_gp.subselect_t2.y = subselect_t1.x
+               ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
+                     Group Key: subselect_gp.subselect_t2.y
+                     ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+                           Sort Key: subselect_gp.subselect_t2.y
+                           ->  Append  (cost=0.00..862.00 rows=2 width=4)
+                                 ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Table Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Table Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: PQO version 2.72.0
+(14 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
  count 
@@ -1239,8 +1211,8 @@ CASE
 	ELSE 'Q2'::text END  AS  cc,  1 AS nn
 FROM t_mpp_20470 b;
 explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  WindowAgg  (cost=0.00..862.00 rows=1 width=16)
    ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=12)
          ->  Result  (cost=0.00..862.00 rows=1 width=12)
@@ -1256,21 +1228,16 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                            ->  Hash  (cost=431.00..431.00 rows=1 width=16)
                                  ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
                                        Group Key: subselect_gp.t_mpp_20470.col_name
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                                              Sort Key: subselect_gp.t_mpp_20470.col_name
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                                                    Hash Key: subselect_gp.t_mpp_20470.col_name
-                                                   ->  Result  (cost=0.00..431.00 rows=1 width=16)
-                                                         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                               Group Key: subselect_gp.t_mpp_20470.col_name
-                                                               ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                                                                     Sort Key: subselect_gp.t_mpp_20470.col_name
-                                                                     ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
-                                                                           ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                                                                 Partitions selected: 2 (out of 2)
-                                                                           ->  Dynamic Table Scan on t_mpp_20470 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
- Optimizer: PQO version 2.55.21
-(29 rows)
+                                                   ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                                                         ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                                               Partitions selected: 2 (out of 2)
+                                                         ->  Dynamic Table Scan on t_mpp_20470 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: PQO version 2.72.0
+(24 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;
@@ -1627,35 +1594,28 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.10 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-               Group Key: public.tenk1.ten
-               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
-                     Sort Key: public.tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
-                           Hash Key: public.tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-                                 Group Key: public.tenk1.ten
-                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
-                                       Sort Key: public.tenk1.ten
-                                       ->  Hash Join  (cost=0.00..864.10 rows=34 width=4)
-                                             Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
-                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.11 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.11 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
+                     Hash Key: public.tenk1.ten
+                     ->  Hash Join  (cost=0.00..864.11 rows=34 width=4)
+                           Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
+                           ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
+                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                       Group Key: public.tenk1.hundred
+                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                             Sort Key: public.tenk1.hundred
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                   Hash Key: public.tenk1.hundred
+                                                   ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: public.tenk1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: public.tenk1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                                     Hash Key: public.tenk1.hundred
-                                                                     ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                                           Group Key: public.tenk1.hundred
-                                                                           ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
- Optimizer: PQO version 2.69.0
-(26 rows)
+                                                         ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: PQO version 2.72.0
+(19 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
@@ -1684,35 +1644,28 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.10 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-               Group Key: public.tenk1.ten
-               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
-                     Sort Key: public.tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..631.98 rows=4 width=4)
-                           Hash Key: public.tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-                                 Group Key: public.tenk1.ten
-                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
-                                       Sort Key: public.tenk1.ten
-                                       ->  Hash Semi Join  (cost=0.00..864.10 rows=34 width=4)
-                                             Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
-                                             ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.11 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.11 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
+                     Hash Key: public.tenk1.ten
+                     ->  Hash Semi Join  (cost=0.00..864.11 rows=34 width=4)
+                           Hash Cond: public.tenk1.unique1 = public.tenk1.hundred
+                           ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
+                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                       Group Key: public.tenk1.hundred
+                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                             Sort Key: public.tenk1.hundred
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                   Hash Key: public.tenk1.hundred
+                                                   ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: public.tenk1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: public.tenk1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                                     Hash Key: public.tenk1.hundred
-                                                                     ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                                           Group Key: public.tenk1.hundred
-                                                                           ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
- Optimizer: PQO version 2.69.0
-(26 rows)
+                                                         ->  Table Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: PQO version 2.72.0
+(19 rows)
 
 --
 -- In case of simple exists query, planner can generate alternative
@@ -1860,8 +1813,8 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN 
 EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b FROM dedup_test1) AND dedup_test3.b IN (SELECT b FROM dedup_test1);
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..2648064.92 rows=4 width=20)
-   ->  Hash Join  (cost=0.00..2648064.92 rows=2 width=20)
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..2648064.90 rows=4 width=20)
+   ->  Hash Join  (cost=0.00..2648064.90 rows=2 width=20)
          Hash Cond: dedup_test3.b = subselect_gp.dedup_test1.b
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324032.71 rows=2 width=20)
                Hash Key: dedup_test3.b
@@ -1874,8 +1827,8 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b 
                                  ->  Dynamic Table Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
                                        Filter: c = 7
                      ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
-         ->  Hash  (cost=1324032.22..1324032.22 rows=2 width=4)
-               ->  Nested Loop Semi Join  (cost=0.00..1324032.22 rows=2 width=4)
+         ->  Hash  (cost=1324032.20..1324032.20 rows=2 width=4)
+               ->  Nested Loop Semi Join  (cost=0.00..1324032.20 rows=2 width=4)
                      Join Filter: true
                      ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
                            Group Key: subselect_gp.dedup_test1.b
@@ -1883,19 +1836,15 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b 
                                  Sort Key: subselect_gp.dedup_test1.b
                                  ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                        Hash Key: subselect_gp.dedup_test1.b
-                                       ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
-                                             Group Key: subselect_gp.dedup_test1.b
-                                             ->  Sort  (cost=0.00..431.00 rows=2 width=4)
-                                                   Sort Key: subselect_gp.dedup_test1.b
-                                                   ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=4)
+                                       ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=4)
                      ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
                            ->  Broadcast Motion 1:3  (slice4)  (cost=0.00..431.00 rows=3 width=1)
                                  ->  Limit  (cost=0.00..431.00 rows=1 width=1)
                                        ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                              ->  Limit  (cost=0.00..431.00 rows=1 width=1)
                                                    ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=1)
- Optimizer: PQO version 2.60.0
-(35 rows)
+ Optimizer: PQO version 2.72.0
+(31 rows)
 
 -- start_ignore
 DROP TABLE IF EXISTS dedup_test1;

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -493,28 +493,24 @@ explain (costs off)
   UNION
   SELECT * FROM t2) t
  WHERE ab = 'ab';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  GroupAggregate
          Group Key: (t1.a || t1.b)
          ->  Sort
                Sort Key: (t1.a || t1.b)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: (t1.a || t1.b)
-                     ->  GroupAggregate
-                           Group Key: (t1.a || t1.b)
-                           ->  Sort
-                                 Sort Key: (t1.a || t1.b)
-                                 ->  Append
-                                       ->  Result
-                                             Filter: (t1.a || t1.b) = 'ab'::text
-                                             ->  Result
-                                                   ->  Table Scan on t1
-                                       ->  Index Scan using t2_pkey on t2
-                                             Index Cond: ab = 'ab'::text
- Optimizer: PQO version 2.64.0
-(19 rows)
+               ->  Append
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: (t1.a || t1.b)
+                           ->  Result
+                                 Filter: (t1.a || t1.b) = 'ab'::text
+                                 ->  Result
+                                       ->  Table Scan on t1
+                     ->  Index Scan using t2_pkey on t2
+                           Index Cond: ab = 'ab'::text
+ Optimizer: PQO version 2.72.0
+(15 rows)
 
 reset enable_seqscan;
 reset enable_indexscan;

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -93,8 +93,8 @@ EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
                 (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
     ) t1
 WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
-                                                                                                       QUERY PLAN                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update
    ->  Result
          ->  Explicit Redistribute Motion 3:3  (slice8; segments: 3)
@@ -124,17 +124,17 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                                                                                    Assert Cond: (row_number() OVER (?)) = 1
                                                                                                    ->  WindowAgg
                                                                                                          ->  Hash Join
-                                                                                                               Hash Cond: public.keo4.keo_para_budget_date::text = (min((min(public.keo4.keo_para_budget_date::text))))
+                                                                                                               Hash Cond: public.keo4.keo_para_budget_date::text = (min(public.keo4.keo_para_budget_date::text))
                                                                                                                ->  Gather Motion 3:1  (slice3; segments: 3)
                                                                                                                      ->  Table Scan on keo4
                                                                                                                ->  Hash
                                                                                                                      ->  Aggregate
                                                                                                                            ->  Gather Motion 3:1  (slice4; segments: 3)
-                                                                                                                                       ->  Table Scan on keo4
+                                                                                                                                 ->  Table Scan on keo4
                                                          ->  Hash
                                                                ->  Broadcast Motion 3:3  (slice6; segments: 3)
                                                                      ->  Table Scan on keo2
- Optimizer: PQO version 2.55.13
+ Optimizer: PQO version 2.74.0
 (40 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
@@ -173,7 +173,7 @@ EXPLAIN (COSTS OFF) DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS
                                              ->  Gather Motion 3:1  (slice1; segments: 3)
                                                    ->  Table Scan on keo5
                                                          Filter: x < 2
- Optimizer status: PQO version 2.42.3
+ Optimizer: PQO version 2.74.0
 (16 rows)
 
 DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS (SELECT x FROM keo5 WHERE x < 2));

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -130,13 +130,12 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                                                                                                ->  Hash
                                                                                                                      ->  Aggregate
                                                                                                                            ->  Gather Motion 3:1  (slice4; segments: 3)
-                                                                                                                                 ->  Aggregate
                                                                                                                                        ->  Table Scan on keo4
                                                          ->  Hash
                                                                ->  Broadcast Motion 3:3  (slice6; segments: 3)
                                                                      ->  Table Scan on keo2
  Optimizer: PQO version 2.55.13
-(41 rows)
+(40 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b 

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -1,16 +1,12 @@
 
--- ----------------------------------------------------------------------
 -- Test: setup.sql
--- ----------------------------------------------------------------------
 
 -- start_ignore
 create schema qp_correlated_query;
 set search_path to qp_correlated_query;
 -- end_ignore
 
--- ----------------------------------------------------------------------
 -- Test: csq_heap_in.sql (Correlated Subquery: CSQ using IN clause (Heap))
--- ----------------------------------------------------------------------
 
 -- start_ignore
 create table qp_csq_t1(a int, b int) distributed by (a);
@@ -91,9 +87,7 @@ insert into E values(78,62);
 analyze E;
 -- end_ignore
 
--- -- -- --
 -- Basic queries with IN clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a in (select x);
 select A.i from A where A.i in (select B.i from B where A.i = B.i) order by A.i;
 select * from B where exists (select * from C,A where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i != 10)) order by 1, 2;
@@ -113,9 +107,7 @@ explain (costs off)
 select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
 select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
 
--- -- -- --
 -- Basic queries with NOT IN clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a not in (select x) order by a,x;
 select A.i from A where A.i not in (select B.i from B where A.i = B.i) order by A.i;
 select * from A where exists (select * from B,C where C.j = A.j and B.i not in (select sum(C.i) from C where C.i = B.i and C.i != 10)) order by 1,2;
@@ -139,14 +131,10 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
 
 
 
--- ----------------------------------------------------------------------
 -- Test: csq_heap_any.sql - Correlated Subquery: CSQ using ANY clause (Heap)
--- ----------------------------------------------------------------------
 
 
--- -- -- --
 -- Basic queries with ANY clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x);
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x) order by a, x;
 select A.i from A where A.i = any (select B.i from B where A.i = B.i) order by A.i;
@@ -166,14 +154,10 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C whe
 select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using ALL clause (Heap)
--- ----------------------------------------------------------------------
 
 
--- -- -- --
 -- Basic queries with ALL clause
--- -- -- --
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = all (select x) order by a;
 select A.i from A where A.i = all (select B.i from B where A.i = B.i) order by A.i;
 
@@ -189,14 +173,10 @@ explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C whe
 select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using EXISTS clause (Heap)
--- ----------------------------------------------------------------------
 
 
--- -- -- -- 
 -- Basic queries with EXISTS clause
--- -- -- --
 select b from qp_csq_t1 where exists(select * from qp_csq_t2 where y=a);
 select b from qp_csq_t1 where exists(select * from qp_csq_t2 where y=a) order by b;
 select A.i from A where exists(select B.i from B where A.i = B.i) order by A.i;
@@ -225,9 +205,7 @@ select * from A where exists (select * from C where C.i = A.i and exists (select
 select * from A where exists (select * from C where C.i = A.i and not exists (select * from B where C.j = B.j and B.j < 10)) order by 1,2;
 
 select * from A,B,C where C.i = A.i and exists (select C.j where C.j = B.j and A.j < 10);
--- -- -- --
 -- Basic queries with NOT EXISTS clause
--- -- -- --
 select b from qp_csq_t1 where not exists(select * from qp_csq_t2 where y=a);
 select b from qp_csq_t1 where not exists(select * from qp_csq_t2 where y=a) order by b;
 select A.i from A where not exists(select B.i from B where A.i = B.i) order by A.i;
@@ -263,9 +241,7 @@ explain select * from A where not exists (select sum(c.i) from C where C.i = A.i
 select * from A where not exists (select sum(c.i) from C where C.i = A.i group by C.i having c.i > 3);
 
 
--- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
--- ----------------------------------------------------------------------
 
 -- start_ignore
 drop table if exists qp_csq_t4;
@@ -279,9 +255,7 @@ analyze qp_csq_t4;
 
 -- end_ignore
 
--- -- -- --
 -- Basic CSQ with UPDATE statements
--- -- -- --
 select * from qp_csq_t4 order by a;
 update qp_csq_t4 set a = (select y from qp_csq_t2 where x=a) where b < 8;
 select * from qp_csq_t4 order by a;
@@ -299,9 +273,7 @@ select * from D;
 update D set i = 22222 from C where C.i = D.i and not exists (select C.j from C,B where C.j = B.j and D.j < 10);
 select * from D;
 
--- -- -- --
 -- Basic CSQ with DELETE statements
--- -- -- --
 select * from qp_csq_t4 order by a;
 delete from qp_csq_t4 where a <= (select min(y) from qp_csq_t2 where x=a);
 select * from qp_csq_t4 order by a;
@@ -319,14 +291,10 @@ select * from D order by D.i;
 
 
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using WHERE clause (Heap)
--- ----------------------------------------------------------------------
 
 
--- -- -- --
 -- Basic queries with WHERE clause
--- -- -- --
 select a, (select y from qp_csq_t2 where x=a) from qp_csq_t1 where b < 8 order by a;
 select a, x from qp_csq_t2, qp_csq_t1 where qp_csq_t1.a = (select x) order by a;
 select a from qp_csq_t1 where (select (y*2)>b from qp_csq_t2 where a=x) order by a;
@@ -335,21 +303,15 @@ SELECT a, (SELECT d FROM qp_csq_t3 WHERE a=c) FROM qp_csq_t1 GROUP BY a order by
 -- Planner should fail due to skip-level correlation not supported. ORCA should pass
 SELECT a, (SELECT (SELECT d FROM qp_csq_t3 WHERE a=c)) FROM qp_csq_t1 GROUP BY a order by a;
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ in select list (Heap) 
--- ----------------------------------------------------------------------
 
 
--- -- -- --
 -- Basic queries in SELECT list
--- -- -- --
 select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
 select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x)) as avg_x from qp_csq_t1 order by 1;
 
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)
--- ----------------------------------------------------------------------
 
 select A.i, B.i from A, B where (A.i,A.j) = (select min(B.i),min(B.j) from B where B.i = A.i) order by A.i, B.i;
 select A.i, B.i from A, B where (A.i,A.j) = all(select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
@@ -364,13 +326,9 @@ select * from A,B,C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < 
 
 select A.i as A_i, B.i as B_i,C.i as C_i from A, B, C where (A.i,B.i) = (select min(A.i), min(B.i) from A,B where A.i = C.i and B.i = C.i) order by A_i, B_i, C_i;
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using HAVING clause (Heap) 
--- ----------------------------------------------------------------------
 
--- -- -- --
 -- Basic queries with HAVING clause
--- -- -- -- 
 select A.i from A group by A.i having min(A.i) not in (select B.i from B where A.i = B.i) order by A.i;
 select A.i, B.i, C.j from A, B, C group by A.j,A.i,B.i,C.j having max(A.j) = any(select max(C.j) from C where C.j = A.j) order by A.i, B.i, C.j limit 10; 
 select A.i, B.i, C.j from A, B, C where exists (select C.j from C group by C.j having max(C.j) = all (select min(B.j) from B)) order by A.i, B.i, C.j limit 10;
@@ -390,9 +348,7 @@ SELECT name, department, salary FROM csq_emp ea group by name, department,salary
     (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department);
 
 
--- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multi-row subqueries (Heap)
--- ----------------------------------------------------------------------
 
 -- start_ignore
 drop table if exists Employee;
@@ -647,9 +603,7 @@ SELECT id, first_name, salary from employee
 
 
 
--- ----------------------------------------------------------------------
 -- Test: Misc Queries
--- ----------------------------------------------------------------------
 
 -- start_ignore
 drop table if exists with_test1 cascade;
@@ -859,9 +813,7 @@ EXPLAIN SELECT a FROM qp_tab1 f1 LEFT JOIN qp_tab2 on a=c WHERE NOT EXISTS(SELEC
 EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
 
--- ----------------------------------------------------------------------
 -- Test: teardown.sql
--- ----------------------------------------------------------------------
 
 -- start_ignore
 drop schema qp_correlated_query cascade;

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -2,6 +2,7 @@ create schema hashagg_spill;
 set search_path to hashagg_spill;
 
 -- start_ignore
+set optimizer_force_multistage_agg = on;
 create language plpythonu;
 -- end_ignore
 


### PR DESCRIPTION
In 2015, to avoid generating plans single stage aggregations due to cardinality misestimation we force the generation of multi-stage aggregation even when such a plan is sub-optimal. Since then we have fixed several of the cardinality estimation bugs. This PR reverts the default to be based on cost rather than a hint.

In cases, when the cardinality is still wrong user will have the opportunity to force it.