### PR TITLE
Restrict folding of stable functions during planning

### DIFF
--- a/src/test/modules/Makefile
+++ b/src/test/modules/Makefile
@@ -1,0 +1,9 @@
+# src/test/modules/Makefile
+
+subdir = src/test/modules
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+
+SUBDIRS = test_planner
+
+$(recurse)

--- a/src/test/modules/test_planner/.gitignore
+++ b/src/test/modules/test_planner/.gitignore
@@ -1,0 +1,3 @@
+regression.diffs
+regression.out
+results/

--- a/src/test/modules/test_planner/Makefile
+++ b/src/test/modules/test_planner/Makefile
@@ -1,0 +1,30 @@
+# src/test/modules/test_planner/Makefile
+
+MODULE_big = test_planner
+
+OBJS = test_planner.o \
+	src/planner_test_helpers.o \
+	src/assertions.o \
+	integration_tests/planner_integration_tests.o \
+	$(WIN32RES)
+
+PGFILEDESC = "test_planner"
+
+EXTENSION = test_planner
+DATA = test_planner--1.0.sql
+
+REGRESS = test_planner
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = src/test/modules/test_planner
+top_builddir = ../../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
+
+test: clean all install
+	psql postgres -f sql/test_planner.sql 2>&1

--- a/src/test/modules/test_planner/README.md
+++ b/src/test/modules/test_planner/README.md
@@ -1,0 +1,29 @@
+# test_planner extension
+
+`test_planner` is for creating expectations about the planner from the perspective
+of downstream components (for example: the executor).
+
+It defines an extension that can be installed into a running instance. The extension
+defines a function that runs a suite of expectations about the planner.
+
+## Run tests
+
+### Run the regress suite
+
+`make installcheck`
+
+### During Development
+
+During development, you can get feedback on success and failure
+
+`make test`
+
+Also, the extension can be installed and run as a query:
+
+`make clean install`
+
+```
+create extension test_planner;
+select test_planner();
+```
+

--- a/src/test/modules/test_planner/expected/test_planner.out
+++ b/src/test/modules/test_planner/expected/test_planner.out
@@ -7,6 +7,8 @@
 CREATE EXTENSION IF NOT EXISTS test_planner;
 --end_ignore
 SELECT test_planner();
+INFO:  Success test_stable_function_in_subquery_is_evaluated_to_const - integration_tests/planner_integration_tests.c:70
+INFO:  Success test_stable_function_in_simple_query_is_not_evaluated_in_planner - integration_tests/planner_integration_tests.c:83
  test_planner 
 --------------
  

--- a/src/test/modules/test_planner/expected/test_planner.out
+++ b/src/test/modules/test_planner/expected/test_planner.out
@@ -1,0 +1,15 @@
+-- start_matchsubs
+-- # Remove all successful
+-- m/INFO:  Success.*\.c:\d+/
+-- s/\d+/###/
+-- end_matchsubs
+--start_ignore
+CREATE EXTENSION IF NOT EXISTS test_planner;
+--end_ignore
+SELECT test_planner();
+ test_planner 
+--------------
+ 
+(1 row)
+
+DROP EXTENSION test_planner;

--- a/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
+++ b/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
@@ -7,7 +7,38 @@
 #include "src/planner_test_helpers.h"
 
 
+static void
+test_stable_function_in_subquery_is_evaluated_to_const()
+{
+	const char *query_string = "select * from (select now()) a;";
+
+	Query *query = make_query(query_string);
+	PlannedStmt *plannedstmt = planner(query, 0, NULL);
+
+	TargetEntry *tle = get_target_entry_from_root_plan_node(plannedstmt);
+
+	assert_that_bool(IsA(tle->expr, Const), is_equal_to(true));
+}
+
+static void
+test_stable_function_in_simple_query_is_not_evaluated_in_planner()
+{
+	const char *query_string = "select now();";
+
+	Query *query = make_query(query_string);
+	PlannedStmt *plannedstmt = planner(query, 0, NULL);
+
+	TargetEntry *tle = get_target_entry_from_root_plan_node(plannedstmt);
+
+	assert_that_bool(IsA(tle->expr, FuncExpr), is_equal_to(true));
+}
+
 void
 run_planner_integration_test_suite(void)
 {
+	/*
+	 * Tests that are generic between planner and optimizer
+	 */
+	test_stable_function_in_subquery_is_evaluated_to_const();
+	test_stable_function_in_simple_query_is_not_evaluated_in_planner();
 }

