### PR TITLE
Add testing for remove_segment

### DIFF
--- a/src/Makefile.mock
+++ b/src/Makefile.mock
@@ -1,9 +1,10 @@
+UNIT_TEST_HELPER_DIR=$(top_builddir)/src/test/unit/helpers
 MOCK_DIR=$(top_builddir)/src/test/unit/mock
 CMOCKERY_DIR=$(top_builddir)/src/test/unit/cmockery
 CMOCKERY_OBJS=$(CMOCKERY_DIR)/cmockery.o
 override CFLAGS+= -w $(PTHREAD_CFLAGS)
 
-override CPPFLAGS+= -I$(CMOCKERY_DIR)
+override CPPFLAGS+= -I$(CMOCKERY_DIR) -I$(UNIT_TEST_HELPER_DIR)
 
 $(MOCK_DIR)/%_mock.c: $(abs_top_srcdir)/src/%.c
 	@echo mocking $<

--- a/src/backend/access/appendonly/test/aomd_test.c
+++ b/src/backend/access/appendonly/test/aomd_test.c
@@ -162,8 +162,7 @@ test_mdunlink_co_no_file_exists(void **state)
 	mdunlink_ao(PATH_TO_DATA_FILE);
 
 	// called 1 time checking column
-	assert_true(num_unlink_called == 0);
-	return;
+	assert_int_equal(num_unlink_called, 0);
 }
 
 /* concurrency = 1 max_column = 4 */
@@ -182,9 +181,8 @@ test_mdunlink_co_4_columns_1_concurrency(void **state)
 
 	mdunlink_ao(PATH_TO_DATA_FILE);
 
-	assert_true(num_unlink_called == 4);
+	assert_int_equal(num_unlink_called, 4);
 	assert_true(unlink_passing);
-	return;
 }
 
 /* concurrency = 1,5 max_column = 3 */
@@ -206,9 +204,8 @@ test_mdunlink_co_3_columns_2_concurrency(void **state)
 	file_present[(2*AOTupleId_MultiplierSegmentFileNum) + 5] = true;
 
 	mdunlink_ao(PATH_TO_DATA_FILE);
-	assert_true(num_unlink_called == 6);
+	assert_int_equal(num_unlink_called, 6);
 	assert_true(unlink_passing);
-	return;
 }
 
 void
@@ -221,9 +218,8 @@ test_mdunlink_co_all_columns_full_concurrency(void **state)
 
 	mdunlink_ao(PATH_TO_DATA_FILE);
 
-	assert_true(num_unlink_called == MaxHeapAttributeNumber * MAX_AOREL_CONCURRENCY);
+	assert_int_equal(num_unlink_called, MaxHeapAttributeNumber * MAX_AOREL_CONCURRENCY);
 	assert_true(unlink_passing);
-	return;
 }
 
 void
@@ -234,9 +230,8 @@ test_mdunlink_co_one_columns_one_concurrency(void **state)
 	file_present[1] = true;
 
 	mdunlink_ao(PATH_TO_DATA_FILE);
-	assert_true(num_unlink_called == 1);
+	assert_int_equal(num_unlink_called, 1);
 	assert_true(unlink_passing);
-	return;
 }
 
 void
@@ -248,9 +243,8 @@ test_mdunlink_co_one_columns_full_concurrency(void **state)
 		file_present[filenum] = true;
 
 	mdunlink_ao(PATH_TO_DATA_FILE);
-	assert_true(num_unlink_called == 127);
+	assert_int_equal(num_unlink_called, 127);
 	assert_true(unlink_passing);
-	return;
 }
 
 int

--- a/src/backend/access/appendonly/test/appendonly_visimap_entry_test.c
+++ b/src/backend/access/appendonly/test/appendonly_visimap_entry_test.c
@@ -23,14 +23,14 @@ test__AppendOnlyVisimapEntry_GetFirstRowNum(void **state)
 	expected = 0;
 
 	result = AppendOnlyVisimapEntry_GetFirstRowNum(NULL, tupleId);
