### PR TITLE
Support optimization of replicated table queries in ORCA

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.2.", GPORCA_VERSION_STRING, 4);
+return strncmp("3.3.", GPORCA_VERSION_STRING, 4);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.2.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.3.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13625,7 +13625,7 @@ int
 main ()
 {
 
-return strncmp("3.2.", GPORCA_VERSION_STRING, 4);
+return strncmp("3.3.", GPORCA_VERSION_STRING, 4);
 
   ;
   return 0;
@@ -13635,7 +13635,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.2.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.3.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.2.0@gpdb/stable
+orca/v3.3.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -121,7 +121,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.2.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.3.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5181,9 +5181,18 @@ CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy
 												gpdb::GetGPSegmentCount());
 
 	GPOS_ASSERT(IMDRelation::EreldistrHash == dxlop->Ereldistrpolicy() ||
-				IMDRelation::EreldistrRandom == dxlop->Ereldistrpolicy());
-	
-	distr_policy->ptype = POLICYTYPE_PARTITIONED;
+				IMDRelation::EreldistrRandom == dxlop->Ereldistrpolicy() ||
+				IMDRelation::EreldistrReplicated == dxlop->Ereldistrpolicy()) ;
+
+	if (IMDRelation::EreldistrReplicated == dxlop->Ereldistrpolicy())
+	{
+		distr_policy->ptype = POLICYTYPE_REPLICATED;
+	}
+	else
+	{
+		distr_policy->ptype = POLICYTYPE_PARTITIONED;
+	}
+
 	distr_policy->nattrs = 0;
 	if (IMDRelation::EreldistrHash == dxlop->Ereldistrpolicy())
 	{

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -919,6 +919,11 @@ CTranslatorRelcacheToDXL::GetRelDistribution
 		return IMDRelation::EreldistrMasterOnly;
 	}
 
+	if (POLICYTYPE_REPLICATED == gp_policy->ptype)
+	{
+		return IMDRelation::EreldistrReplicated;
+	}
+
 	if (POLICYTYPE_PARTITIONED == gp_policy->ptype)
 	{
 		if (0 == gp_policy->nattrs)
@@ -2309,7 +2314,7 @@ CTranslatorRelcacheToDXL::RetrieveRelStats
 		BlockNumber pg_attribute_unused() pages = 0;
 		double pg_attribute_unused() allvisfrac = 0.0;
 		GpPolicy *gp_policy = gpdb::GetDistributionPolicy(rel);
-		if (!gp_policy ||gp_policy->ptype != POLICYTYPE_PARTITIONED)
+		if (!gp_policy || (gp_policy->ptype != POLICYTYPE_PARTITIONED && gp_policy->ptype != POLICYTYPE_REPLICATED))
 		{
 			gpdb::EstimateRelationSize(rel, NULL, &pages, &num_rows, &allvisfrac);
 		}

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -148,7 +148,7 @@ CTranslatorUtils::GetTableDescr
 	IMDRelation::Ereldistrpolicy distribution_policy = rel->GetRelDistribution();
 
 	if (NULL != is_distributed_table &&
-		(IMDRelation::EreldistrHash == distribution_policy || IMDRelation::EreldistrRandom == distribution_policy))
+		(IMDRelation::EreldistrHash == distribution_policy || IMDRelation::EreldistrRandom == distribution_policy || IMDRelation::EreldistrReplicated == distribution_policy))
 	{
 		*is_distributed_table = true;
 	}


### PR DESCRIPTION
This patch enables support for optimization of SELECT and INSERT statements for
replicated tables in ORCA.
UPDATE and DELETE statements are currently not supported in this patch.

Co-authored-by: Abhijit Subramanya <asubramanya@pivotal.io>