### PR TITLE
resgroup: calc cpu rate limit based on parent cgroup.

### DIFF
--- a/src/backend/utils/resgroup/resgroup-ops-dummy.c
+++ b/src/backend/utils/resgroup/resgroup-ops-dummy.c
@@ -246,3 +246,18 @@ ResGroupOps_GetCpuSet(Oid group, char *cpuset, int len)
 {
 	unsupported_system();
 }
+
+/*
+ * Convert the cpu usage to percentage within the duration.
+ *
+ * usage is the delta of GetCpuUsage() of a duration,
+ * duration is in micro seconds.
+ *
+ * When fully consuming one cpu core the return value will be 100.0 .
+ */
+float
+ResGroupOps_ConvertCpuUsageToPercent(int64 usage, int64 duration)
+{
+	unsupported_system();
+	return 0.0;
+}

--- a/src/include/utils/resgroup-ops.h
+++ b/src/include/utils/resgroup-ops.h
@@ -31,11 +31,6 @@ typedef enum
 } ResGroupCompType;
 
 #define RESGROUP_ROOT_ID (InvalidOid)
-/*
- * If group id is RESGROUP_COMPROOT_ID, it will build the root path of comp,
- * which is the parent directory of gpdb
- */
-#define RESGROUP_COMPROOT_ID (-1)
 
 /*
  * Default cpuset group is a group manages the cpu cores which not belong to

--- a/src/include/utils/resgroup-ops.h
+++ b/src/include/utils/resgroup-ops.h
@@ -68,5 +68,6 @@ extern int ResGroupOps_GetCpuCores(void);
 extern int ResGroupOps_GetTotalMemory(void);
 extern void ResGroupOps_SetCpuSet(Oid group, const char *cpuset);
 extern void ResGroupOps_GetCpuSet(Oid group, char *cpuset, int len);
+float ResGroupOps_ConvertCpuUsageToPercent(int64 usage, int64 duration);
 
 #endif   /* RES_GROUP_OPS_H */


### PR DESCRIPTION
We used to assume gpdb's parent cgroup has unlimited cpu settings, but
this is not always true in cloud environment.  Changed the logic to
calculate gpdb's cpu rate limit based on parent cgroup's settings.  Also
adjusted the cpu usages reported by gpdb, instead of report the system
level cpu usages now we report the usages within the parent cgroup.

Also refactored some code:
- make parameters of buildPath() more descriptive;
- retire RESGROUP_COMPROOT_ID;