### PR TITLE
config/python.m4: fix up m4 macro-quoting

### DIFF
--- a/config/python.m4
+++ b/config/python.m4
@@ -32,13 +32,12 @@ fi
 AC_MSG_CHECKING([Python configuration directory])
 python_majorversion=`${PYTHON} -c "import sys; print(sys.version[[0]])"`
 python_version=`${PYTHON} -c "import sys; print(sys.version[[:3]])"`
-if [ "${python_majorversion}" = "2" ];
-then
-	python_configdir=`${PYTHON} -c "from distutils.sysconfig import get_python_lib as f; import os; print(os.path.join(f(plat_specific=1,standard_lib=1),'config'))"`
-else
-	python_configdir=`${PYTHON} -c "import distutils.sysconfig; print(' '.join(filter(None,distutils.sysconfig.get_config_vars('LIBPL'))))"`
-fi
+python_configdir=`${PYTHON} -c "import distutils.sysconfig; print(' '.join(filter(None,distutils.sysconfig.get_config_vars('LIBPL'))))"`
+AC_MSG_RESULT([$python_configdir])
+
+AC_MSG_CHECKING([Python include directories])
 python_includespec=`${PYTHON} -c "import distutils.sysconfig; print('-I'+distutils.sysconfig.get_python_inc())"`
+AC_MSG_RESULT([$python_includespec])
 
 AC_SUBST(python_majorversion)[]dnl
 AC_SUBST(python_version)[]dnl

--- a/configure
+++ b/configure
@@ -9647,13 +9647,15 @@ fi
 $as_echo_n "checking Python configuration directory... " >&6; }
 python_majorversion=`${PYTHON} -c "import sys; print(sys.version[0])"`
 python_version=`${PYTHON} -c "import sys; print(sys.version[:3])"`
-if  "${python_majorversion}" = "2" ;
-then
-	python_configdir=`${PYTHON} -c "from distutils.sysconfig import get_python_lib as f; import os; print(os.path.join(f(plat_specific=1,standard_lib=1),'config'))"`
-else
-	python_configdir=`${PYTHON} -c "import distutils.sysconfig; print(' '.join(filter(None,distutils.sysconfig.get_config_vars('LIBPL'))))"`
-fi
+python_configdir=`${PYTHON} -c "import distutils.sysconfig; print(' '.join(filter(None,distutils.sysconfig.get_config_vars('LIBPL'))))"`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $python_configdir" >&5
+$as_echo "$python_configdir" >&6; }
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking Python include directories" >&5
+$as_echo_n "checking Python include directories... " >&6; }
 python_includespec=`${PYTHON} -c "import distutils.sysconfig; print('-I'+distutils.sysconfig.get_python_inc())"`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $python_includespec" >&5
+$as_echo "$python_includespec" >&6; }
 
 
 


### PR DESCRIPTION
We noticed the following error during configure:

    checking Python configuration directory... ./configure: line 9650: 2: command not found

The brackets for the `if` were being swallowed by m4. Double them up to get the correct result for our Bash script.