### PR TITLE
Fix lost seg_firststart_total_ntuples in explain analyze

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1542,15 +1542,6 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 		noRowRequested = "(No row requested) ";
 	}
 
-	/* Time from start of query on qDisp to this worker's first result row */
-	if (!(INSTR_TIME_IS_ZERO(instr->firststart)))
-	{
-		INSTR_TIME_SET_ZERO(timediff);
-		INSTR_TIME_ACCUM_DIFF(timediff, instr->firststart, ctx->querystarttime);
-		cdbexplain_formatSeconds(startbuf, sizeof(startbuf), INSTR_TIME_GET_DOUBLE(timediff));
-		appendStringInfo(es->str, ", start offset by %s", startbuf);
-	}
-
 	if ((EXPLAIN_MEMORY_VERBOSITY_DETAIL <= explain_memory_verbosity)
 		&& planstate->type == T_MotionState)
 	{

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -963,7 +963,7 @@ ExecProcNode(PlanState *node)
 		ExecReScan(node);		/* let ReScan handle this */
 
 	if (node->instrument)
-		INSTR_START_NODE(node->instrument);
+		InstrStartNode(node->instrument);
 
 	if(!node->fHadSentGpmon)
 		CheckSendPlanStateGpmonPkt(node);
@@ -1181,7 +1181,7 @@ ExecProcNode(PlanState *node)
 	}
 
 	if (node->instrument)
-		INSTR_STOP_NODE(node->instrument, TupIsNull(result) ? 0 : 1);
+		InstrStopNode(node->instrument, TupIsNull(result) ? 0 : 1);
 
 	if (node->plan)
 		TRACE_POSTGRESQL_EXECPROCNODE_EXIT(GpIdentity.segindex, currentSliceId, nodeTag(node), node->plan->plan_node_id);

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -69,11 +69,6 @@ InstrAlloc(int n, int instrument_options)
 }
 
 /* Entry to a plan node */
-/*
- * GPDB Note: Macro INSTR_START_NODE replaces InstrStartNode in ExecProcNode for
- * performance benefits, other files keep using InstrStartNode. Pay attention
- * to keep InstrStartNode/INSTR_START_NODE synchronized when modifying this function.
- */
 void
 InstrStartNode(Instrumentation *instr)
 {
@@ -91,18 +86,13 @@ InstrStartNode(Instrumentation *instr)
 }
 
 /* Exit from a plan node */
-/*
- * GPDB Note: Macro INSTR_STOP_NODE replaces InstrStopNode in ExecProcNode for
- * performance benefits, other files keep using InstrStopNode. Pay attention
- * to keep InstrStopNode/INSTR_STOP_NODE synchronized when modifying this function.
- */
 void
 InstrStopNode(Instrumentation *instr, uint64 nTuples)
 {
 	instr_time	endtime;
-	instr_time	startime;
+	instr_time	starttime;
 
-	startime = instr->starttime;
+	starttime = instr->starttime;
 
 	/* count the returned tuples */
 	instr->tuplecount += nTuples;
@@ -130,7 +120,7 @@ InstrStopNode(Instrumentation *instr, uint64 nTuples)
 		instr->running = true;
 		instr->firsttuple = INSTR_TIME_GET_DOUBLE(instr->counter);
 		/* CDB: save this start time as the first start */
-		instr->firststart = startime;
+		instr->firststart = starttime;
 	}
 }
 

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -100,6 +100,9 @@ void
 InstrStopNode(Instrumentation *instr, uint64 nTuples)
 {
 	instr_time	endtime;
+	instr_time	startime;
+
+	startime = instr->starttime;
 
 	/* count the returned tuples */
 	instr->tuplecount += nTuples;
@@ -127,10 +130,8 @@ InstrStopNode(Instrumentation *instr, uint64 nTuples)
 		instr->running = true;
 		instr->firsttuple = INSTR_TIME_GET_DOUBLE(instr->counter);
 		/* CDB: save this start time as the first start */
-		instr->firststart = instr->starttime;
+		instr->firststart = startime;
 	}
-
-	INSTR_TIME_SET_ZERO(instr->starttime);
 }
 
 /* Finish a run cycle for a plan node */

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -91,47 +91,6 @@ extern void InstrStartNode(Instrumentation *instr);
 extern void InstrStopNode(Instrumentation *instr, uint64 nTuples);
 extern void InstrEndLoop(Instrumentation *instr);
 
