### PR TITLE
Fix ao_upgrade tests and add them to the schedule

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -682,6 +682,76 @@ numeric_out_sci(Numeric num, int scale)
 }
 
 /*
+ * GPDB: for testing purposes, this function will force any Numeric into the old
+ * long format that was in use before Postgres 9.1 (commit 14534353). If the
+ * Numeric is already in long format, it will be returned directly; otherwise a
+ * new Numeric will be allocated.
+ */
+Numeric
+numeric_force_long_format(Numeric num)
+{
+	NumericVar		var;
+	int				sign;
+	Numeric			result;
+
+	if (!NUMERIC_IS_SHORT(num) && !NUMERIC_IS_NAN(num))
+	{
+		/* Already in long format. */
+		return num;
+	}
+
+	init_var_from_num(num, &var);
+	sign = var.sign;
+
+	if (sign == NUMERIC_NAN)
+	{
+		/* Create a NaN in the four-byte legacy format. */
+		result = (Numeric) palloc0(NUMERIC_HDRSZ);
+		SET_VARSIZE(result, NUMERIC_HDRSZ);
+
+		result->choice.n_header = NUMERIC_NAN;
+	}
+	else
+	{
+		/*
+		 * Convert the short numeric to the long format. This code must match
+		 * make_result()'s long format implementation!
+		 */
+		NumericDigit *digits = var.digits;
+		int			weight = var.weight;
+		int			n = var.ndigits;
+		Size		len;
+
+		len = NUMERIC_HDRSZ + n * sizeof(NumericDigit);
+		result = (Numeric) palloc(len);
+		SET_VARSIZE(result, len);
+		result->choice.n_long.n_sign_dscale =
+			sign | (var.dscale & NUMERIC_DSCALE_MASK);
+		result->choice.n_long.n_weight = weight;
+
+		memcpy(NUMERIC_DIGITS(result), digits, n * sizeof(NumericDigit));
+		Assert(NUMERIC_NDIGITS(result) == n);
+
+		/* Check for overflow of int16 fields */
+		if (NUMERIC_WEIGHT(result) != weight ||
+			NUMERIC_DSCALE(result) != var.dscale)
+		{
+			char *ntp = get_str_from_var(&var, var.dscale);
+
+			ereport(ERROR,
+					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+					 errmsg("value overflows numeric format"),
+					 errdetail("Overflowing value: %s", ntp)
+					));
+		}
+	}
+
+	free_var(&var);
+	dump_numeric("numeric_force_long_format()", result);
+	return result;
+}
+
+/*
  *		numeric_recv			- converts external binary format to numeric
  *
  * External format is a sequence of int16's:

--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -66,4 +66,7 @@ extern int numeric_len(Numeric num);
 int32		numeric_maximum_size(int32 typmod);
 extern char *numeric_out_sci(Numeric num, int scale);
 
+/* GPDB-specific additions */
+extern Numeric numeric_force_long_format(Numeric num);
+
 #endif   /* _PG_NUMERIC_H_ */

