### PR TITLE
Add more checks when deduce quals from non-equivalence clauses.

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -49,6 +49,8 @@ static PathKey *make_pathkey_from_sortinfo(PlannerInfo *root,
 						   bool canonicalize);
 static bool right_merge_direction(PlannerInfo *root, PathKey *pathkey);
 
+static bool op_in_eclass_opfamily(Oid opno, EquivalenceClass *eclass);
+
 
 /****************************************************************************
  *		PATHKEY CONSTRUCTION AND REDUNDANCY TESTING
@@ -110,6 +112,26 @@ replace_expression_mutator(Node *node, void *context)
 	return expression_tree_mutator(node, replace_expression_mutator, (void *) context);
 }
 
+/*
+ * op_in_eclass_opfamily
+ *
+ *		Return t iff operator 'opno' is in eclass's operator family.
+ */
+static bool
+op_in_eclass_opfamily(Oid opno, EquivalenceClass *eclass)
+{
+	ListCell	*lc;
+
+	foreach(lc, eclass->ec_opfamilies)
+	{
+		Oid		opfamily = lfirst_oid(lc);
+
+		if (op_in_opfamily(opno, opfamily))
+			return true;
+	}
+	return false;
+}
+
 /**
  * Generate implied qual
  * Input:
@@ -147,8 +169,6 @@ gen_implied_qual(PlannerInfo *root,
 		return;
 
 	new_qualscope = pull_varnos(new_clause);
-
-	/* distribute_qual_to_rels doesn't accept pseudoconstants? XXX: doesn't it? */
 	if (new_qualscope == NULL)
 		return;
 
