### PR TITLE
docs - sql and catalog ref page updates for i/o conversion casts

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/defining-queries.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/defining-queries.xml
@@ -361,7 +361,7 @@
             <body>
                 <p>A type cast specifies a conversion from one data type to another. A cast applied
                     to a value expression of a known type is a run-time type conversion. The cast
-                    succeeds only if a suitable type conversion function is defined. This differs
+                    succeeds only if a suitable type conversion operation is defined. This differs
                     from the use of casts with constants. A cast applied to a string literal
                     represents the initial assignment of a type to a literal constant value, so it
                     succeeds for any type if the contents of the string literal are acceptable input
@@ -373,7 +373,7 @@
                             accepts two equivalent syntaxes for explicit type casts:<p>
                                 <codeblock>CAST ( expression AS type )
 expression::type</codeblock>
-                            </p><p>The <codeph>CAST</codeph> syntax conforms to SQL; the syntax with
+                            </p><p>The <codeph>CAST</codeph> syntax conforms to SQL; the syntax using
                                     <codeph>::</codeph> is historical PostgreSQL usage.</p></li>
                         <li><i>Assignment cast</i> - Greenplum Database implicitly invokes a cast in
                             assignment contexts, when assigning a value to a column of the target
@@ -399,13 +399,13 @@ expression::type</codeblock>
                             type.<codeblock>SELECT * FROM tbl1 WHERE tbl1.c2 = (4.3 + tbl1.c1) ;</codeblock></li>
                     </ul></p>
                 <p>You can usually omit an explicit type cast if there is no ambiguity about the
-                    type a value expression must produce; for example, when it is assigned to a
-                    table column, the system automatically applies a type cast. Greenplum Database
-                    implicitly applies casts only to casts where the is defined with the cast
-                    context of assignment or implicit in the system catalogs. Other casts must be
+                    type a value expression must produce (for example, when it is assigned to a
+                    table column); the system automatically applies a type cast. Greenplum Database
+                    implicitly applies casts only when the cast is marked as "OK to apply
+                    implicitly" in the system catalogs. Other casts must be
                     invoked with explicit casting syntax to prevent unexpected conversions from
                     being applied without the user's knowledge. </p>
-                <p>You can display cast information with the <codeph>psql</codeph> metacommand
+                <p>You can display cast information with the <codeph>psql</codeph> meta-command
                         <codeph>\dC</codeph>. Cast information is stored in the catalog table
                         <codeph>pg_cast</codeph>, and type information is stored in the catalog
                     table <codeph>pg_type</codeph>. </p>

--- a/gpdb-doc/dita/admin_guide/query/topics/defining-queries.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/defining-queries.xml
@@ -361,7 +361,7 @@
             <body>
                 <p>A type cast specifies a conversion from one data type to another. A cast applied
                     to a value expression of a known type is a run-time type conversion. The cast
-                    succeeds only if a suitable type conversion operation is defined. This differs
+                    succeeds only if a suitable type conversion is defined. This differs
                     from the use of casts with constants. A cast applied to a string literal
                     represents the initial assignment of a type to a literal constant value, so it
                     succeeds for any type if the contents of the string literal are acceptable input
@@ -401,8 +401,8 @@ expression::type</codeblock>
                 <p>You can usually omit an explicit type cast if there is no ambiguity about the
                     type a value expression must produce (for example, when it is assigned to a
                     table column); the system automatically applies a type cast. Greenplum Database
-                    implicitly applies casts only when the cast is marked as "OK to apply
-                    implicitly" in the system catalogs. Other casts must be
+                    implicitly applies casts only to casts defined with a cast context of
+                    assignment or explicit in the system catalogs. Other casts must be
                     invoked with explicit casting syntax to prevent unexpected conversions from
                     being applied without the user's knowledge. </p>
                 <p>You can display cast information with the <codeph>psql</codeph> meta-command

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_CAST.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_CAST.xml
@@ -5,15 +5,34 @@
        WITH FUNCTION <varname>funcname</varname> (<varname>argtypes</varname>) 
        [AS ASSIGNMENT | AS IMPLICIT]
 
-CREATE CAST (<varname>sourcetype</varname> AS <varname>targettype</varname>) WITHOUT FUNCTION 
+CREATE CAST (<varname>sourcetype</varname> AS <varname>targettype</varname>)
+       WITHOUT FUNCTION 
+       [AS ASSIGNMENT | AS IMPLICIT]
+
+CREATE CAST (<varname>sourcetype</varname> AS <varname>targettype</varname>)
+       WITH INOUT 
        [AS ASSIGNMENT | AS IMPLICIT]</codeblock></section><section id="section3"><title>Description</title><p><codeph>CREATE CAST</codeph> defines a new cast. A cast specifies how
