### PR TITLE
Function Scans can be rescanned, no need for a Material node.

### DIFF
--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -275,6 +275,13 @@ ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags)
 		SPI_ReserveMemory(((Plan *)node)->operatorMemKB * 1024L);
 	}
 
+	/*
+	 * If eflag contains EXEC_FLAG_REWIND or EXEC_FLAG_BACKWARD or EXEC_FLAG_MARK,
+	 * then this node is not eager free safe.
+	 */
+	scanstate->ss.ps.delayEagerFree =
+		((eflags & (EXEC_FLAG_REWIND | EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)) != 0);
+
 	return scanstate;
 }
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2601,8 +2601,12 @@ create_functionscan_path(PlannerInfo *root, RelOptInfo *rel,
 
 	pathnode->motionHazard = false;
 
-	/* For now, be conservative. */
-	pathnode->rescannable = false;
+	/*
+	 * FunctionScan is always rescannable. It uses a tuplestore to
+	 * materialize the results all by itself.
+	 */
+	pathnode->rescannable = true;
+
 	pathnode->sameslice_relids = NULL;
 
 	cost_functionscan(pathnode, root, rel, pathnode->param_info);

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -312,16 +312,15 @@ select * from test_srf();
 -- Since the function is marked as EXECUTE ON ANY, and IMMUTABLE, the planner
 -- can choose to run it anywhere.
 explain select * from srf_testtab, test_srf();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1.01..281.01 rows=1000 width=38)
-   ->  Nested Loop  (cost=1.01..281.01 rows=334 width=38)
-         ->  Function Scan on test_srf  (cost=0.00..260.00 rows=334 width=32)
-         ->  Materialize  (cost=1.01..1.02 rows=1 width=6)
-               ->  Seq Scan on srf_testtab  (cost=0.00..1.01 rows=1 width=6)
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
-(7 rows)
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.25..10000000021.26 rows=1000 width=38)
+   ->  Nested Loop  (cost=10000000000.25..10000000021.26 rows=334 width=38)
+         ->  Seq Scan on srf_testtab  (cost=0.00..1.01 rows=1 width=6)
+         ->  Function Scan on test_srf  (cost=0.25..10.25 rows=334 width=32)
+ Planning time: 0.220 ms
+ Optimizer: legacy query optimizer
+(6 rows)
 
 explain select * from srf_testtab, test_srf() where test_srf = srf_testtab.t;
                                    QUERY PLAN                                   

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -2724,12 +2724,10 @@ where q1 = thousand or q2 = thousand;
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                  ->  Seq Scan on int4_tbl
-               ->  Materialize
-                     ->  Function Scan on q1
-         ->  Materialize
-               ->  Function Scan on q2
+               ->  Function Scan on q1
+         ->  Function Scan on q2
  Optimizer: legacy query optimizer
-(15 rows)
+(13 rows)
 
 explain (costs off)
 select * from
@@ -2748,13 +2746,12 @@ where thousand = (q1 + q2);
                ->  Hash
                      ->  Nested Loop
                            ->  Function Scan on q1
-                           ->  Materialize
-                                 ->  Function Scan on q2
+                           ->  Function Scan on q2
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on int4_tbl
  Optimizer: legacy query optimizer
-(15 rows)
+(14 rows)
 
 --
 -- test placement of movable quals in a parameterized join tree
@@ -3337,46 +3334,43 @@ select count(*) from tenk1 a, lateral generate_series(1,two) g;
 
 explain (costs off)
   select count(*) from tenk1 a, lateral generate_series(1,two) g;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Nested Loop
                      ->  Seq Scan on tenk1 a
-                     ->  Materialize
-                           ->  Function Scan on generate_series g
+                     ->  Function Scan on generate_series g
  Optimizer: legacy query optimizer
-(8 rows)
+(7 rows)
 
 explain (costs off)
   select count(*) from tenk1 a cross join lateral generate_series(1,two) g;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Nested Loop
                      ->  Seq Scan on tenk1 a
-                     ->  Materialize
-                           ->  Function Scan on generate_series g
+                     ->  Function Scan on generate_series g
  Optimizer: legacy query optimizer
-(8 rows)
+(7 rows)
 
 -- don't need the explicit LATERAL keyword for functions
 explain (costs off)
   select count(*) from tenk1 a, generate_series(1,two) g;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Nested Loop
                      ->  Seq Scan on tenk1 a
-                     ->  Materialize
-                           ->  Function Scan on generate_series g
+                     ->  Function Scan on generate_series g
  Optimizer: legacy query optimizer
-(8 rows)
+(7 rows)
 
 -- lateral with UNION ALL subselect
 explain (costs off)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3435,46 +3435,43 @@ select count(*) from tenk1 a, lateral generate_series(1,two) g;
 
 explain (costs off)
   select count(*) from tenk1 a, lateral generate_series(1,two) g;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Nested Loop
                      ->  Seq Scan on tenk1 a
-                     ->  Materialize
-                           ->  Function Scan on generate_series g
+                     ->  Function Scan on generate_series g
  Optimizer: legacy query optimizer
-(8 rows)
+(7 rows)
 
 explain (costs off)
   select count(*) from tenk1 a cross join lateral generate_series(1,two) g;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Nested Loop
                      ->  Seq Scan on tenk1 a
-                     ->  Materialize
-                           ->  Function Scan on generate_series g
+                     ->  Function Scan on generate_series g
  Optimizer: legacy query optimizer
-(8 rows)
+(7 rows)
 
 -- don't need the explicit LATERAL keyword for functions
 explain (costs off)
   select count(*) from tenk1 a, generate_series(1,two) g;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Nested Loop
                      ->  Seq Scan on tenk1 a
-                     ->  Materialize
-                           ->  Function Scan on generate_series g
+                     ->  Function Scan on generate_series g
  Optimizer: legacy query optimizer
-(8 rows)
+(7 rows)
 
 -- lateral with UNION ALL subselect
 explain (costs off)


### PR DESCRIPTION
Function Scan materializes the result of each in a TupleStore, and can
be rescanned. Mark it as rescannable in the planner, so that we avoid
putting a pointless Materialize node on top of it.