### PR TITLE
Change pretty-printing of expressions in EXPLAIN to match upstream.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2242,7 +2242,7 @@ show_expression(Node *node, const char *qlabel,
 											es->rtable_names);
 
 	/* Deparse the expression */
-	exprstr = deparse_expr_sweet(node, context, useprefix, false);
+	exprstr = deparse_expression(node, context, useprefix, false);
 
 	/* And add to es->str */
 	ExplainPropertyText(qlabel, exprstr, es);
@@ -2461,7 +2461,7 @@ show_sort_group_keys(PlanState *planstate, const char *qlabel,
 		if (!target)
 			elog(ERROR, "no tlist entry for key %d", keyresno);
 		/* Deparse the expression, showing any top-level cast */
-		exprstr = deparse_expr_sweet((Node *) target->expr, context,
+		exprstr = deparse_expression((Node *) target->expr, context,
 									 useprefix, true);
 		result = lappend(result, exprstr);
 	}

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -2355,7 +2355,7 @@ show_motion_keys(PlanState *planstate, List *hashExpr, int nkeys, AttrNumber *ke
 
 	    /* Deparse the expression, showing any top-level cast */
 	    if (target)
-	        exprstr = deparse_expr_sweet((Node *) target->expr, context,
+	        exprstr = deparse_expression((Node *) target->expr, context,
 								         useprefix, true);
         else
         {
@@ -2374,7 +2374,7 @@ show_motion_keys(PlanState *planstate, List *hashExpr, int nkeys, AttrNumber *ke
     if (hashExpr)
     {
 	    /* Deparse the expression */
-	    exprstr = deparse_expr_sweet((Node *)hashExpr, context, useprefix, true);
+	    exprstr = deparse_expression((Node *)hashExpr, context, useprefix, true);
 		ExplainPropertyText("Hash Key", exprstr, es);
     }
 }
@@ -2401,7 +2401,7 @@ explain_partition_selector(PartitionSelector *ps, PlanState *parentstate,
 		useprefix = list_length(es->rtable) > 1;
 
 		/* Deparse the expression */
-		exprstr = deparse_expr_sweet(ps->printablePredicate, context, useprefix, false);
+		exprstr = deparse_expression(ps->printablePredicate, context, useprefix, false);
 
 		ExplainPropertyText("Filter", exprstr, es);
 	}
@@ -2470,7 +2470,7 @@ show_grouping_keys(PlanState *planstate, int nkeys, AttrNumber *subplanColIdx,
 		}
 		else
 			/* Deparse the expression, showing any top-level cast */
-			exprstr = deparse_expr_sweet((Node *) target->expr, context,
+			exprstr = deparse_expression((Node *) target->expr, context,
 										 useprefix, true);
 
 		result = lappend(result, exprstr);

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -2342,19 +2342,6 @@ deparse_expression(Node *expr, List *dpcontext,
 }
 
 /* ----------
- * deparse_expr_sweet			- CDB: expression deparser for EXPLAIN
- *
- * calls deparse_expression_pretty with minimal parentheses but no indenting.
- */
-char *
-deparse_expr_sweet(Node *expr, List *dpcontext,
-				   bool forceprefix, bool showimplicit)
-{
-	return deparse_expression_pretty(expr, dpcontext, forceprefix,
-									 showimplicit, PRETTYFLAG_PAREN, 0);
-}
-
-/* ----------
  * deparse_expression_pretty	- General utility for deparsing expressions
  *
  * expr is the node tree to be deparsed.  It must be a transformed expression

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -710,8 +710,6 @@ extern Datum pg_get_function_identity_arguments(PG_FUNCTION_ARGS);
 extern Datum pg_get_function_result(PG_FUNCTION_ARGS);
 extern char *deparse_expression(Node *expr, List *dpcontext,
 				   bool forceprefix, bool showimplicit);
-extern char *deparse_expr_sweet(Node *expr, List *dpcontext,
-				   bool forceprefix, bool showimplicit);                /*CDB*/
 extern List *deparse_context_for(const char *aliasname, Oid relid);
 extern List *deparse_context_for_planstate(Node *planstate, List *ancestors,
 							  List *rtable, List *rtable_names);

--- a/src/test/isolation/expected/drop-index-concurrently-1.out
+++ b/src/test/isolation/expected/drop-index-concurrently-1.out
@@ -13,7 +13,7 @@ Gather Motion 3:1  (slice1; segments: 3)
   ->  Sort     
         Sort Key: id
         ->  Index Scan using test_dc_data on test_dc
-              Index Cond: data = 34
+              Index Cond: (data = 34)
 Optimizer: legacy query optimizer
 step explains: EXPLAIN (COSTS OFF) EXECUTE getrow_seq;
 QUERY PLAN     
@@ -23,7 +23,7 @@ Gather Motion 3:1  (slice1; segments: 3)
   ->  Sort     
         Sort Key: id, data
         ->  Seq Scan on test_dc
-              Filter: data::text = '34'::text
+              Filter: ((data)::text = '34'::text)
 Optimizer: legacy query optimizer
 step select2: SELECT * FROM test_dc WHERE data=34 ORDER BY id,data;
 id             data           

--- a/src/test/isolation/expected/drop-index-concurrently-1_optimizer.out
+++ b/src/test/isolation/expected/drop-index-concurrently-1_optimizer.out
@@ -13,7 +13,7 @@ Gather Motion 3:1  (slice1; segments: 3)
   ->  Sort     
         Sort Key: id, data
         ->  Index Scan using test_dc_data on test_dc
-              Index Cond: data = 34
+              Index Cond: (data = 34)
 Optimizer: PQO version 2.74.0
 step explains: EXPLAIN (COSTS OFF) EXECUTE getrow_seq;
 QUERY PLAN     
@@ -23,7 +23,7 @@ Gather Motion 3:1  (slice1; segments: 3)
   ->  Sort     
         Sort Key: id, data
         ->  Table Scan on test_dc
-              Filter: data::text = '34'::text
+              Filter: ((data)::text = '34'::text)
 Optimizer: PQO version 2.74.0
 step select2: SELECT * FROM test_dc WHERE data=34 ORDER BY id,data;
 id             data           

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -518,7 +518,7 @@ explain (costs off)
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique1
                  ->  Index Only Scan using tenk1_unique1 on tenk1
-                       Index Cond: unique1 IS NOT NULL
+                       Index Cond: (unique1 IS NOT NULL)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -538,7 +538,7 @@ explain (costs off)
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique1
                  ->  Index Only Scan Backward using tenk1_unique1 on tenk1
-                       Index Cond: unique1 IS NOT NULL
+                       Index Cond: (unique1 IS NOT NULL)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -550,15 +550,15 @@ select max(unique1) from tenk1;
 
 explain (costs off)
   select max(unique1) from tenk1 where unique1 < 42;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice2)
      ->  Limit
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique1
                  ->  Index Only Scan Backward using tenk1_unique1 on tenk1
-                       Index Cond: unique1 IS NOT NULL AND unique1 < 42
+                       Index Cond: ((unique1 IS NOT NULL) AND (unique1 < 42))
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -570,15 +570,15 @@ select max(unique1) from tenk1 where unique1 < 42;
 
 explain (costs off)
   select max(unique1) from tenk1 where unique1 > 42;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice2)
      ->  Limit
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique1
                  ->  Index Only Scan Backward using tenk1_unique1 on tenk1
-                       Index Cond: unique1 IS NOT NULL AND unique1 > 42
+                       Index Cond: ((unique1 IS NOT NULL) AND (unique1 > 42))
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -592,15 +592,15 @@ set enable_seqscan=off;
 set enable_bitmapscan=off;
 explain (costs off)
   select max(unique1) from tenk1 where unique1 > 42000;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice2)
      ->  Limit
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique1
                  ->  Index Only Scan Backward using tenk1_unique1 on tenk1
-                       Index Cond: unique1 IS NOT NULL AND unique1 > 42000
+                       Index Cond: ((unique1 IS NOT NULL) AND (unique1 > 42000))
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -622,7 +622,7 @@ explain (costs off)
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.tenthous
                  ->  Index Only Scan Backward using tenk1_thous_tenthous on tenk1
-                       Index Cond: thousand = 33 AND tenthous IS NOT NULL
+                       Index Cond: ((thousand = 33) AND (tenthous IS NOT NULL))
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -634,15 +634,15 @@ select max(tenthous) from tenk1 where thousand = 33;
 
 explain (costs off)
   select min(tenthous) from tenk1 where thousand = 33;
-                                QUERY PLAN                                
---------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice2)
      ->  Limit
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.tenthous
                  ->  Index Only Scan using tenk1_thous_tenthous on tenk1
-                       Index Cond: thousand = 33 AND tenthous IS NOT NULL
+                       Index Cond: ((thousand = 33) AND (tenthous IS NOT NULL))
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -665,7 +665,7 @@ explain (costs off)
          SubPlan 1  (slice2; segments: 3)
            ->  Aggregate
                  ->  Result
-                       Filter: tenk1.unique1 > int4_tbl.f1
+                       Filter: (tenk1.unique1 > int4_tbl.f1)
                        ->  Materialize
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                    ->  Seq Scan on tenk1
@@ -695,7 +695,7 @@ explain (costs off)
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique2
                  ->  Index Only Scan Backward using tenk1_unique2 on tenk1
-                       Index Cond: unique2 IS NOT NULL
+                       Index Cond: (unique2 IS NOT NULL)
    ->  Result
  Optimizer: legacy query optimizer
 (10 rows)
@@ -717,7 +717,7 @@ explain (costs off)
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique2
                  ->  Index Only Scan Backward using tenk1_unique2 on tenk1
-                       Index Cond: unique2 IS NOT NULL
+                       Index Cond: (unique2 IS NOT NULL)
    ->  Result
  Optimizer: legacy query optimizer
 (10 rows)
@@ -739,7 +739,7 @@ explain (costs off)
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique2
                  ->  Index Only Scan Backward using tenk1_unique2 on tenk1
-                       Index Cond: unique2 IS NOT NULL
+                       Index Cond: (unique2 IS NOT NULL)
    ->  Result
  Optimizer: legacy query optimizer
 (10 rows)
@@ -755,13 +755,13 @@ explain (costs off)
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Sort
-   Sort Key: ($0 + 1)
+   Sort Key: (($0 + 1))
    InitPlan 1 (returns $0)  (slice2)
      ->  Limit
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique2
                  ->  Index Only Scan Backward using tenk1_unique2 on tenk1
-                       Index Cond: unique2 IS NOT NULL
+                       Index Cond: (unique2 IS NOT NULL)
    ->  Result
  Optimizer: legacy query optimizer
 (10 rows)
@@ -783,7 +783,7 @@ explain (costs off)
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  Merge Key: tenk1.unique2
                  ->  Index Only Scan Backward using tenk1_unique2 on tenk1
-                       Index Cond: unique2 IS NOT NULL
+                       Index Cond: (unique2 IS NOT NULL)
    ->  Result
  Optimizer: legacy query optimizer
 (10 rows)
@@ -822,13 +822,13 @@ explain (costs off)
                  ->  Merge Append
                        Sort Key: minmaxtest.f1
                        ->  Index Only Scan using minmaxtesti on minmaxtest
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan using minmaxtest1i on minmaxtest1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan Backward using minmaxtest2i on minmaxtest2
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan using minmaxtest3i on minmaxtest3
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
    InitPlan 2 (returns $1)  (slice4)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
@@ -836,13 +836,13 @@ explain (costs off)
                  ->  Merge Append
                        Sort Key: minmaxtest_1.f1
                        ->  Index Only Scan Backward using minmaxtesti on minmaxtest minmaxtest_1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan Backward using minmaxtest1i on minmaxtest1 minmaxtest1_1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan using minmaxtest2i on minmaxtest2 minmaxtest2_1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan Backward using minmaxtest3i on minmaxtest3 minmaxtest3_1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
  Optimizer: legacy query optimizer
 (30 rows)
 

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -563,7 +563,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using tenk1_unique1 on tenk1
-                     Index Cond: unique1 < 42
+                     Index Cond: (unique1 < 42)
  Optimizer: PQO version 2.55.21
 (6 rows)
 
@@ -581,7 +581,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using tenk1_unique1 on tenk1
-                     Index Cond: unique1 > 42
+                     Index Cond: (unique1 > 42)
  Optimizer: PQO version 2.55.21
 (6 rows)
 
@@ -601,7 +601,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using tenk1_unique1 on tenk1
-                     Index Cond: unique1 > 42000
+                     Index Cond: (unique1 > 42000)
  Optimizer: PQO version 2.55.21
 (6 rows)
 
@@ -621,7 +621,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using tenk1_thous_tenthous on tenk1
-                     Index Cond: thousand = 33
+                     Index Cond: (thousand = 33)
  Optimizer: PQO version 2.55.21
 (6 rows)
 
@@ -639,7 +639,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using tenk1_thous_tenthous on tenk1
-                     Index Cond: thousand = 33
+                     Index Cond: (thousand = 33)
  Optimizer: PQO version 2.55.21
 (6 rows)
 
@@ -663,7 +663,7 @@ explain (costs off)
    SubPlan 1  (slice0)
      ->  Aggregate
            ->  Result
-                 Filter: tenk1.unique1 > int4_tbl.f1
+                 Filter: (tenk1.unique1 > int4_tbl.f1)
                  ->  Materialize
                        ->  Gather Motion 3:1  (slice2; segments: 3)
                              ->  Table Scan on tenk1
@@ -743,7 +743,7 @@ explain (costs off)
 ------------------------------------------------------------------
  Result
    ->  Sort
-         Sort Key: ((max((max(unique2)))) + 1)
+         Sort Key: (((max((max(unique2)))) + 1))
          ->  Result
                ->  Aggregate
                      ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -813,13 +813,13 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
                  ->  Merge Append
                        Sort Key: minmaxtest.f1
                        ->  Index Only Scan using minmaxtesti on minmaxtest
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan using minmaxtest1i on minmaxtest1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan Backward using minmaxtest2i on minmaxtest2
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan using minmaxtest3i on minmaxtest3
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
    InitPlan 2 (returns $1)  (slice4)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
@@ -827,13 +827,13 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
                  ->  Merge Append
                        Sort Key: minmaxtest_1.f1
                        ->  Index Only Scan Backward using minmaxtesti on minmaxtest minmaxtest_1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan Backward using minmaxtest1i on minmaxtest1 minmaxtest1_1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan using minmaxtest2i on minmaxtest2 minmaxtest2_1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
                        ->  Index Only Scan Backward using minmaxtest3i on minmaxtest3 minmaxtest3_1
-                             Index Cond: f1 IS NOT NULL
+                             Index Cond: (f1 IS NOT NULL)
  Optimizer: legacy query optimizer
 (30 rows)
 

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -400,63 +400,63 @@ create table nv_child_2011 () inherits (nv_parent);
 alter table nv_child_2010 add check (d between '2010-01-01'::date and '2010-12-31'::date) not valid;
 alter table nv_child_2011 add check (d between '2011-01-01'::date and '2011-12-31'::date) not valid;
 explain (costs off) select * from nv_parent where d between '2011-08-01' and '2011-08-31';
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
          ->  Seq Scan on nv_parent
-               Filter: d >= '08-01-2011'::date AND d <= '08-31-2011'::date
+               Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
          ->  Seq Scan on nv_child_2010
-               Filter: d >= '08-01-2011'::date AND d <= '08-31-2011'::date
+               Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
          ->  Seq Scan on nv_child_2011
-               Filter: d >= '08-01-2011'::date AND d <= '08-31-2011'::date
+               Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
  Optimizer: legacy query optimizer
 (9 rows)
 
 create table nv_child_2009 (check (d between '2009-01-01'::date and '2009-12-31'::date)) inherits (nv_parent);
 explain (costs off) select * from nv_parent where d between '2011-08-01'::date and '2011-08-31'::date;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
          ->  Seq Scan on nv_parent
-               Filter: d >= '08-01-2011'::date AND d <= '08-31-2011'::date
+               Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
          ->  Seq Scan on nv_child_2010
-               Filter: d >= '08-01-2011'::date AND d <= '08-31-2011'::date
+               Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
          ->  Seq Scan on nv_child_2011
-               Filter: d >= '08-01-2011'::date AND d <= '08-31-2011'::date
+               Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
  Optimizer: legacy query optimizer
 (9 rows)
 
 explain (costs off) select * from nv_parent where d between '2009-08-01'::date and '2009-08-31'::date;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
          ->  Seq Scan on nv_parent
-               Filter: d >= '08-01-2009'::date AND d <= '08-31-2009'::date
+               Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
          ->  Seq Scan on nv_child_2010
-               Filter: d >= '08-01-2009'::date AND d <= '08-31-2009'::date
+               Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
          ->  Seq Scan on nv_child_2011
-               Filter: d >= '08-01-2009'::date AND d <= '08-31-2009'::date
+               Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
          ->  Seq Scan on nv_child_2009
-               Filter: d >= '08-01-2009'::date AND d <= '08-31-2009'::date
+               Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
  Optimizer: legacy query optimizer
 (11 rows)
 
 -- after validation, the constraint should be used
 alter table nv_child_2011 VALIDATE CONSTRAINT nv_child_2011_d_check;
 explain (costs off) select * from nv_parent where d between '2009-08-01'::date and '2009-08-31'::date;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
          ->  Seq Scan on nv_parent
-               Filter: d >= '08-01-2009'::date AND d <= '08-31-2009'::date
+               Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
          ->  Seq Scan on nv_child_2010
-               Filter: d >= '08-01-2009'::date AND d <= '08-31-2009'::date
+               Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
          ->  Seq Scan on nv_child_2009
-               Filter: d >= '08-01-2009'::date AND d <= '08-31-2009'::date
+               Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
  Optimizer: legacy query optimizer
 (9 rows)
 

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3071,17 +3071,17 @@ ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = r
 -----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Left Join
-         Hash Cond: member_subgroup.subgroup_name = region.county_name::text
-         Join Filter: member_group."group_id" = ANY ('{12,13,14,15}'::integer[])
+         Hash Cond: (member_subgroup.subgroup_name = (region.county_name)::text)
+         Join Filter: (member_group."group_id" = ANY ('{12,13,14,15}'::integer[]))
          ->  Redistribute Motion 3:3  (slice3; segments: 3)
                Hash Key: member_subgroup.subgroup_name
                ->  Hash Join
-                     Hash Cond: member."group_id" = member_group."group_id"
+                     Hash Cond: (member."group_id" = member_group."group_id")
                      ->  Seq Scan on member
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                  ->  Hash Join
-                                       Hash Cond: member_group."group_id" = member_subgroup."group_id"
+                                       Hash Cond: (member_group."group_id" = member_subgroup."group_id")
                                        ->  Seq Scan on member_group
                                        ->  Hash
                                              ->  Redistribute Motion 3:3  (slice1; segments: 3)

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3067,20 +3067,20 @@ INNER JOIN member_subgroup
 ON member_group.group_id = member_subgroup.group_id
 LEFT OUTER JOIN region
 ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Left Join
-         Hash Cond: member_subgroup.subgroup_name = region.county_name::text
-         Join Filter: member_group."group_id" = ANY ('{12,13,14,15}'::integer[])
+         Hash Cond: (member_subgroup.subgroup_name = (region.county_name)::text)
+         Join Filter: (member_group."group_id" = ANY ('{12,13,14,15}'::integer[]))
          ->  Redistribute Motion 3:3  (slice3; segments: 3)
                Hash Key: member_subgroup.subgroup_name
                ->  Hash Join
-                     Hash Cond: member."group_id" = member_group."group_id" AND member_subgroup."group_id" = member_group."group_id"
+                     Hash Cond: ((member."group_id" = member_group."group_id") AND (member_subgroup."group_id" = member_group."group_id"))
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: member."group_id"
                            ->  Hash Join
-                                 Hash Cond: member."group_id" = member_subgroup."group_id"
+                                 Hash Cond: (member."group_id" = member_subgroup."group_id")
                                  ->  Table Scan on member
                                  ->  Hash
                                        ->  Broadcast Motion 3:3  (slice1; segments: 3)
@@ -3089,7 +3089,7 @@ ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = r
                            ->  Table Scan on member_group
          ->  Hash
                ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                     Hash Key: region.county_name::text
+                     Hash Key: (region.county_name)::text
                      ->  Table Scan on region
  Optimizer: PQO version 2.69.0
 (23 rows)

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -375,14 +375,14 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM fast_emp4000
     WHERE home_base @ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: ((home_base[0])[0])
    ->  Sort
          Sort Key: ((home_base[0])[0])
          ->  Index Scan using grect2ind on fast_emp4000
-               Index Cond: home_base @ '(2000,1000),(200,200)'::box
+               Index Cond: (home_base @ '(2000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -397,13 +397,13 @@ SELECT * FROM fast_emp4000
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM fast_emp4000 WHERE home_base && '(1000,1000,0,0)'::box;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using grect2ind on fast_emp4000
-                     Index Cond: home_base && '(1000,1000),(0,0)'::box
+                     Index Cond: (home_base && '(1000,1000),(0,0)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -421,7 +421,7 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base IS NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using grect2ind on fast_emp4000
-                     Index Cond: home_base IS NULL
+                     Index Cond: (home_base IS NULL)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -434,14 +434,14 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base IS NULL;
 EXPLAIN (COSTS OFF)
 SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
-                          QUERY PLAN                           
----------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: ((poly_center(f1))[0])
    ->  Sort
          Sort Key: ((poly_center(f1))[0])
          ->  Index Scan using gpolygonind on polygon_tbl
-               Index Cond: f1 ~ '((1,1),(2,2),(2,1))'::polygon
+               Index Cond: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -455,14 +455,14 @@ SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
 EXPLAIN (COSTS OFF)
 SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
     ORDER BY area(f1);
-                      QUERY PLAN                       
--------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: (area(f1))
    ->  Sort
          Sort Key: (area(f1))
          ->  Index Scan using gcircleind on circle_tbl
-               Index Cond: f1 && '<(1,-2),1>'::circle
+               Index Cond: (f1 && '<(1,-2),1>'::circle)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -478,13 +478,13 @@ SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM gpolygon_tbl WHERE f1 && '(1000,1000,0,0)'::polygon;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using ggpolygonind on gpolygon_tbl
-                     Index Cond: f1 && '((1000,1000),(0,0))'::polygon
+                     Index Cond: (f1 && '((1000,1000),(0,0))'::polygon)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -496,13 +496,13 @@ SELECT count(*) FROM gpolygon_tbl WHERE f1 && '(1000,1000,0,0)'::polygon;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using ggcircleind on gcircle_tbl
-                     Index Cond: f1 && '<(500,500),500>'::circle
+                     Index Cond: (f1 && '<(500,500),500>'::circle)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -514,13 +514,13 @@ SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
-                          QUERY PLAN                          
---------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 <@ '(100,100),(0,0)'::box
+                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -532,13 +532,13 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
-                          QUERY PLAN                          
---------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: '(100,100),(0,0)'::box @> f1
+                     Index Cond: ('(100,100),(0,0)'::box @> f1)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -550,13 +550,13 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon
+                     Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -568,13 +568,13 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
-                          QUERY PLAN                          
---------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 <@ '<(50,50),50>'::circle
+                     Index Cond: (f1 <@ '<(50,50),50>'::circle)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -592,7 +592,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl p
-                     Index Cond: f1 << '(0,0)'::point
+                     Index Cond: (f1 << '(0,0)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -610,7 +610,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl p
-                     Index Cond: f1 >> '(0,0)'::point
+                     Index Cond: (f1 >> '(0,0)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -628,7 +628,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl p
-                     Index Cond: f1 <^ '(0,0)'::point
+                     Index Cond: (f1 <^ '(0,0)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -646,7 +646,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl p
-                     Index Cond: f1 >^ '(0,0)'::point
+                     Index Cond: (f1 >^ '(0,0)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -664,7 +664,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl p
-                     Index Cond: f1 ~= '(-5,-12)'::point
+                     Index Cond: (f1 ~= '(-5,-12)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -679,9 +679,9 @@ SELECT * FROM point_tbl ORDER BY f1 <-> '0,1';
                   QUERY PLAN                   
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (f1 <-> '(0,1)'::point)
+   Merge Key: ((f1 <-> '(0,1)'::point))
    ->  Index Scan using gpointind on point_tbl
-         Order By: f1 <-> '(0,1)'::point
+         Order By: (f1 <-> '(0,1)'::point)
  Optimizer: legacy query optimizer
 (5 rows)
 
@@ -703,7 +703,7 @@ SELECT * FROM point_tbl WHERE f1 IS NULL;
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using gpointind on point_tbl
-         Index Cond: f1 IS NULL
+         Index Cond: (f1 IS NULL)
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -718,10 +718,10 @@ SELECT * FROM point_tbl WHERE f1 IS NOT NULL ORDER BY f1 <-> '0,1';
                   QUERY PLAN                   
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (f1 <-> '(0,1)'::point)
+   Merge Key: ((f1 <-> '(0,1)'::point))
    ->  Index Scan using gpointind on point_tbl
-         Index Cond: f1 IS NOT NULL
-         Order By: f1 <-> '(0,1)'::point
+         Index Cond: (f1 IS NOT NULL)
+         Order By: (f1 <-> '(0,1)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -738,13 +738,13 @@ SELECT * FROM point_tbl WHERE f1 IS NOT NULL ORDER BY f1 <-> '0,1';
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
-                     QUERY PLAN                     
-----------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (f1 <-> '(0,1)'::point)
+   Merge Key: ((f1 <-> '(0,1)'::point))
    ->  Index Scan using gpointind on point_tbl
-         Index Cond: f1 <@ '(10,10),(-10,-10)'::box
-         Order By: f1 <-> '(0,1)'::point
+         Index Cond: (f1 <@ '(10,10),(-10,-10)'::box)
+         Order By: (f1 <-> '(0,1)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -765,7 +765,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p IS NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p IS NULL
+                     Index Cond: (p IS NULL)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -783,7 +783,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p IS NOT NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p IS NOT NULL
+                     Index Cond: (p IS NOT NULL)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -818,7 +818,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p <@ box '(200,200,1000,1000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p <@ '(1000,1000),(200,200)'::box
+                     Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -836,7 +836,7 @@ SELECT count(*) FROM quad_point_tbl WHERE box '(200,200,1000,1000)' @> p;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p <@ '(1000,1000),(200,200)'::box
+                     Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -854,7 +854,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p << '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p << '(5000,4000)'::point
+                     Index Cond: (p << '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -872,7 +872,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p >> '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p >> '(5000,4000)'::point
+                     Index Cond: (p >> '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -890,7 +890,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p <^ '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p <^ '(5000,4000)'::point
+                     Index Cond: (p <^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -908,7 +908,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p >^ '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p >^ '(5000,4000)'::point
+                     Index Cond: (p >^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -926,7 +926,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p ~= '(4585, 365)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p ~= '(4585,365)'::point
+                     Index Cond: (p ~= '(4585,365)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -938,13 +938,13 @@ SELECT count(*) FROM quad_point_tbl WHERE p ~= '(4585, 365)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p <@ box '(200,200,1000,1000)';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p <@ '(1000,1000),(200,200)'::box
+                     Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -956,13 +956,13 @@ SELECT count(*) FROM kd_point_tbl WHERE p <@ box '(200,200,1000,1000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE box '(200,200,1000,1000)' @> p;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p <@ '(1000,1000),(200,200)'::box
+                     Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -980,7 +980,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p << '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p << '(5000,4000)'::point
+                     Index Cond: (p << '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -998,7 +998,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p >> '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p >> '(5000,4000)'::point
+                     Index Cond: (p >> '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1016,7 +1016,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p <^ '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p <^ '(5000,4000)'::point
+                     Index Cond: (p <^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1034,7 +1034,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p >^ '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p >^ '(5000,4000)'::point
+                     Index Cond: (p >^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1052,7 +1052,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p ~= '(4585, 365)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p ~= '(4585,365)'::point
+                     Index Cond: (p ~= '(4585,365)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1070,7 +1070,7 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdef';
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'P0123456789abcdef'::text
+                     Index Cond: (t = 'P0123456789abcdef'::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1088,7 +1088,7 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcde';
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'P0123456789abcde'::text
+                     Index Cond: (t = 'P0123456789abcde'::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1106,7 +1106,7 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdefF';
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'P0123456789abcdefF'::text
+                     Index Cond: (t = 'P0123456789abcdefF'::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1118,13 +1118,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdefF';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t <    'Aztec                         Ct  ';
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t < 'Aztec                         Ct  '::text
+                     Index Cond: (t < 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1136,13 +1136,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t <    'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~<~  'Aztec                         Ct  ';
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t ~<~ 'Aztec                         Ct  '::text
+                     Index Cond: (t ~<~ 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1154,13 +1154,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~<~  'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t <=   'Aztec                         Ct  ';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t <= 'Aztec                         Ct  '::text
+                     Index Cond: (t <= 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1172,13 +1172,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t <=   'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~<=~ 'Aztec                         Ct  ';
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t ~<=~ 'Aztec                         Ct  '::text
+                     Index Cond: (t ~<=~ 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1190,13 +1190,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~<=~ 'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t =    'Aztec                         Ct  ';
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'Aztec                         Ct  '::text
+                     Index Cond: (t = 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1208,13 +1208,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t =    'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t =    'Worth                         St  ';
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'Worth                         St  '::text
+                     Index Cond: (t = 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1226,13 +1226,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t =    'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t >=   'Worth                         St  ';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t >= 'Worth                         St  '::text
+                     Index Cond: (t >= 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1244,13 +1244,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t >=   'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~>=~ 'Worth                         St  ';
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t ~>=~ 'Worth                         St  '::text
+                     Index Cond: (t ~>=~ 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1262,13 +1262,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~>=~ 'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t >    'Worth                         St  ';
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t > 'Worth                         St  '::text
+                     Index Cond: (t > 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1280,13 +1280,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t >    'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~>~  'Worth                         St  ';
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t ~>~ 'Worth                         St  '::text
+                     Index Cond: (t ~>~ 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1302,16 +1302,16 @@ SET enable_indexscan = OFF;
 SET enable_bitmapscan = ON;
 EXPLAIN (COSTS OFF)
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (f1 <-> '(0,1)'::point)
+   Merge Key: ((f1 <-> '(0,1)'::point))
    ->  Sort
-         Sort Key: (f1 <-> '(0,1)'::point)
+         Sort Key: ((f1 <-> '(0,1)'::point))
          ->  Bitmap Heap Scan on point_tbl
-               Recheck Cond: f1 <@ '(10,10),(-10,-10)'::box
+               Recheck Cond: (f1 <@ '(10,10),(-10,-10)'::box)
                ->  Bitmap Index Scan on gpointind
-                     Index Cond: f1 <@ '(10,10),(-10,-10)'::box
+                     Index Cond: (f1 <@ '(10,10),(-10,-10)'::box)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1332,9 +1332,9 @@ SELECT count(*) FROM quad_point_tbl WHERE p IS NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p IS NULL
+                     Recheck Cond: (p IS NULL)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p IS NULL
+                           Index Cond: (p IS NULL)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1352,9 +1352,9 @@ SELECT count(*) FROM quad_point_tbl WHERE p IS NOT NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p IS NOT NULL
+                     Recheck Cond: (p IS NOT NULL)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p IS NOT NULL
+                           Index Cond: (p IS NOT NULL)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1384,15 +1384,15 @@ SELECT count(*) FROM quad_point_tbl;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p <@ box '(200,200,1000,1000)';
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p <@ '(1000,1000),(200,200)'::box
+                     Recheck Cond: (p <@ '(1000,1000),(200,200)'::box)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p <@ '(1000,1000),(200,200)'::box
+                           Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1404,15 +1404,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p <@ box '(200,200,1000,1000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE box '(200,200,1000,1000)' @> p;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: '(1000,1000),(200,200)'::box @> p
+                     Recheck Cond: ('(1000,1000),(200,200)'::box @> p)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: '(1000,1000),(200,200)'::box @> p
+                           Index Cond: ('(1000,1000),(200,200)'::box @> p)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1424,15 +1424,15 @@ SELECT count(*) FROM quad_point_tbl WHERE box '(200,200,1000,1000)' @> p;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p << '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p << '(5000,4000)'::point
+                     Recheck Cond: (p << '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p << '(5000,4000)'::point
+                           Index Cond: (p << '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1444,15 +1444,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p << '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p >> '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p >> '(5000,4000)'::point
+                     Recheck Cond: (p >> '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p >> '(5000,4000)'::point
+                           Index Cond: (p >> '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1464,15 +1464,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p >> '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p <^ '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p <^ '(5000,4000)'::point
+                     Recheck Cond: (p <^ '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p <^ '(5000,4000)'::point
+                           Index Cond: (p <^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1484,15 +1484,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p <^ '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p >^ '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p >^ '(5000,4000)'::point
+                     Recheck Cond: (p >^ '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p >^ '(5000,4000)'::point
+                           Index Cond: (p >^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1504,15 +1504,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p >^ '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p ~= '(4585, 365)';
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p ~= '(4585,365)'::point
+                     Recheck Cond: (p ~= '(4585,365)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p ~= '(4585,365)'::point
+                           Index Cond: (p ~= '(4585,365)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1524,15 +1524,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p ~= '(4585, 365)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p <@ box '(200,200,1000,1000)';
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p <@ '(1000,1000),(200,200)'::box
+                     Recheck Cond: (p <@ '(1000,1000),(200,200)'::box)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p <@ '(1000,1000),(200,200)'::box
+                           Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1544,15 +1544,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p <@ box '(200,200,1000,1000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE box '(200,200,1000,1000)' @> p;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: '(1000,1000),(200,200)'::box @> p
+                     Recheck Cond: ('(1000,1000),(200,200)'::box @> p)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: '(1000,1000),(200,200)'::box @> p
+                           Index Cond: ('(1000,1000),(200,200)'::box @> p)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1564,15 +1564,15 @@ SELECT count(*) FROM kd_point_tbl WHERE box '(200,200,1000,1000)' @> p;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p << '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p << '(5000,4000)'::point
+                     Recheck Cond: (p << '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p << '(5000,4000)'::point
+                           Index Cond: (p << '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1584,15 +1584,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p << '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p >> '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p >> '(5000,4000)'::point
+                     Recheck Cond: (p >> '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p >> '(5000,4000)'::point
+                           Index Cond: (p >> '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1604,15 +1604,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p >> '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p <^ '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p <^ '(5000,4000)'::point
+                     Recheck Cond: (p <^ '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p <^ '(5000,4000)'::point
+                           Index Cond: (p <^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1624,15 +1624,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p <^ '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p >^ '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p >^ '(5000,4000)'::point
+                     Recheck Cond: (p >^ '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p >^ '(5000,4000)'::point
+                           Index Cond: (p >^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1644,15 +1644,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p >^ '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p ~= '(4585, 365)';
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p ~= '(4585,365)'::point
+                     Recheck Cond: (p ~= '(4585,365)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p ~= '(4585,365)'::point
+                           Index Cond: (p ~= '(4585,365)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1664,15 +1664,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p ~= '(4585, 365)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdef';
-                             QUERY PLAN                              
----------------------------------------------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'P0123456789abcdef'::text
+                     Recheck Cond: (t = 'P0123456789abcdef'::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'P0123456789abcdef'::text
+                           Index Cond: (t = 'P0123456789abcdef'::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1684,15 +1684,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdef';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcde';
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'P0123456789abcde'::text
+                     Recheck Cond: (t = 'P0123456789abcde'::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'P0123456789abcde'::text
+                           Index Cond: (t = 'P0123456789abcde'::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1704,15 +1704,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcde';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdefF';
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'P0123456789abcdefF'::text
+                     Recheck Cond: (t = 'P0123456789abcdefF'::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'P0123456789abcdefF'::text
+                           Index Cond: (t = 'P0123456789abcdefF'::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1724,15 +1724,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdefF';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t <    'Aztec                         Ct  ';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t < 'Aztec                         Ct  '::text
+                     Recheck Cond: (t < 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t < 'Aztec                         Ct  '::text
+                           Index Cond: (t < 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1744,15 +1744,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t <    'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~<~  'Aztec                         Ct  ';
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t ~<~ 'Aztec                         Ct  '::text
+                     Recheck Cond: (t ~<~ 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t ~<~ 'Aztec                         Ct  '::text
+                           Index Cond: (t ~<~ 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1764,15 +1764,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~<~  'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t <=   'Aztec                         Ct  ';
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t <= 'Aztec                         Ct  '::text
+                     Recheck Cond: (t <= 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t <= 'Aztec                         Ct  '::text
+                           Index Cond: (t <= 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1784,15 +1784,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t <=   'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~<=~ 'Aztec                         Ct  ';
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t ~<=~ 'Aztec                         Ct  '::text
+                     Recheck Cond: (t ~<=~ 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t ~<=~ 'Aztec                         Ct  '::text
+                           Index Cond: (t ~<=~ 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1804,15 +1804,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~<=~ 'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t =    'Aztec                         Ct  ';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'Aztec                         Ct  '::text
+                     Recheck Cond: (t = 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'Aztec                         Ct  '::text
+                           Index Cond: (t = 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1824,15 +1824,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t =    'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t =    'Worth                         St  ';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'Worth                         St  '::text
+                     Recheck Cond: (t = 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'Worth                         St  '::text
+                           Index Cond: (t = 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1844,15 +1844,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t =    'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t >=   'Worth                         St  ';
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t >= 'Worth                         St  '::text
+                     Recheck Cond: (t >= 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t >= 'Worth                         St  '::text
+                           Index Cond: (t >= 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1864,15 +1864,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t >=   'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~>=~ 'Worth                         St  ';
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t ~>=~ 'Worth                         St  '::text
+                     Recheck Cond: (t ~>=~ 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t ~>=~ 'Worth                         St  '::text
+                           Index Cond: (t ~>=~ 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1884,15 +1884,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~>=~ 'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t >    'Worth                         St  ';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t > 'Worth                         St  '::text
+                     Recheck Cond: (t > 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t > 'Worth                         St  '::text
+                           Index Cond: (t > 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1904,15 +1904,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t >    'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~>~  'Worth                         St  ';
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t ~>~ 'Worth                         St  '::text
+                     Recheck Cond: (t ~>~ 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t ~>~ 'Worth                         St  '::text
+                           Index Cond: (t ~>~ 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1938,16 +1938,16 @@ SET enable_bitmapscan = ON;
 CREATE INDEX intarrayidx ON array_index_op_test USING gin (i);
 explain (costs off)
 SELECT * FROM array_index_op_test WHERE i @> '{32}' ORDER BY seqno;
-                       QUERY PLAN                       
---------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: seqno
    ->  Sort
          Sort Key: seqno
          ->  Bitmap Heap Scan on array_index_op_test
-               Recheck Cond: i @> '{32}'::integer[]
+               Recheck Cond: (i @> '{32}'::integer[])
                ->  Bitmap Index Scan on intarrayidx
-                     Index Cond: i @> '{32}'::integer[]
+                     Index Cond: (i @> '{32}'::integer[])
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -2187,16 +2187,16 @@ SELECT * FROM array_op_test WHERE i <@ '{NULL}' ORDER BY seqno;
 CREATE INDEX textarrayidx ON array_index_op_test USING gin (t);
 explain (costs off)
 SELECT * FROM array_index_op_test WHERE t @> '{AAAAAAAA72908}' ORDER BY seqno;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: seqno
    ->  Sort
          Sort Key: seqno
          ->  Bitmap Heap Scan on array_index_op_test
-               Recheck Cond: t @> '{AAAAAAAA72908}'::text[]
+               Recheck Cond: (t @> '{AAAAAAAA72908}'::text[])
                ->  Bitmap Index Scan on textarrayidx
-                     Index Cond: t @> '{AAAAAAAA72908}'::text[]
+                     Index Cond: (t @> '{AAAAAAAA72908}'::text[])
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -2905,18 +2905,18 @@ SET enable_bitmapscan = ON;
 EXPLAIN (COSTS OFF)
 SELECT * FROM tenk1
   WHERE thousand = 42 AND (tenthous = 1 OR tenthous = 3 OR tenthous = 42);
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Heap Scan on tenk1
-         Recheck Cond: (thousand = 42 AND tenthous = 1) OR (thousand = 42 AND tenthous = 3) OR (thousand = 42 AND tenthous = 42)
+         Recheck Cond: (((thousand = 42) AND (tenthous = 1)) OR ((thousand = 42) AND (tenthous = 3)) OR ((thousand = 42) AND (tenthous = 42)))
          ->  BitmapOr
                ->  Bitmap Index Scan on tenk1_thous_tenthous
-                     Index Cond: thousand = 42 AND tenthous = 1
+                     Index Cond: ((thousand = 42) AND (tenthous = 1))
                ->  Bitmap Index Scan on tenk1_thous_tenthous
-                     Index Cond: thousand = 42 AND tenthous = 3
+                     Index Cond: ((thousand = 42) AND (tenthous = 3))
                ->  Bitmap Index Scan on tenk1_thous_tenthous
-                     Index Cond: thousand = 42 AND tenthous = 42
+                     Index Cond: ((thousand = 42) AND (tenthous = 42))
  Optimizer: legacy query optimizer
 (11 rows)
 
@@ -2930,21 +2930,21 @@ SELECT * FROM tenk1
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on tenk1
-                     Recheck Cond: hundred = 42 AND (thousand = 42 OR thousand = 99)
+                     Recheck Cond: ((hundred = 42) AND ((thousand = 42) OR (thousand = 99)))
                      ->  BitmapAnd
                            ->  Bitmap Index Scan on tenk1_hundred
-                                 Index Cond: hundred = 42
+                                 Index Cond: (hundred = 42)
                            ->  BitmapOr
                                  ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                       Index Cond: thousand = 42
+                                       Index Cond: (thousand = 42)
                                  ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                       Index Cond: thousand = 99
+                                       Index Cond: (thousand = 99)
  Optimizer: legacy query optimizer
 (14 rows)
 
@@ -2965,15 +2965,15 @@ ANALYZE dupindexcols;
 EXPLAIN (COSTS OFF)
   SELECT count(*) FROM dupindexcols
     WHERE f1 > 'WA' and id < 1000 and f1 ~<~ 'YX';
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on dupindexcols
-                     Recheck Cond: f1 > 'WA'::text AND id < 1000 AND f1 ~<~ 'YX'::text
+                     Recheck Cond: ((f1 > 'WA'::text) AND (id < 1000) AND (f1 ~<~ 'YX'::text))
                      ->  Bitmap Index Scan on dupindexcols_i
-                           Index Cond: f1 > 'WA'::text AND id < 1000 AND f1 ~<~ 'YX'::text
+                           Index Cond: ((f1 > 'WA'::text) AND (id < 1000) AND (f1 ~<~ 'YX'::text))
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -2992,16 +2992,16 @@ explain (costs off)
 SELECT unique1 FROM tenk1
 WHERE unique1 IN (1,42,7)
 ORDER BY unique1;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: unique1
    ->  Sort
          Sort Key: unique1
          ->  Bitmap Heap Scan on tenk1
-               Recheck Cond: unique1 = ANY ('{1,42,7}'::integer[])
+               Recheck Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
                ->  Bitmap Index Scan on tenk1_unique1
-                     Index Cond: unique1 = ANY ('{1,42,7}'::integer[])
+                     Index Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -3019,14 +3019,14 @@ explain (costs off)
 SELECT thousand, tenthous FROM tenk1
 WHERE thousand < 2 AND tenthous IN (1001,3000)
 ORDER BY thousand;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: thousand
    ->  Sort
          Sort Key: thousand
          ->  Index Only Scan using tenk1_thous_tenthous on tenk1
-               Index Cond: thousand < 2 AND (tenthous = ANY ('{1001,3000}'::integer[]))
+               Index Cond: ((thousand < 2) AND (tenthous = ANY ('{1001,3000}'::integer[])))
  Optimizer: legacy query optimizer
 (7 rows)
 

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -375,8 +375,8 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM fast_emp4000
     WHERE home_base @ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Result
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: ((home_base[0])[0])
@@ -384,8 +384,8 @@ SELECT * FROM fast_emp4000
                Sort Key: ((home_base[0])[0])
                ->  Result
                      ->  Index Scan using grect2ind on fast_emp4000
-                           Index Cond: home_base @ '(2000,1000),(200,200)'::box
-                           Filter: home_base @ '(2000,1000),(200,200)'::box
+                           Index Cond: (home_base @ '(2000,1000),(200,200)'::box)
+                           Filter: (home_base @ '(2000,1000),(200,200)'::box)
  Optimizer: PQO version 2.68.0
 (10 rows)
 
@@ -400,14 +400,14 @@ SELECT * FROM fast_emp4000
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM fast_emp4000 WHERE home_base && '(1000,1000,0,0)'::box;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using grect2ind on fast_emp4000
-                     Index Cond: home_base && '(1000,1000),(0,0)'::box
-                     Filter: home_base && '(1000,1000),(0,0)'::box
+                     Index Cond: (home_base && '(1000,1000),(0,0)'::box)
+                     Filter: (home_base && '(1000,1000),(0,0)'::box)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -425,7 +425,7 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base IS NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using grect2ind on fast_emp4000
-                     Index Cond: home_base IS NULL
+                     Index Cond: (home_base IS NULL)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -438,8 +438,8 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base IS NULL;
 EXPLAIN (COSTS OFF)
 SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  Result
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: ((poly_center(f1))[0])
@@ -447,8 +447,8 @@ SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
                Sort Key: ((poly_center(f1))[0])
                ->  Result
                      ->  Index Scan using gpolygonind on polygon_tbl
-                           Index Cond: f1 ~ '((1,1),(2,2),(2,1))'::polygon
-                           Filter: f1 ~ '((1,1),(2,2),(2,1))'::polygon
+                           Index Cond: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
+                           Filter: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
  Optimizer: PQO version 2.68.0
 (10 rows)
 
@@ -462,16 +462,16 @@ SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
 EXPLAIN (COSTS OFF)
 SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
     ORDER BY area(f1);
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Result
    ->  Sort
          Sort Key: (area(f1))
          ->  Result
                ->  Gather Motion 3:1  (slice1; segments: 3)
                      ->  Index Scan using gcircleind on circle_tbl
-                           Index Cond: f1 && '<(1,-2),1>'::circle
-                           Filter: f1 && '<(1,-2),1>'::circle
+                           Index Cond: (f1 && '<(1,-2),1>'::circle)
+                           Filter: (f1 && '<(1,-2),1>'::circle)
  Optimizer: PQO version 2.68.0
 (9 rows)
 
@@ -487,14 +487,14 @@ SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM gpolygon_tbl WHERE f1 && '(1000,1000,0,0)'::polygon;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using ggpolygonind on gpolygon_tbl
-                     Index Cond: f1 && '((1000,1000),(0,0))'::polygon
-                     Filter: f1 && '((1000,1000),(0,0))'::polygon
+                     Index Cond: (f1 && '((1000,1000),(0,0))'::polygon)
+                     Filter: (f1 && '((1000,1000),(0,0))'::polygon)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -506,14 +506,14 @@ SELECT count(*) FROM gpolygon_tbl WHERE f1 && '(1000,1000,0,0)'::polygon;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using ggcircleind on gcircle_tbl
-                     Index Cond: f1 && '<(500,500),500>'::circle
-                     Filter: f1 && '<(500,500),500>'::circle
+                     Index Cond: (f1 && '<(500,500),500>'::circle)
+                     Filter: (f1 && '<(500,500),500>'::circle)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -525,14 +525,14 @@ SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
-                          QUERY PLAN                          
---------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 <@ '(100,100),(0,0)'::box
-                     Filter: f1 <@ '(100,100),(0,0)'::box
+                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+                     Filter: (f1 <@ '(100,100),(0,0)'::box)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -544,14 +544,14 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
-                          QUERY PLAN                          
---------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 <@ '(100,100),(0,0)'::box
-                     Filter: f1 <@ '(100,100),(0,0)'::box
+                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+                     Filter: (f1 <@ '(100,100),(0,0)'::box)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -563,14 +563,14 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon
-                     Filter: f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon
+                     Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
+                     Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -582,14 +582,14 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
-                          QUERY PLAN                          
---------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 <@ '<(50,50),50>'::circle
-                     Filter: f1 <@ '<(50,50),50>'::circle
+                     Index Cond: (f1 <@ '<(50,50),50>'::circle)
+                     Filter: (f1 <@ '<(50,50),50>'::circle)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -607,8 +607,8 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 << '(0,0)'::point
-                     Filter: f1 << '(0,0)'::point
+                     Index Cond: (f1 << '(0,0)'::point)
+                     Filter: (f1 << '(0,0)'::point)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -626,8 +626,8 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 >> '(0,0)'::point
-                     Filter: f1 >> '(0,0)'::point
+                     Index Cond: (f1 >> '(0,0)'::point)
+                     Filter: (f1 >> '(0,0)'::point)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -645,8 +645,8 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 <^ '(0,0)'::point
-                     Filter: f1 <^ '(0,0)'::point
+                     Index Cond: (f1 <^ '(0,0)'::point)
+                     Filter: (f1 <^ '(0,0)'::point)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -664,8 +664,8 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 >^ '(0,0)'::point
-                     Filter: f1 >^ '(0,0)'::point
+                     Index Cond: (f1 >^ '(0,0)'::point)
+                     Filter: (f1 >^ '(0,0)'::point)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -683,8 +683,8 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using gpointind on point_tbl
-                     Index Cond: f1 ~= '(-5,-12)'::point
-                     Filter: f1 ~= '(-5,-12)'::point
+                     Index Cond: (f1 ~= '(-5,-12)'::point)
+                     Filter: (f1 ~= '(-5,-12)'::point)
  Optimizer: PQO version 2.68.0
 (7 rows)
 
@@ -699,9 +699,9 @@ SELECT * FROM point_tbl ORDER BY f1 <-> '0,1';
                   QUERY PLAN                   
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (f1 <-> '(0,1)'::point)
+   Merge Key: ((f1 <-> '(0,1)'::point))
    ->  Index Scan using gpointind on point_tbl
-         Order By: f1 <-> '(0,1)'::point
+         Order By: (f1 <-> '(0,1)'::point)
  Optimizer: legacy query optimizer
 (5 rows)
 
@@ -723,7 +723,7 @@ SELECT * FROM point_tbl WHERE f1 IS NULL;
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using gpointind on point_tbl
-         Index Cond: f1 IS NULL
+         Index Cond: (f1 IS NULL)
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -738,10 +738,10 @@ SELECT * FROM point_tbl WHERE f1 IS NOT NULL ORDER BY f1 <-> '0,1';
                   QUERY PLAN                   
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (f1 <-> '(0,1)'::point)
+   Merge Key: ((f1 <-> '(0,1)'::point))
    ->  Index Scan using gpointind on point_tbl
-         Index Cond: f1 IS NOT NULL
-         Order By: f1 <-> '(0,1)'::point
+         Index Cond: (f1 IS NOT NULL)
+         Order By: (f1 <-> '(0,1)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -758,16 +758,16 @@ SELECT * FROM point_tbl WHERE f1 IS NOT NULL ORDER BY f1 <-> '0,1';
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                                QUERY PLAN                              
+------------------------------------------------------------------------
  Result
    ->  Sort
-         Sort Key: (f1 <-> '(0,1)'::point)
+         Sort Key: ((f1 <-> '(0,1)'::point))
          ->  Result
                ->  Gather Motion 3:1  (slice1; segments: 3)
                      ->  Index Scan using gpointind on point_tbl
-                           Index Cond: f1 <@ '(10,10),(-10,-10)'::box
-                           Filter: f1 <@ '(10,10),(-10,-10)'::box
+                           Index Cond: (f1 <@ '(10,10),(-10,-10)'::box)
+                           Filter: (f1 <@ '(10,10),(-10,-10)'::box)
  Optimizer: PQO version 2.68.0
 (9 rows)
 
@@ -788,7 +788,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p IS NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p IS NULL
+                     Index Cond: (p IS NULL)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -806,7 +806,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p IS NOT NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p IS NOT NULL
+                     Index Cond: (p IS NOT NULL)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -841,7 +841,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p <@ box '(200,200,1000,1000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p <@ '(1000,1000),(200,200)'::box
+                     Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -859,7 +859,7 @@ SELECT count(*) FROM quad_point_tbl WHERE box '(200,200,1000,1000)' @> p;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p <@ '(1000,1000),(200,200)'::box
+                     Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -877,7 +877,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p << '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p << '(5000,4000)'::point
+                     Index Cond: (p << '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -895,7 +895,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p >> '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p >> '(5000,4000)'::point
+                     Index Cond: (p >> '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -913,7 +913,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p <^ '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p <^ '(5000,4000)'::point
+                     Index Cond: (p <^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -931,7 +931,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p >^ '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p >^ '(5000,4000)'::point
+                     Index Cond: (p >^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -949,7 +949,7 @@ SELECT count(*) FROM quad_point_tbl WHERE p ~= '(4585, 365)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_quad_ind on quad_point_tbl
-                     Index Cond: p ~= '(4585,365)'::point
+                     Index Cond: (p ~= '(4585,365)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -961,13 +961,13 @@ SELECT count(*) FROM quad_point_tbl WHERE p ~= '(4585, 365)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p <@ box '(200,200,1000,1000)';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p <@ '(1000,1000),(200,200)'::box
+                     Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -979,13 +979,13 @@ SELECT count(*) FROM kd_point_tbl WHERE p <@ box '(200,200,1000,1000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE box '(200,200,1000,1000)' @> p;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p <@ '(1000,1000),(200,200)'::box
+                     Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1003,7 +1003,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p << '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p << '(5000,4000)'::point
+                     Index Cond: (p << '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1021,7 +1021,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p >> '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p >> '(5000,4000)'::point
+                     Index Cond: (p >> '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1039,7 +1039,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p <^ '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p <^ '(5000,4000)'::point
+                     Index Cond: (p <^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1057,7 +1057,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p >^ '(5000, 4000)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p >^ '(5000,4000)'::point
+                     Index Cond: (p >^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1075,7 +1075,7 @@ SELECT count(*) FROM kd_point_tbl WHERE p ~= '(4585, 365)';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_kd_ind on kd_point_tbl
-                     Index Cond: p ~= '(4585,365)'::point
+                     Index Cond: (p ~= '(4585,365)'::point)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1093,7 +1093,7 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdef';
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'P0123456789abcdef'::text
+                     Index Cond: (t = 'P0123456789abcdef'::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1111,7 +1111,7 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcde';
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'P0123456789abcde'::text
+                     Index Cond: (t = 'P0123456789abcde'::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1129,7 +1129,7 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdefF';
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'P0123456789abcdefF'::text
+                     Index Cond: (t = 'P0123456789abcdefF'::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1141,13 +1141,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdefF';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t <    'Aztec                         Ct  ';
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t < 'Aztec                         Ct  '::text
+                     Index Cond: (t < 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1159,13 +1159,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t <    'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~<~  'Aztec                         Ct  ';
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t ~<~ 'Aztec                         Ct  '::text
+                     Index Cond: (t ~<~ 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1177,13 +1177,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~<~  'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t <=   'Aztec                         Ct  ';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t <= 'Aztec                         Ct  '::text
+                     Index Cond: (t <= 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1195,13 +1195,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t <=   'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~<=~ 'Aztec                         Ct  ';
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t ~<=~ 'Aztec                         Ct  '::text
+                     Index Cond: (t ~<=~ 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1213,13 +1213,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~<=~ 'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t =    'Aztec                         Ct  ';
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'Aztec                         Ct  '::text
+                     Index Cond: (t = 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1231,13 +1231,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t =    'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t =    'Worth                         St  ';
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t = 'Worth                         St  '::text
+                     Index Cond: (t = 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1249,13 +1249,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t =    'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t >=   'Worth                         St  ';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t >= 'Worth                         St  '::text
+                     Index Cond: (t >= 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1267,13 +1267,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t >=   'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~>=~ 'Worth                         St  ';
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t ~>=~ 'Worth                         St  '::text
+                     Index Cond: (t ~>=~ 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1285,13 +1285,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~>=~ 'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t >    'Worth                         St  ';
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t > 'Worth                         St  '::text
+                     Index Cond: (t > 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1303,13 +1303,13 @@ SELECT count(*) FROM radix_text_tbl WHERE t >    'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~>~  'Worth                         St  ';
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Only Scan using sp_radix_ind on radix_text_tbl
-                     Index Cond: t ~>~ 'Worth                         St  '::text
+                     Index Cond: (t ~>~ 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1325,16 +1325,16 @@ SET enable_indexscan = OFF;
 SET enable_bitmapscan = ON;
 EXPLAIN (COSTS OFF)
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Result
    ->  Sort
-         Sort Key: (f1 <-> '(0,1)'::point)
+         Sort Key: ((f1 <-> '(0,1)'::point))
          ->  Result
                ->  Gather Motion 3:1  (slice1; segments: 3)
                      ->  Index Scan using gpointind on point_tbl
-                           Index Cond: f1 <@ '(10,10),(-10,-10)'::box
-                           Filter: f1 <@ '(10,10),(-10,-10)'::box
+                           Index Cond: (f1 <@ '(10,10),(-10,-10)'::box)
+                           Filter: (f1 <@ '(10,10),(-10,-10)'::box)
  Optimizer: PQO version 2.68.0
 (9 rows)
 
@@ -1355,9 +1355,9 @@ SELECT count(*) FROM quad_point_tbl WHERE p IS NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p IS NULL
+                     Recheck Cond: (p IS NULL)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p IS NULL
+                           Index Cond: (p IS NULL)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1375,9 +1375,9 @@ SELECT count(*) FROM quad_point_tbl WHERE p IS NOT NULL;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p IS NOT NULL
+                     Recheck Cond: (p IS NOT NULL)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p IS NOT NULL
+                           Index Cond: (p IS NOT NULL)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1407,15 +1407,15 @@ SELECT count(*) FROM quad_point_tbl;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p <@ box '(200,200,1000,1000)';
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p <@ '(1000,1000),(200,200)'::box
+                     Recheck Cond: (p <@ '(1000,1000),(200,200)'::box)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p <@ '(1000,1000),(200,200)'::box
+                           Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1427,15 +1427,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p <@ box '(200,200,1000,1000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE box '(200,200,1000,1000)' @> p;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: '(1000,1000),(200,200)'::box @> p
+                     Recheck Cond: ('(1000,1000),(200,200)'::box @> p)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: '(1000,1000),(200,200)'::box @> p
+                           Index Cond: ('(1000,1000),(200,200)'::box @> p)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1447,15 +1447,15 @@ SELECT count(*) FROM quad_point_tbl WHERE box '(200,200,1000,1000)' @> p;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p << '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p << '(5000,4000)'::point
+                     Recheck Cond: (p << '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p << '(5000,4000)'::point
+                           Index Cond: (p << '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1467,15 +1467,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p << '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p >> '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p >> '(5000,4000)'::point
+                     Recheck Cond: (p >> '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p >> '(5000,4000)'::point
+                           Index Cond: (p >> '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1487,15 +1487,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p >> '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p <^ '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p <^ '(5000,4000)'::point
+                     Recheck Cond: (p <^ '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p <^ '(5000,4000)'::point
+                           Index Cond: (p <^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1507,15 +1507,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p <^ '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p >^ '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p >^ '(5000,4000)'::point
+                     Recheck Cond: (p >^ '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p >^ '(5000,4000)'::point
+                           Index Cond: (p >^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1527,15 +1527,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p >^ '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM quad_point_tbl WHERE p ~= '(4585, 365)';
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on quad_point_tbl
-                     Recheck Cond: p ~= '(4585,365)'::point
+                     Recheck Cond: (p ~= '(4585,365)'::point)
                      ->  Bitmap Index Scan on sp_quad_ind
-                           Index Cond: p ~= '(4585,365)'::point
+                           Index Cond: (p ~= '(4585,365)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1547,15 +1547,15 @@ SELECT count(*) FROM quad_point_tbl WHERE p ~= '(4585, 365)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p <@ box '(200,200,1000,1000)';
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p <@ '(1000,1000),(200,200)'::box
+                     Recheck Cond: (p <@ '(1000,1000),(200,200)'::box)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p <@ '(1000,1000),(200,200)'::box
+                           Index Cond: (p <@ '(1000,1000),(200,200)'::box)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1567,15 +1567,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p <@ box '(200,200,1000,1000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE box '(200,200,1000,1000)' @> p;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: '(1000,1000),(200,200)'::box @> p
+                     Recheck Cond: ('(1000,1000),(200,200)'::box @> p)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: '(1000,1000),(200,200)'::box @> p
+                           Index Cond: ('(1000,1000),(200,200)'::box @> p)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1587,15 +1587,15 @@ SELECT count(*) FROM kd_point_tbl WHERE box '(200,200,1000,1000)' @> p;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p << '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p << '(5000,4000)'::point
+                     Recheck Cond: (p << '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p << '(5000,4000)'::point
+                           Index Cond: (p << '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1607,15 +1607,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p << '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p >> '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p >> '(5000,4000)'::point
+                     Recheck Cond: (p >> '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p >> '(5000,4000)'::point
+                           Index Cond: (p >> '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1627,15 +1627,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p >> '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p <^ '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p <^ '(5000,4000)'::point
+                     Recheck Cond: (p <^ '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p <^ '(5000,4000)'::point
+                           Index Cond: (p <^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1647,15 +1647,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p <^ '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p >^ '(5000, 4000)';
-                           QUERY PLAN                            
------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p >^ '(5000,4000)'::point
+                     Recheck Cond: (p >^ '(5000,4000)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p >^ '(5000,4000)'::point
+                           Index Cond: (p >^ '(5000,4000)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1667,15 +1667,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p >^ '(5000, 4000)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM kd_point_tbl WHERE p ~= '(4585, 365)';
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on kd_point_tbl
-                     Recheck Cond: p ~= '(4585,365)'::point
+                     Recheck Cond: (p ~= '(4585,365)'::point)
                      ->  Bitmap Index Scan on sp_kd_ind
-                           Index Cond: p ~= '(4585,365)'::point
+                           Index Cond: (p ~= '(4585,365)'::point)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1687,15 +1687,15 @@ SELECT count(*) FROM kd_point_tbl WHERE p ~= '(4585, 365)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdef';
-                             QUERY PLAN                              
----------------------------------------------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'P0123456789abcdef'::text
+                     Recheck Cond: (t = 'P0123456789abcdef'::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'P0123456789abcdef'::text
+                           Index Cond: (t = 'P0123456789abcdef'::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1707,15 +1707,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdef';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcde';
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'P0123456789abcde'::text
+                     Recheck Cond: (t = 'P0123456789abcde'::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'P0123456789abcde'::text
+                           Index Cond: (t = 'P0123456789abcde'::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1727,15 +1727,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcde';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdefF';
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'P0123456789abcdefF'::text
+                     Recheck Cond: (t = 'P0123456789abcdefF'::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'P0123456789abcdefF'::text
+                           Index Cond: (t = 'P0123456789abcdefF'::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1747,15 +1747,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t = 'P0123456789abcdefF';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t <    'Aztec                         Ct  ';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t < 'Aztec                         Ct  '::text
+                     Recheck Cond: (t < 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t < 'Aztec                         Ct  '::text
+                           Index Cond: (t < 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1767,15 +1767,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t <    'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~<~  'Aztec                         Ct  ';
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t ~<~ 'Aztec                         Ct  '::text
+                     Recheck Cond: (t ~<~ 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t ~<~ 'Aztec                         Ct  '::text
+                           Index Cond: (t ~<~ 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1787,15 +1787,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~<~  'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t <=   'Aztec                         Ct  ';
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t <= 'Aztec                         Ct  '::text
+                     Recheck Cond: (t <= 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t <= 'Aztec                         Ct  '::text
+                           Index Cond: (t <= 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1807,15 +1807,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t <=   'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~<=~ 'Aztec                         Ct  ';
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t ~<=~ 'Aztec                         Ct  '::text
+                     Recheck Cond: (t ~<=~ 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t ~<=~ 'Aztec                         Ct  '::text
+                           Index Cond: (t ~<=~ 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1827,15 +1827,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~<=~ 'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t =    'Aztec                         Ct  ';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'Aztec                         Ct  '::text
+                     Recheck Cond: (t = 'Aztec                         Ct  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'Aztec                         Ct  '::text
+                           Index Cond: (t = 'Aztec                         Ct  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1847,15 +1847,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t =    'Aztec                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t =    'Worth                         St  ';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t = 'Worth                         St  '::text
+                     Recheck Cond: (t = 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t = 'Worth                         St  '::text
+                           Index Cond: (t = 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1867,15 +1867,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t =    'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t >=   'Worth                         St  ';
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t >= 'Worth                         St  '::text
+                     Recheck Cond: (t >= 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t >= 'Worth                         St  '::text
+                           Index Cond: (t >= 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1887,15 +1887,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t >=   'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~>=~ 'Worth                         St  ';
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t ~>=~ 'Worth                         St  '::text
+                     Recheck Cond: (t ~>=~ 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t ~>=~ 'Worth                         St  '::text
+                           Index Cond: (t ~>=~ 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1907,15 +1907,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~>=~ 'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t >    'Worth                         St  ';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t > 'Worth                         St  '::text
+                     Recheck Cond: (t > 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t > 'Worth                         St  '::text
+                           Index Cond: (t > 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1927,15 +1927,15 @@ SELECT count(*) FROM radix_text_tbl WHERE t >    'Worth                         
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE t ~>~  'Worth                         St  ';
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Bitmap Heap Scan on radix_text_tbl
-                     Recheck Cond: t ~>~ 'Worth                         St  '::text
+                     Recheck Cond: (t ~>~ 'Worth                         St  '::text)
                      ->  Bitmap Index Scan on sp_radix_ind
-                           Index Cond: t ~>~ 'Worth                         St  '::text
+                           Index Cond: (t ~>~ 'Worth                         St  '::text)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -1961,16 +1961,16 @@ SET enable_bitmapscan = ON;
 CREATE INDEX intarrayidx ON array_index_op_test USING gin (i);
 explain (costs off)
 SELECT * FROM array_index_op_test WHERE i @> '{32}' ORDER BY seqno;
-                       QUERY PLAN                       
---------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: seqno
    ->  Sort
          Sort Key: seqno
          ->  Bitmap Heap Scan on array_index_op_test
-               Recheck Cond: i @> '{32}'::integer[]
+               Recheck Cond: (i @> '{32}'::integer[])
                ->  Bitmap Index Scan on intarrayidx
-                     Index Cond: i @> '{32}'::integer[]
+                     Index Cond: (i @> '{32}'::integer[])
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -2210,16 +2210,16 @@ SELECT * FROM array_op_test WHERE i <@ '{NULL}' ORDER BY seqno;
 CREATE INDEX textarrayidx ON array_index_op_test USING gin (t);
 explain (costs off)
 SELECT * FROM array_index_op_test WHERE t @> '{AAAAAAAA72908}' ORDER BY seqno;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: seqno
    ->  Sort
          Sort Key: seqno
          ->  Bitmap Heap Scan on array_index_op_test
-               Recheck Cond: t @> '{AAAAAAAA72908}'::text[]
+               Recheck Cond: (t @> '{AAAAAAAA72908}'::text[])
                ->  Bitmap Index Scan on textarrayidx
-                     Index Cond: t @> '{AAAAAAAA72908}'::text[]
+                     Index Cond: (t @> '{AAAAAAAA72908}'::text[])
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -2941,8 +2941,8 @@ SELECT * FROM tenk1
 ---------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using tenk1_thous_tenthous on tenk1
-         Index Cond: thousand = 42
-         Filter: tenthous = 1 OR tenthous = 3 OR tenthous = 42
+         Index Cond: (thousand = 42)
+         Filter: ((tenthous = 1) OR (tenthous = 3) OR (tenthous = 42))
  Optimizer: PQO version 2.64.0
 (5 rows)
 
@@ -2962,8 +2962,8 @@ SELECT count(*) FROM tenk1
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using tenk1_hundred on tenk1
-                     Index Cond: hundred = 42
-                     Filter: thousand = 42 OR thousand = 99
+                     Index Cond: (hundred = 42)
+                     Filter: ((thousand = 42) OR (thousand = 99))
  Optimizer: PQO version 2.64.0
 (7 rows)
 
@@ -2993,8 +2993,8 @@ EXPLAIN (COSTS OFF)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Index Scan using dupindexcols_i on dupindexcols
-                     Index Cond: f1 > 'WA'::text AND id < 1000
-                     Filter: f1 ~<~ 'YX'::text
+                     Index Cond: ((f1 > 'WA'::text) AND (id < 1000))
+                     Filter: (f1 ~<~ 'YX'::text)
  Optimizer: PQO version 2.64.0
 (7 rows)
 
@@ -3013,16 +3013,16 @@ explain (costs off)
 SELECT unique1 FROM tenk1
 WHERE unique1 IN (1,42,7)
 ORDER BY unique1;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: unique1
    ->  Sort
          Sort Key: unique1
          ->  Bitmap Heap Scan on tenk1
-               Recheck Cond: unique1 = ANY ('{1,42,7}'::integer[])
+               Recheck Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
                ->  Bitmap Index Scan on tenk1_unique1
-                     Index Cond: unique1 = ANY ('{1,42,7}'::integer[])
+                     Index Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -3040,14 +3040,14 @@ explain (costs off)
 SELECT thousand, tenthous FROM tenk1
 WHERE thousand < 2 AND tenthous IN (1001,3000)
 ORDER BY thousand;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: thousand
    ->  Sort
          Sort Key: thousand
          ->  Index Only Scan using tenk1_thous_tenthous on tenk1
-               Index Cond: thousand < 2 AND (tenthous = ANY ('{1001,3000}'::integer[]))
+               Index Cond: ((thousand < 2) AND (tenthous = ANY ('{1001,3000}'::integer[])))
  Optimizer: legacy query optimizer
 (7 rows)
 

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -45,11 +45,11 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
 ------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=2432.00..8569.25 rows=77900 width=84)
    ->  Hash Left Join  (cost=4626.75..9527.20 rows=25967 width=84)
-         Hash Cond: boxes.location_id = box_locations.id
+         Hash Cond: (boxes.location_id = box_locations.id)
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3410.75..7240.07 rows=25967 width=48)
                Hash Key: boxes.location_id
                ->  Hash Right Join  (cost=340.75..582.07 rows=2567 width=4)
-                     Hash Cond: apples.id = boxes.apple_id
+                     Hash Cond: (apples.id = boxes.apple_id)
                      ->  Seq Scan on apples  (cost=0.00..115.60 rows=3347 width=6)
                      ->  Hash  (cost=247.00..247.00 rows=2567 width=1)
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..237.00 rows=2967 width=2)
@@ -68,11 +68,11 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=2432.00..8569.25 rows=77900 width=84) (actual time=3.936..3.936 rows=0 loops=1)
    ->  Hash Left Join  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.936..3.936 rows=0 loops=1)
-         Hash Cond: boxes.location_id = box_locations.id
+         Hash Cond: (boxes.location_id = box_locations.id)
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2432.00..8569.25 rows=25967 width=84) (actual time=3.936..3.96 rows=0 loops=1)
                Hash Key: boxes.location_id
                ->  Hash Right Join  (cost=2432.00..569.25 rows=2967 width=4) (actual time=3.936..3.936 rows=0 loops=1)
-                     Hash Cond: apples.id = boxes.apple_id
+                     Hash Cond: (apples.id = boxes.apple_id)
                      ->  Seq Scan on apples  (cost=0.00..110.70 rows=3190 width=6) (never executed)
                      ->  Hash  (cost=2437.00..247.00 rows=2967 width=2) (actual time=3.936..3.969 rows=0 loops=1)
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..247.00 rows=2567 width=1) (actual time=3.96..3.96 rows=0 loops=1)
@@ -158,7 +158,7 @@ QUERY PLAN
         Total Cost: 9521.30
         Plan Rows: 77900
         Plan Width: 84
-        Hash Cond: "boxes.location_id = box_locations.id"
+        Hash Cond: "(boxes.location_id = box_locations.id)"
         Plans: 
           - Node Type: "Redistribute Motion"
             Senders: 3
@@ -183,7 +183,7 @@ QUERY PLAN
                 Total Cost: 5676.18
                 Plan Rows: 77900
                 Plan Width: 48
-                Hash Cond: "apples.id = boxes.apple_id"
+                Hash Cond: "(apples.id = boxes.apple_id)"
                 Plans: 
                   - Node Type: "Seq Scan"
                     Parent Relationship: "Outer"
@@ -288,7 +288,7 @@ QUERY PLAN
         Actual Total Time: 0.000
         Actual Rows: 0
         Actual Loops: 0
-        Hash Cond: "boxes.location_id = box_locations.id"
+        Hash Cond: "(boxes.location_id = box_locations.id)"
         Plans: 
           - Node Type: "Redistribute Motion"
             Senders: 3
@@ -321,7 +321,7 @@ QUERY PLAN
                 Actual Total Time: 0.000
                 Actual Rows: 0
                 Actual Loops: 0
-                Hash Cond: "apples.id = boxes.apple_id"
+                Hash Cond: "(apples.id = boxes.apple_id)"
                 Plans: 
                   - Node Type: "Seq Scan"
                     Parent Relationship: "Outer"
@@ -534,7 +534,7 @@ QUERY PLAN
           "Total Cost": 859.25,
           "Plan Rows": 7700,
           "Plan Width": 10,
-          "Hash Cond": "boxes.location_id = box_locations.id",
+          "Hash Cond": "(boxes.location_id = box_locations.id)",
           "Plans": [
             {
               "Node Type": "Redistribute Motion",
@@ -561,7 +561,7 @@ QUERY PLAN
                   "Total Cost": 4724.12,
                   "Plan Rows": 77900,
                   "Plan Width": 48,
-                  "Hash Cond": "apples.id = boxes.apple_id",
+                  "Hash Cond": "(apples.id = boxes.apple_id)",
                   "Plans": [
                     {
                       "Node Type": "Seq Scan",
@@ -696,7 +696,7 @@ QUERY PLAN
           "Actual Total Time": 0.000,
           "Actual Rows": 0,
           "Actual Loops": 0,
-          "Hash Cond": "boxes.location_id = box_locations.id",
+          "Hash Cond": "(boxes.location_id = box_locations.id)",
           "Plans": [
             {
               "Node Type": "Redistribute Motion",
@@ -731,7 +731,7 @@ QUERY PLAN
                   "Actual Total Time": 0.000,
                   "Actual Rows": 0,
                   "Actual Loops": 0,
-                  "Hash Cond": "apples.id = boxes.apple_id",
+                  "Hash Cond": "(apples.id = boxes.apple_id)",
                   "Plans": [
                     {
                       "Node Type": "Seq Scan",
@@ -996,7 +996,7 @@ QUERY PLAN
           <Total-Cost>8569.25</Total-Cost>
           <Plan-Rows>77900</Plan-Rows>
           <Plan-Width>84</Plan-Width>
-          <Hash-Cond>boxes.location_id = box_locations.id</Hash-Cond>
+          <Hash-Cond>(boxes.location_id = box_locations.id)</Hash-Cond>
           <Plans>
             <Plan>
               <Node-Type>Redistribute Motion</Node-Type>
@@ -1023,7 +1023,7 @@ QUERY PLAN
                   <Total-Cost>4724.12</Total-Cost>
                   <Plan-Rows>77900</Plan-Rows>
                   <Plan-Width>48</Plan-Width>
-                  <Hash-Cond>apples.id = boxes.apple_id</Hash-Cond>
+                  <Hash-Cond>(apples.id = boxes.apple_id)</Hash-Cond>
                   <Plans>
                     <Plan>
                       <Node-Type>Seq Scan</Node-Type>
@@ -1158,7 +1158,7 @@ QUERY PLAN
           <Actual-Total-Time>0.000</Actual-Total-Time>
           <Actual-Rows>0</Actual-Rows>
           <Actual-Loops>0</Actual-Loops>
-          <Hash-Cond>boxes.location_id = box_locations.id</Hash-Cond>
+          <Hash-Cond>(boxes.location_id = box_locations.id)</Hash-Cond>
           <Plans>
             <Plan>
               <Node-Type>Redistribute Motion</Node-Type>
@@ -1193,7 +1193,7 @@ QUERY PLAN
                   <Actual-Total-Time>0.000</Actual-Total-Time>
                   <Actual-Rows>0</Actual-Rows>
                   <Actual-Loops>0</Actual-Loops>
-                  <Hash-Cond>apples.id = boxes.apple_id</Hash-Cond>
+                  <Hash-Cond>(apples.id = boxes.apple_id)</Hash-Cond>
                   <Plans>
                     <Plan>
                       <Node-Type>Seq Scan</Node-Type>

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -54,9 +54,9 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
                            Hash Key: boxes.apple_id
                            ->  Table Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
                      ->  Index Scan using apples_pkey on apples  (cost=11.123..11.123 rows=0 width=1)
-                           Index Cond: id = boxes.apple_id
+                           Index Cond: (id = boxes.apple_id)
          ->  Index Scan using box_locations_pkey on box_locations  (cost=22.234..32.231 rows=1 width=0)
-               Index Cond: id = boxes.location_id
+               Index Cond: (id = boxes.location_id)
 (15 rows)
 
 -- explain_processing_on
@@ -76,9 +76,9 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
                            Hash Key: boxes.apple_id
                            ->  Table Scan on boxes  (cost=1.123..11.322 rows=1 width=0) (actual time=11.222..11.222 rows=1 loops=1)
                      ->  Index Scan using apples_pkey on apples  (cost=12.321..12.123 rows=3 width=3) (never executed)
-                           Index Cond: id = boxes.apple_id
+                           Index Cond: (id = boxes.apple_id)
          ->  Index Scan using box_locations_pkey on box_locations  (cost=12.123..12.321 rows=32 width=321) (never executed)
-               Index Cond: id = boxes.location_id
+               Index Cond: (id = boxes.location_id)
    (slice0)    Executor memory: 386K bytes.  Peak memory: 42342K bytes.  Vmem reserved: 123432K bytes.
    (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Peak memory: 1234532 bytes avg x 2 workers, 123 bytes max (seg0).  Vmem reserved: 100 bytes avg x 3 workers, 123k bytes max (seg0).
    (slice2)    Executor memory: 1110K bytes avg x 3 workers, 1110K bytes max (seg0).  Peak memory: 543 bytes avg x 2 workers, 312 bytes max (seg0).  Vmem reserved: 1234243 bytes avg x 1 workers, 312 bytes max (seg0).
@@ -224,7 +224,7 @@ QUERY PLAN
                     Total Cost: 1.00
                     Plan Rows: 13
                     Plan Width: 43213
-                    Index Cond: "id = boxes.apple_id"
+                    Index Cond: "(id = boxes.apple_id)"
           - Node Type: "Index Scan"
             Parent Relationship: "Inner"
             Slice: 3
@@ -238,7 +238,7 @@ QUERY PLAN
             Total Cost: 3.00
             Plan Rows: 2
             Plan Width: 56
-            Index Cond: "id = boxes.location_id"
+            Index Cond: "(id = boxes.location_id)"
   Settings: 
     Optimizer: "PQO version 2.1.0"
 (1 row)
@@ -362,7 +362,7 @@ QUERY PLAN
                     Actual Total Time: 0.030
                     Actual Rows: 10
                     Actual Loops: 11
-                    Index Cond: "id = boxes.apple_id"
+                    Index Cond: "(id = boxes.apple_id)"
                     Rows Removed by Index Recheck: 0
           - Node Type: "Index Scan"
             Parent Relationship: "Inner"
@@ -381,7 +381,7 @@ QUERY PLAN
             Actual Total Time: 2.000
             Actual Rows: 3
             Actual Loops: 4
-            Index Cond: "id = boxes.location_id"
+            Index Cond: "(id = boxes.location_id)"
             Rows Removed by Index Recheck: 0
   Triggers: 
   Slice statistics: 
@@ -581,7 +581,7 @@ QUERY PLAN
                       "Total Cost": 2.20,
                       "Plan Rows": 3,
                       "Plan Width": 4,
-                      "Index Cond": "id = boxes.apple_id"
+                      "Index Cond": "(id = boxes.apple_id)"
                     }
                   ]
                 }
@@ -601,7 +601,7 @@ QUERY PLAN
               "Total Cost": 2.20,
               "Plan Rows": 3,
               "Plan Width": 4,
-              "Index Cond": "id = boxes.location_id"
+              "Index Cond": "(id = boxes.location_id)"
             }
           ]
         }
@@ -745,7 +745,7 @@ QUERY PLAN
                       "Actual Total Time": 0.060,
                       "Actual Rows": 7,
                       "Actual Loops": 8,
-                      "Index Cond": "id = boxes.apple_id",
+                      "Index Cond": "(id = boxes.apple_id)",
                       "Rows Removed by Index Recheck": 0
                     }
                   ]
@@ -770,7 +770,7 @@ QUERY PLAN
               "Actual Total Time": 6.000,
               "Actual Rows": 7,
               "Actual Loops": 8,
-              "Index Cond": "id = boxes.location_id",
+              "Index Cond": "(id = boxes.location_id)",
               "Rows Removed by Index Recheck": 0
             }
           ]
@@ -1008,7 +1008,7 @@ QUERY PLAN
                       <Total-Cost>2.20</Total-Cost>
                       <Plan-Rows>3</Plan-Rows>
                       <Plan-Width>5</Plan-Width>
-                      <Index-Cond>id = boxes.apple_id</Index-Cond>
+                      <Index-Cond>(id = boxes.apple_id)</Index-Cond>
                     </Plan>
                   </Plans>
                 </Plan>
@@ -1028,7 +1028,7 @@ QUERY PLAN
               <Total-Cost>2.40</Total-Cost>
               <Plan-Rows>3</Plan-Rows>
               <Plan-Width>2</Plan-Width>
-              <Index-Cond>id = boxes.location_id</Index-Cond>
+              <Index-Cond>(id = boxes.location_id)</Index-Cond>
             </Plan>
           </Plans>
         </Plan>
@@ -1172,7 +1172,7 @@ QUERY PLAN
                       <Actual-Total-Time>0.300</Actual-Total-Time>
                       <Actual-Rows>2</Actual-Rows>
                       <Actual-Loops>1</Actual-Loops>
-                      <Index-Cond>id = boxes.apple_id</Index-Cond>
+                      <Index-Cond>(id = boxes.apple_id)</Index-Cond>
                       <Rows-Removed-by-Index-Recheck>0</Rows-Removed-by-Index-Recheck>
                     </Plan>
                   </Plans>
@@ -1197,7 +1197,7 @@ QUERY PLAN
               <Actual-Total-Time>0.010</Actual-Total-Time>
               <Actual-Rows>0</Actual-Rows>
               <Actual-Loops>0</Actual-Loops>
-              <Index-Cond>id = boxes.location_id</Index-Cond>
+              <Index-Cond>(id = boxes.location_id)</Index-Cond>
               <Rows-Removed-by-Index-Recheck>0</Rows-Removed-by-Index-Recheck>
             </Plan>
           </Plans>

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -156,7 +156,7 @@ explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 gro
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
-         Hash Cond: NOT share0_ref2.c IS DISTINCT FROM share0_ref1.c
+         Hash Cond: (NOT (share0_ref2.c IS DISTINCT FROM share0_ref1.c))
          ->  HashAggregate
                Group Key: share0_ref2.c
                ->  HashAggregate
@@ -214,7 +214,7 @@ explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 gro
 --------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: NOT share0_ref2.d IS DISTINCT FROM share0_ref1.d
+         Hash Cond: (NOT (share0_ref2.d IS DISTINCT FROM share0_ref1.d))
          ->  HashAggregate
                Group Key: share0_ref2.d
                ->  HashAggregate
@@ -242,14 +242,14 @@ select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d;
 (1 row)
 
 explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d;
-                     QUERY PLAN                     
-----------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  HashAggregate
                Group Key: dqa_t1.d
                ->  Hash Join
-                     Hash Cond: dqa_t1.d = dqa_t2.d
+                     Hash Cond: (dqa_t1.d = dqa_t2.d)
                      ->  Seq Scan on dqa_t1
                      ->  Hash
                            ->  Seq Scan on dqa_t2
@@ -330,7 +330,7 @@ explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dq
                      ->  HashAggregate
                            Group Key: dqa_t2.dt, dqa_t1.d
                            ->  Hash Join
-                                 Hash Cond: dqa_t1.d = dqa_t2.d
+                                 Hash Cond: (dqa_t1.d = dqa_t2.d)
                                  ->  Seq Scan on dqa_t1
                                  ->  Hash
                                        ->  Seq Scan on dqa_t2
@@ -511,7 +511,7 @@ explain (costs off) select count(distinct c), count(distinct dt), i from dqa_t1 
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
-         Hash Cond: NOT share0_ref2.i IS DISTINCT FROM share0_ref1.i
+         Hash Cond: (NOT (share0_ref2.i IS DISTINCT FROM share0_ref1.i))
          ->  HashAggregate
                Group Key: share0_ref2.i
                ->  HashAggregate
@@ -569,7 +569,7 @@ explain (costs off) select count(distinct i), count(distinct c), d from dqa_t1 g
 -------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: NOT share0_ref2.d IS DISTINCT FROM share0_ref1.d
+         Hash Cond: (NOT (share0_ref2.d IS DISTINCT FROM share0_ref1.d))
          ->  HashAggregate
                Group Key: share0_ref2.d
                ->  HashAggregate
@@ -608,7 +608,7 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                      ->  HashAggregate
                            Group Key: dqa_t1.dt
                            ->  Hash Join
-                                 Hash Cond: dqa_t2.c = dqa_t1.c
+                                 Hash Cond: (dqa_t2.c = dqa_t1.c)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                        ->  Seq Scan on dqa_t2
                                  ->  Hash
@@ -690,7 +690,7 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                      ->  HashAggregate
                            Group Key: dqa_t2.dt, dqa_t1.dt
                            ->  Hash Join
-                                 Hash Cond: dqa_t1.c = dqa_t2.c
+                                 Hash Cond: (dqa_t1.c = dqa_t2.c)
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                        Hash Key: dqa_t1.c
                                        ->  Seq Scan on dqa_t1

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -156,7 +156,7 @@ explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 gro
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
-         Hash Cond: NOT share0_ref2.c IS DISTINCT FROM share0_ref1.c
+         Hash Cond: (NOT (share0_ref2.c IS DISTINCT FROM share0_ref1.c))
          ->  HashAggregate
                Group Key: share0_ref2.c
                ->  HashAggregate
@@ -214,7 +214,7 @@ explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 gro
 --------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: NOT share0_ref2.d IS DISTINCT FROM share0_ref1.d
+         Hash Cond: (NOT (share0_ref2.d IS DISTINCT FROM share0_ref1.d))
          ->  HashAggregate
                Group Key: share0_ref2.d
                ->  HashAggregate
@@ -247,7 +247,7 @@ explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dq
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Hash Join
-               Hash Cond: dqa_t1.d = dqa_t2.d
+               Hash Cond: (dqa_t1.d = dqa_t2.d)
                ->  Table Scan on dqa_t1
                ->  Hash
                      ->  Table Scan on dqa_t2
@@ -316,8 +316,8 @@ select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d gr
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d group by dqa_t2.dt;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Result
          ->  HashAggregate
@@ -330,7 +330,7 @@ explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dq
                                  ->  Sort
                                        Sort Key: dqa_t2.dt
                                        ->  Hash Join
-                                             Hash Cond: dqa_t2.d = dqa_t1.d
+                                             Hash Cond: (dqa_t2.d = dqa_t1.d)
                                              ->  Table Scan on dqa_t2
                                              ->  Hash
                                                    ->  Table Scan on dqa_t1
@@ -525,7 +525,7 @@ explain (costs off) select count(distinct c), count(distinct dt), i from dqa_t1 
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
-         Hash Cond: NOT share0_ref2.i IS DISTINCT FROM share0_ref1.i
+         Hash Cond: (NOT (share0_ref2.i IS DISTINCT FROM share0_ref1.i))
          ->  HashAggregate
                Group Key: share0_ref2.i
                ->  HashAggregate
@@ -583,7 +583,7 @@ explain (costs off) select count(distinct i), count(distinct c), d from dqa_t1 g
 -------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: NOT share0_ref2.d IS DISTINCT FROM share0_ref1.d
+         Hash Cond: (NOT (share0_ref2.d IS DISTINCT FROM share0_ref1.d))
          ->  HashAggregate
                Group Key: share0_ref2.d
                ->  HashAggregate
@@ -624,7 +624,7 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                            ->  HashAggregate
                                  Group Key: dqa_t1.dt
                                  ->  Hash Join
-                                       Hash Cond: dqa_t1.c = dqa_t2.c
+                                       Hash Cond: (dqa_t1.c = dqa_t2.c)
                                        ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                              Hash Key: dqa_t1.c
                                              ->  Table Scan on dqa_t1
@@ -713,7 +713,7 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: dqa_t1.dt
                                              ->  Hash Join
-                                                   Hash Cond: dqa_t1.c = dqa_t2.c
+                                                   Hash Cond: (dqa_t1.c = dqa_t2.c)
                                                    ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                                          Hash Key: dqa_t1.c
                                                          ->  Table Scan on dqa_t1

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -87,11 +87,11 @@ CREATE TABLE mpp22263 (
 create index mpp22263_idx1 on mpp22263 using btree(unique1);
 explain select * from mpp22263, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
 WHERE mpp22263.unique1 = v.i and mpp22263.stringu1 = v.j;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.06..278.70 rows=14 width=280)
    ->  Hash Join  (cost=0.06..278.70 rows=5 width=280)
-         Hash Cond: mpp22263.unique1 = "*VALUES*".column1 AND mpp22263.stringu1::text = "*VALUES*".column2
+         Hash Cond: ((mpp22263.unique1 = "*VALUES*".column1) AND ((mpp22263.stringu1)::text = "*VALUES*".column2))
          ->  Seq Scan on mpp22263  (cost=0.00..219.00 rows=3967 width=244)
          ->  Hash  (cost=0.03..0.03 rows=1 width=36)
                ->  Values Scan on "*VALUES*"  (cost=0.00..0.03 rows=1 width=36)
@@ -121,18 +121,18 @@ SELECT trim(et) et from
 get_explain_output($$ 
 	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b join foo on true join foo as foo2 on true $$) as et
 WHERE et like '%Join Filter:%' or et like '%Hash Cond:%';
-                          et                          
-------------------------------------------------------
- Hash Cond: "*VALUES*".column1 = "*VALUES*_1".column1
+                           et                           
+--------------------------------------------------------
+ Hash Cond: ("*VALUES*".column1 = "*VALUES*_1".column1)
 (1 row)
 
 SELECT trim(et) et from
 get_explain_output($$
 	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b$$) as et
 WHERE et like '%Hash Cond:%';
-                          et                          
-------------------------------------------------------
- Hash Cond: "*VALUES*".column1 = "*VALUES*_1".column1
+                           et                           
+--------------------------------------------------------
+ Hash Cond: ("*VALUES*".column1 = "*VALUES*_1".column1)
 (1 row)
 
 --

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -106,10 +106,10 @@ select * from mpp22263, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
 WHERE mpp22263.unique1 = v.i and mpp22263.stringu1 = v.j;
   $$) as et
 WHERE et like '%Filter: %';
-                           et                            
----------------------------------------------------------
+                             et                              
+-------------------------------------------------------------
          Join Filter: true
-               Filter: stringu1::text = "Values".column2
+               Filter: ((stringu1)::text = "Values".column2)
 (2 rows)
 
 --
@@ -122,20 +122,20 @@ SELECT trim(et) et from
 get_explain_output($$ 
 	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b join foo on true join foo as foo2 on true $$) as et
 WHERE et like '%Join Filter:%' or et like '%Hash Cond:%';
-                      et                      
-----------------------------------------------
+                       et                       
+------------------------------------------------
  Join Filter: true
  Join Filter: true
- Hash Cond: "outer".column1 = "outer".column1
+ Hash Cond: ("outer".column1 = "outer".column1)
 (3 rows)
 
 SELECT trim(et) et from
 get_explain_output($$
 	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b$$) as et
 WHERE et like '%Hash Cond:%';
-              et              
-------------------------------
- Hash Cond: column1 = column1
+               et               
+--------------------------------
+ Hash Cond: (column1 = column1)
 (1 row)
 
 --

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10537,7 +10537,7 @@ explain (costs off) select count(*), t2.c from input_tab1 t1 left join input_tab
                ->  HashAggregate
                      Group Key: t2.c
                      ->  Hash Right Join
-                           Hash Cond: t2.c = t1.a
+                           Hash Cond: (t2.c = t1.a)
                            ->  Seq Scan on input_tab2 t2
                            ->  Hash
                                  ->  Seq Scan on input_tab1 t1

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10587,8 +10587,8 @@ set optimizer_force_multistage_agg = off;
 set optimizer_force_three_stage_scalar_dqa = off;
 -- end_ignore
 explain (costs off) select count(*), t2.c from input_tab1 t1 left join input_tab2 t2 on t1.a = t2.c group by t2.c;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  GroupAggregate
          Group Key: input_tab2.c
@@ -10602,7 +10602,7 @@ explain (costs off) select count(*), t2.c from input_tab1 t1 left join input_tab
                                  ->  Sort
                                        Sort Key: input_tab2.c
                                        ->  Hash Left Join
-                                             Hash Cond: input_tab1.a = input_tab2.c
+                                             Hash Cond: (input_tab1.a = input_tab2.c)
                                              ->  Table Scan on input_tab1
                                              ->  Hash
                                                    ->  Table Scan on input_tab2

--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -1134,11 +1134,11 @@ set enable_seqscan=off;
 set enable_bitmapscan=off;
 explain (costs off)
 select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
-         Hash Cond: patest0.id = int4_tbl.f1
+         Hash Cond: (patest0.id = int4_tbl.f1)
          ->  Append
                ->  Index Scan using patest0i on patest0
                ->  Index Scan using patest1i on patest1
@@ -1150,7 +1150,7 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
                            ->  Gather Motion 3:1  (slice1; segments: 3)
                                  ->  Limit
                                        ->  Seq Scan on int4_tbl
-                                             Filter: f1 < 10 AND f1 > (-10)
+                                             Filter: ((f1 < 10) AND (f1 > (-10)))
  Optimizer: legacy query optimizer
 (16 rows)
 
@@ -1165,11 +1165,11 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
 drop index patest2i;
 explain (costs off)
 select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
-         Hash Cond: patest0.id = int4_tbl.f1
+         Hash Cond: (patest0.id = int4_tbl.f1)
          ->  Append
                ->  Index Scan using patest0i on patest0
                ->  Index Scan using patest1i on patest1
@@ -1181,7 +1181,7 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
                            ->  Gather Motion 3:1  (slice1; segments: 3)
                                  ->  Limit
                                        ->  Seq Scan on int4_tbl
-                                             Filter: f1 < 10 AND f1 > (-10)
+                                             Filter: ((f1 < 10) AND (f1 > (-10)))
  Optimizer: legacy query optimizer
 (16 rows)
 
@@ -1225,10 +1225,10 @@ explain (verbose, costs off) select * from matest0 order by 1-id;
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: matest0.id, matest0.name, ((1 - matest0.id))
-   Merge Key: (1 - matest0.id)
+   Merge Key: ((1 - matest0.id))
    ->  Sort
          Output: matest0.id, matest0.name, ((1 - matest0.id))
-         Sort Key: (1 - matest0.id)
+         Sort Key: ((1 - matest0.id))
          ->  Result
                Output: matest0.id, matest0.name, (1 - matest0.id)
                ->  Append
@@ -1266,16 +1266,16 @@ explain (verbose, costs off) select * from matest0 order by 1-id;
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: matest0.id, matest0.name, ((1 - matest0.id))
-   Merge Key: (1 - matest0.id)
+   Merge Key: ((1 - matest0.id))
    ->  Merge Append
-         Sort Key: (1 - matest0.id)
+         Sort Key: ((1 - matest0.id))
          ->  Index Scan using matest0i on public.matest0
                Output: matest0.id, matest0.name, (1 - matest0.id)
          ->  Index Scan using matest1i on public.matest1
                Output: matest1.id, matest1.name, (1 - matest1.id)
          ->  Sort
                Output: matest2.id, matest2.name, ((1 - matest2.id))
-               Sort Key: (1 - matest2.id)
+               Sort Key: ((1 - matest2.id))
                ->  Seq Scan on public.matest2
                      Output: matest2.id, matest2.name, (1 - matest2.id)
          ->  Index Scan using matest3i on public.matest3
@@ -1358,7 +1358,7 @@ ORDER BY thousand, tenthous;
          Sort Key: tenk1.thousand, tenk1.tenthous
          ->  Index Only Scan using tenk1_thous_tenthous on tenk1
          ->  Sort
-               Sort Key: tenk1_1.thousand, (random()::integer)
+               Sort Key: tenk1_1.thousand, ((random())::integer)
                ->  Index Only Scan using tenk1_thous_tenthous on tenk1 tenk1_1
  Optimizer: legacy query optimizer
 (9 rows)

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1138,7 +1138,7 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
 ----------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
-         Hash Cond: patest0.id = int4_tbl.f1
+         Hash Cond: (patest0.id = int4_tbl.f1)
          ->  Append
                ->  Index Scan using patest0i on patest0
                ->  Index Scan using patest1i on patest1
@@ -1150,7 +1150,7 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
                            ->  Gather Motion 3:1  (slice1; segments: 3)
                                  ->  Limit
                                        ->  Seq Scan on int4_tbl
-                                             Filter: f1 < 10 AND f1 > (-10)
+                                             Filter: ((f1 < 10) AND (f1 > (-10)))
  Optimizer: legacy query optimizer
 (16 rows)
 
@@ -1169,7 +1169,7 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
 ----------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
-         Hash Cond: patest0.id = int4_tbl.f1
+         Hash Cond: (patest0.id = int4_tbl.f1)
          ->  Append
                ->  Index Scan using patest0i on patest0
                ->  Index Scan using patest1i on patest1
@@ -1181,7 +1181,7 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
                            ->  Gather Motion 3:1  (slice1; segments: 3)
                                  ->  Limit
                                        ->  Seq Scan on int4_tbl
-                                             Filter: f1 < 10 AND f1 > (-10)
+                                             Filter: ((f1 < 10) AND (f1 > (-10)))
  Optimizer: legacy query optimizer
 (16 rows)
 
@@ -1225,10 +1225,10 @@ explain (verbose, costs off) select * from matest0 order by 1-id;
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: matest0.id, matest0.name, ((1 - matest0.id))
-   Merge Key: (1 - matest0.id)
+   Merge Key: ((1 - matest0.id))
    ->  Sort
          Output: matest0.id, matest0.name, ((1 - matest0.id))
-         Sort Key: (1 - matest0.id)
+         Sort Key: ((1 - matest0.id))
          ->  Result
                Output: matest0.id, matest0.name, (1 - matest0.id)
                ->  Append
@@ -1266,16 +1266,16 @@ explain (verbose, costs off) select * from matest0 order by 1-id;
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: matest0.id, matest0.name, ((1 - matest0.id))
-   Merge Key: (1 - matest0.id)
+   Merge Key: ((1 - matest0.id))
    ->  Merge Append
-         Sort Key: (1 - matest0.id)
+         Sort Key: ((1 - matest0.id))
          ->  Index Scan using matest0i on public.matest0
                Output: matest0.id, matest0.name, (1 - matest0.id)
          ->  Index Scan using matest1i on public.matest1
                Output: matest1.id, matest1.name, (1 - matest1.id)
          ->  Sort
                Output: matest2.id, matest2.name, ((1 - matest2.id))
-               Sort Key: (1 - matest2.id)
+               Sort Key: ((1 - matest2.id))
                ->  Seq Scan on public.matest2
                      Output: matest2.id, matest2.name, (1 - matest2.id)
          ->  Index Scan using matest3i on public.matest3

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -2544,16 +2544,16 @@ SELECT qq, unique1
   ( SELECT COALESCE(q2, -1) AS qq FROM int8_tbl b ) AS ss2
   USING (qq)
   INNER JOIN tenk1 c ON qq = unique2;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    ->  Hash Join
-         Hash Cond: c.unique2 = COALESCE((COALESCE(a.q1, 0::bigint)), (COALESCE(b.q2, (-1)::bigint)))
+         Hash Cond: (c.unique2 = COALESCE((COALESCE(a.q1, 0::bigint)), (COALESCE(b.q2, (-1)::bigint))))
          ->  Seq Scan on tenk1 c
          ->  Hash
                ->  Broadcast Motion 3:3  (slice3; segments: 3)
                      ->  Hash Full Join
-                           Hash Cond: COALESCE(a.q1, 0::bigint) = COALESCE(b.q2, (-1)::bigint)
+                           Hash Cond: (COALESCE(a.q1, 0::bigint) = COALESCE(b.q2, (-1)::bigint))
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                  Hash Key: COALESCE(a.q1, 0::bigint)
                                  ->  Seq Scan on int8_tbl a
@@ -2596,8 +2596,8 @@ order by 1,2;
    ->  Sort
          Sort Key: t1.q1, t1.q2
          ->  Hash Left Join
-               Hash Cond: t1.q2 = t2.q1
-               Filter: 1 = ((SubPlan 1))
+               Hash Cond: (t1.q2 = t2.q1)
+               Filter: (1 = (SubPlan 1))
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: t1.q2
                      ->  Seq Scan on int8_tbl t1
@@ -2607,7 +2607,7 @@ order by 1,2;
                  ->  Limit
                        ->  Limit
                              ->  Result
-                                   One-Time Filter: (42) IS NOT NULL
+                                   One-Time Filter: ((42) IS NOT NULL)
                                    ->  Result
                                          ->  Materialize
                                                ->  Broadcast Motion 3:3  (slice1; segments: 3)
@@ -2712,14 +2712,14 @@ select * from
   int4(sin(1)) q1,
   int4(sin(0)) q2
 where q1 = thousand or q2 = thousand;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
-         Join Filter: q1.q1 = tenk1.thousand OR q2.q2 = tenk1.thousand
+         Join Filter: ((q1.q1 = tenk1.thousand) OR (q2.q2 = tenk1.thousand))
          ->  Nested Loop
                ->  Hash Join
-                     Hash Cond: tenk1.twothousand = int4_tbl.f1
+                     Hash Cond: (tenk1.twothousand = int4_tbl.f1)
                      ->  Seq Scan on tenk1
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)
@@ -2741,9 +2741,9 @@ where thousand = (q1 + q2);
 ---------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
-         Hash Cond: tenk1.twothousand = int4_tbl.f1
+         Hash Cond: (tenk1.twothousand = int4_tbl.f1)
          ->  Hash Join
-               Hash Cond: tenk1.thousand = (q1.q1 + q2.q2)
+               Hash Cond: (tenk1.thousand = (q1.q1 + q2.q2))
                ->  Seq Scan on tenk1
                ->  Hash
                      ->  Nested Loop
@@ -2768,11 +2768,11 @@ where t1.unique1 = 1;
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    ->  Hash Right Join
-         Hash Cond: t2.hundred = t1.hundred AND t3.ten = t1.ten
+         Hash Cond: ((t2.hundred = t1.hundred) AND (t3.ten = t1.ten))
          ->  Redistribute Motion 3:3  (slice3; segments: 3)
                Hash Key: 1
                ->  Hash Join
-                     Hash Cond: t2.thousand = t3.unique2
+                     Hash Cond: (t2.thousand = t3.unique2)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Hash Key: t2.thousand
                            ->  Seq Scan on tenk1 t2
@@ -2782,7 +2782,7 @@ where t1.unique1 = 1;
                                  ->  Seq Scan on tenk1 t3
          ->  Hash
                ->  Index Scan using tenk1_unique1 on tenk1 t1
-                     Index Cond: unique1 = 1
+                     Index Cond: (unique1 = 1)
  Optimizer: legacy query optimizer
 (18 rows)
 
@@ -2795,12 +2795,12 @@ where t1.unique1 = 1;
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    ->  Hash Right Join
-         Hash Cond: t2.hundred = t1.hundred
-         Join Filter: (t1.ten + t2.ten) = t3.ten
+         Hash Cond: (t2.hundred = t1.hundred)
+         Join Filter: ((t1.ten + t2.ten) = t3.ten)
          ->  Redistribute Motion 3:3  (slice3; segments: 3)
                Hash Key: 1
                ->  Hash Join
-                     Hash Cond: t2.thousand = t3.unique2
+                     Hash Cond: (t2.thousand = t3.unique2)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Hash Key: t2.thousand
                            ->  Seq Scan on tenk1 t2
@@ -2810,7 +2810,7 @@ where t1.unique1 = 1;
                                  ->  Seq Scan on tenk1 t3
          ->  Hash
                ->  Index Scan using tenk1_unique1 on tenk1 t1
-                     Index Cond: unique1 = 1
+                     Index Cond: (unique1 = 1)
  Optimizer: legacy query optimizer
 (19 rows)
 
@@ -2825,8 +2825,8 @@ select count(*) from
    ->  Gather Motion 3:1  (slice5; segments: 3)
          ->  Aggregate
                ->  Hash Right Join
-                     Hash Cond: c.thousand = a.thousand
-                     Join Filter: a.unique2 = b.unique1
+                     Hash Cond: (c.thousand = a.thousand)
+                     Join Filter: (a.unique2 = b.unique1)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Hash Key: c.thousand
                            ->  Seq Scan on tenk1 c
@@ -2834,13 +2834,13 @@ select count(*) from
                            ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                  Hash Key: a.thousand
                                  ->  Hash Join
-                                       Hash Cond: a.unique1 = b.unique2
+                                       Hash Cond: (a.unique1 = b.unique2)
                                        ->  Seq Scan on tenk1 a
                                        ->  Hash
                                              ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                                    Hash Key: b.unique2
                                                    ->  Hash Join
-                                                         Hash Cond: b.thousand = int4_tbl.f1
+                                                         Hash Cond: (b.thousand = int4_tbl.f1)
                                                          ->  Seq Scan on tenk1 b
                                                          ->  Hash
                                                                ->  Broadcast Motion 3:3  (slice2; segments: 3)
@@ -2871,12 +2871,12 @@ select b.unique1 from
    ->  Sort
          Sort Key: b.unique1
          ->  Hash Right Join
-               Hash Cond: b.tenthous = i2.f1
+               Hash Cond: (b.tenthous = i2.f1)
                ->  Redistribute Motion 3:3  (slice5; segments: 3)
                      Hash Key: b.tenthous
                      ->  Hash Right Join
-                           Hash Cond: c.thousand = a.thousand
-                           Join Filter: b.unique1 = 42
+                           Hash Cond: (c.thousand = a.thousand)
+                           Join Filter: (b.unique1 = 42)
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                  Hash Key: c.thousand
                                  ->  Seq Scan on tenk1 c
@@ -2884,13 +2884,13 @@ select b.unique1 from
                                  ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                        Hash Key: a.thousand
                                        ->  Hash Join
-                                             Hash Cond: a.unique1 = b.unique2
+                                             Hash Cond: (a.unique1 = b.unique2)
                                              ->  Seq Scan on tenk1 a
                                              ->  Hash
                                                    ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                                          Hash Key: b.unique2
                                                          ->  Hash Join
-                                                               Hash Cond: b.thousand = i1.f1
+                                                               Hash Cond: (b.thousand = i1.f1)
                                                                ->  Seq Scan on tenk1 b
                                                                ->  Hash
                                                                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
@@ -2927,8 +2927,8 @@ order by fault;
 ---------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Right Join
-         Hash Cond: tenk1.unique2 = int8_tbl.q2
-         Filter: (COALESCE(tenk1.unique1, (-1)) + int8_tbl.q1) = 122
+         Hash Cond: (tenk1.unique2 = int8_tbl.q2)
+         Filter: ((COALESCE(tenk1.unique1, (-1)) + int8_tbl.q1) = 122)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: tenk1.unique2
                ->  Seq Scan on tenk1
@@ -2958,12 +2958,12 @@ explain (costs off)
 select q1, unique2, thousand, hundred
   from int8_tbl a left join tenk1 b on q1 = unique2
   where coalesce(thousand,123) = q1 and q1 = coalesce(hundred,123);
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Right Join
-         Hash Cond: b.unique2 = a.q1
-         Filter: COALESCE(b.thousand, 123) = a.q1 AND a.q1 = COALESCE(b.hundred, 123)
+         Hash Cond: (b.unique2 = a.q1)
+         Filter: ((COALESCE(b.thousand, 123) = a.q1) AND (a.q1 = COALESCE(b.hundred, 123)))
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: b.unique2
                ->  Seq Scan on tenk1 b
@@ -2983,12 +2983,12 @@ explain (costs off)
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
   where (case when unique2 is null then f1 else 0 end) = 0;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Right Join
-         Hash Cond: b.unique2 = a.f1
-         Filter: CASE WHEN b.unique2 IS NULL THEN a.f1 ELSE 0 END = 0
+         Hash Cond: (b.unique2 = a.f1)
+         Filter: (CASE WHEN (b.unique2 IS NULL) THEN a.f1 ELSE 0 END = 0)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: b.unique2
                ->  Seq Scan on tenk1 b
@@ -3014,14 +3014,14 @@ explain (costs off)
 -------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Right Join
-         Hash Cond: b.unique2 = a.f1
+         Hash Cond: (b.unique2 = a.f1)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: 0
                ->  Index Scan using tenk1_unique2 on tenk1 b
-                     Index Cond: unique2 = 0
+                     Index Cond: (unique2 = 0)
          ->  Hash
                ->  Seq Scan on int4_tbl a
-                     Filter: f1 = 0
+                     Filter: (f1 = 0)
  Optimizer: legacy query optimizer
 (11 rows)
 
@@ -3031,16 +3031,16 @@ explain (costs off)
 -------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Full Join
-         Hash Cond: a.unique2 = b.unique2
+         Hash Cond: (a.unique2 = b.unique2)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: a.unique2
                ->  Index Scan using tenk1_unique2 on tenk1 a
-                     Index Cond: unique2 = 42
+                     Index Cond: (unique2 = 42)
          ->  Hash
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: b.unique2
                      ->  Index Scan using tenk1_unique2 on tenk1 b
-                           Index Cond: unique2 = 42
+                           Index Cond: (unique2 = 42)
  Optimizer: legacy query optimizer
 (13 rows)
 
@@ -3090,7 +3090,7 @@ select id from a where id in (
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Semi Join
-         Hash Cond: a.id = b.id
+         Hash Cond: (a.id = b.id)
          ->  Seq Scan on a
          ->  Hash
                ->  Seq Scan on b
@@ -3139,7 +3139,7 @@ explain (costs off)
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Left Join
-         Hash Cond: p.k = c.k
+         Hash Cond: (p.k = c.k)
          ->  Seq Scan on parent p
          ->  Hash
                ->  Seq Scan on child c
@@ -3239,7 +3239,7 @@ explain (costs off)
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: a.unique1 = b.f1
+         Hash Cond: (a.unique1 = b.f1)
          ->  Seq Scan on tenk1 a
          ->  Hash
                ->  Seq Scan on int4_tbl b
@@ -3256,11 +3256,11 @@ from int4_tbl x, lateral (select unique2 from tenk1 where f1 = unique1) ss;
 explain (costs off)
   select unique2, x.*
   from int4_tbl x, lateral (select unique2 from tenk1 where f1 = unique1) ss;
-                QUERY PLAN                
-------------------------------------------
+                 QUERY PLAN                
+-------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: tenk1.unique1 = x.f1
+         Hash Cond: (tenk1.unique1 = x.f1)
          ->  Seq Scan on tenk1
          ->  Hash
                ->  Seq Scan on int4_tbl x
@@ -3270,11 +3270,11 @@ explain (costs off)
 explain (costs off)
   select unique2, x.*
   from int4_tbl x cross join lateral (select unique2 from tenk1 where f1 = unique1) ss;
-                QUERY PLAN                
-------------------------------------------
+                QUERY PLAN                 
+-------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: tenk1.unique1 = x.f1
+         Hash Cond: (tenk1.unique1 = x.f1)
          ->  Seq Scan on tenk1
          ->  Hash
                ->  Seq Scan on int4_tbl x
@@ -3296,10 +3296,10 @@ explain (costs off)
   select unique2, x.*
   from int4_tbl x left join lateral (select unique1, unique2 from tenk1 where f1 = unique1) ss on true;
                 QUERY PLAN                
-------------------------------------------
+-------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Right Join
-         Hash Cond: tenk1.unique1 = x.f1
+         Hash Cond: (tenk1.unique1 = x.f1)
          ->  Seq Scan on tenk1
          ->  Hash
                ->  Seq Scan on int4_tbl x
@@ -3391,9 +3391,9 @@ explain (costs off)
          ->  Materialize
                ->  Append
                      ->  Seq Scan on int8_tbl a
-                           Filter: g.g = q1
+                           Filter: (g.g = q1)
                      ->  Seq Scan on int8_tbl b
-                           Filter: g.g = q2
+                           Filter: (g.g = q2)
  Optimizer: legacy query optimizer
 (10 rows)
 
@@ -3417,7 +3417,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice3; segments: 3)
          ->  Aggregate
                ->  Hash Join
-                     Hash Cond: "*VALUES*".column1 = b.unique2
+                     Hash Cond: ("*VALUES*".column1 = b.unique2)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Hash Key: "*VALUES*".column1
                            ->  Nested Loop
@@ -3766,7 +3766,7 @@ select * from
          Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE(COALESCE(b.q2, 42::bigint), d.q2))
          ->  Hash Right Join
                Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE(COALESCE(b.q2, 42::bigint), d.q2))
-               Hash Cond: d.q1 = c.q2
+               Hash Cond: (d.q1 = c.q2)
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Output: a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE(COALESCE(b.q2, 42::bigint), d.q2))
                      Hash Key: d.q1
@@ -3774,7 +3774,7 @@ select * from
                            Output: a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE(COALESCE(b.q2, 42::bigint), d.q2))
                            ->  Hash Left Join
                                  Output: a.q1, a.q2, b.q1, (COALESCE(b.q2, 42::bigint))
-                                 Hash Cond: a.q2 = b.q1
+                                 Hash Cond: (a.q2 = b.q1)
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                        Output: a.q1, a.q2
                                        Hash Key: a.q2
@@ -3857,7 +3857,7 @@ explain select * from t5370 a , t5370_2 b where a.name=b.name;
 -------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=45.50..92.25 rows=1000 width=14)
    ->  Hash Join  (cost=45.50..92.25 rows=334 width=14)
-         Hash Cond: a.name = b.name
+         Hash Cond: (a.name = b.name)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..33.00 rows=334 width=7)
                Hash Key: a.name
                ->  Seq Scan on t5370 a  (cost=0.00..13.00 rows=334 width=7)

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -10,7 +10,7 @@ explain select * from nhtest a join nhtest b using (i);
 -----------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)  (cost=1.02..2.07 rows=2 width=11)
    ->  Hash Join  (cost=1.02..2.07 rows=2 width=11)
-         Hash Cond: a.i = b.i
+         Hash Cond: (a.i = b.i)
          ->  Seq Scan on nhtest a  (cost=0.00..1.01 rows=1 width=11)
          ->  Hash  (cost=1.01..1.01 rows=1 width=11)
                ->  Seq Scan on nhtest b  (cost=0.00..1.01 rows=1 width=11)
@@ -102,9 +102,9 @@ explain select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
                      ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..3.27 rows=1 width=4)
                            Hash Key: t1.x
                            ->  Seq Scan on t1  (cost=0.00..3.25 rows=1 width=4)
-                                 Filter: x = 100
+                                 Filter: (x = 100)
                      ->  Seq Scan on t2  (cost=0.00..3.25 rows=1 width=4)
-                           Filter: x = 100
+                           Filter: (x = 100)
  Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off
 (11 rows)
 
@@ -122,13 +122,13 @@ explain select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
 --------------------------------------------------------------------------------------------------
  Gather Motion 2:1  (slice2; segments: 2)  (cost=3.28..6.58 rows=2 width=24)
    ->  Nested Loop  (cost=3.28..6.58 rows=2 width=24)
-         Join Filter: t2.x >= t1.x
+         Join Filter: (t2.x >= t1.x)
          ->  Seq Scan on t1  (cost=0.00..3.25 rows=1 width=12)
-               Filter: x = 100
+               Filter: (x = 100)
          ->  Materialize  (cost=3.28..3.30 rows=1 width=12)
                ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..3.28 rows=1 width=12)
                      ->  Seq Scan on t2  (cost=0.00..3.25 rows=1 width=12)
-                           Filter: x >= 100
+                           Filter: (x >= 100)
  Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off
 (10 rows)
 
@@ -147,13 +147,13 @@ explain select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;
 --------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..9.14 rows=4 width=24)
    ->  Nested Loop  (cost=0.00..9.14 rows=2 width=24)
-         Join Filter: t1.x <= t2.x
+         Join Filter: (t1.x <= t2.x)
          ->  Seq Scan on t1  (cost=0.00..4.25 rows=1 width=12)
                Filter: x = 100
          ->  Materialize  (cost=0.00..4.85 rows=1 width=12)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4.79 rows=1 width=12)
                      ->  Seq Scan on t2  (cost=0.00..4.75 rows=1 width=12)
-                           Filter: 100 <= x AND y <= x AND y = 100
+                           Filter: ((100 <= x) AND (y <= x) AND (y = 100))
  Settings:  optimizer=off; optimizer_segments=2
  Optimizer status: legacy query optimizer
 (11 rows)
@@ -493,7 +493,7 @@ explain (costs off) select X.a from input_table X full join (select a from input
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Merge Full Join
-         Merge Cond: x.a::text = input_table.a::text
+         Merge Cond: ((x.a)::text = (input_table.a)::text)
          ->  Sort
                Sort Key: x.a
                ->  Redistribute Motion 3:3  (slice1; segments: 3)

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -499,8 +499,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 set enable_hashjoin = off;
 -- end_ignore
 explain (costs off) select X.a from input_table X full join (select a from input_table) Y ON X.a = Y.a;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice6; segments: 3)
    ->  Result
          ->  Sequence
@@ -515,17 +515,17 @@ explain (costs off) select X.a from input_table X full join (select a from input
                                        ->  Table Scan on input_table
                      ->  Append
                            ->  Hash Left Join
-                                 Hash Cond: share0_ref2.a::text = share1_ref2.a::text
+                                 Hash Cond: ((share0_ref2.a)::text = (share1_ref2.a)::text)
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                        Hash Key: share0_ref2.a
                                        ->  Shared Scan (share slice:id 1:0)
                                  ->  Hash
                                        ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                             Hash Key: share1_ref2.a::text
+                                             Hash Key: (share1_ref2.a)::text
                                              ->  Shared Scan (share slice:id 2:1)
                            ->  Result
                                  ->  Hash Anti Join
-                                       Hash Cond: share1_ref3.a::text = share0_ref3.a::text
+                                       Hash Cond: ((share1_ref3.a)::text = (share0_ref3.a)::text)
                                        ->  Shared Scan (share slice:id 6:1)
                                        ->  Hash
                                              ->  Broadcast Motion 3:3  (slice3; segments: 3)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2567,7 +2567,7 @@ SELECT qq, unique1
                                                                      ->  Table Scan on int8_tbl
                                              ->  Append
                                                    ->  Hash Left Join
-                                                         Hash Cond: share0_ref2.qq = share1_ref2.qq
+                                                         Hash Cond: (share0_ref2.qq = share1_ref2.qq)
                                                          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                                                Hash Key: share0_ref2.qq
                                                                ->  Shared Scan (share slice:id 1:0)
@@ -2577,14 +2577,14 @@ SELECT qq, unique1
                                                                      ->  Shared Scan (share slice:id 2:1)
                                                    ->  Result
                                                          ->  Hash Anti Join
-                                                               Hash Cond: share1_ref3.qq = share0_ref3.qq
+                                                               Hash Cond: (share1_ref3.qq = share0_ref3.qq)
                                                                ->  Shared Scan (share slice:id 6:1)
                                                                ->  Hash
                                                                      ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                                                            ->  Result
                                                                                  ->  Shared Scan (share slice:id 3:0)
                ->  Index Scan using tenk1_unique2 on tenk1
-                     Index Cond: unique2 = (COALESCE(share0_ref2.qq, share1_ref2.qq))
+                     Index Cond: (unique2 = (COALESCE(share0_ref2.qq, share1_ref2.qq)))
  Optimizer: PQO version 2.74.0
 (40 rows)
 
@@ -2622,7 +2622,7 @@ order by 1,2;
          ->  Result
                Filter: (SubPlan 1)
                ->  Hash Left Join
-                     Hash Cond: int8_tbl.q2 = int8_tbl_1.q1
+                     Hash Cond: (int8_tbl.q2 = int8_tbl_1.q1)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Hash Key: int8_tbl.q2
                            ->  Table Scan on int8_tbl
@@ -2632,11 +2632,11 @@ order by 1,2;
                SubPlan 1  (slice3; segments: 3)
                  ->  Result
                        ->  Result
-                             Filter: 1 = "outer".?column?
+                             Filter: (1 = "outer".?column?)
                              ->  Result
                                    ->  Limit
                                          ->  Result
-                                               Filter: NOT "outer".y IS NULL
+                                               Filter: (NOT ("outer".y IS NULL))
                                                ->  Materialize
                                                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                                            ->  Table Scan on int8_tbl int8_tbl_2
@@ -2740,13 +2740,13 @@ select * from
   int4(sin(1)) q1,
   int4(sin(0)) q2
 where q1 = thousand or q2 = thousand;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
-         Hash Cond: tenk1.twothousand = int4_tbl.f1
+         Hash Cond: (tenk1.twothousand = int4_tbl.f1)
          ->  Nested Loop
-               Join Filter: "inner".q1 = tenk1.thousand OR "outer".q2 = tenk1.thousand
+               Join Filter: (("inner".q1 = tenk1.thousand) OR ("outer".q2 = tenk1.thousand))
                ->  Table Scan on tenk1
                ->  Nested Loop
                      Join Filter: true
@@ -2766,11 +2766,11 @@ select * from
   int4(sin(1)) q1,
   int4(sin(0)) q2
 where thousand = (q1 + q2);
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
-         Hash Cond: tenk1.twothousand = int4_tbl.f1
+         Hash Cond: (tenk1.twothousand = int4_tbl.f1)
          ->  Nested Loop
                Join Filter: true
                ->  Nested Loop
@@ -2780,7 +2780,7 @@ where thousand = (q1 + q2);
                      ->  Result
                            ->  Result
                ->  Index Scan using tenk1_thous_tenthous on tenk1
-                     Index Cond: thousand = ("inner".q1 + "outer".q2)
+                     Index Cond: (thousand = ("inner".q1 + "outer".q2))
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Table Scan on int4_tbl
@@ -2795,20 +2795,20 @@ select * from tenk1 t1 left join
   (tenk1 t2 join tenk1 t3 on t2.thousand = t3.unique2)
   on t1.hundred = t2.hundred and t1.ten = t3.ten
 where t1.unique1 = 1;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Left Join
-         Hash Cond: tenk1.hundred = tenk1_1.hundred AND tenk1.ten = tenk1_2.ten
+         Hash Cond: ((tenk1.hundred = tenk1_1.hundred) AND (tenk1.ten = tenk1_2.ten))
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: tenk1.hundred, tenk1.ten
                ->  Index Scan using tenk1_unique1 on tenk1
-                     Index Cond: unique1 = 1
+                     Index Cond: (unique1 = 1)
          ->  Hash
                ->  Redistribute Motion 3:3  (slice4; segments: 3)
                      Hash Key: tenk1_1.hundred, tenk1_2.ten
                      ->  Hash Join
-                           Hash Cond: tenk1_1.thousand = tenk1_2.unique2
+                           Hash Cond: (tenk1_1.thousand = tenk1_2.unique2)
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: tenk1_1.thousand
                                  ->  Table Scan on tenk1 tenk1_1
@@ -2824,21 +2824,21 @@ select * from tenk1 t1 left join
   (tenk1 t2 join tenk1 t3 on t2.thousand = t3.unique2)
   on t1.hundred = t2.hundred and t1.ten + t2.ten = t3.ten
 where t1.unique1 = 1;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Left Join
-         Hash Cond: tenk1.hundred = tenk1_1.hundred
-         Join Filter: (tenk1.ten + tenk1_1.ten) = tenk1_2.ten
+         Hash Cond: (tenk1.hundred = tenk1_1.hundred)
+         Join Filter: ((tenk1.ten + tenk1_1.ten) = tenk1_2.ten)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: tenk1.hundred
                ->  Index Scan using tenk1_unique1 on tenk1
-                     Index Cond: unique1 = 1
+                     Index Cond: (unique1 = 1)
          ->  Hash
                ->  Redistribute Motion 3:3  (slice4; segments: 3)
                      Hash Key: tenk1_1.hundred
                      ->  Hash Join
-                           Hash Cond: tenk1_1.thousand = tenk1_2.unique2
+                           Hash Cond: (tenk1_1.thousand = tenk1_2.unique2)
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: tenk1_1.thousand
                                  ->  Table Scan on tenk1 tenk1_1
@@ -2860,14 +2860,14 @@ select count(*) from
    ->  Gather Motion 3:1  (slice5; segments: 3)
          ->  Aggregate
                ->  Hash Join
-                     Hash Cond: tenk1_1.thousand = int4_tbl.f1
+                     Hash Cond: (tenk1_1.thousand = int4_tbl.f1)
                      ->  Hash Left Join
-                           Hash Cond: tenk1.thousand = tenk1_2.thousand
-                           Join Filter: tenk1.unique2 = tenk1_1.unique1
+                           Hash Cond: (tenk1.thousand = tenk1_2.thousand)
+                           Join Filter: (tenk1.unique2 = tenk1_1.unique1)
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: tenk1.thousand
                                  ->  Hash Join
-                                       Hash Cond: tenk1.unique1 = tenk1_1.unique2
+                                       Hash Cond: (tenk1.unique1 = tenk1_1.unique2)
                                        ->  Table Scan on tenk1
                                        ->  Hash
                                              ->  Redistribute Motion 3:3  (slice1; segments: 3)
@@ -2906,20 +2906,20 @@ select b.unique1 from
    ->  Sort
          Sort Key: tenk1.unique1
          ->  Hash Left Join
-               Hash Cond: int4_tbl.f1 = tenk1.tenthous
+               Hash Cond: (int4_tbl.f1 = tenk1.tenthous)
                ->  Table Scan on int4_tbl
                ->  Hash
                      ->  Redistribute Motion 3:3  (slice5; segments: 3)
                            Hash Key: tenk1.tenthous
                            ->  Hash Join
-                                 Hash Cond: tenk1.thousand = int4_tbl_1.f1
+                                 Hash Cond: (tenk1.thousand = int4_tbl_1.f1)
                                  ->  Hash Left Join
-                                       Hash Cond: tenk1_1.thousand = tenk1_2.thousand
-                                       Join Filter: tenk1.unique1 = 42
+                                       Hash Cond: (tenk1_1.thousand = tenk1_2.thousand)
+                                       Join Filter: (tenk1.unique1 = 42)
                                        ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                              Hash Key: tenk1_1.thousand
                                              ->  Hash Join
-                                                   Hash Cond: tenk1.unique2 = tenk1_1.unique1
+                                                   Hash Cond: (tenk1.unique2 = tenk1_1.unique1)
                                                    ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                                          Hash Key: tenk1.unique2
                                                          ->  Table Scan on tenk1
@@ -2961,20 +2961,20 @@ order by fault;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
-   Merge Key: (COALESCE(tenk1.unique1, (-1)) + int8_tbl.q1)
+   Merge Key: ((COALESCE(tenk1.unique1, (-1)) + int8_tbl.q1))
    ->  Sort
-         Sort Key: (COALESCE(tenk1.unique1, (-1)) + int8_tbl.q1)
+         Sort Key: ((COALESCE(tenk1.unique1, (-1)) + int8_tbl.q1))
          ->  Result
-               Filter: (COALESCE(tenk1.unique1, (-1)) + int8_tbl.q1) = 122
+               Filter: (((COALESCE(tenk1.unique1, (-1)) + int8_tbl.q1)) = 122)
                ->  Result
                      ->  Hash Left Join
-                           Hash Cond: int8_tbl.q2 = tenk1.unique2::bigint
+                           Hash Cond: (int8_tbl.q2 = (tenk1.unique2)::bigint)
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                  Hash Key: int8_tbl.q2
                                  ->  Table Scan on int8_tbl
                            ->  Hash
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                       Hash Key: tenk1.unique2::bigint
+                                       Hash Key: (tenk1.unique2)::bigint
                                        ->  Table Scan on tenk1
  Optimizer: PQO version 2.74.0
 (17 rows)
@@ -2998,17 +2998,17 @@ explain (costs off)
 select q1, unique2, thousand, hundred
   from int8_tbl a left join tenk1 b on q1 = unique2
   where coalesce(thousand,123) = q1 and q1 = coalesce(hundred,123);
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Result
-         Filter: COALESCE(tenk1.thousand, 123) = int8_tbl.q1 AND int8_tbl.q1 = COALESCE(tenk1.hundred, 123)
+         Filter: ((COALESCE(tenk1.thousand, 123) = int8_tbl.q1) AND (int8_tbl.q1 = COALESCE(tenk1.hundred, 123)))
          ->  Hash Left Join
-               Hash Cond: int8_tbl.q1 = tenk1.unique2::bigint
+               Hash Cond: (int8_tbl.q1 = (tenk1.unique2)::bigint)
                ->  Table Scan on int8_tbl
                ->  Hash
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: tenk1.unique2::bigint
+                           Hash Key: (tenk1.unique2)::bigint
                            ->  Table Scan on tenk1
  Optimizer: PQO version 2.74.0
 (11 rows)
@@ -3024,14 +3024,14 @@ explain (costs off)
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
   where (case when unique2 is null then f1 else 0 end) = 0;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Result
          ->  Result
-               Filter: CASE WHEN tenk1.unique2 IS NULL THEN int4_tbl.f1 ELSE 0 END = 0
+               Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
                ->  Hash Left Join
-                     Hash Cond: int4_tbl.f1 = tenk1.unique2
+                     Hash Cond: (int4_tbl.f1 = tenk1.unique2)
                      ->  Table Scan on int4_tbl
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)
@@ -3056,14 +3056,14 @@ explain (costs off)
                         QUERY PLAN                         
 -----------------------------------------------------------
  Hash Left Join
-   Hash Cond: int4_tbl.f1 = tenk1.unique2
+   Hash Cond: (int4_tbl.f1 = tenk1.unique2)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Table Scan on int4_tbl
-               Filter: f1 = 0
+               Filter: (f1 = 0)
    ->  Hash
          ->  Gather Motion 3:1  (slice2; segments: 3)
                ->  Index Scan using tenk1_unique2 on tenk1
-                     Index Cond: unique2 = 0
+                     Index Cond: (unique2 = 0)
  Optimizer: PQO version 2.74.0
 (10 rows)
 
@@ -3074,7 +3074,7 @@ explain (costs off)
  Gather Motion 3:1  (slice4; segments: 3)
    ->  Result
          ->  Result
-               Filter: (COALESCE(share0_ref2.unique2, share1_ref2.unique2)) = 42
+               Filter: ((COALESCE(share0_ref2.unique2, share1_ref2.unique2)) = 42)
                ->  Result
                      ->  Sequence
                            ->  Shared Scan (share slice:id 4:0)
@@ -3086,7 +3086,7 @@ explain (costs off)
                                              ->  Table Scan on tenk1
                                  ->  Append
                                        ->  Hash Left Join
-                                             Hash Cond: share0_ref2.unique2 = share1_ref2.unique2
+                                             Hash Cond: (share0_ref2.unique2 = share1_ref2.unique2)
                                              ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                                    Hash Key: share0_ref2.unique2
                                                    ->  Shared Scan (share slice:id 1:0)
@@ -3096,7 +3096,7 @@ explain (costs off)
                                                          ->  Shared Scan (share slice:id 2:1)
                                        ->  Result
                                              ->  Hash Anti Join
-                                                   Hash Cond: share1_ref3.unique2 = share0_ref3.unique2
+                                                   Hash Cond: (share1_ref3.unique2 = share0_ref3.unique2)
                                                    ->  Shared Scan (share slice:id 4:1)
                                                    ->  Hash
                                                          ->  Broadcast Motion 3:3  (slice3; segments: 3)
@@ -3126,7 +3126,7 @@ explain (costs off) SELECT a.* FROM a LEFT JOIN b ON a.b_id = b.id;
                Hash Key: a.b_id
                ->  Table Scan on a
          ->  Index Scan using b_pkey on b
-               Index Cond: id = a.b_id
+               Index Cond: (id = a.b_id)
  Optimizer: PQO version 2.64.0
 (9 rows)
 
@@ -3140,7 +3140,7 @@ explain (costs off) SELECT b.* FROM b LEFT JOIN c ON b.c_id = c.id;
                Hash Key: b.c_id
                ->  Table Scan on b
          ->  Index Scan using c_pkey on c
-               Index Cond: id = b.c_id
+               Index Cond: (id = b.c_id)
  Optimizer: PQO version 2.64.0
 (9 rows)
 
@@ -3151,7 +3151,7 @@ explain (costs off)
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    ->  Hash Left Join
-         Hash Cond: a.b_id = b.id
+         Hash Cond: (a.b_id = b.id)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: a.b_id
                ->  Table Scan on a
@@ -3164,7 +3164,7 @@ explain (costs off)
                                  Hash Key: b.c_id
                                  ->  Table Scan on b
                            ->  Index Scan using c_pkey on c
-                                 Index Cond: id = b.c_id
+                                 Index Cond: (id = b.c_id)
  Optimizer: PQO version 2.64.0
 (17 rows)
 
@@ -3177,14 +3177,14 @@ select id from a where id in (
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Semi Join
-         Hash Cond: a.id = b.id
+         Hash Cond: (a.id = b.id)
          ->  Table Scan on a
          ->  Hash
                ->  Nested Loop Left Join
                      Join Filter: true
                      ->  Table Scan on b
                      ->  Index Scan using c_pkey on c
-                           Index Cond: id = b.id
+                           Index Cond: (id = b.id)
  Optimizer: PQO version 2.64.0
 (11 rows)
 
@@ -3211,7 +3211,7 @@ explain (costs off)
          Join Filter: true
          ->  Table Scan on parent
          ->  Index Scan using child_k_key on child
-               Index Cond: k = parent.k
+               Index Cond: (k = parent.k)
  Optimizer: PQO version 2.64.0
 (7 rows)
 
@@ -3234,7 +3234,7 @@ explain (costs off)
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Left Join
-         Hash Cond: parent.k = child.k
+         Hash Cond: (parent.k = child.k)
          ->  Table Scan on parent
          ->  Hash
                ->  Result
@@ -3337,7 +3337,7 @@ explain (costs off)
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: a.unique1 = b.f1
+         Hash Cond: (a.unique1 = b.f1)
          ->  Seq Scan on tenk1 a
          ->  Hash
                ->  Seq Scan on int4_tbl b
@@ -3354,11 +3354,11 @@ from int4_tbl x, lateral (select unique2 from tenk1 where f1 = unique1) ss;
 explain (costs off)
   select unique2, x.*
   from int4_tbl x, lateral (select unique2 from tenk1 where f1 = unique1) ss;
-                QUERY PLAN                
-------------------------------------------
+                QUERY PLAN                 
+-------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: tenk1.unique1 = x.f1
+         Hash Cond: (tenk1.unique1 = x.f1)
          ->  Seq Scan on tenk1
          ->  Hash
                ->  Seq Scan on int4_tbl x
@@ -3368,11 +3368,11 @@ explain (costs off)
 explain (costs off)
   select unique2, x.*
   from int4_tbl x cross join lateral (select unique2 from tenk1 where f1 = unique1) ss;
-                QUERY PLAN                
-------------------------------------------
+                QUERY PLAN                 
+-------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: tenk1.unique1 = x.f1
+         Hash Cond: (tenk1.unique1 = x.f1)
          ->  Seq Scan on tenk1
          ->  Hash
                ->  Seq Scan on int4_tbl x
@@ -3393,11 +3393,11 @@ from int4_tbl x left join lateral (select unique1, unique2 from tenk1 where f1 =
 explain (costs off)
   select unique2, x.*
   from int4_tbl x left join lateral (select unique1, unique2 from tenk1 where f1 = unique1) ss on true;
-                QUERY PLAN                
-------------------------------------------
+                QUERY PLAN                 
+-------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Right Join
-         Hash Cond: tenk1.unique1 = x.f1
+         Hash Cond: (tenk1.unique1 = x.f1)
          ->  Seq Scan on tenk1
          ->  Hash
                ->  Seq Scan on int4_tbl x
@@ -3489,9 +3489,9 @@ explain (costs off)
          ->  Materialize
                ->  Append
                      ->  Seq Scan on int8_tbl a
-                           Filter: g.g = q1
+                           Filter: (g.g = q1)
                      ->  Seq Scan on int8_tbl b
-                           Filter: g.g = q2
+                           Filter: (g.g = q2)
  Optimizer: legacy query optimizer
 (10 rows)
 
@@ -3515,7 +3515,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice3; segments: 3)
          ->  Aggregate
                ->  Hash Join
-                     Hash Cond: "*VALUES*".column1 = b.unique2
+                     Hash Cond: ("*VALUES*".column1 = b.unique2)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Hash Key: "*VALUES*".column1
                            ->  Nested Loop
@@ -3864,7 +3864,7 @@ select * from
          Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE(COALESCE(b.q2, 42::bigint), d.q2))
          ->  Hash Right Join
                Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE(COALESCE(b.q2, 42::bigint), d.q2))
-               Hash Cond: d.q1 = c.q2
+               Hash Cond: (d.q1 = c.q2)
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Output: a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE(COALESCE(b.q2, 42::bigint), d.q2))
                      Hash Key: d.q1
@@ -3872,7 +3872,7 @@ select * from
                            Output: a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE(COALESCE(b.q2, 42::bigint), d.q2))
                            ->  Hash Left Join
                                  Output: a.q1, a.q2, b.q1, (COALESCE(b.q2, 42::bigint))
-                                 Hash Cond: a.q2 = b.q1
+                                 Hash Cond: (a.q2 = b.q1)
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                        Output: a.q1, a.q2
                                        Hash Key: a.q2

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -170,13 +170,13 @@ select A.i, B.i, C.j from A, B, C where A.j in (select C.j from C where C.j = A.
 -- Test for sublink pull-up based on both left-hand and right-hand input
 explain (costs off)
 select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
-                 QUERY PLAN                 
---------------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Semi Join
-         Hash Cond: c.i = b.i AND a.i = b.i
+         Hash Cond: ((c.i = b.i) AND (a.i = b.i))
          ->  Hash Semi Join
-               Hash Cond: a.i = c.i
+               Hash Cond: (a.i = c.i)
                ->  Seq Scan on a
                ->  Hash
                      ->  Seq Scan on c
@@ -544,7 +544,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                                              Filter: j = ((SubPlan 1))
                                              SubPlan 1  (slice3; segments: 3)
                                                ->  Hash Semi Join  (cost=3.14..6.31 rows=2 width=4)
-                                                     Hash Cond: c_1.i = b_1.i
+                                                     Hash Cond: (c_1.i = b_1.i)
                                                      ->  Result  (cost=0.00..3.14 rows=1 width=8)
                                                            Filter: c_1.j = a.j
                                                            ->  Materialize  (cost=0.00..3.14 rows=1 width=8)
@@ -602,7 +602,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C wh
                            One-Time Filter: NOT $0
                            ->  Nested Loop  (cost=20000000003.79..20000000023.11 rows=90 width=12)
                                  ->  Hash Semi Join  (cost=10000000003.79..10000000010.77 rows=10 width=8)
-                                       Hash Cond: qp_correlated_query.a.j = qp_correlated_query.c.j
+                                       Hash Cond: (qp_correlated_query.a.j = qp_correlated_query.c.j)
                                        ->  Nested Loop  (cost=10000000000.00..10000000006.40 rows=10 width=12)
                                              ->  Seq Scan on a  (cost=0.00..2.05 rows=2 width=8)
                                              ->  Materialize  (cost=0.00..3.39 rows=6 width=4)
@@ -727,7 +727,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                            ->  Nested Loop  (cost=10000000017.35..10000000023.97 rows=10 width=8)
                                  ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=17.35..19.77 rows=5 width=4)
                                        ->  Hash Join  (cost=17.35..19.57 rows=2 width=4)
-                                             Hash Cond: a.j = "Expr_SUBQUERY".csq_c1
+                                             Hash Cond: (a.j = "Expr_SUBQUERY".csq_c1)
                                              ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.15 rows=2 width=8)
                                                    Hash Key: a.j
                                                    ->  Seq Scan on a  (cost=0.00..2.05 rows=2 width=8)
@@ -1193,7 +1193,7 @@ explain select C.j from C where not exists (select rank() over (order by B.i) fr
    ->  Sort  (cost=6.33..6.33 rows=2 width=4)
          Sort Key: c.j
          ->  Hash Anti Join  (cost=3.14..6.30 rows=2 width=4)
-               Hash Cond: c.i = b.i
+               Hash Cond: (c.i = b.i)
                ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=8)
                ->  Hash  (cost=3.06..3.06 rows=2 width=4)
                      ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
@@ -1214,7 +1214,7 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
 ----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=3.20..6.31 rows=4 width=8)
    ->  Hash Anti Join  (cost=3.20..6.31 rows=2 width=8)
-         Hash Cond: a.i = c.i
+         Hash Cond: (a.i = c.i)
          ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
          ->  Hash  (cost=3.09..3.09 rows=3 width=4)
                ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
@@ -1232,11 +1232,11 @@ explain select A.i from A where not exists (select B.i from B where B.i in (sele
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=6.44..9.55 rows=4 width=4)
    ->  Hash Anti Join  (cost=6.44..9.55 rows=2 width=4)
-         Hash Cond: a.i = b.i
+         Hash Cond: (a.i = b.i)
          ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=4)
          ->  Hash  (cost=6.36..6.36 rows=3 width=4)
                ->  Hash Semi Join  (cost=3.20..6.36 rows=3 width=4)
-                     Hash Cond: b.i = c.i
+                     Hash Cond: (b.i = c.i)
                      ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
                      ->  Hash  (cost=3.09..3.09 rows=3 width=4)
                            ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
@@ -1257,21 +1257,21 @@ explain select * from B where not exists (select * from C,A where C.i in (select
 -------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=8.62..11.74 rows=4 width=8)
    ->  Hash Anti Join  (cost=8.62..11.74 rows=2 width=8)
-         Hash Cond: b.i = c.i
+         Hash Cond: (b.i = c.i)
          ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=8)
          ->  Hash  (cost=8.57..8.57 rows=2 width=4)
                ->  Hash Semi Join  (cost=5.33..8.57 rows=2 width=4)
-                     Hash Cond: a.i = c_1.i
+                     Hash Cond: (a.i = c_1.i)
                      ->  Hash Join  (cost=2.11..5.30 rows=2 width=8)
-                           Hash Cond: c.i = a.i
+                           Hash Cond: (c.i = a.i)
                            ->  Seq Scan on c  (cost=0.00..3.11 rows=3 width=4)
-                                 Filter: i <> 10
+                                 Filter: (i <> 10)
                            ->  Hash  (cost=2.06..2.06 rows=2 width=4)
                                  ->  Seq Scan on a  (cost=0.00..2.06 rows=2 width=4)
-                                       Filter: i <> 10
+                                       Filter: (i <> 10)
                      ->  Hash  (cost=3.11..3.11 rows=3 width=4)
                            ->  Seq Scan on c c_1  (cost=0.00..3.11 rows=3 width=4)
-                                 Filter: i <> 10
+                                 Filter: (i <> 10)
  Optimizer: legacy query optimizer
 (18 rows)
 
@@ -1289,7 +1289,7 @@ explain select * from A where A.i in (select C.j from C,B where B.i in (select i
 -------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000013.48..10000000015.62 rows=6 width=8)
    ->  Hash Semi Join  (cost=10000000013.48..10000000015.62 rows=2 width=8)
-         Hash Cond: a.i = c.j
+         Hash Cond: (a.i = c.j)
          ->  Seq Scan on a  (cost=0.00..2.05 rows=2 width=8)
          ->  Hash  (cost=10000000012.81..10000000012.81 rows=18 width=4)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000003.20..10000000012.81 rows=18 width=4)
@@ -1297,7 +1297,7 @@ explain select * from A where A.i in (select C.j from C,B where B.i in (select i
                      ->  Nested Loop  (cost=10000000003.20..10000000011.73 rows=18 width=4)
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=3.20..6.59 rows=6 width=0)
                                  ->  Hash Semi Join  (cost=3.20..6.35 rows=2 width=0)
-                                       Hash Cond: b.i = c_1.i
+                                       Hash Cond: (b.i = c_1.i)
                                        ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
                                        ->  Hash  (cost=3.09..3.09 rows=3 width=4)
                                              ->  Seq Scan on c c_1  (cost=0.00..3.09 rows=3 width=4)
@@ -1318,11 +1318,11 @@ explain select * from A where not exists (select sum(c.i) from C where C.i = A.i
 ----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=3.18..6.29 rows=4 width=8)
    ->  Hash Anti Join  (cost=3.18..6.29 rows=2 width=8)
-         Hash Cond: a.i = c.i
+         Hash Cond: (a.i = c.i)
          ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
          ->  Hash  (cost=3.11..3.11 rows=2 width=4)
                ->  Seq Scan on c  (cost=0.00..3.11 rows=2 width=4)
-                     Filter: i > 3
+                     Filter: (i > 3)
  Optimizer: legacy query optimizer
 (8 rows)
 
@@ -3591,9 +3591,9 @@ EXPLAIN SELECT a FROM qp_tab1 f1 LEFT JOIN qp_tab2 on a=c WHERE NOT EXISTS(SELEC
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.04..3.14 rows=4 width=4)
    ->  Hash Anti Join  (cost=2.04..3.14 rows=2 width=4)
-         Hash Cond: f1.a = f2.a
+         Hash Cond: (f1.a = f2.a)
          ->  Hash Left Join  (cost=1.02..2.07 rows=2 width=4)
-               Hash Cond: f1.a = qp_tab2.c
+               Hash Cond: (f1.a = qp_tab2.c)
                ->  Seq Scan on qp_tab1 f1  (cost=0.00..1.01 rows=1 width=4)
                ->  Hash  (cost=1.01..1.01 rows=1 width=4)
                      ->  Seq Scan on qp_tab2  (cost=0.00..1.01 rows=1 width=4)
@@ -3611,7 +3611,7 @@ EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE
          InitPlan 1 (returns $0)  (slice3)
            ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..2.07 rows=4 width=0)
                  ->  Hash Semi Join  (cost=1.02..2.07 rows=2 width=0)
-                       Hash Cond: qp_tab2.c = qp_tab3.e
+                       Hash Cond: (qp_tab2.c = qp_tab3.e)
                        ->  Seq Scan on qp_tab2  (cost=0.00..1.01 rows=1 width=4)
                        ->  Hash  (cost=1.01..1.01 rows=1 width=4)
                              ->  Seq Scan on qp_tab3  (cost=0.00..1.01 rows=1 width=4)

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -174,7 +174,7 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
 -----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: a.i = c.i
+         Hash Cond: (a.i = c.i)
          ->  Table Scan on a
          ->  Hash
                ->  GroupAggregate
@@ -182,7 +182,7 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
                      ->  Sort
                            Sort Key: c.i
                            ->  Hash Join
-                                 Hash Cond: c.i = b.i
+                                 Hash Cond: (c.i = b.i)
                                  ->  Table Scan on c
                                  ->  Hash
                                        ->  Table Scan on b

--- a/src/test/regress/expected/regex.out
+++ b/src/test/regress/expected/regex.out
@@ -95,62 +95,62 @@ explain (costs off) select * from pg_proc where proname ~ 'abc';
             QUERY PLAN             
 -----------------------------------
  Seq Scan on pg_proc
-   Filter: proname ~ 'abc'::text
+   Filter: (proname ~ 'abc'::text)
 (2 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^abc';
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
-   Index Cond: proname >= 'abc'::name AND proname < 'abd'::name
-   Filter: proname ~ '^abc'::text
+   Index Cond: ((proname >= 'abc'::name) AND (proname < 'abd'::name))
+   Filter: (proname ~ '^abc'::text)
 (3 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^abc$';
                          QUERY PLAN                         
 ------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
-   Index Cond: proname = 'abc'::name
-   Filter: proname ~ '^abc$'::text
+   Index Cond: (proname = 'abc'::name)
+   Filter: (proname ~ '^abc$'::text)
 (3 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^abcd*e';
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
-   Index Cond: proname >= 'abc'::name AND proname < 'abd'::name
-   Filter: proname ~ '^abcd*e'::text
+   Index Cond: ((proname >= 'abc'::name) AND (proname < 'abd'::name))
+   Filter: (proname ~ '^abcd*e'::text)
 (3 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^abc+d';
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
-   Index Cond: proname >= 'abc'::name AND proname < 'abd'::name
-   Filter: proname ~ '^abc+d'::text
+   Index Cond: ((proname >= 'abc'::name) AND (proname < 'abd'::name))
+   Filter: (proname ~ '^abc+d'::text)
 (3 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^(abc)(def)';
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
-   Index Cond: proname >= 'abcdef'::name AND proname < 'abcdeg'::name
-   Filter: proname ~ '^(abc)(def)'::text
+   Index Cond: ((proname >= 'abcdef'::name) AND (proname < 'abcdeg'::name))
+   Filter: (proname ~ '^(abc)(def)'::text)
 (3 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^(abc)$';
                          QUERY PLAN                         
 ------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
-   Index Cond: proname = 'abc'::name
-   Filter: proname ~ '^(abc)$'::text
+   Index Cond: (proname = 'abc'::name)
+   Filter: (proname ~ '^(abc)$'::text)
 (3 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^(abc)?d';
                QUERY PLAN               
 ----------------------------------------
  Seq Scan on pg_proc
-   Filter: proname ~ '^(abc)?d'::text
+   Filter: (proname ~ '^(abc)?d'::text)
 (2 rows)
 
 -- Test for infinite loop in pullback() (CVE-2007-4772)

--- a/src/test/regress/expected/rowtypes.out
+++ b/src/test/regress/expected/rowtypes.out
@@ -291,11 +291,11 @@ ERROR:  cannot compare dissimilar column types bigint and integer at record colu
 explain (costs off)
 select * from int8_tbl i8
 where i8 in (row(123,456)::int8_tbl, '(4567890123456789,123)');
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on int8_tbl i8
-         Filter: i8.* = ANY (ARRAY[ROW(123::bigint, 456::bigint)::int8_tbl, '(4567890123456789,123)'::int8_tbl])
+         Filter: (i8.* = ANY (ARRAY[ROW(123::bigint, 456::bigint)::int8_tbl, '(4567890123456789,123)'::int8_tbl]))
  Optimizer: legacy query optimizer
 (4 rows)
 

--- a/src/test/regress/expected/select_views_1.out
+++ b/src/test/regress/expected/select_views_1.out
@@ -1335,11 +1335,11 @@ NOTICE:  f_leak => hamburger  (seg0 slice1 127.0.0.1:25432 pid=890)
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_property_normal WHERE f_leak(passwd);
-                           QUERY PLAN                            
------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on customer
-         Filter: f_leak(passwd) AND name = 'regress_alice'::text
+         Filter: (f_leak(passwd) AND (name = 'regress_alice'::text))
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -1351,13 +1351,13 @@ NOTICE:  f_leak => passwd123
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_property_secure WHERE f_leak(passwd);
-                     QUERY PLAN                     
-----------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Subquery Scan on my_property_secure
          Filter: f_leak(my_property_secure.passwd)
          ->  Seq Scan on customer
-               Filter: name = 'regress_alice'::text
+               Filter: (name = 'regress_alice'::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1376,16 +1376,16 @@ NOTICE:  f_leak => 9801-2345-6789-0123  (seg0 slice1 127.0.0.1:25432 pid=12344)
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_normal WHERE f_leak(cnum);
-                        QUERY PLAN                        
-----------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: r.cid = l.cid AND r.dist_key = l.dist_key
+         Hash Cond: ((r.cid = l.cid) AND (r.dist_key = l.dist_key))
          ->  Seq Scan on credit_card r
                Filter: f_leak(cnum)
          ->  Hash
                ->  Seq Scan on customer l
-                     Filter: name = 'regress_alice'::text
+                     Filter: (name = 'regress_alice'::text)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1397,17 +1397,17 @@ NOTICE:  f_leak => 1111-2222-3333-4444
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_secure WHERE f_leak(cnum);
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Subquery Scan on my_credit_card_secure
          Filter: f_leak(my_credit_card_secure.cnum)
          ->  Hash Join
-               Hash Cond: r.cid = l.cid AND r.dist_key = l.dist_key
+               Hash Cond: ((r.cid = l.cid) AND (r.dist_key = l.dist_key))
                ->  Seq Scan on credit_card r
                ->  Hash
                      ->  Seq Scan on customer l
-                           Filter: name = 'regress_alice'::text
+                           Filter: (name = 'regress_alice'::text)
  Optimizer: legacy query optimizer
 (10 rows)
 
@@ -1428,23 +1428,23 @@ NOTICE:  f_leak => 1111-2222-3333-4444
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_usage_normal
        WHERE f_leak(cnum) AND ymd >= '2011-10-01' AND ymd < '2011-11-01';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
-         Hash Cond: r.cid = l.cid
+         Hash Cond: (r.cid = l.cid)
          ->  Seq Scan on credit_usage r
-               Filter: ymd >= '10-01-2011'::date AND ymd < '11-01-2011'::date
+               Filter: ((ymd >= '10-01-2011'::date) AND (ymd < '11-01-2011'::date))
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Subquery Scan on l
                            Filter: f_leak(l.cnum)
                            ->  Hash Join
-                                 Hash Cond: r_1.cid = l_1.cid AND r_1.dist_key = l_1.dist_key
+                                 Hash Cond: ((r_1.cid = l_1.cid) AND (r_1.dist_key = l_1.dist_key))
                                  ->  Seq Scan on credit_card r_1
                                  ->  Hash
                                        ->  Seq Scan on customer l_1
-                                             Filter: name = 'regress_alice'::text
+                                             Filter: (name = 'regress_alice'::text)
  Optimizer: legacy query optimizer
 (16 rows)
 
@@ -1462,23 +1462,23 @@ NOTICE:  f_leak => 1111-2222-3333-4444  (seg0 slice1 127.0.0.1:25434 pid=892)
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_usage_secure
        WHERE f_leak(cnum) AND ymd >= '2011-10-01' AND ymd < '2011-11-01';
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Subquery Scan on my_credit_card_usage_secure
          Filter: f_leak(my_credit_card_usage_secure.cnum)
          ->  Hash Join
-               Hash Cond: r.cid = l.cid
+               Hash Cond: (r.cid = l.cid)
                ->  Seq Scan on credit_usage r
-                     Filter: ymd >= '10-01-2011'::date AND ymd < '11-01-2011'::date
+                     Filter: ((ymd >= '10-01-2011'::date) AND (ymd < '11-01-2011'::date))
                ->  Hash
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)
                            ->  Hash Join
-                                 Hash Cond: r_1.cid = l.cid AND r_1.dist_key = l.dist_key
+                                 Hash Cond: ((r_1.cid = l.cid) AND (r_1.dist_key = l.dist_key))
                                  ->  Seq Scan on credit_card r_1
                                  ->  Hash
                                        ->  Seq Scan on customer l
-                                             Filter: name = 'regress_alice'::text
+                                             Filter: (name = 'regress_alice'::text)
  Optimizer: legacy query optimizer
 (16 rows)
 

--- a/src/test/regress/expected/select_views_optimizer_1.out
+++ b/src/test/regress/expected/select_views_optimizer_1.out
@@ -1341,11 +1341,11 @@ NOTICE:  f_leak => passwd123  (seg0 slice1 10.64.4.155:25432 pid=8483)
 -- cost of the function, do we want to do that?
 -- end_ignore
 EXPLAIN (COSTS OFF) SELECT * FROM my_property_normal WHERE f_leak(passwd);
-                           QUERY PLAN                            
------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Table Scan on customer
-         Filter: name = 'regress_alice'::text AND f_leak(passwd)
+         Filter: ((name = 'regress_alice'::text) AND f_leak(passwd))
  Optimizer: PQO version 2.59.1
 (4 rows)
 
@@ -1357,13 +1357,13 @@ NOTICE:  f_leak => passwd123
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_property_secure WHERE f_leak(passwd);
-                     QUERY PLAN                     
-----------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Subquery Scan on my_property_secure
          Filter: f_leak(my_property_secure.passwd)
          ->  Seq Scan on customer
-               Filter: name = 'regress_alice'::text
+               Filter: (name = 'regress_alice'::text)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1382,16 +1382,16 @@ NOTICE:  f_leak => 9801-2345-6789-0123  (seg0 slice1 127.0.0.1:25432 pid=12344)
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_normal WHERE f_leak(cnum);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
          ->  Table Scan on credit_card
                Filter: f_leak(cnum)
          ->  Index Scan using customer_dist_key_cid_key on customer
-               Index Cond: dist_key = credit_card.dist_key AND cid = credit_card.cid
-               Filter: name = 'regress_alice'::text
+               Index Cond: ((dist_key = credit_card.dist_key) AND (cid = credit_card.cid))
+               Filter: (name = 'regress_alice'::text)
  Optimizer: PQO version 2.67.0
 (9 rows)
 
@@ -1403,17 +1403,17 @@ NOTICE:  f_leak => 1111-2222-3333-4444
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_secure WHERE f_leak(cnum);
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Subquery Scan on my_credit_card_secure
          Filter: f_leak(my_credit_card_secure.cnum)
          ->  Hash Join
-               Hash Cond: r.cid = l.cid AND r.dist_key = l.dist_key
+               Hash Cond: ((r.cid = l.cid) AND (r.dist_key = l.dist_key))
                ->  Seq Scan on credit_card r
                ->  Hash
                      ->  Seq Scan on customer l
-                           Filter: name = 'regress_alice'::text
+                           Filter: (name = 'regress_alice'::text)
  Optimizer: legacy query optimizer
 (10 rows)
 
@@ -1434,23 +1434,23 @@ NOTICE:  f_leak => 1111-2222-3333-4444
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_usage_normal
        WHERE f_leak(cnum) AND ymd >= '2011-10-01' AND ymd < '2011-11-01';
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
-         Hash Cond: r.cid = l.cid
+         Hash Cond: (r.cid = l.cid)
          ->  Seq Scan on credit_usage r
-               Filter: ymd >= '10-01-2011'::date AND ymd < '11-01-2011'::date
+               Filter: ((ymd >= '10-01-2011'::date) AND (ymd < '11-01-2011'::date))
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Subquery Scan on l
                            Filter: f_leak(l.cnum)
                            ->  Hash Join
-                                 Hash Cond: r_1.cid = l_1.cid AND r_1.dist_key = l_1.dist_key
+                                 Hash Cond: ((r_1.cid = l_1.cid) AND (r_1.dist_key = l_1.dist_key))
                                  ->  Seq Scan on credit_card r_1
                                  ->  Hash
                                        ->  Seq Scan on customer l_1
-                                             Filter: name = 'regress_alice'::text
+                                             Filter: (name = 'regress_alice'::text)
  Optimizer: legacy query optimizer
 (16 rows)
 
@@ -1468,23 +1468,23 @@ NOTICE:  f_leak => 1111-2222-3333-4444  (seg0 slice1 127.0.0.1:25434 pid=892)
 
 EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_usage_secure
        WHERE f_leak(cnum) AND ymd >= '2011-10-01' AND ymd < '2011-11-01';
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Subquery Scan on my_credit_card_usage_secure
          Filter: f_leak(my_credit_card_usage_secure.cnum)
          ->  Hash Join
-               Hash Cond: r.cid = l.cid
+               Hash Cond: (r.cid = l.cid)
                ->  Seq Scan on credit_usage r
-                     Filter: ymd >= '10-01-2011'::date AND ymd < '11-01-2011'::date
+                     Filter: ((ymd >= '10-01-2011'::date) AND (ymd < '11-01-2011'::date))
                ->  Hash
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)
                            ->  Hash Join
-                                 Hash Cond: r_1.cid = l.cid AND r_1.dist_key = l.dist_key
+                                 Hash Cond: ((r_1.cid = l.cid) AND (r_1.dist_key = l.dist_key))
                                  ->  Seq Scan on credit_card r_1
                                  ->  Hash
                                        ->  Seq Scan on customer l
-                                             Filter: name = 'regress_alice'::text
+                                             Filter: (name = 'regress_alice'::text)
  Optimizer: legacy query optimizer
 (16 rows)
 

--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -38,19 +38,19 @@ and usename='xxx' and datname='xxx';
                      QUERY PLAN                      
 -----------------------------------------------------
  Hash Join
-   Hash Cond: s.usesysid = u.oid
+   Hash Cond: (s.usesysid = u.oid)
    InitPlan 1 (returns $0)
      ->  Result
    ->  Hash Join
-         Hash Cond: s.datid = d.oid
+         Hash Cond: (s.datid = d.oid)
          ->  Function Scan on pg_stat_get_activity s
-               Filter: query = $0
+               Filter: (query = $0)
          ->  Hash
                ->  Seq Scan on pg_database d
-                     Filter: datname = 'xxx'::name
+                     Filter: (datname = 'xxx'::name)
    ->  Hash
          ->  Seq Scan on pg_authid u
-               Filter: rolname = 'xxx'::name
+               Filter: (rolname = 'xxx'::name)
  Optimizer: legacy query optimizer
 (15 rows)
 

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -474,14 +474,14 @@ explain (costs off)
   UNION ALL
   SELECT * FROM t2) t
  WHERE ab = 'ab';
-                   QUERY PLAN                    
--------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
          ->  Index Scan using t1_ab_idx on t1
-               Index Cond: (a || b) = 'ab'::text
+               Index Cond: ((a || b) = 'ab'::text)
          ->  Index Only Scan using t2_pkey on t2
-               Index Cond: ab = 'ab'::text
+               Index Cond: (ab = 'ab'::text)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -491,22 +491,22 @@ explain (costs off)
   UNION
   SELECT * FROM t2) t
  WHERE ab = 'ab';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Unique
-         Group Key: (t1.a || t1.b)
+         Group Key: ((t1.a || t1.b))
          ->  Sort
-               Sort Key (Distinct): (t1.a || t1.b)
+               Sort Key (Distinct): ((t1.a || t1.b))
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: (t1.a || t1.b)
+                     Hash Key: ((t1.a || t1.b))
                      ->  Append
                            ->  Index Scan using t1_ab_idx on t1
-                                 Index Cond: (a || b) = 'ab'::text
+                                 Index Cond: ((a || b) = 'ab'::text)
                            ->  Index Only Scan using t2_pkey on t2
-                                 Index Cond: ab = 'ab'::text
+                                 Index Cond: (ab = 'ab'::text)
  Optimizer: legacy query optimizer
-(14 rows)
+(13 rows)
 
 reset enable_seqscan;
 reset enable_indexscan;
@@ -568,7 +568,7 @@ ORDER BY x;
  Sort
    Sort Key: ss.x
    ->  Subquery Scan on ss
-         Filter: ss.x < 4
+         Filter: (ss.x < 4)
          ->  HashAggregate
                Group Key: "outer".t, (generate_series(1, 10))
                ->  Append
@@ -596,14 +596,14 @@ SELECT * FROM
    UNION
    SELECT 2 AS t, 4 AS x) ss
 WHERE x > 3;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Subquery Scan on ss
-   Filter: ss.x > 3
+   Filter: (ss.x > 3)
    ->  Unique
-         Group Key: "outer".t, (($0 * 3::double precision)::integer)
+         Group Key: "outer".t, ((($0 * 3::double precision))::integer)
          ->  Sort
-               Sort Key (Distinct): "outer".t, (($0 * 3::double precision)::integer)
+               Sort Key (Distinct): "outer".t, ((($0 * 3::double precision))::integer)
                ->  Append
                      ->  Result
                            InitPlan 1 (returns $0)

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -476,16 +476,16 @@ explain (costs off)
   UNION ALL
   SELECT * FROM t2) t
  WHERE ab = 'ab';
-                    QUERY PLAN                     
----------------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
          ->  Result
-               Filter: (t1.a || t1.b) = 'ab'::text
+               Filter: (((t1.a || t1.b)) = 'ab'::text)
                ->  Result
                      ->  Table Scan on t1
          ->  Index Scan using t2_pkey on t2
-               Index Cond: ab = 'ab'::text
+               Index Cond: (ab = 'ab'::text)
  Optimizer: PQO version 2.74.0
 (9 rows)
 
@@ -495,26 +495,26 @@ explain (costs off)
   UNION
   SELECT * FROM t2) t
  WHERE ab = 'ab';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  GroupAggregate
-         Group Key: (t1.a || t1.b)
+         Group Key: ((t1.a || t1.b))
          ->  Sort
-               Sort Key: (t1.a || t1.b)
+               Sort Key: ((t1.a || t1.b))
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: (t1.a || t1.b)
+                     Hash Key: ((t1.a || t1.b))
                      ->  GroupAggregate
-                           Group Key: (t1.a || t1.b)
+                           Group Key: ((t1.a || t1.b))
                            ->  Sort
-                                 Sort Key: (t1.a || t1.b)
+                                 Sort Key: ((t1.a || t1.b))
                                  ->  Append
                                        ->  Result
-                                             Filter: (t1.a || t1.b) = 'ab'::text
+                                             Filter: (((t1.a || t1.b)) = 'ab'::text)
                                              ->  Result
                                                    ->  Table Scan on t1
                                        ->  Index Scan using t2_pkey on t2
-                                             Index Cond: ab = 'ab'::text
+                                             Index Cond: (ab = 'ab'::text)
  Optimizer: PQO version 2.74.0
 (19 rows)
 
@@ -536,7 +536,7 @@ explain (costs off)
                One-Time Filter: false
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Result
-               Filter: t = 2
+               Filter: (t = 2)
                ->  Result
                      ->  Table Scan on tenk1
  Optimizer: PQO version 2.74.0
@@ -553,7 +553,7 @@ WHERE x < 4;
 --------------------------------------
  Append
    ->  Result
-         Filter: x < 4
+         Filter: (x < 4)
          ->  Result
                ->  Result
    ->  Result
@@ -579,8 +579,8 @@ SELECT * FROM
    SELECT 2 AS t, 4 AS x) ss
 WHERE x < 4
 ORDER BY x;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  GroupAggregate
    Group Key: t, (generate_series(1, 10))
    ->  GroupAggregate
@@ -589,7 +589,7 @@ ORDER BY x;
                Sort Key: (generate_series(1, 10)), t
                ->  Append
                      ->  Result
-                           Filter: (generate_series(1, 10)) < 4
+                           Filter: ((generate_series(1, 10)) < 4)
                            ->  Result
                                  ->  Result
                      ->  Result
@@ -617,14 +617,14 @@ SELECT * FROM
    UNION
    SELECT 2 AS t, 4 AS x) ss
 WHERE x > 3;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Subquery Scan on ss
-   Filter: ss.x > 3
+   Filter: (ss.x > 3)
    ->  Unique
-         Group Key: "outer".t, (($0 * 3::double precision)::integer)
+         Group Key: "outer".t, ((($0 * 3::double precision))::integer)
          ->  Sort
-               Sort Key (Distinct): "outer".t, (($0 * 3::double precision)::integer)
+               Sort Key (Distinct): "outer".t, ((($0 * 3::double precision))::integer)
                ->  Append
                      ->  Result
                            InitPlan 1 (returns $0)

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -287,16 +287,16 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a=6 WHERE a=5;
          Hash Key: "outer".a
          ->  Split
                ->  Seq Scan on base_tbl
-                     Filter: a > 0 AND a = 5
+                     Filter: ((a > 0) AND (a = 5))
  Optimizer: legacy query optimizer
 (7 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view1 WHERE a=5;
-            QUERY PLAN             
------------------------------------
+              QUERY PLAN               
+---------------------------------------
  Delete on base_tbl
    ->  Seq Scan on base_tbl
-         Filter: a > 0 AND a = 5
+         Filter: ((a > 0) AND (a = 5))
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -355,23 +355,23 @@ SELECT * FROM rw_view2;
 (3 rows)
 
 EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
-                       QUERY PLAN                       
---------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Update on base_tbl
    ->  Redistribute Motion 1:3  (slice1; segments: 1)
          Hash Key: "outer".aaa
          ->  Split
                ->  Seq Scan on base_tbl
-                     Filter: a < 10 AND a > 0 AND a = 4
+                     Filter: ((a < 10) AND (a > 0) AND (a = 4))
  Optimizer: legacy query optimizer
 (7 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE aaa=4;
-                 QUERY PLAN                 
---------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Delete on base_tbl
    ->  Seq Scan on base_tbl
-         Filter: a < 10 AND a > 0 AND a = 4
+         Filter: ((a < 10) AND (a > 0) AND (a = 4))
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -552,32 +552,32 @@ SELECT * FROM rw_view2;
 (2 rows)
 
 EXPLAIN (costs off) UPDATE rw_view2 SET a=3 WHERE a=2;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Update on base_tbl
    ->  Nested Loop
          ->  Seq Scan on base_tbl
-               Filter: a < 10 AND a = 2
+               Filter: ((a < 10) AND (a = 2))
          ->  Materialize
                ->  Subquery Scan on rw_view1
-                     Filter: rw_view1.a < 10 AND rw_view1.a = 2
+                     Filter: ((rw_view1.a < 10) AND (rw_view1.a = 2))
                      ->  Seq Scan on base_tbl base_tbl_1
-                           Filter: a > 0
+                           Filter: (a > 0)
  Optimizer: legacy query optimizer
 (10 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE a=2;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Delete on base_tbl
    ->  Nested Loop
          ->  Seq Scan on base_tbl
-               Filter: a < 10 AND a = 2
+               Filter: ((a < 10) AND (a = 2))
          ->  Materialize
                ->  Subquery Scan on rw_view1
-                     Filter: rw_view1.a < 10 AND rw_view1.a = 2
+                     Filter: ((rw_view1.a < 10) AND (rw_view1.a = 2))
                      ->  Seq Scan on base_tbl base_tbl_1
-                           Filter: a > 0
+                           Filter: (a > 0)
  Optimizer: legacy query optimizer
 (10 rows)
 
@@ -822,7 +822,7 @@ UPDATE rw_view1 v SET bb='Updated row 2' WHERE rw_view1_aa(v)=2
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Update on base_tbl
          ->  Seq Scan on base_tbl
-               Filter: a = 2
+               Filter: (a = 2)
  Optimizer: legacy query optimizer
 (5 rows)
 

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -292,7 +292,7 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a=6 WHERE a=5;
                            ->  Split
                                  ->  Result
                                        ->  Index Scan using base_tbl_pkey on base_tbl
-                                             Index Cond: a = 5 AND a > 0
+                                             Index Cond: ((a = 5) AND (a > 0))
  Optimizer: PQO version 2.74.0
 (12 rows)
 
@@ -302,7 +302,7 @@ EXPLAIN (costs off) DELETE FROM rw_view1 WHERE a=5;
  Delete
    ->  Result
          ->  Index Scan using base_tbl_pkey on base_tbl
-               Index Cond: a = 5 AND a > 0
+               Index Cond: ((a = 5) AND (a > 0))
  Optimizer: PQO version 2.74.0
 (5 rows)
 
@@ -361,8 +361,8 @@ SELECT * FROM rw_view2;
 (3 rows)
 
 EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Update
    ->  Result
          ->  Sort
@@ -373,17 +373,17 @@ EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
                            ->  Split
                                  ->  Result
                                        ->  Index Scan using base_tbl_pkey on base_tbl
-                                             Index Cond: a = 4 AND a < 10 AND a > 0
+                                             Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
  Optimizer: PQO version 2.74.0
 (12 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE aaa=4;
-                       QUERY PLAN                       
---------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Delete
    ->  Result
          ->  Index Scan using base_tbl_pkey on base_tbl
-               Index Cond: a = 4 AND a < 10 AND a > 0
+               Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
  Optimizer: PQO version 2.74.0
 (5 rows)
 
@@ -570,14 +570,14 @@ EXPLAIN (costs off) UPDATE rw_view2 SET a=3 WHERE a=2;
    ->  Result
          ->  Split
                ->  Hash Join
-                     Hash Cond: base_tbl.a = base_tbl_1.a
+                     Hash Cond: (base_tbl.a = base_tbl_1.a)
                      ->  Index Scan using base_tbl_pkey on base_tbl
-                           Index Cond: a = 2
+                           Index Cond: (a = 2)
                      ->  Hash
                            ->  Result
-                                 Filter: base_tbl_1.a = 2 AND base_tbl_1.a < 10
+                                 Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
                                  ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
-                                       Index Cond: a > 0
+                                       Index Cond: (a > 0)
  Optimizer: PQO version 2.74.0
 (13 rows)
 
@@ -587,14 +587,14 @@ EXPLAIN (costs off) DELETE FROM rw_view2 WHERE a=2;
  Delete
    ->  Result
          ->  Hash Join
-               Hash Cond: base_tbl.a = base_tbl_1.a
+               Hash Cond: (base_tbl.a = base_tbl_1.a)
                ->  Index Scan using base_tbl_pkey on base_tbl
-                     Index Cond: a = 2
+                     Index Cond: (a = 2)
                ->  Hash
                      ->  Result
-                           Filter: base_tbl_1.a = 2 AND base_tbl_1.a < 10
+                           Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
                            ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
-                                 Index Cond: a > 0
+                                 Index Cond: (a > 0)
  Optimizer: PQO version 2.74.0
 (12 rows)
 
@@ -839,7 +839,7 @@ UPDATE rw_view1 v SET bb='Updated row 2' WHERE rw_view1_aa(v)=2
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Update on base_tbl
          ->  Seq Scan on base_tbl
-               Filter: a = 2
+               Filter: (a = 2)
  Optimizer: legacy query optimizer
 (5 rows)
 

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -333,7 +333,7 @@ EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
 ------------------------------------------------------
  Update on tab3
    ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Hash Key: (c1 + 1), c2, c3
+         Hash Key: ((c1 + 1)), c2, c3
          ->  Split
                ->  Seq Scan on tab3
  Optimizer: legacy query optimizer

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -93,15 +93,15 @@ EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
                 (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
     ) t1
 WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
  Update on keo1
    InitPlan 3 (returns $2)  (slice9)
      ->  Aggregate
            InitPlan 2 (returns $1)  (slice8)
              ->  Gather Motion 3:1  (slice3; segments: 3)
                    ->  Seq Scan on keo4 keo4_1
-                         Filter: keo_para_budget_date::text = $0
+                         Filter: ((keo_para_budget_date)::text = $0)
                          InitPlan 1 (returns $0)  (slice7)
                            ->  Aggregate
                                  ->  Gather Motion 3:1  (slice2; segments: 3)
@@ -110,20 +110,20 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  ->  Aggregate
                        ->  Seq Scan on keo3
-                             Filter: bky_per::text = $1::text
+                             Filter: ((bky_per)::text = ($1)::text)
    ->  Explicit Redistribute Motion 3:3  (slice6; segments: 3)
          ->  Hash Join
-               Hash Cond: b.projects_pk::text = a.user_vie_project_code_pk::text
+               Hash Cond: ((b.projects_pk)::text = (a.user_vie_project_code_pk)::text)
                ->  Seq Scan on keo2 b
                ->  Hash
                      ->  Broadcast Motion 3:3  (slice5; segments: 3)
                            ->  Hash Join
-                                 Hash Cond: keo1.user_vie_project_code_pk::text = a.user_vie_project_code_pk::text
+                                 Hash Cond: ((keo1.user_vie_project_code_pk)::text = (a.user_vie_project_code_pk)::text)
                                  ->  Seq Scan on keo1
                                  ->  Hash
                                        ->  Broadcast Motion 3:3  (slice4; segments: 3)
                                              ->  Seq Scan on keo1 a
-                                                   Filter: user_vie_fiscal_year_period_sk::text = $2
+                                                   Filter: ((user_vie_fiscal_year_period_sk)::text = $2)
  Optimizer: legacy query optimizer
 (30 rows)
 
@@ -146,19 +146,19 @@ SELECT user_vie_act_cntr_marg_cum FROM keo1;
 CREATE TABLE keo5 (x int, y int) DISTRIBUTED BY (x);
 INSERT INTO keo5 VALUES (1,1);
 EXPLAIN (COSTS OFF) DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS (SELECT x FROM keo5 WHERE x < 2));
-                       QUERY PLAN                       
---------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Delete on keo5
    InitPlan 1 (returns $0)  (slice2)
      ->  Limit
            ->  Gather Motion 3:1  (slice1; segments: 3)
                  ->  Limit
                        ->  Seq Scan on keo5 keo5_2
-                             Filter: x < 2
+                             Filter: (x < 2)
    ->  Result
          One-Time Filter: $0
          ->  Hash Join
-               Hash Cond: keo5.x = keo5_1.x
+               Hash Cond: (keo5.x = keo5_1.x)
                ->  Seq Scan on keo5
                ->  Hash
                      ->  HashAggregate

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -93,8 +93,8 @@ EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
                 (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
     ) t1
 WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
-                                                                                                 QUERY PLAN                                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update
    ->  Result
          ->  Explicit Redistribute Motion 3:3  (slice8; segments: 3)
@@ -102,29 +102,29 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                      ->  Split
                            ->  Result
                                  ->  Hash Join
-                                       Hash Cond: keo1.user_vie_project_code_pk::text = keo1_1.user_vie_project_code_pk::text
+                                       Hash Cond: ((keo1.user_vie_project_code_pk)::text = (keo1_1.user_vie_project_code_pk)::text)
                                        ->  Table Scan on keo1
                                        ->  Hash
                                              ->  Broadcast Motion 3:3  (slice7; segments: 3)
                                                    ->  Hash Join
-                                                         Hash Cond: keo1_1.user_vie_project_code_pk::text = keo2.projects_pk::text
+                                                         Hash Cond: ((keo1_1.user_vie_project_code_pk)::text = (keo2.projects_pk)::text)
                                                          ->  Redistribute Motion 1:3  (slice5)
                                                                ->  Hash Join
-                                                                     Hash Cond: keo1_1.user_vie_fiscal_year_period_sk::text = (max(keo3.sky_per::text))
+                                                                     Hash Cond: ((keo1_1.user_vie_fiscal_year_period_sk)::text = (max((keo3.sky_per)::text)))
                                                                      ->  Gather Motion 3:1  (slice1; segments: 3)
                                                                            ->  Table Scan on keo1 keo1_1
                                                                      ->  Hash
                                                                            ->  Aggregate
                                                                                  ->  Hash Join
-                                                                                       Hash Cond: keo3.bky_per::text = keo4.keo_para_required_period::text
+                                                                                       Hash Cond: ((keo3.bky_per)::text = (keo4.keo_para_required_period)::text)
                                                                                        ->  Gather Motion 3:1  (slice2; segments: 3)
                                                                                              ->  Table Scan on keo3
                                                                                        ->  Hash
                                                                                              ->  Assert
-                                                                                                   Assert Cond: (row_number() OVER (?)) = 1
+                                                                                                   Assert Cond: ((row_number() OVER (?)) = 1)
                                                                                                    ->  WindowAgg
                                                                                                          ->  Hash Join
-                                                                                                               Hash Cond: keo4.keo_para_budget_date::text = (min((min(keo4_1.keo_para_budget_date::text))))
+                                                                                                               Hash Cond: ((keo4.keo_para_budget_date)::text = (min((min((keo4_1.keo_para_budget_date)::text)))))
                                                                                                                ->  Gather Motion 3:1  (slice3; segments: 3)
                                                                                                                      ->  Table Scan on keo4
                                                                                                                ->  Hash
@@ -162,7 +162,7 @@ EXPLAIN (COSTS OFF) DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS
  Delete
    ->  Result
          ->  Hash Semi Join
-               Hash Cond: keo5.x = keo5_2.x
+               Hash Cond: (keo5.x = keo5_2.x)
                ->  Table Scan on keo5
                ->  Hash
                      ->  Nested Loop Semi Join
@@ -173,7 +173,7 @@ EXPLAIN (COSTS OFF) DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS
                                        ->  Limit
                                              ->  Gather Motion 3:1  (slice1; segments: 3)
                                                    ->  Table Scan on keo5 keo5_1
-                                                         Filter: x < 2
+                                                         Filter: (x < 2)
  Optimizer: PQO version 2.74.0
 (16 rows)
 

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -334,7 +334,7 @@ EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
  Update
    ->  Result
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: (tab3.c1 + 1), tab3.c2, tab3.c3
+               Hash Key: ((tab3.c1 + 1)), tab3.c2, tab3.c3
                ->  Result
                      ->  Split
                            ->  Result

--- a/src/test/regress/expected/window.out
+++ b/src/test/regress/expected/window.out
@@ -632,11 +632,11 @@ select first_value(max(x)) over (), y
    ->  Gather Motion 3:1  (slice2; segments: 3)
          ->  Subquery Scan on "Window"
                ->  HashAggregate
-                     Group Key: (tenk1.ten + tenk1.four)
+                     Group Key: ((tenk1.ten + tenk1.four))
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: (tenk1.ten + tenk1.four)
+                           Hash Key: ((tenk1.ten + tenk1.four))
                            ->  HashAggregate
-                                 Group Key: tenk1.ten + tenk1.four
+                                 Group Key: (tenk1.ten + tenk1.four)
                                  ->  Seq Scan on tenk1
  Optimizer: legacy query optimizer
 (11 rows)

--- a/src/test/regress/expected/window_optimizer.out
+++ b/src/test/regress/expected/window_optimizer.out
@@ -632,12 +632,12 @@ select first_value(max(x)) over (), y
    ->  Gather Motion 3:1  (slice2; segments: 3)
          ->  Result
                ->  HashAggregate
-                     Group Key: (ten + four)
+                     Group Key: ((ten + four))
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: (ten + four)
+                           Hash Key: ((ten + four))
                            ->  Result
                                  ->  HashAggregate
-                                       Group Key: ten + four
+                                       Group Key: (ten + four)
                                        ->  Result
                                              ->  Table Scan on tenk1
  Optimizer: PQO version 2.74.0

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2139,7 +2139,7 @@ explain (costs off) with t as (select * from with_test1) select * from t where i
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Seq Scan on with_test1
-         Filter: i = 10
+         Filter: (i = 10)
  Optimizer: legacy query optimizer
 (4 rows)
 

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2139,7 +2139,7 @@ explain (costs off) with t as (select * from with_test1) select * from t where i
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Table Scan on with_test1
-         Filter: i = 10
+         Filter: (i = 10)
 (3 rows)
 
 -- Test to validate an old bug which caused incorrect results when a subquery

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -99,8 +99,8 @@ m/Table "pg_temp_\d+.temp/
 s/Table "pg_temp_\d+.temp/Table "pg_temp_#####/
 
 # Mask out some numbers (part of temp table schema) that vary from run to run.
-m/Hash Cond: pg_temp_\d+/
-s/Hash Cond: pg_temp_\d+/Hash Cond: pg_temp_#####/
+m/Hash Cond: \(pg_temp_\d+/
+s/Hash Cond: \(pg_temp_\d+/Hash Cond: \(pg_temp_#####/
 
 # Mask out oid in error concurrent drop message
 m/\d+ was concurrently dropped/

--- a/src/test/regress/output/qp_gist_indexes2.source
+++ b/src/test/regress/output/qp_gist_indexes2.source
@@ -78,11 +78,11 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using propertyboxindex on gisttable1
-         Index Cond: property ~= '(7052,250),(6050,20)'::box
+         Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -123,11 +123,11 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using propertyboxindex on gisttable1
-         Index Cond: property ~= '(7052,250),(6050,20)'::box
+         Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -426,7 +426,7 @@ SELECT owner, property FROM GistTable1
    ->  Sort  (cost=700.38..700.38 rows=1 width=51)
          Sort Key: id
          ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..700.37 rows=1 width=51)
-               Index Cond: property IS NULL
+               Index Cond: (property IS NULL)
  Settings:  enable_seqscan=off; optimizer=off
  Optimizer status: legacy query optimizer
 (8 rows)
@@ -465,7 +465,7 @@ SELECT id, property FROM GistTable1
    ->  Sort  (cost=701.28..701.28 rows=1 width=36)
          Sort Key: id
          ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..701.27 rows=1 width=36)
-               Index Cond: property IS NULL
+               Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -557,11 +557,11 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                         QUERY PLAN                         
-------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using gistindex13 on gisttable13
-         Index Cond: property ~= '(999,999),(998,998)'::box
+         Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -576,11 +576,11 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                         QUERY PLAN                         
-------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using gistindex13 on gisttable13
-         Index Cond: property ~= '(999,999),(998,998)'::box
+         Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -605,11 +605,11 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                         QUERY PLAN                         
-------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using gistindex13 on gisttable13
-         Index Cond: property ~= '(999,999),(998,998)'::box
+         Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (4 rows)
 
@@ -647,7 +647,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Index Scan using propertyboxindex on gisttable1
-               Index Cond: property ~= '(3,4),(1,2)'::box
+               Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -672,7 +672,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Index Scan using propertyboxindex on gisttable1
-               Index Cond: property ~= '(3,4),(1,2)'::box
+               Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -692,14 +692,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Seq Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -781,13 +781,13 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                              QUERY PLAN                             
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
+               Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1077,9 +1077,9 @@ SELECT owner, property FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-               Recheck Cond: property IS NULL
+               Recheck Cond: (property IS NULL)
                ->  Bitmap Index Scan on propertyisnullindex
-                     Index Cond: property IS NULL
+                     Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1170,13 +1170,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Row-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1191,13 +1191,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Row-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1222,13 +1222,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Row-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1259,16 +1259,16 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                ->  Bitmap Index Scan on propertyboxindex
-                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1286,16 +1286,16 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                ->  Bitmap Index Scan on propertyboxindex
-                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1315,14 +1315,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Append-only Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -1404,13 +1404,13 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
+               Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1700,9 +1700,9 @@ SELECT owner, property FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-               Recheck Cond: property IS NULL
+               Recheck Cond: (property IS NULL)
                ->  Bitmap Index Scan on propertyisnullindex
-                     Index Cond: property IS NULL
+                     Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1793,13 +1793,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Row-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1814,13 +1814,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Row-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1845,13 +1845,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Row-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -1882,16 +1882,16 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                ->  Bitmap Index Scan on propertyboxindex
-                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1909,16 +1909,16 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                ->  Bitmap Index Scan on propertyboxindex
-                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1938,14 +1938,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                        QUERY PLAN                      
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Append-only Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -2027,13 +2027,13 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
+               Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -2323,9 +2323,9 @@ SELECT owner, property FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-               Recheck Cond: property IS NULL
+               Recheck Cond: (property IS NULL)
                ->  Bitmap Index Scan on propertyisnullindex
-                     Index Cond: property IS NULL
+                     Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -2416,13 +2416,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Column-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -2437,13 +2437,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Column-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -2468,13 +2468,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Column-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -2512,9 +2512,9 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                ->  Bitmap Index Scan on propertyboxindex
-                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -2539,9 +2539,9 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                ->  Bitmap Index Scan on propertyboxindex
-                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -2561,14 +2561,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Append-only Columnar Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -2650,13 +2650,13 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
+               Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -2946,9 +2946,9 @@ SELECT owner, property FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-               Recheck Cond: property IS NULL
+               Recheck Cond: (property IS NULL)
                ->  Bitmap Index Scan on propertyisnullindex
-                     Index Cond: property IS NULL
+                     Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -3039,13 +3039,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Column-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -3060,13 +3060,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Column-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -3091,13 +3091,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Append-Only Column-Oriented Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: legacy query optimizer
 (6 rows)
 
@@ -3135,9 +3135,9 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                ->  Bitmap Index Scan on propertyboxindex
-                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -3162,9 +3162,9 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                ->  Bitmap Index Scan on propertyboxindex
-                     Index Cond: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -3184,14 +3184,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Append-only Columnar Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: legacy query optimizer
 (7 rows)
 

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -78,12 +78,12 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using propertyboxindex on gisttable1
-         Index Cond: property ~= '(7052,250),(6050,20)'::box
-         Filter: property ~= '(7052,250),(6050,20)'::box
+         Index Cond: (property ~= '(7052,250),(6050,20)'::box)
+         Filter: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: PQO version 2.74.0
 (5 rows)
 
@@ -124,12 +124,12 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using propertyboxindex on gisttable1
-         Index Cond: property ~= '(7052,250),(6050,20)'::box
-         Filter: property ~= '(7052,250),(6050,20)'::box
+         Index Cond: (property ~= '(7052,250),(6050,20)'::box)
+         Filter: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: PQO version 2.74.0
 (5 rows)
 
@@ -434,7 +434,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
    ->  Sort  (cost=701.28..701.28 rows=1 width=51)
          Sort Key: id
          ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..701.27 rows=1 width=51)
-               Index Cond: property IS NULL
+               Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -478,7 +478,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
    ->  Sort  (cost=701.28..701.28 rows=1 width=36)
          Sort Key: id
          ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..701.27 rows=1 width=36)
-               Index Cond: property IS NULL
+               Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (7 rows)
 
@@ -570,12 +570,12 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                         QUERY PLAN                         
-------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using gistindex13 on gisttable13
-         Index Cond: property ~= '(999,999),(998,998)'::box
-         Filter: property ~= '(999,999),(998,998)'::box
+         Index Cond: (property ~= '(999,999),(998,998)'::box)
+         Filter: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (5 rows)
 
@@ -590,12 +590,12 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                         QUERY PLAN                         
-------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using gistindex13 on gisttable13
-         Index Cond: property ~= '(999,999),(998,998)'::box
-         Filter: property ~= '(999,999),(998,998)'::box
+         Index Cond: (property ~= '(999,999),(998,998)'::box)
+         Filter: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (5 rows)
 
@@ -620,12 +620,12 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                         QUERY PLAN                         
-------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using gistindex13 on gisttable13
-         Index Cond: property ~= '(999,999),(998,998)'::box
-         Filter: property ~= '(999,999),(998,998)'::box
+         Index Cond: (property ~= '(999,999),(998,998)'::box)
+         Filter: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (5 rows)
 
@@ -664,8 +664,8 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
          ->  Sort
                Sort Key: id
                ->  Index Scan using propertyboxindex on gisttable1
-                     Index Cond: property ~= '(3,4),(1,2)'::box
-                     Filter: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+                     Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (9 rows)
 
@@ -691,8 +691,8 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
          ->  Sort
                Sort Key: id
                ->  Index Scan using propertyboxindex on gisttable1
-                     Index Cond: property ~= '(3,4),(1,2)'::box
-                     Filter: property ~= '(3,4),(1,2)'::box
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+                     Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (9 rows)
 
@@ -712,14 +712,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Table Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (7 rows)
 
@@ -802,13 +802,13 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable1
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
+               Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -1098,9 +1098,9 @@ SELECT owner, property FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-               Recheck Cond: property IS NULL
+               Recheck Cond: (property IS NULL)
                ->  Bitmap Index Scan on propertyisnullindex
-                     Index Cond: property IS NULL
+                     Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1191,13 +1191,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -1212,13 +1212,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -1243,13 +1243,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -1280,17 +1280,17 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Result
          ->  Sort
                Sort Key: id
                ->  Bitmap Table Scan on gisttable1
-                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: property ~= '(3,4),(1,2)'::box
+                           Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (10 rows)
 
@@ -1308,17 +1308,17 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Result
          ->  Sort
                Sort Key: id
                ->  Bitmap Table Scan on gisttable1
-                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: property ~= '(3,4),(1,2)'::box
+                           Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (10 rows)
 
@@ -1338,14 +1338,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Table Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (7 rows)
 
@@ -1428,13 +1428,13 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable1
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
+               Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -1724,9 +1724,9 @@ SELECT owner, property FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1
-               Recheck Cond: property IS NULL
+               Recheck Cond: (property IS NULL)
                ->  Bitmap Index Scan on propertyisnullindex
-                     Index Cond: property IS NULL
+                     Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -1817,13 +1817,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -1838,13 +1838,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -1869,13 +1869,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -1906,17 +1906,17 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Result
          ->  Sort
                Sort Key: id
                ->  Bitmap Table Scan on gisttable1
-                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: property ~= '(3,4),(1,2)'::box
+                           Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (10 rows)
 
@@ -1934,17 +1934,17 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Result
          ->  Sort
                Sort Key: id
                ->  Bitmap Table Scan on gisttable1
-                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: property ~= '(3,4),(1,2)'::box
+                           Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (10 rows)
 
@@ -1964,14 +1964,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Table Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (7 rows)
 
@@ -2054,13 +2054,13 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable1
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
+               Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -2350,9 +2350,9 @@ SELECT owner, property FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-               Recheck Cond: property IS NULL
+               Recheck Cond: (property IS NULL)
                ->  Bitmap Index Scan on propertyisnullindex
-                     Index Cond: property IS NULL
+                     Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -2443,13 +2443,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -2464,13 +2464,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -2495,13 +2495,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -2532,17 +2532,17 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Result
          ->  Sort
                Sort Key: id
                ->  Bitmap Table Scan on gisttable1
-                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: property ~= '(3,4),(1,2)'::box
+                           Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (10 rows)
 
@@ -2560,17 +2560,17 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Result
          ->  Sort
                Sort Key: id
                ->  Bitmap Table Scan on gisttable1
-                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: property ~= '(3,4),(1,2)'::box
+                           Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (10 rows)
 
@@ -2590,14 +2590,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Table Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (7 rows)
 
@@ -2680,13 +2680,13 @@ SELECT owner, property FROM GistTable1
 EXPLAIN (COSTS OFF)
 SELECT owner, property FROM GistTable1
  WHERE property ~= '( (6050, 20), (7052, 250) )';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable1
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
+               Index Cond: (property ~= '(7052,250),(6050,20)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -2976,9 +2976,9 @@ SELECT owner, property FROM GistTable1
    ->  Sort
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1
-               Recheck Cond: property IS NULL
+               Recheck Cond: (property IS NULL)
                ->  Bitmap Index Scan on propertyisnullindex
-                     Index Cond: property IS NULL
+                     Index Cond: (property IS NULL)
  Optimizer: legacy query optimizer
 (9 rows)
 
@@ -3069,13 +3069,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -3090,13 +3090,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -3121,13 +3121,13 @@ SELECT id, property AS "ProperTee" FROM GistTable13
 
 EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13 
  WHERE property ~= '( (999,999), (998,998) )';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Table Scan on gisttable13
-         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
-               Index Cond: property ~= '(999,999),(998,998)'::box
+               Index Cond: (property ~= '(999,999),(998,998)'::box)
  Optimizer: PQO version 2.74.0
 (6 rows)
 
@@ -3166,9 +3166,9 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
          ->  Sort
                Sort Key: id
                ->  Bitmap Table Scan on gisttable1
-                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: property ~= '(3,4),(1,2)'::box
+                           Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (10 rows)
 
@@ -3186,17 +3186,17 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Result
          ->  Sort
                Sort Key: id
                ->  Bitmap Table Scan on gisttable1
-                     Recheck Cond: property ~= '(3,4),(1,2)'::box
+                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: property ~= '(3,4),(1,2)'::box
+                           Index Cond: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (10 rows)
 
@@ -3216,14 +3216,14 @@ SELECT id FROM GistTable1
 EXPLAIN (COSTS OFF) SELECT id FROM GistTable1 
  WHERE property ~= '( (1,2), (3,4) )'
  ORDER BY id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
    ->  Sort
          Sort Key: id
          ->  Table Scan on gisttable1
-               Filter: property ~= '(3,4),(1,2)'::box
+               Filter: (property ~= '(3,4),(1,2)'::box)
  Optimizer: PQO version 2.74.0
 (7 rows)
 


### PR DESCRIPTION
We had changed this in GPDB, to print less parens. That's fine and dandy,
but it hardly seems worth it to carry a diff vs upstream for this. Which
format is better, is a matter of taste. The extra parens make some
expressions more clear, but OTOH, it's unnecessarily verbose for simple
expressions. Let's follow the upstream on this.

These changes were made to GPDB back in 2006, as part of backporting
to EXPLAIN-related patches from PostgreSQL 8.2. But I didn't see any
explanation for this particular change in output in that commit message.

It's nice to match upstream, to make merging easier. However, this won't
make much difference to that: almost all EXPLAIN plans in regression
tests are different from upstream anyway, because GPDB needs Motion nodes
for most queries. But every little helps.