### PR TITLE
Improve the INFO message on ORCA fallback.

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -261,9 +261,18 @@ CTranslatorScalarToDXL::TranslateScalarToDXL
 
 	if (NULL == func_ptr)
 	{
-		CHAR *str = (CHAR*) gpdb::NodeToString(const_cast<Expr*>(expr));
-		CWStringDynamic *wcstr = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, str);
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion, wcstr->GetBuffer());
+		// This expression is not supported. Check for a few common cases, to
+		// give a better message.
+		if (tag == T_Param)
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion, GPOS_WSZ_LIT("Query Parameter"));
+		}
+		else
+		{
+			CHAR *str = (CHAR*) gpdb::NodeToString(const_cast<Expr*>(expr));
+			CWStringDynamic *wcstr = CDXLUtils::CreateDynamicStringFromCharArray(m_mp, str);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion, wcstr->GetBuffer());
+		}
 	}
 
 	CDXLNode *return_node = (this->*func_ptr)(expr, var_colid_mapping);

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -52,9 +52,6 @@ log_optimizer(PlannedStmt *plan, bool fUnexpectedFailure)
 		return;
 	}
 
-	if (optimizer_trace_fallback)
-		elog(INFO, "GPORCA failed to produce a plan, falling back to planner");
-
 	/* optimizer failed to produce a plan, log failure */
 	if (OPTIMIZER_ALL_FAIL == optimizer_log_failure)
 	{

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -88,6 +88,10 @@ struct SOptContext
 	// did the optimizer fail unexpectedly?
 	BOOL m_is_unexpected_failure;
 
+	// should the error be propagated to user, instead of falling back to the
+	// Postres planner?
+	BOOL m_should_error_out;
+
 	// buffer for optimizer error messages
 	CHAR *m_error_msg;
 
@@ -177,8 +181,7 @@ class COptTasks
 		PlannedStmt *GPOPTOptimizedPlan
 			(
 			Query *query,
-			SOptContext* gpopt_context,
-			BOOL *had_unexpected_failure // output : set to true if optimizer unexpectedly failed to produce plan
+			SOptContext* gpopt_context
 			);
 		
 		// enable/disable a given xforms

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -26,6 +26,7 @@ SELECT avg(b)::numeric(10,3) AS avg_107_943 FROM aggtest;
 
 SELECT avg(gpa) AS avg_3_4 FROM ONLY student;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ONLY in the FROM clause
  avg_3_4 
 ---------
      3.4
@@ -51,6 +52,7 @@ SELECT sum(b) AS avg_431_773 FROM aggtest;
 
 SELECT sum(gpa) AS avg_6_8 FROM ONLY student;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ONLY in the FROM clause
  avg_6_8 
 ---------
      6.8
@@ -76,6 +78,7 @@ SELECT max(aggtest.b) AS max_324_78 FROM aggtest;
 
 SELECT max(student.gpa) AS max_3_7 FROM student;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Inherited tables
  max_3_7 
 ---------
      3.7
@@ -336,6 +339,7 @@ SELECT oldcnt(*) AS cnt_1000 FROM onek;
 
 SELECT sum2(q1,q2) FROM int8_tbl;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
 CONTEXT:  SQL function "sum3" during startup
        sum2        
 -------------------
@@ -370,6 +374,7 @@ select
   (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1)))
 from tenk1 o;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: Aggregate functions with outer references entry found due to incorrect normalization of query
  max  
 ------
  9999
@@ -796,6 +801,7 @@ create index minmaxtest2i on minmaxtest2(f1 desc);
 create index minmaxtest3i on minmaxtest3(f1) where f1 is not null;
 insert into minmaxtest values(11), (12);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Inherited tables
 insert into minmaxtest1 values(13), (14);
 insert into minmaxtest2 values(15), (16);
 insert into minmaxtest3 values(17), (18);
