### PR TITLE
Fix 100% CPU utilization, as a side-effect enables `checkpointer` and `writer` process creation on mirror

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -4586,6 +4586,9 @@ XLogReadRecoveryCommandFile(int emode)
 						RECOVERY_COMMAND_FILE)));
 	}
 
+	/* Enable fetching from archive recovery area */
+	ArchiveRecoveryRequested = true;
+
 	FreeConfigVariables(head);
 }
 
@@ -5371,10 +5374,6 @@ StartupXLOG(void)
 	strncpy(XLogCtl->archiveCleanupCommand,
 			archiveCleanupCommand ? archiveCleanupCommand : "",
 			sizeof(XLogCtl->archiveCleanupCommand));
-
-	if (StandbyModeRequested)
-		ereport(LOG,
-				(errmsg("entering standby mode")));
 
 	if (ArchiveRecoveryRequested)
 	{

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -541,24 +541,6 @@ static XLogCtlData *XLogCtl = NULL;
  */
 static ControlFileData *ControlFile = NULL;
 
-typedef struct ControlFileWatch
-{
-	bool		watcherInitialized;
-	XLogRecPtr	current_checkPointLoc;		/* current last check point record ptr */
-	XLogRecPtr	current_prevCheckPointLoc;  /* current previous check point record ptr */
-	XLogRecPtr	current_checkPointCopy_redo;
-								/* current checkpointCopy value for
-								 * next RecPtr available when we began to
-								 * create CheckPoint (i.e. REDO start point) */
-
-} ControlFileWatch;
-
-
-/*
- * We keep the watcher in shared memory.
- */
-static ControlFileWatch *ControlFileWatcher = NULL;
-
 /*
  * Macros for managing XLogInsert state.  In most cases, the calling routine
  * has local copies of XLogCtl->Insert and/or XLogCtl->Insert->curridx,
@@ -717,9 +699,6 @@ static void CleanupBackupHistory(void);
 static void UpdateMinRecoveryPoint(XLogRecPtr lsn, bool force);
 static XLogRecord *ReadRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 		   int emode, bool fetching_ckpt);
-static void ControlFileWatcherSaveInitial(void);
-static void ControlFileWatcherCheckForChange(void);
-static bool XLogGetWriteAndFlushedLoc(XLogRecPtr *writeLoc, XLogRecPtr *flushedLoc);
 static XLogRecPtr XLogInsert_Internal(RmgrId rmid, uint8 info, XLogRecData *rdata, TransactionId headerXid);
 static void CheckRecoveryConsistency(void);
 static XLogRecord *ReadCheckpointRecord(XLogReaderState *xlogreader,
@@ -3572,64 +3551,6 @@ rescanLatestTimeLine(void)
 	return true;
 }
 
-static void
-ControlFileWatcherSaveInitial(void)
-{
-	ControlFileWatcher->current_checkPointLoc = ControlFile->checkPoint;
-	ControlFileWatcher->current_prevCheckPointLoc = ControlFile->prevCheckPoint;
-	ControlFileWatcher->current_checkPointCopy_redo = ControlFile->checkPointCopy.redo;
-
-	if (Debug_print_control_checkpoints)
-		elog(LOG,"pg_control checkpoint: initial values (checkpoint loc %s, previous loc %s, copy's redo loc %s)",
-			 XLogLocationToString_Long(ControlFile->checkPoint),
-			 XLogLocationToString2_Long(ControlFile->prevCheckPoint),
-			 XLogLocationToString3_Long(ControlFile->checkPointCopy.redo));
-
-	ControlFileWatcher->watcherInitialized = true;
-}
-
-static void
-ControlFileWatcherCheckForChange(void)
-{
-	XLogRecPtr  writeLoc;
-	XLogRecPtr  flushedLoc;
-
-	if (ControlFileWatcher->current_checkPointLoc != ControlFile->checkPoint ||
-		ControlFileWatcher->current_prevCheckPointLoc != ControlFile->prevCheckPoint ||
-		ControlFileWatcher->current_checkPointCopy_redo != ControlFile->checkPointCopy.redo)
-	{
-		ControlFileWatcher->current_checkPointLoc = ControlFile->checkPoint;
-		ControlFileWatcher->current_prevCheckPointLoc = ControlFile->prevCheckPoint;
-		ControlFileWatcher->current_checkPointCopy_redo = ControlFile->checkPointCopy.redo;
-
-		if (XLogGetWriteAndFlushedLoc(&writeLoc, &flushedLoc))
-		{
-			bool problem = (flushedLoc <= ControlFile->checkPoint);
-			if (problem)
-				elog(PANIC,"Checkpoint location %s for pg_control file is not flushed (write loc %s, flushed loc is %s)",
-				     XLogLocationToString_Long(ControlFile->checkPoint),
-				     XLogLocationToString2_Long(writeLoc),
-				     XLogLocationToString3_Long(flushedLoc));
-
-			if (Debug_print_control_checkpoints)
-				elog(LOG,"pg_control checkpoint: change (checkpoint loc %s, previous loc %s, copy's redo loc %s, write loc %s, flushed loc %s)",
-					 XLogLocationToString_Long(ControlFile->checkPoint),
-					 XLogLocationToString2_Long(ControlFile->prevCheckPoint),
-					 XLogLocationToString3_Long(ControlFile->checkPointCopy.redo),
-					 XLogLocationToString4_Long(writeLoc),
-					 XLogLocationToString5_Long(flushedLoc));
-		}
-		else
-		{
-			if (Debug_print_control_checkpoints)
-				elog(LOG,"pg_control checkpoint: change (checkpoint loc %s, previous loc %s, copy's redo loc %s)",
-					 XLogLocationToString_Long(ControlFile->checkPoint),
-					 XLogLocationToString2_Long(ControlFile->prevCheckPoint),
-					 XLogLocationToString3_Long(ControlFile->checkPointCopy.redo));
-		}
-	}
-}
-
 /*
  * I/O routines for pg_control
  *
@@ -3726,8 +3647,6 @@ WriteControlFile(void)
 		ereport(PANIC,
 				(errcode_for_file_access(),
 				 errmsg("could not close control file: %m")));
-
-	ControlFileWatcherSaveInitial();
 }
 
 static void
@@ -3915,29 +3834,6 @@ ReadControlFile(void)
 	/* Make the initdb settings visible as GUC variables, too */
 	SetConfigOption("data_checksums", DataChecksumsEnabled() ? "yes" : "no",
 					PGC_INTERNAL, PGC_S_OVERRIDE);
-
-	if (!ControlFileWatcher->watcherInitialized)
-	{
-		ControlFileWatcherSaveInitial();
-	}
-	else
-	{
-		ControlFileWatcherCheckForChange();
-	}
-}
-
-static bool
-XLogGetWriteAndFlushedLoc(XLogRecPtr *writeLoc, XLogRecPtr *flushedLoc)
-{
-	/* use volatile pointer to prevent code rearrangement */
-	volatile XLogCtlData *xlogctl = XLogCtl;
-
-	SpinLockAcquire(&xlogctl->info_lck);
-	*writeLoc = xlogctl->LogwrtResult.Write;
-	*flushedLoc = xlogctl->LogwrtResult.Flush;
-	SpinLockRelease(&xlogctl->info_lck);
-
-	return (*writeLoc != 0);
 }
 
 void
