### PR TITLE
docs - refactor memory overview page, relocate some info from BP guide

### DIFF
--- a/gpdb-doc/dita/admin_guide/admin_guide.ditamap
+++ b/gpdb-doc/dita/admin_guide/admin_guide.ditamap
@@ -58,11 +58,10 @@
             <topicref href="wlmgmt_intro.xml" navtitle="Workload Management Resource Overview"
                 id="wlmgmt_intro"/>
             <topicref href="wlmgmt.xml" navtitle="Managing Workload and Resources" id="wlmgmt">
+                <topicref href="workload_mgmt_resgroups.xml"
+                    navtitle="Managing Workloads with Resource Groups" id="workload_mgmt_resgroups"/>
                 <topicref href="workload_mgmt.xml"
                     navtitle="Managing Workloads with Resource Queues" id="workload_mgmt"/>
-                <topicref href="workload_mgmt_resgroups.xml"
-                    navtitle="Managing Workloads with Resource Groups" id="workload_mgmt_resgroups"
-                />
             </topicref>
             <topicref href="perf_troubleshoot.xml" navtitle="Investigating a Performance Problem"
                 id="perf_troubleshoot"/>

--- a/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
@@ -25,7 +25,7 @@
           memory usage regularly to detect any changes in the way host memory is consumed by
           Greenplum Database or other processes.</p>
         <p>The following figure illustrates how memory is consumed on a Greenplum Database segment
-            host.<fig id="fig_py5_1sl_zp">
+            host when resource queue-based resource management is active.<fig id="fig_py5_1sl_zp">
             <title>Greenplum Database Segment Host Memory</title>
             <image href="graphics/memory.png" id="image_iqn_dsl_zp"/>
           </fig></p>
@@ -78,14 +78,21 @@
           complexity of queries you can run at the same time by reducing the amount of memory available to
           Greenplum Database. When increasing <codeph>vm.overcommit_ratio</codeph>, it is important
           to remember to always reserve some memory for operating system activities.</p>
+
+      <sectiondiv>
+        <p><b>Configuring vm.overcommit_ratio when Resource Queue-Based Resource Management is Active</b></p>
         <p>To calculate a safe value for <codeph>vm.overcommit_ratio</codeph> when resource queue-based resource management is active, first determine the
-          total memory available to Greenplum Database processes, called <codeph>gp_vmem_rq</codeph>,
+          total memory available to Greenplum Database processes, <codeph>gp_vmem_rq</codeph>,
           with this
           formula:<codeblock>gp_vmem_rq = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock></p>
         <p>where <codeph>SWAP</codeph> is the swap space on the host in GB, and <codeph>RAM</codeph>
           is the number of GB of RAM installed on the host. When resource queue-based resource management is active, use <codeph>gp_vmem_rq</codeph> to calculate the <codeph>vm.overcommit_ratio</codeph> value with this
           formula:<codeblock>vm.overcommit_ratio = (RAM - 0.026 * gp_vmem_rq) / RAM</codeblock></p>
+      </sectiondiv>
+      <sectiondiv>
+        <p><b>Configuring vm.overcommit_ratio when Resource Group-Based Resource Management is Active</b></p>
         <p>When resource group-based resource management is active, the operating system <codeph>vm.overcommit_ratio</codeph> default value is a good starting point. Tune as necessary. If your memory utilization is too low, increase the value; if your memory or swap usage is too high, decrease the setting.</p>
+      </sectiondiv>
       </section>
       <section id="section_nfn_q5r_bs">
         <title>Configuring Greenplum Database Memory</title>
@@ -104,6 +111,8 @@
           primary segments per host, a single host failure would cause other hosts in the block to
           have a maximum of 11 active primaries, compared to 16 for the default grouping mirror
           configuration.</p>
+      <sectiondiv>
+        <p><b>Configuring Segment Memory when Resource Queue-Based Resource Management is Active</b></p>
         <p>When resource queue-based resource management is active, the <varname>gp_vmem_protect_limit</varname> server configuration parameter value 
           identifies the amount of memory to allocate to
           each segment. This value is estimated by calculating the memory available for all Greenplum
@@ -111,23 +120,93 @@
           failure. If <varname>gp_vmem_protect_limit</varname> is set too high, queries can
           fail. Use the following formula to calculate a safe value for
           <varname>gp_vmem_protect_limit</varname>; provide the <codeph>gp_vmem_rq</codeph>
