### PR TITLE
WIP: Fix syntax errors in testsuites that aren't on purpose

### DIFF
--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -798,21 +798,12 @@ Block Size: 32768
 Checksum: t
 Distributed by: (a)
 
--- compresslevel only
+-- compresslevel only (should fail)
 create table ao9 with (compresslevel=0) as select * from ao8
     distributed by (a);
 ERROR:  compresstype can't be used with compresslevel 0
-\d ao9
-select * from ao9 limit 4 order by 1;
-ERROR:  syntax error at or near "order"
-LINE 1: select * from ao9 limit 4 order by 1;
-                                  ^
 create table ao10 with (compresslevel=0, compresstype=none)
-    as select * from ao9 distributed by (a);
-ERROR:  relation "ao9" does not exist
-LINE 2:     as select * from ao9 distributed by (a);
-                             ^
-\d ao10
+    as select * from ao8 distributed by (a);
 -- MPP-14504: we need to allow compresstype=none with compresslevel>0
 create table ao11 (a int, b int) with (compresstype=none, compresslevel=2)
     distributed by (a);

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -2257,46 +2257,41 @@ select count(a.b) from qp_misc_jiras.tbl7616_test a inner join qp_misc_jiras.tbl
   1000
 (1 row)
 
--- start_ignore
 drop table qp_misc_jiras.tbl7616_test;