-/*
- * GPDB Note: Macro INSTR_START_NODE replaces InstrStartNode in ExecProcNode for
- * performance benefits, other files keep using InstrStartNode. Pay attention
- * to keep InstrStartNode/INSTR_START_NODE synchronized when modifying this macro.
- */
-#define INSTR_START_NODE(instr) do {											\
-	if ((instr)->need_timer) {													\
-		if (INSTR_TIME_IS_ZERO((instr)->starttime))								\
-			INSTR_TIME_SET_CURRENT((instr)->starttime);							\
-		else																	\
-			elog(DEBUG2, "INSTR_START_NODE called twice in a row");				\
-	}																			\
-} while(0)
-
-/*
- * GPDB Note: Macro INSTR_STOP_NODE replaces InstrStopNode in ExecProcNode for
- * performance benefits, other files keep using InstrStopNode. Pay attention
- * to keep InstrStopNode/INSTR_STOP_NODE synchronized when modifying this macro.
- */
-#define INSTR_STOP_NODE(instr, nTuples) do {									\
-	(instr)->tuplecount += (nTuples);											\
-	if ((instr)->need_timer)													\
-	{																			\
-		instr_time endtime;														\
-		if (INSTR_TIME_IS_ZERO((instr)->starttime))								\
-		{																		\
-			elog(DEBUG2, "INSTR_STOP_NODE called without start");				\
-			break;																\
-		}																		\
-		INSTR_TIME_SET_CURRENT(endtime);										\
-		INSTR_TIME_ACCUM_DIFF((instr)->counter, endtime, (instr)->starttime);	\
-		INSTR_TIME_SET_ZERO((instr)->starttime);								\
-	}																			\
-	if (!(instr)->running)														\
-	{																			\
-		(instr)->running = true;												\
-		(instr)->firsttuple = INSTR_TIME_GET_DOUBLE((instr)->counter);			\
-		(instr)->firststart = (instr)->starttime;								\
-	}																			\
-} while(0)
-
 #define GP_INSTRUMENT_OPTS (gp_enable_query_metrics ? INSTRUMENT_ROWS : INSTRUMENT_NONE)
 
 /* Greenplum query metrics */

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -279,3 +279,19 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: legacy query optimizer
 (25 rows)
 
+-- github issues 5795. explain fails previously.
+set gp_enable_explain_allstat=on;
+explain analyze SELECT * FROM explaintest;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.245..0.299 rows=5 loops=2)
+ , start offset by 0.342 ms  ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.012..0.013 rows=2 loops=2)
+ , start offset by 0.859 ms        allstat: seg_firststart_total_ntuples/seg0_0.687 ms_0.029 ms_3/seg1_0.859 ms_0.027 ms_5/seg2_0.814 ms_0.040 ms_2//end
+   (slice0)    Executor memory: 322K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.602 ms
+(8 rows)
+
+set gp_enable_explain_allstat=DEFAULT;

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -279,19 +279,19 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: legacy query optimizer
 (25 rows)
 