--- a/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
+++ b/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
@@ -1,0 +1,13 @@
+#include "postgres.h"
+#include "tcop/tcopprot.h"
+
+#include "planner_integration_tests.h"
+
+#include "src/assertions.h"
+#include "src/planner_test_helpers.h"
+
+
+void
+run_planner_integration_test_suite(void)
+{
+}

--- a/src/test/modules/test_planner/integration_tests/planner_integration_tests.h
+++ b/src/test/modules/test_planner/integration_tests/planner_integration_tests.h
@@ -1,0 +1,6 @@
+#ifndef PLANNER_INTEGRATION_TESTS_H
+#define PLANNER_INTEGRATION_TESTS_H
+
+void run_planner_integration_test_suite(void);
+
+#endif //PLANNER_INTEGRATION_TESTS_H

--- a/src/test/modules/test_planner/sql/test_planner.sql
+++ b/src/test/modules/test_planner/sql/test_planner.sql
@@ -1,0 +1,12 @@
+-- start_matchsubs
+-- # Remove all successful
+-- m/INFO:  Success.*\.c:\d+/
+-- s/\d+/###/
+-- end_matchsubs
+
+--start_ignore
+CREATE EXTENSION IF NOT EXISTS test_planner;
+--end_ignore
+
+SELECT test_planner();
+DROP EXTENSION test_planner;

--- a/src/test/modules/test_planner/src/assertions.c
+++ b/src/test/modules/test_planner/src/assertions.c
@@ -1,0 +1,50 @@
+#include "assertions.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+char *
+int_to_bool_string(int value)
+{
+	if (value == 0) return "false";
+	return "true";
+}
+
+char *
+int_to_int_string(int value)
+{
+	char *buffer = malloc(sizeof(char*));
+	sprintf(buffer, "%d", value);
+	return buffer;
+}
+
+void
+test_succeeded(
+	const char* test_function_name,
+	const char* test_file_name,
+	int test_line_number)
+{
+	elog(
+		INFO,
+		"Success %s - %s:%d",
+		test_function_name,
+		test_file_name,
+		test_line_number);
+}
+
+void
+test_failed(
+	char *expected,
+	char *actual,
+	const char *test_function_name,
+	const char *test_file_name,
+	int test_line_number)
+{
+	elog(
+		WARNING,
+		"expected %s, was %s in %s - %s:%d",
+		expected,
+		actual,
+		test_function_name,
+		test_file_name,
+		test_line_number);
+}

--- a/src/test/modules/test_planner/src/assertions.h
+++ b/src/test/modules/test_planner/src/assertions.h
@@ -1,0 +1,33 @@
+#include "postgres.h"
+#include "utils/elog.h"
+
+char* int_to_bool_string(int value);
+char* int_to_int_string(int value);
+
+void test_succeeded(
+	const char *test_function_name,
+	const char *test_file_name,
+	int test_line_number);
+
+void test_failed(
+	char *expected,
+	char *actual,
+	const char *test_function_name,
+	const char *test_file_name,
+	int test_line_number);
+
+#define assert_that_bool(actual, expected) \
+	if (expected == actual) { \
+		test_succeeded(__func__, __FILE__, __LINE__); \
+	} else { \
+		test_failed(int_to_bool_string(expected), int_to_bool_string(actual), __func__, __FILE__, __LINE__); \
+	}
+
+#define assert_that_int(actual, expected) \
+	if (expected == actual) { \
+		test_succeeded(__func__, __FILE__, __LINE__); \
+	} else { \
+		test_failed(int_to_int_string(expected), int_to_int_string(actual), __func__, __FILE__, __LINE__); \
+	}
+
+#define is_equal_to(expected) (expected)

