### PR TITLE
gdd: disable flaky test case non-lock-107.

### DIFF
--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,7 +1,9 @@
 # Tests on global deadlock detector
 test: select_for_update
 test: gdd/prepare
-test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/non-lock-105 gdd/non-lock-107
+test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/non-lock-105
+# until we can improve below flaky case please keep it disabled
+ignore: gdd/non-lock-107
 # keep this in a separate group
 test: gdd/avoid-qd-deadlock
 test: gdd/prepare-for-local


### PR DESCRIPTION
This case has been flaky since it was added, disable it to keep the
pipelines green.  We'll keep working on it and reenable it once we find
out a way to improve it.