### PR TITLE
Fix error caused by creating too many memory accounts

### DIFF
--- a/src/backend/cdb/cdbexplain.c
+++ b/src/backend/cdb/cdbexplain.c
@@ -941,7 +941,7 @@ cdbexplain_collectStatsFromNode(PlanState *planstate, CdbExplain_SendStatCtx *ct
 	si->workmemused = instr->workmemused;
 	si->workmemwanted = instr->workmemwanted;
 	si->workfileCreated = instr->workfileCreated;
-	si->peakMemBalance = MemoryAccounting_GetAccountPeakBalance(planstate->plan->memoryAccountId);
+	si->peakMemBalance = MemoryAccounting_GetAccountPeakBalance(planstate->memoryAccountId);
 	si->firststart = instr->firststart;
 	si->numPartScanned = instr->numPartScanned;
 	si->sortMethod = String2ExplainSortMethod(instr->sortMethod);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -263,7 +263,7 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 	PlannedStmt *plannedStmt = queryDesc->plannedstmt;
 
-	queryDesc->memoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
+	queryDesc->memoryAccountId = MemoryAccounting_CreateExecutorMemoryAccount();
 
 	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -259,15 +259,13 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 	Assert(queryDesc != NULL);
 	Assert(queryDesc->estate == NULL);
 	Assert(queryDesc->plannedstmt != NULL);
+	Assert(queryDesc->memoryAccountId == MEMORY_OWNER_TYPE_Undefined);
 
 	PlannedStmt *plannedStmt = queryDesc->plannedstmt;
 
-	if (MEMORY_OWNER_TYPE_Undefined == plannedStmt->memoryAccountId)
-	{
-		plannedStmt->memoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
-	}
+	queryDesc->memoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
 
-	START_MEMORY_ACCOUNT(plannedStmt->memoryAccountId);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	Assert(queryDesc->plannedstmt->intoPolicy == NULL
 		   || queryDesc->plannedstmt->intoPolicy->ptype == POLICYTYPE_PARTITIONED);
@@ -810,9 +808,9 @@ ExecutorRun(QueryDesc *queryDesc,
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->plannedstmt->memoryAccountId);
+	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->memoryAccountId);
 
