### PR TITLE
Initiliaze MemoryContext to silence compiler warning

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -974,7 +974,7 @@ getDnsCachedAddress(char *name, int port, int elevel, bool use_cache)
 	 */
 	if (!use_cache || (use_cache && e == NULL))
 	{
-		MemoryContext oldContext;
+		MemoryContext oldContext = NULL;
 		int			ret;
 		char		portNumberStr[32];
 		char	   *service;


### PR DESCRIPTION
As reported in #5937: The previous coding led to GCC 7 issuing a warning on uninitialized variable, so set to NULL to try and avoid.

```
  <builtin>: recipe for target 'cdbutil.o' failed
  In file included from ../../../src/include/postgres.h:54:0,
                   from cdbutil.c:23:
  cdbutil.c: In function 'getDnsCachedAddress':
  ../../../src/include/utils/palloc.h:148:23: error: 'oldContext' may be used uninitialized in this function [-Werror=maybe-uninitialized]
    CurrentMemoryContext = context;
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
  cdbutil.c:977:17: note: 'oldContext' was declared here
     MemoryContext oldContext;
                   ^~~~~~~~~~
  cc1: some warnings being treated as errors
  make[3]: *** [cdbutil.o] Error 1
  common.mk:41: recipe for target 'cdb-recursive' failed
```

Reported-by: Jesse Zhang <jzhang@pivotal.io>