@@ -803,6 +809,7 @@ set enable_seqscan=off;
 explain (costs off)
   select min(f1), max(f1) from minmaxtest;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Inherited tables
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Result
@@ -839,6 +846,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select min(f1), max(f1) from minmaxtest;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Inherited tables
  min | max 
 -----+-----
   11 |  18
@@ -849,6 +857,7 @@ reset enable_seqscan;
 explain (costs off)
   select distinct min(f1), max(f1) from minmaxtest;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Inherited tables
                             QUERY PLAN                             
 -------------------------------------------------------------------
  HashAggregate
@@ -866,6 +875,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select distinct min(f1), max(f1) from minmaxtest;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Inherited tables
  min | max 
 -----+-----
   11 |  18
@@ -891,6 +901,7 @@ LINE 1: select (select max(min(unique1)) from int8_tbl) from tenk1;
 select array_agg(a order by b)
   from (values (1,4),(2,3),(3,1),(4,2)) v(a,b);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  array_agg 
 -----------
  {3,4,2,1}
@@ -899,6 +910,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select array_agg(a order by a)
   from (values (1,4),(2,3),(3,1),(4,2)) v(a,b);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  array_agg 
 -----------
  {1,2,3,4}
@@ -907,6 +919,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select array_agg(a order by a desc)
   from (values (1,4),(2,3),(3,1),(4,2)) v(a,b);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  array_agg 
 -----------
  {4,3,2,1}
@@ -915,6 +928,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select array_agg(b order by a desc)
   from (values (1,4),(2,3),(3,1),(4,2)) v(a,b);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  array_agg 
 -----------
  {2,1,3,4}
@@ -930,6 +944,7 @@ select array_agg(distinct a)
 select array_agg(distinct a order by a)
   from (values (1),(2),(1),(3),(null),(2)) v(a);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
   array_agg   
 --------------
  {1,2,3,NULL}
@@ -938,6 +953,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select array_agg(distinct a order by a desc)
   from (values (1),(2),(1),(3),(null),(2)) v(a);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
   array_agg   
 --------------
  {NULL,3,2,1}
@@ -946,6 +962,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select array_agg(distinct a order by a desc nulls last)
   from (values (1),(2),(1),(3),(null),(2)) v(a);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
   array_agg   
 --------------
  {3,2,1,NULL}