-to perform a conversion between two data types. For example,</p><codeblock>SELECT CAST(42 AS text);</codeblock><p>converts the integer constant <codeph>42</codeph> to type <codeph>text</codeph> by invoking a
-        previously specified function, in this case <codeph>text(int4)</codeph>. If no suitable cast
-        has been defined, the conversion fails. </p><p>Two types may be binary compatible, which means that they can be converted
+to perform a conversion between two data types. For example,</p><codeblock>SELECT CAST(42 AS float8);</codeblock><p>converts the integer constant <codeph>42</codeph> to type <codeph>float8</codeph> by invoking a
+        previously specified function, in this case <codeph>float8(int4)</codeph>. If no suitable cast
+        has been defined, the conversion fails. </p><p>Two types may be binary
+        coercible, which means that the types can be converted
 into one another without invoking any function. This requires that corresponding
 values use the same internal representation. For instance, the types
-<codeph>text</codeph> and <codeph>varchar</codeph> are binary compatible.
-</p><p>By default, a cast can be invoked only by an explicit cast request, that is an explicit
+<codeph>text</codeph> and <codeph>varchar</codeph> are binary coercible in
+  both directions. Binary coercibility is not necessarily a symmetric
+  relationship. For example, the cast from <codeph>xml</codeph> to
+  <codeph>text</codeph> can be performed for free in the present
+  implementation, but the reverse direction requires a function that
+  performs at least a syntax check. (Two types that are binary coercible
+  both ways are also referred to as binary compatible.)</p>
+<p>You can define a cast as an <i>I/O conversion cast</i> by using the
+  <codeph>WITH INOUT</codeph> syntax. An I/O conversion cast is performed
+  by invoking the output function of the source data type, and passing the
+  resulting string to the input function of the target data type. In many
+  common cases, this feature avoids the need to write a separate cast
+  function for conversion. An I/O conversion cast acts the same as a
+  regular function-based cast; only the implementation is different.</p>
+<p>By default, a cast can be invoked only by an explicit cast request, that is an explicit
           <codeph>CAST(x AS </codeph>
         <varname>typename</varname><codeph>)</codeph> or <codeph>x:: <varname>typename</varname></codeph> construct.</p><p>If the cast is marked <codeph>AS ASSIGNMENT</codeph> then it can be invoked implicitly when
         assigning a value to a column of the target data type. For example, supposing that
@@ -21,10 +40,30 @@ values use the same internal representation. For instance, the types
         marked <codeph>AS ASSIGNMENT</codeph>, otherwise not. The term <i>assignment cast</i> is
         typically used to describe this kind of cast.</p><p>If the cast is marked <codeph>AS IMPLICIT</codeph> then it can be invoked implicitly in any
         context, whether assignment or internally in an expression. The term <i>implicit cast</i> is
-        typically used to describe this kind of cast. For example, since <codeph>||</codeph> takes
-          <codeph>text</codeph> operands,</p><codeblock>SELECT 'The time is ' || now();</codeblock><p>will be allowed only if the cast from type <codeph>timestamp</codeph>
-to <codeph>text</codeph> is marked <codeph>AS IMPLICIT</codeph>. Otherwise,
-it will be necessary to write the cast explicitly, for example</p><codeblock>SELECT 'The time is ' || CAST(now() AS text);</codeblock><p>It is wise to be conservative about marking casts as implicit. An overabundance
+        typically used to describe this kind of cast. For example, consider this query:</p>
+        <codeblock>SELECT 2 + 4.0;</codeblock><p>The parser initially marks the
+        constants as being of type <codeph>integer</codeph> and
+        <codeph>numeric</codeph>, respectively. There is no
+        <codeph>integer + numeric</codeph> operator in the system catalogs,
+        but there is a <codeph>numeric + numeric</codeph> operator. This
+        query succeeds if a cast from <codeph>integer</codeph> to
+        <codeph>numeric</codeph> exists (it does) and is marked <codeph>AS IMPLICIT</codeph>,
+        which in fact it is. The parser applies only the implicit cast and
+        resolves the query as if it had been written as the following:</p>
+        <codeblock>SELECT CAST ( 2 AS numeric ) + 4.0;</codeblock>
+    <p>The catalogs also provide a cast from <codeph>numeric</codeph> to
+      <codeph>integer</codeph>. If that cast were marked <codeph>AS IMPLICIT</codeph>,
+       which it is not, then the parser would be faced with choosing between
+       the above interpretation and the alternative of casting the
+       <codeph>numeric</codeph> constant to <codeph>integer</codeph> and
+       applying the <codeph>integer + integer</codeph> operator. Lacking any
+       knowledge of which choice to prefer, the parser would give up and
+       declare the query ambiguous. The fact that only one of the two casts
+       is implicit is the way in which we teach the parser to prefer resolution
+       of a mixed <codeph>numeric</codeph>-and-<codeph>integer</codeph>
+       expression as <codeph>numeric</codeph>; the parser has no built-in
+       knowledge about that.</p>
+<p>It is wise to be conservative about marking casts as implicit. An overabundance
 of implicit casting paths can cause Greenplum Database to choose surprising
 interpretations of commands, or to be unable to resolve commands at all
 because there are multiple possible interpretations. A good rule of thumb