-	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccountId);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	/*
 	 * Switch into per-query memory context
@@ -992,9 +990,9 @@ ExecutorEnd(QueryDesc *queryDesc)
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->plannedstmt->memoryAccountId);
+	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->memoryAccountId);
 
-	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccountId);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	if (DEBUG1 >= log_min_messages)
 	{
@@ -1155,9 +1153,9 @@ ExecutorRewind(QueryDesc *queryDesc)
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->plannedstmt->memoryAccountId);
+	Assert(NULL != queryDesc->plannedstmt && MEMORY_OWNER_TYPE_Undefined != queryDesc->memoryAccountId);
 
-	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccountId);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	/* It's probably not sensible to rescan updating queries */
 	Assert(queryDesc->operation == CMD_SELECT);

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -834,7 +834,7 @@ ExecProcNode(PlanState *node)
 {
 	TupleTableSlot *result = NULL;
 
-	START_MEMORY_ACCOUNT(node->plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(node->memoryAccountId);
 	{
 
 	CHECK_FOR_INTERRUPTS();
@@ -1112,7 +1112,7 @@ MultiExecProcNode(PlanState *node)
 
 	Assert(NULL != node->plan);
 
-	START_MEMORY_ACCOUNT(node->plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(node->memoryAccountId);
 {
 	PG_TRACE4(execprocnode__enter, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id);
 

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -161,6 +161,54 @@ static CdbVisitOpt planstate_walk_kids(PlanState *planstate,
 					int flags);
 
 /*
+ * saveExecutorMemoryAccount saves an operator specific memory account
+ * into the PlanState of that operator
+ */
+static inline void
+saveExecutorMemoryAccount(PlanState *execState,
+						  MemoryAccountIdType curMemoryAccountId)
+{
+	Assert(curMemoryAccountId != MEMORY_OWNER_TYPE_Undefined);
+	Assert(MEMORY_OWNER_TYPE_Undefined == execState->memoryAccountId);
+	execState->memoryAccountId = curMemoryAccountId;
+}
+
+
+/*
+ * CREATE_EXECUTOR_MEMORY_ACCOUNT is a convenience macro to create a new
+ * operator specific memory account *if* the operator will be executed in
+ * the current slice, i.e., it is not part of some other slice (alien
+ * plan node). We assign a shared AlienExecutorMemoryAccount for plan nodes
+ * that will not be executed in current slice
+ *
+ * If the operator is a child of an 'X_NestedExecutor' account, the operator
+ * is also assigned to the 'X_NestedExecutor' account, unless the
+ * explain_memory_verbosity guc is set to 'debug' or above.
+ */
+#define CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, planNode, NodeType)    \
+	MemoryAccounting_CreateExecutorAccountWithType(                            \
+		(isAlienPlanNode), (planNode), MEMORY_OWNER_TYPE_Exec_##NodeType)
+
+static inline MemoryAccountIdType
+MemoryAccounting_CreateExecutorAccountWithType(bool isAlienPlanNode,
+											   Plan *node,
+											   MemoryOwnerType ownerType)
+{
+	if (isAlienPlanNode)
+		return MEMORY_OWNER_TYPE_Exec_AlienShared;
+	else
+		if (MemoryAccounting_IsUnderNestedExecutor() &&
+			explain_memory_verbosity < EXPLAIN_MEMORY_VERBOSITY_DEBUG)
+			return MemoryAccounting_GetOrCreateNestedExecutorAccount();
+		else
+		{
+			long maxLimit =
+				node->operatorMemKB == 0 ? work_mem : node->operatorMemKB;
+			return MemoryAccounting_CreateAccount(maxLimit, ownerType);
+		}
+}
+
+/*
  * setSubplanSliceId
  *	 Set the slice id info for the given subplan.
  */
@@ -220,7 +268,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 	int			origSliceIdInPlan = estate->currentSliceIdInPlan;
 	int			origExecutingSliceId = estate->currentExecutingSliceId;
 
-	MemoryAccountIdType curMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
+	MemoryAccountIdType curMemoryAccountId;
 
 	int localMotionId = LocallyExecutingSliceIndex(estate);
 
@@ -775,7 +823,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 
 	if (result != NULL)
 	{
-		SAVE_EXECUTOR_MEMORY_ACCOUNT(result, curMemoryAccountId);
+		saveExecutorMemoryAccount(result, curMemoryAccountId);
 	}
 	return result;
 }

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -281,7 +281,7 @@ ExecHashTableCreate(HashState *hashState, HashJoinState *hjstate, List *hashOper
 	ListCell   *ho;
 	MemoryContext oldcxt;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 	Hash *node = (Hash *) hashState->ps.plan;
 
@@ -666,7 +666,7 @@ ExecHashTableDestroy(HashState *hashState, HashJoinTable hashtable)
 	Assert(hashtable);
 	Assert(!hashtable->eagerlyReleased);
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 
 	/*
@@ -945,7 +945,7 @@ ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
 	int			batchno;
 	int			hashTupleSize;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 	PlanState *ps = &hashState->ps;
 
@@ -1044,7 +1044,7 @@ ExecHashGetHashValue(HashState *hashState, HashJoinTable hashtable,
 	MemoryContext oldContext;
 	bool		result = true;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 
 	Assert(hashkeys_null);
@@ -1181,7 +1181,7 @@ ExecScanHashBucket(HashState *hashState, HashJoinState *hjstate,
 	HashJoinTuple hashTuple = hjstate->hj_CurTuple;
 	uint32		hashvalue = hjstate->hj_CurHashValue;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 	/*
 	 * hj_CurTuple is NULL to start scanning a new bucket, or the address of
@@ -1240,7 +1240,7 @@ ExecHashTableReset(HashState *hashState, HashJoinTable hashtable)
 	MemoryContext oldcxt;
 	int			nbuckets = hashtable->nbuckets;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
 	{
 	Assert(!hashtable->eagerlyReleased);
 
@@ -1290,7 +1290,7 @@ ExecHashTableExplainInit(HashState *hashState, HashJoinState *hjstate,
 	MemoryContext oldcxt;
 	int			nbatch = Max(hashtable->nbatch, 1);
 
-    START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+    START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
     {
     /* Switch to a memory context that survives until ExecutorEnd. */
     oldcxt = MemoryContextSwitchTo(hjstate->js.ps.state->es_query_cxt);
@@ -1577,7 +1577,7 @@ ExecHashTableExplainBatchEnd(HashState *hashState, HashJoinTable hashtable)
     HashJoinBatchData  *batch = NULL;
     int                 i;
     
-    START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
+    START_MEMORY_ACCOUNT(hashState->ps.memoryAccountId);
     {
     Assert(!hashtable->eagerlyReleased);
     Assert(hashtable->batches);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -178,6 +178,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	PlannerConfig *config;
 	instr_time		starttime;
 	instr_time		endtime;
+	MemoryAccountIdType curMemoryAccountId;
 
 	/*
 	 * Use ORCA only if it is enabled and we are in a master QD process.
@@ -197,7 +198,10 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);
 
-		START_MEMORY_ACCOUNT(MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Optimizer));
+		curMemoryAccountId = MemoryAccounting_CreatePlanningMemoryAccount(
+			MEMORY_OWNER_TYPE_Optimizer);
+
+		START_MEMORY_ACCOUNT(curMemoryAccountId);
 		{
 			result = optimize_query(parse, boundParams);
 		}
@@ -221,11 +225,13 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	if (gp_log_optimization_time)
 		INSTR_TIME_SET_CURRENT(starttime);
 
+	curMemoryAccountId =
+		MemoryAccounting_CreatePlanningMemoryAccount(MEMORY_OWNER_TYPE_Planner);
 	/*
 	 * Incorrectly indented on purpose to avoid re-indenting an entire upstream
 	 * function
 	 */
-	START_MEMORY_ACCOUNT(MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Planner));
+	START_MEMORY_ACCOUNT(curMemoryAccountId);
 	{
 
 	/* Cursor options may come from caller or from DECLARE CURSOR stmt */

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -198,8 +198,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);
 
-		curMemoryAccountId = MemoryAccounting_CreatePlanningMemoryAccount(
-			MEMORY_OWNER_TYPE_Optimizer);
+		curMemoryAccountId = MemoryAccounting_GetOrCreateOptimizerAccount();
 
 		START_MEMORY_ACCOUNT(curMemoryAccountId);
 		{
@@ -225,8 +224,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	if (gp_log_optimization_time)
 		INSTR_TIME_SET_CURRENT(starttime);
 
-	curMemoryAccountId =
-		MemoryAccounting_CreatePlanningMemoryAccount(MEMORY_OWNER_TYPE_Planner);
+	curMemoryAccountId = MemoryAccounting_GetOrCreatePlannerAccount();
 	/*
 	 * Incorrectly indented on purpose to avoid re-indenting an entire upstream
 	 * function

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -111,6 +111,7 @@ CreateQueryDesc(PlannedStmt *plannedstmt,
 
 	qd->ddesc = NULL;
 	qd->gpmon_pkt = NULL;
+	qd->memoryAccountId = MEMORY_OWNER_TYPE_Undefined;
 	
 	if (Gp_role != GP_ROLE_EXECUTE)
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5005,7 +5005,7 @@ struct config_string ConfigureNamesString_gp[] =
 	{
 		{"explain_memory_verbosity", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Experimental feature: show memory account usage in EXPLAIN ANALYZE."),
-			gettext_noop("Valid values are SUPPRESS, SUMMARY, and DETAIL."),
+			gettext_noop("Valid values are SUPPRESS, SUMMARY, DETAIL, and DEBUG."),
 			GUC_GPDB_ADDOPT
 		},
 		&explain_memory_verbosity_str,
@@ -5812,6 +5812,11 @@ assign_explain_memory_verbosity(const char *newval, bool doit, GucSource source)
 	{
 		if (doit)
 			explain_memory_verbosity = EXPLAIN_MEMORY_VERBOSITY_DETAIL;
+	}
+	else if (pg_strcasecmp(newval, "debug") == 0)
+	{
+		if (doit)
+			explain_memory_verbosity = EXPLAIN_MEMORY_VERBOSITY_DEBUG;
 	}
 	else
 	{

--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -74,6 +74,35 @@ MemoryAccountIdType liveAccountStartId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
 MemoryAccountIdType nextAccountId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
 
 /*
+ * The memory account for the primary executor account. This will be assigned to the
+ * first executor created during query execution.
+ */
+MemoryAccountIdType mainExecutorAccount = MEMORY_OWNER_TYPE_Undefined;
+
+/*
+ * MemoryAccountId for the 'X_NestedExecutor' account. This account is a direct
+ * child of the mainExecutorAccount. This is intended for accounts created
+ * during a "nested" ExecutorStart (indirectly called by ExecutorRun), anything
+ * that would normally create another account should instead collapse into the
+ * mainNestedExecutorAccount.
+ *
+ * You would think that it would be okay to create short living memory accounts
+ * then roll them over to the X_NestedExecutor account in the same way that we
+ * use the Rollover account. Unfortunately, this does not work because we need
+ * a way to to keep track of which account IDs have been rolled over. In the
+ * case of the Rollover account, we 'retire' any old memory account by calling
+ * AdvanceMemoryAccountingGeneration() to retire all accounts older than the
+ * liveAccountStartId, but when using live accounts the problem is a lot more
+ * complicated. Keeping a list of 'retired' shortLivingMemoryAccounts does not
+ * solve the problem, because the list of retired accounts is unbounded. Even
+ * if we store the list of accounts as a vector, it does not necessarily
+ * resolve the issue, because it is possible to have a 'hole' in the list of
+ * accounts, and we shouldn't assume that all of the retired accounts are
+ * contiguous.
+ */
+MemoryAccountIdType mainNestedExecutorAccount= MEMORY_OWNER_TYPE_Undefined;
+
+/*
  ******************************************************
  * Internal methods declarations
  */
@@ -1123,6 +1152,8 @@ MemoryAccounting_GetOwnerName(MemoryOwnerType ownerType)
 		return "X_CteScan";
 	case MEMORY_OWNER_TYPE_Exec_WorkTableScan:
 		return "X_WorkTableScan";
+	case MEMORY_OWNER_TYPE_Exec_NestedExecutor:
+		return "X_NestedExecutor";
 	default:
 		Assert(false);
 		break;
@@ -1359,6 +1390,16 @@ AdvanceMemoryAccountingGeneration()
 
 	liveAccountStartId = nextAccountId;
 
+	/*
+	 * Currently this is the only place where we reset the mainExecutorAccount.
+	 * XXX: We have a flawed assumption that the first "executor" account is
+	 * the main one and that all subsequently created "executor" accounts are
+	 * nested. Rewrite rules and constant folding during planning are examples
+	 * of false detection of nested executor.
+	 */
+	mainExecutorAccount = MEMORY_OWNER_TYPE_Undefined;
+	mainNestedExecutorAccount = MEMORY_OWNER_TYPE_Undefined;
+
 	Assert(RolloverMemoryAccount->peak >= MemoryAccountingPeakBalance);
 }
 
@@ -1403,4 +1444,67 @@ SaveMemoryBufToDisk(struct StringInfoData *memoryBuf, char *prefix)
 	}
 
 	fclose(file);
+}
+
+/*
+ * CreateMainExecutor
+ *    Creates the mainExecutorAccount
+ */
+MemoryAccountIdType
+MemoryAccounting_CreateMainExecutor()
+{
+	Assert(mainExecutorAccount == MEMORY_OWNER_TYPE_Undefined);
+	mainExecutorAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
+
+	return mainExecutorAccount;
+}
+
+
+/*
+ * GetOrCreateNestedExecutorAccount
+ *    Returns the MemoryAccountId for the 'X_NestedExecutor' account. Creates the
+ *    mainNestedExecutorAccount if it does not already exist.
+ */
+MemoryAccountIdType
+MemoryAccounting_GetOrCreateNestedExecutorAccount()
+{
+	if (mainNestedExecutorAccount == MEMORY_OWNER_TYPE_Undefined)
+	{
+		Assert(mainExecutorAccount != MEMORY_OWNER_TYPE_Undefined);
+		START_MEMORY_ACCOUNT(mainExecutorAccount);
+		mainNestedExecutorAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_NestedExecutor);
+		END_MEMORY_ACCOUNT();
+	}
+	return mainNestedExecutorAccount;
+}
+
+/*
+ *  IsUnderNestedExecutor
+ *    Return weather the currently active memory account is 'X_NestedExecutor'.
+ */
+bool
+MemoryAccounting_IsUnderNestedExecutor()
+{
+	return ActiveMemoryAccountId == mainNestedExecutorAccount;
+}
+
+/*
+ * IsMainExecutorCreated
+ *    Returns whether the top level executor account has been created.
+ */
+bool
+MemoryAccounting_IsMainExecutorCreated()
+{
+	return mainExecutorAccount != MEMORY_OWNER_TYPE_Undefined;
+}
+
+MemoryAccountIdType
+MemoryAccounting_CreatePlanningMemoryAccount(MemoryOwnerType type)
+{
+	if (explain_memory_verbosity >= EXPLAIN_MEMORY_VERBOSITY_DEBUG)
+		return MemoryAccounting_CreateAccount(0, type);
+	else if (MemoryAccounting_IsMainExecutorCreated())
+		return MemoryAccounting_GetOrCreateNestedExecutorAccount();
+	else
+		return MemoryAccounting_CreateAccount(0, type);
 }

--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -73,6 +73,8 @@ MemoryAccountIdType liveAccountStartId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
  */
 MemoryAccountIdType nextAccountId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
 
+MemoryAccountIdType mainOptimizerAccount = MEMORY_OWNER_TYPE_Undefined;
+
 /*
  * The memory account for the primary executor account. This will be assigned to the
  * first executor created during query execution.
@@ -1399,6 +1401,7 @@ AdvanceMemoryAccountingGeneration()
 	 */
 	mainExecutorAccount = MEMORY_OWNER_TYPE_Undefined;
 	mainNestedExecutorAccount = MEMORY_OWNER_TYPE_Undefined;
+	mainOptimizerAccount = MEMORY_OWNER_TYPE_Undefined;
 
 	Assert(RolloverMemoryAccount->peak >= MemoryAccountingPeakBalance);
 }
@@ -1479,6 +1482,39 @@ MemoryAccounting_GetOrCreateNestedExecutorAccount()
 }
 
 /*
+ * GetOrCreateOptimizerAccount
+ *    Returns the MemoryAccountId for the 'Optimizer' account. Creates the
+ *    mainOptimizerAccount if it does not already exist.
+ *
+ *    ORCA has a metadata cache that persists between calls to create a plan.
+ *    This memory is tracked in the memory accounting system using a global
+ *    OptimizerOutstandingMemoryBalance. Any time we create an Optimizer
+ *    account we initialize the memory to the
+ *    OptimizerOutstandingMemoryBalance, if we create more than one optimizer
+ *    account, this memory will be double accounted for. Therefore, restrict
+ *    the memory accounting system to only creating one Optimizer account.
+ */
+MemoryAccountIdType
+MemoryAccounting_GetOrCreateOptimizerAccount()
+{
+	if (mainOptimizerAccount == MEMORY_OWNER_TYPE_Undefined)
+		mainOptimizerAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Optimizer);
+
+	return mainOptimizerAccount;
+}
+
+MemoryAccountIdType
+MemoryAccounting_GetOrCreatePlannerAccount()
+{
+	if (explain_memory_verbosity >= EXPLAIN_MEMORY_VERBOSITY_DEBUG)
+		return MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Planner);
+	else if (MemoryAccounting_IsMainExecutorCreated())
+		return MemoryAccounting_GetOrCreateNestedExecutorAccount();
+	else
+		return MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Planner);
+}
+
+/*
  *  IsUnderNestedExecutor
  *    Return weather the currently active memory account is 'X_NestedExecutor'.
  */
