### PR TITLE
Remove incorrect settings from macOS instructions

### DIFF
--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -85,12 +85,5 @@ export GOPATH=\$HOME/go
 export PATH=\$HOME/go/bin:\$PATH
 EOF
 
-# Step: speed up compile time (optional)
-cat >> ~/.bashrc << EOF
-
-# This assumes that the macOS machine has 8 threads
-export MAKEFLAGS='-j8'
-EOF
-
 # Step: install any optional tools
 brew install gdb

--- a/README.macOS.md
+++ b/README.macOS.md
@@ -1,7 +1,5 @@
 We've confirmed that these steps work on a brand new installation of macOS
-Sierra or a brand new installation of macOS Sierra with [Pivotal's
-workstation-setup](https://github.com/pivotal/workstation-setup)
-
+Sierra.
 
 ## 1. Install needed dependencies
 


### PR DESCRIPTION
Running -j8 for all make invocations regardless of which is a good way to cause spectacular failures in installcheck-world testing, so remove the setting. Also remove the link to workstation-setup repo as it's not helpful for non-Pivotal hackers.