@@ -34,43 +73,93 @@ example, the cast from <codeph>int2</codeph> to <codeph>int4</codeph>
 can reasonably be implicit, but the cast from <codeph>float8</codeph>
 to <codeph>int4</codeph> should probably be assignment-only. Cross-type-category
 casts, such as <codeph>text</codeph> to <codeph>int4</codeph>, are best
-made explicit-only. </p><p>To be able to create a cast, you must own the source or the target
-data type. To create a binary-compatible cast, you must be superuser.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>sourcetype</varname></pt><pd>The name of the source data type of the cast. </pd></plentry><plentry><pt><varname>targettype</varname></pt><pd>The name of the target data type of the cast. </pd></plentry><plentry><pt><varname>funcname(argtypes)</varname></pt><pd>The function used to perform the cast. The function name may be schema-qualified.
-If it is not, the function will be looked up in the schema search path.
+made explicit-only. </p>
+<note>Sometimes it is necessary for usability or standards-compliance
+  reasons to provide multiple implicit casts among a set of types,
+  resulting in ambiguity that cannot be avoided as described above. The
+  parser uses a fallback heuristic based on type categories and preferred
+  types that helps to provide desired behavior in such cases. See <codeph><xref href="./CREATE_TYPE.xml#topic1" type="topic" format="dita"/></codeph>
+  for more information.</note>
+<p>To be able to create a cast, you must own the source or the target
+  data type and have <codeph>USAGE</codeph> privilege on the other type. To
+  create a binary-coercible cast, you must be superuser.</p></section>
+<section id="section4"><title>Parameters</title><parml><plentry><pt><varname>sourcetype</varname></pt><pd>The name of the source data type of the cast. </pd></plentry><plentry><pt><varname>targettype</varname></pt><pd>The name of the target data type of the cast. </pd></plentry><plentry><pt><varname>funcname(argtypes)</varname></pt><pd>The function used to perform the cast. The function name may be schema-qualified.
+If it is not, Greenplum Database looks for the function in the schema search path.
 The function's result data type must match the target type of the cast.</pd><pd>Cast implementation functions may have one to three arguments. The first argument type must be
-            identical to the cast's source type. The second argument, if present, must be type
+            identical to or binary-coercible from the cast's source type. The second
+            argument, if present, must be type
               <codeph>integer</codeph>; it receives the type modifier associated with the
             destination type, or <codeph>-1</codeph> if there is none. The third argument, if
             present, must be type <codeph>boolean</codeph>; it receives <codeph>true</codeph> if the
             cast is an explicit cast, <codeph>false</codeph> otherwise. The SQL specification
             demands different behaviors for explicit and implicit casts in some cases. This argument
             is supplied for functions that must implement such casts. It is not recommended that you
-            design your own data types this way.</pd><pd>Ordinarily a cast must have different source and target data types.
-However, it is allowed to declare a cast with identical source and target
-types if it has a cast implementation function with more than one argument.
+            design your own data types this way.</pd><pd>The return type of a cast function must be identical to or binary-coercible to the cast's target type.</pd><pd>Ordinarily a cast must have different source and target data types.
+However, you are permitted to declare a cast with identical source and target
+types if it has a cast implementation function that takes more than one argument.
 This is used to represent type-specific length coercion functions in
 the system catalogs. The named function is used to coerce a value of
-the type to the type modifier value given by its second argument. (Since
-the grammar presently permits only certain built-in data types to have
-type modifiers, this feature is of no use for user-defined target types.)
+the type to the type modifier value given by its second argument.
 </pd><pd>When a cast has different source and target types and a function