@@ -1498,13 +1534,3 @@ MemoryAccounting_IsMainExecutorCreated()
 	return mainExecutorAccount != MEMORY_OWNER_TYPE_Undefined;
 }
 
-MemoryAccountIdType
-MemoryAccounting_CreatePlanningMemoryAccount(MemoryOwnerType type)
-{
-	if (explain_memory_verbosity >= EXPLAIN_MEMORY_VERBOSITY_DEBUG)
-		return MemoryAccounting_CreateAccount(0, type);
-	else if (MemoryAccounting_IsMainExecutorCreated())
-		return MemoryAccounting_GetOrCreateNestedExecutorAccount();
-	else
-		return MemoryAccounting_CreateAccount(0, type);
-}

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -959,7 +959,7 @@ test__MemoryAccounting_GetAccountName__Validate(void **state)
 			"X_BitmapHeapScan", "X_BitmapAppendOnlyScan", "X_TidScan", "X_SubqueryScan", "X_FunctionScan", "X_TableFunctionScan",
 			"X_ValuesScan", "X_NestLoop", "X_MergeJoin", "X_HashJoin", "X_Material", "X_Sort", "X_Agg", "X_Unique", "X_Hash", "X_SetOp",
 			"X_Limit", "X_Motion", "X_ShareInputScan", "X_Window", "X_Repeat", "X_DML", "X_SplitUpdate", "X_RowTrigger", "X_AssertOp",
