### PR TITLE
Remove remove_subquery_in_RTEs() call in standard_planner()

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -3320,7 +3320,7 @@ remove_subquery_in_RTEs(Node *node)
 			 * be shared by other objects in the tree.
 			 */
 			pfree(rte->subquery);
-			rte->subquery = makeNode(Query);
+			rte->subquery = NULL;
 		}
 
 		return;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -426,12 +426,6 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	}
 	top_plan = replace_shareinput_targetlists(root, top_plan);
 
-	/*
-	 * To save on memory, and on the network bandwidth when the plan is
-	 * dispatched QEs, strip all subquery RTEs of the original Query objects.
-	 */
-	remove_subquery_in_RTEs((Node *) glob->finalrtable);
-
 	/* build the PlannedStmt result */
 	result = makeNode(PlannedStmt);
 

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -248,3 +248,34 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
  </explain>
 (1 row)
 
+-- github issues 5795. explain fails previously.
+explain SELECT * from information_schema.key_column_usage;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=102.67..1432.09 rows=13 width=389)
+   Hash Cond: ((ss.roid = a.attrelid) AND ((ss.x).x = a.attnum))
+   Join Filter: (pg_has_role(ss.relowner, 'USAGE'::text) OR has_column_privilege(ss.roid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text))
+   ->  Subquery Scan on ss  (cost=3.34..106.09 rows=5825 width=333)
+         ->  Result  (cost=3.34..47.85 rows=5825 width=341)
+               ->  Hash Join  (cost=3.34..47.85 rows=5825 width=341)
+                     Hash Cond: (c.connamespace = nc.oid)
+                     ->  Hash Join  (cost=2.19..16.06 rows=6 width=281)
+                           Hash Cond: (r.relnamespace = nr.oid)
+                           ->  Hash Join  (cost=1.04..14.84 rows=7 width=221)
+                                 Hash Cond: (r.oid = c.conrelid)
+                                 ->  Seq Scan on pg_class r  (cost=0.00..13.41 rows=85 width=76)
+                                       Filter: (relkind = 'r'::"char")
+                                 ->  Hash  (cost=1.03..1.03 rows=1 width=149)
+                                       ->  Seq Scan on pg_constraint c  (cost=0.00..1.03 rows=1 width=149)
+                                             Filter: (contype = ANY ('{p,u,f}'::"char"[]))
+                           ->  Hash  (cost=1.09..1.09 rows=2 width=68)
+                                 ->  Seq Scan on pg_namespace nr  (cost=0.00..1.09 rows=5 width=68)
+                                       Filter: (NOT pg_is_other_temp_schema(oid))
+                     ->  Hash  (cost=1.07..1.07 rows=3 width=68)
+                           ->  Seq Scan on pg_namespace nc  (cost=0.00..1.07 rows=7 width=68)
+   ->  Hash  (cost=49.33..49.33 rows=1111 width=70)
+         ->  Seq Scan on pg_attribute a  (cost=0.00..49.33 rows=3333 width=70)
+               Filter: (NOT attisdropped)
+ Optimizer: legacy query optimizer
+(25 rows)
+

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -277,3 +277,34 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
  </explain>
 (1 row)
 
+-- github issues 5795. explain fails previously.
+explain SELECT * from information_schema.key_column_usage;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=102.67..1432.09 rows=13 width=389)
+   Hash Cond: ((ss.roid = a.attrelid) AND ((ss.x).x = a.attnum))
+   Join Filter: (pg_has_role(ss.relowner, 'USAGE'::text) OR has_column_privilege(ss.roid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text))
+   ->  Subquery Scan on ss  (cost=3.34..106.09 rows=5825 width=333)
+         ->  Result  (cost=3.34..47.85 rows=5825 width=341)
+               ->  Hash Join  (cost=3.34..47.85 rows=5825 width=341)
+                     Hash Cond: (c.connamespace = nc.oid)
+                     ->  Hash Join  (cost=2.19..16.06 rows=6 width=281)
+                           Hash Cond: (r.relnamespace = nr.oid)
+                           ->  Hash Join  (cost=1.04..14.84 rows=7 width=221)
+                                 Hash Cond: (r.oid = c.conrelid)
+                                 ->  Seq Scan on pg_class r  (cost=0.00..13.41 rows=85 width=76)
+                                       Filter: (relkind = 'r'::"char")
+                                 ->  Hash  (cost=1.03..1.03 rows=1 width=149)
+                                       ->  Seq Scan on pg_constraint c  (cost=0.00..1.03 rows=1 width=149)
+                                             Filter: (contype = ANY ('{p,u,f}'::"char"[]))
+                           ->  Hash  (cost=1.09..1.09 rows=2 width=68)
+                                 ->  Seq Scan on pg_namespace nr  (cost=0.00..1.09 rows=5 width=68)
+                                       Filter: (NOT pg_is_other_temp_schema(oid))
+                     ->  Hash  (cost=1.07..1.07 rows=3 width=68)
+                           ->  Seq Scan on pg_namespace nc  (cost=0.00..1.07 rows=7 width=68)
+   ->  Hash  (cost=49.33..49.33 rows=1111 width=70)
+         ->  Seq Scan on pg_attribute a  (cost=0.00..49.33 rows=3333 width=70)
+               Filter: (NOT attisdropped)
+ Optimizer: legacy query optimizer
+(25 rows)
+

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -134,3 +134,6 @@ explain (format yaml, costs off) SELECT * FROM dummy_aotab;
 
 -- DML node (with ORCA)
 explain (format xml, costs off) insert into dummy_aotab values (1);
+
+-- github issues 5795. explain fails previously.
+explain SELECT * from information_schema.key_column_usage;


### PR DESCRIPTION
As the comment said, this was useful howerver now that we have
upstream add_rte_to_flat_rtable() to handle that, let's remove
this call.