-          value you calculated earlier.</p><p><codeblock>
+          value that you calculated earlier.</p><p><codeblock>
 gp_vmem_protect_limit = gp_vmem_rq / max_acting_primary_segments</codeblock></p>
           <p>where <codeph>max_acting_primary_segments</codeph> is the maximum number of
           primary segments that could be running on a host when mirror segments are activated
           due to a host or segment failure.</p>
         <p><varname>gp_vmem_protect_limit</varname> does not affect segment memory when using 
           resource groups for Greenplum Database resource management.</p>
+        <p>Resource queues expose additional configuration parameters that
+           enable you to further control and refine the amount of memory allocated for queries.</p>
+      </sectiondiv>
+      <sectiondiv>
+        <p><b>Configuring Segment Memory when Resource Group-Based Resource Management is Active</b></p>
         <p>When resource group-based resource management is active, the amount of memory allocated
           to each segment on a segment host is the memory available to Greenplum Database multiplied by the
           <varname>gp_resource_group_memory_limit</varname> server configuration parameter and
           divided by the number of active primary segments on the host. Use the following
-          formula to calculate a safe value for segment memory when using resource groups for
+          formula to calculate segment memory when using resource groups for
           resource management.</p>
         <p><codeblock>
 rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments</codeblock></p>
-        <p>Resource queues and resource groups support additional configuration parameters that
+        <p>Resource groups expose additional configuration parameters that
            enable you to further control and refine the amount of memory allocated for queries.</p>
+      </sectiondiv>
       </section>
+      <section id="section_example">
+        <title>Example Memory Configuration Calculations</title>
+        <p>This section provides example memory calculations for resource queues and
+          resource groups for a Greenplum Database system with the following specifications:</p>
+        <ul id="ul_q4x_g1g_zt">
+          <li>Total RAM = 256GB </li>
+          <li>Swap = 64GB </li>
+          <li>8 primary segments and 8 mirror segments per host, in blocks of 4 hosts</li>
+          <li>Maximum number of primaries per host during failure is 11</li>
+        </ul>
+      <sectiondiv>
+        <p><b>Resource Queue Example</b></p>
+        <p>Using the formula identified above, the <codeph>vm.overcommit_ratio</codeph>
+          calculation for the example system when resource queue-based resource management
+          is active in Greenplum Database follows:</p>
+        <codeblock>
+gp_vmem_rq = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7
+        = ((64 + 256) - (7.5 + 0.05 * 256)) / 1.7
+        = 176
+
+vm.overcommit_ratio = (RAM - (0.026 * gp_vmem_rq)) / RAM
+                    = (256 - (0.026 * 176)) / 256
+                    = .982</codeblock>
+        <p>You would set <codeph>vm.overcommit_ratio</codeph> of the example system to 98. </p>
+        <p>The <codeph>gp_vmem_protect_limit</codeph> calculation when resource queue-based
+        resource management is active in Greenplum Database:</p>
+        <codeblock>
+gp_vmem_protect_limit = gp_vmem_rq / maximum_acting_primary_segments
+                      = 176 / 11
+                      = 16GB
+                      = 16384MB
+</codeblock>
+        <p>You would set the <codeph>gp_vmem_protect_limit</codeph> server configuration
+          parameter on the example system to 16384.</p>
+      </sectiondiv>
+      <sectiondiv>
+        <p><b>Resource Group Example</b></p>
+          <p>When resource group-based resource management is active in Greenplum
+            Database, the usable memory available on a host is a function of 
+            the amount of RAM and swap space configured for the system, as well as the
+            <codeph>vm.overcommit_ratio</codeph> system parameter setting:</p>
+            <codeblock>
+total_node_usable_memory = RAM * (vm.overcommit_ratio / 100) + Swap
+                         = 256GB * (50/100) + 64GB
+                         = 192GB</codeblock>
+          <p>Assuming the default <codeph>gp_resource_group_memory_limit</codeph> value (.7),
+            the memory allocated to a Greenplum Database host with the example configuration is:</p>
+        <codeblock>
+total_gp_memory = total_node_usable_memory * gp_resource_group_memory_limit
+                = 192GB * .7
+                = 134.4GB</codeblock>
+          <p>The memory available to a Greenplum Database segment on a segment host is a function
+            of the memory reserved for Greenplum on the host and the number of active primary
+            segments on the host. On cluster startup:</p>
+        <codeblock>
+gp_seg_memory = total_gp_memory / number_of_active_primary_segments
+              = 134.4GB / 8
+              = 16.8GB</codeblock>
+          <p>Note that when 3 mirror segments switch to primary segments, the per-segment
+            memory is still 16.8GB. Total memory usage on the segment host may approach:
+            <codeblock>total_gp_memory_with_primaries = 16.8GB * 11 = 184.8GB</codeblock></p>
+      </sectiondiv>
+      </section>
+
     </body>
 </topic>

