### PR TITLE
Remove some leftover initGpmonPkt* functions.

### DIFF
--- a/src/backend/executor/nodeAssertOp.c
+++ b/src/backend/executor/nodeAssertOp.c
@@ -164,8 +164,6 @@ ExecInitAssertOp(AssertOp *node, EState *estate, int eflags)
 	        assertOpState->ps.cdbexplainfun = ExecAssertOpExplainEnd;
 	}
 
-	initGpmonPktForAssertOp((Plan *)node, &assertOpState->ps.gpmon_pkt, estate);
-
 	return assertOpState;
 }
 
@@ -190,13 +188,3 @@ ExecEndAssertOp(AssertOpState *node)
 	ExecEndNode(outerPlanState(node));
 	EndPlanStateGpmonPkt(&node->ps);
 }
-
-/* Tracing execution for GP Monitor. */
-void
-initGpmonPktForAssertOp(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, AssertOp));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
-}
-

--- a/src/backend/executor/nodePartitionSelector.c
+++ b/src/backend/executor/nodePartitionSelector.c
@@ -32,14 +32,6 @@ static void LogPartitionSelection(EState *estate, int32 selectorId);
 static void
 partition_propagation(EState *estate, List *partOids, List *scanIds, int32 selectorId);
 
-void
-initGpmonPktForPartitionSelector(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, PartitionSelector));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
-}
-
 /* ----------------------------------------------------------------
  *		ExecInitPartitionSelector
  *
@@ -87,8 +79,6 @@ ExecInitPartitionSelector(PartitionSelector *node, EState *estate, int eflags)
 													   psstate->partTabSlot,
 													   ExecGetResultType(&psstate->ps));
 	}
-
-	initGpmonPktForPartitionSelector((Plan *)node, &psstate->ps.gpmon_pkt, estate);
 
 	return psstate;
 }

--- a/src/backend/executor/nodeRowTrigger.c
+++ b/src/backend/executor/nodeRowTrigger.c
@@ -585,8 +585,6 @@ ExecInitRowTrigger(RowTrigger *node, EState *estate, int eflags)
 	        rowTriggerState->ps.cdbexplainfun = ExecRowTriggerExplainEnd;
 	}
 
-	initGpmonPktForRowTrigger((Plan *)node, &rowTriggerState->ps.gpmon_pkt, estate);
-
 	return rowTriggerState;
 }
 
@@ -597,13 +595,4 @@ ExecEndRowTrigger(RowTriggerState *node)
 	ExecFreeExprContext(&node->ps);
 	ExecEndNode(outerPlanState(node));
 	EndPlanStateGpmonPkt(&node->ps);
-}
-
-/* Tracing execution for GP Monitor. */
-void
-initGpmonPktForRowTrigger(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, RowTrigger));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }

--- a/src/backend/executor/nodeSplitUpdate.c
+++ b/src/backend/executor/nodeSplitUpdate.c
@@ -192,8 +192,6 @@ ExecInitSplitUpdate(SplitUpdate *node, EState *estate, int eflags)
 			splitupdatestate->ps.cdbexplainfun = ExecSplitUpdateExplainEnd;
 	}
 
-	initGpmonPktForSplitUpdate((Plan *)node, &splitupdatestate->ps.gpmon_pkt, estate);
-
 	return splitupdatestate;
 }
 
@@ -207,14 +205,5 @@ ExecEndSplitUpdate(SplitUpdateState *node)
 	ExecClearTuple(node->deleteTuple);
 	ExecEndNode(outerPlanState(node));
 	EndPlanStateGpmonPkt(&node->ps);
-}
-
-/* Tracing execution for GP Monitor. */
-void
-initGpmonPktForSplitUpdate(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate)
-{
-	Assert(planNode != NULL && gpmon_pkt != NULL && IsA(planNode, SplitUpdate));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 

--- a/src/backend/executor/nodeTableFunction.c
+++ b/src/backend/executor/nodeTableFunction.c
@@ -49,9 +49,6 @@
 
 static void setupFunctionArguments(TableFunctionState *node);
 static TupleTableSlot *TableFunctionNext(TableFunctionState *node);
-static void initGpmonPktForTableFunction(Plan *planNode,
-										 gpmon_packet_t *gpmon_pkt, 
-										 EState *estate);
 
 /* Private structure forward declared in tablefuncapi.h */
 typedef struct AnyTableData
@@ -453,9 +450,6 @@ ExecInitTableFunction(TableFunctionScan *node, EState *estate, int eflags)
 	/* Initialize result tuple type and projection info */
 	ExecAssignResultTypeFromTL(&scanstate->ss.ps);
 	ExecAssignScanProjectionInfo(&scanstate->ss);
-
-	initGpmonPktForTableFunction((Plan *)node, 
-								 &scanstate->ss.ps.gpmon_pkt, estate);
 	
 	return scanstate;
 }
