### PR TITLE
Export env variable GP_QUERY_STRING for web external table

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -34,6 +34,7 @@
 #include "postgres.h"
 
 #include <fstream/gfile.h>
+#include <tcop/tcopprot.h>
 
 #include "funcapi.h"
 #include "access/fileam.h"
@@ -2305,6 +2306,7 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 	extvar->GP_HADOOP_CONN_JARDIR = gp_hadoop_connector_jardir;
 	extvar->GP_HADOOP_CONN_VERSION = gp_hadoop_connector_version;
 	extvar->GP_HADOOP_HOME = gp_hadoop_home;
+	extvar->GP_QUERY_STRING = debug_query_string;
 
 	if (NULL != params)
 	{

--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -220,6 +220,7 @@ make_command(const char *cmd, extvar_t *ev)
 	make_export("GP_SEG_PORT", ev->GP_SEG_PORT, &buf);
 	make_export("GP_SESSION_ID", ev->GP_SESSION_ID, &buf);
 	make_export("GP_SEGMENT_COUNT", ev->GP_SEGMENT_COUNT, &buf);
+	make_export("GP_QUERY_STRING", ev->GP_QUERY_STRING, &buf);
 
 	/* hadoop env var */
 	make_export("GP_HADOOP_CONN_JARDIR", ev->GP_HADOOP_CONN_JARDIR, &buf);

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -69,6 +69,7 @@ typedef struct extvar_t
  	/* EOL vars */
  	char* GP_LINE_DELIM_STR;
  	char GP_LINE_DELIM_LENGTH[8];
+	char *GP_QUERY_STRING;
 } extvar_t;
 
 

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -88,6 +88,7 @@ DROP EXTERNAL TABLE IF EXISTS exttab_txs_2;
 DROP EXTERNAL TABLE IF EXISTS exttab_udfs_1;
 DROP EXTERNAL TABLE IF EXISTS exttab_udfs_2;
 DROP EXTERNAL TABLE IF EXISTS exttab_views_3;
+DROP EXTERNAL WEB TABLE table_env;
 
 DROP VIEW IF EXISTS exttab_views_3;
 
@@ -110,6 +111,11 @@ drop external table check_ps;
 drop external table check_env;
 
 -- end_ignore
+CREATE EXTERNAL WEB TABLE table_env (name TEXT, val TEXT )
+  EXECUTE E'env' ON SEGMENT 0
+  FORMAT 'TEXT' (DELIMITER '=');
+SELECT name, val FROM table_env WHERE name LIKE 'GP_QUERY%' ORDER BY name ASC;
+
 -- --------------------------------------
 -- some negative tests
 -- --------------------------------------

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -81,6 +81,7 @@ select * from check_env;
  GP_HADOOP_CONN_VERSION=CE_1.0.0.0
  GP_MASTER_HOST=127.0.0.1
  GP_MASTER_PORT=5432
+ GP_QUERY_STRING=select * from check_env;
  GP_SEGMENT_COUNT=2
  GP_SEGMENT_ID=0
  GP_SEG_DATADIR=/Users/@gpcurusername@/greenplum-db-data/dbfast1/gpseg0
@@ -127,6 +128,15 @@ select * from check_env;
 (55 rows)
 
 -- end_ignore
+CREATE EXTERNAL WEB TABLE table_env (name TEXT, val TEXT )
+  EXECUTE E'env' ON SEGMENT 0
+  FORMAT 'TEXT' (DELIMITER '=');
+SELECT name, val FROM table_env WHERE name LIKE 'GP_QUERY%' ORDER BY name ASC;
+      name       |                                      val                                       
+-----------------+--------------------------------------------------------------------------------
+ GP_QUERY_STRING | SELECT name, val FROM table_env WHERE name LIKE 'GP_QUERY%' ORDER BY name ASC;
+(1 row)
+
 -- --------------------------------------
 -- some negative tests
 -- --------------------------------------


### PR DESCRIPTION
This PR contains:
- Export env variable GP_QUERY_STRING for web external table
- Fixed error escaping format of shell command for web external table. This bug is found if the value of $GP_QUERY_STRING contains single quote (e.g. query is: SELECT * FROM t1 WHERE c1 LIKE 'GP_QUERY%').

This PR also need to be merged into 5X_STABLE branch.