### PR TITLE
Fix `udf_exception_blocks_panic_scenarios` test.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -203,7 +203,7 @@ int			Debug_dtm_action_target = DEBUG_DTM_ACTION_TARGET_DEFAULT;
 
 int			Debug_dtm_action_protocol = DEBUG_DTM_ACTION_PROTOCOL_DEFAULT;
 
-#define DEBUG_DTM_ACTION_SEGMENT_DEFAULT 1
+#define DEBUG_DTM_ACTION_SEGMENT_DEFAULT -2
 #define DEBUG_DTM_ACTION_NESTINGLEVEL_DEFAULT 0
 
 int			Debug_dtm_action_segment = DEBUG_DTM_ACTION_SEGMENT_DEFAULT;
@@ -3067,7 +3067,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Debug_dtm_action_segment,
-		DEBUG_DTM_ACTION_SEGMENT_DEFAULT, 0, 1000,
+		DEBUG_DTM_ACTION_SEGMENT_DEFAULT, -2, 1000,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
+++ b/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
@@ -56,7 +56,7 @@ p   |p             |0      |s   |u
 p   |p             |1      |s   |u     
 p   |p             |2      |s   |u     
 (8 rows)
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET
 SET debug_dtm_action_target=protocol;
 SET
@@ -84,7 +84,7 @@ LINE 1: select * from employees;
                       ^
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET
 SET debug_dtm_action_target=protocol;
 SET
@@ -112,7 +112,7 @@ LINE 1: select * from employees;
                       ^
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET
 SET debug_dtm_action_target=protocol;
 SET
@@ -140,7 +140,7 @@ LINE 1: select * from employees;
                       ^
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET
 SET debug_dtm_action_target=protocol;
 SET
@@ -168,7 +168,7 @@ LINE 1: select * from employees;
                       ^
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET
 SET debug_dtm_action_target=protocol;
 SET
@@ -196,7 +196,7 @@ LINE 1: select * from employees;
                       ^
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET
 SET debug_dtm_action_target=protocol;
 SET

--- a/src/test/isolation2/sql/udf_exception_blocks_panic_scenarios.sql
+++ b/src/test/isolation2/sql/udf_exception_blocks_panic_scenarios.sql
@@ -91,7 +91,7 @@ END; /* in func */
 $$
 LANGUAGE plpgsql;
 SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=subtransaction_begin;
 SET debug_dtm_action=panic_begin_command;
@@ -104,7 +104,7 @@ select test_protocol_allseg(1, 2,'f');
 select * from employees;
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=subtransaction_release;
 SET debug_dtm_action=panic_begin_command;
@@ -117,7 +117,7 @@ select test_protocol_allseg(1, 2,'f');
 select * from employees;
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=subtransaction_release;
 SET debug_dtm_action=panic_begin_command;
@@ -130,7 +130,7 @@ select test_protocol_allseg(1, 2,'f');
 select * from employees;
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=subtransaction_rollback;
 SET debug_dtm_action=panic_begin_command;
@@ -143,7 +143,7 @@ select test_protocol_allseg(1, 2,'f');
 select * from employees;
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=subtransaction_rollback;
 SET debug_dtm_action=panic_begin_command;
@@ -156,7 +156,7 @@ select test_protocol_allseg(1, 2,'f');
 select * from employees;
 --
 --
-SET debug_dtm_action_segment=1;
+SET debug_dtm_action_segment=0;
 SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=subtransaction_begin;
 SET debug_dtm_action=panic_begin_command;

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -67,6 +67,7 @@ INSERT INTO distxact1_2 VALUES (25);
 INSERT INTO distxact1_2 VALUES (26);
 INSERT INTO distxact1_2 VALUES (27);
 INSERT INTO distxact1_2 VALUES (28);
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "prepare";
@@ -93,6 +94,7 @@ INSERT INTO distxact1_3 VALUES (35);
 INSERT INTO distxact1_3 VALUES (36);
 INSERT INTO distxact1_3 VALUES (37);
 INSERT INTO distxact1_3 VALUES (38);
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "commit_prepared";
@@ -112,6 +114,7 @@ SELECT * FROM distxact1_3;
  37
 (8 rows)
 
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
 RESET debug_dtm_action_protocol;
