### PR TITLE
Only create one 'Optimizer' memory account

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -267,7 +267,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 	PlannedStmt *plannedStmt = queryDesc->plannedstmt;
 
-	queryDesc->memoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
+	queryDesc->memoryAccountId = MemoryAccounting_CreateExecutorMemoryAccount();
 
 	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -201,6 +201,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	PlannerConfig *config;
 	instr_time		starttime;
 	instr_time		endtime;
+	MemoryAccountIdType curMemoryAccountId;
 
 	/*
 	 * Use ORCA only if it is enabled and we are in a master QD process.
@@ -220,7 +221,10 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);
 
-		START_MEMORY_ACCOUNT(MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Optimizer));
+		curMemoryAccountId = MemoryAccounting_CreatePlanningMemoryAccount(
+			MEMORY_OWNER_TYPE_Optimizer);
+
+		START_MEMORY_ACCOUNT(curMemoryAccountId);
 		{
 			result = optimize_query(parse, boundParams);
 		}
@@ -244,11 +248,13 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	if (gp_log_optimization_time)
 		INSTR_TIME_SET_CURRENT(starttime);
 
+	curMemoryAccountId =
+		MemoryAccounting_CreatePlanningMemoryAccount(MEMORY_OWNER_TYPE_Planner);
 	/*
 	 * Incorrectly indented on purpose to avoid re-indenting an entire upstream
 	 * function
 	 */
-	START_MEMORY_ACCOUNT(MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Planner));
+	START_MEMORY_ACCOUNT(curMemoryAccountId);
 	{
 
 	/* Cursor options may come from caller or from DECLARE CURSOR stmt */

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -221,8 +221,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);
 
-		curMemoryAccountId = MemoryAccounting_CreatePlanningMemoryAccount(
-			MEMORY_OWNER_TYPE_Optimizer);
+		curMemoryAccountId = MemoryAccounting_GetOrCreateOptimizerAccount();
 
 		START_MEMORY_ACCOUNT(curMemoryAccountId);
 		{
@@ -248,8 +247,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	if (gp_log_optimization_time)
 		INSTR_TIME_SET_CURRENT(starttime);
 
-	curMemoryAccountId =
-		MemoryAccounting_CreatePlanningMemoryAccount(MEMORY_OWNER_TYPE_Planner);
+	curMemoryAccountId = MemoryAccounting_GetOrCreatePlannerAccount();
 	/*
 	 * Incorrectly indented on purpose to avoid re-indenting an entire upstream
 	 * function

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -531,6 +531,7 @@ static const struct config_enum_entry explain_memory_verbosity_options[] = {
 	{"suppress", EXPLAIN_MEMORY_VERBOSITY_SUPPRESS},
 	{"summary", EXPLAIN_MEMORY_VERBOSITY_SUMMARY},
 	{"detail", EXPLAIN_MEMORY_VERBOSITY_DETAIL},
+	{"debug", EXPLAIN_MEMORY_VERBOSITY_DEBUG},
 	{NULL, 0}
 };
 
@@ -4973,7 +4974,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 	{
 		{"explain_memory_verbosity", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Experimental feature: show memory account usage in EXPLAIN ANALYZE."),
-			gettext_noop("Valid values are SUPPRESS, SUMMARY, and DETAIL."),
+			gettext_noop("Valid values are SUPPRESS, SUMMARY, DETAIL, and DEBUG."),
 			GUC_GPDB_ADDOPT
 		},
 		&explain_memory_verbosity,

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -961,7 +961,7 @@ test__MemoryAccounting_GetAccountName__Validate(void **state)
 			"X_BitmapHeapScan", "X_BitmapAppendOnlyScan", "X_TidScan", "X_SubqueryScan", "X_FunctionScan", "X_TableFunctionScan",
 			"X_ValuesScan", "X_NestLoop", "X_MergeJoin", "X_HashJoin", "X_Material", "X_Sort", "X_Agg", "X_Unique", "X_Hash", "X_SetOp",
 			"X_Limit", "X_Motion", "X_ShareInputScan", "X_WindowAgg", "X_Repeat", "X_ModifyTable", "X_LockRows", "X_DML", "X_SplitUpdate", "X_RowTrigger",
-			"X_AssertOp", "X_BitmapTableScan", "X_PartitionSelector", "X_RecursiveUnion", "X_CteScan", "X_WorkTableScan", "X_ForeignScan"};
+			"X_AssertOp", "X_BitmapTableScan", "X_PartitionSelector", "X_RecursiveUnion", "X_CteScan", "X_WorkTableScan", "X_ForeignScan", "X_NestedExecutor"};
 
 	/* Ensure we have all the long living accounts in the longLivingNames array */
 	assert_true(sizeof(longLivingNames) / sizeof(char*) == MEMORY_OWNER_TYPE_END_LONG_LIVING);

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -243,6 +243,20 @@ MemoryAccounting_CreateMainExecutor(void);
 extern MemoryAccountIdType
 MemoryAccounting_GetOrCreateNestedExecutorAccount(void);
 
+extern MemoryAccountIdType
+MemoryAccounting_GetOrCreateOptimizerAccount(void);
+
+/*
+ * MemoryAccounting_GetOrCreatePlannerAccount creates a memory account for
+ * query planning. If the planner is a direct child of the 'X_NestedExecutor'
+ * account, the planner account will also be assigned to 'X_NestedExecutor'.
+ *
+ * The planner account will always be created if the explain_memory_verbosity
+ * guc is set to 'debug' or above.
+ */
+extern MemoryAccountIdType
+MemoryAccounting_GetOrCreatePlannerAccount(void);
+
 extern bool
 MemoryAccounting_IsUnderNestedExecutor(void);
 
@@ -268,17 +282,6 @@ MemoryAccounting_CreateExecutorMemoryAccount(void)
 		else
 			return MemoryAccounting_CreateMainExecutor();
 }
