### PR TITLE
Refactor the way Split Update nodes are constructed in the planner.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1190,56 +1190,6 @@ getExprListFromTargetList(List *tlist,
 	return elist;
 }
 
-
-/*
- * isAnyColChangedByUpdate
- */
-bool
-isAnyColChangedByUpdate(PlannerInfo *root,
-						Index targetvarno,
-						RangeTblEntry *rte,
-						List *targetlist,
-						int nattrs,
-						AttrNumber *attrs)
-{
-	RelOptInfo *rel = root->simple_rel_array[targetvarno];
-	/*
-	 * Want to test whether an update statement possibly changes the value of
-	 * any of the partitioning columns.
-	 */
-
-	/*
-	 * If the relation has been deemed to be excluded by constraints, then
-	 * this relation will never yield any tuples to update.
-	 */
-	if(relation_excluded_by_constraints(root, rel, rte))
-		return false;
-
-	/*
-	 * For each partitioning column, the TargetListEntry for that varattno
-	 * should be just a Var node with the same varattno.
-	 */
-	int			i;
-
-	for (i = 0; i < nattrs; i++)
-	{
-		TargetEntry *tle = get_tle_by_resno(targetlist, attrs[i]);
-		Var		   *var;
-
-		Insist(tle);
-
-		if (!IsA(tle->expr, Var))
-			return true;
-
-		var = (Var *) tle->expr;
-		if (var->varnoold != targetvarno ||
-			var->varoattno != attrs[i])
-			return true;
-	}
-
-	return false;
-}								/* isAnyColChangedByUpdate */
-
 /*
  * Request an ExplicitRedistribute motion node for a plan node
  */
@@ -1265,155 +1215,6 @@ request_explicit_motion(Plan *plan, Index resultRelationsIdx, List *rtable)
 	Assert(-1 != segidColIdx);
 
 	plan->flow->segidColIdx = segidColIdx;
-}
-
-typedef struct
-{
-	plan_tree_base_prefix	base;	/* Required prefix for
-									 * plan_tree_walker/mutator */
-
-	List					*absent_vars;
-	Index					result_relation_idx;
-	bool					found;
-} add_absent_targetlist_context;
-
-
-/*
- * Workhorse for add_absent_targetlist.
- */
-static void
-add_absent_targetlist_mutator(Plan *plan,
-							  add_absent_targetlist_context *pcontext)
-{
-	Node	*node;
-	int		targetResno;
-
-	node = (Node *) plan;
-
-	Assert(is_plan_node(node));
-
-	if (node->type >= T_SeqScan && node->type <=T_WorkTableScan)
-	{
-		Scan		*scan;
-		ListCell	*lcv;
-
-		scan = (Scan *) node;
-		if (scan->scanrelid != pcontext->result_relation_idx)
-			return;
-
-		targetResno = list_length(plan->targetlist) + 1;
-		foreach(lcv, pcontext->absent_vars)
-		{
-			TargetEntry	*newTle;
-			ListCell	*lct;
-
-			Assert(IsA(lfirst(lcv), Var));
-
-			/* Check if given var exists or not in targetlist */
-			foreach(lct, plan->targetlist)
-			{
-				TargetEntry	*tle;
-
-				Assert(IsA(lfirst(lct), TargetEntry));
-
-				tle = (TargetEntry *) lfirst(lct);
-				if (IsA(tle->expr, Var) &&
-					(((Var *) (tle->expr))->varattno == ((Var *) lfirst(lcv))->varattno))
-					break;
-			}
-
-			/* Skip the given var already exist in targetlist */
-			if (!lct)
-			{
-				newTle = makeTargetEntry((Expr *) lfirst(lcv), targetResno,
-										 "" /* resname */, false /* resjunk */);
-				plan->targetlist = lappend(plan->targetlist, newTle);
-				++targetResno;
-			}
-		}
-		pcontext->found = true;
-
-		return;
-	}
-
-	/* The scan node we want to add vars only exist atmost one child of the plan */
-	if (plan->lefttree)
-	{
-		add_absent_targetlist_mutator(plan->lefttree, pcontext);
-
-		if (!pcontext->found && plan->righttree)
-			add_absent_targetlist_mutator(plan->righttree, pcontext);
-
-		if (pcontext->found)
-		{
-			ListCell	*lcv;
-			int			targetResno;
-
-			targetResno = list_length(plan->targetlist) + 1;
-
-			foreach(lcv, pcontext->absent_vars)
-			{
-				Var			*var;
-				ListCell	*lct;
-				TargetEntry *tle;
-
-				Assert(IsA(lfirst(lcv), Var));
-
-				var = (Var *) lfirst(lcv);
-
-				/* Check given var exists or not in current targetlist */
-				foreach(lct, plan->targetlist)
-				{
-					tle = (TargetEntry *) lfirst(lct);
-
-					if (IsA(tle->expr, Var) &&
-						((Var *) tle->expr)->varno == pcontext->result_relation_idx &&
-						((Var *) tle->expr)->varattno == var->varattno)
-						break;
-				}
-
-				/* Skip if given var already exist in targetlist */
-				if (!lct)
-				{
-
-					tle = makeTargetEntry(lfirst(lcv), targetResno++, "" /* resname */, false /* junk */);
-					plan->targetlist = lappend(plan->targetlist, tle);
-				}
-			}
-
-			return;
-		}
-	}
-
-	return;
-}
-
-
-/*
- * Some old attribute vars of relation maybe absent, so we need to add it back recursively.
- *
- * plan subroot of current plan tree we want to add vars.
- * resultRelationsIdx the varno of scan node we search for adding vars. 
- * varsAbsent the vars we want to add.
- *
- * We always check existence of var in varsAbsent. We append var to targetlist if var
- * in varsAbsent doesn't exist.
- *
- * Please refer to make_splitupdate for more information.
- */
-static void
-add_absent_targetlist(struct PlannerInfo *root, Plan *plan,
-					  List *varsAbsent, Index resultRelationsIdx)
-{
-	add_absent_targetlist_context context;
-
-	planner_init_plan_tree_base(&context.base, root);
-
-	context.absent_vars = varsAbsent;
-	context.result_relation_idx = resultRelationsIdx;
-	context.found = false;
-
-	return add_absent_targetlist_mutator(plan, &context);
 }
 
 static void
