### PR TITLE
WIP: enable hot standby mode on standby master

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -329,7 +329,7 @@ fi
 
 STANDBY_INIT_OPTS=""
 if [ "${WITH_STANDBY}" == "true" ]; then
-	STANDBY_INIT_OPTS="-s ${LOCALHOST} -P ${STANDBY_DEMO_PORT} -F ${STANDBYDIR}"
+	STANDBY_INIT_OPTS="-s ${LOCALHOST} -P ${STANDBY_DEMO_PORT} -F ${STANDBYDIR} -H"
 fi
 
 if [ ! -z "${EXTRA_CONFIG}" ]; then
@@ -366,6 +366,10 @@ if [ -n "${STATEMENT_MEM}" ]; then
 		statement_mem = ${STATEMENT_MEM}
 	EOF
 fi
+
+cat >> $CLUSTER_CONFIG_POSTGRES_ADDONS<<-EOF
+	wal_level = hot_standby
+EOF
 
 if [ "${ONLY_PREPARE_CLUSTER_ENV}" == "true" ]; then
     echo "ONLY_PREPARE_CLUSTER_ENV set, generated clusterConf file: $CLUSTER_CONFIG, exiting"

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -124,6 +124,8 @@ def parseargs():
                       help='datadir of standby master')
     optgrp.add_option('-n', '--no-update', action='store_true', dest='no_update',
                       help='do not update system catalog tables')
+    optgrp.add_option('-h', '--hot-standby', action='store_true', dest='hot_standby',
+                      help='enable hot standby')
     optgrp.add_option('-r', '--remove', action='store_true',
                       help='remove current warm master standby.  Use this option '
                       'if the warm master standby host has failed.  This option will '
@@ -399,9 +401,17 @@ def create_standby(options):
         update_pg_hba_conf_on_segments(array, options.standby_host, options.hba_hostnames)
         logger.info('pg_hba.conf files updated successfully.')
 
+        dburl = dbconn.DbURL(dbname="template1")
+        conn = dbconn.connect(dburl, utility=True)
+        sql = "SELECT pg_start_backup('databackup',true)"
+        cur = dbconn.execSQL(conn, sql)
+
         copy_master_datadir_to_standby(options, array, standby_datadir)
         update_postgresql_conf(options, array)
         update_gpdbid_file(options, array)
+
+        sql = "SELECT pg_stop_backup()"
+        cur = dbconn.execSQL(conn, sql)
 
         try:
             dburl = getDbUrlForInitStandby()
@@ -726,6 +736,14 @@ def update_postgresql_conf(options, array):
                                ctxt=gp.REMOTE,
                                remoteHost=standby.getSegmentHostName())
     cmd.run(validateAfter=True)
+    if options.hot_standby:
+        cmd = gp.GpAddConfigScript('update config',
+                               standby.getSegmentDataDirectory(),
+                               'hot_standby',
+                               'on',
+                               ctxt=gp.REMOTE,
+                               remoteHost=standby.getSegmentHostName())
+        cmd.run(validateAfter=True)
 
 #-------------------------------------------------------------------------
 def update_gpdbid_file(options, array):

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -48,6 +48,7 @@ VERBOSE=1
 INTERACTIVE=1
 MIRRORING=0
 INST_COUNT=0
+MASTER_HOT_STANDBY=0
 # Greenplum database specific parameters
 GP_USER=$USER_NAME
 # System table names