-			"X_BitmapTableScan", "X_PartitionSelector", "X_RecursiveUnion", "X_CteScan", "X_WorkTableScan"};
+			"X_BitmapTableScan", "X_PartitionSelector", "X_RecursiveUnion", "X_CteScan", "X_WorkTableScan", "X_NestedExecutor"};
 
 	/* Ensure we have all the long living accounts in the longLivingNames array */
 	assert_true(sizeof(longLivingNames) / sizeof(char*) == MEMORY_OWNER_TYPE_END_LONG_LIVING);

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -266,6 +266,8 @@ typedef struct QueryDesc
 	/* This is always set NULL by the core system, but plugins can change it */
 	struct Instrumentation *totaltime;	/* total time spent in ExecutorRun */
 
+	/* The overall memory consumption account (i.e., outside of an operator) */
+	MemoryAccountIdType memoryAccountId;
 } QueryDesc;
 
 /* in pquery.c */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1384,6 +1384,9 @@ typedef struct PlanState
 	gpmon_packet_t gpmon_pkt;
 
 	bool		fHadSentNodeStart;
+
+	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
+	MemoryAccountIdType memoryAccountId;
 } PlanState;
 
 typedef struct Gpmon_NameUnit_MaxVal

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -143,9 +143,6 @@ typedef struct PlannedStmt
 
 	/* What is the memory reserved for this query's execution? */
 	uint64		query_mem;