@@ -216,16 +236,40 @@ gen_implied_qual(PlannerInfo *root,
 static void
 gen_implied_quals(PlannerInfo *root, RestrictInfo *rinfo)
 {
+	Expr	   *clause = rinfo->clause;
+	Oid			opno,
+				item1_type,
+				item2_type;
+	Expr	   *item1;
+	Expr	   *item2;
 	ListCell   *lcec;
 
-	/*
-	 * Is it safe to infer from this clause?
-	 */
-	if (contain_volatile_functions((Node *) rinfo->clause) ||
-		contain_subplans((Node *) rinfo->clause))
-	{
+	if (rinfo->pseudoconstant)
 		return;
+	if (contain_volatile_functions((Node *) clause) ||
+		contain_subplans((Node *) clause))
+		return;
+
+	if (is_opclause(clause))
+	{
+		if (list_length(((OpExpr *) clause)->args) != 2)
+			return;
+		opno = ((OpExpr *) clause)->opno;
+		item1 = (Expr *) get_leftop(clause);
+		item2 = (Expr *) get_rightop(clause);
 	}
+	else if (clause && IsA(clause, ScalarArrayOpExpr))
+	{
+		if (list_length(((ScalarArrayOpExpr *) clause)->args) != 2)
+			return;
+		opno = ((ScalarArrayOpExpr *) clause)->opno;
+		item1 = (Expr *) get_leftscalararrayop(clause);
+		item2 = (Expr *) get_rightscalararrayop(clause);
+	}
+	else
+		return;
+
+	op_input_types(opno, &item1_type, &item2_type);
 
 	/*
 	 * Find every equivalence class that's relevant for this RestrictInfo.
@@ -238,13 +282,19 @@ gen_implied_quals(PlannerInfo *root, RestrictInfo *rinfo)
 		EquivalenceClass *eclass = (EquivalenceClass *) lfirst(lcec);
 		ListCell   *lcem1;
 
+		/*
+		 * Only generate derived clauses using operators from the same operator
+		 * family.
+		 */
+		if (!op_in_eclass_opfamily(opno, eclass))
+			continue;
+
 		/* Single-member ECs won't generate any deductions */
 		if (list_length(eclass->ec_members) <= 1)
 			continue;
 
 		if (!bms_overlap(eclass->ec_relids, rinfo->clause_relids))
-			continue;			/* none of the members can appear in the
-								 * clause */
+			continue;
 
 		foreach(lcem1, eclass->ec_members)
 		{
@@ -252,7 +302,7 @@ gen_implied_quals(PlannerInfo *root, RestrictInfo *rinfo)
 			ListCell   *lcem2;
 
 			if (!bms_overlap(em1->em_relids, rinfo->clause_relids))
-				continue;		/* this member cannot appear in the clause */
+				continue;
 
 			/*
 			 * Skip duplicating subplans clauses as multiple subplan node referring
@@ -261,6 +311,15 @@ gen_implied_quals(PlannerInfo *root, RestrictInfo *rinfo)
 			 */
 			if (contain_subplans((Node *) em1->em_expr))
 				continue;
+
+			/*
+			 * Skip if this EquivalenceMember does not match neither left expr
+			 * nor right expr.
+			 */
+			if (!((item1_type == em1->em_datatype && equal(item1, em1->em_expr)) ||
+					(item2_type == em1->em_datatype && equal(item2, em1->em_expr))))
+				continue;
+
 			/* now try to apply to others in the equivalence class */
 			foreach(lcem2, eclass->ec_members)
 			{

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -172,6 +172,38 @@ get_rightop(Expr *clause)
 		return NULL;
 }
 
+/*
+ * get_leftscalararrayop
+ *
+ * Returns the left operand of a clause of the form (scalar op ANY/ALL (array))
+ */
+Node *
+get_leftscalararrayop(Expr *clause)
+{
+	const ScalarArrayOpExpr *expr = (const ScalarArrayOpExpr *) clause;
+
+	if (expr->args != NIL)
+		return linitial(expr->args);
+	else
+		return NULL;
+}
+
+/*
+ * get_rightscalararrayop
+ *
+ * Returns the right operand in a clause of the form (scalar op ANY/ALL (array)).
+ */
+Node *
+get_rightscalararrayop(Expr *clause)
+{
+	const ScalarArrayOpExpr *expr = (const ScalarArrayOpExpr *) clause;
+
+	if (list_length(expr->args) >= 2)
+		return lsecond(expr->args);
+	else
+		return NULL;
+}
+
 /*****************************************************************************
  *		NOT clause functions
  *****************************************************************************/

--- a/src/include/optimizer/clauses.h
+++ b/src/include/optimizer/clauses.h
@@ -54,6 +54,8 @@ extern Expr *make_opclause(Oid opno, Oid opresulttype, bool opretset,
 			  Expr *leftop, Expr *rightop);
 extern Node *get_leftop(Expr *clause);
 extern Node *get_rightop(Expr *clause);
+extern Node *get_leftscalararrayop(Expr *clause);
+extern Node *get_rightscalararrayop(Expr *clause);
 
 extern bool not_clause(Node *clause);
 extern Expr *make_notclause(Expr *notclause);

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3499,6 +3499,110 @@ select rnum, c1, c2 from qp_tjoin2 where 20 > all ( select c1 from qp_tjoin1) or
 (0 rows)
 
 -- ----------------------------------------------------------------------
+-- Test: non-equivalence clauses
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS qp_non_eq_a;
+NOTICE:  table "qp_non_eq_a" does not exist, skipping
+DROP TABLE IF EXISTS qp_non_eq_b;
+NOTICE:  table "qp_non_eq_b" does not exist, skipping
+CREATE TABLE qp_non_eq_a (i int, f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE qp_non_eq_b (i int, f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO qp_non_eq_a VALUES (1, '0'), (2, '-0');
+INSERT INTO qp_non_eq_b VALUES (3, '0'), (1, '-0');
+-- end_ignore
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=1.07..3.17 rows=4 width=24)
+   ->  Hash Join  (cost=1.07..3.17 rows=2 width=24)
+         Hash Cond: qp_non_eq_b.f = qp_non_eq_a.f
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.06 rows=1 width=12)
+               Hash Key: qp_non_eq_b.f
+               ->  Seq Scan on qp_non_eq_b  (cost=0.00..2.02 rows=1 width=12)
+         ->  Hash  (cost=1.05..1.05 rows=1 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=1 width=12)
+                     Hash Key: qp_non_eq_a.f
+                     ->  Seq Scan on qp_non_eq_a  (cost=0.00..1.03 rows=1 width=12)
+                           Filter: f::text <> '-0'::text
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+ 1 | 0 | 3 |  0
+(2 rows)
+
+EXPLAIN SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=1.08..3.19 rows=4 width=24)
+   ->  Hash Join  (cost=1.08..3.19 rows=2 width=24)
+         Hash Cond: qp_non_eq_b.f = qp_non_eq_a.f
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.06 rows=1 width=12)
+               Hash Key: qp_non_eq_b.f
+               ->  Seq Scan on qp_non_eq_b  (cost=0.00..2.04 rows=1 width=12)
+                     Filter: CASE WHEN f::text = '-0'::text THEN 1::double precision ELSE (-1)::double precision END < 0::double precision
+         ->  Hash  (cost=1.06..1.06 rows=1 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.06 rows=1 width=12)
+                     Hash Key: qp_non_eq_a.f
+                     ->  Seq Scan on qp_non_eq_a  (cost=0.00..1.02 rows=1 width=12)
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+ i | f  | i | f 
+---+----+---+---
+ 2 | -0 | 3 | 0
+ 1 |  0 | 3 | 0
+(2 rows)
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.05..3.12 rows=4 width=24)
+   ->  Hash Join  (cost=1.05..3.12 rows=2 width=24)
+         Hash Cond: qp_non_eq_b.i = qp_non_eq_a.i
+         ->  Seq Scan on qp_non_eq_b  (cost=0.00..2.03 rows=1 width=12)
+               Filter: i = ANY ('{1,2,3}'::integer[])
+         ->  Hash  (cost=1.03..1.03 rows=1 width=12)
+               ->  Seq Scan on qp_non_eq_a  (cost=0.00..1.03 rows=1 width=12)
+                     Filter: i = ANY ('{1,2,3}'::integer[])
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+(1 row)
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.05..3.12 rows=4 width=24)
+   ->  Hash Join  (cost=1.05..3.12 rows=2 width=24)
+         Hash Cond: qp_non_eq_b.i = qp_non_eq_a.i
+         ->  Seq Scan on qp_non_eq_b  (cost=0.00..2.02 rows=1 width=12)
+         ->  Hash  (cost=1.03..1.03 rows=1 width=12)
+               ->  Seq Scan on qp_non_eq_a  (cost=0.00..1.03 rows=1 width=12)
+                     Filter: i::numeric = ANY ('{1,2,3}'::numeric[])
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+(1 row)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3592,30 +3592,135 @@ select rnum, c1, c2 from qp_tjoin2 where 20 > all ( select c1 from qp_tjoin1) or
 (0 rows)
 
 -- ----------------------------------------------------------------------
