### PR TITLE
Relax the rules on combinations of UNIQUE/PRIMARY KEY, and DISTRIBUTED BY.

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -473,11 +473,17 @@
               <codeph>gp_create_table_random_default_distribution</codeph> controls the default
             table distribution policy if the <cmdname>DISTRIBUTED BY</cmdname> clause is not
             specified when you create a table. Greenplum Database follows these rules to create a
-            table if a distribution policy is not specified.<p>If the value of the parameter is
+            table if a distribution policy is not specified.
+	    <p>If the value of the parameter is
                 <codeph>off</codeph> (the default), Greenplum Database chooses the table
-              distribution key based on the command. If the <cmdname>LIKE</cmdname> or
-                <cmdname>INHERITS</cmdname> clause is specified in table creation command, the
-              created table uses the same distribution key as the source or parent table. </p><p>If
+		distribution key based on the command. If the <cmdname>LIKE</cmdname> or
+                <cmdname>INHERITS</cmdname> clause is specified, the distribution key
+		is copied from the source or parent table. If the PRIMARY KEY or UNIQUE
+		constraints were specified, the largest subset of all the key columns is used
+		as the distribution key. Finally, if there are no constraints nor
+		<cmdname>LIKE</cmdname>/<cmdname>INHERITS</cmdname>, the first column is chosen.
+	    </p>
+	    <p>If
               the value of the parameter is set to <codeph>on</codeph>, Greenplum Database follows
               these rules:<ul id="ul_tbr_5kq_kq">
                 <li>If <cmdname>PRIMARY KEY</cmdname> or <cmdname>UNIQUE</cmdname> columns are not

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1730,8 +1730,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 	List		*distrkeys = NIL;
 	/* By default tables should be distributed on ALL segments */
 	int			numsegments = GP_POLICY_ALL_NUMSEGMENTS;
-	int		numUniqueIndexes = 0;
-	Constraint	*uniqueindex = NULL;
+	ListCell   *lc;
 
 	/*
 	 * utility mode creates can't have a policy.  Only the QD can have policies
@@ -1749,7 +1748,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 	/* Check replicated policy */
 	if (distributedBy && distributedBy->ptype == POLICYTYPE_REPLICATED)
 	{
-		if (cxt->inhRelations != NIL)	
+		if (cxt->inhRelations != NIL)
 			ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("INHERITS clause cannot be used with DISTRIBUTED REPLICATED clause")));
@@ -1767,93 +1766,78 @@ transformDistributedBy(CreateStmtContext *cxt,
 	 * If distributedBy is NIL, the user did not explicitly say what he
 	 * wanted for a distribution policy.  So, we need to assign one.
 	 */
-	if (distrkeys == NIL && cxt && cxt->pkey != NULL)
+	if (distrkeys == NIL)
 	{
 		/*
-		 * We have a PRIMARY KEY, so let's assign the default distribution
-		 * to be the key
+		 * If we have a PRIMARY KEY or UNIQUE constraints, derive the distribution key
+		 * from them.
+		 *
+		 * The distribution key chosen to be the largest common subset of columns, across
+		 * all the PRIMARY KEY / UNIQUE constraints.
 		 */
-
-		IndexStmt  *index = cxt->pkey;
-		List	   *indexParams;
-		ListCell   *ip = NULL;
-
-		Assert(index->indexParams != NULL);
-		indexParams = index->indexParams;
-
-		foreach(ip, indexParams)
+		/* begin with the PRIMARY KEY, if any */
+		if (cxt->pkey != NULL)
 		{
-			IndexElem  *iparam = lfirst(ip);
+			IndexStmt  *index = cxt->pkey;
+			List	   *indexParams;
+			ListCell   *ip;
 
-			if (iparam && iparam->name != 0)
+			Assert(index->indexParams != NULL);
+			indexParams = index->indexParams;
+
+			foreach(ip, indexParams)
 			{
-				distrkeys = lappend(distrkeys, (Node *) makeString(iparam->name));
-			}
-		}
-	}
+				IndexElem  *iparam = lfirst(ip);
 
-	if (cxt && cxt->ixconstraints != NULL)
-	{
-		ListCell   *lc = NULL;
-
-		foreach(lc, cxt->ixconstraints)
-		{
-			Constraint *cons = lfirst(lc);
-
-			if (cons->contype == CONSTR_UNIQUE)
-			{
-				if (uniqueindex == NULL)
-					uniqueindex = cons;
-
-				numUniqueIndexes++;
-
-				if (cxt->pkey)
+				if (iparam && iparam->name != 0)
 				{
-					ereport(ERROR,
-							(errcode(ERRCODE_SYNTAX_ERROR),
-							 errmsg("Greenplum Database does not allow having both PRIMARY KEY and UNIQUE constraints")));
+					distrkeys = lappend(distrkeys, (Node *) makeString(iparam->name));
 				}
 			}
 		}
-		if (numUniqueIndexes > 1)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("Greenplum Database does not allow having multiple UNIQUE constraints")));
-		}
-	}
 
