### PR TITLE
Remove unused util tables from OLAP test suites

### DIFF
--- a/src/test/regress/expected/olap_setup.out
+++ b/src/test/regress/expected/olap_setup.out
@@ -56,14 +56,6 @@ create table sale_ord
         primary key (cn, vn, pn)
 ) distributed by (cn,vn,pn);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sale_ord_pkey" for table "sale_ord"
-create table util
-(
-	xn int not null,
-	
-	primary key (xn)
-	
-) distributed by (xn);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "util_pkey" for table "util"
 -- Customers
 insert into customer values 
   ( 1, 'Macbeth', 'Inverness'),
@@ -116,8 +108,3 @@ insert into sale_ord values
   ( 10,3, 30, 600, '1401-6-1', 12, 5),
   ( 11,4, 40, 700, '1401-6-1', 1, 1),
   ( 12,4, 40, 800, '1401-6-1', 1, 1);
--- Util
-insert into util values 
-  (1),
-  (20),
-  (300);

--- a/src/test/regress/expected/qp_olap_mdqa.out
+++ b/src/test/regress/expected/qp_olap_mdqa.out
@@ -62,14 +62,6 @@ create table sale_ord
 	
 ) distributed by (cn,vn,pn);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sale_ord_pkey" for table "sale_ord"
-create table util
-(
-	xn int not null,
-	
-	primary key (xn)
-	
-) distributed by (xn);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "util_pkey" for table "util"
 -- Customers
 insert into customer values 
   ( 1, 'Macbeth', 'Inverness'),
@@ -121,11 +113,6 @@ insert into sale_ord values
   ( 10,3, 30, 600, '1401-6-1', 12, 5),
   ( 11,4, 40, 700, '1401-6-1', 1, 1),
   ( 12,4, 40, 800, '1401-6-1', 1, 1);
--- Util
-insert into util values 
-  (1),
-  (20),
-  (300);
 -- end_ignore
 SELECT CASE WHEN sale.vn < 10 THEN 1 ELSE 2 END as newalias1,
 CASE WHEN sale.qty < 10 THEN 1 ELSE 2 END as newalias2,
@@ -7165,7 +7152,6 @@ GROUP BY GROUPING SETS(ROLLUP((sale.qty,sale.vn,sale.vn,sale.pn,sale.dt))),sale.
 
 -- start_ignore
 drop schema qp_olap_mdqa cascade;
-NOTICE:  drop cascades to table util
 NOTICE:  drop cascades to table sale_ord
 NOTICE:  drop cascades to table sale
 NOTICE:  drop cascades to table product

--- a/src/test/regress/expected/qp_olap_windowerr.out
+++ b/src/test/regress/expected/qp_olap_windowerr.out
@@ -13,8 +13,6 @@ drop table cf_olap_windowerr_sale;
 ERROR:  table "cf_olap_windowerr_sale" does not exist
 drop table cf_olap_windowerr_sale_ord;
 ERROR:  table "cf_olap_windowerr_sale_ord" does not exist
-drop table cf_olap_windowerr_util;
-ERROR:  table "cf_olap_windowerr_util" does not exist
 create table cf_olap_windowerr_customer 
 (
 	cn int not null,
@@ -72,14 +70,6 @@ create table cf_olap_windowerr_sale_ord
 	
 ) distributed by (cn,vn,pn);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "cf_olap_windowerr_sale_ord_pkey" for table "cf_olap_windowerr_sale_ord"
-create table cf_olap_windowerr_util
-(
-	xn int not null,
-	
-	primary key (xn)
-	
-) distributed by (xn);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "cf_olap_windowerr_util_pkey" for table "cf_olap_windowerr_util"
 -- cf_olap_windowerr_customers
 insert into cf_olap_windowerr_customer values 
   ( 1, 'Macbeth', 'Inverness'),
@@ -131,11 +121,6 @@ insert into cf_olap_windowerr_sale_ord values
   ( 10,3, 30, 600, '1401-6-1', 12, 5),
   ( 11,4, 40, 700, '1401-6-1', 1, 1),
   ( 12,4, 40, 800, '1401-6-1', 1, 1);
--- cf_olap_windowerr_util
-insert into cf_olap_windowerr_util values 
-  (1),
-  (20),
-  (300);
 -- end_ignore
 -- LEAD() function with OVER() clause having ONLY ORDER BY ASC/DESC (without framing) --
 SELECT cf_olap_windowerr_sale.dt,cf_olap_windowerr_sale.vn,cf_olap_windowerr_sale.pn, TO_CHAR(COALESCE(LEAD(cast(floor(cf_olap_windowerr_sale.pn*cf_olap_windowerr_sale.pn) as int),cast (floor(cf_olap_windowerr_sale.vn-cf_olap_windowerr_sale.pn) as int),NULL) OVER(win1),0),'99999999.9999999'),cf_olap_windowerr_sale.cn
@@ -5128,5 +5113,4 @@ drop table cf_olap_windowerr_vendor;
 drop table cf_olap_windowerr_product;
 drop table cf_olap_windowerr_sale;
 drop table cf_olap_windowerr_sale_ord;
-drop table cf_olap_windowerr_util;
 -- end_ignore

--- a/src/test/regress/sql/olap_setup.sql
+++ b/src/test/regress/sql/olap_setup.sql
@@ -8,7 +8,6 @@ drop table if exists vendor cascade;
 drop table if exists product cascade;
 drop table if exists sale cascade;
 drop table if exists sale_ord cascade;