+-- Test: non-equivalence clauses
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS qp_non_eq_a;
+NOTICE:  table "qp_non_eq_a" does not exist, skipping
+DROP TABLE IF EXISTS qp_non_eq_b;
+NOTICE:  table "qp_non_eq_b" does not exist, skipping
+CREATE TABLE qp_non_eq_a (i int, f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE qp_non_eq_b (i int, f float8);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO qp_non_eq_a VALUES (1, '0'), (2, '-0');
+INSERT INTO qp_non_eq_b VALUES (3, '0'), (1, '-0');
+-- end_ignore
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: qp_non_eq_b.f = qp_non_eq_a.f
+         ->  Table Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Table Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
+                           Filter: f::text <> '-0'::text
+ Optimizer: PQO version 2.72.0
+(9 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 3 |  0
+ 1 | 0 | 1 | -0
+(2 rows)
+
+EXPLAIN SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: qp_non_eq_a.f = qp_non_eq_b.f
+         ->  Table Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Table Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
+                           Filter: CASE WHEN f::text = '-0'::text THEN 1::double precision ELSE (-1)::double precision END < 0::double precision
+ Optimizer: PQO version 2.72.0
+(9 rows)
+
+SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+ i | f  | i | f 
+---+----+---+---
+ 1 |  0 | 3 | 0
+ 2 | -0 | 3 | 0
+(2 rows)
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: qp_non_eq_a.i = qp_non_eq_b.i
+         ->  Table Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
+               Filter: (i = ANY ('{1,2,3}'::integer[])) AND (i = 1 OR i = 2 OR i = 3)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Table Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
+                     Filter: i = 1 OR i = 2 OR i = 3
+ Optimizer: PQO version 2.72.0
+(9 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+(1 row)
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: qp_non_eq_a.i = qp_non_eq_b.i
+         ->  Table Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
+               Filter: i::numeric = ANY ('{1,2,3}'::numeric[])
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Table Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: PQO version 2.72.0
+(8 rows)
+
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+ i | f | i | f  
+---+---+---+----
+ 1 | 0 | 1 | -0
+(1 row)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore
 drop schema qp_correlated_query cascade;
-NOTICE:  drop cascades to table qp_tjoin4
-NOTICE:  drop cascades to table qp_tjoin3
-NOTICE:  drop cascades to table qp_tjoin2
-NOTICE:  drop cascades to table qp_tjoin1
-NOTICE:  drop cascades to table tversion
-NOTICE:  drop cascades to table t1
-NOTICE:  drop cascades to function f(integer)
-NOTICE:  drop cascades to table csq_emp
-NOTICE:  drop cascades to table with_test2
-NOTICE:  drop cascades to table with_test1
-NOTICE:  drop cascades to table employee
-NOTICE:  drop cascades to table job
-NOTICE:  drop cascades to table product_order
-NOTICE:  drop cascades to table product
-NOTICE:  drop cascades to table d
-NOTICE:  drop cascades to table qp_csq_t4
-NOTICE:  drop cascades to table c
-NOTICE:  drop cascades to table b
-NOTICE:  drop cascades to table a
-NOTICE:  drop cascades to table qp_csq_t3
-NOTICE:  drop cascades to table qp_csq_t2
-NOTICE:  drop cascades to table qp_csq_t1
+NOTICE:  drop cascades to 28 other objects
+DETAIL:  drop cascades to table qp_csq_t1
+drop cascades to table qp_csq_t2
+drop cascades to table qp_csq_t3
+drop cascades to table a
+drop cascades to table b
+drop cascades to table c
+drop cascades to table d
+drop cascades to table e
+drop cascades to table qp_csq_t4
+drop cascades to table product
+drop cascades to table product_order
+drop cascades to table job
+drop cascades to table employee
+drop cascades to table with_test1
+drop cascades to table with_test2
+drop cascades to table csq_emp
+drop cascades to function f(integer)
+drop cascades to table t1
+drop cascades to table tversion
+drop cascades to table qp_tjoin1
+drop cascades to table qp_tjoin2
+drop cascades to table qp_tjoin3
+drop cascades to table qp_tjoin4
+drop cascades to table qp_tab1
+drop cascades to table qp_tab2
+drop cascades to table qp_tab3
+drop cascades to table qp_non_eq_a
+drop cascades to table qp_non_eq_b
 -- end_ignore

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -828,6 +828,32 @@ select rnum, c1, c2 from qp_tjoin2 where 75 > all ( select c2 from qp_tjoin1) or
 select rnum, c1, c2 from qp_tjoin2 where 20 > all ( select c1 from qp_tjoin1) order by rnum;
 
 -- ----------------------------------------------------------------------
+-- Test: non-equivalence clauses
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS qp_non_eq_a;
+DROP TABLE IF EXISTS qp_non_eq_b;
+
+CREATE TABLE qp_non_eq_a (i int, f float8);
+CREATE TABLE qp_non_eq_b (i int, f float8);
+INSERT INTO qp_non_eq_a VALUES (1, '0'), (2, '-0');
+INSERT INTO qp_non_eq_b VALUES (3, '0'), (1, '-0');
+-- end_ignore
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
+
+EXPLAIN SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
+
+EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 


### PR DESCRIPTION
When we deduce new quals from non-equivalence clauses, we should
only use operators from the same opfamily, so that the operators can
have consistent semantics. In addition, datatype and expression should
also be checked.