### PR TITLE
[Travis] use libapr1 from apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ os:
 language: c
 sudo: false
 
+cache: ccache
 git:
   submodules: false
 
@@ -117,3 +118,5 @@ notifications:
       - releng@pivotal.io
     on_success: change
     on_failure: always
+
+after_script: ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
     - python-dev
     - python-yaml
     - libsnmp-dev
+    - libapr1-dev
 
 ## ----------------------------------------------------------------------
 ## Build tools
@@ -60,29 +61,9 @@ install:
   - pip install --user paramiko
   - pip install --user setuptools
 
-## ----------------------------------------------------------------------
-## Build APR & APR-UTIL used to build gpfdist
-## ----------------------------------------------------------------------
-
 env:
-  - APR=apr-1.6.5
-    APR_UTIL=apr-util-1.6.1
-    CC=gcc-6
+  - CC=gcc-6
     CXX=g++-6
-
-before_script:
-  - export PATH=${TRAVIS_BUILD_DIR}/tools/bin:$PATH
-  - cd ${TRAVIS_BUILD_DIR}
-  - wget http://ftp.jaist.ac.jp/pub/apache/apr/${APR}.tar.gz
-  - wget http://ftp.jaist.ac.jp/pub/apache/apr/${APR_UTIL}.tar.gz
-  - tar xf ${APR}.tar.gz
-  - tar xf ${APR_UTIL}.tar.gz
-  - cd ${TRAVIS_BUILD_DIR}/${APR}
-  - ./configure --prefix=${TRAVIS_BUILD_DIR}/tools
-  - make install
-  - cd ${TRAVIS_BUILD_DIR}/${APR_UTIL}
-  - ./configure --prefix=${TRAVIS_BUILD_DIR}/tools --with-apr=${TRAVIS_BUILD_DIR}/${APR}
-  - make install
 
 ## ----------------------------------------------------------------------
 ## Perform build:
@@ -92,7 +73,7 @@ before_script:
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --with-apr-config=${TRAVIS_BUILD_DIR}/tools/bin/apr-1-config --disable-orca --disable-gpcloud --enable-pxf --enable-mapreduce --with-perl --enable-snmp
+  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --disable-orca --disable-gpcloud --enable-pxf --enable-mapreduce --with-perl --enable-snmp
 
   - make
   - make install


### PR DESCRIPTION
## Use APR from apt
The Apache Portable Runtime (APR) is not a direct dependency of the Greenplum server, but it's depended upon by `gpfdist` and `gpperfmon`. Judging from the code, we don't seem to depend on any (very) particular version of APR, as long as it's something recent-ish (say 1.5.0+).

Commit 168f612a73e (#58) started our Travis CI config with directly downloading APR from Apache releases. This was probably due to the fact that Travis in 2015 was still running Ubuntu 12.04 Precise with an old version of APR. Over the years, updating APR has been a recurrent biannual ritual, see commits 530db5ea71e (#5873), 27adcf92a13, 19251f3ff72, 5a9885f4f84, 2c68384e510.

This patch ends that fun madness by installing `libapr1-dev` from apt. Interestingly APU (a sister library of APR) wasn't needed in Travis: when we started using Travis (in commit 168f612a73e #58), we were building APU, but APU is really _only_ a dependency of `gpperfmon`, which we _never_ built in Travis.

In passing, I also teach Travis to speed up pull requests by using ccache across builds.

## Should I review this work-in-progress? I don't review WIP
This PR is actually good to review. I'm writing an essay to fill in here (and in the commit messages)

- [x] write longer PR description
- [x] squash the first two commits
- [x] write clearer commit messages
- [ ] should we keep the ccache hit rate at the end?
- [x] why didn't we need apu?

