### PR TITLE
pg_upgrade: improve report about failure to match up old and new tables

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -205,6 +205,9 @@ typedef struct
 	Oid			reloid;			/* relation oid */
 	char		relstorage;
 	Oid			relfilenode;	/* relation relfile node */
+	/* GPDB_96_MERGE_FIXME: indtable and toastheap are backported from 9.6. */
+	Oid			indtable;		/* if index, OID of its table, else 0 */
+	Oid			toastheap;		/* if toast table, OID of base table, else 0 */
 	/* relation tablespace path, or "" for the cluster default */
 	char		tablespace[MAXPGPATH];
 


### PR DESCRIPTION
This is a partial backport of the following commit from upstream:

commit 8b4844cc8a33214b18b62eed6764b90b91da9065
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Fri May 6 14:23:45 2016 -0400

    Improve pg_upgrade's report about failure to match up old and new tables.

    Ordinarily, pg_upgrade shouldn't have any difficulty in matching up all
    the relations it sees in the old and new databases.  If it does, however,
    it just goes belly-up with a pretty unhelpful error message.  That seemed
    fine as long as we expected the case never to occur in the wild, but
    Alvaro reported that it had been seen in a database whose pg_largeobject
    table had somehow acquired a TOAST table.  That doesn't quite seem like
    a case that pg_upgrade actually needs to handle, but it would be good if
    the report were more diagnosable.  Hence, extend the logic to print out
    as much information as we can about the mismatch(es) before we quit.

    In passing, improve the readability of get_rel_infos()'s data collection
    query, which had suffered seriously from lets-not-bother-to-update-comments
    syndrome, and generally was unnecessarily disrespectful to readers.

    It could be argued that this is a bug fix, but given that we have so few
    reports, I don't feel a need to back-patch; at least not before this has
    baked awhile in HEAD.

We have omitted the changes to `get_rel_infos()` in order to (hopefully) minimize the risk of the backport.