### PR TITLE
Set correct numsegments for correlated SubPlan

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -573,6 +573,7 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		 */
 		if (ctx->movement == MOVEMENT_BROADCAST)
 		{
+			Assert (NULL != ctx->currentPlanFlow);
 			broadcastPlan(scanPlan, false /* stable */ , false /* rescannable */,
 						  ctx->currentPlanFlow->numsegments /* numsegments */);
 		}
@@ -740,6 +741,7 @@ ParallelizeSubplan(SubPlan *spExpr, PlanProfile *context)
 
 		if (containingPlanDistributed)
 		{
+			Assert(NULL != context->currentPlanFlow);
 			broadcastPlan(newPlan, false /* stable */ , false /* rescannable */,
 						  context->currentPlanFlow->numsegments /* numsegments */);
 		}

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -2794,6 +2794,41 @@ drop table t;
  Total runtime: 4.955 ms
 (17 rows)
 
+:explain select * from t1, t2 where t1.c1 > any (select max(t2.c1) from t2 where t2.c2 = t1.c2) and t2.c1 > any(select max(c1) from t1 where t1.c2 = t2.c2);
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice4; segments: 1)  (cost=10000000000.00..10182108256.73 rows=1263802500 width=32) (actual time=0.570..0.570 rows=0 loops=2)
+   ->  Nested Loop  (cost=10000000000.00..10182108256.73 rows=421267500 width=32) (actual time=0.000..0.053 rows=0 loops=1)
+         ->  Seq Scan on t1  (cost=0.00..70516404.55 rows=11850 width=16) (actual time=0.000..0.041 rows=0 loops=1)
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice4; segments: 1)
+                 ->  Aggregate  (cost=991.77..991.78 rows=1 width=4) (never executed)
+                       ->  Result  (cost=0.00..989.11 rows=24 width=4) (never executed)
+                             Filter: (t2_1.c2 = t1.c2)
+                             ->  Materialize  (cost=0.00..989.11 rows=24 width=4) (never executed)
+                                   ->  Broadcast Motion 2:1  (slice1; segments: 2)  (cost=0.00..988.75 rows=24 width=4) (never executed)
+                                         ->  Seq Scan on t2 t2_1  (cost=0.00..988.75 rows=24 width=4) (actual time=0.000..0.037 rows=0 loops=1)
+         ->  Materialize  (cost=0.00..70518359.80 rows=35550 width=16) (never executed)
+               ->  Broadcast Motion 2:1  (slice3; segments: 2)  (cost=0.00..70517826.55 rows=35550 width=16) (never executed)
+                     ->  Seq Scan on t2  (cost=0.00..70516404.55 rows=11850 width=16) (actual time=0.000..0.087 rows=0 loops=1)
+                           Filter: (SubPlan 2)
+                           SubPlan 2  (slice3; segments: 2)
+                             ->  Aggregate  (cost=991.77..991.78 rows=1 width=4) (never executed)
+                                   ->  Result  (cost=0.00..989.11 rows=24 width=4) (never executed)
+                                         Filter: (t1_1.c2 = t2.c2)
+                                         ->  Materialize  (cost=0.00..989.11 rows=24 width=4) (never executed)
+                                               ->  Broadcast Motion 1:2  (slice2; segments: 1)  (cost=0.00..988.75 rows=24 width=4) (never executed)
+                                                     ->  Seq Scan on t1 t1_1  (cost=0.00..988.75 rows=24 width=4) (actual time=0.000..0.174 rows=0 loops=1)
+   (slice0)    Executor memory: 514K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice4)    Executor memory: 129K bytes avg x 3 workers, 129K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 14.189 ms
+(30 rows)
+
 --
 -- insert
 --

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -276,7 +276,7 @@ drop table t;
 :explain select * from r2 a left join d2 b using (c1, c2);
 :explain select * from r2 a left join r2 b using (c1);
 :explain select * from r2 a left join r2 b using (c1, c2);
-
+:explain select * from t1, t2 where t1.c1 > any (select max(t2.c1) from t2 where t2.c2 = t1.c2) and t2.c1 > any(select max(c1) from t1 where t1.c2 = t2.c2);
 --
 -- insert
 --


### PR DESCRIPTION
Essentially we can regard `SubPlan` as an expression, it can be used to filter tuples. We have to broadcast the correlated relations which are in the SubPlan so that the `Param` can be used without crossing `Slice`.

In the previous codes, we broadcast the correlated relations according to the distribution of this relation, it may be wrong, we need to adjust it according to the position of SubPlan(or expression).

This PR adds a `flow` to the `context`, then we can get the correct `numsegments`.

For Expample:

```
shzhang=# select relname, numsegments from pg_class,gp_distribution_policy  where pg_class.oid = localoid;
 relname | numsegments
---------+-------------
 t1      |           1
 t2      |           2
 t3      |           3
 t4      |           3
(4 rows)

shzhang=# explain select * from t3,t2 where t3.c1 > any(select max(c1) from t1 where t1.c2 = t3.c2) and t2.c1 > any(select max(c1) from t4 where t2.c2 = t4.c2 and t3.c2 = t4.c2);
                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 2:1  (slice4; segments: 2)  (cost=10000000000.00..9814354262459.43 rows=1517102500 width=24)
   ->  Nested Loop  (cost=10000000000.00..9814354262459.43 rows=505700834 width=24)
         Join Filter: (SubPlan 2)
         ->  Seq Scan on t2  (cost=0.00..879.00 rows=25967 width=12)
         ->  Materialize  (cost=0.00..83906735.30 rows=38950 width=12)
               ->  Broadcast Motion 3:2  (slice2; segments: 3)  (cost=0.00..83906151.05 rows=38950 width=12)
                     ->  Seq Scan on t3  (cost=0.00..83904593.05 rows=12984 width=12)
                           Filter: (SubPlan 1)
                           SubPlan 1  (slice2; segments: 3)
                             ->  Aggregate  (cost=1077.06..1077.07 rows=1 width=4)
                                   ->  Result  (cost=0.00..1074.14 rows=26 width=4)
                                         Filter: (t1.c2 = t3.c2)
                                         ->  Materialize  (cost=0.00..1074.14 rows=26 width=4)
                                               ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..1073.75 rows=26 width=4)
                                                     ->  Seq Scan on t1  (cost=0.00..1073.75 rows=26 width=4)
         SubPlan 2  (slice4; segments: 2)
           ->  Aggregate  (cost=1077.06..1077.07 rows=1 width=4)
                 ->  Result  (cost=0.00..1073.75 rows=26 width=4)
                       One-Time Filter: (t2.c2 = t3.c2)
                       ->  Result  (cost=0.00..1074.14 rows=26 width=4)
                             Filter: (t4.c2 = t3.c2)
                             ->  Materialize  (cost=0.00..1074.14 rows=26 width=4)
                                   ->  Broadcast Motion 3:2  (slice3; segments: 3)  (cost=0.00..1073.75 rows=26 width=4)
                                         ->  Seq Scan on t4  (cost=0.00..1073.75 rows=26 width=4)
 Optimizer: legacy query optimizer
(25 rows)
```