-	assert_true(result == expected);
+	assert_int_equal(result, expected);
 
 	/* test to make sure we can go above INT32_MAX */
 	AOTupleIdInit_rowNum(tupleId, 3000000000);
 	expected = 2999975936;
 
 	result = AppendOnlyVisimapEntry_GetFirstRowNum(NULL, tupleId);
-	assert_true(result == expected);
+	assert_int_equal(result, expected);
 }
 
 void

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1362,7 +1362,7 @@ does_segment_exist(int16 dbid)
 	 * by switching to a different method of checking.
 	 */
 	if (!IS_QUERY_DISPATCHER())
-		elog(ERROR, "dbid_get_dbinfo() executed on execution segment");
+		elog(ERROR, "does_segment_exist() executed on execution segment");
 
 	rel = heap_open(GpSegmentConfigRelationId, AccessShareLock);
 

--- a/src/backend/cdb/test/Makefile
+++ b/src/backend/cdb/test/Makefile
@@ -22,4 +22,5 @@ cdbutil.t: \
 	$(MOCK_DIR)/backend/access/common/scankey_mock.o \
 	$(MOCK_DIR)/backend/utils/error/elog_mock.o \
 	$(MOCK_DIR)/backend/access/index/genam_mock.o \
-	../cdbutil.o
+	../cdbutil.o \
+    $(UNIT_TEST_HELPER_DIR)/elog_helper.o

--- a/src/backend/cdb/test/Makefile
+++ b/src/backend/cdb/test/Makefile
@@ -4,7 +4,8 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=cdbbufferedread \
 	cdbsrlz \
-	cdbdistributedsnapshot
+	cdbdistributedsnapshot \
+	cdbutil
 
 TARGETS += cdbappendonlyxlog
 
@@ -15,3 +16,10 @@ cdbdistributedsnapshot.t: $(MOCK_DIR)/backend/access/transam/distributedlog_mock
 cdbappendonlyxlog.t: \
 	$(MOCK_DIR)/backend/storage/file/fd_mock.o \
 	$(MOCK_DIR)/backend/access/transam/xlogutils_mock.o
+
+cdbutil.t: \
+	$(MOCK_DIR)/backend/access/heap/heapam_mock.o \
+	$(MOCK_DIR)/backend/access/common/scankey_mock.o \
+	$(MOCK_DIR)/backend/utils/error/elog_mock.o \
+	$(MOCK_DIR)/backend/access/index/genam_mock.o \
+	../cdbutil.o