-	if (distrkeys == NIL && cxt && cxt->ixconstraints != NULL &&
-		numUniqueIndexes > 0)
-	{
-		/*
-		 * No explicit distributed by clause, and no primary key.
-		 * If there is a UNIQUE clause, let's use that
-		 */
-		ListCell   *lc;
-
+		/* walk through all UNIQUE constraints next. */
 		foreach(lc, cxt->ixconstraints)
 		{
+			Constraint *constraint = (Constraint *) lfirst(lc);
+			ListCell   *ip;
+			List	   *new_distrkeys = NIL;
 
-			Constraint *constraint = lfirst(lc);
+			if (constraint->contype != CONSTR_UNIQUE)
+				continue;
 
-			if (constraint->contype == CONSTR_UNIQUE)
+			if (distrkeys)
 			{
-
-				ListCell   *ip;
-
+				/*
+				 * We saw a PRIMARY KEY or UNIQUE constraint already. Find
+				 * the columns that are present in the key chosen so far,
+				 * and this constraint.
+				 */
 				foreach(ip, constraint->keys)
 				{
 					Value	   *v = lfirst(ip);
 
-					if (v && v->val.str != 0)
-					{
-						distrkeys = lappend(distrkeys, (Node *) makeString(v->val.str));
-					}
+					if (list_member(distrkeys, v))
+						new_distrkeys = lappend(new_distrkeys, v);
 				}
-			}
-		}
 
+				/* If there were no common columns, we're out of luck. */
+				if (new_distrkeys == NIL)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+							 errmsg("UNIQUE or PRIMARY KEY definitions are incompatible with each other"),
+							 errhint("When there are multiple PRIMARY KEY / UNIQUE constraints, they must have at least one column in common.")));
+			}
+			else
+			{
+				/*
+				 * No distribution key chosen yet. Use this key as is.
+				 */
+				new_distrkeys = constraint->keys;
+			}
+
+			distrkeys = new_distrkeys;
+		}
 	}
 
 	/*
@@ -1979,7 +1963,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 	if (gp_create_table_random_default_distribution && NIL == distrkeys)
 	{
 		Assert(NULL == likeDistributedBy);
-		
+
 		if (!bQuiet)
 		{
 			ereport(NOTICE,
@@ -1987,7 +1971,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 				 errmsg("Using default RANDOM distribution since no distribution was specified."),
 				 errhint("Consider including the 'DISTRIBUTED BY' clause to determine the distribution of rows.")));
 		}
-		
+
 		/*
 		 * Create with default distribution policy and numsegments.
 		 */