-
-	/* The overall memory consumption account (i.e., outside of an operator) */
-	MemoryAccountIdType memoryAccountId;
 } PlannedStmt;
 
 /*
@@ -273,9 +270,6 @@ typedef struct Plan
 	 * How much memory (in KB) should be used to execute this plan node?
 	 */
 	uint64 operatorMemKB;
-
-	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
-	MemoryAccountIdType memoryAccountId;
 
 	/*
 	 * The parent motion node of a plan node.

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -25,6 +25,8 @@ struct MemoryContextData;
 #define EXPLAIN_MEMORY_VERBOSITY_SUPPRESS  0 /* Suppress memory reporting in explain analyze */
 #define EXPLAIN_MEMORY_VERBOSITY_SUMMARY  1 /* Summary of memory usage for each owner in explain analyze */
 #define EXPLAIN_MEMORY_VERBOSITY_DETAIL  2 /* Detail memory accounting tree for each slice in explain analyze */
+#define EXPLAIN_MEMORY_VERBOSITY_DEBUG  3 /* Detail memory accounting tree with every executor having its own account
+										   * for each slice in explain analyze */
 
 /*
  * What level of details of the memory accounting information to show during EXPLAIN ANALYZE?
@@ -137,7 +139,8 @@ typedef enum MemoryOwnerType
 	MEMORY_OWNER_TYPE_Exec_RecursiveUnion,
 	MEMORY_OWNER_TYPE_Exec_CteScan,
 	MEMORY_OWNER_TYPE_Exec_WorkTableScan,
-	MEMORY_OWNER_TYPE_EXECUTOR_END = MEMORY_OWNER_TYPE_Exec_WorkTableScan,
+	MEMORY_OWNER_TYPE_Exec_NestedExecutor,
+	MEMORY_OWNER_TYPE_EXECUTOR_END = MEMORY_OWNER_TYPE_Exec_NestedExecutor,
 	MEMORY_OWNER_TYPE_END_SHORT_LIVING = MEMORY_OWNER_TYPE_EXECUTOR_END
 } MemoryOwnerType;
 
@@ -172,25 +175,7 @@ extern MemoryAccountIdType ActiveMemoryAccountId;
 		ActiveMemoryAccountId = oldActiveMemoryAccountId;\
 	} while (0);
 
-/*
- * CREATE_EXECUTOR_MEMORY_ACCOUNT is a convenience macro to create a new
- * operator specific memory account *if* the operator will be executed in
- * the current slice, i.e., it is not part of some other slice (alien
- * plan node). We assign a shared AlienExecutorMemoryAccount for plan nodes
- * that will not be executed in current slice
- */
-#define CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, planNode, NodeType) \
-		isAlienPlanNode ? MEMORY_OWNER_TYPE_Exec_AlienShared : \
-			MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
-			work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType);
 