--- a/src/backend/cdb/test/cdbutil_test.c
+++ b/src/backend/cdb/test/cdbutil_test.c
@@ -1,0 +1,196 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "c.h"
+
+#include "postgres.h"
+#include "utils/relcache.h"
+#include "cdb/cdbutil.h"
+#include "access/genam.h"
+#include "access/relscan.h"
+#include "cdb/cdbvars.h"
+#include "utils/fmgroids.h"
+#include "catalog/indexing.h"
+#include "utils/tqual.h"
+
+void
+execute_on_master(void);
+void
+execute_on_segment(void);
+void
+revert_to_initial_database(void);
+static void
+expect_elog(int log_level);
+void
+_setup__access_to_gp_segment_configuration_table(const HeapTupleData *tuple);
+
+void
+test__does_segment_exist__when_running_code_in_segment__raises_exception(void)
+{
+	execute_on_segment();
+	expect_elog(ERROR);
+	PG_TRY();
+			{
+				does_segment_exist(123);
+				fail_msg("Should not have reached this location");
+			}
+		PG_CATCH();
+			{
+
+			}
+	PG_END_TRY();
+
+	revert_to_initial_database();
+}
+
+void
+test__does_segment_exist__when_segment_does_not_exist__return_false(void)
+{
+	execute_on_master();
+	HeapTuple tuple = NULL;
+	_setup__access_to_gp_segment_configuration_table(tuple);
+
+	bool result = does_segment_exist(123);
+	assert_false(result);
+
+	revert_to_initial_database();
+}
+
+void
+test__does_segment_exist__when_segment_does_exists__return_true(void)
+{
+	execute_on_master();
+	HeapTupleData tuple;
+	_setup__access_to_gp_segment_configuration_table(&tuple);
+
+	bool result = does_segment_exist(123);
+	assert_true(result);
+
+	revert_to_initial_database();
+}
+
+int
+main(int argc, char *argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] =
+		               {
+			               unit_test(
+				               test__does_segment_exist__when_segment_does_not_exist__return_false),
+			               unit_test(
+				               test__does_segment_exist__when_segment_does_exists__return_true),
+			               unit_test(
+				               test__does_segment_exist__when_running_code_in_segment__raises_exception)
+		               };
+
+	return run_tests(tests);
+}
+
+static int savedSegindex = MASTER_CONTENT_ID;
+
+void
+execute_on_master(void)
+{
+	savedSegindex = GpIdentity.segindex;
+	GpIdentity.segindex = MASTER_CONTENT_ID;
+}
+
+void
+execute_on_segment(void)
+{
+	savedSegindex = GpIdentity.segindex;
+	GpIdentity.segindex = 1;
+}
+
+void
+revert_to_initial_database(void)
+{
+	GpIdentity.segindex = savedSegindex;
+}
+
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
+
+/*
+ * This method will emulate the real ExceptionalCondition
+ * function by re-throwing the exception, essentially falling
+ * back to the next available PG_CATCH();
+ */
+void
+_ExceptionalCondition()
+{
+	PG_RE_THROW();
+}
+
+static void
+expect_elog(int log_level)
+{
+	expect_any(elog_start, filename);
+	expect_any(elog_start, lineno);
+	expect_any(elog_start, funcname);
+	will_be_called(elog_start);
+	if (log_level < ERROR)
+		will_be_called(elog_finish);
+	else
+		will_be_called_with_sideeffect(elog_finish,
+		                               &_ExceptionalCondition,
+		                               NULL);
+
+	expect_value(elog_finish, elevel, log_level);
+	expect_any(elog_finish, fmt);
+}
+
+void
+_setup__access_to_gp_segment_configuration_table(const HeapTupleData *tuple)
+{
+	RelationData    heap;
+	SysScanDescData scan;
+
+	/* 
+	 * Ensure that heap_open is Locked with Share access 
+	 * to the table gp_segment_configuration
+	 */
+	expect_value(heap_open, relationId, GpSegmentConfigRelationId);
+	expect_value(heap_open, lockmode, AccessShareLock);
+	will_return(heap_open, &heap);
+
+	/*
+	 * The next setup will prepare a Scan Key Data that will result in the following
+	 * SQL to be executed:
+	 * SELECT * FROM gp_segment_configuration WHERE dbid = 123
+	 *
+	 * Where 123 is the value that is passed to the does_segment_exist function
+	 */
+	expect_any(ScanKeyInit, entry);
+	expect_value(ScanKeyInit,
+	             attributeNumber,
+	             Anum_gp_segment_configuration_dbid);
+	expect_value(ScanKeyInit, strategy, BTEqualStrategyNumber);
+	expect_value(ScanKeyInit, procedure, F_INT2EQ);
+	expect_value(ScanKeyInit, argument, Int16GetDatum(123));
+	will_be_called(ScanKeyInit);
+
+	/*
+	 * Setup the index scan on the gp_segment_configuration table that was
+	 * prepared using the ScanKeyInit
+	 */
+	expect_value(systable_beginscan, heapRelation, &heap);
+	expect_value(systable_beginscan, indexId, GpSegmentConfigDbidIndexId);
+	expect_value(systable_beginscan, indexOK, true);
+	expect_value(systable_beginscan, snapshot, SnapshotNow);
+	expect_value(systable_beginscan, nkeys, 1);
+	expect_any(systable_beginscan, key);
+	will_return(systable_beginscan, &scan);
+
+	expect_value(systable_getnext, sysscan, &scan);
+	will_return(systable_getnext, tuple);
+
+	expect_value(systable_endscan, sysscan, &scan);
+	will_be_called(systable_endscan);
+
+	expect_value(relation_close, relation, &heap);
+	expect_value(relation_close, lockmode, NoLock);
+	will_be_called(relation_close);
+}

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -488,10 +488,8 @@ gp_add_segment(PG_FUNCTION_ARGS)
 static void
 remove_segment(int16 pridbid, int16 mirdbid)
 {
-	seginfo    *i;
-
-	/* Check that we're removing a mirror, not a primary */
-	i = get_seginfo(mirdbid);
+	if (!does_segment_exist(mirdbid))
+		elog(ERROR, "could not find configuration entry for dbid %i", mirdbid);
 
 	remove_segment_config(mirdbid);
 }

