### PR TITLE
5X:Fix pg_stat_activity show wrong session id after session reset bug

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -20,6 +20,7 @@
 
 #include "libpq-fe.h"
 #include "miscadmin.h"			/* MyDatabaseId */
+#include "pgstat.h"			/* pgstat_report_sessionid() */
 #include "storage/proc.h"		/* MyProc */
 #include "storage/ipc.h"
 #include "utils/memutils.h"
@@ -1636,6 +1637,7 @@ void CheckForResetSession(void)
 
 	gp_session_id = newSessionId;
 	gp_command_count = 0;
+	pgstat_report_sessionid(newSessionId);
 
 	/* Update the slotid for our singleton reader. */
 	if (SharedLocalSnapshotSlot != NULL)

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -2484,6 +2484,27 @@ pgstat_report_waiting(char waiting)
 }
 
 /* ----------
+ * pgstat_report_sessionid() -
+ *
+ * 	Called from cdbgang to report a session is reset.
+ *
+ * ----------
+ */
+void
+pgstat_report_sessionid(int new_sessionid)
+{
+	volatile PgBackendStatus *beentry = MyBEEntry;
+
+	if (!beentry)
+		return;
+
+	beentry->st_changecount++;
+	beentry->st_session_id = new_sessionid;
+	beentry->st_changecount++;
+	Assert((beentry->st_changecount & 1) == 0);
+}
+
+/* ----------
  * pgstat_read_current_status() -
  *
  *	Copy the current contents of the PgBackendStatus array to local memory,

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -723,6 +723,7 @@ extern void pgstat_bestart(void);
 extern void pgstat_report_activity(const char *what);
 extern void pgstat_report_txn_timestamp(TimestampTz tstamp);
 extern void pgstat_report_waiting(char reason);
+extern void pgstat_report_sessionid(int new_sessionid);
 
 extern void pgstat_report_appname(const char *appname);
 extern void pgstat_report_xact_timestamp(TimestampTz tstamp);

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -73,6 +73,9 @@ pg_regress$(X): pg_regress.o pg_regress_main.o
 pg_regress.o: pg_regress.c $(top_builddir)/src/port/pg_config_paths.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) -I$(top_builddir)/src/port $(EXTRADEFS) -c -o $@ $<
 
+regress_gp.o: override CFLAGS += -I$(top_builddir)/src/interfaces/libpq
+regress_gp.o: override LDFLAGS += -L$(top_builddir)/src/interfaces/libpq
+
 twophase_pqexecparams: twophase_pqexecparams.c
 	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq  -o $@ $< -lpq
 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -205,6 +205,7 @@ test: vacuum_full_heap_bitmapindex
 test: ao_checksum_corruption AOCO_Compression2 table_statistics
 test: metadata_track
 test: workfile_mgr_test
+test: session_reset
 
 test: psql_gp_commands pg_resetxlog
 

--- a/src/test/regress/input/session_reset.source
+++ b/src/test/regress/input/session_reset.source
@@ -1,0 +1,14 @@
+
+set log_min_messages to ERROR;
+
+CREATE FUNCTION gp_execute_on_server(content smallint, query cstring) returns boolean
+language C as '@abs_builddir@/regress@DLSUFFIX@', 'gp_execute_on_server';
+
+-- terminate backend process for this session on segment with content ID = 0
+select gp_execute_on_server(0::smallint, 'select pg_terminate_backend(pg_backend_pid())'::cstring);
+
+-- session is reset and gp_session_id value changes
+-- sess_id in pg_stat_activity should be consistent with gp_session_id
+select session_id AS session_not_in_stat_activity from (select paramvalue AS session_id from gp_toolkit.gp_param_settings() where paramname='gp_session_id' and paramsegment = 0) right_id where right_id.session_id not in (select sess_id::text from pg_stat_activity);
+
+set log_min_messages to default;

--- a/src/test/regress/output/session_reset.source
+++ b/src/test/regress/output/session_reset.source
@@ -1,0 +1,16 @@
+set log_min_messages to ERROR;
+CREATE FUNCTION gp_execute_on_server(content smallint, query cstring) returns boolean
+language C as '@abs_builddir@/regress@DLSUFFIX@', 'gp_execute_on_server';
+-- terminate backend process for this session on segment with content ID = 0
+select gp_execute_on_server(0::smallint, 'select pg_terminate_backend(pg_backend_pid())'::cstring);
+ERROR:  could not execute command on QE
+DETAIL:  terminating connection due to administrator command  (seg1 10.152.10.149:25433 pid=4137)
+HINT:  command: 'select pg_terminate_backend(pg_backend_pid())'
+-- session is reset and gp_session_id value changes
+-- sess_id in pg_stat_activity should be consistent with gp_session_id
+select session_id AS session_not_in_stat_activity from (select paramvalue AS session_id from gp_toolkit.gp_param_settings() where paramname='gp_session_id' and paramsegment = 0) right_id where right_id.session_id not in (select sess_id::text from pg_stat_activity);
+ session_not_in_stat_activity 
+------------------------------
+(0 rows)
+
+set log_min_messages to default;

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -22,12 +22,15 @@
 #include <math.h>
 #include <unistd.h>
 
+#include "libpq-fe.h"
 #include "pgstat.h"
 #include "access/transam.h"
 #include "access/xact.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_type.h"
 #include "cdb/memquota.h"
+#include "cdb/cdbdisp_query.h"
+#include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbgang.h"
 #include "cdb/cdbvars.h"
 #include "cdb/ml_ipc.h"
@@ -91,6 +94,7 @@ extern Datum checkRelationAfterInvalidation(PG_FUNCTION_ARGS);
 
 /* XID wraparound */
 extern Datum test_consume_xids(PG_FUNCTION_ARGS);