--- a/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
@@ -80,6 +80,10 @@
           to remember to always reserve some memory for operating system activities.</p>
 
       <sectiondiv>
+        <p><b>Configuring vm.overcommit_ratio when Resource Group-Based Resource Management is Active</b></p>
+        <p>When resource group-based resource management is active, the operating system <codeph>vm.overcommit_ratio</codeph> default value is a good starting point. Tune as necessary. If your memory utilization is too low, increase the value; if your memory or swap usage is too high, decrease the setting.</p>
+      </sectiondiv>
+      <sectiondiv>
         <p><b>Configuring vm.overcommit_ratio when Resource Queue-Based Resource Management is Active</b></p>
         <p>To calculate a safe value for <codeph>vm.overcommit_ratio</codeph> when resource queue-based resource management is active, first determine the
           total memory available to Greenplum Database processes, <codeph>gp_vmem_rq</codeph>,
@@ -88,10 +92,6 @@
         <p>where <codeph>SWAP</codeph> is the swap space on the host in GB, and <codeph>RAM</codeph>
           is the number of GB of RAM installed on the host. When resource queue-based resource management is active, use <codeph>gp_vmem_rq</codeph> to calculate the <codeph>vm.overcommit_ratio</codeph> value with this
           formula:<codeblock>vm.overcommit_ratio = (RAM - 0.026 * gp_vmem_rq) / RAM</codeblock></p>
-      </sectiondiv>
-      <sectiondiv>
-        <p><b>Configuring vm.overcommit_ratio when Resource Group-Based Resource Management is Active</b></p>
-        <p>When resource group-based resource management is active, the operating system <codeph>vm.overcommit_ratio</codeph> default value is a good starting point. Tune as necessary. If your memory utilization is too low, increase the value; if your memory or swap usage is too high, decrease the setting.</p>
       </sectiondiv>
       </section>
       <section id="section_nfn_q5r_bs">
@@ -112,6 +112,19 @@
           have a maximum of 11 active primaries, compared to 16 for the default grouping mirror
           configuration.</p>
       <sectiondiv>
+        <p><b>Configuring Segment Memory when Resource Group-Based Resource Management is Active</b></p>
+        <p>When resource group-based resource management is active, the amount of memory allocated
+          to each segment on a segment host is the memory available to Greenplum Database multiplied by the
+          <varname>gp_resource_group_memory_limit</varname> server configuration parameter and
+          divided by the number of active primary segments on the host. Use the following
+          formula to calculate segment memory when using resource groups for
+          resource management.</p>
+        <p><codeblock>
+rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments</codeblock></p>
+        <p>Resource groups expose additional configuration parameters that
+           enable you to further control and refine the amount of memory allocated for queries.</p>
+      </sectiondiv>
+      <sectiondiv>
         <p><b>Configuring Segment Memory when Resource Queue-Based Resource Management is Active</b></p>
         <p>When resource queue-based resource management is active, the <varname>gp_vmem_protect_limit</varname> server configuration parameter value 
           identifies the amount of memory to allocate to
@@ -130,19 +143,6 @@ gp_vmem_protect_limit = gp_vmem_rq / max_acting_primary_segments</codeblock></p>
         <p>Resource queues expose additional configuration parameters that
            enable you to further control and refine the amount of memory allocated for queries.</p>
       </sectiondiv>
-      <sectiondiv>
-        <p><b>Configuring Segment Memory when Resource Group-Based Resource Management is Active</b></p>
-        <p>When resource group-based resource management is active, the amount of memory allocated
-          to each segment on a segment host is the memory available to Greenplum Database multiplied by the
-          <varname>gp_resource_group_memory_limit</varname> server configuration parameter and
-          divided by the number of active primary segments on the host. Use the following
-          formula to calculate segment memory when using resource groups for
-          resource management.</p>
-        <p><codeblock>
-rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments</codeblock></p>
-        <p>Resource groups expose additional configuration parameters that
-           enable you to further control and refine the amount of memory allocated for queries.</p>
-      </sectiondiv>
       </section>
       <section id="section_example">
         <title>Example Memory Configuration Calculations</title>