-that takes more than one argument, it represents converting from one
-type to another and applying a length coercion in a single step. When
+that takes more than one argument, the cast converts from one
+type to another and applies a length coercion in a single step. When
 no such entry is available, coercion to a type that uses a type modifier
 involves two steps, one to convert between data types and a second to
-apply the modifier.</pd></plentry><plentry><pt>WITHOUT FUNCTION</pt><pd>Indicates that the source type and the target type are binary compatible,
-so no function is required to perform the cast. </pd></plentry><plentry><pt>AS ASSIGNMENT</pt><pd>Indicates that the cast may be invoked implicitly in assignment contexts.</pd></plentry><plentry><pt>AS IMPLICIT</pt><pd>Indicates that the cast may be invoked implicitly in any context.</pd></plentry></parml></section><section id="section5"><title>Notes</title><p>Note that in this release of Greenplum Database, user-defined functions
+apply the modifier.</pd>
+  <pd>A cast to or from a domain type currently has no effect. Casting to or from a domain uses the casts associated with its underlying type.</pd></plentry>
+    <plentry><pt>WITHOUT FUNCTION</pt><pd>Indicates that the source type is binary-coercible to the target type,
+so no function is required to perform the cast.</pd></plentry>
+    <plentry><pt>WITH INOUT</pt><pd>Indicates that the cast is an I/O conversion
+      cast, performed by invoking the output function of the source data type,
+      and passing the resulting string to the input function of the target data type.</pd></plentry>
+    <plentry><pt>AS ASSIGNMENT</pt><pd>Indicates that the cast may be invoked implicitly in assignment contexts.</pd></plentry>
+    <plentry><pt>AS IMPLICIT</pt><pd>Indicates that the cast may be invoked implicitly in any context.</pd></plentry></parml></section><section id="section5"><title>Notes</title><p>Note that in this release of Greenplum Database, user-defined functions
 used in a user-defined cast must be defined as <codeph>IMMUTABLE</codeph>.
 Any compiled code (shared library files) for custom functions must be
 placed in the same location on every host in your Greenplum Database
 array (master and all segments). This location must also be in the <codeph>LD_LIBRARY_PATH</codeph>
 so that the server can locate the files.</p><p>Remember that if you want to be able to convert types both ways you
-need to declare casts both ways explicitly. </p><p>It is recommended that you follow the convention of naming cast implementation functions after
+need to declare casts both ways explicitly. </p>
+  <p>It is normally not necessary to create casts between user-defined types
+    and the standard string types (<codeph>text</codeph>, <codeph>varchar</codeph>,
+    and <codeph>char(<i>n</i>)</codeph>, as well as user-defined types that
+    are defined to be in the string category). Greenplum Database provides
+    automatic I/O conversion casts for these. The automatic casts to string
+    types are treated as assignment casts, while the automatic casts from
+    string types are explicit-only. You can override this behavior by
+    declaring your own cast to replace an automatic cast, but usually the
+    only reason to do so is if you want the conversion to be more easily
+    invokable than the standard assignment-only or explicit-only setting.
+    Another possible reason is that you want the conversion to behave
+    differently from the type's I/O function - think twice before doing this.
+    (A small number of the built-in types do indeed have different behaviors
+     for conversions, mostly because of requirements of the SQL standard.)</p>
+  <p>It is recommended that you follow the convention of naming cast implementation functions after
         the target data type, as the built-in cast implementation functions are named. Many users
         are used to being able to cast data types using a function-style notation, that is
