### PR TITLE
Fix analyze for array type columns

### DIFF
--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -523,8 +523,18 @@ datumHashTableHash(const void *keyPtr, Size keysize)
 {
 	uint32 result = 0;
 	MCVFreqPair *mcvFreqPair = *((MCVFreqPair **)keyPtr);
+	Oid oidType = mcvFreqPair->typinfo->typOid;
+	/*
+	 * if the incoming column type is an array, pass ANYARRAYOID
+	 * as datumhash function handles ANYARRAYOID instead of specific
+	 * array oid to determine the hash to be performed.
+	 */
+	if (typeIsArrayType(oidType))
+	{
+		oidType = ANYARRAYOID;
+	}
 
-	hashDatum(mcvFreqPair->mcv, mcvFreqPair->typinfo->typOid, calculateHashWithHashAny, &result);
+	hashDatum(mcvFreqPair->mcv, oidType, calculateHashWithHashAny, &result);
 
 	return result;
 }

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -33,7 +33,9 @@ CREATE TABLE foo (
     c25_timestamp timestamp, 
     c26_timestamptz timestamptz,
     c27_uuid uuid,
-    c28_tsquery tsquery
+    c28_tsquery tsquery,
+    c29_varchararray character varying(2)[],
+    c30_intarray int[]
 ) PARTITION BY RANGE (b) (START (0) END(6) EVERY(3));
 NOTICE:  CREATE TABLE will create implicit sequence "foo_c04_bigserial_seq" for serial column "foo.c04_bigserial"
 NOTICE:  CREATE TABLE will create implicit sequence "foo_c20_serial4_seq" for serial column "foo.c20_serial4"
@@ -70,7 +72,9 @@ i%6,
 ('2018-01-01 '||(i%6)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%6)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%6)::text||(i%6)::text)::uuid,
-('foo'||(i%6)::text||' & rat'||(i%6)::text)::tsquery
+('foo'||(i%6)::text||' & rat'||(i%6)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' and attname != 'a' ORDER BY attname,tablename;
@@ -157,7 +161,13 @@ SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_
  foo         | c28_tsquery        |         0 |          6 |                                                                                                                  |                   | {"'foo4' & 'rat4'","'foo0' & 'rat0'","'foo1' & 'rat1'","'foo3' & 'rat3'","'foo2' & 'rat2'"}
  foo_1_prt_1 | c28_tsquery        |         0 |          3 | {"'foo1' & 'rat1'","'foo2' & 'rat2'","'foo0' & 'rat0'"}                                                          | {0.34,0.34,0.32}  | 
  foo_1_prt_2 | c28_tsquery        |         0 |          3 | {"'foo4' & 'rat4'","'foo3' & 'rat3'","'foo5' & 'rat5'"}                                                          | {0.34,0.34,0.32}  | 
-(81 rows)
+ foo         | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                        | {1}               | 
+ foo_1_prt_1 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                        | {1}               | 
+ foo_1_prt_2 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                        | {1}               | 
+ foo         | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                        | {1}               | 
+ foo_1_prt_1 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                        | {1}               | 
+ foo_1_prt_2 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                        | {1}               | 
+(87 rows)
 
 -- Case 2: Partitions have no MCVs, only histograms, after merge root has to
 -- have approximately merged histograms.
@@ -191,7 +201,9 @@ i,
 ('2018-01-01 '||(i%12)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%12)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5)::text||(i%5)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 INSERT INTO foo 
 SELECT
@@ -222,7 +234,9 @@ i,
 ('2018-01-01 '||(i%12+12)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%12+12)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5+5)::text||(i%5+5)::text)::uuid,
-('foo'||(i+200)::text||' & rat'||(i+200)::text)::tsquery
+('foo'||(i+200)::text||' & rat'||(i+200)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 INSERT INTO foo 
 SELECT
@@ -253,7 +267,9 @@ i,
 ('2018-01-01 '||(i%12)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%12)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5)::text||(i%5)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,200) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