-
-/*
- * MemoryAccounting_CreatePlanningMemoryAccount creates a memory account for
- * query planning. If the planner is a direct child of the 'X_NestedExecutor'
- * account, the planner account will also be assigned to 'X_NestedExecutor'.
- *
- * The planner account will always be created if the explain_memory_verbosity
- * guc is set to 'debug' or above.
- */
-extern MemoryAccountIdType
-MemoryAccounting_CreatePlanningMemoryAccount(MemoryOwnerType type);
 
 
 #endif   /* MEMACCOUNTING_H */

--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -44,3 +44,146 @@ select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 
  t
 (1 row)
 
+create or replace function has_account_type(query text, search_text text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("^\s+%s" % search_text)
+count = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.match(cur_line)
+    if m is not None:
+        count = count + 1
+return count
+$$
+language plpythonu;
+-- Create functions that will generate nested SQL executors
+CREATE OR REPLACE FUNCTION simple_plpgsql_function(int) RETURNS int AS $$
+ DECLARE RESULT int;
+BEGIN
+ SELECT count(*) FROM pg_class INTO RESULT;
+ RETURN RESULT + $1;
+END;
+$$ LANGUAGE plpgsql NO SQL;
+CREATE OR REPLACE FUNCTION simple_sql_function(argument int) RETURNS bigint AS $$
+SELECT count(*) + argument FROM pg_class;
+$$ LANGUAGE SQL STRICT VOLATILE;
+-- Create a table with tuples only on one segement
+CREATE TABLE all_tuples_on_seg0(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO all_tuples_on_seg0 VALUES (0), (0), (0);
+SELECT gp_segment_id, count(*) FROM all_tuples_on_seg0 GROUP BY 1;
+ gp_segment_id | count 
+---------------+-------
+             0 |     3
+(1 row)
+
+-- The X_NestedExecutor account is only created if we create an executor.
+-- Because all the tuples in all_tuples_on_seg0 are on seg0, only seg0 should
+-- create the X_NestedExecutor account.
+set explain_memory_verbosity to detail;
+-- We expect that only seg0 will create an X_NestedExecutor account, so this
+-- should return '1'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                1
+(1 row)
+
+-- Each node will create a 'main' executor account, so we expect that this
+-- will return '3', one per Query Executor.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+
+-- Same as above, this should return '1'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                1
+(1 row)
+
+-- Same as above, this should return '3'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+
+-- After setting explain_memory_verbosity to 'debug', the X_NestedExecutor
+-- account will no longer be created. Instead, every time we evaluate a code
+-- block in an sql or PL/pgSQL function, it will create a new executor account.
+-- There are three tuples in all_tuples_on_seg0, so we should see three more
+-- Executor accounts than when we had the explain_memory_verbosity guc set to
+-- 'detail'.
+set explain_memory_verbosity to debug;
+-- We expect this will be '0'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- Because there are three tuples in all_tuples_on_seg0, we expect to see three
+-- additional 'Executor' accounts created, a total number of '6'.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                6
+(1 row)
+
+-- Expect '0'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- Expect '6'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                6
+(1 row)
+
+-- Test X_NestedExecutor is created correctly inside multiple slice plans
+set explain_memory_verbosity to detail;
+-- We should see two TableScans- one per slice. Because only one segment has
+-- tuples, only one segment per slice will create the 'X_NestedExecutor'
+-- account. This will return '2'.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                2
+(1 row)
+
+-- There will be two slices, and each slice will create an 'Executor' account
+-- for a total of '6' 'Executor' accounts.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+ has_account_type 
+------------------
+                6
+(1 row)
+
+set explain_memory_verbosity to debug;
+-- We don't create 'X_NestedExecutor' accounts when explain_memory_verbosity is
+-- set to 'debug', so this will return '0'
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- Two slices, each returning three tuples. For each tuple we will create an
+-- 'Executor' account. We also expect one main 'Executor' account per slice, so
+-- expect '12' total Executor accounts
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+ has_account_type 
+------------------
+               12
+(1 row)
+

--- a/src/test/regress/sql/memconsumption.sql
+++ b/src/test/regress/sql/memconsumption.sql
@@ -40,3 +40,89 @@ select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 
 
 set execute_pruned_plan=off;
 select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j') > 0;
+
+create or replace function has_account_type(query text, search_text text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("^\s+%s" % search_text)
+count = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.match(cur_line)
+    if m is not None:
+        count = count + 1
+return count
+$$
+language plpythonu;
+
+-- Create functions that will generate nested SQL executors
+CREATE OR REPLACE FUNCTION simple_plpgsql_function(int) RETURNS int AS $$
+ DECLARE RESULT int;
+BEGIN
+ SELECT count(*) FROM pg_class INTO RESULT;
+ RETURN RESULT + $1;
+END;
+$$ LANGUAGE plpgsql NO SQL;
+
+
+CREATE OR REPLACE FUNCTION simple_sql_function(argument int) RETURNS bigint AS $$
+SELECT count(*) + argument FROM pg_class;
+$$ LANGUAGE SQL STRICT VOLATILE;
+
+-- Create a table with tuples only on one segement
+CREATE TABLE all_tuples_on_seg0(i int);
+INSERT INTO all_tuples_on_seg0 VALUES (0), (0), (0);
+SELECT gp_segment_id, count(*) FROM all_tuples_on_seg0 GROUP BY 1;
+
+-- The X_NestedExecutor account is only created if we create an executor.
+-- Because all the tuples in all_tuples_on_seg0 are on seg0, only seg0 should
+-- create the X_NestedExecutor account.
+set explain_memory_verbosity to detail;
+-- We expect that only seg0 will create an X_NestedExecutor account, so this
+-- should return '1'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Each node will create a 'main' executor account, so we expect that this
+-- will return '3', one per Query Executor.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+-- Same as above, this should return '1'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Same as above, this should return '3'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+
+-- After setting explain_memory_verbosity to 'debug', the X_NestedExecutor
+-- account will no longer be created. Instead, every time we evaluate a code
+-- block in an sql or PL/pgSQL function, it will create a new executor account.
+-- There are three tuples in all_tuples_on_seg0, so we should see three more
+-- Executor accounts than when we had the explain_memory_verbosity guc set to
+-- 'detail'.
+set explain_memory_verbosity to debug;
+-- We expect this will be '0'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Because there are three tuples in all_tuples_on_seg0, we expect to see three
+-- additional 'Executor' accounts created, a total number of '6'.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+-- Expect '0'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Expect '6'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+
+-- Test X_NestedExecutor is created correctly inside multiple slice plans
+set explain_memory_verbosity to detail;
+-- We should see two TableScans- one per slice. Because only one segment has
+-- tuples, only one segment per slice will create the 'X_NestedExecutor'
+-- account. This will return '2'.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+-- There will be two slices, and each slice will create an 'Executor' account
+-- for a total of '6' 'Executor' accounts.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+
+
+set explain_memory_verbosity to debug;
+-- We don't create 'X_NestedExecutor' accounts when explain_memory_verbosity is
+-- set to 'debug', so this will return '0'
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+-- Two slices, each returning three tuples. For each tuple we will create an
+-- 'Executor' account. We also expect one main 'Executor' account per slice, so
+-- expect '12' total Executor accounts
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');


### PR DESCRIPTION
This is an attempt to fix the issues we found in #5614 where if you enabled the `optimizer_use_gpdb_allocators` guc, we would underflow the `X_NestedExecutor` account.

Because ORCA keeps a cache, and does not utilize `AllocationSets` for memory allocation, we prevent the memory accounting system from creating more than one `Optimizer` account. All calls to ORCA will be accounted for inside this account. More details can be found in the commit message of the second commit.