### PR TITLE
Improve Oid sync logic for both QD and QE in wraparound cases

### DIFF
--- a/src/backend/cdb/cdboidsync.c
+++ b/src/backend/cdb/cdboidsync.c
@@ -33,6 +33,8 @@ get_max_oid_from_segDBs(void)
 	int			i;
 	CdbPgResults cdb_pgresults = {NULL, 0};
 
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+
 	const char *cmd = "select pg_catalog.pg_highest_oid()";
 
 	CdbDispatchCommand(cmd, DF_WITH_SNAPSHOT, &cdb_pgresults);
@@ -70,7 +72,18 @@ get_max_oid_from_segDBs(void)
 			DirectFunctionCall1(oidin,
 								CStringGetDatum(PQgetvalue(res, 0, 0))));
 
-		/* XXX: This doesn't do the right thing at OID wraparound. */
+		/*
+		 * We take the *numerically* maximum OID among the primaries.
+		 *
+		 * It might be tempting to find the "logically highest" OID among the
+		 * primaries because we do pair-wise OID logical comparison
+		 * elsewhere. However, that "logically maximum" of N Oids is undefined
+		 * for N > 2 primaries. This is because "logically precedes" is not a
+		 * transitive relationship.
+		 *
+		 * For example, take into consideration this set of four Oids:
+		 * {0, 1<<30, 1<<31, 3 * (1 << 30)}.
+		 */
 		if (tempoid > oid)
 			oid = tempoid;
 	}
@@ -91,7 +104,13 @@ pg_highest_oid(PG_FUNCTION_ARGS __attribute__((unused)))
 	{
 		max_from_segdbs = get_max_oid_from_segDBs();
 
-		if (max_from_segdbs > result)
+		/*
+		 * Return the logically larger Oid between the numeric maximum of the
+		 * primaries and the master's Oid counter. This is not 100% accurate
+		 * because the primaries can be in a wide range of Oids... but this is
+		 * good enough for the majority of production clusters.
+		 */
+		if (OidFollowsNextOid(max_from_segdbs))
 			result = max_from_segdbs;
 	}
 
@@ -103,13 +122,8 @@ cdb_sync_oid_to_segments(void)
 {
 	if (Gp_role == GP_ROLE_DISPATCH && IsNormalProcessingMode())
 	{
-		Oid			max_oid = get_max_oid_from_segDBs();
+		Oid max_oid_from_primaries = get_max_oid_from_segDBs();
 
-		/* Move our oid counter ahead of QEs */
-		while (GetNewObjectId() <= max_oid);
-
-		/* Burn a few extra just for safety */
-		for (int i = 0; i < 10; i++)
-			GetNewObjectId();
+		AdvanceObjectId(max_oid_from_primaries + 1);
 	}
 }

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -153,5 +153,8 @@ extern bool ForceTransactionIdLimitUpdate(void);
 extern Oid	GetNewObjectId(void);
 extern void AdvanceObjectId(Oid newOid);
 extern Oid	GetNewSegRelfilenode(void);
+extern bool OidFollowsNextOid(Oid id);
 
 #endif   /* TRAMSAM_H */
+
+

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -41,3 +41,4 @@ autovacuum-template0.out
 rpt_tpch.out
 session_reset.out
 dropdb_check_shared_buffer_cache.out
+/oid_wraparound.out

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -224,6 +224,11 @@ test: psql_gp_commands pg_resetxlog dropdb_check_shared_buffer_cache
 # Check for shmem leak for instrumentation slots
 test: instr_in_shmem_verify
 
+# This cannot run in parallel because other tests could increment the Oid
+# counters and make the Oid counter observations hardcoded in the answer file
+# incorrect.
+test: oid_wraparound
+
 # fts_recovery_in_progresss uses fault injectors to simulate FTS fault states,
 # hence it should be run in isolation.
 test: fts_recovery_in_progress