@@ -137,6 +138,7 @@ USAGE () {
 		$ECHO "      -h, gp_hostlist_file [optional]"
 		$ECHO "          Contains a list of all segment instance hostnames required to participate in"
 		$ECHO "          the new Greenplum instance. Normally set in gp_config_file."
+		$ECHO "      -H, enable hot standby master"
 		$ECHO "      -I, <input_configuration_file>"
 		$ECHO "          The full path and filename of an input configuration file, which defines the"
 		$ECHO "          Greenplum Database members and segments using the QD_PRIMARY_ARRAY and"
@@ -1527,7 +1529,10 @@ CREATE_STANDBY_QD () {
 			INIT_STANDBY_ARGS+=" -F $STANDBY_DATADIR"
 		fi
 		if [ $HBA_HOSTNAMES -eq 1 ]; then
-		    INIT_STANDBY_ARGS+=" --hba-hostnames"
+			INIT_STANDBY_ARGS+=" --hba-hostnames"
+		fi
+		if [ x"" != x"$MASTER_HOT_STANDBY" ]; then
+			INIT_STANDBY_ARGS+=" -h"
 		fi
 		export MASTER_DATA_DIRECTORY=${MASTER_DIRECTORY}/${SEG_PREFIX}-1;$INIT_STANDBY_PROG -s $STANDBY_HOSTNAME $INIT_STANDBY_ARGS -a
 		STANDBY_RET_CODE=$?
@@ -1936,7 +1941,7 @@ SET_DCA_CONFIG_SETTINGS () {
 # Main Section
 #******************************************************************************
 trap 'ERROR_EXIT "[FATAL]:-Received INT or TERM signal" 2' INT TERM
-while getopts ":vaqe:c:l:-:p:m:h:n:s:P:F:b:DB:SI:O:" opt
+while getopts ":vaqe:c:l:-:p:m:Hh:n:s:P:F:b:DB:SI:O:" opt
 		do
 		case $opt in
 				v ) print_version ;;
@@ -1947,6 +1952,7 @@ while getopts ":vaqe:c:l:-:p:m:h:n:s:P:F:b:DB:SI:O:" opt
 				e ) GP_PASSWD=$OPTARG ;;
 				p ) PG_CONF_ADD_FILE=$OPTARG ;;
 				h ) MACHINE_LIST_FILE_ALT=$OPTARG ;;
+				H ) set MASTER_HOT_STANDBY ;;
 				m ) MASTER_MAX_CONNECT=$OPTARG ;;
 				b ) NEW_BUFFERS=$OPTARG ;;
 				s ) STANDBY_HOSTNAME=$OPTARG ;;

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1244,7 +1244,12 @@ StandbyTransactionIdIsPrepared(TransactionId xid)
 	 * files, so we cannot use ReadTwoPhaseFile() here. Fortunately, this
 	 * isn't needed until we try to use Hot Standby.
 	 */
-	elog(ERROR, "Hot Standby not supported");
+	Assert(standbyState != STANDBY_DISABLED);
+	Assert(IS_QUERY_DISPATCHER());
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+	Assert(EnableHotStandby);
+	return false;
+
 #if 0
 	char	   *buf;
 	TwoPhaseFileHeader *hdr;
@@ -1827,7 +1832,10 @@ PrescanPreparedTransactions(TransactionId **xids_p, int *nxids_p)
 void
 StandbyRecoverPreparedTransactions(bool overwriteOK)
 {
-	elog(ERROR, "Hot Standby not supported");
+	Assert(standbyState != STANDBY_DISABLED);
+	Assert(IS_QUERY_DISPATCHER());
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+	Assert(EnableHotStandby);
 }
 
 /*

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -63,6 +63,7 @@
 #include "utils/resource_manager.h"
 #include "utils/sharedsnapshot.h"
 #include "access/clog.h"
+#include "utils/snapshot.h"
 #include "utils/snapmgr.h"
 #include "utils/timestamp.h"
 #include "pg_trace.h"
@@ -183,6 +184,7 @@ typedef struct TransactionStateData
 	struct TransactionStateData *parent;		/* back link to parent */
 
 	struct TransactionStateData *fastLink;        /* back link to jump to parent for efficient search */
+	DistributedSnapshot *distributedSnapshot;
 } TransactionStateData;
 
 typedef TransactionStateData *TransactionState;