@@ -2214,61 +2198,82 @@ transformDistributedBy(CreateStmtContext *cxt,
 	/*
 	 * Ok, we have decided on the distribution key columns now, and have the column
 	 * names in 'distrkeys'. Perform last cross-checks between UNIQUE and PRIMARY KEY
-	 * constraints and the chosen distribution key.
+	 * constraints and the chosen distribution key. (These tests should always pass,
+	 * if the distribution key was derived from the PRIMARY KEY or UNIQUE constraints,
+	 * but it doesn't hurt to check even in those cases.)
 	 */
-	if (cxt && cxt->pkey)	/* Primary key	specified.	Make sure
-								 * distribution columns match */
+	if (cxt && cxt->pkey)
 	{
+		/* The distribution key must be a subset of the primary key */
 		IndexStmt  *index = cxt->pkey;
-		List	   *indexParams = index->indexParams;
-		ListCell   *ip;
 		ListCell   *dk;
 
-		forboth(ip, indexParams, dk, distrkeys)
+		foreach(dk, distrkeys)
 		{
-			IndexElem  *iparam = lfirst(ip);
 			char	   *distcolname = strVal(lfirst(dk));
+			ListCell   *ip;
+			bool		found = false;
 
-			if (!iparam->name)
-				elog(ERROR, "PRIMARY KEY on an expresion index not supported");
+			foreach(ip, index->indexParams)
+			{
+				IndexElem  *iparam = lfirst(ip);
 
-			if (strcmp(iparam->name, distcolname) != 0)
+				if (!iparam->name)
+					elog(ERROR, "PRIMARY KEY on an expression index not supported");
+
+				if (strcmp(iparam->name, distcolname) == 0)
+				{
+					found = true;
+					break;
+				}
+			}
+
+			if (!found)
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-						 errmsg("PRIMARY KEY and DISTRIBUTED BY definitions incompatible"),
-						 errhint("When there is both a PRIMARY KEY, and a "
-								 "DISTRIBUTED BY clause, the DISTRIBUTED BY "
-								 "clause must be equal to or a left-subset "
-								 "of the PRIMARY KEY")));
+						 errmsg("PRIMARY KEY and DISTRIBUTED BY definitions are incompatible"),
+						 errhint("When there is both a PRIMARY KEY and a DISTRIBUTED BY clause, the DISTRIBUTED BY clause must be a subset of the PRIMARY KEY.")));
 			}
 		}
 	}
 
-	if (uniqueindex) /* UNIQUE specified.  Make sure distribution
-								 * columns match */
+	/* Make sure distribution columns match any UNIQUE and PRIMARY KEY constraints. */
+	foreach (lc, cxt->ixconstraints)
 	{
-		List	   *keys = uniqueindex->keys;
-		ListCell   *ip;
+		Constraint *constraint = (Constraint *) lfirst(lc);
 		ListCell   *dk;
 
-		forboth(ip, keys, dk, distrkeys)
+		if (constraint->contype != CONSTR_PRIMARY &&
+			constraint->contype != CONSTR_UNIQUE)
+			continue;
+
+		foreach(dk, distrkeys)
 		{
-			IndexElem  *iparam = lfirst(ip);
 			char	   *distcolname = strVal(lfirst(dk));
+			ListCell   *ip;
+			bool		found = false;
 
-			if (!iparam->name)
-				elog(ERROR, "UNIQUE constraint on an expresion index not supported");
+			foreach (ip, constraint->keys)
+			{
+				IndexElem  *iparam = lfirst(ip);
 
-			if (strcmp(iparam->name, distcolname) != 0)
+				if (!iparam->name)
+					elog(ERROR, "UNIQUE constraint on an expression index not supported");
+
+				if (strcmp(iparam->name, distcolname) == 0)
+				{
+					found = true;
+					break;
+				}
+			}
+
+			if (!found)
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-						 errmsg("UNIQUE constraint and DISTRIBUTED BY definitions incompatible"),
-						 errhint("When there is both a UNIQUE constraint, "
-								 "and a DISTRIBUTED BY clause, the "
-								 "DISTRIBUTED BY clause must be equal to "
-								 "or a left-subset of the UNIQUE columns")));
+						 errmsg("UNIQUE constraint and DISTRIBUTED BY definitions are incompatible"),
+						 errhint("When there is both a UNIQUE constraint and a DISTRIBUTED BY clause, the DISTRIBUTED BY clause must be a subset of the UNIQUE constraint.")));
 			}
 		}
 	}