-            <codeph><varname>typename</varname>(x)</codeph>.</p></section><section id="section6"><title>Examples</title><p>To create a cast from type <codeph>text</codeph> to type <codeph>int4</codeph> using the function
-          <codeph>int4(text)</codeph> (This cast is already predefined in the system.):</p><codeblock>CREATE CAST (text AS int4) WITH FUNCTION int4(text);</codeblock></section><section id="section7"><title>Compatibility</title><p>The <codeph>CREATE CAST</codeph> command conforms to the SQL standard,
-except that SQL does not make provisions for binary-compatible types
+            <codeph><varname>typename</varname>(x)</codeph>.</p>
+  <p>There are two cases in which a function-call construct is treated as
+    a cast request without having matched it to an actual function. If a
+    function call <codeph><i>name(x)</i></codeph> does not exactly match
+    any existing function, but <codeph><i>name</i></codeph> is the name of
+    a data type and <codeph>pg_cast</codeph> provides a binary-coercible
+    cast to this type from the type of <codeph><i>x</i></codeph>, then the
+    call will be construed as a binary-coercible cast. Greenplum Database
+    makes this exception so that binary-coercible casts can be invoked
+    using functional syntax, even though they lack any function. Likewise,
+    if there is no <codeph>pg_cast</codeph> entry but the cast would be to
+    or from a string type, the call is construed as an I/O conversion cast.
+    This exception allows I/O conversion casts to be invoked using functional syntax.</p>
+  <p>There is an exception to the exception above: I/O conversion casts from
+    composite types to string types cannot be invoked using functional
+    syntax, but must be written in explicit cast syntax (either <codeph>CAST</codeph> or
+    :: notation). This exception exists because after the introduction
+    of automatically-provided I/O conversion casts, it was found to be too
+    easy to accidentally invoke such a cast when you intended a function or column
+    reference.</p></section>
+<section id="section6"><title>Examples</title><p>To create an assignment cast from type <codeph>bigint</codeph> to type <codeph>int4</codeph> using the function
+          <codeph>int4(bigint)</codeph> (This cast is already predefined in the system.):</p><codeblock>CREATE CAST (bigint AS int4) WITH FUNCTION int4(bigint) AS ASSIGNMENT;</codeblock></section><section id="section7"><title>Compatibility</title><p>The <codeph>CREATE CAST</codeph> command conforms to the SQL standard,
+except that SQL does not make provisions for binary-coercible types
 or extra arguments to implementation functions. <codeph>AS IMPLICIT</codeph>
 is a Greenplum Database extension, too.</p></section><section id="section8"><title>See Also</title><p><codeph><xref href="./CREATE_FUNCTION.xml#topic1" type="topic" format="dita"/></codeph>,
             <codeph><xref href="./CREATE_TYPE.xml#topic1" type="topic" format="dita"/></codeph>,

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TYPE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TYPE.xml
@@ -16,6 +16,8 @@ CREATE TYPE <varname>name</varname> (
     [, PASSEDBYVALUE]
     [, ALIGNMENT = <varname>alignment</varname>]
     [, STORAGE = <varname>storage</varname>]
+    [, CATEGORY = <varname>category</varname>]
+    [, PREFERRED = <varname>preferred</varname>]
     [, DEFAULT = <varname>default</varname>]
     [, ELEMENT = <varname>element</varname>]
     [, DELIMITER = <varname>delimiter</varname>]
@@ -162,7 +164,25 @@ PostgreSQL documentation. Enum types take a list of one or more quoted labels, e
                     particular column.) </p><p>To indicate that a type is an array, specify the type
                     of the array elements using the <codeph>ELEMENT</codeph> key word. For example,
                     to define an array of 4-byte integers (int4), specify <codeph>ELEMENT =
-                        int4</codeph>. More details about array types appear below. </p><p>To
+                        int4</codeph>. More details about array types appear below. </p>
+               <p>The <i>category</i> and <i>preferred</i> parameters
+                 can be used to help control which implicit cast Greenplum Database applies in
+                 ambiguous situations. Each data type belongs to a category named by a
+                 single ASCII character, and each type is either "preferred" or not
+                 within its category. The parser will prefer casting to preferred types
+                 (but only from other types within the same category) when this rule
+                 helps resolve overloaded functions or operators. For types that
+                 have no implicit casts to or from any other types, it is sufficient to
+                 retain the default settings. However, for a group of related
+                 types that have implicit casts, it is often helpful to mark them all
+                 as belonging to a category and select one or two of the "most general"
+                 types as being preferred within the category. The <i>category</i>
+                  parameter is especially useful when you add a user-defined type to an
+                  existing built-in category, such as the numeric or string types.
+                  It is also possible to create new entirely-user-defined type categories.
+                  Select any ASCII character other than an upper-case letter to name such
+                  a category.</p>
+               <p>To
                     indicate the delimiter to be used between values in the external representation
                     of arrays of this type, <codeph>delimiter</codeph> can be set to a specific
                     character. The default delimiter is the comma (,). Note that the delimiter is
@@ -207,7 +227,18 @@ variable-length. </pd></plentry><plentry><pt><varname>alignment</varname></pt><p
 <codeph>char</codeph>, <codeph>int2</codeph>, <codeph>int4</codeph>,
 or <codeph>double</codeph>. The default is <codeph>int4</codeph>. </pd></plentry><plentry><pt><varname>storage</varname></pt><pd>The storage strategy for the data type. Must be one of <codeph>plain</codeph>,
 <codeph>external</codeph>, <codeph>extended</codeph>, or <codeph>main</codeph>.
