### PR TITLE
Support custom socket directory during upgrades

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -427,6 +427,8 @@ typedef struct
 	bool		progress;
 	segmentMode	segment_mode;
 	checksumMode checksum_mode;
+	char	   *socketdir;		/* directory to use for sockets, NULL means
+								 * using the default of CWD */
 
 } UserOpts;
 


### PR DESCRIPTION
During the upgrade process, the current working directory is set as the socket directory. This can be a problem when the current hierarchy is deep as the socketdir is limited to just over 100 characters. Add a command line option to set a specific directory in those cases.

I've hit the 100 byte limit on socket directory a fair number of times now, and have each time hacked the code to get around it. This is getting somewhat tiresome so it seemed about time to fix it once and for all. This will be done as a postgres-first feature and it will soon be submitted to pgsql-hackers@, this PR was opened mainly to solicit feedback on whether this is a good idea or not, and if others have had the same problem.