@@ -128,18 +131,20 @@ INSERT INTO distxact1_4 VALUES (45);
 INSERT INTO distxact1_4 VALUES (46);
 INSERT INTO distxact1_4 VALUES (47);
 INSERT INTO distxact1_4 VALUES (48);
+SET debug_dtm_action_segment=1;
 SET debug_abort_after_distributed_prepared = true;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "abort_prepared";
 COMMIT;
-WARNING:  the distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid = 1477546849-0000000078.  Retrying ... try 1
+WARNING:  the distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid = 1539036319-0000000288.  Retrying ... try 0
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 SELECT * FROM distxact1_4;
  a 
 ---
 (0 rows)
 
+RESET debug_dtm_action_segment;
 RESET debug_abort_after_distributed_prepared;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -151,13 +156,15 @@ RESET debug_dtm_action_protocol;
 -- Invoke a failure during a CREATE TABLE command.  
 --
 --SET debug_print_full_dtm=true;
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "MPPEXEC UTILITY";
 CREATE TABLE distxact2_1 (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = MPPEXEC UTILITY  (seg1 cmcdevitt-mac-pro.local:50002 pid=66019)
+ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = MPPEXEC UTILITY  (seg1 127.0.1.1:25433 pid=1127)
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -174,13 +181,15 @@ DROP TABLE distxact2_1;
 -- Invoke a failure during a CREATE TABLE command.  
 -- Action_Target = 2 is SQL.
 --
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_end_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "MPPEXEC UTILITY";
 CREATE TABLE distxact2_2 (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  Raise ERROR for debug_dtm_action = 3, commandTag = MPPEXEC UTILITY  (seg1 cmcdevitt-mac-pro.local:50002 pid=66019)
+ERROR:  Raise ERROR for debug_dtm_action = 3, commandTag = MPPEXEC UTILITY  (seg1 127.0.1.1:25433 pid=1127)
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -200,6 +209,7 @@ DROP TABLE distxact2_2;
 -- Invoke a failure during a SAVEPOINT command.  
 --
 --SET debug_print_full_dtm=true;
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "SAVEPOINT";
@@ -208,8 +218,9 @@ CREATE TABLE distxact3_1 (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SAVEPOINT s;
-ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = SAVEPOINT  (seg1 127.0.0.1:40001 pid=19151)
+ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = SAVEPOINT  (seg1 127.0.1.1:25433 pid=1127)
 ROLLBACK;
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -226,6 +237,7 @@ DROP TABLE distxact3_1;
 -- Invoke a failure during a RELEASE SAVEPOINT command.  
 --
 --SET debug_print_full_dtm=true;
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "RELEASE";
@@ -243,8 +255,9 @@ INSERT INTO distxact3_2 VALUES (26);
 INSERT INTO distxact3_2 VALUES (27);
 INSERT INTO distxact3_2 VALUES (28);
 RELEASE SAVEPOINT s;
-ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = RELEASE  (seg1 127.0.0.1:40001 pid=19151)
+ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = RELEASE  (seg1 127.0.1.1:25433 pid=1127)
 ROLLBACK;
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -261,6 +274,7 @@ DROP TABLE distxact3_2;
 -- Invoke a failure during a ROLLBACK TO SAVEPOINT command.  
 --
 --SET debug_print_full_dtm=true;
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "ROLLBACK";
@@ -278,8 +292,9 @@ INSERT INTO distxact3_3 VALUES (36);
 INSERT INTO distxact3_3 VALUES (37);
 INSERT INTO distxact3_3 VALUES (38);
 ROLLBACK TO SAVEPOINT s;
-ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = ROLLBACK  (seg1 127.0.0.1:40001 pid=19151)
+ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = ROLLBACK  (seg1 127.0.1.1:25433 pid=1127)
 ROLLBACK;
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;

--- a/src/test/regress/sql/distributed_transactions.sql
+++ b/src/test/regress/sql/distributed_transactions.sql
@@ -61,6 +61,7 @@ INSERT INTO distxact1_2 VALUES (25);
 INSERT INTO distxact1_2 VALUES (26);
 INSERT INTO distxact1_2 VALUES (27);
 INSERT INTO distxact1_2 VALUES (28);
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "prepare";
@@ -84,11 +85,13 @@ INSERT INTO distxact1_3 VALUES (35);
 INSERT INTO distxact1_3 VALUES (36);
 INSERT INTO distxact1_3 VALUES (37);
 INSERT INTO distxact1_3 VALUES (38);
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "commit_prepared";
 COMMIT;
 SELECT * FROM distxact1_3;
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
 RESET debug_dtm_action_protocol;
@@ -106,12 +109,14 @@ INSERT INTO distxact1_4 VALUES (45);
 INSERT INTO distxact1_4 VALUES (46);
 INSERT INTO distxact1_4 VALUES (47);
 INSERT INTO distxact1_4 VALUES (48);
+SET debug_dtm_action_segment=1;
 SET debug_abort_after_distributed_prepared = true;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "abort_prepared";
 COMMIT;
 SELECT * FROM distxact1_4;
+RESET debug_dtm_action_segment;
 RESET debug_abort_after_distributed_prepared;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -126,10 +131,12 @@ RESET debug_dtm_action_protocol;
 -- Invoke a failure during a CREATE TABLE command.  
 --
 --SET debug_print_full_dtm=true;
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "MPPEXEC UTILITY";
 CREATE TABLE distxact2_1 (a int);
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -145,11 +152,12 @@ DROP TABLE distxact2_1;
 -- Invoke a failure during a CREATE TABLE command.  
 -- Action_Target = 2 is SQL.
 --
-
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_end_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "MPPEXEC UTILITY";
 CREATE TABLE distxact2_2 (a int);
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -169,6 +177,7 @@ DROP TABLE distxact2_2;
 -- Invoke a failure during a SAVEPOINT command.  
 --
 --SET debug_print_full_dtm=true;
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "SAVEPOINT";
@@ -176,6 +185,7 @@ BEGIN;
 CREATE TABLE distxact3_1 (a int);
 SAVEPOINT s;
 ROLLBACK;
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -191,6 +201,7 @@ DROP TABLE distxact3_1;
 -- Invoke a failure during a RELEASE SAVEPOINT command.  
 --
 --SET debug_print_full_dtm=true;
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "RELEASE";
@@ -207,6 +218,7 @@ INSERT INTO distxact3_2 VALUES (27);
 INSERT INTO distxact3_2 VALUES (28);
 RELEASE SAVEPOINT s;
 ROLLBACK;
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -223,6 +235,7 @@ DROP TABLE distxact3_2;
 -- Invoke a failure during a ROLLBACK TO SAVEPOINT command.  
 --
 --SET debug_print_full_dtm=true;
+SET debug_dtm_action_segment=1;
 SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "sql";
 SET debug_dtm_action_sql_command_tag = "ROLLBACK";
@@ -239,6 +252,7 @@ INSERT INTO distxact3_3 VALUES (37);
 INSERT INTO distxact3_3 VALUES (38);
 ROLLBACK TO SAVEPOINT s;
 ROLLBACK;
+RESET debug_dtm_action_segment;
 RESET debug_dtm_action_sql_command_tag;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;


### PR DESCRIPTION
The test was setting `debug_dtm_action_segment=1` means take action of segment
with content id 1. But when checking for if segment recovered fine or not
checked for content id 0 using `0U: select 1;`.

So, lets make the test deterministic by using content 0 for PANIC as well and
content 0 for checking if recovery completed as well.'

Aslo, while at it make the default value of guc `Debug_dtm_action_segment` to invalid segment. This will make sure fault doesn't happen on unintended segment.