### PR TITLE
Disable stable function evaluation in pl/pgsql simple expressions

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -148,6 +148,7 @@ static Node *substitute_actual_srf_parameters_mutator(Node *node,
 static bool tlist_matches_coltypelist(List *tlist, List *coltypelist);
 static bool contain_grouping_clause_walker(Node *node, void *context);
 
+bool gp_enable_stable_function_eval = true;
 
 /*****************************************************************************
  *		OPERATOR clause functions
@@ -4338,7 +4339,8 @@ evaluate_function(Oid funcid, Oid result_type, int32 result_typmod,
 		 /* okay */ ;
 	else if (context->estimate && funcform->provolatile == PROVOLATILE_STABLE)
 		 /* okay */ ;
-	else if (context->root && context->root->glob && funcform->provolatile == PROVOLATILE_STABLE)
+	else if (context->root && context->root->glob && funcform->provolatile == PROVOLATILE_STABLE
+			 && gp_enable_stable_function_eval)
 	{
 		/*
 		 * okay, but we cannot reuse this plan

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -886,6 +886,12 @@ extern bool gp_cost_hashjoin_chainwalk;
 extern int cdb_total_slices;
 extern int cdb_max_slices;
 
+/*
+ * When true, the planner evaluates stable functions to generate a
+ * oneoffPlan.
+ */
+extern bool gp_enable_stable_function_eval;
+
 typedef struct GpId
 {
 	int32		numsegments;	/* count of distinct segindexes */

--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -187,3 +187,52 @@ select has_account_type('select * from (select simple_sql_function(i) from all_t
                12
 (1 row)
 
+create or replace function oneoff_plan_func(a integer)
+returns integer AS
+$$
+BEGIN
+if date_part('month', now()) + 1 > a then
+   return 0;
+else
+   return 1;
+end if;
+END
+$$ LANGUAGE 'plpgsql' stable;
+-- The oneoff_plan_func calls the stable function "now()".  Normally,
+-- GPDB will agressively evaluate stable functions in the planner, at
+-- the cost of being required to regenerate a plan during every
+-- execution.  The benefit of this is partition elimination because
+-- partition elimination is done inside the planner, by evaluating
+-- stable functions we can avoid costly full table scans on tables
+-- that will yield no tuples.  However, in the case of simple
+-- expressions in pl/pgsql the resulting plan will never do partition
+-- elimination.  In cases where we will end up with simple
+-- expressions, we can prevent the planner from evaluating stable
+-- functions in order for it to create a reusable plan.  A reusable
+-- plan will be cached and reused for subsequent executions of
+-- oneoff_plan_func.
+-- Three plans, one for each statement block in oneoff_plan_func will
+-- be created on seg0.  Because seg0 is the only segment having
+-- tuples, no other segment will create a plan.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Planner');
+ has_account_type 
+------------------
+                3
+(1 row)
+
+-- All the three plans, cached during previous execution should be
+-- reused, therefore, we expect the output to be 0.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Planner');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- We expect only three Executor accounts, one per segment, because
+-- simple expressions in pl/pgsql should not need a full executor.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -135,11 +135,15 @@ test: gporca_faults
 test: aggregate_with_groupingsets 
 
 test: nested_case_null sort bb_mpph
-test: bb_memory_quota memconsumption
+
+# Memconsumption test relies on cached plpgsql plans.  Concurrently
+# committing transactions may invalidate the cache.  So the test must
+# be run by itself.
+test: memconsumption
 
 test: tuple_serialization
-# Tests for replicated table
-test: rpt rpt_joins rpt_tpch rpt_returning
+
+test: rpt rpt_joins rpt_tpch rpt_returning bb_memory_quota
 
 # NOTE: The bfv_temp test assumes that there are no temporary tables in
 # other sessions. Therefore the other tests in this group mustn't create

--- a/src/test/regress/sql/memconsumption.sql
+++ b/src/test/regress/sql/memconsumption.sql
@@ -126,3 +126,42 @@ select has_account_type('select * from (select simple_sql_function(i) from all_t
 -- 'Executor' account. We also expect one main 'Executor' account per slice, so
 -- expect '12' total Executor accounts
 select has_account_type('select * from (select simple_sql_function(i) from all_tuples_on_seg0) a, (select simple_sql_function(i) from all_tuples_on_seg0) b', 'Executor');
+
+create or replace function oneoff_plan_func(a integer)
+returns integer AS
+$$
+BEGIN
+if date_part('month', now()) + 1 > a then
+   return 0;
+else
+   return 1;
+end if;
+END
+$$ LANGUAGE 'plpgsql' stable;
+
+-- The oneoff_plan_func calls the stable function "now()".  Normally,
+-- GPDB will agressively evaluate stable functions in the planner, at
+-- the cost of being required to regenerate a plan during every
+-- execution.  The benefit of this is partition elimination because
+-- partition elimination is done inside the planner, by evaluating
+-- stable functions we can avoid costly full table scans on tables
+-- that will yield no tuples.  However, in the case of simple
+-- expressions in pl/pgsql the resulting plan will never do partition
+-- elimination.  In cases where we will end up with simple
+-- expressions, we can prevent the planner from evaluating stable
+-- functions in order for it to create a reusable plan.  A reusable
+-- plan will be cached and reused for subsequent executions of
+-- oneoff_plan_func.
+
+-- Three plans, one for each statement block in oneoff_plan_func will
+-- be created on seg0.  Because seg0 is the only segment having
+-- tuples, no other segment will create a plan.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Planner');
+
+-- All the three plans, cached during previous execution should be
+-- reused, therefore, we expect the output to be 0.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Planner');
+
+-- We expect only three Executor accounts, one per segment, because
+-- simple expressions in pl/pgsql should not need a full executor.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Executor');


### PR DESCRIPTION
In Greenplum, stable functions are evaluated during planning to facilitate partition elimination.  Simple expressions in pl/pgsql UDFs cannot eliminate partitions because they do not involve table scans.
This patch disables stable function evaluation in the planner in the case that we are planning what pl/pgsql has previously determined to be a simple expression.

Without this patch, every time a simple expression is evaluated, a new plan and a new ExprState are generated.  Because we only clean up the expression states created for simple expressions at the end of transaction, this will result in millions of expression states, one per tuple, being generated that are not reused after they are initially created.
