### PR TITLE
Avoid infinite autovacuum respawn loop

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -4289,7 +4289,7 @@ BootStrapXLOG(void)
 	ShmemVariableCache->nextRelfilenode = checkPoint.nextRelfilenode;
 	ShmemVariableCache->relfilenodeCount = 0;
 	MultiXactSetNextMXact(checkPoint.nextMulti, checkPoint.nextMultiOffset);
-	SetTransactionIdLimit(checkPoint.oldestXid, checkPoint.oldestXidDB);
+	SetTransactionIdLimit(checkPoint.oldestXid, checkPoint.oldestXidDB, true);
 	SetMultiXactIdLimit(checkPoint.oldestMulti, checkPoint.oldestMultiDB);
 
 	/* Set up the XLOG page header */
@@ -5665,7 +5665,7 @@ StartupXLOG(void)
 	ShmemVariableCache->nextRelfilenode = checkPoint.nextRelfilenode;
 	ShmemVariableCache->relfilenodeCount = 0;
 	MultiXactSetNextMXact(checkPoint.nextMulti, checkPoint.nextMultiOffset);
-	SetTransactionIdLimit(checkPoint.oldestXid, checkPoint.oldestXidDB);
+	SetTransactionIdLimit(checkPoint.oldestXid, checkPoint.oldestXidDB, true);
 	SetMultiXactIdLimit(checkPoint.oldestMulti, checkPoint.oldestMultiDB);
 	XLogCtl->ckptXidEpoch = checkPoint.nextXidEpoch;
 	XLogCtl->ckptXid = checkPoint.nextXid;
@@ -8840,7 +8840,7 @@ xlog_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribut
 		LWLockRelease(OidGenLock);
 		MultiXactSetNextMXact(checkPoint.nextMulti,
 							  checkPoint.nextMultiOffset);