@@ -154,31 +154,6 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
           <li>8 primary segments and 8 mirror segments per host, in blocks of 4 hosts</li>
           <li>Maximum number of primaries per host during failure is 11</li>
         </ul>
-      <sectiondiv>
-        <p><b>Resource Queue Example</b></p>
-        <p>Using the formula identified above, the <codeph>vm.overcommit_ratio</codeph>
-          calculation for the example system when resource queue-based resource management
-          is active in Greenplum Database follows:</p>
-        <codeblock>
-gp_vmem_rq = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7
-        = ((64 + 256) - (7.5 + 0.05 * 256)) / 1.7
-        = 176
-
-vm.overcommit_ratio = (RAM - (0.026 * gp_vmem_rq)) / RAM
-                    = (256 - (0.026 * 176)) / 256
-                    = .982</codeblock>
-        <p>You would set <codeph>vm.overcommit_ratio</codeph> of the example system to 98. </p>
-        <p>The <codeph>gp_vmem_protect_limit</codeph> calculation when resource queue-based
-        resource management is active in Greenplum Database:</p>
-        <codeblock>
-gp_vmem_protect_limit = gp_vmem_rq / maximum_acting_primary_segments
-                      = 176 / 11
-                      = 16GB
-                      = 16384MB
-</codeblock>
-        <p>You would set the <codeph>gp_vmem_protect_limit</codeph> server configuration
-          parameter on the example system to 16384.</p>
-      </sectiondiv>
       <sectiondiv>
         <p><b>Resource Group Example</b></p>
           <p>When resource group-based resource management is active in Greenplum
@@ -205,6 +180,31 @@ gp_seg_memory = total_gp_memory / number_of_active_primary_segments
           <p>Note that when 3 mirror segments switch to primary segments, the per-segment
             memory is still 16.8GB. Total memory usage on the segment host may approach:
             <codeblock>total_gp_memory_with_primaries = 16.8GB * 11 = 184.8GB</codeblock></p>
+      </sectiondiv>
+      <sectiondiv>
+        <p><b>Resource Queue Example</b></p>
+        <p>The <codeph>vm.overcommit_ratio</codeph>
+          calculation for the example system when resource queue-based resource management
+          is active in Greenplum Database follows:</p>
+        <codeblock>
+gp_vmem_rq = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7
+        = ((64 + 256) - (7.5 + 0.05 * 256)) / 1.7
+        = 176
+
+vm.overcommit_ratio = (RAM - (0.026 * gp_vmem_rq)) / RAM
+                    = (256 - (0.026 * 176)) / 256
+                    = .982</codeblock>
+        <p>You would set <codeph>vm.overcommit_ratio</codeph> of the example system to 98. </p>
+        <p>The <codeph>gp_vmem_protect_limit</codeph> calculation when resource queue-based
+        resource management is active in Greenplum Database:</p>
+        <codeblock>
+gp_vmem_protect_limit = gp_vmem_rq / maximum_acting_primary_segments
+                      = 176 / 11
+                      = 16GB
+                      = 16384MB
+</codeblock>
+        <p>You would set the <codeph>gp_vmem_protect_limit</codeph> server configuration
+          parameter on the example system to 16384.</p>
       </sectiondiv>
       </section>
 

--- a/gpdb-doc/dita/best_practices/best-practices.ditamap
+++ b/gpdb-doc/dita/best_practices/best-practices.ditamap
@@ -8,8 +8,8 @@
         <topicref href="summary.xml"/>
         <topicref href="sysconfig.xml"/>
         <topicref href="schema.xml"/>
-        <topicref href="workloads.xml"/>
         <topicref href="resgroups.xml"/>
+        <topicref href="workloads.xml"/>
         <topicref href="maintenance.xml">
             <topicref href="analyze.xml"/>
             <topicref href="bloat.xml"/>

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -16,9 +16,6 @@
         <xref href="#topic_hhc_z5w_r4/configuring_rg" format="dita"/>
       </li>
       <li>
-        <xref href="#topic_hhc_z5w_r4/section_upm_rbl_zt" format="dita"/>
-      </li>
-      <li>
         <xref href="#topic_hhc_z5w_r4/section113x" format="dita"/>
       </li>
       <li>
@@ -113,40 +110,6 @@
           to create and manage resource groups, and to define the criteria under which
           Command Center dynamically assigns a transaction to a resource group.</li>
       </ul>
