### PR TITLE
Remove the printing of overflowed value, when scale is exceeded.

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -5574,15 +5574,9 @@ make_result(NumericVar *var)
 	/* Check for overflow of int16 fields */
 	if (NUMERIC_WEIGHT(result) != weight ||
 		NUMERIC_DSCALE(result) != var->dscale)
-	{
-		char *ntp = get_str_from_var(var, var->dscale);
-
 		ereport(ERROR,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-				 errmsg("value overflows numeric format"),
-				 errdetail("Overflowing value: %s", ntp)
-				));
-	}
+				 errmsg("value overflows numeric format")));
 
 	free_var(var);
 	dump_numeric("make_result()", result);
@@ -5650,20 +5644,15 @@ apply_typmod(NumericVar *var, int32 typmod)
 #error unsupported NBASE
 #endif
 				if (ddigits > maxdigits)
-				{
-					char *ntp = get_str_from_var(var, scale);
-
 					ereport(ERROR,
 							(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 							 errmsg("numeric field overflow"),
-							 errdetail("A field with precision %d, scale %d must round to an absolute value less than %s%d. Rounded overflowing value: %s",
+							 errdetail("A field with precision %d, scale %d must round to an absolute value less than %s%d.",
 									   precision, scale,
 					/* Display 10^0 as 1 */
 									   maxdigits ? "10^" : "",
-									   maxdigits ? maxdigits : 1,
-									   ntp
+									   maxdigits ? maxdigits : 1
 									   )));
-				}
 				break;
 			}
 			ddigits -= DEC_DIGITS;

--- a/src/test/regress/expected/domain.out
+++ b/src/test/regress/expected/domain.out
@@ -568,7 +568,7 @@ begin
 end$$ language plpgsql;
 select array_elem_check(121.00);
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2. Rounded overflowing value: 121.00
+DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2.
 CONTEXT:  PL/pgSQL function array_elem_check(numeric) line 5 at assignment
 select array_elem_check(1.23456);
  array_elem_check 
@@ -586,7 +586,7 @@ begin
 end$$ language plpgsql;
 select array_elem_check(121.00);
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2. Rounded overflowing value: 121.00
+DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2.
 CONTEXT:  PL/pgSQL function array_elem_check(numeric) line 5 at assignment
 select array_elem_check(1.23456);
  array_elem_check 
@@ -604,7 +604,7 @@ begin
 end$$ language plpgsql;
 select array_elem_check(121.00);
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2. Rounded overflowing value: 121.00
+DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2.
 CONTEXT:  PL/pgSQL function array_elem_check(numeric) line 5 at assignment
 select array_elem_check(1.23456);
  array_elem_check 

--- a/src/test/regress/expected/domain_optimizer.out
+++ b/src/test/regress/expected/domain_optimizer.out
@@ -589,7 +589,7 @@ begin
 end$$ language plpgsql;
 select array_elem_check(121.00);
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2. Rounded overflowing value: 121.00
+DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2.
 CONTEXT:  PL/pgSQL function array_elem_check(numeric) line 5 at assignment
 select array_elem_check(1.23456);
  array_elem_check 
@@ -607,7 +607,7 @@ begin
 end$$ language plpgsql;
 select array_elem_check(121.00);
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2. Rounded overflowing value: 121.00
+DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2.
 CONTEXT:  PL/pgSQL function "array_elem_check" line 5 at assignment
 select array_elem_check(1.23456);
  array_elem_check 
@@ -625,7 +625,7 @@ begin
 end$$ language plpgsql;
 select array_elem_check(121.00);
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2. Rounded overflowing value: 121.00
+DETAIL:  A field with precision 4, scale 2 must round to an absolute value less than 10^2.
 CONTEXT:  PL/pgSQL function array_elem_check(numeric) line 5 at assignment
 select array_elem_check(1.23456);
  array_elem_check 

--- a/src/test/regress/expected/gp_types.out
+++ b/src/test/regress/expected/gp_types.out
@@ -170,7 +170,7 @@ SELECT * FROM dml_numeric2 ORDER BY 1;
 -- out of range values
 INSERT  INTO  dml_numeric2 VALUES (1.00e+3);
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3. Rounded overflowing value: 1000.00
+DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3.
 SELECT * FROM dml_numeric2 ORDER BY 1;
    a   
 -------
@@ -179,7 +179,7 @@ SELECT * FROM dml_numeric2 ORDER BY 1;
 
 UPDATE dml_numeric2 SET a = 1.00e+3;
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3. Rounded overflowing value: 1000.00
+DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3.
 SELECT * FROM dml_numeric2 ORDER BY 1;
    a   
 -------

--- a/src/test/regress/expected/gp_types_optimizer.out
+++ b/src/test/regress/expected/gp_types_optimizer.out
@@ -170,7 +170,7 @@ SELECT * FROM dml_numeric2 ORDER BY 1;
 -- out of range values
 INSERT  INTO  dml_numeric2 VALUES (1.00e+3);
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3. Rounded overflowing value: 1000.00
+DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3.
 SELECT * FROM dml_numeric2 ORDER BY 1;
    a   
 -------
@@ -179,7 +179,7 @@ SELECT * FROM dml_numeric2 ORDER BY 1;
 
 UPDATE dml_numeric2 SET a = 1.00e+3;
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3. Rounded overflowing value: 1000.00
+DETAIL:  A field with precision 5, scale 2 must round to an absolute value less than 10^3.
 SELECT * FROM dml_numeric2 ORDER BY 1;
    a   
 -------

--- a/src/test/regress/expected/numeric.out
+++ b/src/test/regress/expected/numeric.out
@@ -688,12 +688,12 @@ INSERT INTO fract_only VALUES (1, '0.0');
 INSERT INTO fract_only VALUES (2, '0.1');
 INSERT INTO fract_only VALUES (3, '1.0');	-- should fail
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 4, scale 4 must round to an absolute value less than 1. Rounded overflowing value: 1.0000
+DETAIL:  A field with precision 4, scale 4 must round to an absolute value less than 1.
 INSERT INTO fract_only VALUES (4, '-0.9999');
 INSERT INTO fract_only VALUES (5, '0.99994');
 INSERT INTO fract_only VALUES (6, '0.99995');  -- should fail
 ERROR:  numeric field overflow
-DETAIL:  A field with precision 4, scale 4 must round to an absolute value less than 1. Rounded overflowing value: 1.0000
+DETAIL:  A field with precision 4, scale 4 must round to an absolute value less than 1.
 INSERT INTO fract_only VALUES (7, '0.00001');
 INSERT INTO fract_only VALUES (8, '0.00017');
 SELECT * FROM fract_only;


### PR DESCRIPTION
Printing the value was added in GPDB, back in 2007. The commit message of
that change (in the historical pre-open-sourcing git repository) said:

    Merge forward from Release-3_0_0-branch. Update comment block.
    Tidy numeric_to_pos_int8_trunc.

That wasn't not very helpful...

Arguably, printing the value can be useful, but if so, we should submit
this change to upstream. I don't think it's worth the trouble, though, so
I suggest that we just revert this to the way it is in the upstream. The
reason I'm doing this now is that this caused merge conflicts in the 9.3
merge, that we're working on right now. We could probably fix the conflict
in a way that keeps the extra message, but it's simpler to just drop it.