-/*
- * SAVE_EXECUTOR_MEMORY_ACCOUNT saves an operator specific memory account
- * into the PlanState of that operator
- */
-#define SAVE_EXECUTOR_MEMORY_ACCOUNT(execState, curMemoryAccountId)\
-		Assert(MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->memoryAccountId); \
-		((PlanState *)execState)->memoryAccountId = curMemoryAccountId;
 
 extern MemoryAccountIdType
 MemoryAccounting_CreateAccount(long maxLimit, enum MemoryOwnerType ownerType);
@@ -237,5 +222,49 @@ MemoryAccounting_RequestQuotaIncrease();
 
 extern void
 MemoryAccounting_ExplainAppendCurrentOptimizerAccountInfo(StringInfoData *str);
+
+extern MemoryAccountIdType
+MemoryAccounting_CreateMainExecutor(void);
+
+extern MemoryAccountIdType
+MemoryAccounting_GetOrCreateNestedExecutorAccount(void);
+
+extern bool
+MemoryAccounting_IsUnderNestedExecutor(void);
+
+extern bool
+MemoryAccounting_IsMainExecutorCreated(void);
+
+/*
+ * MemoryAccounting_CreateExecutorMemoryAccount will create the main executor
+ * account. Any subsequent calls to this function will assign the executor to
+ * the 'X_NestedExecutor' account.
+ *
+ * If the explain_memory_verbosity guc is set to 'debug' or above, all
+ * executors will be given its own memory account.
+ */
+static inline MemoryAccountIdType
+MemoryAccounting_CreateExecutorMemoryAccount(void)
+{
+	if (explain_memory_verbosity >= EXPLAIN_MEMORY_VERBOSITY_DEBUG)
+		return MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
+	else
+		if (MemoryAccounting_IsMainExecutorCreated())
+			return MemoryAccounting_GetOrCreateNestedExecutorAccount();
+		else
+			return MemoryAccounting_CreateMainExecutor();
+}
+
+/*
+ * MemoryAccounting_CreatePlanningMemoryAccount creates a memory account for
+ * query planning. If the planner is a direct child of the 'X_NestedExecutor'
+ * account, the planner account will also be assigned to 'X_NestedExecutor'.
+ *
+ * The planner account will always be created if the explain_memory_verbosity
+ * guc is set to 'debug' or above.
+ */
+extern MemoryAccountIdType
+MemoryAccounting_CreatePlanningMemoryAccount(MemoryOwnerType type);
+
 
 #endif   /* MEMACCOUNTING_H */

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -229,6 +229,20 @@ MemoryAccounting_CreateMainExecutor(void);
 extern MemoryAccountIdType
 MemoryAccounting_GetOrCreateNestedExecutorAccount(void);
 
+extern MemoryAccountIdType
+MemoryAccounting_GetOrCreateOptimizerAccount(void);
+
+/*
+ * MemoryAccounting_GetOrCreatePlannerAccount creates a memory account for
+ * query planning. If the planner is a direct child of the 'X_NestedExecutor'
+ * account, the planner account will also be assigned to 'X_NestedExecutor'.
+ *
+ * The planner account will always be created if the explain_memory_verbosity
+ * guc is set to 'debug' or above.
+ */
+extern MemoryAccountIdType
+MemoryAccounting_GetOrCreatePlannerAccount(void);
+
 extern bool
 MemoryAccounting_IsUnderNestedExecutor(void);
 
@@ -254,17 +268,6 @@ MemoryAccounting_CreateExecutorMemoryAccount(void)
 		else
 			return MemoryAccounting_CreateMainExecutor();
 }
