### PR TITLE
Update gpsd and minirepro to dump HLL stats as an option

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -74,7 +74,7 @@ def dumpTupleCount(cur):
                                             t, zip(columns[2:], vals[2:], types))), vals[0], vals[1])
 
 
-def dumpStats(cur):
+def dumpStats(cur, inclHLL):
     query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgt.typname, pgs.* ' \
         'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt ' \
         'WHERE pgc.relnamespace = pgn.oid and pgn.nspname NOT IN ' + \
@@ -126,6 +126,8 @@ def dumpStats(cur):
             i = i + 1
             str_val = "'%s'" % val
             if i == 10 and (val == 98 or val == 99):
+                if inclHLL == False:
+                    val = 0
                 hll = True
 
             if val is None:
@@ -134,7 +136,10 @@ def dumpStats(cur):
                 val = val.replace("'", "''").replace('\\', '\\\\')
                 val = "E'" + val + "'"
             if i == 25 and hll == True:
-                rowVals.append('\t{0}::{1}'.format(str_val, 'bytea[]'))
+                if inclHLL == True:
+                    rowVals.append('\t{0}::{1}'.format(str_val, 'bytea[]'))
+                else:
+                    rowVals.append('\t{0}'.format('NULL::int4[]'))
             else:
                 rowVals.append('\t{0}::{1}'.format(val, typ))
         print pstring.format(vals[0], vals[2], ',\n'.join(rowVals))
@@ -151,6 +156,8 @@ def parseCmdLine():
                  help='Connect as someone other than current user')
     p.add_option('-s', '--stats-only', action='store_false', dest='dumpSchema',
                  default=True, help='Just dump the stats, do not do a schema dump')
+    p.add_option('-l', '--hll', action='store_true', dest='dumpHLL',
+                 default=False, help='Include HLL stats')
     return p
 
 
@@ -178,6 +185,7 @@ def main():
     user = options.user or os.getlogin()
     port = options.port or '5432'
     inclSchema = options.dumpSchema
+    inclHLL = options.dumpHLL
 
     envOpts = os.environ
     envOpts['PGOPTIONS'] = pgoptions
@@ -229,7 +237,7 @@ def main():
         with closing(pgdb.connect(connectionString)) as connection:
             with closing(connection.cursor()) as cursor:
                 dumpTupleCount(cursor)
-                dumpStats(cursor)
+                dumpStats(cursor, inclHLL)
     except pgdb.DatabaseError, err:  # catch *all* exceptions
         sys.stderr.write('Error while dumping statistics:\n')
         sys.stderr.write(err.message)

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -115,6 +115,8 @@ def parse_cmd_line():
                  help='file name that contains the query')
     p.add_option('-f', action='store', dest='output_file',
                  help='minirepro output file name')
+    p.add_option('-l', '--hll', action='store_true', dest='dumpHLL',
+                 default=False, help='Include HLL stats')
     return p
 
 def dump_query(connectionInfo, query_file):
@@ -207,7 +209,7 @@ def dump_tuple_count(cur, oid_str, f_out):
         updateStmt = templateStmt.format(E(',\n'.join(lines)), E(vals[0]), E(vals[1]))
         f_out.writelines(updateStmt)
 
-def dump_stats(cur, oid_str, f_out):
+def dump_stats(cur, oid_str, f_out, inclHLL):
     query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgt.typname, pgs.* ' \
         'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt ' \
         'WHERE pgc.relnamespace = pgn.oid and pgc.oid in (%s) ' \
@@ -263,6 +265,8 @@ def dump_stats(cur, oid_str, f_out):
             i = i + 1
             str_val = "'%s'" % val
             if i == 10 and (val == 98 or val == 99):
+                if inclHLL == False:
+                    val = 0
                 hll = True
 
             if val is None:
@@ -270,7 +274,10 @@ def dump_stats(cur, oid_str, f_out):
             elif isinstance(val, (str, unicode)) and val[0] == '{':
                 val = "E'%s'" % E(val)
             if i == 25 and hll == True:
-                rowVals.append('\t{0}::{1}'.format(str_val, 'bytea[]'))
+                if inclHLL == True:
+                    rowVals.append('\t{0}::{1}'.format(str_val, 'bytea[]'))
+                else:
+                    rowVals.append('\t{0}'.format('NULL::int4[]'))
             else:
                 rowVals.append('\t{0}::{1}'.format(val, typ))
 
@@ -297,6 +304,7 @@ def main():
     port = options.port or ('PGPORT' in envOpts and envOpts['PGPORT']) or '5432'
     query_file = options.query_file
     output_file = options.output_file
+    inclHLL = options.dumpHLL
 
     if query_file is None:
         parser.error("No query file specified.")
@@ -386,7 +394,7 @@ def main():
 
     # dump column stats
     print "Writing column statistics ..."
-    dump_stats(cursor, mr_query.relids, f_out)
+    dump_stats(cursor, mr_query.relids, f_out, inclHLL)
 
     cursor.close()
     conn.close()


### PR DESCRIPTION
Currently `gpsd` and `minirepro` dumps the hll stats aaand it causes the
output files to have bigger size. As we use these tools to debug
query plans, we do not use the HLL counter info in the query planning.
Instead it is just used to derive root level stats for partition tables.
For this reason, it is better to provide HLL stats dump as an option
instead of having `gpsd` and `minirepro` dump it by default.

This commit addresses this issue.