### PR TITLE
Remove a FIXME comment about the need to have EvalPlanQual recheck functions for AO table scans

### DIFF
--- a/src/backend/executor/execScan.c
+++ b/src/backend/executor/execScan.c
@@ -42,7 +42,12 @@ getScanMethod(int tableType)
 			&HeapScanNext, &HeapScanRecheck, &BeginScanHeapRelation, &EndScanHeapRelation,
 			&ReScanHeapRelation, &MarkPosHeapRelation, &RestrPosHeapRelation
 		},
-		// GPDB_90_MERGE_FIXME: should we have rechecks for AO / AOCS scans?
+		/*
+		 * AO and AOCS tables don't need a recheck-method, because they never
+		 * participate in EvalPlanQual rechecks. (They don't have a ctid
+		 * field, so UPDATE in REPEATABLE READ mode cannot follow the chain
+		 * to the updated tuple.
+		 */
 		{
 			&AppendOnlyScanNext, NULL, &BeginScanAppendOnlyRelation, &EndScanAppendOnlyRelation,
 			&ReScanAppendOnlyRelation, &MarkRestrNotAllowed, &MarkRestrNotAllowed


### PR DESCRIPTION
This GPDB_90_MERGE_FIXME in src/backend/executor/execBitmapTableScan.c 
has been cleaned by commit 83d055aa7448d2a22d085c9f2fccd4bf8c3174af

This  maybe a leftover of the commit
