### PR TITLE
Remove commented-out block of macOS makefile stuff.

### DIFF
--- a/src/pl/plpython/Makefile
+++ b/src/pl/plpython/Makefile
@@ -28,20 +28,6 @@ python_includespec := $(subst \,/,$(python_includespec))
 override python_libspec =
 endif
 
-# GPDB_93_MERGE_FIXME: This OS X block was removed in upstream, but we had some
-# GPDB hacks in it. Do we still need something special here?
-# Darwin (OS X) has its own ideas about how to do this.
-
-# ifeq ($(PORTNAME), darwin)
-# shared_libpython = yes
-# # Replaced to allow use of Greenplum-provided Python
-# #override python_libspec = -framework Python
-# #override python_additional_libs =
-# # sys.prefix reflects the runtime location of the python tree;
-# # the GP install has the dylib in the lib directory of that tree.
-# override python_libspec = -L$(shell ${PYTHON} -c "import sys, os; print (os.path.join(sys.prefix, 'lib'))") -lpython${python_version}
-# endif
-
 override python_libspec := -L${python_configdir}/../.. ${python_libspec}
 
 # If we don't have a shared library, we have to skip it.
@@ -50,7 +36,6 @@ ifeq ($(shared_libpython),yes)
 # do not fail build due to warnings in this code
 #override CPPFLAGS := -Wno-error -I. -I$(srcdir) $(python_includespec) $(CPPFLAGS) -DPLPYTHON_SHOW_DEBUG_INFO
 override CPPFLAGS := -Wno-error -I. -I$(srcdir) $(python_includespec) $(CPPFLAGS)
-
 
 rpathdir = $(python_libdir):$(INSTLOC)/ext/python/lib
 


### PR DESCRIPTION
I don't understand what all this was about, but people have compiled GPDB
successfully after the merge commit, where this was commented out, so
apparently it's not needed.