### PR TITLE
Remove FIXME in RemoveLocalLock, it's alright.

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1397,9 +1397,6 @@ RemoveLocalLock(LOCALLOCK *locallock)
 		if (locallock->lockOwners[i].owner != NULL)
 			ResourceOwnerForgetLock(locallock->lockOwners[i].owner, locallock);
 	}
-
-	// GPDB_93_MERGE_FIXME: where did this TODO come from? Action needed?
-	// TODO FIX_COMMTI^ does not have this check, why?
 	if (locallock->lockOwners != NULL)
 		pfree(locallock->lockOwners);
 	locallock->lockOwners = NULL;


### PR DESCRIPTION
The FIXME was added to GPDB in commit f86622d95a, which backported the
local cache of resource owners attached to LOCALLOCK. I think the comment
was added, because in the upstream commit that added the cache, the
upstream didn't thave the check guarding the pfree() yet. It was added
later in upstream, too, in commit 7e6e3bdd3c, and that had already been
backported to GPDB. So it's alright, the guard on the pfree is a good thing
to have, and there's nothing further to do here.