### PR TITLE
Dismiss format-truncation warnings from GCC 8

### DIFF
--- a/configure
+++ b/configure
@@ -5762,6 +5762,47 @@ if test x"$pgac_cv_prog_cc_cflags__ftree_vectorize" = x"yes"; then
   CFLAGS_VECTOR="${CFLAGS_VECTOR} -ftree-vectorize"
 fi
 
+  # We want to suppress clang's unhelpful unused-command-line-argument warnings
+  # but gcc won't complain about unrecognized -Wno-foo switches, so we have to
+  # test for the positive form and if that works, add the negative form
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wunused-command-line-argument" >&5
+$as_echo_n "checking whether $CC supports -Wunused-command-line-argument... " >&6; }
+if ${pgac_cv_prog_cc_cflags__Wunused_command_line_argument+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -Wunused-command-line-argument"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__Wunused_command_line_argument=yes
+else
+  pgac_cv_prog_cc_cflags__Wunused_command_line_argument=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Wunused_command_line_argument" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__Wunused_command_line_argument" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__Wunused_command_line_argument" = x"yes"; then
+  NOT_THE_CFLAGS="${NOT_THE_CFLAGS} -Wunused-command-line-argument"
+fi
+
+  if test -n "$NOT_THE_CFLAGS"; then
+    CFLAGS="$CFLAGS -Wno-unused-command-line-argument"
+  fi
 elif test "$ICC" = yes; then
   # Intel's compiler has a bug/misoptimization in checking for
   # division by NAN (NaN == 0), -mp1 fixes it, so add it to the CFLAGS.

--- a/configure
+++ b/configure
@@ -5765,6 +5765,7 @@ fi
   # We want to suppress clang's unhelpful unused-command-line-argument warnings
   # but gcc won't complain about unrecognized -Wno-foo switches, so we have to
   # test for the positive form and if that works, add the negative form
+  NOT_THE_CFLAGS=""
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wunused-command-line-argument" >&5
 $as_echo_n "checking whether $CC supports -Wunused-command-line-argument... " >&6; }
 if ${pgac_cv_prog_cc_cflags__Wunused_command_line_argument+:} false; then :
@@ -5802,6 +5803,85 @@ fi
 
   if test -n "$NOT_THE_CFLAGS"; then
     CFLAGS="$CFLAGS -Wno-unused-command-line-argument"