@@ -955,6 +972,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select aggfstr(a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
@@ -964,6 +982,7 @@ CONTEXT:  SQL function "aggf_trans" during startup
 select aggfns(a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
@@ -974,6 +993,7 @@ select aggfstr(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
@@ -984,6 +1004,7 @@ select aggfns(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
@@ -994,7 +1015,9 @@ select aggfstr(distinct a,b,c order by b)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
@@ -1005,7 +1028,9 @@ select aggfns(distinct a,b,c order by b)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
@@ -1017,7 +1042,9 @@ select aggfns(distinct a,a,c order by c using ~<~,a)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
@@ -1028,7 +1055,9 @@ select aggfns(distinct a,a,c order by c using ~<~)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
@@ -1039,7 +1068,9 @@ select aggfns(distinct a,a,c order by a)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
@@ -1050,7 +1081,9 @@ select aggfns(distinct a,b,c order by a,c using ~<~,b)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
@@ -1226,6 +1259,7 @@ select string_agg(a,',') from (values(null),(null)) g(a);
 -- check some implicit casting cases, as per bug #5564
 select string_agg(distinct f1, ',' order by f1) from varchar_tbl;  -- ok
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  string_agg 
 ------------
  a,ab,abcd
@@ -1241,6 +1275,7 @@ LINE 1: select string_agg(distinct f1, ',' order by f1::text) from v...
                                                     ^
 select string_agg(distinct f1::text, ',' order by f1::text) from varchar_tbl;  -- ok
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  string_agg 
 ------------
  a,ab,abcd
@@ -1249,6 +1284,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 -- FILTER tests
 select min(unique1) filter (where unique1 > 100) from tenk1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Aggregate functions with FILTER
  min 
 -----
  101
@@ -1257,6 +1293,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select ten, sum(distinct four) filter (where four::text ~ '123') from onek a
 group by ten;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Aggregate functions with FILTER
  ten | sum 
 -----+-----
    0 |    
@@ -1275,6 +1312,7 @@ select ten, sum(distinct four) filter (where four > 10) from onek a
 group by ten
 having exists (select 1 from onek b where sum(distinct a.four) = b.four);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Aggregate functions with FILTER
  ten | sum 
 -----+-----
    0 |    
@@ -1287,6 +1325,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select max(foo COLLATE "C") filter (where (bar collate "POSIX") > '0')
 from (values ('a', 'b')) AS v(foo,bar);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Non-default collation
  max 
 -----
  a
@@ -1306,6 +1345,7 @@ select (select count(*) filter (where outer_c <> 0)
         from (values (1)) t0(inner_c))
 from (values (2),(3)) t1(outer_c); -- outer query is aggregation query
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: Aggregate functions with outer references entry found due to incorrect normalization of query
  count 
 -------
      2
@@ -1315,6 +1355,7 @@ select (select count(inner_c) filter (where outer_c <> 0)
         from (values (1)) t0(inner_c))
 from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Aggregate functions with FILTER
  count 
 -------
      1
@@ -1326,6 +1367,7 @@ select
      filter (where o.unique1 < 10))
 from tenk1 o;					-- outer query is aggregation query
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: Aggregate functions with outer references entry found due to incorrect normalization of query
  max  
 ------
  9998
@@ -1335,6 +1377,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select sum(unique1) FILTER (WHERE
   unique1 IN (SELECT unique1 FROM onek where unique1 < 100)) FROM tenk1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Aggregate functions with FILTER
  sum  
 ------
  4950
@@ -1345,7 +1388,9 @@ select aggfns(distinct a,b,c order by a,c using ~<~,b) filter (where a > 1)
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
     generate_series(1,2) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
           aggfns           
 ---------------------------
@@ -1358,6 +1403,7 @@ from generate_series(1,5) x,
      (values (0::float8),(0.1),(0.25),(0.4),(0.5),(0.6),(0.75),(0.9),(1)) v(p)
 group by p order by p;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
   p   | percentile_cont 
 ------+-----------------
     0 |               1
@@ -1394,6 +1440,7 @@ LINE 1: select p, percentile_cont(p,p)
                   ^
 select percentile_cont(0.5) within group (order by b) from aggtest;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  percentile_cont  
 ------------------
  53.4485001564026
@@ -1401,6 +1448,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select percentile_cont(0.5) within group (order by b), sum(b) from aggtest;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  percentile_cont  |   sum   
 ------------------+---------
  53.4485001564026 | 431.773
@@ -1408,6 +1456,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select percentile_cont(0.5) within group (order by thousand) from tenk1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  percentile_cont 
 -----------------
            499.5
@@ -1415,6 +1464,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select percentile_disc(0.5) within group (order by thousand) from tenk1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  percentile_disc 
 -----------------
              499
@@ -1423,6 +1473,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select rank(3) within group (order by x)
 from (values (1),(1),(2),(2),(3),(3),(4)) v(x);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  rank 
 ------
     5
@@ -1431,6 +1482,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select cume_dist(3) within group (order by x)
 from (values (1),(1),(2),(2),(3),(3),(4)) v(x);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  cume_dist 
 -----------
      0.875
@@ -1439,6 +1491,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select percent_rank(3) within group (order by x)
 from (values (1),(1),(2),(2),(3),(3),(4),(5)) v(x);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  percent_rank 
 --------------
           0.5
@@ -1447,6 +1500,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select dense_rank(3) within group (order by x)
 from (values (1),(1),(2),(2),(3),(3),(4)) v(x);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  dense_rank 
 ------------
           3
@@ -1455,6 +1509,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select percentile_disc(array[0,0.1,0.25,0.5,0.75,0.9,1]) within group (order by thousand)
 from tenk1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
       percentile_disc       
 ----------------------------
  {0,99,249,499,749,899,999}
@@ -1463,6 +1518,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select percentile_cont(array[0,0.25,0.5,0.75,1]) within group (order by thousand)
 from tenk1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
        percentile_cont       
 -----------------------------
  {0,249.75,499.5,749.25,999}
@@ -1471,6 +1527,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select percentile_disc(array[[null,1,0.5],[0.75,0.25,null]]) within group (order by thousand)
 from tenk1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
          percentile_disc         
 ---------------------------------
  {{NULL,999,499},{749,249,NULL}}
@@ -1479,6 +1536,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select percentile_cont(array[0,1,0.25,0.75,0.5,1]) within group (order by x)
 from generate_series(1,6) x;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
     percentile_cont    
 -----------------------
  {1,6,2.25,4.75,3.5,6}
@@ -1486,6 +1544,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select ten, mode() within group (order by string4) from tenk1 group by ten order by ten;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  ten |  mode  
 -----+--------
    0 | HHHHxx
@@ -1503,6 +1562,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select percentile_disc(array[0.25,0.5,0.75]) within group (order by x)
 from unnest('{fred,jim,fred,jack,jill,fred,jill,jim,jim,sheila,jim,sheila}'::text[]) u(x);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  percentile_disc 
 -----------------
  {fred,jill,jim}
@@ -1512,6 +1572,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select pg_collation_for(percentile_disc(1) within group (order by x collate "POSIX"))
   from (values ('fred'),('jim')) v(x);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Non-default collation
  pg_collation_for 
 ------------------
  "POSIX"
@@ -1521,6 +1582,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 select test_rank(3) within group (order by x)
 from (values (1),(1),(2),(2),(3),(3),(4)) v(x);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  test_rank 
 -----------
          5
@@ -1528,6 +1590,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select test_percentile_disc(0.5) within group (order by thousand) from tenk1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  test_percentile_disc 
 ----------------------
                   499
@@ -1573,6 +1636,7 @@ LINE 1: ...adam'::text collate "C") within group (order by x collate "P...
 -- hypothetical-set type unification successes:
 select rank('adam'::varchar) within group (order by x) from (values ('fred'),('jim')) v(x);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  rank 
 ------
     1
@@ -1580,6 +1644,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select rank('3') within group (order by x) from generate_series(1,5) x;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  rank 
 ------
     3
@@ -1588,6 +1653,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 -- divide by zero check
 select percent_rank(0) within group (order by x) from generate_series(1,0) x;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  percent_rank 
 --------------
             0
@@ -1615,6 +1681,7 @@ select pg_get_viewdef('aggordview1');
 
 select * from aggordview1 order by ten;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Ordered aggregates not supported in DXL
  ten | p50 | px  | rank 
 -----+-----+-----+------
    0 | 490 |     |  101
@@ -1633,6 +1700,7 @@ drop view aggordview1;
 -- variadic aggregates
 select least_agg(q1,q2) from int8_tbl;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
 CONTEXT:  SQL function "least_accum" during startup
      least_agg     
 -------------------
@@ -1641,6 +1709,7 @@ CONTEXT:  SQL function "least_accum" during startup
 
 select least_agg(variadic array[q1,q2]) from int8_tbl;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
 CONTEXT:  SQL function "least_accum" during startup
      least_agg     
 -------------------

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -40,6 +40,7 @@ set optimizer_trace_fallback = on;
 -- expected fall back to the planner
 select sum(distinct a), count(distinct b) from orca.r;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  sum | count 
 -----+-------
  210 |     7
@@ -6602,6 +6603,7 @@ select * from orca.r where a in (select count(*)+1 as v from orca.foo full join 
 
 select * from orca.r where r.a in (select d+r.b+1 as v from orca.foo full join orca.bar on (foo.d = bar.a) group by d+r.b) order by r.a, r.b;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: No variable entry found due to incorrect normalization of query
  a  | b 
 ----+---
   3 | 0
@@ -8024,8 +8026,10 @@ NOTICE:  CREATE TABLE will create partition "multilevel_p_1_prt_bb_2_2_prt_sp2_3
 NOTICE:  CREATE TABLE will create partition "multilevel_p_1_prt_bb_2_2_prt_sp2_4" for table "multilevel_p_1_prt_bb_2"
 insert into orca.multilevel_p values (1,1), (100,200);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Multi-level partitioned tables with non-uniform partitioning structure
 select * from orca.multilevel_p;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Multi-level partitioned tables with non-uniform partitioning structure
   a  |  b  
 -----+-----
    1 |   1
@@ -8783,6 +8787,7 @@ CREATE FUNCTION sum_combinefunc(anyelement,anyelement) returns anyelement AS 'se
 CREATE AGGREGATE myagg1(anyelement) (SFUNC = sum_sfunc, COMBINEFUNC = sum_combinefunc, STYPE = anyelement, INITCOND = '0');
 SELECT myagg1(i) FROM orca.tab1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
 CONTEXT:  SQL function "sum_sfunc" during startup
  myagg1 
 --------
@@ -8793,6 +8798,7 @@ CREATE FUNCTION sum_sfunc2(anyelement,anyelement,anyelement) returns anyelement 
 CREATE AGGREGATE myagg2(anyelement,anyelement) (SFUNC = sum_sfunc2, STYPE = anyelement, INITCOND = '0');
 SELECT myagg2(i,j) FROM orca.tab1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
 CONTEXT:  SQL function "sum_sfunc2" during startup
  myagg2 
 --------
@@ -8815,8 +8821,10 @@ INSERT INTO array_table values(7,array[3],'a');
 INSERT INTO array_table values(8,array[3],'b');
 SELECT f3, myagg3(f1) from (select * from array_table order by f1 limit 10) as foo GROUP BY f3 ORDER BY f3;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
 CONTEXT:  SQL function "gptfp" during startup
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
 CONTEXT:  SQL function "gpffp" during startup
  f3 | myagg3  
 ----+---------
@@ -9636,6 +9644,7 @@ set optimizer_enable_dynamictablescan = off;
 -- gather on 1 segment because of direct dispatch
 explain select * from orca.bm_dyn_test_onepart where i=2 and t='2';
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..13.52 rows=13 width=10)
@@ -9657,6 +9666,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 select * from orca.bm_dyn_test_onepart where i=2 and t='2';
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
  i | j | t 
 ---+---+---
  2 | 2 | 2
@@ -10296,6 +10306,7 @@ CREATE TABLE btree_test as SELECT * FROM generate_series(1,100) as a distributed
 CREATE INDEX btree_test_index ON btree_test(a);
 EXPLAIN SELECT * FROM btree_test WHERE a in (1, 47);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  DXL-to-PlStmt Translation: ScalarArrayOpExpr condition on index scan not supported
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.25 rows=2 width=4)
@@ -10307,6 +10318,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('2', 47);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  DXL-to-PlStmt Translation: ScalarArrayOpExpr condition on index scan not supported
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.25 rows=2 width=4)
@@ -10318,6 +10330,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2');
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  DXL-to-PlStmt Translation: ScalarArrayOpExpr condition on index scan not supported
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.25 rows=2 width=4)
@@ -10329,6 +10342,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2', 47);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  DXL-to-PlStmt Translation: ScalarArrayOpExpr condition on index scan not supported
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.38 rows=3 width=4)
@@ -10414,6 +10428,7 @@ set client_min_messages='log';
 explain select count(*) from foo group by cube(a,b);
 LOG:  2018-03-29 10:22:52:869837 PDT,THD000,NOTICE,"Feature not supported by the Pivotal Query Optimizer: Cube",
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: Cube
 LOG:  Planner produced plan :0
                                                                    QUERY PLAN                                                                   
 ------------------------------------------------------------------------------------------------------------------------------------------------