@@ -343,7 +359,13 @@ SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_
  foo         | c28_tsquery        |         0 |      -0.75 | {"'foo8' & 'rat8'","'foo4' & 'rat4'","'foo9' & 'rat9'","'foo1' & 'rat1'"} | {0.005,0.005,0.005,0.005} | {"'foo5' & 'rat5'","'foo26' & 'rat26'","'foo130' & 'rat130'","'foo243' & 'rat243'","'foo109' & 'rat109'"}
  foo_1_prt_1 | c28_tsquery        |         0 |         -1 |                                                                           |                           | {"'foo8' & 'rat8'","'foo57' & 'rat57'","'foo273' & 'rat273'","'foo272' & 'rat272'","'foo296' & 'rat296'"}
  foo_1_prt_2 | c28_tsquery        |         0 |         -1 |                                                                           |                           | {"'foo8' & 'rat8'","'foo57' & 'rat57'","'foo141' & 'rat141'","'foo171' & 'rat171'","'foo109' & 'rat109'"}
-(84 rows)
+ foo         | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                 | {1}                       | 
+ foo_1_prt_1 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                 | {1}                       | 
+ foo_1_prt_2 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                 | {1}                       | 
+ foo         | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                 | {1}                       | 
+ foo_1_prt_1 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                 | {1}                       | 
+ foo_1_prt_2 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                 | {1}                       | 
+(90 rows)
 
 -- Case 3: Partitions have MCVs but after merge, MCVs that do not qualify as 
 -- global MCV for the root will be used to create root histograms