-drop table if exists util cascade;
 -- end_ignore
 
 create table customer 
@@ -68,14 +67,6 @@ create table sale_ord
 
 ) distributed by (cn,vn,pn);
 
-create table util
-(
-	xn int not null,
-	
-	primary key (xn)
-	
-) distributed by (xn);
-
 -- Customers
 insert into customer values 
   ( 1, 'Macbeth', 'Inverness'),
@@ -133,10 +124,3 @@ insert into sale_ord values
   ( 10,3, 30, 600, '1401-6-1', 12, 5),
   ( 11,4, 40, 700, '1401-6-1', 1, 1),
   ( 12,4, 40, 800, '1401-6-1', 1, 1);
-
--- Util
-
-insert into util values 
-  (1),
-  (20),
-  (300);

--- a/src/test/regress/sql/qp_olap_mdqa.sql
+++ b/src/test/regress/sql/qp_olap_mdqa.sql
@@ -64,14 +64,6 @@ create table sale_ord
 	
 ) distributed by (cn,vn,pn);
 
-create table util
-(
-	xn int not null,
-	
-	primary key (xn)
-	
-) distributed by (xn);
-
 -- Customers
 insert into customer values 
   ( 1, 'Macbeth', 'Inverness'),
@@ -128,14 +120,6 @@ insert into sale_ord values
   ( 10,3, 30, 600, '1401-6-1', 12, 5),
   ( 11,4, 40, 700, '1401-6-1', 1, 1),
   ( 12,4, 40, 800, '1401-6-1', 1, 1);
-
--- Util
-
-insert into util values 
-  (1),
-  (20),
-  (300);
-
 -- end_ignore
 
 SELECT CASE WHEN sale.vn < 10 THEN 1 ELSE 2 END as newalias1,

--- a/src/test/regress/sql/qp_olap_window.sql
+++ b/src/test/regress/sql/qp_olap_window.sql
@@ -23,7 +23,6 @@ drop table ow_vendor;
 drop table ow_product;
 drop table ow_sale;
 drop table ow_sale_ord;
-drop table ow_util;
 
 create table ow_customer 
 (
@@ -82,14 +81,6 @@ create table ow_sale_ord
 	
 ) distributed by (cn,vn,pn);
 
-create table ow_util
-(
-	xn int not null,
-	
-	primary key (xn)
-	
-) distributed by (xn);
-
 -- Customers
 insert into ow_customer values 
   ( 1, 'Macbeth', 'Inverness'),
@@ -146,14 +137,6 @@ insert into ow_sale_ord values
   ( 10,3, 30, 600, '1401-6-1', 12, 5),
   ( 11,4, 40, 700, '1401-6-1', 1, 1),
   ( 12,4, 40, 800, '1401-6-1', 1, 1);
-
--- ow_util
-
-insert into ow_util values 
-  (1),
-  (20),
-  (300);
-
 -- end_ignore
 
 set datestyle="ISO, MDY";
@@ -24047,6 +24030,5 @@ drop table ow_vendor;
 drop table ow_product;
 drop table ow_sale;
 drop table ow_sale_ord;
-drop table ow_util;
-drop function ow_count_operator;
+drop function ow_count_operator(text, text);
 -- end_ignore

--- a/src/test/regress/sql/qp_olap_windowerr.sql
+++ b/src/test/regress/sql/qp_olap_windowerr.sql
@@ -9,8 +9,6 @@ drop table cf_olap_windowerr_vendor;
 drop table cf_olap_windowerr_product;
 drop table cf_olap_windowerr_sale;
 drop table cf_olap_windowerr_sale_ord;
-drop table cf_olap_windowerr_util;
-
 
 create table cf_olap_windowerr_customer 
 (
@@ -69,14 +67,6 @@ create table cf_olap_windowerr_sale_ord
 	
 ) distributed by (cn,vn,pn);
 
-create table cf_olap_windowerr_util
-(
-	xn int not null,
-	
-	primary key (xn)
-	
-) distributed by (xn);
-
 -- cf_olap_windowerr_customers
 insert into cf_olap_windowerr_customer values 
   ( 1, 'Macbeth', 'Inverness'),
@@ -133,14 +123,6 @@ insert into cf_olap_windowerr_sale_ord values
   ( 10,3, 30, 600, '1401-6-1', 12, 5),
   ( 11,4, 40, 700, '1401-6-1', 1, 1),
   ( 12,4, 40, 800, '1401-6-1', 1, 1);
-
--- cf_olap_windowerr_util
-
-insert into cf_olap_windowerr_util values 
-  (1),
-  (20),
-  (300);
-
 -- end_ignore
 
 -- LEAD() function with OVER() clause having ONLY ORDER BY ASC/DESC (without framing) --
@@ -3782,5 +3764,4 @@ drop table cf_olap_windowerr_vendor;
 drop table cf_olap_windowerr_product;
 drop table cf_olap_windowerr_sale;
 drop table cf_olap_windowerr_sale_ord;
-drop table cf_olap_windowerr_util;
 -- end_ignore


### PR DESCRIPTION
The util tables in the OLAP suites was never used in any query, just created, populated and subsequently dropped. Remove, and fix a drop function statement which had the wrong syntax while at it.