--- a/src/test/regress/expected/gpdist.out
+++ b/src/test/regress/expected/gpdist.out
@@ -452,19 +452,60 @@ drop table mpp5746, mpp5746_2;
 --
 create table distby_with_constraint (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED RANDOMLY;
 ERROR:  PRIMARY KEY and DISTRIBUTED RANDOMLY are incompatible
-create table distby_with_constraint (col1 int4 UNIQUE, col2 int4) DISTRIBUTED RANDOMLY;
+create table distby_with_constraint (col1 int4 UNIQUE,      col2 int4) DISTRIBUTED RANDOMLY;
 ERROR:  UNIQUE and DISTRIBUTED RANDOMLY are incompatible
 create table distby_with_constraint (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED BY (col2);
-ERROR:  PRIMARY KEY and DISTRIBUTED BY definitions incompatible
-HINT:  When there is both a PRIMARY KEY, and a DISTRIBUTED BY clause, the DISTRIBUTED BY clause must be equal to or a left-subset of the PRIMARY KEY
-create table distby_with_constraint (col1 int4 UNIQUE, col2 int4) DISTRIBUTED BY (col2);
-ERROR:  UNIQUE constraint and DISTRIBUTED BY definitions incompatible
-HINT:  When there is both a UNIQUE constraint, and a DISTRIBUTED BY clause, the DISTRIBUTED BY clause must be equal to or a left-subset of the UNIQUE columns
+ERROR:  PRIMARY KEY and DISTRIBUTED BY definitions are incompatible
+HINT:  When there is both a PRIMARY KEY and a DISTRIBUTED BY clause, the DISTRIBUTED BY clause must be a subset of the PRIMARY KEY.
+create table distby_with_constraint (col1 int4 UNIQUE,      col2 int4) DISTRIBUTED BY (col2);
+ERROR:  UNIQUE constraint and DISTRIBUTED BY definitions are incompatible
+HINT:  When there is both a UNIQUE constraint and a DISTRIBUTED BY clause, the DISTRIBUTED BY clause must be a subset of the UNIQUE constraint.
+create table distby_with_constraint (col1 int4, col2 int4, col3 int4, UNIQUE      (col1, col2)) distributed by (col3);
+ERROR:  UNIQUE constraint and DISTRIBUTED BY definitions are incompatible
+HINT:  When there is both a UNIQUE constraint and a DISTRIBUTED BY clause, the DISTRIBUTED BY clause must be a subset of the UNIQUE constraint.
+create table distby_with_constraint (col1 int4, col2 int4, col3 int4, UNIQUE      (col1), UNIQUE (col2));
+ERROR:  UNIQUE or PRIMARY KEY definitions are incompatible with each other
+HINT:  When there are multiple PRIMARY KEY / UNIQUE constraints, they must have at least one column in common.
+create table distby_with_constraint (col1 int4, col2 int4, col3 int4, UNIQUE      (col1), PRIMARY KEY (col2));
+ERROR:  UNIQUE or PRIMARY KEY definitions are incompatible with each other
+HINT:  When there are multiple PRIMARY KEY / UNIQUE constraints, they must have at least one column in common.
 -- these are allowed
-create table distby_with_constraint1 (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED BY (col1);
-create table distby_with_constraint2 (col1 int4 UNIQUE, col2 int4) DISTRIBUTED BY (col1);
-create table distby_with_constraint3 (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED REPLICATED;
-create table distby_with_constraint4 (col1 int4 UNIQUE, col2 int4) DISTRIBUTED REPLICATED;
+create table distby_with_constraint01 (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED BY (col1);
+create table distby_with_constraint02 (col1 int4 UNIQUE,      col2 int4) DISTRIBUTED BY (col1);
+create table distby_with_constraint03 (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED REPLICATED;
+create table distby_with_constraint04 (col1 int4 UNIQUE,      col2 int4) DISTRIBUTED REPLICATED;
+-- More complicated cases. Allowed.
+create table distby_with_constraint11 (col1 int4, col2 int4, UNIQUE      (col1, col2)) distributed by (col1);
+create table distby_with_constraint12 (col1 int4, col2 int4, PRIMARY KEY (col1, col2)) distributed by (col1);
+create table distby_with_constraint13 (col1 int4, col2 int4, UNIQUE      (col1, col2)) distributed by (col2);
+create table distby_with_constraint14 (col1 int4, col2 int4, PRIMARY KEY (col1, col2)) distributed by (col2);
+create table distby_with_constraint15 (col1 int4, col2 int4, UNIQUE      (col1, col2)) distributed by (col2, col1);
+create table distby_with_constraint16 (col1 int4, col2 int4, PRIMARY KEY (col1, col2)) distributed by (col2, col1);
+create table distby_with_constraint17 (col1 int4, col2 int4, UNIQUE      (col1, col2)) distributed by (col1, col2);
+create table distby_with_constraint18 (col1 int4, col2 int4, PRIMARY KEY (col1, col2)) distributed by (col1, col2);
+-- Test deriving the distribution key from constraint columns.
+create table distby_with_constraint21 (col1 int4, col2 int4, col3 int4, UNIQUE      (col1, col2), UNIQUE (col3, col1));
+create table distby_with_constraint22 (col1 int4, col2 int4, col3 int4, UNIQUE      (col1, col2), PRIMARY KEY (col3, col1));
+-- Check what distribution key was chosen for all the cases above.
+select c.relname, policytype, attrnums from pg_class c, gp_distribution_policy p where c.oid = p.localoid and relname LIKE 'distby_with_%' order by relname;
+         relname          | policytype | attrnums 
+--------------------------+------------+----------
+ distby_with_constraint01 | p          | {1}
+ distby_with_constraint02 | p          | {1}
+ distby_with_constraint03 | r          | 
+ distby_with_constraint04 | r          | 
+ distby_with_constraint11 | p          | {1}
+ distby_with_constraint12 | p          | {1}
+ distby_with_constraint13 | p          | {2}
+ distby_with_constraint14 | p          | {2}
+ distby_with_constraint15 | p          | {2,1}
+ distby_with_constraint16 | p          | {2,1}
+ distby_with_constraint17 | p          | {1,2}
+ distby_with_constraint18 | p          | {1,2}
+ distby_with_constraint21 | p          | {1}
+ distby_with_constraint22 | p          | {1}
+(14 rows)
+
 --
 -- Test that DISTRIBUTED BY is interpreted correctly with inheritance.
 --

--- a/src/test/regress/expected/typed_table.out
+++ b/src/test/regress/expected/typed_table.out
@@ -43,13 +43,14 @@ ERROR:  cannot change inheritance of typed table
 CREATE TABLE personsx OF person_type (myname WITH OPTIONS NOT NULL); -- error
 ERROR:  column "myname" does not exist
 -- This test comes from postgres, and we expect it to fail on Greenplum
--- because Greenplum does not support both primary keys and unique constraints
--- at the same time.
+-- because Greenplum does not support having two primary key / unique
+-- constraints with no columns in common.
 CREATE TABLE persons2 OF person_type (
     id WITH OPTIONS PRIMARY KEY,
     UNIQUE (name)
 );
-ERROR:  Greenplum Database does not allow having both PRIMARY KEY and UNIQUE constraints
+ERROR:  UNIQUE or PRIMARY KEY definitions are incompatible with each other
+HINT:  When there are multiple PRIMARY KEY / UNIQUE constraints, they must have at least one column in common.
 \d persons2
 -- These are added for Greenplum, as the previous table creation statement
 -- should have failed.

--- a/src/test/regress/sql/gpdist.sql
+++ b/src/test/regress/sql/gpdist.sql
@@ -392,15 +392,38 @@ drop table mpp5746, mpp5746_2;
 -- constraints
 --
 create table distby_with_constraint (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED RANDOMLY;
-create table distby_with_constraint (col1 int4 UNIQUE, col2 int4) DISTRIBUTED RANDOMLY;
+create table distby_with_constraint (col1 int4 UNIQUE,      col2 int4) DISTRIBUTED RANDOMLY;
 create table distby_with_constraint (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED BY (col2);
-create table distby_with_constraint (col1 int4 UNIQUE, col2 int4) DISTRIBUTED BY (col2);
+create table distby_with_constraint (col1 int4 UNIQUE,      col2 int4) DISTRIBUTED BY (col2);
+
+create table distby_with_constraint (col1 int4, col2 int4, col3 int4, UNIQUE      (col1, col2)) distributed by (col3);
+create table distby_with_constraint (col1 int4, col2 int4, col3 int4, UNIQUE      (col1), UNIQUE (col2));
+create table distby_with_constraint (col1 int4, col2 int4, col3 int4, UNIQUE      (col1), PRIMARY KEY (col2));
 
 -- these are allowed
-create table distby_with_constraint1 (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED BY (col1);
-create table distby_with_constraint2 (col1 int4 UNIQUE, col2 int4) DISTRIBUTED BY (col1);
-create table distby_with_constraint3 (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED REPLICATED;
-create table distby_with_constraint4 (col1 int4 UNIQUE, col2 int4) DISTRIBUTED REPLICATED;
+create table distby_with_constraint01 (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED BY (col1);
+create table distby_with_constraint02 (col1 int4 UNIQUE,      col2 int4) DISTRIBUTED BY (col1);
+create table distby_with_constraint03 (col1 int4 PRIMARY KEY, col2 int4) DISTRIBUTED REPLICATED;
+create table distby_with_constraint04 (col1 int4 UNIQUE,      col2 int4) DISTRIBUTED REPLICATED;
+
+-- More complicated cases. Allowed.
+create table distby_with_constraint11 (col1 int4, col2 int4, UNIQUE      (col1, col2)) distributed by (col1);
+create table distby_with_constraint12 (col1 int4, col2 int4, PRIMARY KEY (col1, col2)) distributed by (col1);
+create table distby_with_constraint13 (col1 int4, col2 int4, UNIQUE      (col1, col2)) distributed by (col2);
+create table distby_with_constraint14 (col1 int4, col2 int4, PRIMARY KEY (col1, col2)) distributed by (col2);
+
+create table distby_with_constraint15 (col1 int4, col2 int4, UNIQUE      (col1, col2)) distributed by (col2, col1);
+create table distby_with_constraint16 (col1 int4, col2 int4, PRIMARY KEY (col1, col2)) distributed by (col2, col1);
+create table distby_with_constraint17 (col1 int4, col2 int4, UNIQUE      (col1, col2)) distributed by (col1, col2);
+create table distby_with_constraint18 (col1 int4, col2 int4, PRIMARY KEY (col1, col2)) distributed by (col1, col2);
+
+-- Test deriving the distribution key from constraint columns.
+create table distby_with_constraint21 (col1 int4, col2 int4, col3 int4, UNIQUE      (col1, col2), UNIQUE (col3, col1));
+create table distby_with_constraint22 (col1 int4, col2 int4, col3 int4, UNIQUE      (col1, col2), PRIMARY KEY (col3, col1));
+
+-- Check what distribution key was chosen for all the cases above.
+select c.relname, policytype, attrnums from pg_class c, gp_distribution_policy p where c.oid = p.localoid and relname LIKE 'distby_with_%' order by relname;
+
 
 --
 -- Test that DISTRIBUTED BY is interpreted correctly with inheritance.

--- a/src/test/regress/sql/typed_table.sql
+++ b/src/test/regress/sql/typed_table.sql
@@ -25,8 +25,8 @@ ALTER TABLE persons INHERIT stuff;
 CREATE TABLE personsx OF person_type (myname WITH OPTIONS NOT NULL); -- error
 
 -- This test comes from postgres, and we expect it to fail on Greenplum
--- because Greenplum does not support both primary keys and unique constraints
--- at the same time.
+-- because Greenplum does not support having two primary key / unique
+-- constraints with no columns in common.
 CREATE TABLE persons2 OF person_type (
     id WITH OPTIONS PRIMARY KEY,
     UNIQUE (name)


### PR DESCRIPTION
Allow specifying multiple UNIQUE constraints in the CREATE TABLE command,
or PRIMARY KEY and UNIQUE constraints, as long as they are all compatible
with the DISTRIBUTED BY clause.

Don't require the constraint's key columns to be a left-subset of the
DISTRIBUTED BY clause. It still needs to be a subset, but any subset will
do.

Likewise adjust the rules for deriving the distribution key from the
constraints, if no DISTRIBUTED BY was given, to choose the largest common
subset across all constraints.

Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/OJzz8I6WuVI/tMB8GcXdAgAJ