--- a/src/test/regress/input/oid_wraparound.source
+++ b/src/test/regress/input/oid_wraparound.source
@@ -1,0 +1,52 @@
+-- Create a new database to be certain that we'll be able to create objects with
+-- the Oids specified in this test. We have tighter control when we don't have
+-- to deal with leftover objects in the regression database.
+DROP DATABASE IF EXISTS oid_wraparound;
+CREATE DATABASE oid_wraparound;
+\c oid_wraparound
+
+-- Create the functions that we will be using to set and observe the Oid counter
+-- on the master and the segments.
+CREATE OR REPLACE FUNCTION gp_set_next_oid_master(new_oid Oid)
+	RETURNS VOID
+	AS '@abs_builddir@/regress.so', 'gp_set_next_oid'
+	LANGUAGE C EXECUTE ON MASTER;
+
+CREATE OR REPLACE FUNCTION gp_set_next_oid_segments(new_oid Oid)
+	RETURNS VOID
+	AS '@abs_builddir@/regress.so', 'gp_set_next_oid'
+	LANGUAGE C EXECUTE ON ALL SEGMENTS;
+
+CREATE OR REPLACE FUNCTION gp_get_next_oid_master()
+	RETURNS OID
+	AS '@abs_builddir@/regress.so', 'gp_get_next_oid'
+	LANGUAGE C EXECUTE ON MASTER;
+
+CREATE OR REPLACE FUNCTION gp_get_next_oid_segments()
+	RETURNS SETOF OID
+	AS '@abs_builddir@/regress.so', 'gp_get_next_oid'
+	LANGUAGE C EXECUTE ON ALL SEGMENTS;
+
+-- Scenario 1: QD is at 16384 while QE is at 4 billion
+SELECT gp_set_next_oid_master(16384);
+SELECT gp_set_next_oid_segments(4290000000);
+
+-- We expect the QE to fast-forward to 16384
+SELECT gp_get_next_oid_master();
+SELECT gp_get_next_oid_segments();
+CREATE TABLE oid_wraparound_table (a int);
+DROP TABLE oid_wraparound_table;
+SELECT gp_get_next_oid_master();
+SELECT gp_get_next_oid_segments();
+
+-- Scenario 2: QD is at 4 billion while QE is at 16384
+SELECT gp_set_next_oid_master(4290000000);
+SELECT gp_set_next_oid_segments(16384);
+
+-- We expect the QE to increment once to 16385 and the QD should
+-- fast-forward to 16388
+SELECT gp_get_next_oid_master();
+SELECT gp_get_next_oid_segments();
+CREATE TABLE oid_wraparound_table_other AS SELECT 1 AS a;
+SELECT gp_get_next_oid_master();
+SELECT gp_get_next_oid_segments();

