### PR TITLE
resgroup: detect gpdb cgroup comp dirs automatically (again)

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupimpl
+++ b/gpMgmt/bin/gpcheckresgroupimpl
@@ -44,6 +44,12 @@ class cgroup(object):
         if not self.compdirs:
             self.die("failed to detect cgroup component dirs.")
 
+        # 'memory' on 5X is special, although dir 'memory/gpdb' is optional,
+        # dir 'memory' is mandatory to provide 'memory.limit_in_bytes'.
+        # in such a case we must always put 'memory' in compdirs on 5X.
+        if gpver.version < [6, 0, 0] and 'memory' not in self.compdirs:
+            self.compdirs['memory'] = ''
+
         self.validate_permission("cpu", "gpdb/", "rwx")
         self.validate_permission("cpu", "gpdb/cgroup.procs", "rw")
         self.validate_permission("cpu", "gpdb/cpu.cfs_period_us", "rw")
@@ -106,11 +112,7 @@ class cgroup(object):
         otherwise return False.
         """
 
-        comps = ['cpu', 'cpuacct']
-        if gpver.version >= [6, 0, 0]:
-            comps.extend(['cpuset', 'memory'])
-
-        for comp in comps:
+        for comp in self.required_comps():
             if comp not in self.compdirs:
                 return False
 

--- a/gpMgmt/bin/gpcheckresgroupimpl
+++ b/gpMgmt/bin/gpcheckresgroupimpl
@@ -9,29 +9,26 @@ import psutil
 from gppylib.commands import gp
 from gppylib import gpversion
 
+gpverstr = gp.GpVersion.local("", os.getenv("GPHOME"))
+gpver = gpversion.GpVersion(gpverstr)
+
 class dummy(object):
 
     def validate_all(self):
         exit("resource group is not supported on this platform")
 
 
-def detectCgroupMountPoint():
-    proc_mounts_path = "/proc/self/mounts"
-    if os.path.exists(proc_mounts_path):
-        with open(proc_mounts_path) as f:
-            for line in f:
-                mntent = line.split()
-                if mntent[2] != "cgroup": continue
-                mount_point = os.path.dirname(mntent[1])
-                return mount_point
-    return ""
-
 class cgroup(object):
 
-    mount_point = detectCgroupMountPoint()
-    tab = { 'r': os.R_OK, 'w': os.W_OK, 'x': os.X_OK, 'f': os.F_OK }
-    impl = "cgroup"
-    error_prefix = " is not properly configured: "
+    def __init__(self):
+        self.mount_point = self.detect_cgroup_mount_point()
+        self.tab = { 'r': os.R_OK, 'w': os.W_OK, 'x': os.X_OK, 'f': os.F_OK }
+        self.impl = "cgroup"
+        self.error_prefix = " is not properly configured: "
+
+        self.compdirs = self.detect_comp_dirs()
+        if not self.validate_comp_dirs():
+            self.compdirs = self.fallback_comp_dirs()
 
     def validate_all(self):
         """
@@ -44,44 +41,49 @@ class cgroup(object):
         if not self.mount_point:
             self.die("failed to detect cgroup mount point.")
 
-        self.validate_permission("cpu/gpdb/", "rwx")
-        self.validate_permission("cpu/gpdb/cgroup.procs", "rw")
-        self.validate_permission("cpu/gpdb/cpu.cfs_period_us", "rw")
-        self.validate_permission("cpu/gpdb/cpu.cfs_quota_us", "rw")
-        self.validate_permission("cpu/gpdb/cpu.shares", "rw")
+        if not self.compdirs:
+            self.die("failed to detect cgroup component dirs.")
 
-        self.validate_permission("cpuacct/gpdb/", "rwx")
-        self.validate_permission("cpuacct/gpdb/cgroup.procs", "rw")
-        self.validate_permission("cpuacct/gpdb/cpuacct.usage", "r")
-        self.validate_permission("cpuacct/gpdb/cpuacct.stat", "r")
+        self.validate_permission("cpu", "gpdb/", "rwx")
+        self.validate_permission("cpu", "gpdb/cgroup.procs", "rw")
+        self.validate_permission("cpu", "gpdb/cpu.cfs_period_us", "rw")
+        self.validate_permission("cpu", "gpdb/cpu.cfs_quota_us", "rw")
+        self.validate_permission("cpu", "gpdb/cpu.shares", "rw")
 
