### PR TITLE
Fix compilation error without curl

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1818,7 +1818,7 @@ curl_not_compiled_error(void)
 }
 
 URL_FILE *
-url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, int *response_code, const char **response_string)
+url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 {
 	curl_not_compiled_error();
 	return NULL; /* keep compiler quiet */


### PR DESCRIPTION
Commit df050f9bfd9 changed the signature of url_curl_fopen but left
behind the stub for when we configure the server without linking to
libcurl. This patch fixes the following compilation error:

```
make[4]: Entering directory '/home/pivotal/src/pvtl/gpdb/src/backend/access/external'
ccache clang-8 -O3 -std=gnu99  -Wall -Wmissing-prototypes
-Wpointer-arith -Wendif-labels -Wmissing-format-attribute
-Wformat-security -fno-strict-aliasing -fwrapv -Wno-address
-Wno-unused-command-line-argument -g -ggdb -Werror=uninitialized
-Werror=implicit-function-declaration -I../../../../src/include
-D_GNU_SOURCE   -c -o url_curl.o url_curl.c -MMD -MP -MF
.deps/url_curl.Po
url_curl.c:1821:1: error: conflicting types for 'url_curl_fopen'
url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, int *response_code, const char **response_string)
^
../../../../src/include/access/url.h:88:18: note: previous declaration is here
extern URL_FILE *url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate);
                 ^
1 error generated.
../../../../src/Makefile.global:768: recipe for target 'url_curl.o'
failed

```