+  fi
+  # Similarly disable useless truncation warnings from gcc 8+
+  NOT_THE_CFLAGS=""
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wformat-truncation" >&5
+$as_echo_n "checking whether $CC supports -Wformat-truncation... " >&6; }
+if ${pgac_cv_prog_cc_cflags__Wformat_truncation+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -Wformat-truncation"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__Wformat_truncation=yes
+else
+  pgac_cv_prog_cc_cflags__Wformat_truncation=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Wformat_truncation" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__Wformat_truncation" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__Wformat_truncation" = x"yes"; then
+  NOT_THE_CFLAGS="${NOT_THE_CFLAGS} -Wformat-truncation"
+fi
+
+  if test -n "$NOT_THE_CFLAGS"; then
+    CFLAGS="$CFLAGS -Wno-format-truncation"
+  fi
+  NOT_THE_CFLAGS=""
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wstringop-truncation" >&5
+$as_echo_n "checking whether $CC supports -Wstringop-truncation... " >&6; }
+if ${pgac_cv_prog_cc_cflags__Wstringop_truncation+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -Wstringop-truncation"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__Wstringop_truncation=yes
+else
+  pgac_cv_prog_cc_cflags__Wstringop_truncation=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Wstringop_truncation" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__Wstringop_truncation" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__Wstringop_truncation" = x"yes"; then
+  NOT_THE_CFLAGS="${NOT_THE_CFLAGS} -Wstringop-truncation"
+fi
+
+  if test -n "$NOT_THE_CFLAGS"; then
+    CFLAGS="$CFLAGS -Wno-stringop-truncation"
   fi
 elif test "$ICC" = yes; then
   # Intel's compiler has a bug/misoptimization in checking for

--- a/configure.in
+++ b/configure.in
@@ -620,6 +620,13 @@ if test "$GCC" = yes -a "$ICC" = no; then
   # Optimization flags for specific files that benefit from vectorization
   PGAC_PROG_CC_VAR_OPT(CFLAGS_VECTOR, [-funroll-loops])
   PGAC_PROG_CC_VAR_OPT(CFLAGS_VECTOR, [-ftree-vectorize])
+  # We want to suppress clang's unhelpful unused-command-line-argument warnings
+  # but gcc won't complain about unrecognized -Wno-foo switches, so we have to
+  # test for the positive form and if that works, add the negative form
+  PGAC_PROG_CC_VAR_OPT(NOT_THE_CFLAGS, [-Wunused-command-line-argument])
+  if test -n "$NOT_THE_CFLAGS"; then
+    CFLAGS="$CFLAGS -Wno-unused-command-line-argument"
+  fi
 elif test "$ICC" = yes; then
   # Intel's compiler has a bug/misoptimization in checking for
   # division by NAN (NaN == 0), -mp1 fixes it, so add it to the CFLAGS.

--- a/configure.in
+++ b/configure.in
@@ -623,9 +623,21 @@ if test "$GCC" = yes -a "$ICC" = no; then
   # We want to suppress clang's unhelpful unused-command-line-argument warnings
   # but gcc won't complain about unrecognized -Wno-foo switches, so we have to
   # test for the positive form and if that works, add the negative form
+  NOT_THE_CFLAGS=""
   PGAC_PROG_CC_VAR_OPT(NOT_THE_CFLAGS, [-Wunused-command-line-argument])
   if test -n "$NOT_THE_CFLAGS"; then
     CFLAGS="$CFLAGS -Wno-unused-command-line-argument"
+  fi
+  # Similarly disable useless truncation warnings from gcc 8+
+  NOT_THE_CFLAGS=""
+  PGAC_PROG_CC_VAR_OPT(NOT_THE_CFLAGS, [-Wformat-truncation])
+  if test -n "$NOT_THE_CFLAGS"; then
+    CFLAGS="$CFLAGS -Wno-format-truncation"
+  fi
+  NOT_THE_CFLAGS=""
+  PGAC_PROG_CC_VAR_OPT(NOT_THE_CFLAGS, [-Wstringop-truncation])
+  if test -n "$NOT_THE_CFLAGS"; then
+    CFLAGS="$CFLAGS -Wno-stringop-truncation"
   fi
 elif test "$ICC" = yes; then
   # Intel's compiler has a bug/misoptimization in checking for


### PR DESCRIPTION
This patch set cherry-picks two upstream commits:

1. postgres/postgres@e716585235b "Use -Wno-format-truncation and -Wno-stringop-truncation, if available." ,
   This dismisses GCC 8 warnings like this
   ```
   misc.c: In function ‘ECPGset_var’:
   misc.c:528:3: warning: ‘strncpy’ output truncated before terminating nul copying 5 bytes from a string of 
   the same length [-Wstringop-truncation]
      strncpy(sqlca->sqlstate, "YE001", sizeof(sqlca->sqlstate));
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   ```
   and this
   ```
   fd.c: In function ‘GetTempFilePath’:
   fd.c:1150:51: warning: ‘%s’ directive output may be truncated writing 9 bytes into a region of size between 0 and 1023 [-Wformat-truncation=]
     snprintf(tempfilepath, sizeof(tempfilepath), "%s/%s_%s",
                                                      ^~
   fd.c:1150:2: note: ‘snprintf’ output 12 or more bytes (assuming 1035) into a destination of size 1024
     snprintf(tempfilepath, sizeof(tempfilepath), "%s/%s_%s",
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        tempdirpath, PG_TEMP_FILE_PREFIX, filename);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   fd.c: In function ‘OpenTemporaryFileInTablespace’:
   fd.c:1204:52: warning: ‘%s’ directive output may be truncated writing 9 bytes into a region of size between 0 and 1023 [-Wformat-truncation=]
      snprintf(tempfilepath, sizeof(tempfilepath), "%s/%s_%s",
                                                       ^~
   fd.c:1204:3: note: ‘snprintf’ output 12 or more bytes (assuming 1035) into a destination of size 1024
      snprintf(tempfilepath, sizeof(tempfilepath), "%s/%s_%s",
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         tempdirpath, PG_TEMP_FILE_PREFIX, filename);
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   fd.c:1200:52: warning: ‘%s’ directive output may be truncated writing 9 bytes into a region of size between 0 and 1023 [-Wformat-truncation=]
      snprintf(tempfilepath, sizeof(tempfilepath), "%s/%s%s%d.%ld",
                                                       ^~

   ```
1. and 73b416b2e41 "Suppress clang's unhelpful gripes about -pthread switch being unused."
   This is a dependency of postgres/postgres@e716585235b, but also it's generally useful for detecting GCC/Clang flags in the negative form