### PR TITLE
Build gpnetbench with the same Makefile patterns/rules as the rest of the tree

### DIFF
--- a/gpAux/platform/gpnetbench/Makefile
+++ b/gpAux/platform/gpnetbench/Makefile
@@ -1,5 +1,3 @@
-SHELL=/usr/bin/env bash
-
 default: all
 
 top_builddir = ../../..
@@ -8,23 +6,22 @@ include $(top_builddir)/src/Makefile.global
 SERVER_OBJS=gpnetbenchServer.o
 CLIENT_OBJS=gpnetbenchClient.o
 
-CFLAGS=-Werror -Wall -g -O2
+OBJS = $(SERVER_OBJS) $(CLIENT_OBJS)
 
 all: gpnetbenchServer gpnetbenchClient
 
 gpnetbenchServer: $(SERVER_OBJS)
-	$(CC) -o gpnetbenchServer $(SERVER_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(SERVER_OBJS) -o $@$(X)
 
 gpnetbenchClient: $(CLIENT_OBJS)
-	$(CC) -o gpnetbenchClient $(CLIENT_OBJS)
-
-%.o: %.c
-	$(CC) $(CFLAGS) -o $@ -c $<
+	$(CC) $(CFLAGS) $(LDFLAGS) $(CLIENT_OBJS) -o $@$(X)
 
 clean:
-	rm -rf *.o gpnetbenchServer gpnetbenchClient
+	rm -rf $(OBJS) *.o gpnetbenchServer$(X) gpnetbenchClient$(X)
 
-install: all
-	mkdir -p $(prefix)/bin/lib
-	cp -p gpnetbenchServer $(prefix)/bin/lib
-	cp -p gpnetbenchClient $(prefix)/bin/lib
+installdirs:
+	$(MKDIR_P) '$(DESTDIR)$(bindir)/lib'
+
+install: all installdirs
+	$(INSTALL_PROGRAM) gpnetbenchClient$(X) '$(DESTDIR)$(bindir)/lib/gpnetbenchClient$(X)'
+	$(INSTALL_PROGRAM) gpnetbenchServer$(X) '$(DESTDIR)$(bindir)/lib/gpnetbenchServer$(X)'

--- a/gpAux/platform/gpnetbench/gpnetbenchClient.c
+++ b/gpAux/platform/gpnetbench/gpnetbenchClient.c
@@ -10,11 +10,14 @@
 #include <sys/time.h>
 
 #define INIT_RETRIES 5
-void send_buffer(int fd, char* buffer, int bytes);
-void print_headers();
-double subtractTimeOfDay(struct timeval* begin, struct timeval* end);
 
-void usage()
+static void send_buffer(int fd, char* buffer, int bytes);
+static void print_headers(void);
+static double subtractTimeOfDay(struct timeval* begin, struct timeval* end);
+static void usage(void);
+
+static void
+usage(void)
 {
 	fprintf(stdout, "usage: gpnetbench -p PORT -H HOST [-l SECONDS] [-t EXPERIMENT] [-f UNITS] [-P HEADERS] [-b KB] [-h]\n");
 	fprintf(stdout, "where\n");
@@ -29,7 +32,8 @@ void usage()
 	fprintf(stdout, "       -h shows this help message\n");
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
 	int socketFd;
 	int retVal;
@@ -169,7 +173,8 @@ int main(int argc, char** argv)
 	return 0;
 }
 
-void send_buffer(int fd, char* buffer, int bytes)
+static void
+send_buffer(int fd, char* buffer, int bytes)
 {
 	ssize_t retval;
 
@@ -192,7 +197,8 @@ void send_buffer(int fd, char* buffer, int bytes)
 	}
 }
 
-double subtractTimeOfDay(struct timeval* begin, struct timeval* end)
+static double
+subtractTimeOfDay(struct timeval* begin, struct timeval* end)
 {
 	double seconds;
 
@@ -209,7 +215,8 @@ double subtractTimeOfDay(struct timeval* begin, struct timeval* end)
 	return seconds;
 }
 
-void print_headers()
+static void
+print_headers()
 {
 	printf("               Send\n");
 	printf("               Message  Elapsed\n");

--- a/gpAux/platform/gpnetbench/gpnetbenchServer.c
+++ b/gpAux/platform/gpnetbench/gpnetbenchServer.c
@@ -10,14 +10,17 @@
 #define SERVER_APPLICATION_RECEIVE_BUF_SIZE 65536
 char* receiveBuffer = NULL;
 
-void handleIncomingConnection(int fd);
+static void handleIncomingConnection(int fd);
+static void usage(void);
 
-void usage()
+static void
+usage(void)
 {
 	fprintf(stdout, "usage: gpnetbenchServer -p PORT [-h]\n");
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
 	int socketFd;
 	int clientFd;
@@ -130,7 +133,8 @@ int main(int argc, char** argv)
 	return 0;
 }
 
-void handleIncomingConnection(int fd)
+static void
+handleIncomingConnection(int fd)
 {
 	ssize_t bytes;
 


### PR DESCRIPTION
gpnetbench was building more like a separate project, than as a part of a project with etablished patterns for how to build.  This ports the gpnetbench Makefile over to using the standard way to build objs and binaries in the tree.  Also removes an unused variable in the process.

However, with the gpnetbench Makefile building with the same warninglevels as
the rest of the tree, the code no longer compiled without warnings. The second commit fixes that to again make the code build cleanly.