--- github issues 5795. explain fails previously.
+-- github issues 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
-                                                                       QUERY PLAN                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.245..0.299 rows=5 loops=2)
- , start offset by 0.342 ms  ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.012..0.013 rows=2 loops=2)
- , start offset by 0.859 ms        allstat: seg_firststart_total_ntuples/seg0_0.687 ms_0.029 ms_3/seg1_0.859 ms_0.027 ms_5/seg2_0.814 ms_0.040 ms_2//end
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.384..0.593 rows=5 loops=2)
+   ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.022..0.024 rows=2 loops=2)
+         allstat: seg_firststart_total_ntuples/seg0_1.023 ms_0.041 ms_3/seg1_1.308 ms_0.048 ms_5/seg2_1.063 ms_0.031 ms_2//end
    (slice0)    Executor memory: 322K bytes.
    (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
- Total runtime: 1.602 ms
+ Total runtime: 2.600 ms
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -279,7 +279,7 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: legacy query optimizer
 (25 rows)
 
--- github issues 5794.
+-- github issue 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
                                                           QUERY PLAN                                                           

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -284,9 +284,9 @@ set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.384..0.593 rows=5 loops=2)
-   ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.022..0.024 rows=2 loops=2)
-         allstat: seg_firststart_total_ntuples/seg0_1.023 ms_0.041 ms_3/seg1_1.308 ms_0.048 ms_5/seg2_1.063 ms_0.031 ms_2//end
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.266..0.384 rows=5 loops=2)
+   ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.011..0.013 rows=2 loops=2)
+         allstat: seg_firststart_total_ntuples/seg0_0.745 ms_0.028 ms_3/seg1_0.640 ms_0.025 ms_5/seg2_0.997 ms_0.019 ms_2//end
    (slice0)    Executor memory: 322K bytes.
    (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
  Memory used:  128000kB

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -308,14 +308,14 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: legacy query optimizer
 (25 rows)
 
--- github issues 5795. explain fails previously.
+-- github issues 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
-                                                                       QUERY PLAN                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.245..0.299 rows=5 loops=2)
- , start offset by 0.342 ms  ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.012..0.013 rows=2 loops=2)
- , start offset by 0.859 ms        allstat: seg_firststart_total_ntuples/seg0_0.687 ms_0.029 ms_3/seg1_0.859 ms_0.027 ms_5/seg2_0.814 ms_0.040 ms_2//end
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.384..0.593 rows=5 loops=2)
+   ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.022..0.024 rows=2 loops=2)
+         allstat: seg_firststart_total_ntuples/seg0_1.023 ms_0.041 ms_3/seg1_1.308 ms_0.048 ms_5/seg2_1.063 ms_0.031 ms_2//end
    (slice0)    Executor memory: 322K bytes.
    (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
  Memory used:  128000kB

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -313,13 +313,14 @@ set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.384..0.593 rows=5 loops=2)
-   ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.022..0.024 rows=2 loops=2)
-   (slice0)    Executor memory: 322K bytes.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4) (actual time=0.298..0.302 rows=5 loops=2)
+   ->  Table Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.013..0.015 rows=2 loops=2)
+         allstat: seg_firststart_total_ntuples/seg0_0.938 ms_0.027 ms_3/seg1_0.880 ms_0.029 ms_5/seg2_0.866 ms_0.029 ms_2//end
+   (slice0)    Executor memory: 290K bytes.
    (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: legacy query optimizer
- Total runtime: 1.602 ms
+ Optimizer: PQO version 3.2.0
+ Total runtime: 1.577 ms
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -308,7 +308,7 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: legacy query optimizer
 (25 rows)
 
--- github issues 5794.
+-- github issue 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
                                                           QUERY PLAN                                                           

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -308,3 +308,19 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: legacy query optimizer
 (25 rows)
 
+-- github issues 5795. explain fails previously.
+set gp_enable_explain_allstat=on;
+explain analyze SELECT * FROM explaintest;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.245..0.299 rows=5 loops=2)
+ , start offset by 0.342 ms  ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.012..0.013 rows=2 loops=2)
+ , start offset by 0.859 ms        allstat: seg_firststart_total_ntuples/seg0_0.687 ms_0.029 ms_3/seg1_0.859 ms_0.027 ms_5/seg2_0.814 ms_0.040 ms_2//end
+   (slice0)    Executor memory: 322K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Total runtime: 1.602 ms
+(8 rows)
+
+set gp_enable_explain_allstat=DEFAULT;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -315,7 +315,6 @@ explain analyze SELECT * FROM explaintest;
 -------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.384..0.593 rows=5 loops=2)
    ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.022..0.024 rows=2 loops=2)
-         allstat: seg_firststart_total_ntuples/seg0_1.023 ms_0.041 ms_3/seg1_1.308 ms_0.048 ms_5/seg2_1.063 ms_0.031 ms_2//end
    (slice0)    Executor memory: 322K bytes.
    (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
  Memory used:  128000kB

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -138,7 +138,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
 -- github issues 5795. explain fails previously.
 explain SELECT * from information_schema.key_column_usage;
 
--- github issues 5795. explain fails previously.
+-- github issues 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
 set gp_enable_explain_allstat=DEFAULT;

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -138,7 +138,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
 -- github issues 5795. explain fails previously.
 explain SELECT * from information_schema.key_column_usage;
 
--- github issues 5794.
+-- github issue 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
 set gp_enable_explain_allstat=DEFAULT;

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -137,3 +137,8 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
 
 -- github issues 5795. explain fails previously.
 explain SELECT * from information_schema.key_column_usage;
+
+-- github issues 5795. explain fails previously.
+set gp_enable_explain_allstat=on;
+explain analyze SELECT * FROM explaintest;
+set gp_enable_explain_allstat=DEFAULT;


### PR DESCRIPTION
Fix https://github.com/greenplum-db/gpdb/issues/5794

The reason is in INSTR_STOP_NODE, there is a line:`(instr)->firststart = (instr)->starttime;` , so `(instr)->firststart` is always zero because six lines before that line, there exists a `INSTR_TIME_SET_ZERO((instr)->starttime);`

Change use of INSTR_START_NODE to InstrStopNode  and INSTR_STOP_NODE to InstrStopNode


Co-authored-by: Paul Guo <pguo@pivotal.io>
Co-authored-by: Shaoqi Bai <sbai@pivotal.io>