### PR TITLE
docs - add content for PXF JDBC connector

### DIFF
--- a/gpdb-doc/dita/admin_guide/external/pxf-overview.xml
+++ b/gpdb-doc/dita/admin_guide/external/pxf-overview.xml
@@ -4,8 +4,8 @@
   <title>Accessing External Data with PXF</title>
   <shortdesc>Data managed by your organization may already reside in external sources. The Greenplum Platform Extension Framework (PXF) provides access to this external data via built-in connectors that map an external data source to a Greenplum Database table definition.</shortdesc>
   <body>
-    <p>PXF is installed with HDFS, Hive, and HBase connectors. These connectors enable you to read external HDFS file system and Hive and HBase table data stored in text, Avro, JSON, RCFile, Parquet, SequenceFile, and ORC formats.</p>
-    <note>PXF supports filter pushdown in the Hive and HBase connectors only.</note>
+    <p>PXF is installed with HDFS, Hive, HBase, and JDBC connectors. These connectors enable you to read external HDFS file system and Hive and HBase table data stored in text, Avro, JSON, RCFile, Parquet, SequenceFile, and ORC formats. You can use the JDBC connector to access an external SQL database.</p>
+    <note>PXF supports filter pushdown in the Hive, HBase, and JDBC connectors.</note>
     <p>The Greenplum Platform Extension Framework includes a protocol C library and a Java service. After you configure and initialize PXF, you start a single PXF JVM process on each Greenplum Database segment host. This long-running process concurrently serves multiple query requests.</p>
     <p>For detailed information about the architecture of and using PXF, refer to the <xref href="../../pxf/overview_pxf.html" type="topic" format="html">Greenplum Platform Extension Framework (PXF)</xref> documentation.</p>
   </body>

--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -2,13 +2,7 @@
 title: Installing and Configuring Hadoop Clients for PXF
 ---
 
-You use PXF connectors to access external data sources. PXF requires a client installation on each Greenplum Database segment host when reading external data from the following sources:
-
-- Hadoop
-- Hive
-- HBase
-
-PXF requires you install a Hadoop client. Hive and HBase client installation is required only if you plan to access those external data stores.
+You use PXF connectors to access external data sources. PXF requires that you install a Hadoop client on each Greenplum Database segment host. Hive and HBase client installation is required only if you plan to access those external data stores.
 
 Compatible Hadoop, Hive, and HBase clients for PXF include Cloudera, Hortonworks Data Platform, and generic Apache distributions.
 

--- a/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
@@ -2,7 +2,7 @@
 title: Installing and Configuring PXF
 ---
 
-The Greenplum Platform Extension Framework (PXF) provides connectors to Hadoop, Hive, and HBase data stores. To use these PXF connectors, you must install Hadoop, Hive, and HBase clients on each Greenplum Database segment host as described in this one-time installation and configuration procedure:
+The Greenplum Platform Extension Framework (PXF) provides connectors to Hadoop, Hive, HBase and external SQL data stores. To use these PXF connectors, you must install Hadoop, Hive, and HBase clients on each Greenplum Database segment host as described in this one-time installation and configuration procedure:
 
 - **[Installing and Configuring Hadoop Clients for PXF](client_instcfg.html)**
 

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -21,15 +21,15 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Some of your data may already reside in an external SQL database. Greenplum Database provides access to this data via the PXF JDBC Connector. The JDBC connector is a JDBC client. It can read data from and write data to SQL databases including MySQL, ORACLE, PostgreSQL, and Hive.
+Some of your data may already reside in an external SQL database. PXF provides access to this data via the PXF JDBC Connector. The JDBC connector is a JDBC client. It can read data from and write data to SQL databases including MySQL, ORACLE, PostgreSQL, and Hive.
 
-This section describes how to use the PXF JDBC connector to access data in an external SQL database, including how to create and query or insert data into a PXF external table referencing a table in an external database.
+This section describes how to use the PXF JDBC connector to access data in an external SQL database, including how to create and query or insert data into a PXF external table that references a table in an external database.
 
-**Note**: The JDBC Connector does not guarantee consistency when writing to an external SQL database. Be aware that even if an `INSERT` operation fails, some data maybe still be written to the external database table. Consider writing to a staging table in the external database, and loading to the target table only after verifying the write operation.
+**Note**: The JDBC Connector does not guarantee consistency when writing to an external SQL database. Be aware that even if an `INSERT` operation fails, some data maybe still be written to the external database table. If you require consistency for writes, consider writing to a staging table in the external database, and loading to the target table only after verifying the write operation.
 
 ## <a id="prereq"></a>Prerequisites
 
-Before accessing an external SQL database using the PXF JDBC connector, ensure that:
+Before you access an external SQL database using the PXF JDBC connector, ensure that:
 
 - You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring, Initializing, and Managing PXF](instcfg_pxf.html) for PXF initialization, configuration, and startup information.
 - Connectivity exists between all Greenplum Database segment hosts and the external SQL database.
