### PR TITLE
Enable ALL_SUBLINK pullup based on LHS input.

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1833,7 +1833,7 @@ standard_join_search(PlannerInfo *root, int levels_needed, List *initial_rels)
 	 * We should have a single rel at the final level.
 	 */
 	if (root->join_rel_level[levels_needed] == NIL)
-		return NULL;
+		elog(ERROR, "failed to build any %d-way joins", levels_needed);
 	Assert(list_length(root->join_rel_level[levels_needed]) == 1);
 
 	rel = (RelOptInfo *) linitial(root->join_rel_level[levels_needed]);

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -459,19 +459,7 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 		}
 		else if (sublink->subLinkType == ALL_SUBLINK)
 		{
-			/*
-			 * GPDB_92_MERGE_FIXME: This is bogus but works.
-			 *
-			 * 	select * from A,B where exists
-			 *     (select * from C where B.i not in (select C.i from C where C.i != 10))
-			 *
-			 * The ALL SUBLINK in above query would not be converted. Otherwise, the Query tree
-			 * would be messed up.
-			 *
-			 * Future work: look into the implementation of `convert_IN_to_antijoin`.
-			 */
-			if (available_rels2 == NULL &&
-					(j = convert_IN_to_antijoin(root, sublink, available_rels1)) != NULL)
+			if ((j = convert_IN_to_antijoin(root, sublink, available_rels1)) != NULL)
 			{
 				/* Yes; insert the new join node into the join tree */
 				j->larg = *jtlink1;

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -192,6 +192,39 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
  1 | 1
 (2 rows)
 
+-- Test for ALL_SUBLINK pull-up based on both left-hand and right-hand input
+explain (costs off)
+select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop Semi Join
+         ->  Hash Left Anti Semi (Not-In) Join
+               Hash Cond: (b.i = c_1.i)
+               ->  Nested Loop
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Seq Scan on a
+                     ->  Materialize
+                           ->  Seq Scan on b
+               ->  Hash
+                     ->  Seq Scan on c c_1
+                           Filter: (i <> 10)
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on c
+ Optimizer: legacy query optimizer
+(16 rows)
+
+select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
+ i  | j  | i  | j 
+----+----+----+---
+ 78 | -1 | 88 | 1
+  1 |  1 | 88 | 1
+ 19 |  5 | 88 | 1
+ 99 | 62 | 88 | 1
+  1 |  1 | 88 | 1
+(5 rows)
+
 -- -- -- --
 -- Basic queries with NOT IN clause
 -- -- -- --

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -196,6 +196,49 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
  1 | 1
 (2 rows)
 
+-- Test for ALL_SUBLINK pull-up based on both left-hand and right-hand input
+explain (costs off)
+select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
+                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice3; segments: 3)
+               ->  Table Scan on a
+         ->  Materialize
+               ->  Result
+                     Filter: ((SubPlan 1) > 0::bigint)
+                     ->  Table Scan on b
+                     SubPlan 1  (slice4; segments: 3)
+                       ->  Aggregate
+                             ->  Nested Loop
+                                   Join Filter: true
+                                   ->  Result
+                                         Filter: ((CASE WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (c_1.i IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (b.i IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
+                                         ->  Result
+                                               ->  Aggregate
+                                                     ->  Result
+                                                           ->  Materialize
+                                                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                                       ->  Table Scan on c c_1
+                                                                             Filter: (i <> 10)
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                               ->  Table Scan on c
+ Optimizer: PQO version 3.1.0
+(26 rows)
+
+select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
+ i  | j  | i  | j 
+----+----+----+---
+ 78 | -1 | 88 | 1
+  1 |  1 | 88 | 1
+ 19 |  5 | 88 | 1
+ 99 | 62 | 88 | 1
+  1 |  1 | 88 | 1
+(5 rows)
+
 -- -- -- --
 -- Basic queries with NOT IN clause
 -- -- -- --

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -113,6 +113,12 @@ explain (costs off)
 select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
 select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
 
+
+-- Test for ALL_SUBLINK pull-up based on both left-hand and right-hand input
+explain (costs off)
+select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
+select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
+
 -- -- -- --
 -- Basic queries with NOT IN clause
 -- -- -- --


### PR DESCRIPTION
Enable ALL_SUBLINK pullup based on LHS input.

This patch takes LHS input into consideration when pull up sublink type
of ALL_SUBLINK. As a result, there would be more subplans conveyed into
joins, such as the query below:

```
select * from A,B where exists (select * from C where C.j = A.j and B.i
	not in (select C.i from C where C.i != 10));
```

This is only possible after commit eb919e8, in which as a last-ditch
effort, a set of cartesian-product joins would be generated if failed to
find any usable joins.