### PR TITLE
Fts prober free current components snapshot for every loop 

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -581,15 +581,6 @@ cdbcomponent_getCdbComponents(bool DNSLookupAsError)
 	}
 	PG_CATCH();
 	{
-#ifdef FAULT_INJECTOR
-		const char *dbname = NULL;
-		if (MyProcPort)
-			dbname = MyProcPort->database_name;
-
-		FaultInjector_InjectFaultIfSet(BeforeFtsNotify, DDLNotSpecified,
-								   dbname?dbname: "", "");
-#endif
-
 		FtsNotifyProber();
 
 		PG_RE_THROW();

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -512,12 +512,6 @@ void FtsLoop()
 
 		probe_start_time = time(NULL);
 
-		if (cdbs != NULL)
-		{
-			cdbcomponent_destroyCdbComponents();
-			cdbs = NULL;
-		}
-
 		/* Need a transaction to access the catalogs */
 		StartTransactionCommand();
 
@@ -543,6 +537,7 @@ void FtsLoop()
 			elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,
 				   "skipping FTS probes due to %s",
 				   !has_mirrors ? "no mirrors" : "fts_probe fault");
+
 		}
 		else
 		{
@@ -563,12 +558,15 @@ void FtsLoop()
 
 			/* free any pallocs we made inside probeSegments() */
 			MemoryContextReset(probeContext);
-			cdbs = NULL;
 
 			/* Bump the version if configuration was updated. */
 			if (updated_probe_state)
 				ftsProbeInfo->fts_statusVersion++;
 		}
+
+		/* free current components info and free ip addr caches */	
+		cdbcomponent_destroyCdbComponents();
+
 		/* Notify any waiting backends about probe cycle completion. */
 		ftsProbeInfo->probeTick++;
 

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -247,8 +247,6 @@ FI_IDENT(CreateResourceGroupFail, "create_resource_group_fail")
 FI_IDENT(AutoVacWorkerBeforeDoAutovacuum, "auto_vac_worker_before_do_autovacuum")
 /* inject fault when search DNS cache */
 FI_IDENT(GetDnsCachedAddress, "get_dns_cached_address")
-/* inject fault before notify fts probe */
-FI_IDENT(BeforeFtsNotify, "before_fts_notify")
 /* inject fault before aquiring lock during AlterTableCreateAoBlkdirTable */
 FI_IDENT(BeforeAcquireLockDuringCreateAoBlkdirTable, "before_acquire_lock_during_create_ao_blkdir_table")
 /* inject fault during gang creation, before check for interrupts */

--- a/src/test/isolation2/expected/fts_dns_error.out
+++ b/src/test/isolation2/expected/fts_dns_error.out
@@ -39,8 +39,15 @@ CREATE
 -- end_ignore
 (exited with code 0)
 
--- skip FTS probes firstly
-select gp_inject_fault_infinite('fts_probe', 'skip', 1);
+-- no down segment in the beginning
+select count(*) from gp_segment_configuration where status = 'd';
+count
+-----
+0    
+(1 row)
+
+-- trigger a DNS error
+select gp_inject_fault_infinite('get_dns_cached_address', 'skip', 1);
 gp_inject_fault_infinite
 ------------------------
 t                       
@@ -50,84 +57,22 @@ gp_request_fts_probe_scan
 -------------------------
 t                        
 (1 row)
-select gp_wait_until_triggered_fault('fts_probe', 1, 1);
+select gp_wait_until_triggered_fault('get_dns_cached_address', 1, 1);
 gp_wait_until_triggered_fault
 -----------------------------
 t                            
 (1 row)
-
--- no down segment in the beginning
-select count(*) from gp_segment_configuration where status = 'd';
-count
------
-0    
-(1 row)
-
--- inject dns error
-select gp_inject_fault_infinite('get_dns_cached_address', 'skip', 1);
+select gp_inject_fault_infinite('get_dns_cached_address', 'reset', 1);
 gp_inject_fault_infinite
 ------------------------
 t                       
 (1 row)
--- specify database name, so gdd backend will not be affected
-SELECT gp_inject_fault('before_fts_notify', 'suspend', '', 'isolation2test', '', 1, -1, 1, 1);
-gp_inject_fault
----------------
-t              
-(1 row)
-
-
--- trigger a DNS error in segment 0 in session 0,
--- Before error out,QD will notify the FTS to do
--- a probe, fts probe is currently skipped, so this
--- query will get stuck
-0&: create table fts_dns_error_test (c1 int, c2 int);  <waiting ...>
-
-select gp_wait_until_triggered_fault('before_fts_notify', 1, 1);
-gp_wait_until_triggered_fault
------------------------------
-t                            
-(1 row)
-
--- enable fts probe
-select gp_inject_fault_infinite('fts_probe', 'reset', 1);
-gp_inject_fault_infinite
-------------------------
-t                       
-(1 row)
-
--- resume fts notify for session 0 to notify fts to probe
-select gp_inject_fault_infinite('before_fts_notify', 'resume', 1);
-gp_inject_fault_infinite
-------------------------
-t                       
-(1 row)
-select gp_inject_fault_infinite('before_fts_notify', 'reset', 1);
-gp_inject_fault_infinite
-------------------------
-t                       
-(1 row)
-
--- wait until fts done the probe and this query will fail
-0<:  <... completed>
-ERROR:  cannot resolve network address for dbid=2
 
 -- verify a fts failover happens
 select count(*) from gp_segment_configuration where status = 'd';
 count
 -----
 1    
-(1 row)
-
--- fts failover happens, so the following query will success.
-0: create table fts_dns_error_test (c1 int, c2 int);
-CREATE
-
--- reset dns fault so segment can be recovered
-select gp_inject_fault_infinite('get_dns_cached_address', 'reset', 1);
-gp_inject_fault_infinite
-------------------------
-t                       
 (1 row)
 
 -- fully recover the failed primary as new mirror


### PR DESCRIPTION

Fts prober is supposed to free current components snapshot and create
a brand new snapshot of current components in the cluster for every
loop to make sure fts prober not misled by outdated components info
and outdated  <hostname, ip> caches.

This commit also adds cases based on fts_dns_error to verify components
snapshot is actually freed.

refer to https://github.com/greenplum-db/gpdb/pull/5424