### PR TITLE
Fix 100% CPU utilization or infinite loop on mirror.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6384,17 +6384,6 @@ StartupXLOG(void)
 		exitArchiveRecovery(xlogreader->readPageTLI, endLogSegNo);
 
 	/*
-	 * Recovery command file must be deleted during promotion to prevent
-	 * StartupXLOG from incorrectly concluding that we are still a standby.
-	 * This could happen if the promoted standby goes through a restart.
-	 */
-	if (ControlFile->state == DB_IN_STANDBY_PROMOTED)
-	{
-		elog(LOG, "pg_control state is DB_IN_STANDBY_PROMOTED hence renaming recovery file");
-		renameRecoveryFile();
-	}
-
-	/*
 	 * Prepare to write WAL starting at EndOfLog position, and init xlog
 	 * buffer cache using the block containing the last record from the
 	 * previous incarnation.

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -4586,6 +4586,9 @@ XLogReadRecoveryCommandFile(int emode)
 						RECOVERY_COMMAND_FILE)));
 	}
 
+	/* Enable fetching from archive recovery area */
+	ArchiveRecoveryRequested = true;
+
 	FreeConfigVariables(head);
 }
 


### PR DESCRIPTION
In GPDB, with no work load running on primary, mirror went in tight loop reading
xlog files and switching between XLOG_FROM_PG_XLOG to XLOG_FROM_STREAM and back
to XLOG_FROM_PG_XLOG. This causes 100% cpu utilization on mirror for idle
primaries. Intended behavior is wait in XLOG_FROM_STREAM for more xlog to arrive
and receive signal from walreceiver to move forward. This situation was tried to
be fixed by staying in `XLOG_FROM_STREAM` once entered in that state. But if
reading via `XLOG_FROM_STREAM` fails, must go back to try other sources. Failing
to do so also causes infinite loop.

Expected state machine flow is start in XLOG_FROM_ARCHIVE, then move to
XLOG_FROM_PG_XLOG and then to XLOG_FROM_STREAM. Keypoint is switch the source if
and only if current source fails. Due to missed setting of `InArchiveRecovery`
in GPDB, it was incorrectly always setting the source to `XLOG_FROM_PG_XLOG`
whenever `WaitForWALToBecomeAvailable()` was called. This caused the state
machine to go wrong. Now, the code aligns with upstream, removing the FIXME.

We still need to align better to upstream by removing the
`DB_IN_STANDBY_PROMOTED` and fixing more places for archieve recovery code but that's for some other commit. This fixes the current problems at hand.