### PR TITLE
Fix UPDATE RETURNING on distribution key columns.

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -871,7 +871,11 @@ ldelete:;
 	}
 
 	/* Process RETURNING if present */
-	if (resultRelInfo->ri_projectReturning)
+	/*
+	 * In a split update, the processed rows are returned by the INSERT
+	 * of the new row, not the DELETE of the old one.
+	 */
+	if (resultRelInfo->ri_projectReturning && !isUpdate)
 	{
 		/*
 		 * We have to put the target tuple into a slot, which means first we
@@ -1716,7 +1720,7 @@ ExecModifyTable(ModifyTableState *node)
 					}
 					else /* DML_DELETE */
 						slot = ExecDelete(tupleid, oldtuple, planSlot,
-										  &node->mt_epqstate, estate, node->canSetTag,
+										  &node->mt_epqstate, estate, false,
 										  PLANGEN_PLANNER, true /* isUpdate */);
 				}
 				break;

--- a/src/test/regress/expected/returning_gp.out
+++ b/src/test/regress/expected/returning_gp.out
@@ -98,3 +98,21 @@ CREATE TEMP TABLE returning_aotab (id int4) WITH (appendonly=true);
 INSERT INTO returning_aotab VALUES (1);
 DELETE FROM returning_aotab RETURNING *;
 ERROR:  DELETE RETURNING is not supported on appendonly tables
+--
+-- Test UPDATE RETURNING with a split update, i.e. an update of the distribution
+-- key.
+--
+CREATE TEMP TABLE returning_disttest (id int4) DISTRIBUTED BY (id);
+INSERT INTO returning_disttest VALUES (1), (2);
+-- Disable QUIET mode, so that we get some testing of the command tag as well.
+-- (At one point, each split update incorrectly counted as two updated rows.)
+\set QUIET off
+UPDATE returning_disttest SET id = id + 1;
+UPDATE 2
+SELECT * FROM returning_disttest;
+ id 
+----
+  3
+  2
+(2 rows)
+

--- a/src/test/regress/sql/returning_gp.sql
+++ b/src/test/regress/sql/returning_gp.sql
@@ -47,3 +47,19 @@ select * from returning_parttab;
 CREATE TEMP TABLE returning_aotab (id int4) WITH (appendonly=true);
 INSERT INTO returning_aotab VALUES (1);
 DELETE FROM returning_aotab RETURNING *;
+
+
+--
+-- Test UPDATE RETURNING with a split update, i.e. an update of the distribution
+-- key.
+--
+CREATE TEMP TABLE returning_disttest (id int4) DISTRIBUTED BY (id);
+INSERT INTO returning_disttest VALUES (1), (2);
+
+-- Disable QUIET mode, so that we get some testing of the command tag as well.
+-- (At one point, each split update incorrectly counted as two updated rows.)
+\set QUIET off
+
+UPDATE returning_disttest SET id = id + 1;
+
+SELECT * FROM returning_disttest;


### PR DESCRIPTION
Updating a distribution key column is performed as a "split update", i.e.
separate DELETE and INSERT operations, which may happen on different nodes.
In case of RETURNING, the DELETE operation was also returning a row, and it
was also incorrectly counted in the row count returned to the client, in
the command tag (e.g. "UPDATE 2"). Fix, and add a regression test.

Fixes https://github.com/greenplum-db/gpdb/issues/5839