### PR TITLE
Fix mixup between bitmap index's int48 and int42 support functions.

### DIFF
--- a/src/include/catalog/pg_amproc.h
+++ b/src/include/catalog/pg_amproc.h
@@ -409,8 +409,8 @@ DATA(insert (	7026	 21   21 1 350 ));		/* int2 */
 DATA(insert (	7026   21 23 1 2190 ));	/* int24 */
 DATA(insert (	7026   21 20 1 2192 ));	/* int28 */
 DATA(insert (	7027	 23   23 1 351 ));		/* int4 */
-DATA(insert (	7027   23 20 1 2191 ));	/* int42 */
-DATA(insert (	7027   23 21 1 2188 ));	/* int48 */
+DATA(insert (	7027   23 20 1 2188 ));	/* int48 */
+DATA(insert (	7027   23 21 1 2191 ));	/* int42 */
 DATA(insert (	7028	 20   20 1 842 ));		/* int8 */
 DATA(insert (	7028   20 21 1 2193 ));	/* int82 */
 DATA(insert (	7028   20 23 1 2189 ));	/* int84 */


### PR DESCRIPTION
These were swapped. It's been wrong ever since we merged the operator
family patch, during the 8.3 merge. But apparently it wasn't causing any
ill effect, or at least I was not able to find a case that would fail
because of it.

This was caught by new sanity checks in the 'opr_sanity' regression
test, introduced in the upcoming 9.4 merge.