### PR TITLE
Mark various objects as internal, for purposes of object access hooks.

### DIFF
--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -181,7 +181,7 @@ _bitmap_create_lov_heapandindex(Relation rel,
 								 false, 0,
 								 ONCOMMIT_NOOP, NULL /* GP Policy */,
 								 (Datum)0, false, true,
-								 false, /* is_internal */
+								 true, /* is_internal */
 								 /* valid_opts */ true,
 								 /* is_part_child */ false,
 								 /* is_part_parent */ false);
@@ -250,7 +250,7 @@ _bitmap_create_lov_heapandindex(Relation rel,
 						 /* allow_system_table_mods */ true,
 						 /* skip_build */ false,
 						 /* concurrent */ false,
-						 /* is_internal */ false,	/* GPDB_93_MERGE_FIXME: What's the appropriate is_internal flag? */
+						 /* is_internal */ true,
 						 NULL);
 	*lovIndexOid = idxid;
 

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -8429,7 +8429,7 @@ constraint_apply_mapped(HeapTuple tuple, AttrMap *map, Relation cand,
 									  con->conislocal,
 									  con->coninhcount,
 									  false, /* conNoInherit */
-									  false /* is_internal */); /* GPDB_93_MERGE_FIXME: should this be considered internal? */
+									  true /* is_internal */);
 				break;
 			}
 
@@ -8484,7 +8484,7 @@ constraint_apply_mapped(HeapTuple tuple, AttrMap *map, Relation cand,
 									  con->conislocal,
 									  con->coninhcount,
 									  true, /* conNoInherit */
-									  false /* is_internal */); /* GPDB_93_MERGE_FIXME: should this be considered internal? */
+									  true /* is_internal */);
 
 				heap_close(frel, AccessExclusiveLock);
 				break;


### PR DESCRIPTION
As far as I can see, the 'is_internal' flag is passed through to possible
object access hook, but it has no other effect. Mark the LOV index and
heap created for bitmap indexes, as well as constrains created for
exchanged partitions as 'internal'