### PR TITLE
Use bootstrap superuser as the authenticated user in GDD process.

### DIFF
--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -45,6 +45,7 @@
 #include "storage/proc.h"
 #include "storage/procarray.h"
 #include "utils/builtins.h"
+#include "utils/gdd.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/resgroup.h"
@@ -538,7 +539,9 @@ InitializeSessionUserIdStandalone(void)
 	 * workers, and in background workers.
 	 */
 	AssertState(!IsUnderPostmaster || IsAutoVacuumWorkerProcess() || IsBackgroundWorker
-				|| am_startup || (am_ftshandler && am_mirror));
+				|| am_startup
+				|| (am_ftshandler && am_mirror)
+				|| am_global_deadlock_detector);
 
 	/* call only once */
 	AssertState(!OidIsValid(AuthenticatedUserId));

--- a/src/include/utils/gdd.h
+++ b/src/include/utils/gdd.h
@@ -13,6 +13,8 @@
 #ifndef GDD_H
 #define GDD_H
 
+extern bool am_global_deadlock_detector;
+
 extern int global_deadlock_detector_start(void);
 
 extern int gp_global_deadlock_detector_period;


### PR DESCRIPTION
That's what we were effectively choosing for session user before already
but findSuperuser() was an overly complicated way to do it. In addition
to setting the session userid, also set authenticated userid by calling
InitializeSessionUserIdStandalone(), like in most other aux processes.