@@ -377,7 +399,9 @@ i%4,
 ('2018-01-01 '||'12:'||(i%4)::text||':00')::timestamp,
 ('2018-01-01 '||'12:'||(i%4)::text||':00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%4)::text||(i%4)::text)::uuid,
-('foo'||(i%4)::text||' & rat'||(i%4)::text)::tsquery
+('foo'||(i%4)::text||' & rat'||(i%4)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 INSERT INTO foo 
 SELECT
@@ -408,7 +432,9 @@ i,
 ('2018-01-01 '||'12:'||(i%60)::text||':00')::timestamp,
 ('2018-01-01 '||'12:'||(i%60)::text||':00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%6)::text||(i%6)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,60) i;
 INSERT INTO foo 
 SELECT
@@ -439,7 +465,9 @@ i%4+61,
 ('2018-01-01 '||'12:59:'||(i%4+10)::text)::timestamp,
 ('2018-01-01 '||'12:59:'||(i%4+10)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%4+6)::text||(i%4+6)::text)::uuid,
-('foo'||(i%4)::text||' & rat'||(i%4)::text)::tsquery
+('foo'||(i%4)::text||' & rat'||(i%4)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,40) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
@@ -529,7 +557,13 @@ SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_
  foo         | c28_tsquery        |         0 |     -0.305 | {"'foo1' & 'rat1'","'foo3' & 'rat3'","'foo2' & 'rat2'","'foo0' & 'rat0'"}                                                                             | {0.18,0.18,0.18,0.175}    | {"'foo8' & 'rat8'","'foo31' & 'rat31'","'foo60' & 'rat60'","'foo32' & 'rat32'","'foo16' & 'rat16'"}
  foo_1_prt_1 | c28_tsquery        |         0 |          4 | {"'foo0' & 'rat0'","'foo1' & 'rat1'","'foo3' & 'rat3'","'foo2' & 'rat2'"}                                                                             | {0.25,0.25,0.25,0.25}     | 
  foo_1_prt_2 | c28_tsquery        |         0 |      -0.61 | {"'foo1' & 'rat1'","'foo3' & 'rat3'","'foo2' & 'rat2'","'foo0' & 'rat0'"}                                                                             | {0.11,0.11,0.11,0.1}      | {"'foo8' & 'rat8'","'foo31' & 'rat31'","'foo60' & 'rat60'","'foo32' & 'rat32'","'foo16' & 'rat16'"}
-(84 rows)
+ foo         | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                                                             | {1}                       | 
+ foo_1_prt_1 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                                                             | {1}                       | 
+ foo_1_prt_2 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                                                             | {1}                       | 
+ foo         | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                                                             | {1}                       | 
+ foo_1_prt_1 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                                                             | {1}                       | 
+ foo_1_prt_2 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                                                             | {1}                       | 
+(90 rows)
 
 -- Case 4: A partition has MCVs but after merge, those MCVs do not qualify as 
 -- global MCV for the root will be used to create root histograms
@@ -563,7 +597,9 @@ i,
 ('2018-01-01 '||(i%12)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%12)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5)::text||(i%5)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 INSERT INTO foo 
 SELECT
@@ -594,7 +630,9 @@ i%4+61,
 ('2018-01-01 '||'12:'||(i%4+56)::text||':00')::timestamp,
 ('2018-01-01 '||'12:'||(i%4+56)::text||':00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%4+6)::text||(i%4+6)::text)::uuid,
-('foo'||(i%4+61)::text||' & rat'||(i%4+61)::text)::tsquery
+('foo'||(i%4+61)::text||' & rat'||(i%4+61)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,8) i;
 INSERT INTO foo 
 SELECT
@@ -625,7 +663,9 @@ i,
 ('2018-01-01 '||'12:00'||(i%60)::text)::timestamp,
 ('2018-01-01 '||'12:00'||(i%60)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%10)::text||(i%10)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,60) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' and attname != 'a' ORDER BY attname,tablename;
@@ -712,7 +752,13 @@ SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_
  foo         | c28_tsquery        |         0 |  -0.595238 | {"'foo61' & 'rat61'","'foo64' & 'rat64'","'foo62' & 'rat62'","'foo63' & 'rat63'"}                                             | {0.0178571,0.0178571,0.0178571,0.0178571} | {"'foo8' & 'rat8'","'foo90' & 'rat90'","'foo60' & 'rat60'","'foo32' & 'rat32'","'foo100' & 'rat100'"}
  foo_1_prt_1 | c28_tsquery        |         0 |         -1 |                                                                                                                               |                                           | {"'foo8' & 'rat8'","'foo35' & 'rat35'","'foo57' & 'rat57'","'foo36' & 'rat36'","'foo100' & 'rat100'"}
  foo_1_prt_2 | c28_tsquery        |         0 |  -0.941176 | {"'foo61' & 'rat61'","'foo64' & 'rat64'","'foo62' & 'rat62'","'foo63' & 'rat63'"}                                             | {0.0294118,0.0294118,0.0294118,0.0294118} | {"'foo8' & 'rat8'","'foo14' & 'rat14'","'foo11' & 'rat11'","'foo47' & 'rat47'","'foo16' & 'rat16'"}
-(81 rows)
+ foo         | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                                     | {1}                                       | 
+ foo_1_prt_1 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                                     | {1}                                       | 
+ foo_1_prt_2 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                                     | {1}                                       | 
+ foo         | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                                     | {1}                                       | 
+ foo_1_prt_1 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                                     | {1}                                       | 
+ foo_1_prt_2 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                                     | {1}                                       | 
+(87 rows)
 
 -- Case 5: A partition has MCVs but after merge, those MCVs qualify as global
 -- MCVs for the root
@@ -746,7 +792,9 @@ i,
 ('2018-01-01 '||'12:'||(i%60)::text||':'||(i%30)::text)::timestamp,
 ('2018-01-01 '||'12:'||(i%60)::text||':'||(i%30)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5)::text||(i%5)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,60) i;
 INSERT INTO foo 
 SELECT
@@ -777,7 +825,9 @@ i%4+61,
 ('2018-01-01 '||'01:00:'||(i%4)::text)::timestamp,
 ('2018-01-01 '||'01:00:'||(i%4)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%4+6)::text||(i%4+6)::text)::uuid,
-('foo'||(i%4+61)::text||' & rat'||(i%4+61)::text)::tsquery
+('foo'||(i%4+61)::text||' & rat'||(i%4+61)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,8) i;
 INSERT INTO foo 
 SELECT
