### PR TITLE
Concurrent updates distribution keys on the same row is not allowed

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -809,6 +809,14 @@ ldelete:;
 					ereport(ERROR,
 							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 							 errmsg("could not serialize access due to concurrent update")));
+
+				if (isUpdate)
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_IN_FAILED_SQL_TRANSACTION ),
+							 errmsg("concurrent updates distribution keys on the same row is not allowed")));
+				}
+
 				if (!ItemPointerEquals(tupleid, &hufd.ctid))
 				{
 					TupleTableSlot *epqslot;

--- a/src/test/isolation2/expected/concurrent_update_distkeys.out
+++ b/src/test/isolation2/expected/concurrent_update_distkeys.out
@@ -1,0 +1,97 @@
+-- test for heap table
+create table tab_update_hashcol (c1 int, c2 int) distributed by(c1);
+CREATE
+insert into tab_update_hashcol select i, i from generate_series(1, 10)i;
+INSERT 10
+select * from tab_update_hashcol order by 1;
+c1|c2
+--+--
+1 |1 
+2 |2 
+3 |3 
+4 |4 
+5 |5 
+6 |6 
+7 |7 
+8 |8 
+9 |9 
+10|10
+(10 rows)
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+1: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+UPDATE 1
+2&: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;  <waiting ...>
+1: end;
+END
+2<:  <... completed>
+ERROR:  concurrent updates distribution keys on the same row is not allowed  (seg2 127.0.0.1:25434 pid=6045)
+2: end;
+END
+select * from tab_update_hashcol order by 1;
+c1|c2
+--+--
+2 |2 
+2 |1 
+3 |3 
+4 |4 
+5 |5 
+6 |6 
+7 |7 
+8 |8 
+9 |9 
+10|10
+(10 rows)
+drop table tab_update_hashcol;
+DROP
+-- test for ao table create table tab_update_hashcol (c1 int, c2 int) with(appendonly=true) distributed by(c1);
+CREATE
+insert into tab_update_hashcol select i, i from generate_series(1, 10)i;
+INSERT 10
+select * from tab_update_hashcol order by 1;
+c1|c2
+--+--
+1 |1 
+2 |2 
+3 |3 
+4 |4 
+5 |5 
+6 |6 
+7 |7 
+8 |8 
+9 |9 
+10|10
+(10 rows)
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+1: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+UPDATE 1
+2&: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;  <waiting ...>
+1: end;
+END
+2<:  <... completed>
+UPDATE 0
+2: end;
+END
+select * from tab_update_hashcol order by 1;
+c1|c2
+--+--
+2 |2 
+2 |1 
+3 |3 
+4 |4 
+5 |5 
+6 |6 
+7 |7 
+8 |8 
+9 |9 
+10|10
+(10 rows)
+drop table tab_update_hashcol;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -162,3 +162,5 @@ test: reindex/vacuum_while_reindex_ao_bitmap reindex/vacuum_while_reindex_heap_b
 
 # Cancel test
 test: cancel_plpython
+
+test: concurrent_update_distkeys

--- a/src/test/isolation2/sql/concurrent_update_distkeys.sql
+++ b/src/test/isolation2/sql/concurrent_update_distkeys.sql
@@ -1,0 +1,28 @@
+-- test for heap table
+create table tab_update_hashcol (c1 int, c2 int) distributed by(c1);
+insert into tab_update_hashcol select i, i from generate_series(1, 10)i;
+select * from tab_update_hashcol order by 1;
+1: begin;
+2: begin;
+1: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+2&: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+1: end;
+2<:
+2: end;
+select * from tab_update_hashcol order by 1;
+drop table tab_update_hashcol;
+ -- test for ao table
+create table tab_update_hashcol (c1 int, c2 int) with(appendonly=true) distributed by(c1);
+insert into tab_update_hashcol select i, i from generate_series(1, 10)i;
+select * from tab_update_hashcol order by 1;
+1: begin;
+2: begin;
+1: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+2&: update tab_update_hashcol set c1 = c1 + 1 where c1 = 1;
+1: end;
+2<:
+2: end;
+select * from tab_update_hashcol order by 1;
+drop table tab_update_hashcol;
+1q:
+2q:


### PR DESCRIPTION
Splitupdate Node was introduced to support update hash cols
of hash-distributed tables. This technique depends on that
we acquire ExclusiveLock on the tables. With the commit of
GDD, we do not upgrade lock for heaptable's update/delete
the operation, which breaks the assumption of splitupdate, which
will leads to more tuples when concurrently update the
same row's hash columns.

We fix this by raising an error when the tuple is updated by the 
other sessions.


Co-authored-by: Zhenghua Lyu zlv@pivotal.io
Co-authored-by: Ning Yu nyu@pivotal.io
Co-authored-by: Shujie Zhang shzhang@pivotal.io