### PR TITLE
Only perform SIRV function transformation in the target list of DML

### DIFF
--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -1576,121 +1576,101 @@ insert into PLine values ('PL.001', '-0', 'Central call', 'PS.base.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.002', '-101', '', 'PS.base.ta2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.003', '-102', '', 'PS.base.ta3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.004', '-103', '', 'PS.base.ta5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.005', '-104', '', 'PS.base.ta6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.006', '-106', '', 'PS.base.tb2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.007', '-108', '', 'PS.base.tb3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.008', '-109', '', 'PS.base.tb4');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.009', '-121', '', 'PS.base.tb5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.010', '-122', '', 'PS.base.tb6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.015', '-134', '', 'PS.first.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.016', '-137', '', 'PS.first.ta3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.017', '-139', '', 'PS.first.ta4');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.018', '-362', '', 'PS.first.tb1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.019', '-363', '', 'PS.first.tb2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.020', '-364', '', 'PS.first.tb3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.021', '-365', '', 'PS.first.tb5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.022', '-367', '', 'PS.first.tb6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.028', '-501', 'Fax entrance', 'PS.base.ta2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.029', '-502', 'Fax first floor', 'PS.first.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 --
 -- Buy some phones, plug them into the wall and patch the
@@ -1700,28 +1680,24 @@ insert into PHone values ('PH.hc001', 'Hicom standard', 'WS.001.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function tg_slotlink_set(character,character) line 38 at SQL statement
-SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function tg_slotlink_a() line 7 at assignment
 update PSlot set slotlink = 'PS.base.ta1' where slotname = 'PS.base.a1';
 insert into PHone values ('PH.hc002', 'Hicom standard', 'WS.002.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function tg_slotlink_set(character,character) line 38 at SQL statement
-SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function tg_slotlink_a() line 7 at assignment
 update PSlot set slotlink = 'PS.base.ta5' where slotname = 'PS.base.b1';
 insert into PHone values ('PH.hc003', 'Hicom standard', 'WS.002.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function tg_slotlink_set(character,character) line 38 at SQL statement
-SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function tg_slotlink_a() line 7 at assignment
 update PSlot set slotlink = 'PS.base.tb2' where slotname = 'PS.base.b3';
 insert into PHone values ('PH.fax001', 'Canon fax', 'WS.001.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function tg_slotlink_set(character,character) line 38 at SQL statement
-SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function tg_slotlink_a() line 7 at assignment
 update PSlot set slotlink = 'PS.base.ta2' where slotname = 'PS.base.a3';
 --
@@ -1733,7 +1709,6 @@ ERROR:  function cannot execute on a QE slice because it issues a non-SELECT sta
 CONTEXT:  SQL statement "insert into HSlot (slotname, hubname, slotno, slotlink)
 		values ('HS.dummy', hname, i, '')"
 PL/pgSQL function tg_hub_adjustslots(character,integer,integer) line 11 at SQL statement
-SQL statement "SELECT tg_hub_adjustslots(new.name, 0, new.nslots)"
 PL/pgSQL function tg_hub_a() line 7 at assignment
 insert into System values ('orion', 'PC');
 insert into IFace values ('IF', 'orion', 'eth0', 'WS.002.1b');
@@ -4590,7 +4565,6 @@ SAVEPOINT a;
 select error2('nonexistent.stuffs');
 ERROR:  schema "nonexistent" does not exist
 CONTEXT:  SQL function "error1" statement 1
-SQL statement "SELECT error1(p_name_table)"
 PL/pgSQL function error2(text) line 3 at RETURN
 ROLLBACK TO a;
 select error2('public.stuffs');

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -1576,121 +1576,101 @@ insert into PLine values ('PL.001', '-0', 'Central call', 'PS.base.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.002', '-101', '', 'PS.base.ta2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.003', '-102', '', 'PS.base.ta3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.004', '-103', '', 'PS.base.ta5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.005', '-104', '', 'PS.base.ta6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.006', '-106', '', 'PS.base.tb2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.007', '-108', '', 'PS.base.tb3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.008', '-109', '', 'PS.base.tb4');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.009', '-121', '', 'PS.base.tb5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.010', '-122', '', 'PS.base.tb6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.015', '-134', '', 'PS.first.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.016', '-137', '', 'PS.first.ta3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.017', '-139', '', 'PS.first.ta4');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.018', '-362', '', 'PS.first.tb1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.019', '-363', '', 'PS.first.tb2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.020', '-364', '', 'PS.first.tb3');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.021', '-365', '', 'PS.first.tb5');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.022', '-367', '', 'PS.first.tb6');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.028', '-501', 'Fax entrance', 'PS.base.ta2');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 insert into PLine values ('PL.029', '-502', 'Fax first floor', 'PS.first.ta1');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from PSlot where slotname = myname"
 PL/pgSQL function tg_backlink_set(character,character) line 18 at SQL statement
-SQL statement "SELECT tg_backlink_set(new.backlink, new.slotname)"
 PL/pgSQL function tg_backlink_a() line 7 at assignment
 --
 -- Buy some phones, plug them into the wall and patch the
@@ -1700,28 +1680,24 @@ insert into PHone values ('PH.hc001', 'Hicom standard', 'WS.001.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function tg_slotlink_set(character,character) line 38 at SQL statement
-SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function tg_slotlink_a() line 7 at assignment
 update PSlot set slotlink = 'PS.base.ta1' where slotname = 'PS.base.a1';
 insert into PHone values ('PH.hc002', 'Hicom standard', 'WS.002.1a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
 CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function tg_slotlink_set(character,character) line 38 at SQL statement
-SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function tg_slotlink_a() line 7 at assignment
 update PSlot set slotlink = 'PS.base.ta5' where slotname = 'PS.base.b1';
 insert into PHone values ('PH.hc003', 'Hicom standard', 'WS.002.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function tg_slotlink_set(character,character) line 38 at SQL statement
-SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function tg_slotlink_a() line 7 at assignment
 update PSlot set slotlink = 'PS.base.tb2' where slotname = 'PS.base.b3';
 insert into PHone values ('PH.fax001', 'Canon fax', 'WS.001.2a');
 ERROR:  function cannot execute on a QE slice because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
 CONTEXT:  SQL statement "select          * from WSlot where slotname = myname"
 PL/pgSQL function tg_slotlink_set(character,character) line 38 at SQL statement
-SQL statement "SELECT tg_slotlink_set(new.slotlink, new.slotname)"
 PL/pgSQL function tg_slotlink_a() line 7 at assignment
 update PSlot set slotlink = 'PS.base.ta2' where slotname = 'PS.base.a3';
 --
@@ -1733,7 +1709,6 @@ ERROR:  function cannot execute on a QE slice because it issues a non-SELECT sta
 CONTEXT:  SQL statement "insert into HSlot (slotname, hubname, slotno, slotlink)
 		values ('HS.dummy', hname, i, '')"
 PL/pgSQL function tg_hub_adjustslots(character,integer,integer) line 11 at SQL statement
-SQL statement "SELECT tg_hub_adjustslots(new.name, 0, new.nslots)"
 PL/pgSQL function tg_hub_a() line 7 at assignment
 insert into System values ('orion', 'PC');
 insert into IFace values ('IF', 'orion', 'eth0', 'WS.002.1b');
@@ -4568,7 +4543,6 @@ SAVEPOINT a;
 select error2('nonexistent.stuffs');
 ERROR:  schema "nonexistent" does not exist
 CONTEXT:  SQL function "error1" statement 1
-SQL statement "SELECT error1(p_name_table)"
 PL/pgSQL function error2(text) line 3 at RETURN
 ROLLBACK TO a;
 select error2('public.stuffs');

--- a/src/test/regress/expected/qp_resource_queue.out
+++ b/src/test/regress/expected/qp_resource_queue.out
@@ -365,19 +365,16 @@ select tbl16369_func9();
 select tbl16369_func10(5);
 NOTICE:  Yo there I'm number 5, next: 4
 NOTICE:  Yo there I'm number 4, next: 3
-CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
-PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 3, next: 2
 CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 2, next: 1
 CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 1, next: 0
 CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
@@ -386,7 +383,6 @@ SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 INFO:  Alas we are at the end of our journey
 CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
@@ -397,7 +393,6 @@ SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
  tbl16369_func10 
 -----------------
@@ -410,19 +405,16 @@ PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 select tbl16369_func11(5);
 NOTICE:  Yo there I'm number 5, next: 4
 NOTICE:  Yo there I'm number 4, next: 3
-CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
-PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 3, next: 2
 CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 2, next: 1
 CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 1, next: 0
 CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
@@ -431,7 +423,6 @@ SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 INFO:  Alas we are at the end of our journey
 CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
@@ -442,7 +433,6 @@ SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
  tbl16369_func11 
 -----------------
@@ -479,19 +469,16 @@ select tbl16369_func12();
 select tbl16369_func1(),tbl16369_func2(),tbl16369_func4(),tbl16369_func5(),tbl16369_func10(5), tbl16369_func11(5), tbl16369_func12(), generate_series(1,10);
 NOTICE:  Yo there I'm number 5, next: 4
 NOTICE:  Yo there I'm number 4, next: 3
-CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
-PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 3, next: 2
 CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 2, next: 1
 CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 1, next: 0
 CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
@@ -500,7 +487,6 @@ SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 INFO:  Alas we are at the end of our journey
 CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
@@ -511,23 +497,19 @@ SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
 PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 5, next: 4
 NOTICE:  Yo there I'm number 4, next: 3
-CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
-PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 3, next: 2
 CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 2, next: 1
 CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 NOTICE:  Yo there I'm number 1, next: 0
 CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
@@ -536,7 +518,6 @@ SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
-SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 INFO:  Alas we are at the end of our journey
 CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
@@ -547,7 +528,626 @@ SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func10(param_numcount - 1)"
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func10(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 5, next: 4
+NOTICE:  Yo there I'm number 4, next: 3
+CONTEXT:  PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 3, next: 2
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 2, next: 1
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+NOTICE:  Yo there I'm number 1, next: 0
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+INFO:  Alas we are at the end of our journey
+CONTEXT:  SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
+SQL statement "SELECT tbl16369_func11(param_numcount - 1)"
+PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
 PL/pgSQL function tbl16369_func11(integer) line 8 at assignment
  tbl16369_func1 | tbl16369_func2 | tbl16369_func4 | tbl16369_func5 | tbl16369_func10 | tbl16369_func11 | tbl16369_func12 | generate_series 
 ----------------+----------------+----------------+----------------+-----------------+-----------------+-----------------+-----------------

--- a/src/test/regress/output/query_info_hook_test.source
+++ b/src/test/regress/output/query_info_hook_test.source
@@ -37,7 +37,6 @@ WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
 WARNING:  Plan node executing
-WARNING:  Plan node executing
 WARNING:  Query Canceling
 WARNING:  Query Canceled
 ERROR:  canceling statement due to user request


### PR DESCRIPTION
The SIRV transformation was preventing some PL/pgSQL expressions from
being treated as "simple". That's a lost optimization, and it also caused
some extra context lines being printed in error messages, compared to
upstream. While those context lines are harmless, and I wouldn't expect
GPDB necessarily to totally match upstream behavior on when and how error
context is printed, it's always nicer if we can match upstream, for the
sake of avoiding differences in expected output of regression tests.

There's one interesting test query in 'qp_resource_queue', where this
causes functions in target list to be called more times than before.
The case involves test functions, as well as a set-returning-function
(generate_series), being used in the same target list. The new behavior,
which is what PostgreSQL also does, is to call all the functions for
each row returned by generate_series(), whereas before this commit, they
were only called once. The behavior with set-returning-functions in
target list is pretty whacky in many ways, so I don't think there's any
principled way to say which is more correct, but following the upstream
always seems reasonable. However - and this perhaps not so reasonable -
the behavior is now different in a DML statement and a plain SELECT, as
we still do the SIRV transformation in DML statements, but think we
can live with that.