### PR TITLE
Add error position to error on coercing partition boundaries.

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -3658,7 +3658,7 @@ magic_expr_to_datum(Relation rel, PartitionNode *partnode,
 				/* see coerce_partition_value */
 				Node	   *out;
 
-				out = coerce_partition_value(n1, lhsid, attribute->atttypmod,
+				out = coerce_partition_value(NULL, n1, lhsid, attribute->atttypmod,
 											 char_to_parttype(partnode->part->parkind));
 				if (!out)
 					ereport(ERROR,

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4713,7 +4713,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 							PartitionByType t = (parkind == 'r') ?
 												 PARTTYP_RANGE : PARTTYP_LIST;
 
-							n = coerce_partition_value(n, typid, typmod, t);
+							n = coerce_partition_value(NULL, n, typid, typmod, t);
 
 							lfirst(lc2) = n;
 

--- a/src/include/parser/parse_partition.h
+++ b/src/include/parser/parse_partition.h
@@ -19,7 +19,7 @@
 extern void transformPartitionBy(CreateStmtContext *cxt,
 					 CreateStmt *stmt, Node *partitionBy);
 extern void PartitionRangeItemIsValid(ParseState *pstate, PartitionRangeItem *pri);
-extern Node *coerce_partition_value(Node *node, Oid typid, int32 typmod,
+extern Node *coerce_partition_value(ParseState *pstate, Node *node, Oid typid, int32 typmod,
 					   PartitionByType partype);
 
 #endif   /* PARSE_PARTITION_H */

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -3728,7 +3728,9 @@ start (date '2005-01-01')
 );
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  cannot coerce RANGE partition parameter ('01-01-2001'::date) to column type (integer)
+ERROR:  cannot coerce partition parameter to column type "integer"
+LINE 6: start (date '2001-01-01'),
+                    ^
 set optimizer_analyze_root_partition=on;
 create table mpp3487 (i int) partition by range (i) (start(1) end(10) every(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -2026,7 +2026,9 @@ create table f (n numeric(20, 2)) partition by range(n) (start(1::bigint)
 end('f'::bool));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'n' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  cannot coerce RANGE partition parameter (false) to column type (numeric)
+ERROR:  cannot coerce partition parameter to column type "numeric"
+LINE 2: end('f'::bool));
+            ^
 -- see that grant and revoke cascade to children
 create role part_role;
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -2030,7 +2030,9 @@ create table f (n numeric(20, 2)) partition by range(n) (start(1::bigint)
 end('f'::bool));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'n' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  cannot coerce RANGE partition parameter (false) to column type (numeric)
+ERROR:  cannot coerce partition parameter to column type "numeric"
+LINE 2: end('f'::bool));
+            ^
 -- see that grant and revoke cascade to children
 create role part_role;
 NOTICE:  resource queue required -- using default resource queue "pg_default"


### PR DESCRIPTION
I think this is more clear. Now that we the error position is displayed
with the error, we don't need to work so hard to deparse the value and the
partition type. The error position makes that clear.

This came up during the 9.3 merge. Passing InvalidOid to
deparse_context_for() will no longer work in 9.3, so we'd need to change
this somehow in the 9.3 merge, anyway.