### PR TITLE
gprecoverseg: Do not throw exception in  `CleanSharedMem.execute()`.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/unix.py
+++ b/gpMgmt/bin/gppylib/operations/unix.py
@@ -182,7 +182,13 @@ class CleanSharedMem(Operation):
             for item in pool.getCompletedItems():
                 result = item.get_results()
 
-                if result.rc != 0:
+                # This code is usually called after a GPDB segment has
+                # been terminated.  In that case, it is possible that
+                # the shared memory has already been freed by the
+                # time we are called to clean up.  Due to this race
+                # condition, it is possible to get an `ipcrm: invalid
+                # id1` error from ipcrm.  We, therefore, ignore it.
+                if result.rc != 0 and not result.stderr.startswith("ipcrm: invalid id"):
                     raise Exception('Unable to clean up shared memory for segment: (%s)' % (result.stderr))
         finally:
             pool.haltWork()


### PR DESCRIPTION
The `CleanSharedMem.execute()` routine throws an exception if it cannot cleanup
shared memory.  However, there is a race condition between stopping the segments
and explicitly cleaning the shared memory.

This can happen when `CleanSharedMem.execute()` is able to read the
postmaster.pid file and find the shared memory to free, but the shared memory
has already been freed from previously stopping the segments with
`GpMirrorListToBuild.__ensurestopped()`.

Therefore, we are not throwing an exception in `CleanSharedMem.execute()` when
there is an error in cleaning up the shared memory when the shared memory does
not exist as it is most likely already freed from stopping the segements.

Co-authored-by: Shoaib Lari <slari@pivotal.io>
Co-authored-by: Kalen Krempely <kkrempely@pivotal.io>
(cherry picked from commit f9ac1023f44819fa5e6dbf24c51d2bf87de5f6fb)