-        self.validate_permission("memory/memory.limit_in_bytes", "r")
+        self.validate_permission("cpuacct", "gpdb/", "rwx")
+        self.validate_permission("cpuacct", "gpdb/cgroup.procs", "rw")
+        self.validate_permission("cpuacct", "gpdb/cpuacct.usage", "r")
+        self.validate_permission("cpuacct", "gpdb/cpuacct.stat", "r")
+
+        self.validate_permission("memory", "memory.limit_in_bytes", "r")
 
         # resgroup memory auditor is introduced in 6.0 devel and backported
         # to 5.x branch since 5.6.1.  To provide backward compatibilities
         # memory permissions are only checked since 6.0.
-        gpverstr = gp.GpVersion.local("", os.getenv("GPHOME"))
-        gpver = gpversion.GpVersion(gpverstr)
         if gpver.version >= [6, 0, 0]:
-            self.validate_permission("memory/gpdb/", "rwx")
-            self.validate_permission("memory/gpdb/memory.limit_in_bytes", "rw")
-            self.validate_permission("memory/gpdb/memory.usage_in_bytes", "r")
+            self.validate_permission("memory", "gpdb/", "rwx")
+            self.validate_permission("memory", "gpdb/memory.limit_in_bytes", "rw")
+            self.validate_permission("memory", "gpdb/memory.usage_in_bytes", "r")
 
-            self.validate_permission("cpuset/gpdb/", "rwx")
-            self.validate_permission("cpuset/gpdb/cgroup.procs", "rw")
-            self.validate_permission("cpuset/gpdb/cpuset.cpus", "rw")
-            self.validate_permission("cpuset/gpdb/cpuset.mems", "rw")
+            self.validate_permission("cpuset", "gpdb/", "rwx")
+            self.validate_permission("cpuset", "gpdb/cgroup.procs", "rw")
+            self.validate_permission("cpuset", "gpdb/cpuset.cpus", "rw")
+            self.validate_permission("cpuset", "gpdb/cpuset.mems", "rw")
 
     def die(self, msg):
         exit(self.impl + self.error_prefix + msg)
 
-    def validate_permission(self, path, mode):
+    def validate_permission(self, comp, path, mode):
         """
         Validate permission on path.
         If path is a dir it must ends with '/'.
         """
         try:
-            fullpath = os.path.join(self.mount_point, path)
+            if comp not in self.compdirs:
+                self.die("can't find dir of cgroup component '%s'" % (comp))
+
+            compdir = self.compdirs[comp]
+            fullpath = os.path.join(self.mount_point, comp, compdir, path)
             pathtype = path[-1] == "/" and "directory" or "file"
             modebits = reduce(lambda x, y: x | y,
                               map(lambda x: self.tab[x], mode), 0)
@@ -95,6 +97,70 @@ class cgroup(object):
         except IOError, e:
             self.die("can't check permission on %s '%s': %s" \
                      % (pathtype, fullpath, str(e)))