-The default is <codeph>plain</codeph>. </pd></plentry><plentry><pt><varname>default</varname></pt><pd>The default value for the data type. If this is omitted, the default
+The default is <codeph>plain</codeph>. </pd></plentry>
+        <plentry><pt><varname>category</varname></pt><pd>The category code (a single
+          ASCII character) for this type. The default is '<codeph>U</codeph>', signifying a
+          user-defined type. You can find the other standard category codes in
+          <xref href="../system_catalogs/pg_type.xml#topic1/typcategory" type="topic" format="dita"><codeph>pg_type</codeph> Category Codes</xref>.
+          You may also assign unused ASCII characters to custom categories that you
+          create.</pd></plentry>
+        <plentry><pt><varname>preferred</varname></pt><pd><codeph>true</codeph> if this type is a
+          preferred type within its type category, else <codeph>false</codeph>. The default value
+          is <codeph>false</codeph>. Be careful when you create a new preferred type within an
+          existing type category; this could cause surprising behaviour changes.</pd></plentry>
+       <plentry><pt><varname>default</varname></pt><pd>The default value for the data type. If this is omitted, the default
 is null. </pd></plentry><plentry><pt><varname>element</varname></pt><pd>The type being created is an array; this specifies the type of the
 array elements. </pd></plentry><plentry><pt><varname>delimiter</varname></pt><pd>The delimiter character to be used between values in arrays made
 of this type.</pd></plentry><plentry><pt><varname>compression_type</varname></pt><pd>Set to <codeph>ZLIB</codeph> (the default), <codeph>ZSTD</codeph>,

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_cast.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_cast.xml
@@ -2,7 +2,16 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic1" xml:lang="en"><title id="ge143896">pg_cast</title><body><p>The <codeph>pg_cast</codeph> table stores data type conversion paths, both built-in paths and
-      those defined with <codeph>CREATE CAST</codeph>. The cast functions listed in
+      those defined with <codeph>CREATE CAST</codeph>.</p>
+    <p>Note that <codeph>pg_cast</codeph> does not represent every type conversion
+      known to the system, only those that cannot be deduced from some generic
+      rule. For example, casting between a domain and its base type is not
+      explicitly represented in <codeph>pg_cast</codeph>. Another important
+      exception is that "automatic I/O conversion casts", those performed using
+      a data type's own I/O functions to convert to or from <codeph>text</codeph>
+      or other string types, are not explicitly represented in
+      <codeph>pg_cast</codeph>.</p>
+    <p>The cast functions listed in
         <codeph>pg_cast</codeph> must always take the cast source type as their first argument type,
       and return the cast destination type as their result type. A cast function can have up to
       three arguments. The second argument, if present, must be type <codeph>integer</codeph>; it
@@ -13,18 +22,25 @@
 the source and target types are the same, if the associated function
 takes more than one argument. Such entries represent 'length coercion
 functions' that coerce values of the type to be legal for a particular
-type modifier value. Note however that at present there is no support
-for associating non-default type modifiers with user-created data types,
-and so this facility is only of use for the small number of built-in
-types that have type modifier syntax built into the grammar.</p><p>When a <codeph>pg_cast</codeph> entry has different source and target
-types and a function that takes more than one argument, it represents
-converting from one type to another and applying a length coercion in
+type modifier value.</p>
+    <p>When a <codeph>pg_cast</codeph> entry has different source and target
+types and a function that takes more than one argument, the entry
+converts from one type to another and applies a length coercion in
 a single step. When no such entry is available, coercion to a type that
 uses a type modifier involves two steps, one to convert between data
 types and a second to apply the modifier.</p><table id="ge143898"><title>pg_catalog.pg_cast</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>castsource</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_type.oid</entry><entry colname="col4">OID of the source data type.</entry></row><row><entry colname="col1"><codeph>casttarget</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_type.oid</entry><entry colname="col4">OID of the target data type.</entry></row><row><entry colname="col1"><codeph>castfunc</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">The OID of the function to use to perform this
-cast. Zero is stored if the data types are binary compatible (that is,
-no run-time operation is needed to perform the cast).</entry></row><row><entry colname="col1"><codeph>castcontext</codeph></entry><entry colname="col2">char</entry><entry colname="col3"/><entry colname="col4">Indicates what contexts the cast may be invoked
+cast. Zero is stored if the cast method does not require a function.</entry></row>
+<row><entry colname="col1"><codeph>castcontext</codeph></entry><entry colname="col2">char</entry><entry colname="col3"/><entry colname="col4">Indicates what contexts the cast may be invoked
 in. <codeph>e</codeph> means only as an explicit cast (using <codeph>CAST</codeph>
 or <codeph>::</codeph> syntax). <codeph>a</codeph> means implicitly in
 assignment to a target column, as well as explicitly. <codeph>i</codeph>