+extern Datum gp_execute_on_server(PG_FUNCTION_ARGS);
 
 /* Triggers */
 
@@ -1936,3 +1940,57 @@ test_consume_xids(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
+/*
+ * Function to execute a DML/DDL command on segment with specified content id.
+ * Returns true on success or error on failure.
+ */
+PG_FUNCTION_INFO_V1(gp_execute_on_server);
+Datum
+gp_execute_on_server(PG_FUNCTION_ARGS)
+{
+	int16	content = PG_GETARG_INT16(0);
+	char *query = PG_GETARG_CSTRING(1);
+	int ret;
+	int proc;
+	if (GpIdentity.segindex == content)
+	{
+		if ((ret = SPI_connect()) < 0)
+			/* internal error */
+			elog(ERROR, "SPI_connect returned %d", ret);
+
+		/* Retrieve the desired rows */
+		ret = SPI_execute(query, false, 0);
+		proc = SPI_processed;
+		if (ret != SPI_OK_SELECT || proc <= 0)
+		{
+			SPI_finish();
+			elog(ERROR, "SPI failed on segment %d, return code %d",
+				 GpIdentity.segindex, ret);
+		}
+		SPI_finish();
+		PG_RETURN_BOOL(true);
+	}
+	else if (GpIdentity.segindex == MASTER_CONTENT_ID)
+	{
+		proc = 0;
+		CdbPgResults cdb_pgresults;
+		int i;
+		CdbDispatchCommand(query, DF_CANCEL_ON_ERROR | DF_WITH_SNAPSHOT, &cdb_pgresults);
+		for (i = 0; i < cdb_pgresults.numResults; i++)
+		{
+			struct pg_result *pgresult = cdb_pgresults.pg_results[i];
+
+			if (PQresultStatus(pgresult) != PGRES_TUPLES_OK &&
+				PQresultStatus(pgresult) != PGRES_COMMAND_OK)
+			{
+				cdbdisp_clearCdbPgResults(&cdb_pgresults);
+				elog(ERROR, "execution failed with status %d", PQresultStatus(pgresult));
+			}
+		}
+
+		cdbdisp_clearCdbPgResults(&cdb_pgresults);
+		PG_RETURN_BOOL(true);
+	}
+	else
+		PG_RETURN_BOOL(true);
+}

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -36,3 +36,4 @@ transient_types.sql
 hooktest.sql
 gpcopy.sql
 query_info_hook_test.sql
+session_reset.sql


### PR DESCRIPTION
Currently if a session is reset because of some error such as OOM,
after call CheckForResetSession, gp_session_id will bump to a new one,
but sess_id in pg_stat_activity remains unchanged and show the wrong number.
This commit changes sess_id in pg_stat_activity, once a session is reset.

Similar with #5757 except test because no `gp_execute_on_server ` on 5X 