--- a/src/test/isolation2/input/ao_upgrade.source
+++ b/src/test/isolation2/input/ao_upgrade.source
@@ -21,7 +21,9 @@ CREATE TABLE aocs_upgrade_test (rowid int, n numeric) WITH (appendonly=true, ori
 CREATE TABLE aocs_rle_upgrade_test (rowid int, n numeric) WITH (appendonly=true, orientation=column, compresstype=RLE_TYPE);
 
 INSERT INTO ao_upgrade_test (SELECT a, convert_to_v4((a + 5) !) FROM generate_series(1, 10) a);
+INSERT INTO ao_upgrade_test VALUES(11, convert_to_v4('NaN'));
 INSERT INTO aocs_upgrade_test (SELECT a, convert_to_v4((a + 5) !) FROM generate_series(1, 10) a);
+INSERT INTO aocs_upgrade_test VALUES(11, convert_to_v4('NaN'));
 
 -- For the RLE test case, insert a bunch of identical numerics so they will be
 -- run-length compressed.

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -23,6 +23,7 @@ test: vacuum_recently_dead_tuple_due_to_distributed_snapshot
 test: invalidated_toast_index
 test: distributed_snapshot
 test: gp_collation
+test: ao_upgrade
 
 test: setup
 # Tests on Append-Optimized tables (row-oriented).

--- a/src/test/isolation2/output/ao_upgrade.source
+++ b/src/test/isolation2/output/ao_upgrade.source
@@ -21,8 +21,12 @@ CREATE
 
 INSERT INTO ao_upgrade_test (SELECT a, convert_to_v4((a + 5) !) FROM generate_series(1, 10) a);
 INSERT 10
+INSERT INTO ao_upgrade_test VALUES(11, convert_to_v4('NaN'));
+INSERT 1
 INSERT INTO aocs_upgrade_test (SELECT a, convert_to_v4((a + 5) !) FROM generate_series(1, 10) a);
 INSERT 10
+INSERT INTO aocs_upgrade_test VALUES(11, convert_to_v4('NaN'));
+INSERT 1
 
 -- For the RLE test case, insert a bunch of identical numerics so they will be
 -- run-length compressed.
@@ -42,9 +46,10 @@ rowid|n
 8    |62.27 
 9    |871.78
 10   |1.308 
+11   |0     
 1    |720   
 2    |5040  
-(10 rows)
+(11 rows)
 SELECT * FROM aocs_upgrade_test;
 rowid|n     
 -----+------
@@ -56,9 +61,10 @@ rowid|n
 8    |62.27 
 9    |871.78
 10   |1.308 
+11   |0     
 1    |720   
 2    |5040  
-(10 rows)
+(11 rows)
 SELECT * FROM aocs_rle_upgrade_test;
 rowid|n   
 -----+----
@@ -145,6 +151,7 @@ rowid|n
 8    |6227020800   
 9    |87178291200  
 10   |1307674368000
+11   |NaN          
 1    |720          
 2    |5040         
 3    |40320        
@@ -152,7 +159,7 @@ rowid|n
 5    |3628800      
 6    |39916800     
 7    |479001600    
-(10 rows)
+(11 rows)
 SELECT * FROM aocs_upgrade_test;
 rowid|n            
 -----+-------------
@@ -166,7 +173,8 @@ rowid|n
 8    |6227020800   
 9    |87178291200  
 10   |1307674368000
-(10 rows)
+11   |NaN          
+(11 rows)
 SELECT * FROM aocs_rle_upgrade_test;
 rowid|n     
 -----+------

--- a/src/test/isolation2/output/ao_upgrade_optimizer.source
+++ b/src/test/isolation2/output/ao_upgrade_optimizer.source
@@ -21,8 +21,12 @@ CREATE
 
 INSERT INTO ao_upgrade_test (SELECT a, convert_to_v4((a + 5) !) FROM generate_series(1, 10) a);
 INSERT 10
+INSERT INTO ao_upgrade_test VALUES(11, convert_to_v4('NaN'));
+INSERT 1
 INSERT INTO aocs_upgrade_test (SELECT a, convert_to_v4((a + 5) !) FROM generate_series(1, 10) a);
 INSERT 10
+INSERT INTO aocs_upgrade_test VALUES(11, convert_to_v4('NaN'));
+INSERT 1
 
 -- For the RLE test case, insert a bunch of identical numerics so they will be
 -- run-length compressed.
@@ -42,9 +46,10 @@ rowid|n
 8    |62.27 
 9    |871.78
 10   |1.308 
+11   |0     
 1    |720   
 2    |5040  
-(10 rows)
+(11 rows)
 SELECT * FROM aocs_upgrade_test;
 rowid|n     
 -----+------
@@ -56,9 +61,10 @@ rowid|n
 8    |62.27 
 9    |871.78
 10   |1.308 
+11   |0     
 1    |720   
 2    |5040  
-(10 rows)
+(11 rows)
 SELECT * FROM aocs_rle_upgrade_test;
 rowid|n   
 -----+----
@@ -145,6 +151,7 @@ rowid|n
 8    |6227020800   
 9    |87178291200  
 10   |1307674368000
+11   |NaN          
 1    |720          
 2    |5040         
 3    |40320        
@@ -152,7 +159,7 @@ rowid|n
 5    |3628800      
 6    |39916800     
 7    |479001600    
-(10 rows)
+(11 rows)
 SELECT * FROM aocs_upgrade_test;
 rowid|n            
 -----+-------------
@@ -166,7 +173,8 @@ rowid|n
 8    |6227020800   
 9    |87178291200  
 10   |1307674368000
-(10 rows)
+11   |NaN          
+(11 rows)
 SELECT * FROM aocs_rle_upgrade_test;
 rowid|n     
 -----+------


### PR DESCRIPTION
9.1 added a new, more compact "short" format to the numeric datatype. This format wasn't handled by the ao_upgrade test in isolation2, so it failed -- but the pipeline was still green because I forgot to add the new test to the schedule in 54895f54.

To fix the issue, add a new helper which will force any Numeric back to the legacy long format, and call that from `convertNumericToGPDB4()` in the ao_upgrade test. And add the test to the schedule, so we don't have to do this again.