### PR TITLE
getgpsegmentCount() fixups

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -75,8 +75,6 @@ makeCdbCopy(bool is_copy_in)
 	c->total_segs = getgpsegmentCount();
 	c->aotupcounts = NULL;
 
-	Assert(c->total_segs >= 0);
-
 	/* Initialize the state of each segment database */
 	c->segdb_state = (SegDbState **) palloc((c->total_segs) * sizeof(SegDbState *));
 

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -56,6 +56,7 @@
 #include "cdb/cdbpullup.h"
 #include "cdb/cdbsetop.h"
 #include "cdb/cdbvars.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbtargeteddispatch.h"
 
 #include "nodes/print.h"

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1234,10 +1234,6 @@ contentid_get_dbid(int16 contentid, char role, bool getPreferredRoleNotCurrentRo
 
 /*
  * Returns the number of segments
- *
- * N.B.  Gp_role must be either dispatch or execute, since
- * when utiliy	no GP catalog tables are read.  An Assert is
- * thrown if Gp_role = utility.
  */
 int
 getgpsegmentCount(void)
@@ -1246,12 +1242,11 @@ getgpsegmentCount(void)
 	{
 		if (GpIdentity.numsegments <= 0)
 		{
-			elog(DEBUG5, "getgpsegmentCount called when Gp_role == utility. returning zero segments.");
+			elog(DEBUG5, "getgpsegmentCount called when Gp_role == utility, returning zero segments.");
 			return 0;
 		}
 
 		elog(DEBUG1, "getgpsegmentCount called when Gp_role == utility, but is relying on gp_id info");
-
 	}
 
 	verifyGpIdentityIsSet();

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -31,6 +31,7 @@
 #include "cdb/cdbhash.h"
 #include "cdb/cdbpartition.h"
 #include "cdb/cdbtm.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 #include "commands/analyzeutils.h"
 #include "commands/dbcommands.h"

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -51,6 +51,7 @@
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbaocsam.h"
 #include "cdb/cdbdisp_query.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 #include "cdb/memquota.h"
 

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -50,6 +50,7 @@
 #include "commands/vacuum.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbpartition.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbsrlz.h"
 #include "cdb/cdbdispatchresult.h"      /* CdbDispatchResults */

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -42,6 +42,7 @@
 #include "utils/syscache.h"
 
 #include "cdb/cdbexplain.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 
 static void ExecHashIncreaseNumBatches(HashJoinTable hashtable);

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -95,6 +95,7 @@
 #include "utils/spccache.h"
 #include "utils/tuplesort.h"
 
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 
 #define LOG2(x)  (log(x) / 0.693147180559945)

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -58,6 +58,7 @@
 #include "cdb/cdbpullup.h"
 #include "cdb/cdbgroup.h"		/* grouping_planner extensions */
 #include "cdb/cdbsetop.h"		/* motion utilities */
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 
 #include "storage/lmgr.h"

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -142,7 +142,8 @@
 #include "utils/tqual.h"
 #include "utils/typcache.h"
 
-#include "cdb/cdbvars.h"                /* getgpsegmentCount */
+#include "cdb/cdbutil.h"
+#include "cdb/cdbvars.h"
 
 /* Hooks for plugins to get control when we ask for stats */
 get_relation_stats_hook_type get_relation_stats_hook = NULL;

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -172,10 +172,6 @@ extern int16 contentid_get_dbid(int16 contentid, char role, bool getPreferredRol
 
 /*
  * Returns the number of segments
- *
- * N.B.  Gp_role must be either dispatch or execute, since
- * when utiliy	no mpp catalog tables are read.  An Assert is
- * thrown if Gp_role = utility.
  */
 extern int	getgpsegmentCount(void);
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -445,8 +445,6 @@ extern bool gp_interconnect_cache_future_packets;
 
 #define UNDEF_SEGMENT -2
 
-extern int	getgpsegmentCount(void);
-
 /*
  * Parameter interconnect_setup_timeout
  *


### PR DESCRIPTION
`getgpsegmentCount()` is defined in both `cdbvars.h` and `cdbutil.h`. While not needing another header include in some cases, `getgpsegmentCount()` is not a variable and the correct location is `cdbutil.h`. Remove the prototype from `cdbvars.h` and update includes as required.

Remove duplicate assertion on `getgpsegmentCount()` return value. There is already an assertion in `getgpsegmentCount()` testing the count to be > 0 (and 0 can only be returned in utility mode which still holds this assertion always true).

Also fix the function comment to match reality and minor tweaking of the debug `elog()` performed.