@@ -3980,10 +3876,6 @@ UpdateControlFile(void)
 		ereport(PANIC,
 				(errcode_for_file_access(),
 				 errmsg("could not close control file: %m")));
-
-	Assert (ControlFileWatcher->watcherInitialized);
-	if (!InRecovery)
-		ControlFileWatcherCheckForChange();
 }
 
 /*
@@ -4138,22 +4030,18 @@ XLOGShmemSize(void)
 void
 XLOGShmemInit(void)
 {
-	bool		foundCFile,
-				foundXLog,
-				foundCFileWatcher;
+	bool		foundCFile, foundXLog;
 	char	   *allocptr;
 
 	ControlFile = (ControlFileData *)
 		ShmemInitStruct("Control File", sizeof(ControlFileData), &foundCFile);
-	ControlFileWatcher = (ControlFileWatch *)
-		ShmemInitStruct("Control File Watcher", sizeof(ControlFileWatch), &foundCFileWatcher);
 	XLogCtl = (XLogCtlData *)
 		ShmemInitStruct("XLOG Ctl", XLOGShmemSize(), &foundXLog);
 
-	if (foundCFile || foundXLog || foundCFileWatcher)
+	if (foundCFile || foundXLog)
 	{
 		/* both should be present or neither */
-		Assert(foundCFile && foundXLog && foundCFileWatcher);
+		Assert(foundCFile && foundXLog);
 		return;
 	}
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -3937,7 +3937,7 @@ XLogGetWriteAndFlushedLoc(XLogRecPtr *writeLoc, XLogRecPtr *flushedLoc)
 	*flushedLoc = xlogctl->LogwrtResult.Flush;
 	SpinLockRelease(&xlogctl->info_lck);
 