--- a/src/backend/utils/gp/test/Makefile
+++ b/src/backend/utils/gp/test/Makefile
@@ -1,0 +1,15 @@
+subdir=src/backend/utils/gp
+top_builddir=../../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS = segadmin
+
+include $(top_builddir)/src/backend/mock.mk
+
+segadmin.t: \
+	$(MOCK_DIR)/backend/cdb/cdbutil_mock.o \
+	$(MOCK_DIR)/backend/access/heap/heapam_mock.o \
+	$(MOCK_DIR)/backend/access/common/scankey_mock.o \
+	$(MOCK_DIR)/backend/utils/error/elog_mock.o \
+	$(MOCK_DIR)/backend/access/index/genam_mock.o \
+	$(UNIT_TEST_HELPER_DIR)/elog_helper.o

--- a/src/backend/utils/gp/test/segadmin_test.c
+++ b/src/backend/utils/gp/test/segadmin_test.c
@@ -1,0 +1,164 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../segadmin.c"
+#include "elog_helper.h"
+#include "access/relscan.h"
+
+void
+_setup__access_to_gp_segment_configuration_table(const HeapTupleData *tuple);
+void
+_LocalExceptionalCondition();
+
+void
+test__remove_segment__when_mirror_does_not_exist(void)
+{
+	expect_elog(ERROR);
+
+	expect_value(does_segment_exist, dbid, 10);
+	will_return(does_segment_exist, false);
+
+	PG_TRY();
+			{
+				remove_segment(1, 10);
+				fail_msg("Should have raised");
+			}
+		PG_CATCH();
+			{
+
+			}
+	PG_END_TRY();
+}
+
+void
+test__remove_segment__when_mirror_does_exist__error_deleting_mirror(void)
+{
+	HeapTupleData tuple;
+	expect_elog(ERROR);
+
+	expect_value(does_segment_exist, dbid, 10);
+	will_return(does_segment_exist, true);
+	_setup__access_to_gp_segment_configuration_table(&tuple);
+
+	/*
+	 * Execute elog when simple_heap_delete is called
+	 */
+	expect_any(simple_heap_delete, relation);
+	expect_value(simple_heap_delete, tid, &(&tuple)->t_self);
+	will_be_called_with_sideeffect(simple_heap_delete,
+	                               &_LocalExceptionalCondition,
+	                               NULL);
+
+	PG_TRY();
+			{
+				remove_segment(1, 10);
+				fail_msg("Should have raised");
+			}
+		PG_CATCH();
+			{}
+	PG_END_TRY();
+}
+
+void
+test__remove_segment__when_mirror_does_exist_can_delete_the_mirror(void)
+{
+	HeapTupleData tuple;
+
+	expect_value(does_segment_exist, dbid, 10);
+	will_return(does_segment_exist, true);
+	_setup__access_to_gp_segment_configuration_table(&tuple);
+
+	/*
+	 * Successfully deletes a segment
+	 */
+	expect_any(simple_heap_delete, relation);
+	expect_value(simple_heap_delete, tid, &(&tuple)->t_self);
+	will_be_called(simple_heap_delete);
+
+	/*
+	 * Second time that the systable_getnext is called
+	 */
+	expect_any(systable_getnext, sysscan);
+	will_return(systable_getnext, NULL);
+
+	/*
+	 * Release ScanKeyData and the heap relation lock
+	 */
+	expect_any(systable_endscan, sysscan);
+	will_be_called(systable_endscan);
+
+	expect_any(relation_close, relation);
+	expect_value(relation_close, lockmode, NoLock);
+	will_be_called(relation_close);
+
+	remove_segment(1, 10);
+}
+
+int
+main(int argc, char *argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test__remove_segment__when_mirror_does_not_exist),
+		unit_test(
+			test__remove_segment__when_mirror_does_exist_can_delete_the_mirror),
+		unit_test(
+			test__remove_segment__when_mirror_does_exist__error_deleting_mirror),
+	};
+	return run_tests(tests);
+}
+
+void
+_LocalExceptionalCondition()
+{
+	elog(ERROR, "Failed deleting the segment");
+}
+
+void
+_setup__access_to_gp_segment_configuration_table(const HeapTupleData *tuple)
+{
+	RelationData    heap;
+	SysScanDescData scan;
+
+	/*
+	 * Ensure that heap_open is Locked with Row Exclusivity access
+	 * to the table gp_segment_configuration
+	 */
+	expect_value(heap_open, relationId, GpSegmentConfigRelationId);
+	expect_value(heap_open, lockmode, RowExclusiveLock);
+	will_return(heap_open, &heap);
+
+	/*
+	 * The next setup will prepare a Scan Key Data that will result in the following
+	 * SQL to be executed:
+	 * SELECT * FROM gp_segment_configuration WHERE dbid = 123
+	 *
+	 * Where 123 is the value that is passed to the does_segment_exist function
+	 */
+	expect_any(ScanKeyInit, entry);
+	expect_value(ScanKeyInit,
+	             attributeNumber,
+	             Anum_gp_segment_configuration_dbid);
+	expect_value(ScanKeyInit, strategy, BTEqualStrategyNumber);
+	expect_value(ScanKeyInit, procedure, F_INT2EQ);
+	expect_value(ScanKeyInit, argument, Int16GetDatum(10));
+	will_be_called(ScanKeyInit);
+
+	/*
+	 * Setup the index scan on the gp_segment_configuration table that was
+	 * prepared using the ScanKeyInit
+	 */
+	expect_value(systable_beginscan, heapRelation, &heap);
+	expect_value(systable_beginscan, indexId, GpSegmentConfigDbidIndexId);
+	expect_value(systable_beginscan, indexOK, true);
+	expect_value(systable_beginscan, snapshot, SnapshotNow);
+	expect_value(systable_beginscan, nkeys, 1);
+	expect_any(systable_beginscan, key);
+	will_return(systable_beginscan, &scan);
+
+	expect_value(systable_getnext, sysscan, &scan);
+	will_return(systable_getnext, tuple);
+}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3892,7 +3892,6 @@ groupMemOnDumpForCgroup(ResGroupData *group, StringInfo str)
 
 /*
  * Parse cpuset to bitset
- * if onlyCheck is true, the function only check whether cpuset is valid
  * If cpuset is "1,3-5", Bitmapset 1,3,4,5 are set.
  */
 Bitmapset *

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -184,6 +184,7 @@ extern bool *makeRandomSegMap(int total_primaries, int total_to_skip);
 extern char *getDnsAddress(char *name, int port, int elevel);
 
 extern int16 master_standby_dbid(void);
