### PR TITLE
Remove unused variable

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -230,9 +230,6 @@ cdb_build_distribution_pathkeys(PlannerInfo *root,
 	List	   *retval = NIL;
 	List	   *eq = list_make1(makeString("="));
 	int			i;
-	bool		isAppendChildRelation = false;
-
-	isAppendChildRelation = (rel->reloptkind == RELOPT_OTHER_MEMBER_REL);
 
 	for (i = 0; i < nattrs; ++i)
 	{


### PR DESCRIPTION
The special handling for children of append nodes was removed in the 9.3 merge, but the variable was left behind. Fix by removing.