### PR TITLE
Upgrade APR to 1.6.5 because 1.6.3 is no longer available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
 ## ----------------------------------------------------------------------
 
 env:
-  - APR=apr-1.6.3
+  - APR=apr-1.6.5
     APR_UTIL=apr-util-1.6.1
     APR_TAR=${APR}.tar.gz
     APR_UTIL_TAR=${APR_UTIL}.tar.gz


### PR DESCRIPTION
Let's let this run through the PR pipeline and see what happens.