+extern bool does_segment_exist(int16 dbid);
 extern CdbComponentDatabaseInfo *dbid_get_dbinfo(int16 dbid);
 extern int16 contentid_get_dbid(int16 contentid, char role, bool getPreferredRoleNotCurrentRole);
 

--- a/src/test/unit/cmockery/cmockery.c
+++ b/src/test/unit/cmockery/cmockery.c
@@ -1402,7 +1402,16 @@ void _assert_true(const LargestIntegralType result,
 		const char * const expression,
 		const char * const file, const int line) {
 	if (!result) {
-		print_error(OUTPUT_PADDING "%s\n", expression);
+		print_error(OUTPUT_PADDING "expected '%s' to be true\n", expression);
+		_fail(file, line);
+	}
+}
+
+void _assert_false(const LargestIntegralType result,
+		const char * const expression,
+		const char * const file, const int line) {
+	if (!result) {
+		print_error(OUTPUT_PADDING "expected '%s' to be false\n", expression);
 		_fail(file, line);
 	}
 }

--- a/src/test/unit/cmockery/cmockery.h
+++ b/src/test/unit/cmockery/cmockery.h
@@ -276,6 +276,12 @@
 // Forces the test to fail immediately and quit.
 #define fail() _fail(__FILE__, __LINE__)
 
