### PR TITLE
Make fts_error test deterministic.

### DIFF
--- a/src/test/regress/expected/fts_error.out
+++ b/src/test/regress/expected/fts_error.out
@@ -21,7 +21,7 @@ NOTICE:  Success:
 -- injected on content 0 primary.
 select gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15439)
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=23250)
  gp_inject_fault_infinite 
 --------------------------
  t
@@ -39,7 +39,7 @@ NOTICE:  Success:
 
 select gp_inject_fault('fts_handle_message', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15439)
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=23250)
  gp_inject_fault 
 -----------------
  t
@@ -49,6 +49,14 @@ select gp_inject_fault('fts_update_config', 'reset', 1);
 NOTICE:  Success:
  gp_inject_fault 
 -----------------
+ t
+(1 row)
+
+-- Postmaster should have restarted FTS by now. Trigger a scan and
+-- validate that configuration is sane.
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
  t
 (1 row)
 
@@ -60,21 +68,6 @@ relation = 'gp_configuration_history'::regclass;
  locktype | mode | relation | pid | granted 
 ----------+------+----------+-----+---------
 (0 rows)
-
-select gp_inject_fault('fts_update_config', 'reset', 1);
-NOTICE:  Success:
- gp_inject_fault 
------------------
- t
-(1 row)
-
--- Postmaster should have restarted FTS by now.  Trigger a scan and
--- validate that configuration is sane.
-select gp_request_fts_probe_scan();
- gp_request_fts_probe_scan 
----------------------------
- t
-(1 row)
 
 select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';

--- a/src/test/regress/sql/fts_error.sql
+++ b/src/test/regress/sql/fts_error.sql
@@ -20,14 +20,15 @@ from gp_segment_configuration where content = 0 and role = 'p';
 
 select gp_inject_fault('fts_update_config', 'reset', 1);
 
+-- Postmaster should have restarted FTS by now. Trigger a scan and
+-- validate that configuration is sane.
+select gp_request_fts_probe_scan();
+
 -- Verify that FTS didn't leak any locks due to the error during
 -- config update.
 select locktype, mode, relation, pid, granted from pg_locks where
 relation = 'gp_segment_configuration'::regclass or
 relation = 'gp_configuration_history'::regclass;
-select gp_inject_fault('fts_update_config', 'reset', 1);
--- Postmaster should have restarted FTS by now.  Trigger a scan and
--- validate that configuration is sane.
-select gp_request_fts_probe_scan();
+
 select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';


### PR DESCRIPTION
The fts_error tests fails sometimes, as `gp_wait_until_triggered_fault()`
functions behavior is to return after the fault location is hit. It can't
communicate whether the fault action was taken or not. Due to this, the test
sometimes used to fail if checking for locks happened before FTS process
completed error handling.

So, adding fts scan to be performed which should make sure the new FTS process
is spanned and then only check if any locks remain.

Co-authored-by: Joao Pereira <jdealmeidapereira@pivotal.io>