-
-/*
- * MemoryAccounting_CreatePlanningMemoryAccount creates a memory account for
- * query planning. If the planner is a direct child of the 'X_NestedExecutor'
- * account, the planner account will also be assigned to 'X_NestedExecutor'.
- *
- * The planner account will always be created if the explain_memory_verbosity
- * guc is set to 'debug' or above.
- */
-extern MemoryAccountIdType
-MemoryAccounting_CreatePlanningMemoryAccount(MemoryOwnerType type);
 
 
 #endif   /* MEMACCOUNTING_H */

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -180,21 +180,17 @@ extern MemoryAccountIdType ActiveMemoryAccountId;
  * that will not be executed in current slice
  */
 #define CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, planNode, NodeType) \
-		(MEMORY_OWNER_TYPE_Undefined != planNode->memoryAccountId) ?\
-			planNode->memoryAccountId : \
-			(isAlienPlanNode ? MEMORY_OWNER_TYPE_Exec_AlienShared : \
-				MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
-				work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType));
+		isAlienPlanNode ? MEMORY_OWNER_TYPE_Exec_AlienShared : \
+			MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
+			work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType);
 
 /*
  * SAVE_EXECUTOR_MEMORY_ACCOUNT saves an operator specific memory account
  * into the PlanState of that operator
  */
 #define SAVE_EXECUTOR_MEMORY_ACCOUNT(execState, curMemoryAccountId)\
-		Assert(MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->plan->memoryAccountId || \
-		MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->plan->memoryAccountId || \
-		curMemoryAccountId == ((PlanState *)execState)->plan->memoryAccountId);\
-		((PlanState *)execState)->plan->memoryAccountId = curMemoryAccountId;
+		Assert(MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->memoryAccountId); \
+		((PlanState *)execState)->memoryAccountId = curMemoryAccountId;
 
 extern MemoryAccountIdType
 MemoryAccounting_CreateAccount(long maxLimit, enum MemoryOwnerType ownerType);

--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -44,3 +44,146 @@ select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 
  t
 (1 row)
 