-	return (writeLoc != 0);
+	return (*writeLoc != 0);
 }
 
 void

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6380,17 +6380,6 @@ StartupXLOG(void)
 		exitArchiveRecovery(xlogreader->readPageTLI, endLogSegNo);
 
 	/*
-	 * Recovery command file must be deleted during promotion to prevent
-	 * StartupXLOG from incorrectly concluding that we are still a standby.
-	 * This could happen if the promoted standby goes through a restart.
-	 */
-	if (ControlFile->state == DB_IN_STANDBY_PROMOTED)
-	{
-		elog(LOG, "pg_control state is DB_IN_STANDBY_PROMOTED hence renaming recovery file");
-		renameRecoveryFile();
-	}
-
-	/*
 	 * Prepare to write WAL starting at EndOfLog position, and init xlog
 	 * buffer cache using the block containing the last record from the
 	 * previous incarnation.

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5140,7 +5140,6 @@ StartupXLOG(void)
 	uint32		freespace;
 	TransactionId oldestActiveXID;
 	bool		backupEndRequired = false;
-	bool		bgwriterLaunched = false;
 	bool		backupFromStandby = false;
 	DBState		dbstate_at_startup;
 	XLogReaderState *xlogreader;


### PR DESCRIPTION
**Summary:**

- Sets `InArchiveRecovery` and `ArchiveRecoveryRequested` to true
- With that mirrors will now have `checkpointer` and `writer` process created and running
- Removing the `ControlFileWatcher facility`. As it was more of debug facility enabled even in production. Caused diff against upstream and didn't seem useful. Simple asserts could serve the purpose if required.

**Details:**
In GPDB, with no work load running on primary, mirror went in tight loop reading
xlog files and switching between XLOG_FROM_PG_XLOG to XLOG_FROM_STREAM and back
to XLOG_FROM_PG_XLOG. This causes 100% cpu utilization on mirror for idle
primaries. Intended behavior is wait in XLOG_FROM_STREAM for more xlog to arrive
and receive signal from walreceiver to move forward. This situation was tried to
be fixed by staying in XLOG_FROM_STREAM once entered in that state. But if
reading via XLOG_FROM_STREAM fails, must go back to try other sources. Failing
to do so also causes infinite loop.

Expected state machine flow is start in XLOG_FROM_ARCHIVE, then move to
XLOG_FROM_PG_XLOG and then to XLOG_FROM_STREAM. Keypoint is switch the source if
and only if current source fails. Due to missed setting of InArchiveRecovery
in GPDB, it was incorrectly always setting the source to XLOG_FROM_PG_XLOG
whenever WaitForWALToBecomeAvailable() was called. This caused the state
machine to go wrong. Now, the code aligns with upstream, removing the FIXME.

We still need to align better to upstream by removing the
DB_IN_STANDBY_PROMOTED and fixing more places for archive recovery code but that's for some other commit. This fixes the current problems at hand.

Enabling `ArchiveRecoveryRequested` also starts the checkpointer and writer processes on mirror. In GPDB till mirror was running similar to crash recovery. This commit shifts it from that and aligns with upstream behavior.