### PR TITLE
Increase default value of wal_keep_segments GUC.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2049,7 +2049,7 @@ static struct config_int ConfigureNamesInt[] =
 			NULL
 		},
 		&wal_keep_segments,
-		0, 0, INT_MAX,
+		5, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
Until we have replication slots this will keep enough xlog segments
around so that mirrors have an opportunity to reconnect when a
checkpoint removes a segment while the mirror is not streaming.