@@ -1464,15 +1265,16 @@ find_junk_tle(List *targetList, const char *junkAttrName, TargetEntry **targetEn
 	}
 }
 
-static void
-find_ctid_attribute_check(List *targetList, AttrNumber *ctidAttr, Index resultRelationsIdx)
+static AttrNumber
+find_ctid_attribute_check(List *targetList, Index resultRelationsIdx)
 {
 	TargetEntry	*ctid;
 	Var			*var;
 
 	find_junk_tle(targetList, "ctid", &ctid);
 
-	Assert(NULL != ctid);
+	if (!ctid)
+		elog(ERROR, "could not find \"ctid\" column in input to UPDATE");
 	Assert(IsA(ctid->expr, Var));
 
 	var = (Var *) (ctid->expr);
@@ -1483,7 +1285,30 @@ find_ctid_attribute_check(List *targetList, AttrNumber *ctidAttr, Index resultRe
 		   (var->varnoold == resultRelationsIdx &&
 			var->varoattno == SelfItemPointerAttributeNumber));
 
-	*ctidAttr = ctid->resno;
+	return ctid->resno;
+}
+
+static AttrNumber
+find_oid_attribute_check(List *targetList, Index resultRelationsIdx)
+{
+	TargetEntry	*tle;
+	Var			*var;
+
+	find_junk_tle(targetList, "oid", &tle);
+
+	if (!tle)
+		elog(ERROR, "could not find \"oid\" column in input to UPDATE");
+	Assert(IsA(tle->expr, Var));
+
+	var = (Var *) (tle->expr);
+
+	/* OID should follow after normal attributes */
+	Assert((var->varno == resultRelationsIdx &&
+			var->varattno == ObjectIdAttributeNumber) ||
+		   (var->varnoold == resultRelationsIdx &&
+			var->varoattno == ObjectIdAttributeNumber));
+
+	return tle->resno;
 }
 
 /*
@@ -1520,65 +1345,34 @@ copy_junk_attributes(List *src, List **dest, AttrNumber startAttrIdx)
 }
 
 /*
- * The delete index should be corrected after all absent vars have been pushed to targetlist of subplan, because
- * not all absent vars will be added to targetlist, some of them maybe already exist.
- */
-static void
-correct_delete_idxes(List *deleteColIdx, List *targetList, List *varsAbsent, int absentAttrStart)
-{
-	ListCell	*currAbsentTle = NULL;
-	ListCell	*lct;
-
-	Assert(list_length(targetList) >= absentAttrStart);
-
-	if (list_length(targetList) > absentAttrStart)
-		currAbsentTle = list_nth_cell(targetList, absentAttrStart);
-
-	foreach(lct, varsAbsent)
-	{
-		TargetEntry	*appendTarget;
-		int			attrno;
-
-		Assert(currAbsentTle);
-
-		attrno = (int) ((Var *) lfirst(lct))->varattno;
-		appendTarget = lfirst(currAbsentTle);
-		currAbsentTle = lnext(currAbsentTle);
-
-		Assert(IsA(appendTarget->expr, Var));
-		list_nth_cell(deleteColIdx, attrno - 1)->data.int_value = appendTarget->resno;
-	}
-}
-
-/*
- * Check whether attributes exist in the targetlist of top plan.
- * If not exist, we need to add it to varsAbsent for pushing down later.
+ * Find attributes in the targetlist of top plan.
  *
  * We generates informations as following:
  *
- * varsAbsent absent OLD tuple attribute vars we need to push down
  * splitUpdateTargetList which should be a simple var list used by SplitUpdate
  * insertColIdx which point to resno of corresponding attributes in targetlist
  * deleteColIdx which contains placeholder, and value will be corrected later
  */
 static void
