### PR TITLE
Use WITH syntax for options in create tablespace.

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -294,12 +294,9 @@ static Node *makeIsNotDistinctFromNode(Node *expr, int position);
 %type <list>	ext_on_clause_list format_opt format_opt_list format_def_list
 				ext_options ext_options_opt ext_options_list
 				ext_opt_encoding_list
-				OptTableSpaceOptions
-				tblspace_options tblspace_options_list
 %type <defelt>	ext_on_clause_item format_opt_item format_def_item
 				ext_options_item
 				ext_opt_encoding_item
-				tblspace_options_item
 
 %type <ival>	opt_lock lock_type cast_context
 %type <ival>	vacuum_option_list vacuum_option_elem
@@ -5820,7 +5817,7 @@ opt_procedural:
  *
  *****************************************************************************/
 
-CreateTableSpaceStmt: CREATE TABLESPACE name OptTableSpaceOwner LOCATION Sconst OptTableSpaceOptions
+CreateTableSpaceStmt: CREATE TABLESPACE name OptTableSpaceOwner LOCATION Sconst opt_reloptions
 				{
 					CreateTableSpaceStmt *n = makeNode(CreateTableSpaceStmt);
 					n->tablespacename = $3;
@@ -5830,35 +5827,6 @@ CreateTableSpaceStmt: CREATE TABLESPACE name OptTableSpaceOwner LOCATION Sconst 
 					$$ = (Node *) n;
 				}
 		;
-
-OptTableSpaceOptions:
-			OPTIONS tblspace_options			{ $$ = $2; }
-			| /* EMPTY */						{ $$ = NIL; }
-			;
-
-tblspace_options:
-			'(' tblspace_options_list ')'		{ $$ = $2; }
-			| '(' ')'							{ $$ = NIL; }
-			;
-
-
-tblspace_options_list:
-			tblspace_options_item
-			{
-				$$ = list_make1($1);
-			}
-			| tblspace_options_list ',' tblspace_options_item
-			{
-				$$ = lappend($1, $3);
-			}
-			;
-
-tblspace_options_item:
-			ColLabel Sconst
-			{
-				$$ = makeDefElem($1, (Node *) makeString($2));
-			}
-			;
 
 OptTableSpaceOwner: OWNER name			{ $$ = $2; }
 			| /*EMPTY */				{ $$ = NULL; }

--- a/src/test/regress/input/gp_tablespace.source
+++ b/src/test/regress/input/gp_tablespace.source
@@ -52,8 +52,8 @@ drop table aoco_ts_table;
 drop tablespace testspace;
 
 -- Greenplum tablespaces have the option to define tablespace location for specific segments
-CREATE TABLESPACE testspace_otherloc LOCATION '@testtablespace@' OPTIONS (content9999 '@testtablespace@_otherloc'); -- should fail
-CREATE TABLESPACE testspace_otherloc LOCATION '@testtablespace@' OPTIONS (content1 '@testtablespace@_otherloc');
+CREATE TABLESPACE testspace_otherloc LOCATION '@testtablespace@' WITH (content9999='@testtablespace@_otherloc'); -- should fail
+CREATE TABLESPACE testspace_otherloc LOCATION '@testtablespace@' WITH (content1='@testtablespace@_otherloc');
 SELECT gp_segment_id,
        CASE tblspc_loc
             WHEN '@testtablespace@' THEN 'testtablespace'

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -83,10 +83,10 @@ drop table ao_ts_table;
 drop table aoco_ts_table;
 drop tablespace testspace;
 -- Greenplum tablespaces have the option to define tablespace location for specific segments
-CREATE TABLESPACE testspace_otherloc LOCATION '@testtablespace@' OPTIONS (content9999 '@testtablespace@_otherloc'); -- should fail
+CREATE TABLESPACE testspace_otherloc LOCATION '@testtablespace@' WITH (content9999='@testtablespace@_otherloc'); -- should fail
 ERROR:  segment content ID 9999 does not exist
 HINT:  Segment content IDs can be found in gp_segment_configuration table.
-CREATE TABLESPACE testspace_otherloc LOCATION '@testtablespace@' OPTIONS (content1 '@testtablespace@_otherloc');
+CREATE TABLESPACE testspace_otherloc LOCATION '@testtablespace@' WITH (content1='@testtablespace@_otherloc');
 SELECT gp_segment_id,
        CASE tblspc_loc
             WHEN '@testtablespace@' THEN 'testtablespace'


### PR DESCRIPTION
PG9.4 starts to allow the WITH syntax to support options
in create tablespace. Greenplum previous had the OPTIONS syntax
to support per segment location. Let's union them all to use
the WITH syntax, following upstream.

Note the greenplum specific OPTIONS exists in gpdb master only.