### PR TITLE
Reduce granularity of timeout sleep in gpfdist

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3623,7 +3623,8 @@ int gpfdist_run()
 
 int main(int argc, const char* const argv[])
 {
-	gpfdist_init(argc, argv);
+	if (gpfdist_init(argc, argv) == -1)
+		gfatal(NULL, "Initialization failed");
 	return gpfdist_run();
 }
 
@@ -3790,7 +3791,8 @@ int main(int argc, const char* const argv[])
 	srv_ret = StartServiceCtrlDispatcher(ServiceTable);
 	if (0 == srv_ret) /* program is being run as a Windows console application */
 	{
-		gpfdist_init(argc, argv);
+		if (gpfdist_init(argc, argv) == -1)
+			gfatal(NULL, "Initialization failed");
 		main_ret = gpfdist_run();
 	}
 

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3587,10 +3587,21 @@ int gpfdist_init(int argc, const char* const argv[])
 	 */
 
 #ifndef WIN32
-	char* wd = getenv("GPFDIST_WATCHDOG_TIMER");
+	char	   *wd = getenv("GPFDIST_WATCHDOG_TIMER");
+	char	   *endptr;
+	long		val;
+
 	if (wd != NULL)
 	{
-		gcb.wdtimer = atoi(wd);
+		val = strtol(wd, &endptr, 10);
+
+		if (errno || endptr == wd || val > INT_MAX)
+		{
+			fprintf(stderr, "incorrect watchdog timer: %s\n", strerror(errno));
+			return -1;
+		}
+
+		gcb.wdtimer = (int) val;
 		if (gcb.wdtimer > 0)
 		{
 			gprintln(NULL, "Watchdog enabled, abort in %d seconds if no activity", gcb.wdtimer);
@@ -4345,10 +4356,15 @@ pcalloc_safe(request_t *r, apr_pool_t *pool, apr_size_t size, const char *fmt, .
 #ifndef WIN32
 static void* watchdog_thread(void* p)
 {
-	while(apr_time_now() < shutdown_time)
+	apr_time_t		duration;
+
+	do
 	{
-		sleep(1);
-	}
+		/* apr_time_now is defined in microseconds since epoch */
+		duration = apr_time_sec(shutdown_time - apr_time_now());
+		if (duration > 0)
+			(void)sleep(duration);
+	} while(apr_time_now() < shutdown_time);
 	gprintln(NULL, "Watchdog timer expired, abort gpfdist");
 	abort();
 }


### PR DESCRIPTION
The `shutdown_time` is repeatedly set into the future to keep the watchdog thread from waking up and aborting operations, the documentation use 300 seconds as example. Rather than waking up every second, sleep until the next configured shutdown_time at the time of entering sleep. The timer can only increase, so waking up before then will only lead to more calls to `sleep(3)`.

Also move to parsing the watchdog timer from the environment option with `strtol(3)` to improve error handling and guard against overflow and honor the return from the init function.

I don't really know gpfdist so eyes on this would be much appreciated.