-process_targetlist_for_splitupdate(TupleDesc resultDesc, Index resultRelationsIdx, List *targetlist, List **varsAbsent,
+process_targetlist_for_splitupdate(Relation resultRel, Index resultRelationsIdx, List *targetlist,
 								   List **splitUpdateTargetList, List **insertColIdx, List **deleteColIdx)
 {
-	int attrIdx;
+	TupleDesc	resultDesc = RelationGetDescr(resultRel);
+	GpPolicy   *cdbpolicy = resultRel->rd_cdbpolicy;
+	int			attrIdx;
+	Var		   *splitVar;
+	TargetEntry	*splitTargetEntry;
+	ListCell   *lc;
 
+	lc = list_head(targetlist);
 	for (attrIdx = 1; attrIdx <= resultDesc->natts; ++attrIdx)
 	{
 		TargetEntry			*tle;
-		Var					*splitVar;
-		TargetEntry			*splitTargetEntry;
 		Form_pg_attribute	attr;
+		int			oldAttrIdx = -1;
 
-		*insertColIdx = lappend_int(*insertColIdx, attrIdx);
-		*deleteColIdx = lappend_int(*deleteColIdx, attrIdx);
-
-		tle = (TargetEntry *) list_nth(targetlist, attrIdx - 1);
-
+		tle = (TargetEntry *) lfirst(lc);
+		lc = lnext(lc);
 		Assert(tle);
 
 		attr = resultDesc->attrs[attrIdx - 1];
@@ -1588,70 +1382,58 @@ process_targetlist_for_splitupdate(TupleDesc resultDesc, Index resultRelationsId
 
 			splitTargetEntry = makeTargetEntry((Expr *) copyObject(tle->expr), tle->resno, tle->resname, tle->resjunk);
 			*splitUpdateTargetList = lappend(*splitUpdateTargetList, splitTargetEntry);
-			continue;
 		}
 		else
 		{
-			splitVar = makeVar(OUTER_VAR, attrIdx, exprType((Node *) tle->expr),
-							   exprTypmod((Node *) tle->expr), exprCollation((Node *) tle->expr), 0 /* varlevelsup */);
+			int			i;
+
+			Assert(exprType((Node *) tle->expr) == attr->atttypid);
+
+			splitVar = (Var *) makeVar(OUTER_VAR,
+									   attrIdx,
+									   attr->atttypid,
+									   attr->atttypmod,
+									   attr->attcollation,
+									   0);
+
 			splitTargetEntry = makeTargetEntry((Expr *) splitVar, tle->resno, tle->resname, tle->resjunk);
 			*splitUpdateTargetList = lappend(*splitUpdateTargetList, splitTargetEntry);
+
+			/*
+			 * Is this a distribution key column? If so, we will need its old value.
+			 * expand_targetlist() put the old values for distribution key columns in
+			 * the target list after the new column values.
+			 */
+			for (i = 0; i < cdbpolicy->nattrs; i++)
+			{
+				AttrNumber	keyattno = cdbpolicy->attrs[i];
+
+				if (keyattno == attrIdx)
+				{
+					TargetEntry *oldtle;
+
+					oldAttrIdx = resultDesc->natts + i + 1;
+
+					/* sanity checks. */
+					if (oldAttrIdx > list_length(targetlist))
+						elog(ERROR, "old value for attribute \"%s\" missing from split update input target list",
+							 NameStr(attr->attname));
+					oldtle = list_nth(targetlist, oldAttrIdx - 1);
+					if (exprType((Node *) oldtle->expr) != attr->atttypid)
+						elog(ERROR, "datatype mismatch for old value for attribute \"%s\" in split update input target list",
+							 NameStr(attr->attname));
+
+					break;
+				}
+			}
+			/*
+			 * If oldAttrIdx is still -1, this is not a distribution key column.
+			 */
 		}
-		/*
-		 *  if the TargetEntry is a Var and it is from the RESULT relation,
-		 *  it indicates that this column is not the column that we want to UPDATE.
-		 *  otherwise, we need add it to the lower plan node as an old values,
-		 *  so we record it as absent Vars, and we will add it to lower plan node in
-		 *  ensuing steps.
-		 */
-		if (IsA(tle->expr, Var) &&
-			((Var *) tle->expr)->varnoold == resultRelationsIdx &&
-			((Var *) tle->expr)->varoattno == attrIdx)
-			continue;
 
-		*varsAbsent = lappend(*varsAbsent,
-							 makeVar(resultRelationsIdx, attrIdx, exprType((Node *) tle->expr),
-									 exprTypmod((Node *) tle->expr), exprCollation((Node *) tle->expr), 0 /* varlevelsup */));
+		*insertColIdx = lappend_int(*insertColIdx, attrIdx);
+		*deleteColIdx = lappend_int(*deleteColIdx, oldAttrIdx);
 	}
-}
-
-/*
- * Add target entry for oid at the end of targetlist, as well as splitUpdateTargetList.
- */
-static void
-add_oid_target_entry(PlannerInfo *root, Plan *subplan, Index resultRelationsIdx, List **splitUpdateTargetList, int *oidColIdx)
-{
-	Var			*oidVar;
-	Var			*splitVar;
-	TargetEntry	*splitTargetEntry;
-	int			oidIdx = 0;
-	ListCell	*lct;
-
-	oidVar = makeVar(resultRelationsIdx, ObjectIdAttributeNumber, OIDOID,
-					 -1 /* type mod */, InvalidOid, 0 /* varlevelsup */);
-
-	add_absent_targetlist(root, subplan, list_make1(oidVar), resultRelationsIdx);
-
-	foreach(lct, subplan->targetlist)
-	{
-		TargetEntry	*tle = (TargetEntry *) lfirst(lct);
-		if (IsA(tle->expr, Var) &&
-			((Var *) (tle->expr))->varno == resultRelationsIdx &&
-			((Var *) (tle->expr))->varattno == ObjectIdAttributeNumber)
-		{
-			break;
-		}
-		++oidIdx;
-	}
-
-	Assert(oidIdx < list_length(subplan->targetlist));
-
-	*oidColIdx = list_length(*splitUpdateTargetList) + 1;
-	splitVar = makeVar(OUTER_VAR, oidIdx + 1, OIDOID, -1 /* type mod */, InvalidOid, 0 /* varlevelsup */);
-	splitVar->varnoold = resultRelationsIdx;
-	splitVar->varoattno = ObjectIdAttributeNumber;
-	splitTargetEntry = makeTargetEntry((Expr *) splitVar, *oidColIdx, "oid", true);
-	*splitUpdateTargetList = lappend(*splitUpdateTargetList, splitTargetEntry);
 }
 
 /*
@@ -1662,6 +1444,7 @@ add_oid_target_entry(PlannerInfo *root, Plan *subplan, Index resultRelationsIdx,
  *
  * First, in order to split each update operation into two operations: delete + insert,
  * we add several columns into targetlist:
+ *
  * ctid: the tuple id used for deletion
  * action: which is generated by SplitUpdate node, and can be value of delete or insert
  * oid: if result relation has oids, we need to add oid to targetlist
@@ -1669,13 +1452,15 @@ add_oid_target_entry(PlannerInfo *root, Plan *subplan, Index resultRelationsIdx,
  * Second, if the result relation has update triggers, we should reject and error out, because currently
  * we don't support running triggers on that.
  *
- * Third, to support deletion, and hash delete operation to correct segment, we need to get attributes of OLD
- * tuple. As a result, we need add those columns back if not exist in the targetlist of subplan recursively.
+ * Third, to support deletion, and hash delete operation to correct segment,
+ * we need to get attributes of OLD tuple. The old attributes must therefore
+ * be present in the subplan's target list. That is handled earlier in the
+ * planner, in expand_targetlist().
  *
  * For example, a typical plan would be as following for statement:
  * update foo set id = l.v + 1 from dep l where foo.v = l.id:
  *
- * |-- join ( targetlist: [ l.v + 1, foo.v, foo.ctid, foo.gp_segment_id ] )
+ * |-- join ( targetlist: [ l.v + 1, foo.v, foo.id, foo.ctid, foo.gp_segment_id ] )
  *       |
  *       |-- motion ( targetlist: [l.id, l.v] )
  *       |    |
@@ -1683,28 +1468,29 @@ add_oid_target_entry(PlannerInfo *root, Plan *subplan, Index resultRelationsIdx,
  *       |
  *       |-- hash (targetlist [ v, foo.ctid, foo.gp_segment_id ] )
  *            |
- *            |-- seqscan on foo (targetlist: [ v, foo.ctid, foo.gp_segment_id ] )
+ *            |-- seqscan on foo (targetlist: [ v, foo.id, foo.ctid, foo.gp_segment_id ] )
  *
- * From the plan above, the target foo.id is assigned as l.v + 1, but old value of id is not available.
- * So we need to add foo.id to seqscan on foo and its parent to make it available.
+ * From the plan above, the target foo.id is assigned as l.v + 1, and expand_targetlist()
+ * ensured that the old value of id, is also available, even though it would not otherwise
+ * be needed.
+ *
+ * 'result_relation' is the RTI of the UPDATE target relation.
  */
-SplitUpdate*
-make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan, RangeTblEntry *rte, Index resultRelationsIdx)
+SplitUpdate *
+make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan, RangeTblEntry *rte,
+				 Index result_relation)
 {
 	AttrNumber		ctidColIdx = 0;
 	List			*deleteColIdx = NIL;
 	List			*insertColIdx = NIL;
-	List			*varsAbsent = NIL;
 	int				actionColIdx;
-	int				oidColIdx = 0;
-	int				absentAttrStart;
+	AttrNumber		oidColIdx = 0;
 	List			*splitUpdateTargetList = NIL;
 	TargetEntry		*newTargetEntry;
 	SplitUpdate		*splitupdate;
 	DMLActionExpr	*actionExpr;
 	Relation		resultRelation;
 	TupleDesc		resultDesc;
-	bool			hasOids = false;
 
 	Assert(IsA(mt, ModifyTable));
 
@@ -1716,40 +1502,23 @@ make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan, RangeTblEntr
 	resultDesc = RelationGetDescr(resultRelation);
 
 	/*
-	 * 1.insertColIdx/deleteColIdx: In split update mode, we have to form two tuples,
-	 *   one is for deleting and the other is for inserting, so we need record the correct
-	 *   attno which get from the target list of lower plan node. (NOTE:the deleteColIdx
-	 *   is not correct after process_targetlist_for_splitupdate function, we will
-	 *   correct it in correct_delete_idxes function.)
-	 * 2.we need to get the old value which would be used to compute the segment ID,
-	 *   but the lower plan node have no TargetEntry for old values, so we need to
-	 *   add the TargetEntry of old values to the lower plan node, we use the varsAbsent
-	 *   to record the TargetEntry for old values.
+	 * insertColIdx/deleteColIdx: In split update mode, we have to form two tuples,
+	 * one is for deleting and the other is for inserting. Find the old and new
+	 * values in the subplan's target list, and store their column indexes in
+	 * insertColIdx and deleteColIdx.
 	 */
-	process_targetlist_for_splitupdate(resultDesc, resultRelationsIdx, subplan->targetlist, &varsAbsent,
+	process_targetlist_for_splitupdate(resultRelation,
+									   result_relation,
+									   subplan->targetlist,
 									   &splitUpdateTargetList, &insertColIdx, &deleteColIdx);
+	ctidColIdx = find_ctid_attribute_check(subplan->targetlist, result_relation);
 
 	if (resultRelation->rd_rel->relhasoids)
-		hasOids = true;
+		oidColIdx = find_oid_attribute_check(subplan->targetlist, result_relation);
 
-	find_ctid_attribute_check(subplan->targetlist, &ctidColIdx, resultRelationsIdx);
 	copy_junk_attributes(subplan->targetlist, &splitUpdateTargetList, resultDesc->natts);
 
 	relation_close(resultRelation, NoLock);
-
-	/* add the TargetEntry of old values to the lower plan node */
-	absentAttrStart = list_length(subplan->targetlist);
-
-	add_absent_targetlist(root, subplan, varsAbsent, resultRelationsIdx);
-
-	/*
-	 * The deleteColIdx which is returned by process_targetlist_for_splitupdate
-	 * function is not correct, now we correct it to the index of old values.
-	 */
-	correct_delete_idxes(deleteColIdx, subplan->targetlist, varsAbsent, absentAttrStart);
-
-	if (hasOids)
-		add_oid_target_entry(root, subplan, resultRelationsIdx, &splitUpdateTargetList, &oidColIdx);
 
 	/* finally, we should add action column at the end of targetlist */
 	actionExpr = makeNode(DMLActionExpr);

--- a/src/backend/executor/nodeSplitUpdate.c
+++ b/src/backend/executor/nodeSplitUpdate.c
@@ -25,8 +25,9 @@
 #include "utils/memutils.h"
 
 /* Splits an update tuple into a DELETE/INSERT tuples. */
-void
-SplitTupleTableSlot(List *targetList, SplitUpdate *plannode, SplitUpdateState *node, Datum *values, bool *nulls);
+static void SplitTupleTableSlot(TupleTableSlot *slot,
+								List *targetList, SplitUpdate *plannode, SplitUpdateState *node,
+								Datum *values, bool *nulls);
 
 /* Memory used by node */
 #define SPLITUPDATE_MEM 1
@@ -42,12 +43,14 @@ ExecSplitUpdateExplainEnd(PlanState *planstate, struct StringInfoData *buf)
 }
 
 /* Split TupleTableSlot into a DELETE and INSERT TupleTableSlot */
-void
-SplitTupleTableSlot(List *targetList, SplitUpdate *plannode, SplitUpdateState *node, Datum *values, bool *nulls)
+static void
+SplitTupleTableSlot(TupleTableSlot *slot,
+					List *targetList, SplitUpdate *plannode, SplitUpdateState *node,
+					Datum *values, bool *nulls)
 {
-	ListCell *element = NULL;
-	ListCell *deleteAtt = plannode->deleteColIdx->head;
-	ListCell *insertAtt = plannode->insertColIdx->head;
+	ListCell *element;
+	ListCell *deleteAtt = list_head(plannode->deleteColIdx);
+	ListCell *insertAtt = list_head(plannode->insertColIdx);
 
 	Datum *delete_values = slot_get_values(node->deleteTuple);
 	bool *delete_nulls = slot_get_isnull(node->deleteTuple);
@@ -69,26 +72,40 @@ SplitTupleTableSlot(List *targetList, SplitUpdate *plannode, SplitUpdateState *n
 			insert_values[resno] = Int32GetDatum((int)DML_INSERT);
 			insert_nulls[resno] = false;
 		}
-		else if (((int)tle->resno) < plannode->ctidColIdx)
+		else if (((int)tle->resno) <= list_length(plannode->insertColIdx))
 		{
 			/* Old and new values */
-			delete_values[resno] = values[deleteAtt->data.int_value-1];
-			delete_nulls[resno] = nulls[deleteAtt->data.int_value-1];
+			int			deleteAttNo = lfirst_int(deleteAtt);
+			int			insertAttNo = lfirst_int(insertAtt);
 
-			insert_values[resno] = values[insertAtt->data.int_value-1];
-			insert_nulls[resno] = nulls[insertAtt->data.int_value-1];
+			if (deleteAttNo == -1)
+			{
+				delete_values[resno] = (Datum) 0;
+				delete_nulls[resno] = true;
+			}
+			else
+			{
+				delete_values[resno] = values[deleteAttNo - 1];
+				delete_nulls[resno] = nulls[deleteAttNo - 1];
+			}
 
-			deleteAtt = deleteAtt->next;
-			insertAtt = insertAtt->next;
+			insert_values[resno] = values[insertAttNo - 1];
+			insert_nulls[resno] = nulls[insertAttNo - 1];
+
+			deleteAtt = lnext(deleteAtt);
+			insertAtt = lnext(insertAtt);
 		}
 		else
 		{
+			Assert(IsA(tle->expr, Var));
 			/* `Resjunk' values */
 			delete_values[resno] = values[((Var *)tle->expr)->varattno-1];
 			delete_nulls[resno] = nulls[((Var *)tle->expr)->varattno-1];
 
 			insert_values[resno] = values[((Var *)tle->expr)->varattno-1];
 			insert_nulls[resno] = nulls[((Var *)tle->expr)->varattno-1];
+
+			Assert(exprType((Node *) tle->expr) == slot->tts_tupleDescriptor->attrs[((Var *)tle->expr)->varattno-1]->atttypid);
 		}
 	}
 }