-    </section>
-    <section id="section_upm_rbl_zt">
-      <title>Example Memory Configuration Calculations</title>
-      <p>This section provides example memory calculations for a Greenplum Database system with
-        the following specifications:</p>
-      <ul id="ul_q4x_g1g_zt">
-        <li>Total RAM = 256GB </li>
-        <li>Swap = 64GB </li>
-        <li>8 primary segments and 8 mirror segments per host, in blocks of 4 hosts</li>
-        <li>Maximum number of primaries per host during failure is 11</li>
-      </ul>
-      <p>The usable memory available on a host is a function of 
-        the amount of RAM and swap space configured for the system, as well as the
-        <codeph>vm.overcommit_ratio</codeph> system parameter setting:</p>
-        <codeblock>
-total_node_usable_memory = RAM * (vm.overcommit_ratio / 100) + Swap
-                         = 256GB * (50/100) + 64GB
-                         = 192GB</codeblock>
-      <p>Assuming the default <codeph>gp_resource_group_memory_limit</codeph> value (.7),
-        the memory allocated to a Greenplum Database host with the example configuration is:</p>
-        <codeblock>
-total_gp_memory = total_node_usable_memory * gp_resource_group_memory_limit
-                = 192GB * .7
-                = 134.4GB</codeblock>
-      <p>The memory available to a Greenplum Database segment on a segment host is a function
-        of the memory reserved for Greenplum on the host and the number of active primary
-        segments on the host. On cluster startup:</p>
-        <codeblock>
-gp_seg_memory = total_gp_memory / number_of_active_primary_segments
-              = 134.4GB / 8
-              = 16.8GB</codeblock>
-      <p>Note that when 3 mirror segments switch to primary segments, the per-segment
-        memory is still 16.8GB. Total memory usage on the segment host may approach:
-        <codeblock>total_gp_memory_with_primaries = 16.8GB * 11 = 184.8GB</codeblock></p>
     </section>
     <section id="section113x" xml:lang="en">
       <title>Low Memory Queries</title>

--- a/gpdb-doc/dita/best_practices/workloads.xml
+++ b/gpdb-doc/dita/best_practices/workloads.xml
@@ -19,9 +19,6 @@
         <xref href="#topic_hhc_z5w_r4/section_r52_rbl_zt" format="dita"/>
       </li>
       <li>
-        <xref href="#topic_hhc_z5w_r4/section_upm_rbl_zt" format="dita"/>
-      </li>
-      <li>
         <xref href="#topic_hhc_z5w_r4/configuring_rq" format="dita"/>
       </li>
     </ul>
@@ -158,35 +155,6 @@ VM Protect failed to allocate 4096 bytes, 0 MB available</codeblock></p>
             operations. </p>
         </li>
       </ul>
-    </section>
-    <section id="section_upm_rbl_zt">
-      <title>Example Memory Configuration Calculations</title>
-      <ul id="ul_q4x_g1g_zt">
-        <li>Total RAM = 256GB </li>
-        <li>SWAP = 64GB </li>
-        <li>8 primary segments and 8 mirror segments per host, in blocks of 4 hosts</li>
-        <li>Maximum number of primaries per host during failure is 11</li>
-      </ul>
-      <p>
-        <b>vm.overcommit_ratio calculation</b>
-        <codeblock>
-gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7
-        = ((64 + 256) - (7.5 + 0.05 * 256)) / 1.7 
-        = 176
-
-vm.overcommit_ratio = (RAM - (0.026 * gp_vmem)) / RAM 
-                    = (256 - (0.026 * 176)) / 256 
-                    = .982</codeblock>
-        Set <codeph>vm.overcommit_ratio</codeph> to 98. </p>
-      <p>
-        <b>gp_vmem_protect_limit calculation</b>
-        <codeblock>
-gp_vmem_protect_limit = gp_vmem / maximum_acting_primary_segments
-                      = 176 / 11 
-                      = 16GB
-                      = 16384MB
-</codeblock>
-      </p>
     </section>
     <section id="configuring_rq">
       <title>Configuring Resource Queues</title>


### PR DESCRIPTION
in this PR:
- updated the "Greenplum Database Memory Overview" page to call out the specific formulas for resource queues vs. resource groups
- add an "Example Memory Configuration Calculations" section to the page 
  - relocated a parallel section from Best Practices (RQs) to this page
  - relocated a parallel section from Best Practices (RGs) to this page
  
doc review staging site links:
- http://docs-gpdb-review-staging.cfapps.io/review/admin_guide/wlmgmt_intro.html