### PR TITLE
Fix update the same row concurrently bug.

### DIFF
--- a/src/backend/executor/nodeSplitUpdate.c
+++ b/src/backend/executor/nodeSplitUpdate.c
@@ -17,10 +17,12 @@
 #include "miscadmin.h"
 
 #include "cdb/cdbpartition.h"
+#include "cdb/cdbvars.h"
 #include "commands/tablecmds.h"
 #include "executor/execDML.h"
 #include "executor/instrument.h"
 #include "executor/nodeSplitUpdate.h"
+#include "storage/lmgr.h"
 
 #include "utils/memutils.h"
 
@@ -192,6 +194,14 @@ ExecInitSplitUpdate(SplitUpdate *node, EState *estate, int eflags)
 			splitupdatestate->ps.cdbexplainfun = ExecSplitUpdateExplainEnd;
 	}
 
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		Assert(estate->es_result_relation_info);
+		Assert(estate->es_result_relation_info->ri_RelationDesc);
+
+		LockRelation(estate->es_result_relation_info->ri_RelationDesc,
+					 ExclusiveLock);
+	}
 	return splitupdatestate;
 }
 

--- a/src/test/isolation2/expected/concurrent_update_hashcol.out
+++ b/src/test/isolation2/expected/concurrent_update_hashcol.out
@@ -1,0 +1,114 @@
+-- test for heap table
+create table tab_update_hashcol (c1 int, c2 int) distributed by(c1);
+CREATE
+insert into tab_update_hashcol select i, i from generate_series(1, 10)i;
+INSERT 10
+
+select * from tab_update_hashcol order by 1;
+c1|c2
+--+--
+1 |1 
+2 |2 
+3 |3 
+4 |4 
+5 |5 
+6 |6 
+7 |7 
+8 |8 
+9 |9 
+10|10
+(10 rows)
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+
+1: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+UPDATE 1
+
+2&: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;  <waiting ...>
+
+1: end;
+END
+2<:  <... completed>
+UPDATE 0
+2: end;
+END
+
+select * from tab_update_hashcol order by 1;
+c1|c2
+--+--
+2 |2 
+2 |1 
+3 |3 
+4 |4 
+5 |5 
+6 |6 
+7 |7 
+8 |8 
+9 |9 
+10|10
+(10 rows)
+
+drop table tab_update_hashcol;
+DROP
+
+-- test for ao table
+create table tab_update_hashcol (c1 int, c2 int) with(appendonly=true) distributed by(c1);
+CREATE
+insert into tab_update_hashcol select i, i from generate_series(1, 10)i;
+INSERT 10
+
+select * from tab_update_hashcol order by 1;
+c1|c2
+--+--
+1 |1 
+2 |2 
+3 |3 
+4 |4 
+5 |5 
+6 |6 
+7 |7 
+8 |8 
+9 |9 
+10|10
+(10 rows)
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+
+1: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+UPDATE 1
+
+2&: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;  <waiting ...>
+
+1: end;
+END
+2<:  <... completed>
+UPDATE 0
+2: end;
+END
+
+select * from tab_update_hashcol order by 1;
+c1|c2
+--+--
+2 |2 
+2 |1 
+3 |3 
+4 |4 
+5 |5 
+6 |6 
+7 |7 
+8 |8 
+9 |9 
+10|10
+(10 rows)
+
+drop table tab_update_hashcol;
+DROP
+
+1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,3 +1,5 @@
+test: concurrent_update_hashcol
+
 # Tests on global deadlock detector
 test: select_for_update
 test: gdd/prepare

--- a/src/test/isolation2/sql/concurrent_update_hashcol.sql
+++ b/src/test/isolation2/sql/concurrent_update_hashcol.sql
@@ -1,0 +1,44 @@
+-- test for heap table
+create table tab_update_hashcol (c1 int, c2 int) distributed by(c1);
+insert into tab_update_hashcol select i, i from generate_series(1, 10)i;
+
+select * from tab_update_hashcol order by 1;
+
+1: begin;
+2: begin;
+
+1: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+
+2&: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+
+1: end;
+2<:
+2: end;
+
+select * from tab_update_hashcol order by 1;
+
+drop table tab_update_hashcol;
+
+-- test for ao table
+create table tab_update_hashcol (c1 int, c2 int) with(appendonly=true) distributed by(c1);
+insert into tab_update_hashcol select i, i from generate_series(1, 10)i;
+
+select * from tab_update_hashcol order by 1;
+
+1: begin;
+2: begin;
+
+1: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+
+2&: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+
+1: end;
+2<:
+2: end;
+
+select * from tab_update_hashcol order by 1;
+
+drop table tab_update_hashcol;
+
+1q:
+2q:


### PR DESCRIPTION
Splitupdate Node was introduced to support update hash cols
of hash-distributed tables. This technique depends on that
we acquire ExclusiveLock on the tables. With the commit of
GDD, we do not upgrade lock for heaptable's update/delete
operation, which breaks the assumption of splitupdate, which
will leads to more tuples when concurrently update the
same row's hash columns.

We fix this by lock the table in ExclusiveMode in ExecInitSplitUpdate
on QD to make thing correct but lose the performance of concurrency.

We should refactor this part of the code to improve concurrency performance.

Co-authored-by: Zhenghua Lyu zlv@pivotal.io
Co-authored-by: Shujie Zhang shzhang@pivotal.io