--- a/src/test/modules/test_planner/src/planner_test_helpers.c
+++ b/src/test/modules/test_planner/src/planner_test_helpers.c
@@ -32,3 +32,11 @@ get_first_subplan(PlannedStmt *plannedStmt)
 {
 	return (Plan *)list_nth(plannedStmt->subplans, 0);
 }
+
+TargetEntry *
+get_target_entry_from_root_plan_node(PlannedStmt *plannedstmt)
+{
+	Result *result_node = (Result*) plannedstmt->planTree;
+	List *tlist = result_node->plan.targetlist;
+	return list_nth(tlist, 0);
+}

--- a/src/test/modules/test_planner/src/planner_test_helpers.c
+++ b/src/test/modules/test_planner/src/planner_test_helpers.c
@@ -1,0 +1,34 @@
+#include "planner_test_helpers.h"
+
+#include "optimizer/planmain.h"
+#include "tcop/tcopprot.h"
+
+static Node *
+get_parsetree_for(const char *query_string)
+{
+	List *parsetree_list = pg_parse_query(query_string);
+	ListCell *parsetree_item = list_head(parsetree_list);
+	return (Node *)lfirst(parsetree_item);
+}
+
+static Query *
+get_query_for_parsetree(Node *parsetree, const char *query_string)
+{
+	List *querytree_list = pg_analyze_and_rewrite(parsetree, query_string, NULL, 0);
+	ListCell *querytree = list_head(querytree_list);
+	return (Query *)lfirst(querytree);
+}
+
+Query *
+make_query(const char *query_string)
+{
+	Node *parsetree = get_parsetree_for(query_string);
+
+	return get_query_for_parsetree(parsetree, query_string);
+}
+
+Plan *
+get_first_subplan(PlannedStmt *plannedStmt)
+{
+	return (Plan *)list_nth(plannedStmt->subplans, 0);
+}

--- a/src/test/modules/test_planner/src/planner_test_helpers.h
+++ b/src/test/modules/test_planner/src/planner_test_helpers.h
@@ -1,0 +1,12 @@
+#ifndef PLANNER_TEST_HELPERS_H
+#define PLANNER_TEST_HELPERS_H
+
+#include "postgres.h"
+
+#include "catalog/pg_type.h"
+#include "optimizer/planner.h"
+
+extern Query *make_query(const char *query_string);
+extern Plan *get_first_subplan(PlannedStmt *plannedStmt);
+
+#endif //PLANNER_TEST_HELPERS_H

--- a/src/test/modules/test_planner/src/planner_test_helpers.h
+++ b/src/test/modules/test_planner/src/planner_test_helpers.h
@@ -8,5 +8,6 @@
 
 extern Query *make_query(const char *query_string);
 extern Plan *get_first_subplan(PlannedStmt *plannedStmt);
+extern TargetEntry *get_target_entry_from_root_plan_node(PlannedStmt *plannedstmt);
 
 #endif //PLANNER_TEST_HELPERS_H

