### PR TITLE
Attempt to make olap_window_seq query deterministic

### DIFF
--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -3467,54 +3467,23 @@ count(*) over (order by cn,vn,pn) as c3 from sale;
   4 | 800 | 40 | 12 | 12 | 12
 (12 rows)
 
--- The following  case is flaky! Please look at the plan.
---                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
--- WindowAgg  (rows=12 width=12)
---   Output: cn, pn, vn, (count(*) OVER (?)), (count(*) OVER (?)), count(*) OVER (?)
---   Order By: sale.cn, sale.vn, sale.pn
---   ->  Sort  (rows=12 width=12)
---         Output: cn, pn, vn, cn, (count(*) OVER (?)), (count(*) OVER (?))
---         Sort Key: sale.cn, sale.vn, sale.pn
---         ->  WindowAgg  (rows=12 width=12)
---               Output: cn, pn, vn, cn, (count(*) OVER (?)), count(*) OVER (?)
---               Order By: sale.cn, sale.vn
---               ->  Sort  (rows=12 width=12)
---                     Output: cn, pn, vn, cn, (count(*) OVER (?))
---                     Sort Key: sale.cn, sale.vn
---                     ->  WindowAgg  (rows=12 width=12)
---                           Output: cn, pn, vn, cn, count(*) OVER (?)
---                           Order By: sale.cn
---                           ->  Gather Motion 3:1  (slice1; segments: 3)  (rows=12 width=12)
---                                 Output: cn, pn, vn, cn
---                                 Merge Key: cn
---                                 ->  Sort  (rows=4 width=12)
---                                       Output: cn, pn, vn, cn
---                                       Sort Key: sale.cn
---                                       ->  Seq Scan on public.sale  (rows=4 width=12)
---                                             Output: cn, pn, vn, cn
--- c2's value is flaky, because there are tuples with the same cn, vn but different
--- pn. So their order is uncertain. However, the order is important to the value returned by
--- window function. Previous case assumes the first time running on pipeline env is always
--- the same as the answer. We keep the assumption here after changing the underlying hash
--- algorithm to jump consistent hash.
-select cn,pn,vn, count(*) over (order by cn range between 2 preceding and 2 following) as c1,
-count(*) over (order by cn,vn rows between 2 preceding and 2 following) as c2,
-count(*) over (order by cn,vn,pn) as c3 from sale;
+select cn,pn,vn, count(*) over (order by ord range between 2 preceding and 2 following) as c1,
+count(*) over (order by ord,cn,vn rows between 2 preceding and 2 following) as c2,
+count(*) over (order by ord,cn,vn,pn) as c3 from sale_ord;
  cn | pn  | vn | c1 | c2 | c3 
 ----+-----+----+----+----+----
-  1 | 200 | 10 | 10 |  3 |  1
-  1 | 100 | 20 | 10 |  4 |  2
-  1 | 300 | 30 | 10 |  5 |  3
-  1 | 500 | 30 | 10 |  5 |  4
-  1 | 400 | 50 | 10 |  5 |  5
-  2 | 100 | 40 | 12 |  5 |  6
-  2 | 400 | 50 | 12 |  5 |  7
-  3 | 500 | 30 | 12 |  5 |  8
-  3 | 600 | 30 | 12 |  5 |  9
-  3 | 200 | 40 | 12 |  5 | 10
-  4 | 700 | 40 |  7 |  3 | 11
-  4 | 800 | 40 |  7 |  4 | 12
+  2 | 100 | 40 |  3 |  3 |  1
+  1 | 200 | 10 |  4 |  4 |  2
+  3 | 200 | 40 |  5 |  5 |  3
+  1 | 100 | 20 |  5 |  5 |  4
+  1 | 300 | 30 |  5 |  5 |  5
+  1 | 400 | 50 |  5 |  5 |  6
+  2 | 400 | 50 |  5 |  5 |  7
+  1 | 500 | 30 |  5 |  5 |  8
+  3 | 500 | 30 |  5 |  5 |  9
+  3 | 600 | 30 |  5 |  5 | 10
+  4 | 700 | 40 |  4 |  4 | 11
+  4 | 800 | 40 |  3 |  3 | 12
 (12 rows)
 
 -- MPP-1897

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -3469,54 +3469,23 @@ count(*) over (order by cn,vn,pn) as c3 from sale;
   4 | 800 | 40 | 12 | 12 | 12
 (12 rows)
 