-create table qp_misc_jiras.tbl6874 ( a int, b text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table qp_misc_jiras.tbl6874 (a int, b text) distributed by (a);
 \d+ qp_misc_jiras.tbl6874
-             Table "qp_misc_jiras.tbl6874"
- Column |  Type   | Modifiers | Storage  | Description 
---------+---------+-----------+----------+-------------
- a      | integer |           | plain    | 
- b      | text    |           | extended | 
+                    Table "qp_misc_jiras.tbl6874"
+ Column |  Type   | Modifiers | Storage  | Stats target | Description 
+--------+---------+-----------+----------+--------------+-------------
+ a      | integer |           | plain    |              | 
+ b      | text    |           | extended |              | 
 Has OIDs: no
 Distributed by: (a)
 
-insert into qp_misc_jiras.tbl6874 values ( generate_series(1,1000),'test_1');
-create index qp_misc_jiras.tbl6874_a on qp_misc_jiras.tbl6874 using bitmap(a);
-ERROR:  syntax error at or near "."
-LINE 1: create index qp_misc_jiras.tbl6874_a on qp_misc_jiras.tbl687...
-                                  ^
+insert into qp_misc_jiras.tbl6874 values (generate_series(1,10),'test_1');
+create index tbl6874_a on qp_misc_jiras.tbl6874 using bitmap(a);
 \d+ qp_misc_jiras.tbl6874
-             Table "qp_misc_jiras.tbl6874"
- Column |  Type   | Modifiers | Storage  | Description 
---------+---------+-----------+----------+-------------
- a      | integer |           | plain    | 
- b      | text    |           | extended | 
+                    Table "qp_misc_jiras.tbl6874"
+ Column |  Type   | Modifiers | Storage  | Stats target | Description 
+--------+---------+-----------+----------+--------------+-------------
+ a      | integer |           | plain    |              | 
+ b      | text    |           | extended |              | 
+Indexes:
+    "tbl6874_a" bitmap (a)
 Has OIDs: no
 Distributed by: (a)
 
 drop index qp_misc_jiras.tbl6874_a;
-ERROR:  index "tbl6874_a" does not exist
 \d+ qp_misc_jiras.tbl6874
-             Table "qp_misc_jiras.tbl6874"
- Column |  Type   | Modifiers | Storage  | Description 
---------+---------+-----------+----------+-------------
- a      | integer |           | plain    | 
- b      | text    |           | extended | 
+                    Table "qp_misc_jiras.tbl6874"
+ Column |  Type   | Modifiers | Storage  | Stats target | Description 
+--------+---------+-----------+----------+--------------+-------------
+ a      | integer |           | plain    |              | 
+ b      | text    |           | extended |              | 
 Has OIDs: no
 Distributed by: (a)
 
-drop table qp_misc_jiras.tbl6874 ;
+drop table qp_misc_jiras.tbl6874;
 CREATE TABLE qp_misc_jiras.tbl7740_rank (id int, gender char(1), count char(1) )
             DISTRIBUTED BY (id)
             PARTITION BY LIST (gender,count)
@@ -2306,7 +2301,6 @@ CREATE TABLE qp_misc_jiras.tbl7740_rank (id int, gender char(1), count char(1) )
 NOTICE:  CREATE TABLE will create partition "tbl7740_rank_1_prt_girls" for table "tbl7740_rank"
 NOTICE:  CREATE TABLE will create partition "tbl7740_rank_1_prt_boys" for table "tbl7740_rank"
 NOTICE:  CREATE TABLE will create partition "tbl7740_rank_1_prt_other" for table "tbl7740_rank"
--- end_ignore
 insert into qp_misc_jiras.tbl7740_rank values(1,'F','1');
 insert into qp_misc_jiras.tbl7740_rank values(1,'F','0');
 insert into qp_misc_jiras.tbl7740_rank values(1,'M','1');

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -2254,46 +2254,41 @@ select count(a.b) from qp_misc_jiras.tbl7616_test a inner join qp_misc_jiras.tbl
   1000
 (1 row)
 
--- start_ignore
 drop table qp_misc_jiras.tbl7616_test;
-create table qp_misc_jiras.tbl6874 ( a int, b text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table qp_misc_jiras.tbl6874 (a int, b text) distributed by (a);
 \d+ qp_misc_jiras.tbl6874
-             Table "qp_misc_jiras.tbl6874"
- Column |  Type   | Modifiers | Storage  | Description 
---------+---------+-----------+----------+-------------
- a      | integer |           | plain    | 
- b      | text    |           | extended | 
+                    Table "qp_misc_jiras.tbl6874"
+ Column |  Type   | Modifiers | Storage  | Stats target | Description 
+--------+---------+-----------+----------+--------------+-------------
+ a      | integer |           | plain    |              | 
+ b      | text    |           | extended |              | 
 Has OIDs: no
 Distributed by: (a)
 
-insert into qp_misc_jiras.tbl6874 values ( generate_series(1,1000),'test_1');
-create index qp_misc_jiras.tbl6874_a on qp_misc_jiras.tbl6874 using bitmap(a);
-ERROR:  syntax error at or near "."
-LINE 1: create index qp_misc_jiras.tbl6874_a on qp_misc_jiras.tbl687...
-                                  ^
+insert into qp_misc_jiras.tbl6874 values (generate_series(1,10),'test_1');
+create index tbl6874_a on qp_misc_jiras.tbl6874 using bitmap(a);
 \d+ qp_misc_jiras.tbl6874
-             Table "qp_misc_jiras.tbl6874"
- Column |  Type   | Modifiers | Storage  | Description 
---------+---------+-----------+----------+-------------
- a      | integer |           | plain    | 
- b      | text    |           | extended | 
+                    Table "qp_misc_jiras.tbl6874"
+ Column |  Type   | Modifiers | Storage  | Stats target | Description 
+--------+---------+-----------+----------+--------------+-------------
+ a      | integer |           | plain    |              | 
+ b      | text    |           | extended |              | 
+Indexes:
+    "tbl6874_a" bitmap (a)
 Has OIDs: no
 Distributed by: (a)
 
 drop index qp_misc_jiras.tbl6874_a;
-ERROR:  index "tbl6874_a" does not exist
 \d+ qp_misc_jiras.tbl6874
-             Table "qp_misc_jiras.tbl6874"
- Column |  Type   | Modifiers | Storage  | Description 
---------+---------+-----------+----------+-------------
- a      | integer |           | plain    | 
- b      | text    |           | extended | 
+                    Table "qp_misc_jiras.tbl6874"
+ Column |  Type   | Modifiers | Storage  | Stats target | Description 
+--------+---------+-----------+----------+--------------+-------------
+ a      | integer |           | plain    |              | 
+ b      | text    |           | extended |              | 
 Has OIDs: no
 Distributed by: (a)
 
-drop table qp_misc_jiras.tbl6874 ;
+drop table qp_misc_jiras.tbl6874;
 CREATE TABLE qp_misc_jiras.tbl7740_rank (id int, gender char(1), count char(1) )
             DISTRIBUTED BY (id)
             PARTITION BY LIST (gender,count)
@@ -2303,7 +2298,6 @@ CREATE TABLE qp_misc_jiras.tbl7740_rank (id int, gender char(1), count char(1) )
 NOTICE:  CREATE TABLE will create partition "tbl7740_rank_1_prt_girls" for table "tbl7740_rank"
 NOTICE:  CREATE TABLE will create partition "tbl7740_rank_1_prt_boys" for table "tbl7740_rank"
 NOTICE:  CREATE TABLE will create partition "tbl7740_rank_1_prt_other" for table "tbl7740_rank"
--- end_ignore
 insert into qp_misc_jiras.tbl7740_rank values(1,'F','1');
 insert into qp_misc_jiras.tbl7740_rank values(1,'F','0');
 insert into qp_misc_jiras.tbl7740_rank values(1,'M','1');

--- a/src/test/regress/expected/rangefuncs_cdb.out
+++ b/src/test/regress/expected/rangefuncs_cdb.out
@@ -373,10 +373,7 @@ select z.fooid, z.f2 from fooro(sin(pi()/2)::int) z ORDER BY 1,2;
      1 | 33
 (2 rows)
 
-DROP FUNCTION fooro;
-ERROR:  syntax error at or near ";"
-LINE 1: DROP FUNCTION fooro;
-                           ^
+DROP FUNCTION fooro(int);
 --
 -- RETURNS TABLE
 --
@@ -484,10 +481,7 @@ select z.fooid, z.f2 from foot(sin(pi()/2)::int) z ORDER BY 1,2;
      1 | 33
 (2 rows)
 
-DROP FUNCTION foot;
-ERROR:  syntax error at or near ";"
-LINE 1: DROP FUNCTION foot;
-                          ^
+DROP FUNCTION foot(int);
 -- sql, proretset = f, prorettype = b
 CREATE FUNCTION getfoo(int) RETURNS int AS 'SELECT $1;' LANGUAGE SQL CONTAINS SQL;
 SELECT * FROM getfoo(1) AS t1;

--- a/src/test/regress/expected/rpt_joins.out
+++ b/src/test/regress/expected/rpt_joins.out
@@ -1947,16 +1947,13 @@ on (x1 = xx1) where (xx2 is not null);
 -- to outside an IN
 --
 create table foo (unique1 int, unique2 int) distributed replicated;
-insert into foo vaules (1, 2), (2, 42);
-ERROR:  syntax error at or near "vaules"
-LINE 1: insert into foo vaules (1, 2), (2, 42);
-                        ^
+insert into foo values (1, 2), (2, 42);
 select count(*) from foo a where unique1 in
   (select unique1 from foo b join foo c using (unique1)
    where b.unique2 = 42);
  count 
 -------
-     0
+     1
 (1 row)
 
 drop table if exists foo;

--- a/src/test/regress/sql/dsp.sql
+++ b/src/test/regress/sql/dsp.sql
@@ -326,14 +326,11 @@ show gp_default_storage_options;
 create table ao8 with (compresstype=none) as select * from ao7
     distributed by (a);
 \d ao8
--- compresslevel only
+-- compresslevel only (should fail)
 create table ao9 with (compresslevel=0) as select * from ao8
     distributed by (a);
-\d ao9
-select * from ao9 limit 4 order by 1;
 create table ao10 with (compresslevel=0, compresstype=none)
-    as select * from ao9 distributed by (a);
-\d ao10
+    as select * from ao8 distributed by (a);
 
 -- MPP-14504: we need to allow compresstype=none with compresslevel>0
 create table ao11 (a int, b int) with (compresstype=none, compresslevel=2)

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -1366,23 +1366,23 @@ create table qp_misc_jiras.tbl7616_test (a int, b text) with (appendonly=true, o
 insert into qp_misc_jiras.tbl7616_test select generate_series(1,1000), generate_series(1,1000);
 select count(a.*) from qp_misc_jiras.tbl7616_test a inner join qp_misc_jiras.tbl7616_test b using (a);
 select count(a.b) from qp_misc_jiras.tbl7616_test a inner join qp_misc_jiras.tbl7616_test b using (a);
--- start_ignore
 drop table qp_misc_jiras.tbl7616_test;
-create table qp_misc_jiras.tbl6874 ( a int, b text);
+
+create table qp_misc_jiras.tbl6874 (a int, b text) distributed by (a);
 \d+ qp_misc_jiras.tbl6874
-insert into qp_misc_jiras.tbl6874 values ( generate_series(1,1000),'test_1');
-create index qp_misc_jiras.tbl6874_a on qp_misc_jiras.tbl6874 using bitmap(a);
+insert into qp_misc_jiras.tbl6874 values (generate_series(1,10),'test_1');
+create index tbl6874_a on qp_misc_jiras.tbl6874 using bitmap(a);
 \d+ qp_misc_jiras.tbl6874
 drop index qp_misc_jiras.tbl6874_a;
 \d+ qp_misc_jiras.tbl6874
-drop table qp_misc_jiras.tbl6874 ;
+drop table qp_misc_jiras.tbl6874;
 CREATE TABLE qp_misc_jiras.tbl7740_rank (id int, gender char(1), count char(1) )
             DISTRIBUTED BY (id)
             PARTITION BY LIST (gender,count)
             ( PARTITION girls VALUES (('F','1')),
               PARTITION boys VALUES (('M','1')),
               DEFAULT PARTITION other );
--- end_ignore
+
 insert into qp_misc_jiras.tbl7740_rank values(1,'F','1');
 insert into qp_misc_jiras.tbl7740_rank values(1,'F','0');
 insert into qp_misc_jiras.tbl7740_rank values(1,'M','1');

--- a/src/test/regress/sql/rangefuncs_cdb.sql
+++ b/src/test/regress/sql/rangefuncs_cdb.sql
@@ -217,7 +217,7 @@ ORDER BY 1,2;
 -- nested functions
 select z.fooid, z.f2 from fooro(sin(pi()/2)::int) z ORDER BY 1,2;
 
-DROP FUNCTION fooro;
+DROP FUNCTION fooro(int);
 
 --
 -- RETURNS TABLE
@@ -275,7 +275,7 @@ ORDER BY 1,2;
 -- nested functions
 select z.fooid, z.f2 from foot(sin(pi()/2)::int) z ORDER BY 1,2;
 
-DROP FUNCTION foot;
+DROP FUNCTION foot(int);
 
 -- sql, proretset = f, prorettype = b
 CREATE FUNCTION getfoo(int) RETURNS int AS 'SELECT $1;' LANGUAGE SQL CONTAINS SQL;

--- a/src/test/regress/sql/rpt_joins.sql
+++ b/src/test/regress/sql/rpt_joins.sql
@@ -303,7 +303,7 @@ on (x1 = xx1) where (xx2 is not null);
 -- to outside an IN
 --
 create table foo (unique1 int, unique2 int) distributed replicated;
-insert into foo vaules (1, 2), (2, 42);
+insert into foo values (1, 2), (2, 42);
 
 select count(*) from foo a where unique1 in
   (select unique1 from foo b join foo c using (unique1)


### PR DESCRIPTION
There were a few cases of broken queries in the test suites which weren't done on purpose in order to test the parser/grammar. This fixes the ones that stood out, but there are likely to be more in ignore blocks that slip through the cracks.

I fully expect this to test red. It's Sunday afternoon and I'm shamelessly using the PR pipeline to validate the patch.. hence WIP.