@@ -808,7 +858,9 @@ i,
 ('2018-01-01 '||'12:'||(i%60)::text||':'||(i%30)::text)::timestamp,
 ('2018-01-01 '||'12:'||(i%60)::text||':'||(i%30)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%10)::text||(i%10)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,10) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' and attname != 'a' ORDER BY attname,tablename;
@@ -895,7 +947,13 @@ SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_
  foo         | c28_tsquery        |         0 |  -0.820513 | {"'foo8' & 'rat8'","'foo4' & 'rat4'","'foo9' & 'rat9'","'foo1' & 'rat1'"}                                                                             | {0.025641,0.025641,0.025641,0.025641}     | {"'foo5' & 'rat5'","'foo14' & 'rat14'","'foo64' & 'rat64'","'foo55' & 'rat55'","'foo63' & 'rat63'"}
  foo_1_prt_1 | c28_tsquery        |         0 |         -1 |                                                                                                                                                       |                                           | {"'foo8' & 'rat8'","'foo14' & 'rat14'","'foo11' & 'rat11'","'foo47' & 'rat47'","'foo16' & 'rat16'"}
  foo_1_prt_2 | c28_tsquery        |         0 |  -0.777778 | {"'foo61' & 'rat61'","'foo64' & 'rat64'","'foo62' & 'rat62'","'foo63' & 'rat63'"}                                                                     | {0.111111,0.111111,0.111111,0.111111}     | {"'foo8' & 'rat8'","'foo9' & 'rat9'","'foo5' & 'rat5'","'foo3' & 'rat3'","'foo10' & 'rat10'"}
-(81 rows)
+ foo         | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                                                             | {1}                                       | 
+ foo_1_prt_1 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                                                             | {1}                                       | 
+ foo_1_prt_2 | c29_varchararray   |         0 |          1 | {"{t,t}"}                                                                                                                                             | {1}                                       | 
+ foo         | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                                                             | {1}                                       | 
+ foo_1_prt_1 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                                                             | {1}                                       | 
+ foo_1_prt_2 | c30_intarray       |         0 |          1 | {"{1,2}"}                                                                                                                                             | {1}                                       | 
+(87 rows)
 
 -- Test merging leaf stats where HLL is empty
 DROP TABLE IF EXISTS foo;

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -40,7 +40,9 @@ CREATE TABLE foo (
     c25_timestamp timestamp, 
     c26_timestamptz timestamptz,
     c27_uuid uuid,
-    c28_tsquery tsquery
+    c28_tsquery tsquery,
+    c29_varchararray character varying(2)[],
+    c30_intarray int[]
 ) PARTITION BY RANGE (b) (START (0) END(6) EVERY(3));
 INSERT INTO foo
 SELECT
@@ -71,7 +73,9 @@ i%6,
 ('2018-01-01 '||(i%6)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%6)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%6)::text||(i%6)::text)::uuid,
-('foo'||(i%6)::text||' & rat'||(i%6)::text)::tsquery
+('foo'||(i%6)::text||' & rat'||(i%6)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' and attname != 'a' ORDER BY attname,tablename;
@@ -107,7 +111,9 @@ i,
 ('2018-01-01 '||(i%12)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%12)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5)::text||(i%5)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 INSERT INTO foo 
 SELECT
@@ -138,7 +144,9 @@ i,
 ('2018-01-01 '||(i%12+12)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%12+12)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5+5)::text||(i%5+5)::text)::uuid,
-('foo'||(i+200)::text||' & rat'||(i+200)::text)::tsquery
+('foo'||(i+200)::text||' & rat'||(i+200)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 INSERT INTO foo 
 SELECT
@@ -169,7 +177,9 @@ i,
 ('2018-01-01 '||(i%12)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%12)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5)::text||(i%5)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,200) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
