### PR TITLE
Remove an outdated GPDB_90_MERGE_FIXME in src/backend/optimizer/plan/setrefs.c

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -827,13 +827,11 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 				if (cdb_expr_requires_full_eval((Node *)plan->targetlist))
 					return cdb_insert_result_node(root, plan, rtoffset);
 
-				/* recursively process the subplan */
-				/* GPDB_90_MERGE_FIXME: How about rowmarks here? Do we need to stash them
-				 * in TableFunctionScan? */
 				/* Need to look up the subquery's RelOptInfo, since we need its subroot */
 				rel = find_base_rel(root, tplan->scan.scanrelid);
 				Assert(rel->subplan == subplan);
 
+				/* recursively process the subplan */
 				plan->lefttree = set_plan_references(rel->subroot, subplan);
 
 				/* adjust for the new range table offset */

--- a/src/test/regress/input/table_functions.source
+++ b/src/test/regress/input/table_functions.source
@@ -466,7 +466,9 @@ explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hell
 select count(*) from multiset_5(table(select * from example)) s ;
 
 -- Test for 'select for update'
+begin;
 select count(*) from multiset_5(table(select * from example for update)) s ;
+abort;
 
 -- ===========================================
 -- Test invalid use of table value expressions

--- a/src/test/regress/input/table_functions.source
+++ b/src/test/regress/input/table_functions.source
@@ -465,6 +465,9 @@ explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hell
 -- Test for an old bug in aggregate planning - this used to crash.
 select count(*) from multiset_5(table(select * from example)) s ;
 
+-- Test for 'select for update'
+select count(*) from multiset_5(table(select * from example for update)) s ;
+
 -- ===========================================
 -- Test invalid use of table value expressions
 -- ===========================================

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -2042,12 +2042,14 @@ select count(*) from multiset_5(table(select * from example)) s ;
 (1 row)
 
 -- Test for 'select for update'
+begin;
 select count(*) from multiset_5(table(select * from example for update)) s ;
  count 
 -------
     10
 (1 row)
 
+abort;
 -- ===========================================
 -- Test invalid use of table value expressions
 -- ===========================================

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -2041,6 +2041,13 @@ select count(*) from multiset_5(table(select * from example)) s ;
     10
 (1 row)
 
+-- Test for 'select for update'
+select count(*) from multiset_5(table(select * from example for update)) s ;
+ count 
+-------
+    10
+(1 row)
+
 -- ===========================================
 -- Test invalid use of table value expressions
 -- ===========================================

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -2042,6 +2042,15 @@ select count(*) from multiset_5(table(select * from example)) s ;
     10
 (1 row)
 
+-- Test for 'select for update'
+begin;
+select count(*) from multiset_5(table(select * from example for update)) s ;
+ count 
+-------
+    10
+(1 row)
+
+abort;
 -- ===========================================
 -- Test invalid use of table value expressions
 -- ===========================================


### PR DESCRIPTION
When the FIXME was introduced, it looks like 
```
                                /* recursively process the subplan */
				/* GPDB_90_MERGE_FIXME: How about rowmarks here? Do we need to stash them
				 * in TableFunctionScan? */
				plan->lefttree = set_plan_references(glob, subplan,
													 subrtable, NIL);
```

But then function set_plan_references() only offer two parameter now.
```
                                /* recursively process the subplan */
				/* GPDB_90_MERGE_FIXME: How about rowmarks here? Do we need to stash them
				 * in TableFunctionScan? */
				/* Need to look up the subquery's RelOptInfo, since we need its subroot */
				rel = find_base_rel(root, tplan->scan.scanrelid);
				Assert(rel->subplan == subplan);

				plan->lefttree = set_plan_references(rel->subroot, subplan);
```

So I removed the FIXME, is there anything I missed?
And I also setting position for comment `/* recursively process the subplan */`