### PR TITLE
Fix shell-quoting in COPY PROGRAM and EXECUTE external table.

### DIFF
--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -177,12 +177,19 @@ make_export(char *name, const char *value, StringInfo buf)
 {
 	char		ch;
 
+	/*
+	 * Shell-quote the value. (We assume the variable name doesn't contain
+	 * funny characters.
+	 *
+	 * Every single-quote is replaced with '\''. For example, value
+	 * foo'bar becomes 'foo'\''bar'.
+	 */
 	appendStringInfo(buf, "%s='", name);
 
 	for ( ; 0 != (ch = *value); value++)
 	{
-		if (ch == '\'' || ch == '\\')
-			appendStringInfoChar(buf, '\\');
+		if (ch == '\'')
+			appendStringInfoString(buf, "\'\\\'");
 
 		appendStringInfoChar(buf, ch);
 	}

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1199,3 +1199,23 @@ copy t from '/tmp/b<SEGID>' on segment;
 select count(*) from t;
 
 \set QUIET on
+
+-- GPDB makes the database name, and many other things, available
+-- as environment variables to the program. Test those.
+--
+-- Perform these tests in a funnily named database, to test
+-- escaping
+set client_min_messages='warning';
+DROP DATABASE IF EXISTS "funny copy""db'with\\quotes";
+reset client_min_messages;
+CREATE DATABASE "funny copy""db'with\\quotes";
+
+\c "funny copy""db'with\\quotes"
+
+COPY (SELECT 'data1') TO PROGRAM 'cat > /tmp/gpcopyenvtest; echo database in COPY TO: $GP_DATABASE >> /tmp/gpcopyenvtest';
+
+CREATE TABLE foo (t text);
+COPY foo FROM PROGRAM 'cat /tmp/gpcopyenvtest';
+COPY foo FROM PROGRAM 'echo database in COPY FROM: $GP_DATABASE';
+
+select * from foo;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1399,3 +1399,25 @@ select count(*) from t;
 (1 row)
 
 \set QUIET on
+-- GPDB makes the database name, and many other things, available
+-- as environment variables to the program. Test those.
+--
+-- Perform these tests in a funnily named database, to test
+-- escaping
+set client_min_messages='warning';
+DROP DATABASE IF EXISTS "funny copy""db'with\\quotes";
+reset client_min_messages;
+CREATE DATABASE "funny copy""db'with\\quotes";
+\c "funny copy""db'with\\quotes"
+COPY (SELECT 'data1') TO PROGRAM 'cat > /tmp/gpcopyenvtest; echo database in COPY TO: $GP_DATABASE >> /tmp/gpcopyenvtest';
+CREATE TABLE foo (t text);
+COPY foo FROM PROGRAM 'cat /tmp/gpcopyenvtest';
+COPY foo FROM PROGRAM 'echo database in COPY FROM: $GP_DATABASE';
+select * from foo;
+                        t                        
+-------------------------------------------------
+ data1
+ database in COPY FROM: funny copy"db'withquotes
+ database in COPY TO: funny copy"db'withquotes
+(3 rows)
+


### PR DESCRIPTION
The external program executed with COPY PROGRAM or EXECUTE-type external
table is passed a bunch of environment variables. They are passed by
adding them to the command line of the program being executed, with
"<var>=<value> && export VAR && ...". However, the quoting in the code
that builds that command line was broken. Fix it, and add a test.

Fixes github issue https://github.com/greenplum-db/gpdb/issues/5925