-means implicitly in expressions, as well as the other cases<i>.</i></entry></row></tbody></tgroup></table></body></topic>
+means implicitly in expressions, as well as the other cases<i>.</i></entry></row>
+    <row><entry colname="col1"><codeph>castmethod</codeph></entry>
+       <entry colname="col2">char</entry>
+       <entry colname="col3"/>
+       <entry colname="col4">Indicates how the cast is performed:<p><codeph>f</codeph> - The function identified in the <codeph>castfunc</codeph> field is used.</p>
+         <p><codeph>i</codeph> - The input/output functions are used.</p>
+         <p><codeph>b</codeph> - The types are binary-coercible, and no conversion is required.</p>
+      </entry>
+    </row>
+</tbody></tgroup></table></body></topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_type.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_type.xml
@@ -71,8 +71,7 @@
               value or by reference. <codeph>typbyval </codeph>had better be false if
                 <codeph>typlen</codeph> is not 1, 2, or 4 (or 8 on machines where Datum is 8 bytes).
               Variable-length types are always passed by reference. Note that
-                <codeph>typbyval</codeph> can be false even if the length would allow pass-by-value;
-              this is currently true for type <codeph>float4</codeph>, for example.</entry>
+                <codeph>typbyval</codeph> can be false even if the length would allow pass-by-value.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -82,7 +81,27 @@
             <entry colname="col3"/>
             <entry colname="col4"><codeph>b</codeph> for a base type, <codeph>c</codeph> for a
               composite type, <codeph>d</codeph> for a domain, <codeph>e</codeph> for an enum 
-              type, or <codeph>p</codeph> for a pseudo-type.</entry>
+              type, <codeph>p</codeph> for a pseudo-type, or <codeph>r</codeph> for a range
+              type. See also <codeph>typrelid</codeph> and <codeph>typbasetype</codeph>.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>typcategory</codeph>
+            </entry>
+            <entry colname="col2">char</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Arbitrary classification of data types that is used
+              by the parser to determine which implicit casts should be preferred.
+              See <xref href="#topic1/typcategory" type="topic" format="dita">Category Codes</xref>.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>typispreferred</codeph>
+            </entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">True if the type is a preferred cast target within
+              its <codeph>typcategory</codeph>.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -124,7 +143,7 @@
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
             <entry colname="col4">If not <codeph>0</codeph> then it identifies another row in
-              pg_type. The current type can then be subscripted like an array yielding values of
+              <codeph>pg_type</codeph>. The current type can then be subscripted like an array yielding values of
               type <codeph>typelem</codeph>. A true array type is variable length
                 (<codeph>typlen</codeph> = <codeph>-1</codeph>), but some fixed-length
                 (<codeph>tylpen</codeph> &gt; <codeph>0</codeph>) types also have nonzero
@@ -261,8 +280,8 @@
             </entry>
             <entry colname="col2">int4</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Domains use typtypmod to record the typmod to be applied to their
-              base type (-1 if base type does not use a typmod). -1 if this type is not a
+            <entry colname="col4">Domains use <codeph>typtypmod</codeph> to record the <codeph>typmod</codeph> to be applied to their
+              base type (-1 if base type does not use a <codeph>typmod</codeph>). -1 if this type is not a
               domain.</entry>
           </row>
           <row>
@@ -271,16 +290,26 @@
             </entry>
             <entry colname="col2">int4</entry>
             <entry colname="col3"/>