-		SetTransactionIdLimit(checkPoint.oldestXid, checkPoint.oldestXidDB);
+		SetTransactionIdLimit(checkPoint.oldestXid, checkPoint.oldestXidDB, true);
 		SetMultiXactIdLimit(checkPoint.oldestMulti, checkPoint.oldestMultiDB);
 
 		/*
@@ -8953,7 +8953,8 @@ xlog_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribut
 		if (TransactionIdPrecedes(ShmemVariableCache->oldestXid,
 								  checkPoint.oldestXid))
 			SetTransactionIdLimit(checkPoint.oldestXid,
-								  checkPoint.oldestXidDB);
+								  checkPoint.oldestXidDB,
+								  true);
 		MultiXactAdvanceOldest(checkPoint.oldestMulti,
 							   checkPoint.oldestMultiDB);
 

--- a/src/backend/commands/test/Makefile
+++ b/src/backend/commands/test/Makefile
@@ -2,9 +2,18 @@ subdir=src/backend/commands
 top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=tablecmds
+TARGETS=tablecmds vacuum
 
 include $(top_builddir)/src/backend/mock.mk
 
 tablecmds.t: \
 	$(MOCK_DIR)/backend/access/aocs/aocs_compaction_mock.o
+
+vacuum_test.o: FORCE
+
+.PHONY: FORCE
+
+test_vacuum: vacuum.t
+	./vacuum.t
+
+FORCE:

--- a/src/backend/commands/test/Makefile
+++ b/src/backend/commands/test/Makefile
@@ -2,18 +2,10 @@ subdir=src/backend/commands
 top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=tablecmds vacuum
+TARGETS=tablecmds
 
 include $(top_builddir)/src/backend/mock.mk
 
 tablecmds.t: \
 	$(MOCK_DIR)/backend/access/aocs/aocs_compaction_mock.o
 
-vacuum_test.o: FORCE
-
-.PHONY: FORCE
-
-test_vacuum: vacuum.t
-	./vacuum.t
-
-FORCE:

--- a/src/backend/commands/test/vacuum_test.c
+++ b/src/backend/commands/test/vacuum_test.c
@@ -1,0 +1,88 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../vacuum.c"
+
+void
+test__gp_database_needs_vacuum_when_not_connectable(void **state)
+{
+    bool needs_autovacuum;
+    Form_pg_database dbform = palloc0(sizeof(Form_pg_database));
+    TransactionId currentTransactionId = 10;
+    dbform->datallowconn = false;
+	dbform->datfrozenxid = 4;
+
+
+	autovacuum_freeze_max_age = 2;
+
+    needs_autovacuum = gp_database_needs_autovacuum(dbform, currentTransactionId);
+	assert_true(needs_autovacuum);
+}
+
+void
+test__gp_database_does_not_need_vacuum_when_not_connectable(void **state)
+{
+	bool needs_autovacuum;
+	Form_pg_database dbform = palloc0(sizeof(Form_pg_database));
+	TransactionId currentTransactionId = 5;
+	dbform->datallowconn = false;
+	dbform->datfrozenxid = 4;
+
+	autovacuum_freeze_max_age = 2;
+
+	needs_autovacuum = gp_database_needs_autovacuum(dbform, currentTransactionId);
+	assert_false(needs_autovacuum);
+}
+
+void
+test__gp_database_does_not_need_vacuum_when_connectable(void **state)
+{
+    bool needs_autovacuum;
+	Form_pg_database dbform = palloc0(sizeof(Form_pg_database));
+	TransactionId currentTransactionId;
+	dbform->datallowconn = true;
+	dbform->datfrozenxid = 4;
+
+	autovacuum_freeze_max_age = 2;
+
+	currentTransactionId = 5;
+	needs_autovacuum = gp_database_needs_autovacuum(dbform, currentTransactionId);
+	assert_false(needs_autovacuum);
+
+	currentTransactionId = 10;
+	needs_autovacuum = gp_database_needs_autovacuum(dbform, currentTransactionId);
+	assert_false(needs_autovacuum);
+}
+
+void
+test__gp_database_needs_vacuum_when_connectable_and_only_current_xid_has_wraped_around(void **state)
+{
+	bool needs_autovacuum;
+	Form_pg_database dbform = palloc0(sizeof(Form_pg_database));
+	dbform->datallowconn = false;
+	dbform->datfrozenxid = MaxTransactionId;
+
+	autovacuum_freeze_max_age = 2;
+
+	needs_autovacuum = gp_database_needs_autovacuum(dbform, MaxTransactionId + 10);
+	assert_true(needs_autovacuum);
+}
+int
+main(int argc, char* argv[]) 
+{
+	cmockery_parse_arguments(argc, argv);
+
+
+	const UnitTest tests[] = {
+			unit_test(test__gp_database_needs_vacuum_when_not_connectable),
+			unit_test(test__gp_database_does_not_need_vacuum_when_not_connectable),
+			unit_test(test__gp_database_does_not_need_vacuum_when_connectable),
+			unit_test(test__gp_database_needs_vacuum_when_connectable_and_only_current_xid_has_wraped_around)
+	};
+
+	MemoryContextInit();
+
+	return run_tests(tests);
+}

--- a/src/backend/postmaster/test/Makefile
+++ b/src/backend/postmaster/test/Makefile
@@ -2,7 +2,16 @@ subdir=src/backend/postmaster
 top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=syslogger checkpointer
+TARGETS=syslogger checkpointer autovacuum
 
 include $(top_builddir)/src/backend/mock.mk
 checkpointer.t: $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o
+
+autovacuum_test.o: FORCE
+
+.PHONY: FORCE
+
+test_autovacuum: autovacuum.t
+	./autovacuum.t
+
+FORCE:

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -148,7 +148,7 @@ extern TransactionId GetNewTransactionId(bool isSubXact);
 extern TransactionId ReadNewTransactionId(void);
 extern TransactionId GetTransactionIdLimit(void);
 extern void SetTransactionIdLimit(TransactionId oldest_datfrozenxid,
-					  Oid oldest_datoid);
+					  Oid oldest_datoid, bool signal_autovacuum);
 extern bool ForceTransactionIdLimitUpdate(void);
 extern Oid	GetNewObjectId(void);
 extern void AdvanceObjectId(Oid newOid);

--- a/src/include/postmaster/autovacuum.h
+++ b/src/include/postmaster/autovacuum.h
@@ -15,6 +15,7 @@
 #define AUTOVACUUM_H
 
 #include "tcop/utility.h"
+#include "catalog/pg_database.h"
 
 /* GUC variables */
 extern bool autovacuum_start_daemon;
@@ -53,6 +54,11 @@ extern void AutoVacWorkerFailed(void);
 
 /* autovacuum cost-delay balancer */
 extern void AutoVacuumUpdateDelay(void);
+
+extern bool GpAutovacuumEnabled(Form_pg_database dbform);
+extern bool GpDatabaseNeedsAutovacuum(Form_pg_database dbform,
+                                      TransactionId xid);
+
 
 #ifdef EXEC_BACKEND
 extern void AutoVacLauncherMain(int argc, char *argv[]) __attribute__((noreturn));


### PR DESCRIPTION
In GPDB we only run autovacuum on databases that do not allow connections,
like template0. When a database that *does* allow connections is older than
autovacuum_freeze_max_age, the autovacuum launcher starts a worker and
immediately exits.  The worker, finding a database that is older than
autovacuum_freeze_max_age, immediately starts the launcher so that the
next database can be processed. We only want to do this for databases
that do not allow connections, or we'll end up signaling for another
autovacuum worker to start that will not have any work to do, entering
an endless loop.

In order to prevent this from happening, we added a flag to
SetTransactionIdLimit() to prevent signaling an autovacuum worker start
when there will not be any work to do.

Co-authored-by: Adam Berlin <aberlin@pivotal.io>