### PR TITLE
Update admin guide and ref guide functions docs for replicated tables

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
@@ -7,8 +7,7 @@
     <body>
         <ul>
             <li id="in140953">
-                <xref format="dita" href="#topic27" type="topic"/>
-            </li>
+                <xref format="dita" href="#topic27" type="topic"/></li>
             <li id="in141620">
                 <xref format="dita" href="#topic28" type="topic"/>
             </li>
@@ -34,12 +33,11 @@
                     ON</codeph> indicates where it is executed. The volatility attributes are
                 PostgreSQL based attributes, the <codeph>EXECUTE ON</codeph> attributes are
                 Greenplum Database attributes.</p>
-            <p>For example, a function defined with the <codeph>IMMUTABLE</codeph> attribute can be
-                executed at query planning time, while a function with the <codeph>VOLATILE</codeph>
-                attribute must be executed for every row in the query. A function with the
-                    <codeph>EXECUTE ON MASTER</codeph> attribute executes only on the master
-                segment, and a function with the <codeph>EXECUTE ON ALL SEGMENTS</codeph> attribute
-                executes on all primary segment instances (not the master). </p>
+            <p>For example, a function defined with the <codeph>IMMUTABLE</codeph> attribute can be executed at query
+                planning time, while a function with the <codeph>VOLATILE</codeph> attribute must be executed for every
+                row in the query. A function with the <codeph>EXECUTE ON MASTER</codeph> attribute executes only on the
+                master instance, and a function with the <codeph>EXECUTE ON ALL SEGMENTS</codeph> attribute executes on
+                all primary segment instances (not the master). </p>
             <p>These tables summarize what Greenplum Database assumes about function execution based
                 on the attribute.</p>
             <table id="in201681">
@@ -149,6 +147,8 @@
                 such as <codeph>setval()</codeph> are not allowed to execute on distributed data in
                 Greenplum Database because they can cause inconsistent data between segment
                 instances.</p>
+            <p>A function can execute read-only queries on replicated tables (<codeph>DISTRIBUTED REPLICATED</codeph>)
+                on the segments, but any SQL command that modifies data must execute on the master instance. </p>
             <p>To ensure data consistency, you can safely use <codeph>VOLATILE</codeph> and
                     <codeph>STABLE</codeph> functions in statements that are evaluated on and run
                 from the master. For example, the following statements run on the master (statements
@@ -194,13 +194,14 @@ SELECT foo();</codeblock>
                 default, user-defined functions are declared as <codeph>VOLATILE</codeph>, so if
                 your user-defined function is <codeph>IMMUTABLE</codeph> or <codeph>STABLE</codeph>,
                 you must specify the correct volatility level when you register your function.</p>
-            <p>By default, user-defined functions are declared as <codeph>EXEUCTE ON ANY</codeph>. A
-                function that executes queries to access tables is supported only when a function
-                executes on the master instance. Such functions must be defined with the
-                    <codeph>EXECUTE ON MASTER</codeph> attribute. Otherwise, the function might
-                return incorrect results when the function is used in a complicated query. Without
-                the attribute, planner optimization might determine it would be beneficial to push
-                the function invocation to segment instances. </p>
+            <p>By default, user-defined functions are declared as <codeph>EXECUTE ON ANY</codeph>. A function that
+                executes queries to access tables is supported only when the function executes on the master instance,
+                except that a function can execute <codeph>SELECT</codeph> commands that access only replicated tables
+                on the segment instances. A function that accesses hash-distributed or randomly distributed tables must
+                be defined with the <codeph>EXECUTE ON MASTER</codeph> attribute. Otherwise, the function might return
+                incorrect results when the function is used in a complicated query. Without the attribute, planner
+                optimization might determine it would be beneficial to push the function invocation to segment
+                instances. </p>
             <p>When you create user-defined functions, avoid using fatal errors or destructive
                 calls. Greenplum Database may respond to such errors with a sudden shutdown or
                 restart.</p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
@@ -366,11 +366,11 @@ $SomeTag$Dianne's horse$SomeTag$</codeblock>
                         only takes input arguments that are constant values. The function is
                         supported if it can be changed to require no input arguments.</li>
                 </ul></sectiondiv>
-            <sectiondiv><b>Using EXECUTE ON attributes</b><p>A function that executes queries to
-                    access tables can only execute on the master, except that a function that
-                    executes only <codeph>SELECT</codeph> queries on replicated tables can run on
-                    segments. If the function accesses a hash-distributed table or a randomly
-                    distributed table, the function should be defined with the <codeph>EXECUTE ON
+            <sectiondiv><b>Using EXECUTE ON attributes</b><p>Most functions that execute queries to
+                    access tables can only execute on the master. However, functions that execute
+                    only <codeph>SELECT</codeph> queries on replicated tables can run on segments.
+                    If the function accesses a hash-distributed table or a randomly distributed
+                    table, the function should be defined with the <codeph>EXECUTE ON
                         MASTER</codeph> attribute. Otherwise, the function might return incorrect
                     results when the function is used in a complicated query. Without the attribute,
                     planner optimization might determine it would be beneficial to push the function

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
@@ -23,9 +23,9 @@
     | AS '<varname>obj_file</varname>', '<varname>link_symbol</varname>' } ...
     [ WITH ({ DESCRIBE = describe_function
            } [, ...] ) ]</codeblock></section>