@@ -1325,7 +1327,7 @@ RecordTransactionCommit(void)
 		if (nrels > 0 || nmsgs > 0 || RelcacheInitFileInval || forceSyncCommit
 				|| isDtxPrepared)
 		{
-			XLogRecData rdata[5];
+			XLogRecData rdata[7];
 			int			lastrdata = 0;
 			xl_xact_commit xlrec;
 
@@ -1383,12 +1385,35 @@ RecordTransactionCommit(void)
 			{
 				/* add global transaction information */
 				getDtxLogInfo(&gxact_log);
-
 				rdata[lastrdata].next = &(rdata[4]);
 				rdata[4].data = (char *) &gxact_log;
 				rdata[4].len = sizeof(gxact_log);
 				rdata[4].buffer = InvalidBuffer;
-				rdata[4].next = NULL;
+				lastrdata = 4;
+
+				if (XLogStandbyInfoActive())
+				{
+					Assert(CurrentTransactionState->distributedSnapshot);
+					LWLockAcquire(ProcArrayLock, LW_SHARED);
+					CreateDistributedSnapshot(CurrentTransactionState->distributedSnapshot, false);
+					LWLockRelease(ProcArrayLock);
+
+					rdata[lastrdata].next = &(rdata[5]);
+					rdata[5].data = (char *)CurrentTransactionState->distributedSnapshot;
+					rdata[5].len = sizeof(DistributedSnapshot);
+					rdata[5].buffer = InvalidBuffer;
+					lastrdata = 5;
+					if (CurrentTransactionState->distributedSnapshot->count > 0)
+					{
+						rdata[lastrdata].next = &(rdata[6]);
+						rdata[6].data = (char *) CurrentTransactionState->distributedSnapshot->inProgressXidArray;
+						rdata[6].len = CurrentTransactionState->distributedSnapshot->count * sizeof(DistributedTransactionId);
+						rdata[6].buffer = InvalidBuffer;
+						lastrdata = 6;
+					}
+				}
+
+				rdata[lastrdata].next = NULL;
 
 				insertingDistributedCommitted();
 
@@ -1565,7 +1590,6 @@ RecordDistributedForgetCommitted(TMGXACT_LOG *gxact_log)
 	XLogRecData rdata[1];
 
 	memcpy(&xlrec.gxact_log, gxact_log, sizeof(TMGXACT_LOG));
-
 	rdata[0].data = (char *) &xlrec;
 	rdata[0].len = sizeof(xl_xact_distributed_forget);
 	rdata[0].buffer = InvalidBuffer;
@@ -2184,13 +2208,6 @@ StartTransaction(void)
 	AtStart_ResourceOwner();
 
 	/*
-	 * Transactions may be started while recovery is in progress, if
-	 * hot standby is enabled.  This mode is not supported in
-	 * Greenplum yet.
-	 */
-	AssertImply(DistributedTransactionContext != DTX_CONTEXT_LOCAL_ONLY,
-				!s->startedInRecovery);
-	/*
 	 * MPP Modification
 	 *
 	 * If we're an executor and don't have a valid QDSentXID, then we're starting
@@ -2584,6 +2601,20 @@ CommitTransaction(void)
 		ereport(ERROR,
 				(errcode(ERRCODE_FAULT_INJECT),
 				 errmsg("Raise an error as directed by Debug_abort_after_distributed_prepared")));
+	}
+
+	if (isPreparedDtxTransaction() && XLogStandbyInfoActive())
+	{
+		CurrentTransactionState->distributedSnapshot = (DistributedSnapshot*)
+				palloc0(sizeof(DistributedSnapshot));
+		if (CurrentTransactionState->distributedSnapshot == NULL)
+			ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("out of memory")));
+
+		CurrentTransactionState->distributedSnapshot->inProgressXidArray = (DistributedTransactionId*)
+				palloc0(sizeof(DistributedTransactionId) * max_prepared_xacts);
+		if (CurrentTransactionState->distributedSnapshot->inProgressXidArray == NULL)
+			ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("out of memory")));
+		CurrentTransactionState->distributedSnapshot->maxCount = max_prepared_xacts;
 	}
 
 	/* Prevent cancel/die interrupt while cleaning up */
@@ -5749,16 +5780,28 @@ xactGetCommittedChildren(TransactionId **ptr)
 /*
  *	XLOG support routines
  */
-static TMGXACT_LOG *
-xact_get_distributed_info_from_commit(xl_xact_commit *xlrec)
+static void
+xact_get_distributed_info_from_commit(xl_xact_commit *xlrec,
+									 TMGXACT_LOG **ppgxact,
+									 DistributedSnapshot **ppds,
+									 DistributedTransactionId **ppInprogress)
 {
 	TransactionId *xacts;
 	SharedInvalidationMessage *msgs;
+	TMGXACT_LOG *gxact;
+	DistributedSnapshot *ds;
+	DistributedTransactionId *inprogress;
+
 
 	xacts = (TransactionId *) &xlrec->xnodes[xlrec->nrels];
 	msgs = (SharedInvalidationMessage *) &xacts[xlrec->nsubxacts];
-
-	return (TMGXACT_LOG *) &msgs[xlrec->nmsgs];
+	gxact = (TMGXACT_LOG *) &msgs[xlrec->nmsgs];
+	ds = (DistributedSnapshot*) &gxact[1];
+	inprogress = (DistributedTransactionId*) &ds[1];
+	*ppgxact = gxact;
+	*ppds = ds;
+	*ppInprogress = inprogress;
+	return;
 }
 
 /*
@@ -5962,21 +6005,20 @@ xact_redo_commit_compact(xl_xact_commit_compact *xlrec,
  * because subtransaction commit is never WAL logged.
  */
 static void
-xact_redo_distributed_commit(xl_xact_commit *xlrec, TransactionId xid)
+xact_redo_distributed_commit(xl_xact_commit *xlrec, TransactionId xid, XLogRecPtr lsn)
 {
 	TMGXACT_LOG *gxact_log;
-	
+	DistributedSnapshot *ds;
+	DistributedTransactionId *inProgress;
+
 	DistributedTransactionTimeStamp	distribTimeStamp;
 	DistributedTransactionId 		distribXid;
 
-	TransactionId *sub_xids;
-	TransactionId max_xid;
-	int			i;
 
 	/* 
 	 * Get the global transaction information first.
 	 */
-	gxact_log = xact_get_distributed_info_from_commit(xlrec);
+	xact_get_distributed_info_from_commit(xlrec, &gxact_log, &ds, &inProgress);
 
 	/*
 	 * Crack open the gid to get the timestamp.
@@ -5992,69 +6034,9 @@ xact_redo_distributed_commit(xl_xact_commit *xlrec, TransactionId xid)
 		     gxact_log->gxid, distribXid);
 
 	if (TransactionIdIsValid(xid))
-	{
-		/*
-		 * Mark the distributed transaction committed before we
-		 * update the CLOG in xact_redo_commit.
-		 */
-		/*
-		 * Make room in the DistributedLog, if necessary.
-		 */
-		if (TransactionIdFollowsOrEquals(xid,
-										 ShmemVariableCache->nextXid))
-		{
-			ShmemVariableCache->nextXid = xid;
-			TransactionIdAdvance(ShmemVariableCache->nextXid);
-		}
+		xact_redo_commit(xlrec, xid, lsn, distribXid, distribTimeStamp);
 
-		/*
-		 * Now update the CLOG and do local commit actions.
-		 *
-		 * NOTE: The following logic is a copy of xact_redo_commit, with the
-		 * only addition being redo of DistributeLog updates to subtransaction
-		 * log.
-		 */
-
-		/* Mark the transaction committed in pg_clog */
-		sub_xids = (TransactionId *) &xlrec->xnodes[xlrec->nrels];
-
-		/* Add the committed subtransactions to the DistributedLog, too. */
-		DistributedLog_SetCommittedTree(xid, xlrec->nsubxacts, sub_xids,
-										distribTimeStamp,
-										gxact_log->gxid,
-										/* isRedo */ true);
-
-		TransactionIdCommitTree(xid, xlrec->nsubxacts, sub_xids);
-
-		/* Make sure nextXid is beyond any XID mentioned in the record */
-		max_xid = xid;
-		for (i = 0; i < xlrec->nsubxacts; i++)
-		{
-			if (TransactionIdPrecedes(max_xid, sub_xids[i]))
-				max_xid = sub_xids[i];
-		}
-		if (TransactionIdFollowsOrEquals(max_xid,
-										 ShmemVariableCache->nextXid))
-		{
-			ShmemVariableCache->nextXid = max_xid;
-			TransactionIdAdvance(ShmemVariableCache->nextXid);
-		}
-
-		for (i = 0; i < xlrec->nrels; i++)
-		{
-			SMgrRelation srel = smgropen(xlrec->xnodes[i].node, InvalidBackendId);
-			ForkNumber	fork;
-
-			for (fork = 0; fork <= MAX_FORKNUM; fork++)
-				XLogDropRelation(xlrec->xnodes[i].node, fork);
-			smgrdounlink(srel, true, xlrec->xnodes[i].relstorage);
-			smgrclose(srel);
-		}
-	}
-
-	/*
-	 * End copy of xact_redo_commit logic.
-	 */
+	UpdateStandbyDistributedSnapshot(ds, inProgress);
 	redoDistributedCommitRecord(gxact_log);
 }
 
@@ -6191,7 +6173,7 @@ xact_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribut
 	{
 		xl_xact_commit *xlrec = (xl_xact_commit *) XLogRecGetData(record);
 
-		xact_redo_distributed_commit(xlrec, record->xl_xid);
+		xact_redo_distributed_commit(xlrec, record->xl_xid, lsn);
 	}
 	else if (info == XLOG_XACT_DISTRIBUTED_FORGET)
 	{

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2415,6 +2415,11 @@ retry1:
 				Assert(am_mirror);
 				break;
 			}
+			if (EnableHotStandby)
+			{
+				Assert(IS_QUERY_DISPATCHER());
+				break;
+			}
 
 			recptr = last_xlog_replay_location();
 			ereport(FATAL,

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -166,6 +166,7 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 #endif
 
 		size = add_size(size, SharedSnapshotShmemSize());
+		size = add_size(size, StandbyDistributedSnapshotShmemSize());
 		size = add_size(size, FtsShmemSize());
 		size = add_size(size, tmShmemSize());
 		size = add_size(size, CheckpointerShmemSize());
@@ -297,6 +298,7 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	 *		 know who we are.  
 	 */
 	CreateSharedSnapshotArray();
+	StandbyDistributedSnapshotInit();
 	TwoPhaseShmemInit();
 
 	/*

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -83,6 +83,7 @@ typedef struct ProcArrayStruct
 	int			numKnownAssignedXids;	/* currrent # of valid entries */
 	int			tailKnownAssignedXids;	/* index of oldest valid element */
 	int			headKnownAssignedXids;	/* index of newest element, + 1 */
+
 	slock_t		known_assigned_xids_lck;		/* protects head/tail pointers */
 
 	/*
@@ -168,6 +169,7 @@ static void KnownAssignedXidsRemove(TransactionId xid);
 static void KnownAssignedXidsRemoveTree(TransactionId xid, int nsubxids,
 							TransactionId *subxids);
 static void KnownAssignedXidsRemovePreceding(TransactionId xid);
+
 static int	KnownAssignedXidsGet(TransactionId *xarray, TransactionId xmax);
 static int KnownAssignedXidsGetAndSetXmin(TransactionId *xarray,
 							   TransactionId *xmin,
@@ -245,6 +247,7 @@ CreateSharedProcArray(void)
 		procArray->numKnownAssignedXids = 0;
 		procArray->tailKnownAssignedXids = 0;
 		procArray->headKnownAssignedXids = 0;
+
 		SpinLockInit(&procArray->known_assigned_xids_lck);
 		procArray->lastOverflowedXid = InvalidTransactionId;
 	}
@@ -362,7 +365,8 @@ ProcArrayRemove(PGPROC *proc, TransactionId latestXid)
 	}
 
 	gxid = allTmGxact[proc->pgprocno].gxid;
-	if (InvalidDistributedTransactionId != gxid &&
+	if (!RecoveryInProgress() &&
+		InvalidDistributedTransactionId != gxid &&
 		TransactionIdPrecedes(ShmemVariableCache->latestCompletedDxid, gxid))
 	{
 		ShmemVariableCache->latestCompletedDxid = gxid;
@@ -395,7 +399,8 @@ ProcArrayEndGxact(void)
 	Assert(LWLockHeldByMe(ProcArrayLock));
 	DistributedTransactionId gxid = MyTmGxact->gxid;
 
-	if (InvalidDistributedTransactionId != gxid &&
+	if (!RecoveryInProgress() &&
+		InvalidDistributedTransactionId != gxid &&
 		TransactionIdPrecedes(ShmemVariableCache->latestCompletedDxid, gxid))
 		ShmemVariableCache->latestCompletedDxid = gxid;
 	initGxact(MyTmGxact);
@@ -1476,6 +1481,9 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo, Snapshot snapshot, cha
 static int
 GetDistributedSnapshotMaxCount(void)
 {
+	if (RecoveryInProgress())
+		return max_prepared_xacts;
+
 	switch (DistributedTransactionContext)
 	{
 	case DTX_CONTEXT_LOCAL_ONLY:
@@ -1779,8 +1787,8 @@ DistributedSnapshotMappedEntry_Compare(const void *p1, const void *p2)
 /*
  * create distributed snapshot based on current visible distributed transaction
  */
-static bool
-CreateDistributedSnapshot(DistributedSnapshot *ds)
+bool
+CreateDistributedSnapshot(DistributedSnapshot *ds, bool includeSelf)
 {
 	int			i;
 	int			count;
@@ -1791,7 +1799,7 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	ProcArrayStruct *arrayP = procArray;
 
 	Assert(LWLockHeldByMe(ProcArrayLock));
-	if (*shmNumCommittedGxacts != 0)
+	if (*shmNumCommittedGxacts != 0 && !RecoveryInProgress())
 		elog(ERROR, "Create distributed snapshot before DTM recovery finish");
 
 	xmin = xmax = ShmemVariableCache->latestCompletedDxid;
@@ -1841,15 +1849,23 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 		 * Include the current distributed transaction in the min/max
 		 * calculation.
 		 */
+		Assert(xmin <= xmax);
+		if (gxid >= xmax)
+		{
+			if (!includeSelf && gxact_candidate == MyTmGxact)
+				xmax = gxid + 1;
+			else
+				xmax = gxid;
+			continue;
+		}
+
+		if (!includeSelf && gxact_candidate == MyTmGxact)
+			continue;
+
 		if (gxid < xmin)
 		{
 			xmin = gxid;
 		}
-		if (gxid > xmax)
-		{
-			xmax = gxid;
-		}
-
 		if (gxact_candidate == MyTmGxact)
 			continue;
 
@@ -2287,54 +2303,6 @@ GetSnapshotData(Snapshot snapshot)
 			(errmsg("GetSnapshotData setting globalxmin and xmin to %u",
 					xmin)));
 
-	/*
-	 * Get the distributed snapshot if needed and copy it into the field 
-	 * called distribSnapshotWithLocalMapping in the snapshot structure.
-	 *
-	 * For a distributed transaction:
-	 *   => The corrresponding distributed snapshot is made up of distributed
-	 *      xids from the DTM that are considered in-progress will be kept in
-	 *      the snapshot structure separately from any local in-progress xact.
-	 *
-	 *      The MVCC function XidInSnapshot is used to evaluate whether
-	 *      a tuple is visible through a snapshot. Only committed xids are
-	 *      given to XidInSnapshot for evaluation. XidInSnapshot will first
-	 *      determine if the committed tuple is for a distributed transaction.  
-	 *      If the xact is distributed it will be evaluated only against the
-	 *      distributed snapshot and not the local snapshot.
-	 *
-	 *      Otherwise, when the committed transaction being evaluated is local,
-	 *      then it will be evaluated only against the local portion of the
-	 *      snapshot.
-	 *
-	 * For a local transaction:
-	 *   => Only the local portion of the snapshot: xmin, xmax, xcnt,
-	 *      in-progress (xip), etc, will be filled in.
-	 *
-	 *      Note that in-progress distributed transactions that have reached
-	 *      this database instance and are active will be represented in the
-	 *      local in-progress (xip) array with the distributed transaction's
-	 *      local xid.
-	 *
-	 * In summary: This 2 snapshot scheme (optional distributed, required local)
-	 * handles late arriving distributed transactions properly since that work
-	 * is only evaluated against the distributed snapshot. And, the scheme
-	 * handles local transaction work seeing distributed work properly by
-	 * including distributed transactions in the local snapshot via their
-	 * local xids.
-	 */
-	if (DistributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE)
-	{
-		snapshot->haveDistribSnapshot = CreateDistributedSnapshot(&snapshot->distribSnapshotWithLocalMapping.ds);
-
-		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-				(errmsg("Got distributed snapshot from DistributedSnapshotWithLocalXids_Create = %s",
-						(snapshot->haveDistribSnapshot ? "true" : "false"))));
-
-		/* Nice that we may have collected it, but turn it off... */
-		if (Debug_disable_distributed_snapshot)
-			snapshot->haveDistribSnapshot = false;
-	}
 
 	snapshot->takenDuringRecovery = RecoveryInProgress();
 
@@ -2342,6 +2310,55 @@ GetSnapshotData(Snapshot snapshot)
 	{
 		int		   *pgprocnos = arrayP->pgprocnos;
 		int			numProcs;
+
+		/*
+		 * Get the distributed snapshot if needed and copy it into the field
+		 * called distribSnapshotWithLocalMapping in the snapshot structure.
+		 *
+		 * For a distributed transaction:
+		 *   => The corrresponding distributed snapshot is made up of distributed
+		 *      xids from the DTM that are considered in-progress will be kept in
+		 *      the snapshot structure separately from any local in-progress xact.
+		 *
+		 *      The MVCC function XidInSnapshot is used to evaluate whether
+		 *      a tuple is visible through a snapshot. Only committed xids are
+		 *      given to XidInSnapshot for evaluation. XidInSnapshot will first
+		 *      determine if the committed tuple is for a distributed transaction.
+		 *      If the xact is distributed it will be evaluated only against the
+		 *      distributed snapshot and not the local snapshot.
+		 *
+		 *      Otherwise, when the committed transaction being evaluated is local,
+		 *      then it will be evaluated only against the local portion of the
+		 *      snapshot.
+		 *
+		 * For a local transaction:
+		 *   => Only the local portion of the snapshot: xmin, xmax, xcnt,
+		 *      in-progress (xip), etc, will be filled in.
+		 *
+		 *      Note that in-progress distributed transactions that have reached
+		 *      this database instance and are active will be represented in the
+		 *      local in-progress (xip) array with the distributed transaction's
+		 *      local xid.
+		 *
+		 * In summary: This 2 snapshot scheme (optional distributed, required local)
+		 * handles late arriving distributed transactions properly since that work
+		 * is only evaluated against the distributed snapshot. And, the scheme
+		 * handles local transaction work seeing distributed work properly by
+		 * including distributed transactions in the local snapshot via their
+		 * local xids.
+		 */
+		if (DistributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE)
+		{
+			snapshot->haveDistribSnapshot = CreateDistributedSnapshot(&snapshot->distribSnapshotWithLocalMapping.ds, true);
+
+			ereport((Debug_print_full_dtm ? LOG : DEBUG5),
+					(errmsg("Got distributed snapshot from DistributedSnapshotWithLocalXids_Create = %s",
+							(snapshot->haveDistribSnapshot ? "true" : "false"))));
+
+			/* Nice that we may have collected it, but turn it off... */
+			if (Debug_disable_distributed_snapshot)
+				snapshot->haveDistribSnapshot = false;
+		}
 
 		/*
 		 * Spin over procArray checking xid, xmin, and subxids.  The goal is
@@ -2430,6 +2447,9 @@ GetSnapshotData(Snapshot snapshot)
 	}
 	else
 	{
+		snapshot->haveDistribSnapshot =
+				GetDistributedSnapshotForStandby(&snapshot->distribSnapshotWithLocalMapping.ds);
+
 		/*
 		 * We're in hot standby, so get XIDs from KnownAssignedXids.
 		 *
@@ -3903,7 +3923,6 @@ ExpireOldKnownAssignedTransactionIds(TransactionId xid)
 	KnownAssignedXidsRemovePreceding(xid);
 	LWLockRelease(ProcArrayLock);
 }
-
 
 /*
  * Private module functions to manipulate KnownAssignedXids

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -105,6 +105,8 @@ typedef struct VariableCacheData
 	 */
 	TransactionId latestCompletedXid;	/* newest XID that has committed or
 										 * aborted */
+	TransactionId latestCompletedDxid;	/* newest distributed XID that has
+										   committed or aborted */
 } VariableCacheData;
 
 typedef VariableCacheData *VariableCache;

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -256,7 +256,6 @@ typedef struct TMGALLXACTSTATUS
 typedef struct TmControlBlock
 {
 	LWLockId					ControlLock;
-	slock_t 					ControlSeqnoLock;
 
 	bool						recoverred;
 	DistributedTransactionTimeStamp	distribTimeStamp;
@@ -278,6 +277,7 @@ extern DtxContext DistributedTransactionContext;
 /* state variables for how much of the log file has been flushed */
 extern volatile bool *shmDtmStarted;
 extern volatile DistributedTransactionTimeStamp *shmDistribTimeStamp;
+extern volatile DistributedTransactionId *shmGIDSeq;
 extern uint32 *shmNextSnapshotId;
 extern TMGXACT_LOG *shmCommittedGxactArray;
 extern volatile int *shmNumCommittedGxacts;
@@ -300,7 +300,6 @@ extern void getDtxLogInfo(TMGXACT_LOG *gxact_log);
 extern bool notifyCommittedDtxTransactionIsNeeded(void);
 extern void notifyCommittedDtxTransaction(void);
 extern void	rollbackDtxTransaction(void);
-extern DistributedTransactionId getMaxDistributedXid(void);
 
 extern bool includeInCheckpointIsNeeded(TMGXACT *gxact);
 extern void insertingDistributedCommitted(void);

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -10,6 +10,7 @@
 #include "storage/lwlock.h"
 #include "lib/stringinfo.h"
 #include "access/xlogdefs.h"
+#include "access/xact.h"
 #include "cdb/cdbdistributedsnapshot.h"
 #include "cdb/cdblocaldistribxact.h"
 #include "cdb/cdbdtxcontextinfo.h"
@@ -275,9 +276,7 @@ typedef struct TmControlBlock
 extern DtxContext DistributedTransactionContext;
 
 /* state variables for how much of the log file has been flushed */
-extern volatile bool *shmDtmStarted;
 extern volatile DistributedTransactionTimeStamp *shmDistribTimeStamp;
-extern volatile DistributedTransactionId *shmGIDSeq;
 extern uint32 *shmNextSnapshotId;
 extern TMGXACT_LOG *shmCommittedGxactArray;
 extern volatile int *shmNumCommittedGxacts;
@@ -344,8 +343,14 @@ extern void UtilityModeFindOrCreateDtmRedoFile(void);
 extern void UtilityModeCloseDtmRedoFile(void);
 
 extern bool doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType);
+extern void UpdateStandbyDistributedSnapshot(DistributedSnapshot *ds, DistributedTransactionId *inProgress);
+extern bool CreateDistributedSnapshot(DistributedSnapshot *ds, bool includeSelf);
+extern bool GetDistributedSnapshotForStandby(DistributedSnapshot *ds);
 
 extern void markCurrentGxactWriterGangLost(void);
 
 extern bool currentGxactWriterGangLost(void);
+extern Size StandbyDistributedSnapshotShmemSize(void);
+extern void StandbyDistributedSnapshotInit(void);
+extern void ResetTmForPromotion();
 #endif   /* CDBTM_H */

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -535,6 +535,7 @@ extern void ValidatePgVersion(const char *path);
 extern void process_shared_preload_libraries(void);
 extern void process_local_preload_libraries(void);
 extern void pg_bindtextdomain(const char *domain);
+extern bool is_authenticated_user_replication_role(void);
 extern bool has_rolreplication(Oid roleid);
 
 /* in access/transam/xlog.c */

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -102,6 +102,7 @@ typedef enum LWLockId
 	RelfilenodeGenLock,
 	TablespaceHashLock,
 	GpReplicationConfigFileLock,
+	StandbyDistributedSnapshotLock,
 	/* must be last except for MaxDynamicLWLock: */
 	NumFixedLWLocks,
 


### PR DESCRIPTION
Enable hot standby mode on standby master gives standby master the ability to accept read-only queries.
I tried to copy the logical of 'known xids' in upstream to create the distributed snapshot on standby master, but the distributed transactions don't write xlog on abort, and they don't have sub-transactions, it looks simpler to me to just create the snapshot on master and send it to standby master on transaction commit. 