-            <entry colname="col4">The number of array dimensions for a domain that is an array (if
-                <codeph>typbasetype</codeph> is an array type; the domain's <codeph>typelem</codeph>
-              will match the base type's <codeph>typelem</codeph>). Zero for types other than array
-              domains.</entry>
+            <entry colname="col4">The number of array dimensions for a domain over an array (if
+               <codeph>typbasetype</codeph> is an array type). Zero for types other than
+               domains over  array types.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>typcollation</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_collation.oid</entry>
+            <entry colname="col4">Specifies the collation of the type. Zero if the type
+              does not support collations. The value is <codeph>DEFAULT_COLLATION_OID</codeph>
+              for a base type that suppports collations. A domain over a collatable type
+              can have some other collation OID if one was specified for the domain.</entry>
           </row>
           <row>
             <entry colname="col1">
               <codeph>typdefaultbin</codeph>
             </entry>
-            <entry colname="col2">text</entry>
+            <entry colname="col2">pg_node_tree</entry>
             <entry colname="col3"/>
             <entry colname="col4">If not null, it is the <codeph>nodeToString()</codeph>
               representation of a default expression for the type. This is only used for
@@ -293,10 +322,102 @@
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
             <entry colname="col4">Null if the type has no associated default value. If not null,
-              typdefault must contain a human-readable version of the default expression represented
-              by typdefaultbin. If typdefaultbin is null and typdefault is not, then typdefault is
+              <codeph>typdefault</codeph> must contain a human-readable version of
+              the default expression represented
+              by <codeph>typdefaultbin</codeph>. If <codeph>typdefaultbin</codeph> is
+              null and <codeph>typdefault</codeph> is not, then <codeph>typdefault</codeph> is
               the external representation of the type's default value, which may be fed to the
               type's input converter to produce a constant.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>typacl</codeph>
+            </entry>
+            <entry colname="col2">aclitem[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Access privileges; see <codeph><xref href="../sql_commands/GRANT.xml#topic1" type="topic" format="dita"/></codeph>
+              and <codeph><xref href="../sql_commands/REVOKE.xml#topic1" type="topic" format="dita"/></codeph>
+              for details.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+
+    <p>The following table lists the system-defined values of
+       <codeph>typcategory</codeph>. Any future additions to this list will also
+       be upper-case ASCII letters. All other ASCII characters are reserved for
+        user-defined categories.</p>
+    <table id="typcategory">
+      <title>typcategory Codes</title>
+      <tgroup cols="2">
+        <colspec colnum="1" colname="col1" colwidth="52pt"/>
+        <colspec colnum="2" colname="col2" colwidth="352pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">Code</entry>
+            <entry colname="col2">Category</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">A</entry>
+            <entry colname="col2">Array types</entry>
+          </row>
+          <row>
+            <entry colname="col1">B</entry>
+            <entry colname="col2">Boolean types</entry>
+          </row>
+          <row>
+            <entry colname="col1">C</entry>
+            <entry colname="col2">Composite types</entry>
+          </row>
+          <row>
+            <entry colname="col1">D</entry>
+            <entry colname="col2">Date/time types</entry>
+          </row>
+          <row>
+            <entry colname="col1">E</entry>
+            <entry colname="col2">Enum types</entry>
+          </row>
+          <row>
+            <entry colname="col1">G</entry>
+            <entry colname="col2">Geometric types</entry>
+          </row>
+          <row>
+            <entry colname="col1">I</entry>
+            <entry colname="col2">Network address types</entry>
+          </row>
+          <row>
+            <entry colname="col1">N</entry>
+            <entry colname="col2">Numeric types</entry>
+          </row>
+          <row>
+            <entry colname="col1">P</entry>
+            <entry colname="col2">Pseudo-types</entry>
+          </row>
+          <row>
+            <entry colname="col1">R</entry>
+            <entry colname="col2">Range types</entry>
+          </row>
+          <row>
+            <entry colname="col1">S</entry>
+            <entry colname="col2">String types</entry>
+          </row>
+          <row>
+            <entry colname="col1">T</entry>
+            <entry colname="col2">Timespan types</entry>
+          </row>
+          <row>
+            <entry colname="col1">U</entry>
+            <entry colname="col2">User-defined types</entry>
+          </row>
+          <row>
+            <entry colname="col1">V</entry>
+            <entry colname="col2">Bit-string types</entry>
+          </row>
+          <row>
+            <entry colname="col1">X</entry>
+            <entry colname="col2"><codeph>unknown</codeph> type</entry>
           </row>
         </tbody>
       </tgroup>


### PR DESCRIPTION
(6.0/master only)

in this PR:
- pg_cast system catalog ref page - add castmethod field, other content updates to reflect postgres 9.3 docs
- pg_type system catalog ref page - add typcategory/typispreferred fields, add typcategory table
    - added missing typcollation/typacl fields (not related to i/o conversion casts)
    - other content updates to reflect postgres 9.3 docs
- create cast ref page - add INOUT variant, update all to reflect postgres 9.3 docs
- create type ref page - added content and descriptions for the CATEGORY and PREFERRED parameters (this PR does not address other parameters that may be missing from this page; they will be added as we document other features related to creating types)

doc review site links:
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_cast.html#topic1
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_type.html#topic1
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/sql_commands/CREATE_CAST.html
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/sql_commands/CREATE_TYPE.html
