### PR TITLE
Move test query to where it is in the upstream.

### DIFF
--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -558,21 +558,6 @@ select (select (a.*)::text) from view_a a;
 (1 row)
 
 --
--- Test case for sublinks pushed down into subselects via join alias expansion
---
--- Greenplum note: This query will only work with ORCA. This type of query
--- was not supported in postgres versions prior to 8.4, and thus was never
--- supported in the planner. After 8.4 versions, the planner works, but
--- the plan it creates is not currently parallel safe.
-select
-  (select sq1) as qq1
-from
-  (select exists(select 1 from int4_tbl where f1 = q2) as sq1, 42 as dummy
-   from int8_tbl) sq0
-  join
-  int4_tbl i4 on dummy = i4.f1;
-ERROR:  correlated subquery with skip-level correlations is not supported
---
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --
@@ -598,6 +583,21 @@ with q as (select max(f1) from int4_tbl group by f1 order by f1)
  (2147483647)
 (5 rows)
 
+--
+-- Test case for sublinks pushed down into subselects via join alias expansion
+--
+-- Greenplum note: This query will only work with ORCA. This type of query
+-- was not supported in postgres versions prior to 8.4, and thus was never
+-- supported in the planner. After 8.4 versions, the planner works, but
+-- the plan it creates is not currently parallel safe.
+select
+  (select sq1) as qq1
+from
+  (select exists(select 1 from int4_tbl where f1 = q2) as sq1, 42 as dummy
+   from int8_tbl) sq0
+  join
+  int4_tbl i4 on dummy = i4.f1;
+ERROR:  correlated subquery with skip-level correlations is not supported
 --
 -- Test case for cross-type partial matching in hashed subplan (bug #7597)
 --

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -569,24 +569,6 @@ select (select (a.*)::text) from view_a a;
 (1 row)
 
 --
--- Test case for sublinks pushed down into subselects via join alias expansion
---
--- Greenplum note: This query will only work with ORCA. This type of query
--- was not supported in postgres versions prior to 8.4, and thus was never
--- supported in the planner. After 8.4 versions, the planner works, but
--- the plan it creates is not currently parallel safe.
-select
-  (select sq1) as qq1
-from
-  (select exists(select 1 from int4_tbl where f1 = q2) as sq1, 42 as dummy
-   from int8_tbl) sq0
-  join
-  int4_tbl i4 on dummy = i4.f1;
- qq1 
------
-(0 rows)
-
---
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --
@@ -611,6 +593,24 @@ with q as (select max(f1) from int4_tbl group by f1 order by f1)
  (123456)
  (2147483647)
 (5 rows)
+
+--
+-- Test case for sublinks pushed down into subselects via join alias expansion
+--
+-- Greenplum note: This query will only work with ORCA. This type of query
+-- was not supported in postgres versions prior to 8.4, and thus was never
+-- supported in the planner. After 8.4 versions, the planner works, but
+-- the plan it creates is not currently parallel safe.
+select
+  (select sq1) as qq1
+from
+  (select exists(select 1 from int4_tbl where f1 = q2) as sq1, 42 as dummy
+   from int8_tbl) sq0
+  join
+  int4_tbl i4 on dummy = i4.f1;
+ qq1 
+-----
+(0 rows)
 
 --
 -- Test case for cross-type partial matching in hashed subplan (bug #7597)

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -340,6 +340,16 @@ select (select (select view_a)) from view_a;
 select (select (a.*)::text) from view_a a;
 
 --
+-- Check that whole-row Vars reading the result of a subselect don't include
+-- any junk columns therein
+--
+
+select q from (select max(f1) from int4_tbl group by f1 order by f1) q
+  order by max;
+with q as (select max(f1) from int4_tbl group by f1 order by f1)
+  select q from q;
+
+--
 -- Test case for sublinks pushed down into subselects via join alias expansion
 --
 -- Greenplum note: This query will only work with ORCA. This type of query
@@ -354,16 +364,6 @@ from
    from int8_tbl) sq0
   join
   int4_tbl i4 on dummy = i4.f1;
-
---
--- Check that whole-row Vars reading the result of a subselect don't include
--- any junk columns therein
---
-
-select q from (select max(f1) from int4_tbl group by f1 order by f1) q
-  order by max;
-with q as (select max(f1) from int4_tbl group by f1 order by f1)
-  select q from q;
 
 --
 -- Test case for cross-type partial matching in hashed subplan (bug #7597)


### PR DESCRIPTION
The " Check that whole-row Vars ..." test query was backported earlier,
as part of catching up to 8.3.23, before the GPDB 5 release. In the 9.0
merge, it was accidentally moved to a different location than where it
is in the upstream. Move it back.