### PR TITLE
Remove unused bitmap AM "NEWLOV" WAL record type.

### DIFF
--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -1563,15 +1563,6 @@ create_lovitem(Relation rel, Buffer metabuf, uint64 tidnum,
 		newLovBuffer = _bitmap_getbuf(rel, P_NEW, BM_WRITE);
 		_bitmap_init_lovpage(rel, newLovBuffer);
 
-		/*
-		START_CRIT_SECTION();
-
-		if(use_wal)
-			_bitmap_log_newpage(rel, XLOG_BITMAP_INSERT_NEWLOV, 
-								newLovBuffer);
-		END_CRIT_SECTION();
-		*/
-
 		_bitmap_relbuf(currLovBuffer);
 
 		currLovBuffer = newLovBuffer;

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -793,38 +793,6 @@ _bitmap_begin_iterate(BMBatchWords *words, BMIterateResult *result)
 	result->nextTidLoc = 0;
 }
 
-
-/*
- * _bitmap_log_newpage() -- log a new page.
- *
- * This function is called before writing a new buffer.
- */
-void
-_bitmap_log_newpage(Relation rel, uint8 info, Buffer buf)
-{
-	Page page;
-
-	xl_bm_newpage		xlNewPage;
-	XLogRecPtr			recptr;
-	XLogRecData			rdata[1];
-
-	page = BufferGetPage(buf);
-
-	xlNewPage.bm_node = rel->rd_node;
-	xlNewPage.bm_new_blkno = BufferGetBlockNumber(buf);
-
-	elog(DEBUG1, "_bitmap_log_newpage: blkno=%d", xlNewPage.bm_new_blkno);
-
-	rdata[0].buffer = InvalidBuffer;
-	rdata[0].data = (char *)&xlNewPage;
-	rdata[0].len = sizeof(xl_bm_newpage);
-	rdata[0].next = NULL;
-			
-	recptr = XLogInsert(RM_BITMAP_ID, info, rdata);
-
-	PageSetLSN(page, recptr);
-}
-
 /*
  * _bitmap_log_metapage() -- log the changes to the metapage
  */

--- a/src/backend/access/rmgrdesc/bitmapdesc.c
+++ b/src/backend/access/rmgrdesc/bitmapdesc.c
@@ -31,14 +31,6 @@ bitmap_desc(StringInfo buf, XLogRecord *record)
 
 	switch (info)
 	{
-		case XLOG_BITMAP_INSERT_NEWLOV:
-		{
-			xl_bm_newpage *xlrec = (xl_bm_newpage *)rec;
-
-			appendStringInfo(buf, "insert a new LOV page: ");
-			out_target(buf, &(xlrec->bm_node));
-			break;
-		}
 		case XLOG_BITMAP_INSERT_LOVITEM:
 		{
 			xl_bm_lovitem *xlrec = (xl_bm_lovitem *)rec;

--- a/src/include/access/bitmap.h
+++ b/src/include/access/bitmap.h
@@ -559,7 +559,7 @@ typedef BMScanOpaqueData *BMScanOpaque;
  *
  * Some information in high 4 bits of log record xl_info field.
  */
-#define XLOG_BITMAP_INSERT_NEWLOV	0x10 /* add a new LOV page */
+/* 0x10 is unused */
 #define XLOG_BITMAP_INSERT_LOVITEM	0x20 /* add a new entry into a LOV page */
 #define XLOG_BITMAP_INSERT_META		0x30 /* update the metapage */
 #define XLOG_BITMAP_INSERT_BITMAP_LASTWORDS	0x40 /* update the last 2 words
@@ -801,7 +801,6 @@ extern void _bitmap_intersect(BMBatchWords **batches, uint32 numBatches,
 extern void _bitmap_union(BMBatchWords **batches, uint32 numBatches,
 					   BMBatchWords *result);
 extern void _bitmap_begin_iterate(BMBatchWords *words, BMIterateResult *result);
-extern void _bitmap_log_newpage(Relation rel, uint8 info, Buffer buf);
 extern void _bitmap_log_metapage(Relation rel, ForkNumber fork, Page page);
 extern void _bitmap_log_bitmap_lastwords(Relation rel, Buffer lovBuffer,
 									 OffsetNumber lovOffset, BMLOVItem lovItem);


### PR DESCRIPTION
Looks like it was used to WAL-log the creation of new LOW pages, but has
been unused since time immemorial. New LOV pages are actually logged as
XLOG_BITMAP_INSERT_LOVITEM records, with the 'bm_is_new_lov_blkno' flag
set in the xl_bm_lovitem struct.