+
+    def validate_comp_dirs(self):
+        """
+        Validate existance of cgroup component dirs.
+
+        Return True if all the components dir exist and have good permission,
+        otherwise return False.
+        """
+
+        comps = ['cpu', 'cpuacct']
+        if gpver.version >= [6, 0, 0]:
+            comps.extend(['cpuset', 'memory'])
+
+        for comp in comps:
+            if comp not in self.compdirs:
+                return False
+
+            compdir = self.compdirs[comp]
+            fullpath = os.path.join(self.mount_point, comp, compdir, 'gpdb')
+
+            if not os.access(fullpath, os.R_OK | os.W_OK | os.X_OK):
+                return False
+
+        return True
+
+    def detect_cgroup_mount_point(self):
+        proc_mounts_path = "/proc/self/mounts"
+        if os.path.exists(proc_mounts_path):
+            with open(proc_mounts_path) as f:
+                for line in f:
+                    mntent = line.split()
+                    if mntent[2] != "cgroup": continue
+                    mount_point = os.path.dirname(mntent[1])
+                    return mount_point
+        return ""
+
+    def detect_comp_dirs(self):
+        compdirs = {}
+        path = "/proc/1/cgroup"
+
+        if not os.path.exists(path):
+            return compdirs
+
+        for line in open(path):
+            line = line.strip()
+            compid, compnames, comppath = line.split(":")
+            if not compnames or '=' in compnames:
+                continue
+            for compname in compnames.split(','):
+                compdirs[compname] = comppath.strip(os.path.sep)
+
+        return compdirs
+
+    def required_comps(self):
+        comps = ['cpu', 'cpuacct']
+        if gpver.version >= [6, 0, 0]:
+            comps.extend(['cpuset', 'memory'])
+        return comps
+
+    def fallback_comp_dirs(self):
+        compdirs = {}
+        for comp in self.required_comps():
+            compdirs[comp] = ''
+        return compdirs
 
 if __name__ == '__main__':
     if sys.platform.startswith('linux'):

--- a/src/backend/utils/resgroup/resgroup-ops-dummy.c
+++ b/src/backend/utils/resgroup/resgroup-ops-dummy.c
@@ -112,10 +112,10 @@ ResGroupOps_AssignGroup(Oid group, ResGroupCaps *caps, int pid)
  * immediately.
  *
  * On success it return a fd to the OS group, pass it to
- * ResGroupOps_UnLockGroup() to unblock it.
+ * ResGroupOps_UnLockGroup() to unlock it.
  */
 int
-ResGroupOps_LockGroup(Oid group, const char *comp, bool block)
+ResGroupOps_LockGroup(Oid group, ResGroupCompType comp, bool block)
 {
 	unsupported_system();
 	return -1;

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -396,7 +396,11 @@ detectCompDirs(void)
 	if (maskDetected != maskAll)
 		goto fallback; /* not all the comps are detected */
 
-	dumpCompDirs();
+	/*
+	 * Dump the comp dirs for debugging?  No!
+	 * This function is executed before timezone initialization, logs are
+	 * forbidden.
+	 */
 
 	fclose(f);
 	return;
@@ -407,8 +411,6 @@ fallback:
 	{
 		compSetDir(comp, FALLBACK_COMP_DIR);
 	}
-
-	dumpCompDirs();
 
 	fclose(f);
 }
@@ -1168,6 +1170,12 @@ ResGroupOps_Bless(void)
 	 * Check again, this time we will fail on unmet requirements.
 	 */
 	checkPermission(RESGROUP_ROOT_ID, true);