-        <section id="section3"><title>Description</title><p><codeph>CREATE FUNCTION</codeph> defines
-                a new function. <codeph>CREATE OR REPLACE FUNCTION</codeph> will either create a new
-                function, or replace an existing definition. </p><p>The name of the new function
+        <section id="section3"><title>Description</title><p><codeph>CREATE FUNCTION</codeph> defines a new function. <codeph>CREATE OR REPLACE
+                    FUNCTION</codeph> will either create a new function, or replace an existing
+                definition.</p><p>The name of the new function
                 must not match any existing function with the same argument types in the same
                 schema. However, functions of different argument types may share a name
                 (overloading). </p><p>To update the definition of an existing function, use
@@ -40,18 +40,18 @@
                 information about creating functions, see the <xref
                     href="https://www.postgresql.org/docs/8.3/static/xfunc.html" scope="external"
                     format="html">User Defined Functions</xref> section of the PostgreSQL
-                documentation.</p><sectiondiv id="section4"><b>Limited Use of VOLATILE and STABLE
-                    Functions</b><p>To prevent data from becoming out-of-sync across the segments in
-                    Greenplum Database, any function classified as <codeph>STABLE</codeph> or
-                        <codeph>VOLATILE</codeph> cannot be executed at the segment level if it
-                    contains SQL or modifies the database in any way. For example, functions such as
-                        <codeph>random()</codeph> or <codeph>timeofday()</codeph> are not allowed to
-                    execute on distributed data in Greenplum Database because they could potentially
-                    cause inconsistent data between the segment instances.</p><p>To ensure data
-                    consistency, <codeph>VOLATILE</codeph> and <codeph>STABLE</codeph> functions can
-                    safely be used in statements that are evaluated on and execute from the master.
-                    For example, the following statements are always executed on the master
-                    (statements without a <codeph>FROM</codeph>
+                documentation.</p><sectiondiv id="section4"><b>Limited Use of VOLATILE and STABLE Functions</b><p>To prevent data from
+                    becoming out-of-sync across the segments in Greenplum Database, any function
+                    classified as <codeph>STABLE</codeph> or <codeph>VOLATILE</codeph> cannot be
+                    executed at the segment level if it contains SQL or modifies the database in any
+                    way. For example, functions such as <codeph>random()</codeph> or
+                        <codeph>timeofday()</codeph> are not allowed to execute on distributed data
+                    in Greenplum Database because they could potentially cause inconsistent data
+                    between the segment instances.</p><p>To ensure data consistency,
+                        <codeph>VOLATILE</codeph> and <codeph>STABLE</codeph> functions can safely
+                    be used in statements that are evaluated on and execute from the master. For
+                    example, the following statements are always executed on the master (statements
+                    without a <codeph>FROM</codeph>
                     clause):</p><codeblock>SELECT setval('myseq', 201);
 SELECT foo();</codeblock><p>In
                     cases where a statement has a <codeph>FROM</codeph> clause containing a
@@ -62,8 +62,8 @@ SELECT foo();</codeblock><p>In
                     or functions that use the <codeph>refCursor</codeph> data type. Note that you
                     cannot return a <codeph>refcursor</codeph> from any kind of function in
                     Greenplum Database.</p></sectiondiv>
-            <sectiondiv><b>Function Volitionality and EXECUTE ON Attributes</b><p>Volatility
-                    attributes (<codeph>IMMUTABLE</codeph>, <codeph>STABLE</codeph>,
+            <sectiondiv><b>Function Volatility and EXECUTE ON Attributes</b><p>Volatility attributes
+                        (<codeph>IMMUTABLE</codeph>, <codeph>STABLE</codeph>,
                         <codeph>VOLATILE</codeph>) and <codeph>EXECUTE ON</codeph> attributes
                     specify two different aspects of function execution. In general, volatility
                     indicates when the function is executed, and <codeph>EXECUTE ON</codeph>
@@ -76,7 +76,13 @@ SELECT foo();</codeblock><p>In
                     on all primary segment instances (not the master).</p><p>See <xref
                         href="../../admin_guide/query/topics/functions-operators.xml#topic26/in151167"
                         >Using Functions and Operators</xref> in the <cite>Greenplum Database
-                        Administrator Guide</cite>.</p></sectiondiv></section>
+                        Administrator Guide</cite>.</p></sectiondiv>
+            <sectiondiv><b>Functions And Replicated Tables</b><p>A user-defined function that
+                    executes only <codeph>SELECT</codeph> commands on replicated tables can run on
+                    segments. Replicated tables, created with the <codeph>DISTRIBUTED
+                        REPLICATED</codeph> clause, store all of their rows on every segment. It is
+                    safe for a function to read them on the segments, but updates to replicated
+                    tables must execute on the master instance. </p></sectiondiv></section>
         <section id="section5"><title>Parameters</title><parml>
                 <plentry>
                     <pt><varname>name</varname></pt>
@@ -361,11 +367,13 @@ $SomeTag$Dianne's horse$SomeTag$</codeblock>
                         supported if it can be changed to require no input arguments.</li>
                 </ul></sectiondiv>
             <sectiondiv><b>Using EXECUTE ON attributes</b><p>A function that executes queries to
-                    access tables is only supported when a function is executed on the master. Such
-                    functions should be defined with the <codeph>EXECUTE ON MASTER</codeph>
-                    attribute. Otherwise, the function might return incorrect results when the
-                    function is used in a complicated query. Without the attribute, planner
-                    optimization might determine it would be beneficial to push the function
+                    access tables can only execute on the master, except that a function that
+                    executes only <codeph>SELECT</codeph> queries on replicated tables can run on
+                    segments. If the function accesses a hash-distributed table or a randomly
+                    distributed table, the function should be defined with the <codeph>EXECUTE ON
+                        MASTER</codeph> attribute. Otherwise, the function might return incorrect
+                    results when the function is used in a complicated query. Without the attribute,
+                    planner optimization might determine it would be beneficial to push the function
                     invocation to segment instances.</p>These are limitations for functions defined
                 with the <codeph>EXECUTE ON MASTER</codeph> or <codeph>EXECUTE ON ALL
                     SEGMENTS</codeph> attribute:<ul id="ul_nlg_jky_fcb">
@@ -382,23 +390,24 @@ $SomeTag$Dianne's horse$SomeTag$</codeblock>
     LANGUAGE SQL
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;</codeblock><p>Increment
-                an integer, making use of an argument name, in PL/pgSQL:</p><codeblock>CREATE OR REPLACE FUNCTION increment(i integer) RETURNS 
+                an integer, making use of an argument name, in
+                PL/pgSQL:</p><codeblock>CREATE OR REPLACE FUNCTION increment(i integer) RETURNS 
 integer AS $$
         BEGIN
                 RETURN i + 1;
         END;
-$$ LANGUAGE plpgsql;</codeblock>
-            <p>Increase the default segment host memory per query for a PL/pgSQL function:</p>
-            <codeblock>CREATE OR REPLACE FUNCTION function_with_query() RETURNS 
+$$ LANGUAGE plpgsql;</codeblock><p>Increase
+                the default segment host memory per query for a PL/pgSQL
+                function:</p><codeblock>CREATE OR REPLACE FUNCTION function_with_query() RETURNS 
 SETOF text AS $$
         BEGIN
                 RETURN QUERY
                 EXPLAIN ANALYZE SELECT * FROM large_table;
         END;
 $$ LANGUAGE plpgsql
-SET statement_mem='256MB';</codeblock>
-            <p>Use polymorphic types to return an <codeph>ENUM</codeph> array:</p>
-            <codeblock>CREATE TYPE rainbow AS ENUM('red','orange','yellow','green','blue','indigo','violet');
+SET statement_mem='256MB';</codeblock><p>Use
+                polymorphic types to return an <codeph>ENUM</codeph>
+                array:</p><codeblock>CREATE TYPE rainbow AS ENUM('red','orange','yellow','green','blue','indigo','violet');
 CREATE FUNCTION return_enum_as_array( anyenum, anyelement, anyelement ) 
     RETURNS TABLE (ae anyenum, aa anyarray) AS $$
     SELECT $1, array[$2, $3] 
@@ -411,22 +420,39 @@ SELECT * FROM return_enum_as_array('red'::rainbow, 'green'::rainbow, 'blue'::rai
     LANGUAGE SQL;
 
 SELECT * FROM dup(42);</codeblock><p>You
-                can do the same thing more verbosely with an explicitly named composite type:</p><codeblock>CREATE TYPE dup_result AS (f1 int, f2 text);
+                can do the same thing more verbosely with an explicitly named composite
+                type:</p><codeblock>CREATE TYPE dup_result AS (f1 int, f2 text);
 CREATE FUNCTION dup(int) RETURNS dup_result
     AS $$ SELECT $1, CAST($1 AS text) || ' is text' $$
     LANGUAGE SQL;
 
-SELECT * FROM dup(42);</codeblock>
-            <p>This function is defined with the <codeph>EXECUTE ON ALL SEGMENTS</codeph> to run on
-                all primary segment instances. The <codeph>SELECT</codeph> command executes the
-                function that returns the time it was run on each segment
+SELECT * FROM dup(42);</codeblock><p>This
+                function is defined with the <codeph>EXECUTE ON ALL SEGMENTS</codeph> to run on all
+                primary segment instances. The <codeph>SELECT</codeph> command executes the function
+                that returns the time it was run on each segment
                 instance.<codeblock>CREATE FUNCTION run_on_segs (text) returns setof text as $$
   begin 
     return next ($1 || ' - ' || now()::text ); 
   end;
  $$ language plpgsql VOLATILE EXECUTE ON ALL SEGMENTS;
 
-SELECT run_on_segs('my test');</codeblock></p></section>
+SELECT run_on_segs('my test');</codeblock></p><p>This
+                function looks up a part name in the parts table. The parts table is replicated, so
+                the function can execute on the master or on the primary segments.
+            </p><codeblock>CREATE OR REPLACE FUNCTION get_part_name(partno int) RETURNS text AS
+$$
+DECLARE
+   result text := ' ';
+BEGIN
+    SELECT part_name INTO result FROM parts WHERE part_id = partno;
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;</codeblock>If
+            you execute <codeph>SELECT get_part_name(100);</codeph> at the master the function
+            executes on the master. (The master instance directs the query to a single primary
+            segment.) If orders is a distributed table and you execute the following query,  the
+                <codeph>get_part_name()</codeph> function executes on the primary
+            segments.<codeblock><codeph>SELECT order_id, get_part_name(orders.part_no) FROM orders;</codeph></codeblock></section>
         <section id="section9"><title>Compatibility</title><p><codeph>CREATE FUNCTION</codeph> is
                 defined in SQL:1999 and later. The Greenplum Database version is similar but not
                 fully compatible. The attributes are not portable, neither are the different


### PR DESCRIPTION
Functions that execute on segments can perform read-only queries on replicated tables.
Add an example function that queries a replicated table on segments.

A review branch with these changes is staged at  http://docs-litzell-gpdb6.cfapps.io