@@ -82,7 +82,7 @@ The specific keywords and values used by the `pxf` protocol in the [CREATE EXTER
 
 You include JDBC connector custom options in the `LOCATION` URI, prefacing each option with an ampersand `&`.
 
-The `Jdbc` profile supports the following \<custom-option\>s:
+The `Jdbc` profile supports the following \<custom-option\> values:
 
 | Option Name   | Operation | Description
 |---------------|------------|--------|
@@ -92,7 +92,7 @@ The `Jdbc` profile supports the following \<custom-option\>s:
 | PASS | Read, Write | The database password for `USER`. Required if `USER` is provided. |
 | BATCH_SIZE | Write | Integer identifying the number of `INSERT` operations to batch to the external SQL database. PXF always validates a `BATCH_SIZE` option, even when provided on a read operation. Batching is enabled by default. |
 | POOL_SIZE | Write | Enable thread pooling on `INSERT` operations and identify the number of threads in the pool. Thread pooling is disabled by default. |
-| PARTITION_BY | Read | The partition column, \<column-name\>:\<column-type\>. You may specify only one partition column. The JDBC connector supports `date`, `int`, and `enum` \<column-type\>s. A null `PARTITION_BY` defaults to a single fragment. |
+| PARTITION_BY | Read | The partition column, \<column-name\>:\<column-type\>. You may specify only one partition column. The JDBC connector supports `date`, `int`, and `enum` \<column-type\> values. A null `PARTITION_BY` defaults to a single fragment. |
 | RANGE | Read | (Used only when `PARTITION_BY` is specified.) The query range, \<start-value\>[:\<end-value\>]. When the partition column is an `enum` type, `RANGE` must specify a list of values, each of which forms its own fragment. If the partition column is an `int` or `date` type, `RANGE` must specify a finite left-closed range. That is, the range includes the \<start-value\> but does *not* include the \<end-value\>. If the partition column is a `date` type, use the `yyyy-MM-dd` date format. |
 | INTERVAL | Read | (Used only when `PARTITION_BY` is specified and of the `int` or `date` type.) The interval, \<interval-value\>[:\<interval-unit\>], of one fragment. Specify the size of the fragment in \<interval-value\>. If the partition column is a `date` type, use the \<interval-unit\> to specify `year`, `month`, or `day`. |
 
@@ -109,17 +109,17 @@ When the JDBC driver of the external SQL database supports it, batching of `INSE
 
 Batching is enabled by default, and the default batch size is 100. To disable batching or to modify the default batch size value, create the PXF external table with a `BATCH_SIZE` setting:
 
-- `BATCH_SIZE=0` or `&BATCH_SIZE=1` - disable batching
-- `BATCH_SIZE=(n>1)` - set the `BATCH_SIZE` to `n`
+- `BATCH_SIZE=0` or `BATCH_SIZE=1` - disables batching
+- `BATCH_SIZE=(n>1)` - sets the `BATCH_SIZE` to `n`
 
 When the external database JDBC driver does not support batching, the behaviour of the PXF JDBC connector depends on the `BATCH_SIZE` setting as follows:
 
-- `BATCH_SIZE` omitted - the JDBC connector inserts without batching
-- `BATCH_SIZE=(n>1)` - the `INSERT` operation fails and the connector returns an error
+- `BATCH_SIZE` omitted - The JDBC connector inserts without batching.
+- `BATCH_SIZE=(n>1)` - The `INSERT` operation fails and the connector returns an error.
 
 #### <a id="threadpool"></a>Thread Pooling (Write)
 
-The PXF JDBC connector can further increase write performance by processing `INSERT` operations in multiple threads, when threading is supported by the JDBC driver of the external SQL database.
+The PXF JDBC connector can further increase write performance by processing `INSERT` operations in multiple threads when threading is supported by the JDBC driver of the external SQL database.
 
 Consider using batching together with a thread pool. When used together, each thread receives and processes one complete batch of data. If you use a thread pool without batching, each thread in the pool receives exactly one tuple.
 
@@ -156,15 +156,15 @@ In this example, you:
 
 - Create a PostgreSQL database and table, and insert data into the table
 - Create a PostgreSQL user and assign all privileges on the table to the user
-- Create a PXF readable external table referencing the PostgreSQL table
+- Create a PXF readable external table that references the PostgreSQL table
 - Read the data in the PostgreSQL table
-- Create a PXF writable external table referencing the PostgreSQL table
+- Create a PXF writable external table that references the PostgreSQL table
 - Write data to the PostgreSQL table
 - Read the data in the PostgreSQL table again
 
 #### <a id="ex_create_pgtbl"></a>Create a PostgreSQL Table
 
-Perform the following steps to create a PostgreSQL table named `forpxf_table1` in the `public` schema of a database named `pgtestdb` and grant a user named `pxfuser1` all privileges on this table:
+Perform the following steps to create a PostgreSQL table named `forpxf_table1` in the `public` schema of a database named `pgtestdb`, and grant a user named `pxfuser1` all privileges on this table:
 
 1. Identify the host name and port of your PostgreSQL server.
 
@@ -255,7 +255,7 @@ You must download the PostgreSQL driver JAR file to your system, identify the lo
 
 #### <a id="ex_readjdbc"></a>Read from the PostgreSQL Table
 
-Perform the following procedure to create a PXF external table referencing the `forpxf_table1` PostgreSQL table that you created in the previous section, and read the data in the table:
+Perform the following procedure to create a PXF external table that references the `forpxf_table1` PostgreSQL table that you created in the previous section, and read the data in the table:
 
 1. Create the PXF external table specifying the `Jdbc` profile. For example:
 

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -25,7 +25,7 @@ Some of your data may already reside in an external SQL database. PXF provides a
 
 This section describes how to use the PXF JDBC connector to access data in an external SQL database, including how to create and query or insert data into a PXF external table that references a table in an external database.
 
-**Note**: The JDBC Connector does not guarantee consistency when writing to an external SQL database. Be aware that even if an `INSERT` operation fails, some data maybe still be written to the external database table. If you require consistency for writes, consider writing to a staging table in the external database, and loading to the target table only after verifying the write operation.
+**Note**: The JDBC Connector does not guarantee consistency when writing to an external SQL database. Be aware that if an `INSERT` operation fails, some data may be written to the external database table. If you require consistency for writes, consider writing to a staging table in the external database, and loading to the target table only after verifying the write operation.
 
 ## <a id="prereq"></a>Prerequisites
 
@@ -63,7 +63,7 @@ Use the following syntax to create a Greenplum Database external table that refe
 CREATE [READABLE | WRITABLE] EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<external-table-name>?PROFILE=Jdbc[&<custom-option>=<value>[...]]')
-FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import'|'pxfwritable_import');
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import'|'pxfwritable_export');
 ```
 
 The specific keywords and values used by the `pxf` protocol in the [CREATE EXTERNAL TABLE](../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html) command are described in the table below.
@@ -93,8 +93,8 @@ The `Jdbc` profile supports the following \<custom-option\> values:
 | BATCH_SIZE | Write | Integer identifying the number of `INSERT` operations to batch to the external SQL database. PXF always validates a `BATCH_SIZE` option, even when provided on a read operation. Batching is enabled by default. |
 | POOL_SIZE | Write | Enable thread pooling on `INSERT` operations and identify the number of threads in the pool. Thread pooling is disabled by default. |
 | PARTITION_BY | Read | The partition column, \<column-name\>:\<column-type\>. You may specify only one partition column. The JDBC connector supports `date`, `int`, and `enum` \<column-type\> values. A null `PARTITION_BY` defaults to a single fragment. |
-| RANGE | Read | (Used only when `PARTITION_BY` is specified.) The query range, \<start-value\>[:\<end-value\>]. When the partition column is an `enum` type, `RANGE` must specify a list of values, each of which forms its own fragment. If the partition column is an `int` or `date` type, `RANGE` must specify a finite left-closed range. That is, the range includes the \<start-value\> but does *not* include the \<end-value\>. If the partition column is a `date` type, use the `yyyy-MM-dd` date format. |
-| INTERVAL | Read | (Used only when `PARTITION_BY` is specified and of the `int` or `date` type.) The interval, \<interval-value\>[:\<interval-unit\>], of one fragment. Specify the size of the fragment in \<interval-value\>. If the partition column is a `date` type, use the \<interval-unit\> to specify `year`, `month`, or `day`. |
+| RANGE | Read | Required when `PARTITION_BY` is specified. The query range, \<start-value\>[:\<end-value\>]. When the partition column is an `enum` type, `RANGE` must specify a list of values, each of which forms its own fragment. If the partition column is an `int` or `date` type, `RANGE` must specify a finite left-closed range. That is, the range includes the \<start-value\> but does *not* include the \<end-value\>. If the partition column is a `date` type, use the `yyyy-MM-dd` date format. |
+| INTERVAL | Read | Required when `PARTITION_BY` is specified and of the `int` or `date` type. The interval, \<interval-value\>[:\<interval-unit\>], of one fragment. Specify the size of the fragment in \<interval-value\>. If the partition column is a `date` type, use the \<interval-unit\> to specify `year`, `month`, or `day`. |
 
 Example JDBC \<custom-option\> connection strings:
 
@@ -123,7 +123,7 @@ The PXF JDBC connector can further increase write performance by processing `INS
 
 Consider using batching together with a thread pool. When used together, each thread receives and processes one complete batch of data. If you use a thread pool without batching, each thread in the pool receives exactly one tuple.
 
-The JDBC connector returns an error when any thread in the thread pool fails. Be aware that even if the `INSERT` operation fails, some data maybe still be written to the external database table.
+The JDBC connector returns an error when any thread in the thread pool fails. Be aware that if an `INSERT` operation fails, some data may be written to the external database table.
 
 To disable or enable a thread pool and set the pool size, create the PXF external table with a `POOL_SIZE` setting as follows:
 

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -1,0 +1,318 @@
+---
+title: Accessing an External SQL Database with PXF (JDBC)
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Some of your data may already reside in an external SQL database. Greenplum Database provides access to this data via the PXF JDBC Connector. The JDBC connector is a JDBC client. It can read data from and write data to SQL databases including MySQL, ORACLE, PostgreSQL, and Hive.
+
+This section describes how to use the PXF JDBC connector to access data in an external SQL database, including how to create and query or insert data into a PXF external table referencing a table in an external database.
+
+**Note**: The JDBC Connector does not guarantee consistency when writing to an external SQL database. Be aware that even if an `INSERT` operation fails, some data maybe still be written to the external database table. Consider writing to a staging table in the external database, and loading to the target table only after verifying the write operation.
+
+## <a id="prereq"></a>Prerequisites
+
+Before accessing an external SQL database using the PXF JDBC connector, ensure that:
+
+- You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring, Initializing, and Managing PXF](instcfg_pxf.html) for PXF initialization, configuration, and startup information.
+- Connectivity exists between all Greenplum Database segment hosts and the external SQL database.
+- You have configured your external SQL database for user access from all Greenplum Database segment hosts.
+- You have installed the JDBC driver JAR files for the external SQL database in the same location on each segment host. Be sure to install JDBC driver JAR files that are compatible with your JRE version.
+- You have added the file system locations of the external SQL database JDBC JAR files to `$GPHOME/pxf/conf/pxf-public.classpath` and restarted PXF on each segment host. See [PXF JAR Dependencies](using_pxf.html#profile-dependencies) for additional information.
+
+## <a id="datatypes"></a>Data Types Supported
+
+The PXF JDBC connector supports the following data types:
+
+- INTEGER, BIGINT, SMALLINT
+- REAL, FLOAT8
+- NUMERIC
+- BOOLEAN
+- VARCHAR, BPCHAR, TEXT
+- DATE
+- TIMESTAMP
+- BYTEA
+
+Any data type not listed above is not supported by the PXF JDBC connector.
+
+## <a id="queryextdata"></a>Accessing External SQL Data
+The PXF JDBC connector supports a single profile named `Jdbc`. You can both read data from and write data to an external SQL database table with this profile.
+
+To access data in an external SQL database, you create a readable or writable Greenplum Database external table that references the external database table. The Greenplum and external database tables must have the same definition; the column names, types, and order must match.
+
+Use the following syntax to create a Greenplum Database external table that references an external SQL database table and uses the JDBC connector to read or write data:
+
+``` sql
+CREATE [READABLE | WRITABLE] EXTERNAL TABLE <table_name>
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<external-table-name>?PROFILE=Jdbc[&<custom-option>=<value>[...]]')
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import'|'pxfwritable_import');
+```
+
+The specific keywords and values used by the `pxf` protocol in the [CREATE EXTERNAL TABLE](../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<external-table-name\>    | The full name of the external table. Depends on the external SQL database, may include a schema name and a table name. |
+| PROFILE    | The `PROFILE` keyword value must specify `Jdbc`. |
+| \<custom-option\>  | \<custom-option\> is profile-specific. `Jdbc` profile-specific options are discussed in the next section.|
+| FORMAT 'CUSTOM' | The JDBC `CUSTOM` `FORMAT` supports the built-in `'pxfwritable_import'` `FORMATTER` function for read operations and the built-in `'pxfwritable_export'` function for write operations. |
+
+**Note**: You cannot use the `HEADER` option in your `FORMAT` specification when you create a PXF external table.
+
+
+### <a id="jdbcoptions"></a>JDBC Custom Options
+
+You include JDBC connector custom options in the `LOCATION` URI, prefacing each option with an ampersand `&`.
+
+The `Jdbc` profile supports the following \<custom-option\>s:
+
+| Option Name   | Operation | Description
+|---------------|------------|--------|
+| JDBC_DRIVER | Read, Write | The JDBC driver class name. (Required) |
+| DB_URL | Read, Write | The external database URL. Depends on the external SQL database, typically includes at least the hostname, port, and database name. (Required) |
+| USER | Read, Write | The database user name. Required if `PASS` is provided. |
+| PASS | Read, Write | The database password for `USER`. Required if `USER` is provided. |
+| BATCH_SIZE | Write | Integer identifying the number of `INSERT` operations to batch to the external SQL database. PXF always validates a `BATCH_SIZE` option, even when provided on a read operation. Batching is enabled by default. |
+| POOL_SIZE | Write | Enable thread pooling on `INSERT` operations and identify the number of threads in the pool. Thread pooling is disabled by default. |
+| PARTITION_BY | Read | The partition column, \<column-name\>:\<column-type\>. You may specify only one partition column. The JDBC connector supports `date`, `int`, and `enum` \<column-type\>s. A null `PARTITION_BY` defaults to a single fragment. |
+| RANGE | Read | (Used only when `PARTITION_BY` is specified.) The query range, \<start-value\>[:\<end-value\>]. When the partition column is an `enum` type, `RANGE` must specify a list of values, each of which forms its own fragment. If the partition column is an `int` or `date` type, `RANGE` must specify a finite left-closed range. That is, the range includes the \<start-value\> but does *not* include the \<end-value\>. If the partition column is a `date` type, use the `yyyy-MM-dd` date format. |
+| INTERVAL | Read | (Used only when `PARTITION_BY` is specified and of the `int` or `date` type.) The interval, \<interval-value\>[:\<interval-unit\>], of one fragment. Specify the size of the fragment in \<interval-value\>. If the partition column is a `date` type, use the \<interval-unit\> to specify `year`, `month`, or `day`. |
+
+Example JDBC \<custom-option\> connection strings:
+
+``` pre
+&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://gpmaster:5432/pgtestdb&USER=pguser1&PASS=changeme
+&JDBC_DRIVER=com.mysql.jdbc.Driver&DB_URL=jdbc:mysql://mysqlhost:3306/testdb&USER=user1&PASS=changeme
+```
+
+#### <a id="batching"></a>Batching Insert Operations (Write)
+
+When the JDBC driver of the external SQL database supports it, batching of `INSERT` operations may significantly increase performance.
+
+Batching is enabled by default, and the default batch size is 100. To disable batching or to modify the default batch size value, create the PXF external table with a `BATCH_SIZE` setting:
+
+- `BATCH_SIZE=0` or `&BATCH_SIZE=1` - disable batching
+- `BATCH_SIZE=(n>1)` - set the `BATCH_SIZE` to `n`
+
+When the external database JDBC driver does not support batching, the behaviour of the PXF JDBC connector depends on the `BATCH_SIZE` setting as follows:
+
+- `BATCH_SIZE` omitted - the JDBC connector inserts without batching
+- `BATCH_SIZE=(n>1)` - the `INSERT` operation fails and the connector returns an error
+
+#### <a id="threadpool"></a>Thread Pooling (Write)
+
+The PXF JDBC connector can further increase write performance by processing `INSERT` operations in multiple threads, when threading is supported by the JDBC driver of the external SQL database.
+
+Consider using batching together with a thread pool. When used together, each thread receives and processes one complete batch of data. If you use a thread pool without batching, each thread in the pool receives exactly one tuple.
+
+The JDBC connector returns an error when any thread in the thread pool fails. Be aware that even if the `INSERT` operation fails, some data maybe still be written to the external database table.
+
+To disable or enable a thread pool and set the pool size, create the PXF external table with a `POOL_SIZE` setting as follows:
+
+- `POOL_SIZE=(n<1)` - thread pool size is the number of CPUs in the system
+- `POOL_SIZE=1` - disable thread pooling
+- `POOL_SIZE=(n>1)`- set the `POOL_SIZE` to `n`
+
+#### <a id="partitioning"></a>Partitioning (Read)
+
+The PXF JDBC Connector supports simultaneous read access from PXF instances running on multiple segment hosts to an external SQL table. This feature is referred to as partitioning.
+
+When you specify the `PARTITION_BY` option, tune the `INTERVAL` value and unit based upon the optimal number of JDBC connections to the target database and the optimal distribution of fragments across Greenplum Database segments. The `INTERVAL` low boundary is driven by the number of Greenplum Database segments while the high boundary is driven by the acceptable number of JDBC connections to the target database. The `INTERVAL` setting influences the number of fragments, and should ideally not be set too high nor too low. Testing with multiple values may help you select the optimal settings. 
+
+Example JDBC \<custom-option\> substrings identifying partitioning parameters:
+
+``` pre
+&PARTITION_BY=year:int&RANGE=2011:2013&INTERVAL=1
+&PARTITION_BY=createdate:date&RANGE=2013-01-01:2016-01-01&INTERVAL=1:month
+&PARTITION_BY=color:enum&RANGE=red:yellow:blue
+```
+
+When you enable partitioning, the PXF JDBC Connector splits a `SELECT` query into a set of small queries each of which is called a fragment. All PXF instances process a fragment simultaneously.
+
+The JDBC connector automatically adds extra query constraints (`WHERE` expressions) to each fragment to guarantee that every tuple of data is retrieved from the external database exactly once.
+
+
+### <a id="jdbc_example_postgresql"></a>Example: Reading From and Writing to a PostgreSQL Table
+
+In this example, you:
+
+- Create a PostgreSQL database and table, and insert data into the table
+- Create a PostgreSQL user and assign all privileges on the table to the user
+- Create a PXF readable external table referencing the PostgreSQL table
+- Read the data in the PostgreSQL table
+- Create a PXF writable external table referencing the PostgreSQL table
+- Write data to the PostgreSQL table
+- Read the data in the PostgreSQL table again
+
+#### <a id="ex_create_pgtbl"></a>Create a PostgreSQL Table
+
+Perform the following steps to create a PostgreSQL table named `forpxf_table1` in the `public` schema of a database named `pgtestdb` and grant a user named `pxfuser1` all privileges on this table:
+
+1. Identify the host name and port of your PostgreSQL server.
+
+2. Connect to the default PostgreSQL database as the `postgres` user. For example, if your PostgreSQL server is running on the default port on the host named `pserver`:
+
+    ``` shell
+    $ psql -U postgres -h pserver
+    ```
+
+3. Create a PostgreSQL database named `pgtestdb` and connect to this database:
+
+    ``` sql
+    =# CREATE DATABASE pgtestdb;
+    =# \connect pgtestdb;
+    ```
+
+4. Create a table named `forpxf_table1` and insert some data into this table:
+
+    ``` sql
+    =# CREATE TABLE forpxf_table1(id int);
+    =# INSERT INTO forpxf_table1 VALUES (1);
+    =# INSERT INTO forpxf_table1 VALUES (2);
+    =# INSERT INTO forpxf_table1 VALUES (3);
+    ```
+
+5. Create a PostgreSQL user named `pxfuser1`:
+
+    ``` sql
+    =# CREATE USER pxfuser1 WITH PASSWORD 'changeme';
+    ```
+ 
+6. Assign user `pxfuser1` all privileges on table `forpxf_table1`, and exit the `psql` subsystem:
+
+    ``` sql
+    =# GRANT ALL ON forpxf_table1 TO pxfuser1;
+    =# \q
+    ```
+
+    With these privileges, `pxfuser1` can read from and write to the `forpxf_table1` table.
+
+7. Update the PostgreSQL configuration to allow user `pxfuser1` to access `pgtestdb` from each Greenplum Database segment host. This configuration is specific to your PostgreSQL environment. You will update the `/var/lib/pgsql/pg_hba.conf` file and then restart the PostgreSQL server.
+
+8. Construct the JDBC connection string, substituting your PostgreSQL server hostname and port number. For example:
+
+    ``` pre
+    &JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://pserver:5432/pgtestdb&USER=pxfuser1&PASS=changeme
+    ```
+
+    Save this string for use later.
+
+
+#### <a id="ex_jdbconfig"></a>Configure PXF
+
+You must download the PostgreSQL driver JAR file to your system, identify the location of the JAR in the PXF `pxf-public.classpath` configuration file, and then restart PXF.
+
+1. Log in to the Greenplum Database master node and set up your environment:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    gpadmin@gpmaster$ . /usr/local/greenplum-db/greenplum_path.sh
+    ```
+
+2. [Download](https://jdbc.postgresql.org/download.html) a PostgreSQL JDBC driver JAR file and note the location of the downloaded file.
+
+3. Add the JDBC driver JAR file location to `$GPHOME/pxf/conf/pxf-public.classpath`. For example, if the PostgreSQL JDBC jar file is located at `/usr/share/java/postgresql-42.2.5.jar`, add the following line to the `pxf-public.classpath` file:
+
+    ``` pre
+    /usr/share/java/postgresql-42.2.5.jar
+    ```
+
+4. Copy the JDBC driver JAR file to this location on each segment host. For example, if `seghostfile` contains a list, one-host-per-line, of the segment hosts in your Greenplum Database cluster:
+
+    ``` shell
+    gpadmin@gpmaster$ gpscp -v -f seghostfile /usr/share/java/postgresql-42.2.5.jar =:/usr/share/java/postgresql-42.2.5.jar
+    ``` 
+
+5. Copy the updated `pxf-public.classpath` file to each segment host. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ gpscp -v -f seghostfile /usr/local/greenplum-db/pxf/conf/pxf-public.classpath =:/usr/local/greenplum-db/pxf/conf/pxf-public.classpath
+    ``` 
+
+6. Restart PXF on *each* Greenplum Database segment host with the following command:
+
+    ``` shell
+    gpadmin@gpmaster$ gpssh -e -v -f seghostfile "/usr/local/greenplum-db/pxf/bin/pxf restart"
+    ```
+
+#### <a id="ex_readjdbc"></a>Read from the PostgreSQL Table
+
+Perform the following procedure to create a PXF external table referencing the `forpxf_table1` PostgreSQL table that you created in the previous section, and read the data in the table:
+
+1. Create the PXF external table specifying the `Jdbc` profile. For example:
+
+    ``` sql
+    gpadmin=# CREATE EXTERNAL TABLE pxf_tblfrompg(id int)
+                LOCATION ('pxf://public.forpxf_table1?PROFILE=Jdbc&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://pserver:5432/pgtestdb&USER=pxfuser1&PASS=changeme')
+                FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+    ```
+
+    Substitute the `DB_URL` string that you constructed in the previous exercise.
+
+2. Display all rows of the `pxf_tblfrompg` table:
+
+    ``` sql
+    gpadmin=# SELECT * FROM pxf_tblfrompg;
+     id
+    ----
+      1
+      2
+      3
+    (3 rows)
+    ```
+
+#### <a id="ex_writejdbc"></a>Write to the PostgreSQL Table
+
+Perform the following procedure to insert some data into the `forpxf_table1` Postgres table and then read from the table. You must create a new external table for the write operation.
+
+1. Create a writable PXF external table specifying the `Jdbc` profile. For example:
+
+    ``` sql
+    gpadmin=# CREATE WRITABLE EXTERNAL TABLE pxf_writeto_postgres(id int)
+                LOCATION ('pxf://public.forpxf_table1?PROFILE=Jdbc&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://pserver:5432/pgtestdb&USER=pxfuser1&PASS=changeme')
+              FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
+    ```
+
+    Again, substitute the `DB_URL` string that you constructed in the previous exercise.
+
+4. Insert some data into the `pxf_writeto_postgres` table. For example:
+
+    ``` sql
+    =# INSERT INTO pxf_writeto_postgres VALUES (111);
+    =# INSERT INTO pxf_writeto_postgres VALUES (222);
+    =# INSERT INTO pxf_writeto_postgres VALUES (333);
+    ```
+
+5. Use the `pxf_tblfrompg` readable external table that you created in the previous section to view the new data in the `forpxf_table1` PostgreSQL table:
+
+    ``` sql
+    gpadmin=# SELECT * FROM pxf_tblfrompg ORDER BY id DESC;
+     id
+    -----
+     333
+     222
+     111
+       3
+       2
+       1
+    (6 rows)
+    ```
+

--- a/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
@@ -55,6 +55,10 @@ The Greenplum Platform Extension Framework (PXF) provides parallel, high through
 
     This topic describes how to use the PXF HBase connector to read HBase table data.
 
+-   **[Accessing an External SQL Database](jdbc_pxf.html)**
+
+    This topic describes how to use the PXF JDBC connector to read from and write to an external SQL database such as Postgres or MySQL.
+
 -   **[Troubleshooting PXF](troubleshooting_pxf.html)**
 
     This topic details the service- and database- level logging configuration procedures for PXF. It also identifies some common PXF errors and describes how to address PXF memory issues.

--- a/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
@@ -25,7 +25,7 @@ The Greenplum Platform Extension Framework (PXF) implements a protocol named `px
 
 You must enable the PXF extension in each database in which you plan to use the framework to access external data. You must also explicitly `GRANT` permission to the `pxf` protocol to those users/roles who require access.
 
-After the extension is registered and privileges are assigned, you can use the `CREATE EXTERNAL TABLE` command to create an external table using the `pxf` protocol. PXF provides built-in HDFS, Hive, and HBase connectors. These connectors define profiles that support different file formats. You specify the profile name in the `CREATE EXTERNAL TABLE` command `LOCATION` URI.
+After the extension is registered and privileges are assigned, you can use the `CREATE EXTERNAL TABLE` command to create an external table using the `pxf` protocol. PXF provides built-in HDFS, Hive, HBase, and JDBC connectors. These connectors define profiles that support varied external data sources and file formats. You specify the profile name in the `CREATE EXTERNAL TABLE` command `LOCATION` URI.
 
 
 ## <a id="enable-pxf-ext"></a>Enabling/Disabling PXF
@@ -105,6 +105,7 @@ PXF accesses data sources using different connectors, and filter pushdown suppor
 
 - Hive Connector
 - HBase Connector
+- JDBC Connector
 
 PXF filter pushdown can be used with these data types:
 
@@ -127,11 +128,11 @@ To summarize, all of the following criteria must be met for filter pushdown to o
 * You enable external table filter pushdown by setting the `gp_external_enable_filter_pushdown` server configuration parameter to `'on'`.
 * The Greenplum Database protocol that you use to access external data source must support filter pushdown. The `pxf` external table protocol supports pushdown.
 * The external data source that you are accessing must support pushdown. For example, HBase and Hive support pushdown.
-* For queries on external tables that you create with the `pxf` protocol, the underlying PXF connector must also support filter pushdown. For example, the PXF Hive and HBase connectors support pushdown.
+* For queries on external tables that you create with the `pxf` protocol, the underlying PXF connector must also support filter pushdown. For example, the PXF Hive, HBase, and JDBC connectors support pushdown.
 
 ## <a id="built-inprofiles"></a> PXF Profiles
 
-PXF is installed with HDFS, Hive, and HBase connectors that provide a number of built-in profiles. These profiles simplify and unify access to external data sources of varied formats. You provide the profile name when you specify the `pxf` protocol on a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table referencing an external data store.
+PXF is installed with HDFS, Hive, HBase, and JDBC connectors that provide a number of built-in profiles. These profiles simplify and unify access to external data sources of varied formats. You provide the profile name when you specify the `pxf` protocol on a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table referencing an external data store.
 
 PXF provides the following built-in profiles. Those profiles that support write access are identified as such in their `Description`.
 
@@ -149,6 +150,7 @@ PXF provides the following built-in profiles. Those profiles that support write 
 | Hive | SequenceFile | Hive | Data consisting of binary key/value pairs. |
 | Hive | ORC | Hive, HiveORC, HiveVectorizedORC | Optimized row columnar data with stripe, footer, and postscript sections. |
 | Hive | Parquet | Hive | Compressed columnar data representation.|
+| SQL Database | Many | Jdbc | Read from and write to external SQL database.|
 
 A PXF profile definition includes the name of the profile, a description, and the Java classes that implement parsing and reading external data for the profile. Built-in PXF profiles are defined in the `$GPHOME/pxf/conf/pxf-profiles-default.xml` configuration file. The built-in `HdfsTextSimple` profile definition is reproduced below:
 
@@ -175,7 +177,7 @@ You use PXF to access data stored on external systems. Depending upon the extern
 
 PXF depends on JAR files and other configuration information provided by these additional components. The `$GPHOME/pxf/conf/pxf-private.classpath` and `$GPHOME/pxf/conf/pxf-public.classpath` configuration files identify PXF JAR dependencies. In most cases, PXF manages the `pxf-private.classpath` file, adding entries as necessary based on your Hadoop distribution and optional Hive and HBase client installations. 
 
-Should you need to add additional JAR dependencies for PXF, you must add them to the `pxf-public.classpath` file on each segment host, and then restart PXF on each host.
+Should you need to add additional JAR dependencies for PXF, for example a JDBC driver JAR file, you must add them to the `pxf-public.classpath` file on each segment host, and then restart PXF on each host.
 
 
 ## <a id="creatinganexternaltable"></a>Creating an External Table using PXF
@@ -204,7 +206,7 @@ Greenplum Database passes the parameters in the `LOCATION` string as headers to 
 | Keyword               | Value and Description                                                                                                                                                                                                                                                          |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | \<path\-to\-data\>        | A directory, file name, wildcard pattern, table name, etc. The syntax of \<path-to-data\> is dependent upon the profile currently in use.                                                                                                                                                                                                                    |
-| PROFILE              | The profile PXF uses to access the data. PXF supports HBase, HDFS, and Hive connectors that expose profiles named `HBase`, `HdfsTextSimple`, `HdfsTextMulti`, `Avro`, `Json`, `SequenceWritable`, `Hive`, `HiveText`, `HiveRC`, `HiveORC`, and `HiveVectorizedORC`.                                                                                                                                                                                   |
+| PROFILE              | The profile PXF uses to access the data. PXF supports HBase, HDFS, Hive, and JDBC connectors that expose profiles named `HBase`, `HdfsTextSimple`, `HdfsTextMulti`, `Avro`, `Json`, `SequenceWritable`, `Hive`, `HiveText`, `HiveRC`, `HiveORC`, `HiveVectorizedORC`, and `Jdbc`.                                                                                                                                                                                   |
 | \<custom-option\>=\<value\> | Additional options and values supported by the profile.                                                                  |
 | FORMAT  \<value\>| PXF profiles support the '`TEXT`', '`CSV`', and '`CUSTOM`' `FORMAT`s.  |
 | \<formatting-properties\> | Formatting properties supported by the profile; for example, the `formatter` or `delimiter`.                                                                   |


### PR DESCRIPTION
in this PR:
- create new PXF topic "Accessing an External SQL Database with PXF (JDBC)"
   - treat it like topics for other connectors
   - use some content from hawq docs and the connector README
   - create a simple postgresql example (previous example was mysql)
- misc updates on other pages with references to the connectors and pushdown

**plan to create a partitioning-related example in a follow on PR/release 

doc review site link to new topic:
- http://docs-lisa-pxfjdbc.cfapps.io/600/pxf/jdbc_pxf.html