--- The following  case is flaky! Please look at the plan.
---                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
--- WindowAgg  (rows=12 width=12)
---   Output: cn, pn, vn, (count(*) OVER (?)), (count(*) OVER (?)), count(*) OVER (?)
---   Order By: sale.cn, sale.vn, sale.pn
---   ->  Sort  (rows=12 width=12)
---         Output: cn, pn, vn, cn, (count(*) OVER (?)), (count(*) OVER (?))
---         Sort Key: sale.cn, sale.vn, sale.pn
---         ->  WindowAgg  (rows=12 width=12)
---               Output: cn, pn, vn, cn, (count(*) OVER (?)), count(*) OVER (?)
---               Order By: sale.cn, sale.vn
---               ->  Sort  (rows=12 width=12)
---                     Output: cn, pn, vn, cn, (count(*) OVER (?))
---                     Sort Key: sale.cn, sale.vn
---                     ->  WindowAgg  (rows=12 width=12)
---                           Output: cn, pn, vn, cn, count(*) OVER (?)
---                           Order By: sale.cn
---                           ->  Gather Motion 3:1  (slice1; segments: 3)  (rows=12 width=12)
---                                 Output: cn, pn, vn, cn
---                                 Merge Key: cn
---                                 ->  Sort  (rows=4 width=12)
---                                       Output: cn, pn, vn, cn
---                                       Sort Key: sale.cn
---                                       ->  Seq Scan on public.sale  (rows=4 width=12)
---                                             Output: cn, pn, vn, cn
--- c2's value is flaky, because there are tuples with the same cn, vn but different
--- pn. So their order is uncertain. However, the order is important to the value returned by
--- window function. Previous case assumes the first time running on pipeline env is always
--- the same as the answer. We keep the assumption here after changing the underlying hash
--- algorithm to jump consistent hash.
-select cn,pn,vn, count(*) over (order by cn range between 2 preceding and 2 following) as c1,
-count(*) over (order by cn,vn rows between 2 preceding and 2 following) as c2,
-count(*) over (order by cn,vn,pn) as c3 from sale;
+select cn,pn,vn, count(*) over (order by ord range between 2 preceding and 2 following) as c1,
+count(*) over (order by ord,cn,vn rows between 2 preceding and 2 following) as c2,
+count(*) over (order by ord,cn,vn,pn) as c3 from sale_ord;
  cn | pn  | vn | c1 | c2 | c3 
 ----+-----+----+----+----+----
-  1 | 200 | 10 | 10 |  3 |  1
-  1 | 100 | 20 | 10 |  4 |  2
-  1 | 300 | 30 | 10 |  5 |  3
-  1 | 500 | 30 | 10 |  5 |  4
-  1 | 400 | 50 | 10 |  5 |  5
-  2 | 100 | 40 | 12 |  5 |  6
-  2 | 400 | 50 | 12 |  5 |  7
-  3 | 500 | 30 | 12 |  5 |  8
-  3 | 600 | 30 | 12 |  5 |  9
-  3 | 200 | 40 | 12 |  5 | 10
-  4 | 700 | 40 |  7 |  3 | 11
-  4 | 800 | 40 |  7 |  4 | 12
+  2 | 100 | 40 |  3 |  3 |  1
+  1 | 200 | 10 |  4 |  4 |  2
+  3 | 200 | 40 |  5 |  5 |  3
+  1 | 100 | 20 |  5 |  5 |  4
+  1 | 300 | 30 |  5 |  5 |  5
+  1 | 400 | 50 |  5 |  5 |  6
+  2 | 400 | 50 |  5 |  5 |  7
+  1 | 500 | 30 |  5 |  5 |  8
+  3 | 500 | 30 |  5 |  5 |  9
+  3 | 600 | 30 |  5 |  5 | 10
+  4 | 700 | 40 |  4 |  4 | 11
+  4 | 800 | 40 |  3 |  3 | 12
 (12 rows)
 
 -- MPP-1897


### PR DESCRIPTION
One of the queries in the `olap_window_seq` suite was non-deterministic as it was ordering around a column which had duplicate values. Switch to the `_ord` version of the table and use the sequence which yields deterministic results.