### PR TITLE
Modify a sublink test VIEW to avoid unnecessary diffs in pg_upgrade test

### DIFF
--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -118,9 +118,6 @@ DROP TABLE IF EXISTS stat_heap6.stat_part_heap_t6 CASCADE;
 --    No match found in old cluster for new relation with OID 556718 in database "regression": "public.newpart_pkey" which is an index on "public.newpart"
 DROP TABLE IF EXISTS public.newpart CASCADE;
 
--- This view definition changes after upgrade.
-DROP VIEW IF EXISTS v_xpect_triangle_de CASCADE;
-
 -- The dump location for this protocol changes sporadically and causes a false
 -- negative. This may indicate a bug in pg_dump's sort priority for PROTOCOLs.
 DROP PROTOCOL IF EXISTS demoprot_untrusted;

--- a/src/test/regress/expected/sublink.out
+++ b/src/test/regress/expected/sublink.out
@@ -1,6 +1,6 @@
 -- start_ignore
-DROP TABLE IF EXISTS d_xpect_setup;
 DROP VIEW IF EXISTS v_xpect_triangle_de;
+DROP TABLE IF EXISTS d_xpect_setup;
 -- end_ignore
 CREATE TABLE d_xpect_setup (
     key character varying(20) NOT NULL,
@@ -9,7 +9,7 @@ CREATE TABLE d_xpect_setup (
     key_desc character varying(200)
 ) DISTRIBUTED BY (country ,key);
 CREATE VIEW v_xpect_triangle_de AS
-    SELECT x.rep_year, y.age, ((x.rep_year - y.age) - t."offset") AS yob, t.triangle FROM (SELECT s.a AS rep_year FROM (SELECT generate_series.generate_series FROM generate_series((SELECT (substr((d_xpect_setup.key_value)::text, 1, 4))::integer AS valid_from FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'data_valid_from'::text) AND ((d_xpect_setup.country)::text = 'DE'::text))), (SELECT (to_char(((SELECT CASE d_xpect_setup.key_value WHEN IS NOT DISTINCT FROM 'NULL'::text THEN ('now'::text)::date ELSE to_date((d_xpect_setup.key_value)::text, 'YYYYMM'::text) END AS to_date FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'launch_date'::text) AND ((d_xpect_setup.country)::text = 'DE'::text))) - (((d_xpect_setup.key_value)::integer)::double precision * '1 mon'::interval)), 'yyyy'::text))::integer AS valid_to FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'data_valid_to'::text) AND ((d_xpect_setup.country)::text = 'DE'::text)))) generate_series(generate_series)) s(a)) x, (SELECT s.a AS age FROM (SELECT generate_series.generate_series FROM generate_series(0, 120) generate_series(generate_series)) s(a)) y, (SELECT 1 AS "offset", 'HT' AS triangle UNION SELECT 0 AS "offset", 'LT') t ORDER BY x.rep_year DESC, y.age DESC;
+    SELECT x.rep_year, y.age, ((x.rep_year - y.age) - t."offset") AS yob, t.triangle FROM (SELECT s.a AS rep_year FROM (SELECT generate_series.generate_series FROM generate_series((SELECT (substr((d_xpect_setup.key_value)::text, 1, 4))::integer AS valid_from FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'data_valid_from'::text) AND ((d_xpect_setup.country)::text = 'DE'::text))), (SELECT (to_char(((SELECT CASE d_xpect_setup.key_value WHEN IS NOT DISTINCT FROM 'NULL'::text THEN ('now'::text)::date ELSE to_date((d_xpect_setup.key_value)::text, 'YYYYMM'::text) END AS to_date FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'launch_date'::text) AND ((d_xpect_setup.country)::text = 'DE'::text))) - (((d_xpect_setup.key_value)::integer)::double precision * '1 mon'::interval)), 'yyyy'::text))::integer AS valid_to FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'data_valid_to'::text) AND ((d_xpect_setup.country)::text = 'DE'::text)))) generate_series(generate_series)) s(a)) x, (SELECT s.a AS age FROM (SELECT generate_series.generate_series FROM generate_series(0, 120) generate_series(generate_series)) s(a)) y, (SELECT 1 AS "offset", 'HT' AS triangle UNION SELECT 0 AS "offset", 'LT' AS triangle) t ORDER BY x.rep_year DESC, y.age DESC;
 SELECT * FROM v_xpect_triangle_de , ( SELECT lpad(s.a ::text, 2, '0'::text) AS all_months FROM generate_series(1, 12) s(a)) b WHERE (v_xpect_triangle_de.rep_year::text || b.all_months)::text>=  ( SELECT d_xpect_setup.key_value AS valid_from FROM d_xpect_setup WHERE d_xpect_setup.key::text = 'data_valid_from'::text AND d_xpect_setup.country::text = 'NL'::text);
  rep_year | age | yob | triangle | all_months 
 ----------+-----+-----+----------+------------

