### PR TITLE
Run CHECKPOINT after standby master is promoted

### DIFF
--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -324,7 +324,10 @@ def promote_standby(master_data_dir):
         try:
             dburl = dbconn.DbURL()
             with dbconn.connect(dburl, utility=True, logConn=False) as conn:
-                pass
+                # When the new master is available for connections, we should
+                # run a CHECKPOINT to force the new TimeLineID to be written to
+                # the pg_control file.
+                dbconn.execSQL(conn, 'CHECKPOINT')
             logger.info('Standby master is promoted')
             return True
         except pygresql.InternalError, e:


### PR DESCRIPTION
When the standby master is promoted, a new TimeLineID is generated to avoid
split brain scenario if the old master comes back up. This TimeLineID is
recorded in the WAL and written to the pg_control file. However, after a recent
commit (referenced below), updating the pg_control file can be delayed. There's
a very small timing window (a couple seconds) where a user could run gpstart on
the old master and have it come up because gpstart only compares TimeLineID
dumped from the master and standby master pg_control files. We don't expect this
to ever happen in production but we should prevent it (and also this is why the
gpactivatestandby Behave test is failing). To minimize the timing window, we run
a CHECKPOINT at the end of gpactivatestandby (when the new master is available
for connections) to force the new TimeLineID to be written to the pg_control
file. Of course, there's still the scenario where a user could run gpstart on
the old master during an execution of gpactivatestandby but there's not much we
can do to prevent that.

Reference commit:
https://github.com/greenplum-db/gpdb/commit/37feac26e6c84132e37a5696d716d6d5b00fb647