--- a/src/test/regress/output/oid_wraparound.source
+++ b/src/test/regress/output/oid_wraparound.source
@@ -1,0 +1,116 @@
+-- Create a new database to be certain that we'll be able to create objects with
+-- the Oids specified in this test. We have tighter control when we don't have
+-- to deal with leftover objects in the regression database.
+DROP DATABASE IF EXISTS oid_wraparound;
+CREATE DATABASE oid_wraparound;
+\c oid_wraparound
+-- Create the functions that we will be using to set and observe the Oid counter
+-- on the master and the segments.
+CREATE OR REPLACE FUNCTION gp_set_next_oid_master(new_oid Oid)
+	RETURNS VOID
+	AS '@abs_builddir@/regress.so', 'gp_set_next_oid'
+	LANGUAGE C EXECUTE ON MASTER;
+CREATE OR REPLACE FUNCTION gp_set_next_oid_segments(new_oid Oid)
+	RETURNS VOID
+	AS '@abs_builddir@/regress.so', 'gp_set_next_oid'
+	LANGUAGE C EXECUTE ON ALL SEGMENTS;
+CREATE OR REPLACE FUNCTION gp_get_next_oid_master()
+	RETURNS OID
+	AS '@abs_builddir@/regress.so', 'gp_get_next_oid'
+	LANGUAGE C EXECUTE ON MASTER;
+CREATE OR REPLACE FUNCTION gp_get_next_oid_segments()
+	RETURNS SETOF OID
+	AS '@abs_builddir@/regress.so', 'gp_get_next_oid'
+	LANGUAGE C EXECUTE ON ALL SEGMENTS;
+-- Scenario 1: QD is at 16384 while QE is at 4 billion
+SELECT gp_set_next_oid_master(16384);
+ gp_set_next_oid_master 
+------------------------
+ 
+(1 row)
+
+SELECT gp_set_next_oid_segments(4290000000);
+ gp_set_next_oid_segments 
+--------------------------
+ 
+ 
+ 
+(3 rows)
+
+-- We expect the QE to fast-forward to 16384
+SELECT gp_get_next_oid_master();
+ gp_get_next_oid_master 
+------------------------
+                  16384
+(1 row)
+
+SELECT gp_get_next_oid_segments();
+ gp_get_next_oid_segments 
+--------------------------
+               4290000000
+               4290000000
+               4290000000
+(3 rows)
+
+CREATE TABLE oid_wraparound_table (a int);
+DROP TABLE oid_wraparound_table;
+SELECT gp_get_next_oid_master();
+ gp_get_next_oid_master 
+------------------------
+                  16387
+(1 row)
+
+SELECT gp_get_next_oid_segments();
+ gp_get_next_oid_segments 
+--------------------------
+                    16384
+                    16384
+                    16384
+(3 rows)
+
+-- Scenario 2: QD is at 4 billion while QE is at 16384
+SELECT gp_set_next_oid_master(4290000000);
+ gp_set_next_oid_master 
+------------------------
+ 
+(1 row)
+
+SELECT gp_set_next_oid_segments(16384);
+ gp_set_next_oid_segments 
+--------------------------
+ 
+ 
+ 
+(3 rows)
+
+-- We expect the QE to increment once to 16385 and the QD should
+-- fast-forward to 16388
+SELECT gp_get_next_oid_master();
+ gp_get_next_oid_master 
+------------------------
+             4290000000
+(1 row)
+
+SELECT gp_get_next_oid_segments();
+ gp_get_next_oid_segments 
+--------------------------
+                    16384
+                    16384
+                    16384
+(3 rows)
+
+CREATE TABLE oid_wraparound_table_other AS SELECT 1 AS a;
+SELECT gp_get_next_oid_master();
+ gp_get_next_oid_master 
+------------------------
+                  16388
+(1 row)
+
+SELECT gp_get_next_oid_segments();
+ gp_get_next_oid_segments 
+--------------------------
+                    16385
+                    16385
+                    16385
+(3 rows)
+

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -98,6 +98,10 @@ extern Datum gp_execute_on_server(PG_FUNCTION_ARGS);
 /* Check shared buffer cache for a database Oid */
 extern Datum check_shared_buffer_cache_for_dboid(PG_FUNCTION_ARGS);
 
+/* oid wraparound tests */
+extern void gp_set_next_oid(PG_FUNCTION_ARGS);
+extern Datum gp_get_next_oid(PG_FUNCTION_ARGS);
+
 /* Triggers */
 
 typedef struct
@@ -2043,4 +2047,24 @@ check_shared_buffer_cache_for_dboid(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_BOOL(false);
+}
+
+PG_FUNCTION_INFO_V1(gp_set_next_oid);
+void
+gp_set_next_oid(PG_FUNCTION_ARGS)
+{
+	Oid new_oid = PG_GETARG_OID(0);
+
+	LWLockAcquire(OidGenLock, LW_EXCLUSIVE);
+
+	ShmemVariableCache->nextOid = new_oid;
+
+	LWLockRelease(OidGenLock);
+}
+
+PG_FUNCTION_INFO_V1(gp_get_next_oid);
+Datum
+gp_get_next_oid(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_OID(ShmemVariableCache->nextOid);
 }

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -8,6 +8,7 @@
 /misc.sql
 /security_label.sql
 /tablespace.sql
+/oid_wraparound.sql
 
 sreh.sql
 upg2.sql


### PR DESCRIPTION
When Oid count between the QD and QE were not synced as expected, there are
cases where object creation could take a long time due to Oid synchronizing.

These are the two that we found:
1. If the QD wrapped around and the QE did not, the QD syncing with the highest
QE Oid counter value could result in a long loop. Additionally, there's a hack
in how the QD advances its Oid counter above the highest QE Oid counter value
where it will increment the Oid counter 10 more times to be *safe*. However,
this hack introduces holes in the Oid count and makes this bug more probable.
2. The QE advances its Oid counter when creating objects with dispatched
pre-assigned Oids. If the pre-assigned Oid dispatched by the QD was not from
wraparound and the QE had already wrapped around, it would result in a long
loop for the QE to synchronize with the QD.

To prevent long Oid synchronization loops, we add logic to handle wraparound
cases in both QD and QE.

This can be easily reproduced by running `pg_resetxlog -o <Oid>` to set the Oid
counter value on QD and/or QE to simulate the scenarios.

Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>