--- a/src/test/regress/sql/sublink.sql
+++ b/src/test/regress/sql/sublink.sql
@@ -1,6 +1,6 @@
 -- start_ignore
-DROP TABLE IF EXISTS d_xpect_setup;
 DROP VIEW IF EXISTS v_xpect_triangle_de;
+DROP TABLE IF EXISTS d_xpect_setup;
 -- end_ignore
 
 CREATE TABLE d_xpect_setup (
@@ -11,7 +11,7 @@ CREATE TABLE d_xpect_setup (
 ) DISTRIBUTED BY (country ,key);
 
 CREATE VIEW v_xpect_triangle_de AS
-    SELECT x.rep_year, y.age, ((x.rep_year - y.age) - t."offset") AS yob, t.triangle FROM (SELECT s.a AS rep_year FROM (SELECT generate_series.generate_series FROM generate_series((SELECT (substr((d_xpect_setup.key_value)::text, 1, 4))::integer AS valid_from FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'data_valid_from'::text) AND ((d_xpect_setup.country)::text = 'DE'::text))), (SELECT (to_char(((SELECT CASE d_xpect_setup.key_value WHEN IS NOT DISTINCT FROM 'NULL'::text THEN ('now'::text)::date ELSE to_date((d_xpect_setup.key_value)::text, 'YYYYMM'::text) END AS to_date FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'launch_date'::text) AND ((d_xpect_setup.country)::text = 'DE'::text))) - (((d_xpect_setup.key_value)::integer)::double precision * '1 mon'::interval)), 'yyyy'::text))::integer AS valid_to FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'data_valid_to'::text) AND ((d_xpect_setup.country)::text = 'DE'::text)))) generate_series(generate_series)) s(a)) x, (SELECT s.a AS age FROM (SELECT generate_series.generate_series FROM generate_series(0, 120) generate_series(generate_series)) s(a)) y, (SELECT 1 AS "offset", 'HT' AS triangle UNION SELECT 0 AS "offset", 'LT') t ORDER BY x.rep_year DESC, y.age DESC;
+    SELECT x.rep_year, y.age, ((x.rep_year - y.age) - t."offset") AS yob, t.triangle FROM (SELECT s.a AS rep_year FROM (SELECT generate_series.generate_series FROM generate_series((SELECT (substr((d_xpect_setup.key_value)::text, 1, 4))::integer AS valid_from FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'data_valid_from'::text) AND ((d_xpect_setup.country)::text = 'DE'::text))), (SELECT (to_char(((SELECT CASE d_xpect_setup.key_value WHEN IS NOT DISTINCT FROM 'NULL'::text THEN ('now'::text)::date ELSE to_date((d_xpect_setup.key_value)::text, 'YYYYMM'::text) END AS to_date FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'launch_date'::text) AND ((d_xpect_setup.country)::text = 'DE'::text))) - (((d_xpect_setup.key_value)::integer)::double precision * '1 mon'::interval)), 'yyyy'::text))::integer AS valid_to FROM d_xpect_setup WHERE (((d_xpect_setup.key)::text = 'data_valid_to'::text) AND ((d_xpect_setup.country)::text = 'DE'::text)))) generate_series(generate_series)) s(a)) x, (SELECT s.a AS age FROM (SELECT generate_series.generate_series FROM generate_series(0, 120) generate_series(generate_series)) s(a)) y, (SELECT 1 AS "offset", 'HT' AS triangle UNION SELECT 0 AS "offset", 'LT' AS triangle) t ORDER BY x.rep_year DESC, y.age DESC;
 
 
 


### PR DESCRIPTION
When the v_xpect_triangle_de VIEW from sublink regress test is dumped and
restored, an unnecessary alias is added to one variable in a UNION which causes
a syntactic difference but not a semantic one. This results in an unnecessary
diff during pg_upgrade testing even though the functionality of the VIEW is the
same. We do not want to change the underlying logic so we modify the VIEW so
that no diff is unnecessarily produced for pg_upgrade tests.

Example:
```
From the test SQL file...
(SELECT 1 AS "offset", 'HT' AS triangle UNION SELECT 0 AS "offset", 'LT') t

From the \d+ of the VIEW which is what is dumped on old cluster...
(SELECT 1 AS "offset", 'HT'::text AS triangle UNION SELECT 0 AS "offset", 'LT'::text) t

From the \d+ of the VIEW after restoring the VIEW on new cluster...
(SELECT 1 AS "offset", 'HT'::text AS triangle UNION SELECT 0 AS "offset", 'LT'::text AS text) t

With this patch, it will show in dump and after restore as...
(SELECT 1 AS "offset", 'HT'::text AS triangle UNION SELECT 0 AS "offset", 'LT'::text AS triangle) t
```

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>