--- a/src/test/modules/test_planner/test_planner--1.0.sql
+++ b/src/test/modules/test_planner/test_planner--1.0.sql
@@ -1,0 +1,8 @@
+/* src/test/modules/test_planner/test_planner--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_planner" to load this file. \quit
+
+CREATE FUNCTION test_planner() RETURNS VOID
+STRICT
+AS 'MODULE_PATHNAME' LANGUAGE C;

--- a/src/test/modules/test_planner/test_planner.c
+++ b/src/test/modules/test_planner/test_planner.c
@@ -1,0 +1,30 @@
+/*--------------------------------------------------------------------------
+ *
+ * test_planner.c
+ *		Test correctness of optimizer's predicate proof logic.
+ *
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ *
+ * IDENTIFICATION
+ *		src/test/modules/test_planner/test_planner.c
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "funcapi.h"
+
+#include "integration_tests/planner_integration_tests.h"
+
+PG_MODULE_MAGIC;
+extern Datum test_planner(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(test_planner);
+
+Datum
+test_planner(PG_FUNCTION_ARGS)
+{
+	run_planner_integration_test_suite();
+
+
+	PG_RETURN_VOID();
+}

--- a/src/test/modules/test_planner/test_planner.control
+++ b/src/test/modules/test_planner/test_planner.control
@@ -1,0 +1,4 @@
+comment = 'Test code'
+default_version = '1.0'
+module_pathname = '$libdir/test_planner'
+relocatable = true

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -295,6 +295,60 @@ NOTICE:  stabletestfunc executed
   1
 (1 row)
 
+-- Test that pl/pgsql simple expressions are not considered a
+-- oneoffPlan.  We validate this by ensuring that a simple expression
+-- involving a stable function is planned only once and the same plan
+-- is re-executed for each tuple.  The NOTICE in the immutable
+-- function allows us to detect when it is executed.  We assume that
+-- the planner folds immutablefunc() into a const.
+CREATE FUNCTION immutablefunc() RETURNS int2
+LANGUAGE plpgsql IMMUTABLE STRICT AS
+$$
+BEGIN
+	raise notice 'immutablefunc executed';
+	return 42;
+END
+$$;
+CREATE FUNCTION stablenow (dummy int2) RETURNS timestamp
+LANGUAGE plpgsql STABLE STRICT AS
+$fn$
+BEGIN
+	return now();
+END
+$fn$;
+CREATE FUNCTION volatilefunc(a int) RETURNS int
+LANGUAGE plpgsql VOLATILE STRICT AS
+$fn$
+DECLARE
+  t timestamp;
+BEGIN
+	t := stablenow(immutablefunc());
+	if date_part('month', t) > a then
+		return 0;
+	else
+		return 1;
+	end if;
+END
+$fn$;
+CREATE TABLE oneoffplantest (a int) distributed by (a);
+INSERT INTO oneoffplantest VALUES (0), (0), (0);
+-- Plan for the following query should be cached such that the call to
+-- immutablefun() is folded into a const.  Note that all the
+-- statements within volatilefunc() are pl/pgsql simple expressions.
+-- Their plans should NOT be classified as oneoffPlan and should be
+-- cached.  So we expect the NOTICE to be printed only once,
+-- regardless of the number of tuples in the table.
+select volatilefunc(a) from oneoffplantest;
+NOTICE:  immutablefunc executed  (seg0 slice1 127.0.1.1:25432 pid=6257)
+CONTEXT:  SQL statement "SELECT stablenow(immutablefunc())"
+PL/pgSQL function volatilefunc(integer) line 5 at assignment
+ volatilefunc 
+--------------
+            0
+            0
+            0
+(3 rows)
+
 -- Test agg on top of join subquery on partition table with ORDER-BY clause
 CREATE TABLE bfv_planner_t1 (a int, b int, c int) distributed by (c);
 CREATE TABLE bfv_planner_t2 (f int,g int) DISTRIBUTED BY (f) PARTITION BY RANGE(g)

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -691,7 +691,7 @@ CONTEXT:  SQL statement "set local work_mem = '2MB'"
 PL/pgSQL function myfunc(integer) line 3 at SQL statement
  myfunc | current_setting 
 --------+-----------------
- 2MB    | 3MB
+ 2MB    | 2MB
 (1 row)
 
 set work_mem = '3MB';
@@ -713,18 +713,7 @@ CONTEXT:  SQL statement "set work_mem = '2MB'"
 PL/pgSQL function myfunc(integer) line 3 at SQL statement
  myfunc | current_setting 
 --------+-----------------
- 2MB    | 3MB
-(1 row)
-
--- In GPDB, the plan looks somewhat different from what you get on
--- PostgreSQL, so that the current_setting() in previous query is
--- evaluated before myfunc(0), and therefore it shows the old value,
--- '3 MB'. Query again to show that the myfunc(0) call actually changed
--- the setting.
-select current_setting('work_mem');
- current_setting 
------------------
- 2MB
+ 2MB    | 2MB
 (1 row)
 
 set work_mem = '3MB';
@@ -761,7 +750,7 @@ CONTEXT:  SQL statement "set work_mem = '2MB'"
 PL/pgSQL function myfunc(integer) line 3 at SQL statement
  myfunc | current_setting 
 --------+-----------------
- 2MB    | 3MB
+ 2MB    | 2MB
 (1 row)
 
 -- Normally, CREATE FUNCTION should complain about invalid values in

--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -187,3 +187,52 @@ select has_account_type('select * from (select simple_sql_function(i) from all_t
                12
 (1 row)
 
+create or replace function oneoff_plan_func(a integer)
+returns integer AS
+$$
+BEGIN
+if date_part('month', now()) + 1 > a then
+   return 0;
+else
+   return 1;
+end if;
+END
+$$ LANGUAGE 'plpgsql' stable;
+-- The oneoff_plan_func calls the stable function "now()".  Normally,
+-- GPDB will agressively evaluate stable functions in the planner, at
+-- the cost of being required to regenerate a plan during every
+-- execution.  The benefit of this is partition elimination because
+-- partition elimination is done inside the planner, by evaluating
+-- stable functions we can avoid costly full table scans on tables
+-- that will yield no tuples.  However, in the case of simple
+-- expressions in pl/pgsql the resulting plan will never do partition
+-- elimination.  In cases where we will end up with simple
+-- expressions, we can prevent the planner from evaluating stable
+-- functions in order for it to create a reusable plan.  A reusable
+-- plan will be cached and reused for subsequent executions of
+-- oneoff_plan_func.
+-- Two planners, one for each evaluated statement block in oneoff_plan_func will
+-- be executed on seg0.  Because seg0 is the only segment having tuples, no
+-- other segment will create a plan.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Planner');
+ has_account_type 
+------------------
+                2
+(1 row)
+
+-- Both plans will have been cached during previous executions will be reused,
+-- therefore, we expect the output to be 0.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Planner');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- We expect only three Executor accounts, one per segment, because
+-- simple expressions in pl/pgsql should not need a full executor.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+

--- a/src/test/regress/sql/guc.sql
+++ b/src/test/regress/sql/guc.sql
@@ -242,13 +242,6 @@ set work_mem = '1MB';
 
 select myfunc(0), current_setting('work_mem');
 
--- In GPDB, the plan looks somewhat different from what you get on
--- PostgreSQL, so that the current_setting() in previous query is
--- evaluated before myfunc(0), and therefore it shows the old value,
--- '3 MB'. Query again to show that the myfunc(0) call actually changed
--- the setting.
-select current_setting('work_mem');
-
 set work_mem = '3MB';
 
 -- it should roll back on error, though


### PR DESCRIPTION
Stable functions need not be folded in case the query is simple enough (e.g. pl/pgsql simple expression, or "select foo()").

Without this patch, every time a simple expression is evaluated, a new plan and a new ExprState are generated. Because we only clean up the expression states created for simple expressions at the end of transaction, this will result in millions of expression states, one per tuple, being generated that are not reused after they are initially created.

This patch is taken from Heikki's review comment: https://github.com/greenplum-db/gpdb/pull/5947#issuecomment-428103480

This patch also removes GPDB specific update for the test `guc.sql`. Prior to this commit, since we were aggressively folding stable functions, `current_setting()` was evaluated at plan time causing a diff from upstream. This patch realigns the test with upstream.

Thanks to @d for valuable guidance and carving out the test case.

We plan to close PR #5947 in favor of this one.
