### PR TITLE
Fix returned collation for get_atttypetypmodcoll() with system attrs.

### DIFF
--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -1018,15 +1018,16 @@ get_atttypetypmodcoll(Oid relid, AttrNumber attnum,
 	HeapTuple	tp;
 	Form_pg_attribute att_tup;
 
-    /* CDB: Get type for sysattr even if relid is no good (e.g. SubqueryScan) */
-    if (attnum < 0 &&
-        attnum > FirstLowInvalidHeapAttributeNumber)
-    {
-        att_tup = SystemAttributeDefinition(attnum, true);
-	    *typid = att_tup->atttypid;
-	    *typmod = att_tup->atttypmod;
-        return;
-    }
+	/* CDB: Get type for sysattr even if relid is no good (e.g. SubqueryScan) */
+	if (attnum < 0 &&
+		attnum > FirstLowInvalidHeapAttributeNumber)
+	{
+		att_tup = SystemAttributeDefinition(attnum, true);
+		*typid = att_tup->atttypid;
+		*typmod = att_tup->atttypmod;
+		*collid = att_tup->attcollation;
+		return;
+	}
 
 	tp = SearchSysCache2(ATTNUM,
 						 ObjectIdGetDatum(relid),


### PR DESCRIPTION
This showed up as a regression test failure on the 9.4 merge branch,
although I forgot which test it was :-(. On master, I believe this is
harmless, because none of the callers will look at the collation if it's
a system column, but we should certainly fix this in any case.