### PR TITLE
pg_upgrade: map oid to constraint index name correctly

### DIFF
--- a/contrib/pg_upgrade/function.c
+++ b/contrib/pg_upgrade/function.c
@@ -97,7 +97,12 @@ install_support_functions_in_new_db(const char *db_name)
 							  "RETURNS VOID "
 							  "AS '$libdir/pg_upgrade_support' "
 							  "LANGUAGE C STRICT;"));
-
+	PQclear(executeQueryOrDie(conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.generate_index_name_for_constraint(TEXT, OID, BOOL, BOOL, TEXT) "
+							  "RETURNS TEXT "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
 	PQfinish(conn);
 }
 

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -210,6 +210,9 @@ typedef struct
 
 	RelType		reltype;
 
+	/* index that backs a primary key / unique / exclusion contraint */
+	bool		is_constraint_index;
+
 	/* Extra information for append-only tables */
 	AOSegInfo  *aosegments;
 	AOCSSegInfo *aocssegments;

--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -113,11 +113,6 @@ DROP TABLE IF EXISTS stat_heap5.stat_part_heap_t5 CASCADE;
 DROP TABLE IF EXISTS stat_heap6.stat_heap_t6 CASCADE;
 DROP TABLE IF EXISTS stat_heap6.stat_part_heap_t6 CASCADE;
 
--- This one's interesting:
---    No match found in new cluster for old relation with OID 173472 in database "regression": "public.sales_1_prt_bb_pkey" which is an index on "public.newpart"
---    No match found in old cluster for new relation with OID 556718 in database "regression": "public.newpart_pkey" which is an index on "public.newpart"
-DROP TABLE IF EXISTS public.newpart CASCADE;
-
 -- This view definition changes after upgrade.
 DROP VIEW IF EXISTS v_xpect_triangle_de CASCADE;
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13779,9 +13779,9 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 						Oid part_oid = atooid(PQgetvalue(partres, i, 0));
 
 						binary_upgrade_set_pg_class_oids(fout, q, part_oid, false);
+						binary_upgrade_set_type_oids_by_rel_oid(fout, q, part_oid);
 					}
 				}