+
+	/*
+	 * Dump the cgroup comp dirs to logs.
+	 * Check detectCompDirs() to know why this is not done in that function.
+	 */
+	dumpCompDirs();
 }
 
 /* Initialize the OS group */

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3794,6 +3794,7 @@ groupMemOnAlterForCgroup(Oid groupId, ResGroupData *group)
 static void
 groupApplyCgroupMemInc(ResGroupData *group)
 {
+	ResGroupCompType comp = RESGROUP_COMP_TYPE_MEMORY;
 	int32 memory_limit;
 	int32 memory_inc;
 	int fd;
@@ -3806,7 +3807,7 @@ groupApplyCgroupMemInc(ResGroupData *group)
 	if (memory_inc <= 0)
 		return;
 
-	fd = ResGroupOps_LockGroup(group->groupId, "memory", true);
+	fd = ResGroupOps_LockGroup(group->groupId, comp, true);
 	memory_limit = ResGroupOps_GetMemoryLimit(group->groupId);
 	ResGroupOps_SetMemoryLimitByValue(group->groupId, memory_limit + memory_inc);
 	ResGroupOps_UnLockGroup(group->groupId, fd);
@@ -3822,6 +3823,7 @@ groupApplyCgroupMemInc(ResGroupData *group)
 static void
 groupApplyCgroupMemDec(ResGroupData *group)
 {
+	ResGroupCompType comp = RESGROUP_COMP_TYPE_MEMORY;
 	int32 memory_limit;
 	int32 memory_dec;
 	int fd;
@@ -3829,7 +3831,7 @@ groupApplyCgroupMemDec(ResGroupData *group)
 	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
 	Assert(group->memGap > 0);
 
-	fd = ResGroupOps_LockGroup(group->groupId, "memory", true);
+	fd = ResGroupOps_LockGroup(group->groupId, comp, true);
 	memory_limit = ResGroupOps_GetMemoryLimit(group->groupId);
 	Assert(memory_limit > group->memGap);
 

--- a/src/include/utils/resgroup-ops.h
+++ b/src/include/utils/resgroup-ops.h
@@ -14,6 +14,22 @@
 #ifndef RES_GROUP_OPS_H
 #define RES_GROUP_OPS_H
 
+/*
+ * Resource Group underlying component types.
+ */
+typedef enum
+{
+	RESGROUP_COMP_TYPE_FIRST			= 0,
+	RESGROUP_COMP_TYPE_UNKNOWN			= -1,
+
+	RESGROUP_COMP_TYPE_CPU,
+	RESGROUP_COMP_TYPE_CPUACCT,
+	RESGROUP_COMP_TYPE_MEMORY,
+	RESGROUP_COMP_TYPE_CPUSET,
+
+	RESGROUP_COMP_TYPE_COUNT,
+} ResGroupCompType;
+
 #define RESGROUP_ROOT_ID (InvalidOid)
 /*
  * If group id is RESGROUP_COMPROOT_ID, it will build the root path of comp,
@@ -32,11 +48,12 @@
  * If cpu_rate_limit is set to this value, it means this feature is disabled
  */
 #define CPU_RATE_LIMIT_DISABLED (-1)
+
 /*
  * Interfaces for OS dependent operations
  */
 
-extern const char * ResGroupOps_Name(void);
+extern const char *ResGroupOps_Name(void);
 extern bool ResGroupOps_Probe(void);
 extern void ResGroupOps_Bless(void);
 extern void ResGroupOps_Init(void);
@@ -44,7 +61,7 @@ extern void ResGroupOps_AdjustGUCs(void);
 extern void ResGroupOps_CreateGroup(Oid group);
 extern void ResGroupOps_DestroyGroup(Oid group, bool migrate);
 extern void ResGroupOps_AssignGroup(Oid group, ResGroupCaps *caps, int pid);
-extern int ResGroupOps_LockGroup(Oid group, const char *comp, bool block);
+extern int ResGroupOps_LockGroup(Oid group, ResGroupCompType comp, bool block);
 extern void ResGroupOps_UnLockGroup(Oid group, int fd);
 extern void ResGroupOps_SetCpuRateLimit(Oid group, int cpu_rate_limit);
 extern void ResGroupOps_SetMemoryLimit(Oid group, int memory_limit);


### PR DESCRIPTION
Push https://github.com/greenplum-db/gpdb/pull/5737 again:

commit f3dc101a7b4fa3d392f79cc5146b20c83894eb19
Author: Ning Yu <nyu@pivotal.io>
Date:   Thu Sep 13 11:07:15 2018 +0800

    resgroup: detect gpdb cgroup comp dirs automatically.

    Take cpu for example, by default we expect gpdb dir to locate at
    cgroup/cpu/gpdb.  But we'll also check for the cgroup dirs of init
    process (pid 1), e.g. cgroup/cpu/custom, then we'll look for gpdb dir at
    cgroup/cpu/custom/gpdb, if it's found and has good permissions, it can
    be used instead of the default one.

    If any of the gpdb cgroup component dir can not be found under init
    process' cgroup dirs or has bad permissions we'll fallback all the gpdb
    cgroup component dirs to the default ones.

    NOTE: This auto detection will look for memory & cpuset gpdb dirs even
    on 5X.

Logs were generated too early at that commit, even earlier than timezone initialization, which cause pipeline job `gpinitsystem` to fail.  Fixed by logging late enough.  Also included a 5X specific fix to keep the code in sync.