@@ -10459,6 +10474,8 @@ CREATE FUNCTION func_enum_element(ANYENUM, ANYELEMENT) RETURNS TABLE(a ANYENUM, 
 AS $$ SELECT $1, ARRAY[$2] $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_enum_element('red'::rainbow, 'blue'::rainbow::anyelement);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+CONTEXT:  SQL function "func_enum_element" during startup
   a  |   b    
 -----+--------
  red | {blue}
@@ -10470,6 +10487,8 @@ CREATE FUNCTION func_element_array(ANYELEMENT, ANYARRAY) RETURNS TABLE(a ANYELEM
 AS $$ SELECT $1, $2[1]$$ LANGUAGE SQL STABLE;
 SELECT * FROM func_element_array('red'::rainbow, ARRAY['blue'::rainbow]);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+CONTEXT:  SQL function "func_element_array" during startup
   a  |  b   
 -----+------
  red | blue
@@ -10481,6 +10500,8 @@ CREATE FUNCTION func_element_array(ANYARRAY, ANYENUM) RETURNS TABLE(a ANYELEMENT
 AS $$ SELECT $1[1], $2 $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_element_array(ARRAY['blue'::rainbow], 'blue'::rainbow);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+CONTEXT:  SQL function "func_element_array" during startup
   a   |  b   
 ------+------
  blue | blue
@@ -10492,6 +10513,8 @@ CREATE FUNCTION func_array(ANYARRAY) RETURNS TABLE(a ANYELEMENT, b ANYENUM)
 AS $$ SELECT $1[1], $1[2] $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_array(ARRAY['blue'::rainbow, 'yellow'::rainbow]);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+CONTEXT:  SQL function "func_array" during startup
   a   |   b    
 ------+--------
  blue | yellow
@@ -10503,6 +10526,8 @@ CREATE FUNCTION func_element_variadic(ANYELEMENT, VARIADIC ANYARRAY) RETURNS TAB
 AS $$ SELECT array_prepend($1, $2); $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_element_variadic(1.1, 1.1, 2.2, 3.3);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+CONTEXT:  SQL function "func_element_variadic" during startup
          a         
 -------------------
  {1.1,1.1,2.2,3.3}
@@ -10514,6 +10539,8 @@ CREATE FUNCTION func_nonarray(ANYNONARRAY) RETURNS TABLE(a ANYNONARRAY)
 AS $$ SELECT $1; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_nonarray(5);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+CONTEXT:  SQL function "func_nonarray" during startup
  a 
 ---
  5
@@ -10525,6 +10552,8 @@ CREATE FUNCTION func_nonarray_enum(ANYNONARRAY, ANYENUM) RETURNS TABLE(a ANYARRA
 AS $$ SELECT ARRAY[$1, $2]; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_nonarray_enum('blue'::rainbow, 'red'::rainbow);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+CONTEXT:  SQL function "func_nonarray_enum" during startup
      a      
 ------------
  {blue,red}
@@ -10536,6 +10565,8 @@ CREATE FUNCTION func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM) RETURNS
 AS $$ SELECT $1[1]; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_array_nonarray_enum(ARRAY['blue'::rainbow, 'red'::rainbow], 'red'::rainbow, 'yellow'::rainbow);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+CONTEXT:  SQL function "func_array_nonarray_enum" during startup
   a   
 ------
  blue
@@ -10568,6 +10599,7 @@ set client_min_messages='log';
 create table foo_ctas(a) as (select generate_series(1,10)) distributed by (a);
 LOG:  2017-05-31 14:43:22:338568 PDT,THD000,NOTICE,"Feature not supported by the Pivotal Query Optimizer: CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA",
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA
 LOG:  Planner produced plan :0
 LOG:  Computing Scalar Stats : column a
 reset client_min_messages;

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -7,6 +7,7 @@ CREATE TABLE constr_tab ( a int check (a>0) , b int, c int, d int, CHECK (a+b>5)
 set optimizer_enable_dml_constraints = off;
 explain insert into constr_tab values (1,2,3);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: INSERT with constraints
                        QUERY PLAN                       
 --------------------------------------------------------
  Insert on constr_tab  (cost=0.00..0.01 rows=1 width=0)
@@ -33,6 +34,7 @@ INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: UPDATE with constraints
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
  Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
@@ -45,6 +47,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 explain update constr_tab set b = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: UPDATE with constraints
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
@@ -71,6 +74,7 @@ INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: UPDATE with constraints
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
  Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
@@ -85,11 +89,14 @@ DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int NOT NULL, b int NOT NULL, c int NOT NULL, d int NOT NULL) DISTRIBUTED BY (a,b);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: INSERT with constraints
 INSERT INTO constr_tab VALUES(1,5,3,4);
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: INSERT with constraints
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set b = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: UPDATE with constraints
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
  Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
@@ -137,18 +144,21 @@ NOTICE:  CREATE TABLE will create partition "homer_1_prt_2_2_prt_2" for table "h
 INSERT INTO homer VALUES (1,0,40),(2,1,43),(3,2,41),(4,3,44);
 SELECT * FROM ONLY homer;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ONLY in the FROM clause
  a | b | c 
 ---+---+---
 (0 rows)
 
 SELECT * FROM ONLY homer_1_prt_1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ONLY in the FROM clause
  a | b | c 
 ---+---+---
 (0 rows)
 
 UPDATE ONLY homer SET c = c + 1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ONLY in the FROM clause
 SELECT * FROM homer;
  a | b | c  
 ---+---+----
@@ -160,6 +170,7 @@ SELECT * FROM homer;
 
 DELETE FROM ONLY homer WHERE a = 3;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ONLY in the FROM clause
 SELECT * FROM homer;
  a | b | c  
 ---+---+----
@@ -184,6 +195,7 @@ EXPLAIN SELECT * FROM ext_table_no_fallback;
 
 EXPLAIN SELECT * FROM ONLY ext_table_no_fallback;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ONLY in the FROM clause
                                        QUERY PLAN
 -----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..11000.00 rows=1000000 width=8)
@@ -193,6 +205,7 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 EXPLAIN INSERT INTO heap_t1 SELECT * FROM ONLY ext_table_no_fallback;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: ONLY in the FROM clause
                                            QUERY PLAN
 -------------------------------------------------------------------------------------------------
  Insert on heap_t1  (cost=0.00..11000.00 rows=333334 width=8)

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -402,6 +402,7 @@ set optimizer_trace_fallback = TRUE;
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
             owner            | property 
 -----------------------------+----------
  A. Gent                     | 
@@ -412,7 +413,9 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 SELECT count_index_scans('EXPLAIN SELECT owner, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: SIRV functions
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
 CONTEXT:  SQL statement "EXPLAIN SELECT owner, property FROM GistTable1 WHERE property IS NULL ORDER BY id;"
 PL/Python function "count_index_scans"
  count_index_scans 
@@ -446,6 +449,7 @@ SELECT id, property FROM GistTable1
  ORDER BY id
  ;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
  id | property 
 ----+----------
   8 | 
@@ -456,7 +460,9 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 
 SELECT count_index_scans('EXPLAIN SELECT id, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported by the Pivotal Query Optimizer: SIRV functions
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
 CONTEXT:  SQL statement "EXPLAIN SELECT id, property FROM GistTable1 WHERE property IS NULL ORDER BY id;"
 PL/Python function "count_index_scans"
  count_index_scans 


### PR DESCRIPTION
If optimizer_trace_fallback is enabled, report the ORCA exception's message
to the user. It usually says something like "Feature not supported by the
Pivotal Query Optimizer: Non-default collation", which is quite helpful.

While we're at it, simplify setting the "had unexpected failure" flag,
by putting it in SOptContext. That allows removing one layer of catching and
re-throwing the exception.

