### PR TITLE
Support equijoin on coerced distribution keys

### DIFF
--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3067,8 +3067,8 @@ INNER JOIN member_subgroup
 ON member_group.group_id = member_subgroup.group_id
 LEFT OUTER JOIN region
 ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Left Join
          Hash Cond: (member_subgroup.subgroup_name = (region.county_name)::text)
@@ -3093,6 +3093,41 @@ ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = r
                      ->  Seq Scan on region
  Optimizer: legacy query optimizer
 (23 rows)
+
+-- Test colocated equijoins on coerced distribution keys
+CREATE TABLE coercejoin (a varchar(10), b varchar(10)) DISTRIBUTED BY (a);
+-- Positive test, the join should be colocated as the implicit cast from the
+-- parse rewrite is a relabeling (varchar::text).
+EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a=b.a;
+                 QUERY PLAN                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((a.a)::text = (b.a)::text)
+         ->  Seq Scan on coercejoin a
+         ->  Hash
+               ->  Seq Scan on coercejoin b
+ Optimizer: legacy query optimizer
+(7 rows)
+
+-- Negative test, the join should not be colocated since the cast is a coercion
+-- which cannot guarantee that the coerced value would hash to the same segment
+-- as the uncoerced tuple.
+EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=b.a::numeric;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((a.a)::numeric = (b.a)::numeric)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (a.a)::numeric
+               ->  Seq Scan on coercejoin a
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (b.a)::numeric
+                     ->  Seq Scan on coercejoin b
+ Optimizer: legacy query optimizer
+(11 rows)
 
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3094,6 +3094,39 @@ ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = r
  Optimizer: PQO version 2.69.0
 (23 rows)
 
