### PR TITLE
Fix the one-element tuple visibility cache in heap scans, for multi-xids.

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -317,8 +317,8 @@ heapgetpage(HeapScanDesc scan, BlockNumber page)
 	OffsetNumber lineoff;
 	ItemId		lpp;
 	bool		all_visible;
-	TransactionId t_xmin, t_xmax;
-	CommandId     t_cid;
+	TransactionId t_xmin;
+	CommandId	t_cid;
 
 	Assert(page < scan->rs_nblocks);
 
@@ -364,7 +364,7 @@ heapgetpage(HeapScanDesc scan, BlockNumber page)
 	lines = PageGetMaxOffsetNumber(dp);
 	ntup = 0;
 
-	t_xmin = t_xmax = 0;
+	t_xmin = 0;
 	t_cid = 0;
 
 	/*
@@ -407,25 +407,40 @@ heapgetpage(HeapScanDesc scan, BlockNumber page)
 			{
 				valid = true;
 			}
-			/* GPDB: We have a one-item cache for the common case that a lot of
-			 * tuples have the same visibility info. */
-			// GPDB_93_MERGE_FIXME: does this still work with the new multixid stuff?
-			// Should we check some additional flags too, to check if the xmax if
-			// locked only or something?
-			else if (t_xmax == HeapTupleHeaderGetRawXmax(theader) &&
-					 t_xmin == HeapTupleHeaderGetXmin(theader) &&
-					 t_cid == HeapTupleHeaderGetRawCommandId(theader))
-			{
-				valid = true;
-			}
 			else
 			{
-				valid = HeapTupleSatisfiesVisibility(scan->rs_rd, &loctup, snapshot, buffer);
-				if (valid)
+				/*
+				 * GPDB: We have a one-item cache for the common case that a
+				 * lot of tuples have the same visibility info. Don't use the
+				 * cache, if the tuple was ever deleted, though (i.e. if xmax
+				 * is valid, and not just for tuple-locking). We could cache
+				 * the xmax too, but the visibility rules get more complicated
+				 * with locked-only tuples and multi-XIDs, so it seems better
+				 * to just give up early.
+				 */
+				bool		use_cache;
+
+				if ((theader->t_infomask & HEAP_XMAX_INVALID) != 0 ||
+					HEAP_XMAX_IS_LOCKED_ONLY(theader->t_infomask))
+					use_cache = true;
+				else
+					use_cache = false;
+
+				if (use_cache &&
+					t_xmin == HeapTupleHeaderGetXmin(theader) &&
+					t_cid == HeapTupleHeaderGetRawCommandId(theader))
 				{
-					t_xmax = HeapTupleHeaderGetRawXmax(loctup.t_data);
-					t_xmin = HeapTupleHeaderGetXmin(loctup.t_data);
-					t_cid = HeapTupleHeaderGetRawCommandId(loctup.t_data);
+					valid = true;
+				}
+				else
+				{
+					valid = HeapTupleSatisfiesVisibility(scan->rs_rd, &loctup, snapshot, buffer);
+
+					if (valid && use_cache)
+					{
+						t_xmin = HeapTupleHeaderGetXmin(loctup.t_data);
+						t_cid = HeapTupleHeaderGetRawCommandId(loctup.t_data);
+					}
 				}
 			}
 


### PR DESCRIPTION
It's not cool to use the raw xmax value as part of the cache key. If the
raw xmax represents a multi-xid, the real deleter XID would be something
else. We could get fooled, if we cached a multi-XID value, and later saw
a tuple with a regular xmax, with the same numerical value as the cached
multi-XID.

I think this was actually broken before the 9.3 merge already. If a
transaction locked a tuple, and deleted another tuple, and a concurrent
scan sees the locked tuple first, it might think that the deleted tuple
is also visible to it, because it has the same xmin+xmax combination as
the locked tuple.