### PR TITLE
Handle opendir() errors gracefully in gp_replica_check.

### DIFF
--- a/gpcontrib/gp_replica_check/gp_replica_check.c
+++ b/gpcontrib/gp_replica_check/gp_replica_check.c
@@ -538,6 +538,8 @@ gp_replica_check(PG_FUNCTION_ARGS)
 	char *relation_types = TextDatumGetCString(PG_GETARG_DATUM(2));
 	struct dirent *dent = NULL;
 	bool dir_equal = true;
+	DIR		   *primarydir;
+	DIR		   *mirrordir;
 
 	init_relation_types(relation_types);
 
@@ -548,9 +550,6 @@ gp_replica_check(PG_FUNCTION_ARGS)
 	mirrordirpath = psprintf("%s/%s",
 							 mirrordirpath,
 							 GetDatabasePath(MyDatabaseId, DEFAULTTABLESPACE_OID));
-
-	DIR *primarydir = AllocateDir(primarydirpath);
-	DIR *mirrordir = AllocateDir(mirrordirpath);
 
 	/*
 	 * Checkpoint, so that all the changes are on disk.
@@ -572,6 +571,7 @@ gp_replica_check(PG_FUNCTION_ARGS)
 	 * For each relfilenode in primary, if it is of type specified from user
 	 * input, do comparison with its corresponding file on the mirror
 	 */
+	primarydir = AllocateDir(primarydirpath);
 	while ((dent = ReadDir(primarydir, primarydirpath)) != NULL)
 	{
 		char primaryfilename[MAXPGPATH] = {'\0'};
@@ -614,6 +614,7 @@ gp_replica_check(PG_FUNCTION_ARGS)
 	FreeDir(primarydir);
 
 	/* Open up mirrordirpath and verify each mirror file exist in the primary hash table */
+	mirrordir = AllocateDir(mirrordirpath);
 	while ((dent = ReadDir(mirrordir, mirrordirpath)) != NULL)
 	{
 		char *d_name_copy;


### PR DESCRIPTION
The return value from AllocateDir() was not checked. That's not
mandatory, if you immediately pass the return value to ReadDir(), as
explained in the comment in ReadDir(), but you can't rely on that if
you do anything in between the calls that might change errno. We were
requesting a checkpoint, and doing many other things in between.

Also, don't try to open the directory in the mirror until after the
checkpoint. Before the checkpoint, the directory might not exist in
the mirror yet. (I don't think there's any guarantee that it will exist
after requesting the checkpoint either, but we're taking chances with
that here anyway. At least it makes it a lot more likely.)

I think this explains the occasional errors like:

ERROR:  could not open directory "/tmp/build/e18b2f02/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0/base/513914": Success (fd.c:2207)

that we've been seeing on the pipeline. Or at least, if this doesn't fix
them, we should now get a more correct error message than "Success".