-
 				PQclear(partres);
 				destroyPQExpBuffer(partquery);
 			}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -282,6 +282,14 @@ static bool binary_upgrade_set_type_oids_by_rel_oid(Archive *fout,
 static void binary_upgrade_set_pg_class_oids(Archive *fout,
 								 PQExpBuffer upgrade_buffer,
 								 Oid pg_class_oid, bool is_index);
+static void binary_upgrade_set_pg_class_oids_for_con_index(Archive *fout,
+														   PQExpBuffer upgrade_buffer,
+														   Oid pg_class_oid,
+														   char *gen_index_query);
+static void binary_upgrade_set_pg_class_oids_helper(Archive *fout,
+													PQExpBuffer upgrade_buffer,
+													Oid pg_class_oid, bool is_index,
+													char *gen_index_query);
 static const char *getAttrName(int attrnum, TableInfo *tblInfo);
 static const char *fmtCopyColumnList(const TableInfo *ti, PQExpBuffer buffer);
 static char *get_synchronized_snapshot(Archive *fout);
@@ -3180,9 +3188,27 @@ binary_upgrade_set_type_oids_by_rel_oid(Archive *fout,
 }
 
 static void
+binary_upgrade_set_pg_class_oids_for_con_index(Archive *fout,
+											   PQExpBuffer upgrade_buffer, Oid pg_class_oid,
+											   char *gen_index_query)
+{
+	binary_upgrade_set_pg_class_oids_helper(
+		fout, upgrade_buffer, pg_class_oid, true, gen_index_query);
+}
+
+static void
 binary_upgrade_set_pg_class_oids(Archive *fout,
 								 PQExpBuffer upgrade_buffer, Oid pg_class_oid,
 								 bool is_index)
+{
+	binary_upgrade_set_pg_class_oids_helper(
+		fout, upgrade_buffer, pg_class_oid, is_index, NULL);
+}
+
+static void
+binary_upgrade_set_pg_class_oids_helper(Archive *fout,
+										PQExpBuffer upgrade_buffer, Oid pg_class_oid,
+										bool is_index, char *gen_index_query)
 {
 	PQExpBuffer upgrade_query = createPQExpBuffer();
 	PGresult   *upgrade_res;
@@ -3259,9 +3285,14 @@ binary_upgrade_set_pg_class_oids(Archive *fout,
 	}
 	else
 	{
-		appendPQExpBuffer(upgrade_buffer,
-						  "SELECT binary_upgrade.set_next_index_pg_class_oid('%u'::pg_catalog.oid, '%u'::pg_catalog.oid, $$%s$$::text);\n",
-						  pg_class_oid, pg_class_relnamespace, pg_class_relname);
+		if (gen_index_query)
+			appendPQExpBuffer(upgrade_buffer,
+							  "SELECT binary_upgrade.set_next_index_pg_class_oid('%u'::pg_catalog.oid, '%u'::pg_catalog.oid,\n\t%s::text);\n",
+							  pg_class_oid, pg_class_relnamespace, gen_index_query);
+		else
+			appendPQExpBuffer(upgrade_buffer,
+							  "SELECT binary_upgrade.set_next_index_pg_class_oid('%u'::pg_catalog.oid, '%u'::pg_catalog.oid, $$%s$$::text);\n",
+							  pg_class_oid, pg_class_relnamespace, pg_class_relname);
 
 		/*
 		 * If this is a bitmap index, we need to preserve the oid of the aux
@@ -14699,7 +14730,33 @@ dumpConstraint(Archive *fout, ConstraintInfo *coninfo)
 						  coninfo->dobj.name);
 
 		if (binary_upgrade)
-			binary_upgrade_set_pg_class_oids(fout, q, indxinfo->dobj.catId.oid, true);
+		{
+			PQExpBuffer genindq;
+			genindq = createPQExpBuffer();
+			Assert(indxinfo->dobj.namespace);
+			appendPQExpBuffer(genindq, "binary_upgrade.generate_index_name_for_constraint('%s'::text, '%u'::pg_catalog.oid, %s, %s, ",
+							  tbinfo->dobj.name, indxinfo->dobj.namespace->dobj.catId.oid,
+							  coninfo->contype == 'x' ? "true" : "false",
+							  coninfo->contype == 'p' ? "true" : "false");
+			appendPQExpBuffer(genindq,"'");
+			for (k = 0; k < indxinfo->indnkeys; k++)
+			{
+				int			indkey = (int) indxinfo->indkeys[k];
+				const char *attname;
+
+				if (indkey == InvalidAttrNumber)
+					break;
+				attname = getAttrName(indkey, tbinfo);
+
+				appendPQExpBuffer(genindq, "%s%s",
+								  (k == 0) ? "" : "_",
+								  fmtId(attname));
+			}
+			appendPQExpBuffer(genindq,"'::text");
+			appendPQExpBuffer(genindq, ")");
+			binary_upgrade_set_pg_class_oids_for_con_index(fout, q, indxinfo->dobj.catId.oid, genindq->data);
+			destroyPQExpBuffer(genindq);
+		}
 
 		appendPQExpBuffer(q, "ALTER TABLE ONLY %s\n",
 						  fmtId(tbinfo->dobj.name));


### PR DESCRIPTION
ALTER TABLE ... ADD CONSTRAINT generates the name of the index to be created.  This patch uses the same logic to generate the name during upgrade, so that OIDs can be pre-assigned to the right name.  Exclusion constraints do not have a SQL syntax that allows the index name to be specified, so we do so via a udf.  This complicates the fix, because the udf must be executed in the upgraded instance.  So we cannot execute the udf in the old instance and get the constraint index name.  While we could have done without the udf for primary and unique constraints with "ALTER TABLE ... ADD CONSTRAINT USING INDEX" syntax, we decided to use the udf for all three to make this procedure uniform.

Including fac044b(assign OID to partitioned table's type) for our testing; we do not intend to push this to origin/master.