@@ -132,7 +149,7 @@ ExecSplitUpdate(SplitUpdateState *node)
 		ExecStoreAllNullTuple(node->deleteTuple);
 		ExecStoreAllNullTuple(node->insertTuple);
 
-		SplitTupleTableSlot(plannode->plan.targetlist, plannode, node, values, nulls);
+		SplitTupleTableSlot(slot, plannode->plan.targetlist, plannode, node, values, nulls);
 
 		result = node->deleteTuple;
 		node->processInsert = false;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -881,6 +881,7 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 									   list_make1_int(parse->resultRelation),
 											 list_make1(plan),
 											 returningLists,
+											 list_make1_int(root->is_split_update),
 											 rowMarks,
 											 SS_assign_special_param(root));
 		}
@@ -1097,6 +1098,7 @@ inheritance_planner(PlannerInfo *root)
 	RelOptInfo **save_rel_array = NULL;
 	List	   *subplans = NIL;
 	List	   *resultRelations = NIL;
+	List	   *is_split_updates = NIL;
 	List	   *returningLists = NIL;
 	List	   *rowMarks;
 	ListCell   *lc;
@@ -1341,6 +1343,12 @@ inheritance_planner(PlannerInfo *root)
 		if (parse->returningList)
 			returningLists = lappend(returningLists,
 									 subroot.parse->returningList);
