### PR TITLE
Fix compiler warnings from 9.3 merge

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -123,12 +123,15 @@ static bool ConditionalMultiXactIdWait(MultiXactId multi,
  * update them).  This table (and the macros below) helps us determine the
  * heavyweight lock mode and MultiXactStatus values to use for any particular
  * tuple lock strength.
+ *
+ * Don't look at lockstatus/updstatus directly!  Use get_mxact_status_for_lock
+ * instead.
  */
 static const struct
 {
 	LOCKMODE	hwlock;
-	MultiXactStatus lockstatus;
-	MultiXactStatus updstatus;
+	int			lockstatus;
+	int			updstatus;
 }
 
 			tupleLockExtraInfo[MaxLockTupleMode + 1] =
@@ -4386,7 +4389,7 @@ simple_heap_update(Relation relation, ItemPointer otid, HeapTuple tup)
 static MultiXactStatus
 get_mxact_status_for_lock(LockTupleMode mode, bool is_update)
 {
-	MultiXactStatus retval;
+	int		retval;
 
 	if (is_update)
 		retval = tupleLockExtraInfo[mode].updstatus;
@@ -4397,7 +4400,7 @@ get_mxact_status_for_lock(LockTupleMode mode, bool is_update)
 		elog(ERROR, "invalid lock tuple mode %d/%s", mode,
 			 is_update ? "true" : "false");
 
-	return retval;
+	return (MultiXactStatus) retval;
 }
 
 

--- a/src/backend/tcop/idle_resource_cleaner.c
+++ b/src/backend/tcop/idle_resource_cleaner.c
@@ -22,7 +22,6 @@
 int			IdleSessionGangTimeout = 18000;
 
 static volatile sig_atomic_t clientWaitTimeoutInterruptEnabled = 0;
-static volatile sig_atomic_t clientWaitTimeoutInterruptOccurred = 0;
 
 static volatile sig_atomic_t idle_gang_timeout_occurred;
 


### PR DESCRIPTION
Two new compiler warnings showed up, which are both easy to avoid. Backporting the fix from 9.4 is jumping the gun since we will merge with 9.4 at some point anyways, but everyone looking at a warning until then seems worse than backporting something that shouldn't cause conflicts.