+-- Test colocated equijoins on coerced distribution keys
+CREATE TABLE coercejoin (a varchar(10), b varchar(10)) DISTRIBUTED BY (a);
+-- Positive test, the join should be colocated as the implicit cast from the
+-- parse rewrite is a relabeling (varchar::text).
+EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a=b.a;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((coercejoin.a)::text = (coercejoin_1.a)::text)
+         ->  Table Scan on coercejoin
+         ->  Hash
+               ->  Table Scan on coercejoin coercejoin_1
+(7 rows)
+
+-- Negative test, the join should not be colocated since the cast is a coercion
+-- which cannot guarantee that the coerced value would hash to the same segment
+-- as the uncoerced tuple.
+EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=b.a::numeric;
+                                 QUERY PLAN                                    
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((coercejoin.a)::numeric = (coercejoin_1.a)::numeric)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (coercejoin.a)::numeric
+               ->  Table Scan on coercejoin
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (coercejoin_1.a)::numeric
+                     ->  Table Scan on coercejoin coercejoin_1
+(11 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -482,35 +482,22 @@ select t1.id, t1.data, t2.id, t2.data from test_int1 t1, test_int2 t2 where t1.d
 (2 rows)
 
 -- Test to ensure that for full outer join on varchar columns, planner is successful in finding a sort operator in the catalog
--- start_ignore
-create table input_table(a varchar(30), b varchar(30));
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table input_table(a varchar(30), b varchar(30)) distributed by (a);
 set enable_hashjoin = off;
--- end_ignore
 explain (costs off) select X.a from input_table X full join (select a from input_table) Y ON X.a = Y.a;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Merge Full Join
          Merge Cond: ((x.a)::text = (input_table.a)::text)
          ->  Sort
                Sort Key: x.a
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: x.a
-                     ->  Seq Scan on input_table x
+               ->  Seq Scan on input_table x
          ->  Sort
                Sort Key: input_table.a
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: input_table.a
-                     ->  Seq Scan on input_table
+               ->  Seq Scan on input_table
  Optimizer: legacy query optimizer
-(14 rows)
-
-select X.a from input_table X full join (select a from input_table) Y ON X.a = Y.a;
- a 
----
-(0 rows)
+(10 rows)
 
 -- Cleanup
 set client_min_messages='warning'; -- silence drop-cascade NOTICEs

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -492,12 +492,8 @@ select t1.id, t1.data, t2.id, t2.data from test_int1 t1, test_int2 t2 where t1.d
 (2 rows)
 
 -- Test to ensure that for full outer join on varchar columns, planner is successful in finding a sort operator in the catalog
--- start_ignore
-create table input_table(a varchar(30), b varchar(30));
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table input_table(a varchar(30), b varchar(30)) distributed by (a);
 set enable_hashjoin = off;
--- end_ignore
 explain (costs off) select X.a from input_table X full join (select a from input_table) Y ON X.a = Y.a;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
@@ -533,11 +529,6 @@ explain (costs off) select X.a from input_table X full join (select a from input
                                                          ->  Shared Scan (share slice:id 3:0)
  Optimizer: PQO version 2.74.0
 (31 rows)
-
-select X.a from input_table X full join (select a from input_table) Y ON X.a = Y.a;
- a 
----
-(0 rows)
 
 -- Cleanup
 set client_min_messages='warning'; -- silence drop-cascade NOTICEs

--- a/src/test/regress/expected/window.out
+++ b/src/test/regress/expected/window.out
@@ -1065,27 +1065,21 @@ SELECT * FROM
           min(salary) OVER (PARTITION BY depname, empno order by enroll_date) depminsalary
    FROM empsalary) emp
 WHERE depname = 'sales';
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Subquery Scan on emp
          ->  WindowAgg
                Order By: empsalary.empno
-               ->  Sort
-                     Sort Key: empsalary.empno
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: empsalary.depname
-                           ->  WindowAgg
-                                 Partition By: empsalary.empno
-                                 Order By: empsalary.enroll_date
-                                 ->  Sort
-                                       Sort Key: empsalary.empno, empsalary.enroll_date
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                             Hash Key: empsalary.depname, empsalary.empno
-                                             ->  Seq Scan on empsalary
-                                                   Filter: ((depname)::text = 'sales'::text)
+               ->  WindowAgg
+                     Partition By: empsalary.empno
+                     Order By: empsalary.enroll_date
+                     ->  Sort
+                           Sort Key: empsalary.empno, empsalary.enroll_date
+                           ->  Seq Scan on empsalary
+                                 Filter: ((depname)::text = 'sales'::text)
  Optimizer: legacy query optimizer
-(18 rows)
+(12 rows)
 
 -- Test Sort node reordering
 EXPLAIN (COSTS OFF)
@@ -1093,9 +1087,9 @@ SELECT
   lead(1) OVER (PARTITION BY depname ORDER BY salary, enroll_date),
   lag(1) OVER (PARTITION BY depname ORDER BY salary,enroll_date,empno)
 FROM empsalary;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  WindowAgg
          Partition By: depname
          Order By: salary, enroll_date
@@ -1104,11 +1098,9 @@ FROM empsalary;
                Order By: salary, enroll_date, empno
                ->  Sort
                      Sort Key: depname, salary, enroll_date, empno
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: depname
-                           ->  Seq Scan on empsalary
+                     ->  Seq Scan on empsalary
  Optimizer: legacy query optimizer
-(13 rows)
+(11 rows)
 
 -- cleanup
 DROP TABLE empsalary;

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -289,12 +289,9 @@ insert into test_int2 values(3, 10), (4, 20);
 select t1.id, t1.data, t2.id, t2.data from test_int1 t1, test_int2 t2 where t1.data = t2.data;
 
 -- Test to ensure that for full outer join on varchar columns, planner is successful in finding a sort operator in the catalog
--- start_ignore
-create table input_table(a varchar(30), b varchar(30));
+create table input_table(a varchar(30), b varchar(30)) distributed by (a);
 set enable_hashjoin = off;
--- end_ignore
 explain (costs off) select X.a from input_table X full join (select a from input_table) Y ON X.a = Y.a;
-select X.a from input_table X full join (select a from input_table) Y ON X.a = Y.a;
 
 -- Cleanup
 set client_min_messages='warning'; -- silence drop-cascade NOTICEs


### PR DESCRIPTION
Distribution key joins on pathkeys where the parser invokes an implicit cast, or where the user invokes an explicit cast, would introduce a redistribution motion due to the join not being recognized as a colocated equijoin. As an example, consider the following relation
```SQL
create table test (a varchar(10), b varchar(10)) distributed by (a);
```
The below query will introduce an implicit cast on a.a and b.a to `TEXT` by the parser. This means that the pathkey `EquivalenceClass` is on `VARCHAR` but the `RestrictInfo` ECs are for `TEXT`.
```SQL
select * from test a, test b where a.a=b.a;
```
Similarly, an explicit cast would also introduce a redistribution motion as the ECs didn't match.
```SQL
select * from test a, test b where a.a::numeric=b.a::numeric;
```
Fix by following the EC members and checking for coercion conditions under which we can allow colocated equijoins.

It should be noted that I expect to see ICW fallout as my laptop is running out of battery faster than I can run ICW, so opening here in a WIP state for now until the dust has settled.