+
+		/*
+		 * If this subplan requires a Split Update, pass that information
+		 * back to the top.
+		 */
+		is_split_updates = lappend_int(is_split_updates, subroot.is_split_update);
 	}
 
 	Assert(parentPolicy != NULL);
@@ -1394,6 +1402,7 @@ inheritance_planner(PlannerInfo *root)
 									 resultRelations,
 									 subplans,
 									 returningLists,
+									 is_split_updates,
 									 rowMarks,
 									 SS_assign_special_param(root));
 }

--- a/src/backend/optimizer/prep/preptlist.c
+++ b/src/backend/optimizer/prep/preptlist.c
@@ -43,7 +43,7 @@
 #include "utils/rel.h"
 
 
-static List *expand_targetlist(List *tlist, int command_type,
+static List *expand_targetlist(PlannerInfo *root, List *tlist, int command_type,
 				  Index result_relation, List *range_table);
 static List *supplement_simply_updatable_targetlist(List *range_table,
 													List *tlist);
@@ -83,7 +83,7 @@ preprocess_targetlist(PlannerInfo *root, List *tlist)
 	 * 10/94
 	 */
 	if (command_type == CMD_INSERT || command_type == CMD_UPDATE)
-		tlist = expand_targetlist(tlist, command_type,
+		tlist = expand_targetlist(root, tlist, command_type,
 								  result_relation, range_table);
 
 	/* simply updatable cursors */
@@ -208,7 +208,7 @@ preprocess_targetlist(PlannerInfo *root, List *tlist)
  *	  non-junk attributes appear in proper field order.
  */
 static List *
-expand_targetlist(List *tlist, int command_type,
+expand_targetlist(PlannerInfo *root, List *tlist, int command_type,
 				  Index result_relation, List *range_table)
 {
 	List	   *new_tlist = NIL;
@@ -216,6 +216,7 @@ expand_targetlist(List *tlist, int command_type,
 	Relation	rel;
 	int			attrno,
 				numattrs;
+	Bitmapset  *changed_cols = NULL;
 
 	tlist_item = list_head(tlist);
 
@@ -246,6 +247,32 @@ expand_targetlist(List *tlist, int command_type,
 				new_tle = old_tle;
 				tlist_item = lnext(tlist_item);
 			}
+		}
+
+		/*
+		 * GPDB: If it's an UPDATE, keep track of which columns are being
+		 * updated, and which ones are just passed through from old relation.
+		 * We need that information later, to determine whether this UPDATE
+		 * can move tuples from one segment to another.
+		 */
+		if (new_tle && command_type == CMD_UPDATE)
+		{
+			bool		col_changed = true;
+
+			/*
+			 * The column is unchanged, if the new value is a Var that refers
+			 * directly to the same attribute in the same table.
+			 */
+			if (IsA(new_tle->expr, Var))
+			{
+				Var		   *var = (Var *) new_tle->expr;
+
+				if (var->varno == result_relation && var->varattno == attrno)
+					col_changed = false;
+			}
+
+			if (col_changed)
+				changed_cols = bms_add_member(changed_cols, attrno);
 		}
 
 		if (new_tle == NULL)
@@ -345,6 +372,97 @@ expand_targetlist(List *tlist, int command_type,
 		}
 
 		new_tlist = lappend(new_tlist, new_tle);
+	}
+
+	/*
+	 * If an UPDATE can move the tuples from one segment to another, we will
+	 * need to create a Split Update node for it. The node is created later
+	 * in the planning, but if it's needed, we must ensure that the target
+	 * list contains all the original values of each distribution key column,
+	 * because the Split Update needs them as input. The old distribution
+	 * key columns come in the target list after all the new values, and
+	 * before the 'ctid' and other resjunk columns. (The logic in
+	 * process_targetlist_for_splitupdate() relies on that order.)
+	 */
+	if (command_type == CMD_UPDATE)
+	{
+		GpPolicy   *targetPolicy;
+		bool		key_col_updated = false;
+
+		/* Was any distribution key column among the changed columns? */
+		targetPolicy = GpPolicyFetch(CurrentMemoryContext, RelationGetRelid(rel));
+		if (targetPolicy->ptype == POLICYTYPE_PARTITIONED)
+		{
+			int			i;
+
+			for (i = 0; i < targetPolicy->nattrs; i++)
+			{
+				if (bms_is_member(targetPolicy->attrs[i], changed_cols))
+				{
+					key_col_updated = true;
+					break;
+				}
+			}
+		}
+
+		if (key_col_updated)
+		{
+			/*
+			 * Yes, this is a split update.
+			 *
+			 * For each column that was changed, add the original column value
+			 * to the target list, if it's not there already.
+			 */
+			int			i;
+
+			for (i = 0; i < targetPolicy->nattrs; i++)
+			{
+				AttrNumber	keycolidx = targetPolicy->attrs[i];
+				Var		   *origvar;
+				Form_pg_attribute att_tup = rel->rd_att->attrs[keycolidx - 1];
+
+				origvar = makeVar(result_relation,
+								  keycolidx,
+								  att_tup->atttypid,
+								  att_tup->atttypmod,
+								  att_tup->attcollation,
+								  0);
+				TargetEntry *new_tle = makeTargetEntry((Expr *) origvar,
+													   attrno,
+													   NameStr(att_tup->attname),
+													   true);
+				new_tlist = lappend(new_tlist, new_tle);
+				attrno++;
+			}
+
+			/* Also add the old OID to the tlist, if the table has OIDs. */
+			if (rel->rd_rel->relhasoids)
+			{
+				TargetEntry *new_tle;
+				Var		   *oidvar;
+
+				oidvar = makeVar(result_relation,
+								 ObjectIdAttributeNumber,
+								 OIDOID,
+								 -1,
+								 InvalidOid,
+								 0);
+				new_tle = makeTargetEntry((Expr *) oidvar,
+										  attrno,
+										  "oid",
+										  true);
+				new_tlist = lappend(new_tlist, new_tle);
+				attrno++;
+			}
+
+			/*
+			 * Since we just went through a lot of work to determine whether a
+			 * Split Update is needed, memorize that in the PlannerInfo, so that
+			 * we don't need redo all that work later in the planner, when it's
+			 * time to actually create the ModifyTable, and SplitUpdate, node.
+			 */
+			root->is_split_update = true;
+		}
 	}
 
 	/*

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -53,13 +53,6 @@ extern Plan *replace_shareinput_targetlists(PlannerInfo *root, Plan *plan);
 extern Plan *apply_shareinput_xslice(Plan *plan, PlannerInfo *root);
 extern void assign_plannode_id(PlannedStmt *stmt);
 
-extern bool isAnyColChangedByUpdate(PlannerInfo *root,
-						Index targetvarno,
-						RangeTblEntry *rte,
-						List *targetlist,
-						int nattrs,
-						AttrNumber *attrs);
-
 extern List *getExprListFromTargetList(List *tlist, int numCols, AttrNumber *colIdx,
 									   bool useExecutorVarFormat);
 extern void remove_unused_initplans(Plan *plan, PlannerInfo *root);
@@ -77,7 +70,6 @@ extern void request_explicit_motion(Plan *plan, Index resultRelationIdx, List *r
 extern void sri_optimize_for_result(PlannerInfo *root, Plan *plan, RangeTblEntry *rte,
 									GpPolicy **targetPolicy, List **hashExpr);
 extern SplitUpdate *make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan,
-									 RangeTblEntry *rte, Index resultRelationsIdx);
-
+									 RangeTblEntry *rte, Index result_relation);
 
 #endif   /* CDBMUTATE_H */

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -296,6 +296,8 @@ typedef struct PlannerInfo
 	void	   *join_search_private;
 
 	int		   upd_del_replicated_table;
+	bool		is_split_update;	/* true if UPDATE that modifies
+									 * distribution key columns */
 } PlannerInfo;
 
 /*

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -213,6 +213,7 @@ extern Repeat *make_repeat(List *tlist,
 extern ModifyTable *make_modifytable(PlannerInfo *root,
 				 CmdType operation, bool canSetTag,
 				 List *resultRelations, List *subplans, List *returningLists,
+				 List *is_split_updates,
 				 List *rowMarks, int epqParam);
 extern bool is_projection_capable_plan(Plan *plan);
 extern Plan *add_sort_cost(PlannerInfo *root, Plan *input, 

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -70,6 +70,36 @@ update target set b = 10 where c = 10;
 drop table todelete;
 drop table target;
 --
+-- Test updated on inheritance parent table, where some child tables need a
+-- Split Update, but not all.
+--
+create table base_tbl (a int4, b int4) distributed by (a);
+create table child_a (a int4, b int4) inherits (base_tbl) distributed by (a);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+create table child_b (a int4, b int4) inherits (base_tbl) distributed by (b);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+insert into base_tbl select g, g from generate_series(1, 5) g;
+explain (costs off) update base_tbl set a=a+1;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Update on base_tbl
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: ((base_tbl.a + 1))
+         ->  Split
+               ->  Seq Scan on base_tbl
+   ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         Hash Key: ((child_a.a + 1))
+         ->  Split
+               ->  Seq Scan on child_a
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
+         ->  Seq Scan on child_b
+ Optimizer: legacy query optimizer
+(12 rows)
+
+update base_tbl set a = 5;
+--
 -- Explicit Distribution motion must be added if any of the child nodes
 -- contains any motion excluding the motions in initplans.
 -- These test cases and expectation are applicable for GPDB planner not for ORCA.

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -70,6 +70,36 @@ update target set b = 10 where c = 10;
 drop table todelete;
 drop table target;
 --
+-- Test updated on inheritance parent table, where some child tables need a
+-- Split Update, but not all.
+--
+create table base_tbl (a int4, b int4) distributed by (a);
+create table child_a (a int4, b int4) inherits (base_tbl) distributed by (a);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+create table child_b (a int4, b int4) inherits (base_tbl) distributed by (b);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+insert into base_tbl select g, g from generate_series(1, 5) g;
+explain (costs off) update base_tbl set a=a+1;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Update on base_tbl
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: ((base_tbl.a + 1))
+         ->  Split
+               ->  Seq Scan on base_tbl
+   ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         Hash Key: ((child_a.a + 1))
+         ->  Split
+               ->  Seq Scan on child_a
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
+         ->  Seq Scan on child_b
+ Optimizer: legacy query optimizer
+(12 rows)
+
+update base_tbl set a = 5;
+--
 -- Explicit Distribution motion must be added if any of the child nodes
 -- contains any motion excluding the motions in initplans.
 -- These test cases and expectation are applicable for GPDB planner not for ORCA.

--- a/src/test/regress/sql/update_gp.sql
+++ b/src/test/regress/sql/update_gp.sql
@@ -52,6 +52,19 @@ update target set b = 10 where c = 10;
 
 drop table todelete;
 drop table target;
+
+--
+-- Test updated on inheritance parent table, where some child tables need a
+-- Split Update, but not all.
+--
+create table base_tbl (a int4, b int4) distributed by (a);
+create table child_a (a int4, b int4) inherits (base_tbl) distributed by (a);
+create table child_b (a int4, b int4) inherits (base_tbl) distributed by (b);
+insert into base_tbl select g, g from generate_series(1, 5) g;
+
+explain (costs off) update base_tbl set a=a+1;
+update base_tbl set a = 5;
+
 --
 -- Explicit Distribution motion must be added if any of the child nodes
 -- contains any motion excluding the motions in initplans.


### PR DESCRIPTION
First commit:
```
Refactor the way Split Update nodes are constructed in the planner.

One specialty in a Split Update is that the node needs the *old* values
for all the updated rows, to compute the distribution hash for each
old row, so that they can be deleted. That was previously handled at
the time when the SplitUpdate node was created, by adding any missing
Vars for the old values to the subplan's target list, pushing them down
through joins and any other plan nodes, all the way down to the Scan
node for that relation. That seemed complicated and fragile.

The reason to tackle this right now is that we were seeing failures related
to this, while working on the PostgreSQL 9.4 merge. It added a test case,
where a Split Update was done through a security barrier view. The security
barrier view added a SubqueryScan to the plan tree, and the mechanism to
push through the old attributes couldn't cope with that. I'm sure we
could've hacked that to make it work, but this refactoring seems like a
better long term fix.

This patch makes it the responsibility of preprocess_targetlist(), to ensure
that the old values are made available to the top of the tree, if a Split
Update is needed. preprocess_targetlist() seems like the appropriate place,
because it already does that for columns that are not modified by the
UPDATE.

Now that we are making the decision on whether to do a split update in
preprocess_targetlist() already, add a flag to PlannerInfo to remember that
decision, to the point where the ModifyTable node is added to the top of
the plan tree.

Also add a test case, for an inherited table where some children have a
different distribution key, and an UPDATE on some of the children require a
Split Update, and others don't. That was causing me trouble at one point
during the development, and I'm not sure if there was any existing test to
cover that.
```

Second commit:
```
Move the code that adds 'gp_segment_id' column to UPDATE tlist.

Per the comment, it should be added in rewriteTargetListUD(), just like
'ctid' is.
```
