### PR TITLE
For 5x: Fts prober free current components snapshot for every loop

### DIFF
--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -516,9 +516,12 @@ void FtsLoop()
 
 		MemoryContextSwitchTo(oldContext);
 
+		/* free current segments info and IP address caches */
+		freeCdbComponentDatabases(cdb_component_dbs);
+		cdb_component_dbs = NULL;
+
 		/* free any pallocs we made inside probeSegments() */
 		MemoryContextReset(probeContext);
-		cdb_component_dbs = NULL;
 
 		if (!FtsIsActive())
 		{


### PR DESCRIPTION
Fts prober is supposed to free current components snapshot and create
a brand new snapshot of current components in the cluster for every
loop to make sure fts prober not misled by outdated components info
and outdated <hostname, ip> caches.

linked to https://github.com/greenplum-db/gpdb/pull/5748