+// Write an error message and forces the test to fail immediately and quit
+#define fail_msg(msg, ...) do { \
+    print_error("ERROR: " msg "\n", ##__VA_ARGS__); \
+    fail(); \
+} while (0)
+
 // Generic method to kick off testing
 #define run_test(f) _run_test(#f, f, NULL, UNIT_TEST_FUNCTION_TYPE_TEST, NULL)
 

--- a/src/test/unit/cmockery/cmockery.h
+++ b/src/test/unit/cmockery/cmockery.h
@@ -220,7 +220,7 @@
 #define assert_true(c) _assert_true(cast_to_largest_integral_type(c), #c, \
                                     __FILE__, __LINE__)
 // Assert that the given expression is false.
-#define assert_false(c) _assert_true(!(cast_to_largest_integral_type(c)), #c, \
+#define assert_false(c) _assert_false(!(cast_to_largest_integral_type(c)), #c, \
                                      __FILE__, __LINE__)
 
 // Assert that the two given integers are equal, otherwise fail.
@@ -520,6 +520,9 @@ void _will_be_called(const char * const function_name, const char * const file,
         const int count);
 
 void _assert_true(const LargestIntegralType result,
+                  const char* const expression,
+                  const char * const file, const int line);
+void _assert_false(const LargestIntegralType result,
                   const char* const expression,
                   const char * const file, const int line);
 void _assert_int_equal(

--- a/src/test/unit/helpers/elog_helper.c
+++ b/src/test/unit/helpers/elog_helper.c
@@ -1,0 +1,41 @@
+#include "elog_helper.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "c.h"
+
+#include "postgres.h"
+
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
+
+/*
+ * This method will emulate the real ExceptionalCondition
+ * function by re-throwing the exception, essentially falling
+ * back to the next available PG_CATCH();
+ */
+void
+_ExceptionalCondition()
+{
+	PG_RE_THROW();
+}
+
+void
+expect_elog(int log_level)
+{
+	expect_any(elog_start, filename);
+	expect_any(elog_start, lineno);
+	expect_any(elog_start, funcname);
+	will_be_called(elog_start);
+	if (log_level < ERROR)
+		will_be_called(elog_finish);
+	else
+		will_be_called_with_sideeffect(elog_finish,
+		                               &_ExceptionalCondition,
+		                               NULL);
+
+	expect_value(elog_finish, elevel, log_level);
+	expect_any(elog_finish, fmt);
+}

--- a/src/test/unit/helpers/elog_helper.h
+++ b/src/test/unit/helpers/elog_helper.h
@@ -1,0 +1,7 @@
+#ifndef GPDB_ELOG_HELPER_H
+#define GPDB_ELOG_HELPER_H
+
+void
+expect_elog(int log_level);
+
+#endif //GPDB_ELOG_HELPER_H


### PR DESCRIPTION
This PR will add some testing around remove_segment and make the code more explicit. We found that the `remove_segment` was calling `get_seginfo` and ignoring the the output because it was piggy backing on that function to call `elog` if the segment did not exist.

To solve this we created a new function called `does_segment_exist` that will check if the segment exit.


Also in this PR improves cmockery functions to make the errors more explicit and add a function that allow a test to fail and write a custom message