@@ -480,19 +474,6 @@ ExecReScanTableFunction(TableFunctionState *node)
 {
 	/* TableFunction Planner marks TableFunction nodes as not rescannable */
 	elog(ERROR, "invalid rescan of TableFunctionScan");
-}
-
-
-void
-initGpmonPktForTableFunction(Plan *planNode, 
-							 gpmon_packet_t *gpmon_pkt, 
-							 EState *estate)
-{
-	Assert(planNode != NULL);
-	Assert(gpmon_pkt != NULL);
-	Assert(IsA(planNode, TableFunctionScan));
-
-	InitPlanNodeGpmonPkt(planNode, gpmon_pkt, estate);
 }
 
 

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -440,7 +440,6 @@ extern void BitmapAOScanReScan(ScanState *scanState);
 /*
  * prototypes from functions in execBitmapTableScan.c
  */
-extern void initGpmonPktForBitmapTableScan(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
 extern TupleTableSlot *BitmapTableScanNext(BitmapTableScanState *scanState);
 extern void BitmapTableScanBegin(BitmapTableScanState *scanState, Plan *plan, EState *estate, int eflags);
 extern void BitmapTableScanEnd(BitmapTableScanState *scanState);

--- a/src/include/executor/nodeAssertOp.h
+++ b/src/include/executor/nodeAssertOp.h
@@ -21,7 +21,6 @@ extern TupleTableSlot* ExecAssertOp(AssertOpState *node);
 extern AssertOpState* ExecInitAssertOp(AssertOp *node, EState *estate, int eflags);
 extern void ExecEndAssertOp(AssertOpState *node);
 extern void ExecReScanAssertOp(AssertOpState *node);
-extern void initGpmonPktForAssertOp(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
 
 #endif   /* NODEASSERTOP_H */
 

--- a/src/include/executor/nodeDML.h
+++ b/src/include/executor/nodeDML.h
@@ -21,7 +21,5 @@ extern TupleTableSlot* ExecDML(DMLState *node);
 extern DMLState* ExecInitDML(DML *node, EState *estate, int eflags);
 extern void ExecEndDML(DMLState *node);
 
-extern void initGpmonPktForDML(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-
 #endif   /* NODEDML_H */
 

--- a/src/include/executor/nodePartitionSelector.h
+++ b/src/include/executor/nodePartitionSelector.h
@@ -21,7 +21,6 @@ extern TupleTableSlot* ExecPartitionSelector(PartitionSelectorState *node);
 extern PartitionSelectorState* ExecInitPartitionSelector(PartitionSelector *node, EState *estate, int eflags);
 extern void ExecEndPartitionSelector(PartitionSelectorState *node);
 extern void ExecReScanPartitionSelector(PartitionSelectorState *node);
-extern void initGpmonPktForPartitionSelector(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
 
 #endif   /* NODEPARTITIONSELECTOR_H */
 

--- a/src/include/executor/nodeRowTrigger.h
+++ b/src/include/executor/nodeRowTrigger.h
@@ -21,8 +21,6 @@ extern TupleTableSlot* ExecRowTrigger(RowTriggerState *node);
 extern RowTriggerState* ExecInitRowTrigger(RowTrigger *node, EState *estate, int eflags);
 extern void ExecEndRowTrigger(RowTriggerState *node);
 
-extern void initGpmonPktForRowTrigger(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-
 #endif   /* NODEROWTRIGGER_H */
 
 

--- a/src/include/executor/nodeSplitUpdate.h
+++ b/src/include/executor/nodeSplitUpdate.h
@@ -21,7 +21,5 @@ extern TupleTableSlot* ExecSplitUpdate(SplitUpdateState *node);
 extern SplitUpdateState* ExecInitSplitUpdate(SplitUpdate *node, EState *estate, int eflags);
 extern void ExecEndSplitUpdate(SplitUpdateState *node);
 
-extern void initGpmonPktForSplitUpdate(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);
-
 #endif   /* NODESplitUpdate_H */
 


### PR DESCRIPTION
Commit c169001054 removed most of these, but missed these few in GPDB-
specific executor node. These are no longer needed, just like all the ones
that were removed in commit c169001054.