### PR TITLE
Introduce 'latestCompletedDxid' to determine xmax of distributed snapshot

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -360,6 +360,14 @@ ProcArrayRemove(PGPROC *proc, TransactionId latestXid)
 		Assert(!TransactionIdIsValid(allPgXact[proc->pgprocno].xid));
 	}
 
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		DistributedTransactionId gxid = allTmGxact[proc->pgprocno].gxid;
+		if (InvalidDistributedTransactionId != gxid &&
+			TransactionIdPrecedes(ShmemVariableCache->latestCompletedDxid, gxid))
+			ShmemVariableCache->latestCompletedDxid = gxid;
+	}
+
 	for (index = 0; index < arrayP->numProcs; index++)
 	{
 		if (arrayP->pgprocnos[index] == proc->pgprocno)
@@ -385,6 +393,11 @@ void
 ProcArrayEndGxact(void)
 {
 	Assert(LWLockHeldByMe(ProcArrayLock));
+	DistributedTransactionId gxid = MyTmGxact->gxid;
+
+	if (InvalidDistributedTransactionId != gxid &&
+		TransactionIdPrecedes(ShmemVariableCache->latestCompletedDxid, gxid))
+		ShmemVariableCache->latestCompletedDxid = gxid;
 	initGxact(MyTmGxact);
 }
 
@@ -1781,14 +1794,7 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	if (*shmNumCommittedGxacts != 0)
 		elog(ERROR, "Create distributed snapshot before DTM recovery finish");
 
-	xmin = LastDistributedTransactionId;
-
-	/*
-	 * This is analogous to the code in GetSnapshotData() (which calls
-	 * ReadNewTransactionId(), the distributed-xmax of a transaction is the
-	 * last distributed-xmax available
-	 */
-	xmax = getMaxDistributedXid();
+	xmin = xmax = ShmemVariableCache->latestCompletedDxid + 1;
 
 	/*
 	 * initialize for calculation with xmax, the calculation for this is on

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -105,6 +105,8 @@ typedef struct VariableCacheData
 	 */
 	TransactionId latestCompletedXid;	/* newest XID that has committed or
 										 * aborted */
+	TransactionId latestCompletedDxid;	/* newest distributed XID that has
+										   committed or aborted */
 } VariableCacheData;
 
 typedef VariableCacheData *VariableCache;

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -259,7 +259,6 @@ typedef struct TMGALLXACTSTATUS
 typedef struct TmControlBlock
 {
 	LWLockId					ControlLock;
-	slock_t 					ControlSeqnoLock;
 
 	bool						recoverred;
 	DistributedTransactionTimeStamp	distribTimeStamp;
@@ -281,6 +280,7 @@ extern DtxContext DistributedTransactionContext;
 /* state variables for how much of the log file has been flushed */
 extern volatile bool *shmDtmStarted;
 extern volatile DistributedTransactionTimeStamp *shmDistribTimeStamp;
+extern volatile DistributedTransactionId *shmGIDSeq;
 extern uint32 *shmNextSnapshotId;
 extern TMGXACT_LOG *shmCommittedGxactArray;
 extern volatile int *shmNumCommittedGxacts;
@@ -303,7 +303,6 @@ extern void getDtxLogInfo(TMGXACT_LOG *gxact_log);
 extern bool notifyCommittedDtxTransactionIsNeeded(void);
 extern void notifyCommittedDtxTransaction(void);
 extern void	rollbackDtxTransaction(void);
-extern DistributedTransactionId getMaxDistributedXid(void);
 
 extern bool includeInCheckpointIsNeeded(TMGXACT *gxact);
 extern void insertingDistributedCommitted(void);


### PR DESCRIPTION
Use the same idea of 'latestCompletedXid' in upstream 6bd4f40.

'shmGidSeq' is written under the protection of spinlock 'ControlSeqnoLock' while
reading directly in CreateDistributedSnapshot(), it seems wrong. Determine the
xmax with 'latestCompletedDxid' can get rid of the reading of 'shmGidSeq'.