### PR TITLE
Fix subquery with column alias `zero` produces wrong result

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -1241,7 +1241,8 @@ is_targetlist_nullable(Query *subq)
 			 */
 			Const	   *constant = (Const *) tle->expr;
 
-			if (strcmp(tle->resname, DUMMY_COLUMN_NAME) != 0
+			if ((strcmp(tle->resname, DUMMY_COLUMN_NAME) != 0
+				|| constant->consttypmod == -1)
 				&& constant->constisnull == true)
 			{
 				result = true;


### PR DESCRIPTION
Fix [issue](https://github.com/greenplum-db/gpdb/issues/5454)

Because  user column called "zero" have Const struct with` consttypmod != -1`， 

so I use this to differ between user column called "zero"  with "gpdb entended zero column"