+create or replace function has_account_type(query text, search_text text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("^\s+%s" % search_text)
+count = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.match(cur_line)
+    if m is not None:
+        count = count + 1
+return count
+$$
+language plpythonu;
+-- Create functions that will generate nested SQL executors
+CREATE OR REPLACE FUNCTION simple_plpgsql_function(int) RETURNS int AS $$
+ DECLARE RESULT int;
+BEGIN
+ SELECT count(*) FROM pg_class INTO RESULT;
+ RETURN RESULT + $1;
+END;
+$$ LANGUAGE plpgsql NO SQL;
+CREATE OR REPLACE FUNCTION simple_sql_function(argument int) RETURNS bigint AS $$
+SELECT count(*) + $1 FROM pg_class;
+$$ LANGUAGE SQL STRICT VOLATILE;
+-- Create a table with tuples only on one segement
+CREATE TABLE all_tuples_on_seg0(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO all_tuples_on_seg0 VALUES (0), (0), (0);
+SELECT gp_segment_id, count(*) FROM all_tuples_on_seg0 GROUP BY 1;
+ gp_segment_id | count 
+---------------+-------
+             0 |     3
+(1 row)
+
+-- The X_NestedExecutor account is only created if we create an executor.
+-- Because all the tuples in all_tuples_on_seg0 are on seg0, only seg0 should
+-- create the X_NestedExecutor account.
+set explain_memory_verbosity to detail;
+-- We expect that only seg0 will create an X_NestedExecutor account, so this
+-- should return '1'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                1
+(1 row)
+
+-- Each node will create a 'main' executor account, so we expect that this
+-- will return '3', one per Query Executor.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+
+-- Same as above, this should return '1'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                1
+(1 row)
+
+-- Same as above, this should return '3'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+
+-- After setting explain_memory_verbosity to 'debug', the X_NestedExecutor
+-- account will no longer be created. Instead, every time we evaluate a code
+-- block in an sql or PL/pgSQL function, it will create a new executor account.
+-- There are three tuples in all_tuples_on_seg0, so we should see three more
+-- Executor accounts than when we had the explain_memory_verbosity guc set to
+-- 'detail'.
+set explain_memory_verbosity to debug;
+-- We expect this will be '0'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- Because there are three tuples in all_tuples_on_seg0, we expect to see three
+-- additional 'Executor' accounts created, a total number of '6'.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                6
+(1 row)
+
+-- Expect '0'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- Expect '6'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                6
+(1 row)
+
+-- Test X_NestedExecutor is created correctly inside multiple slice plans
+set explain_memory_verbosity to detail;
+-- We should see two TableScans- one per slice. Because only one segment has
+-- tuples, only one segment per slice will create the 'X_NestedExecutor'
+-- account. This will return '2'.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                2
+(1 row)
+
+-- There will be two slices, and each slice will create an 'Executor' account
+-- for a total of '6' 'Executor' accounts.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+ has_account_type 
+------------------
+                6
+(1 row)
+
+set explain_memory_verbosity to debug;
+-- We don't create 'X_NestedExecutor' accounts when explain_memory_verbosity is
+-- set to 'debug', so this will return '0'
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- Two slices, each returning three tuples. For each tuple we will create an
+-- 'Executor' account. We also expect one main 'Executor' account per slice, so
+-- expect '12' total Executor accounts
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+ has_account_type 
+------------------
+               12
+(1 row)
+

--- a/src/test/regress/sql/memconsumption.sql
+++ b/src/test/regress/sql/memconsumption.sql
@@ -40,3 +40,89 @@ select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 
 
 set execute_pruned_plan=off;
 select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j') > 0;
+
+create or replace function has_account_type(query text, search_text text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("^\s+%s" % search_text)
+count = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.match(cur_line)
+    if m is not None:
+        count = count + 1
+return count
+$$
+language plpythonu;
+
+-- Create functions that will generate nested SQL executors
+CREATE OR REPLACE FUNCTION simple_plpgsql_function(int) RETURNS int AS $$
+ DECLARE RESULT int;
+BEGIN
+ SELECT count(*) FROM pg_class INTO RESULT;
+ RETURN RESULT + $1;
+END;
+$$ LANGUAGE plpgsql NO SQL;
+
+
+CREATE OR REPLACE FUNCTION simple_sql_function(argument int) RETURNS bigint AS $$
+SELECT count(*) + $1 FROM pg_class;
+$$ LANGUAGE SQL STRICT VOLATILE;
+
+-- Create a table with tuples only on one segement
+CREATE TABLE all_tuples_on_seg0(i int);
+INSERT INTO all_tuples_on_seg0 VALUES (0), (0), (0);
+SELECT gp_segment_id, count(*) FROM all_tuples_on_seg0 GROUP BY 1;
+
+-- The X_NestedExecutor account is only created if we create an executor.
+-- Because all the tuples in all_tuples_on_seg0 are on seg0, only seg0 should
+-- create the X_NestedExecutor account.
+set explain_memory_verbosity to detail;
+-- We expect that only seg0 will create an X_NestedExecutor account, so this
+-- should return '1'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Each node will create a 'main' executor account, so we expect that this
+-- will return '3', one per Query Executor.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+-- Same as above, this should return '1'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Same as above, this should return '3'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+
+-- After setting explain_memory_verbosity to 'debug', the X_NestedExecutor
+-- account will no longer be created. Instead, every time we evaluate a code
+-- block in an sql or PL/pgSQL function, it will create a new executor account.
+-- There are three tuples in all_tuples_on_seg0, so we should see three more
+-- Executor accounts than when we had the explain_memory_verbosity guc set to
+-- 'detail'.
+set explain_memory_verbosity to debug;
+-- We expect this will be '0'
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Because there are three tuples in all_tuples_on_seg0, we expect to see three
+-- additional 'Executor' accounts created, a total number of '6'.
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+-- Expect '0'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'X_NestedExecutor');
+-- Expect '6'
+select has_account_type('select simple_plpgsql_function(i) from all_tuples_on_seg0', 'Executor');
+
+-- Test X_NestedExecutor is created correctly inside multiple slice plans
+set explain_memory_verbosity to detail;
+-- We should see two TableScans- one per slice. Because only one segment has
+-- tuples, only one segment per slice will create the 'X_NestedExecutor'
+-- account. This will return '2'.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+-- There will be two slices, and each slice will create an 'Executor' account
+-- for a total of '6' 'Executor' accounts.
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+
+
+set explain_memory_verbosity to debug;
+-- We don't create 'X_NestedExecutor' accounts when explain_memory_verbosity is
+-- set to 'debug', so this will return '0'
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'X_NestedExecutor');
+-- Two slices, each returning three tuples. For each tuple we will create an
+-- 'Executor' account. We also expect one main 'Executor' account per slice, so
+-- expect '12' total Executor accounts
+select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');


### PR DESCRIPTION
This is a backport to 5.X of the changes in PR #5860  and #5614 

The memory accounting system generates a new memory account for every
execution node initialized in ExecInitNode. The address to these memory
accounts is stored in the shortLivingMemoryAccountArray. If the memory
allocated for shortLivingMemoryAccountArray is full, we will repalloc
the array with double the number of available entries.

After creating approximately 67000000 memory accounts, it will need to
allocate more than 1GB of memory to increase the array size, and throw
an ERROR, canceling the running query.

PL/pgSQL and SQL functions will create new executors/plan nodes that
must be tracked my the memory accounting system. This level of detail is
not necessary for tracking memory leaks, and creating a separate memory
account for every executor will use large amount of memory just to track
these memory accounts.

Instead of tracking millions of individual memory accounts, we
consolidate any child executor account into a special 'X_Project'
account. If explain_memory_verbosity is set to 'detailed' and below,
consolidate all child executors into this account.

If more detail is needed for debugging, set explain_memory_verbosity to
'debug', where, as was the previous behavior, every executor will be
assigned its own MemoryAccountId.

Additionally, move the memoryAccountId into PlanState/QueryDesc, which
will insure that every time we initialize an executor, it will be assigned a unique
memoryAccountId. This solves several potential problems with nested executors
incorrectly sharing the same memory account.