### PR TITLE
Add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ lib*.pc
 /Debug/
 /Release/
 /CMakeLists.txt
+/.idea/


### PR DESCRIPTION
IntelliJ is a popular IDE used by many developers which creates a .idea directory that should be added to the gitignore

Authored-by: Kalen Krempely <kkrempely@pivotal.io>