### PR TITLE
gpcreateseg.sh: Only remove CIDR for localhost if pg_hba.conf exists

### DIFF
--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -212,9 +212,11 @@ PROCESS_QE () {
         $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          $USER_NAME         $CIDR_ADDR      trust >> ${GP_DIR}/$PG_HBA"
         done
     else
-        # cleanup the pg_hba.conf
-        $GREP "^#" ${GP_DIR}/$PG_HBA > $TMP_PG_HBA
-        $MV $TMP_PG_HBA ${GP_DIR}/$PG_HBA
+        # clean up localhost CIDR in pg_hba.conf if exists
+        if [ -f ${GP_DIR}/$PG_HBA ]; then
+            $GREP "^#" ${GP_DIR}/$PG_HBA > $TMP_PG_HBA
+            $MV $TMP_PG_HBA ${GP_DIR}/$PG_HBA
+        fi
 
         # add localhost
         $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          all         localhost      trust >> ${GP_DIR}/$PG_HBA"


### PR DESCRIPTION
From cadd7ea#diff-aa9e6dccf77fa1790f69169029082330, we introduced an error if the pg_hba.conf file doesn't exist. Here is an example error message:

20180918:18:49:11:000108 gpinitsystem:master:gpadmin-[INFO]:-Waiting for parallel processes batch [1], please wait...
.........../bin/grep: /greenplum/data/pg_hba.conf: No such file or directory
/bin/mv: cannot move '/tmp/pg_hba_conf_master.1225' to '/greenplum/data/pg_hba.conf': No such file or directory
This commit fix the above issue.

5X PR is at https://github.com/greenplum-db/gpdb/pull/5847

[#160659122]

Authored-by: Xin Zhang <xzhang@pivotal.io>