### PR TITLE
Move 'am_startup' variable to a better place.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -120,7 +120,6 @@ bool		XLOG_DEBUG = false;
  */
 #define XLOGfileslop	(2*CheckPointSegments + 1)
 
-bool am_startup = false;
 
 /*
  * GUC support

--- a/src/backend/postmaster/startup.c
+++ b/src/backend/postmaster/startup.c
@@ -30,6 +30,7 @@
 #include "storage/proc.h"
 #include "utils/guc.h"
 
+bool am_startup = false;
 
 /*
  * Flags set by interrupt handlers for later service in the redo loop.

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -18,7 +18,6 @@
 #include "libpq-fe.h"
 #include "pqexpbuffer.h"
 
-#include "access/xlog.h"
 #include "catalog/gp_segment_config.h"
 #include "catalog/pg_proc.h"
 #include "catalog/indexing.h"
@@ -26,6 +25,7 @@
 #include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbfts.h"
+#include "postmaster/startup.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -36,6 +36,7 @@
 #include "postmaster/autovacuum.h"
 #include "postmaster/fts.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/startup.h"
 #include "replication/walsender.h"
 #include "storage/fd.h"
 #include "storage/ipc.h"

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -241,8 +241,6 @@ extern int	wal_level;
 /* Do we need to WAL-log information required only for Hot Standby? */
 #define XLogStandbyInfoActive() (wal_level >= WAL_LEVEL_HOT_STANDBY)
 
-extern bool am_startup;
-
 #ifdef WAL_DEBUG
 extern bool XLOG_DEBUG;
 #endif

--- a/src/include/postmaster/startup.h
+++ b/src/include/postmaster/startup.h
@@ -12,6 +12,8 @@
 #ifndef _STARTUP_H
 #define _STARTUP_H
 
+extern bool am_startup;
+
 extern void HandleStartupProcInterrupts(void);
 extern void StartupProcessMain(void);
 extern void PreRestoreCommand(void);


### PR DESCRIPTION
I think startup.c is a more natural place for it. Also, xlog.c is so large
and heavily modified from upstream, that anything that we can do to reduce
that diff helps.

Just refactoring, no user-visible change.