@@ -205,7 +215,9 @@ i%4,
 ('2018-01-01 '||'12:'||(i%4)::text||':00')::timestamp,
 ('2018-01-01 '||'12:'||(i%4)::text||':00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%4)::text||(i%4)::text)::uuid,
-('foo'||(i%4)::text||' & rat'||(i%4)::text)::tsquery
+('foo'||(i%4)::text||' & rat'||(i%4)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 INSERT INTO foo 
 SELECT
@@ -236,7 +248,9 @@ i,
 ('2018-01-01 '||'12:'||(i%60)::text||':00')::timestamp,
 ('2018-01-01 '||'12:'||(i%60)::text||':00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%6)::text||(i%6)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,60) i;
 INSERT INTO foo 
 SELECT
@@ -267,7 +281,9 @@ i%4+61,
 ('2018-01-01 '||'12:59:'||(i%4+10)::text)::timestamp,
 ('2018-01-01 '||'12:59:'||(i%4+10)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%4+6)::text||(i%4+6)::text)::uuid,
-('foo'||(i%4)::text||' & rat'||(i%4)::text)::tsquery
+('foo'||(i%4)::text||' & rat'||(i%4)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,40) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
@@ -303,7 +319,9 @@ i,
 ('2018-01-01 '||(i%12)::text||':59:00')::timestamp,
 ('2018-01-01 '||(i%12)::text||':59:00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5)::text||(i%5)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,100) i;
 INSERT INTO foo 
 SELECT
@@ -334,7 +352,9 @@ i%4+61,
 ('2018-01-01 '||'12:'||(i%4+56)::text||':00')::timestamp,
 ('2018-01-01 '||'12:'||(i%4+56)::text||':00 EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%4+6)::text||(i%4+6)::text)::uuid,
-('foo'||(i%4+61)::text||' & rat'||(i%4+61)::text)::tsquery
+('foo'||(i%4+61)::text||' & rat'||(i%4+61)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,8) i;
 INSERT INTO foo 
 SELECT
@@ -365,7 +385,9 @@ i,
 ('2018-01-01 '||'12:00'||(i%60)::text)::timestamp,
 ('2018-01-01 '||'12:00'||(i%60)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%10)::text||(i%10)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,60) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' and attname != 'a' ORDER BY attname,tablename;
@@ -401,7 +423,9 @@ i,
 ('2018-01-01 '||'12:'||(i%60)::text||':'||(i%30)::text)::timestamp,
 ('2018-01-01 '||'12:'||(i%60)::text||':'||(i%30)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%5)::text||(i%5)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,60) i;
 INSERT INTO foo 
 SELECT
@@ -432,7 +456,9 @@ i%4+61,
 ('2018-01-01 '||'01:00:'||(i%4)::text)::timestamp,
 ('2018-01-01 '||'01:00:'||(i%4)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%4+6)::text||(i%4+6)::text)::uuid,
-('foo'||(i%4+61)::text||' & rat'||(i%4+61)::text)::tsquery
+('foo'||(i%4+61)::text||' & rat'||(i%4+61)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,8) i;
 INSERT INTO foo 
 SELECT
@@ -463,7 +489,9 @@ i,
 ('2018-01-01 '||'12:'||(i%60)::text||':'||(i%30)::text)::timestamp,
 ('2018-01-01 '||'12:'||(i%60)::text||':'||(i%30)::text||' EST')::timestamptz,
 ('11111111-1111-1111-1111-1111111111'||(i%10)::text||(i%10)::text)::uuid,
-('foo'||(i)::text||' & rat'||(i)::text)::tsquery
+('foo'||(i)::text||' & rat'||(i)::text)::tsquery,
+'{"t", "t"}',
+'{1,2}'
 FROM generate_series(1,10) i;
 ANALYZE foo;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' and attname != 'a' ORDER BY attname,tablename;


### PR DESCRIPTION
`hashDatum` expects the incoming oid for the array types to be
ANYARRAYOID, else it will flag them as unsupported.  While performing
the MCV calcuation on the array type columns, we were passing the
specific array oid, i.e character array oid for char array type column,
due to which `hashdatum` was marking them as not supported.  However, we
should pass ANYARRAYOID if the column is an array type. This commit
fixes the issue.

Also, relevant test cases are added.