### PR TITLE
Remove references to reltoastidxid from gpcheckcat.

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1854,8 +1854,7 @@ def checkPGClass():
     logger.info('-----------------------------------')
     logger.info('Checking pg_class ...')
     qry = '''
-    SELECT relname, relkind, tc.oid as oid,
-           reltoastrelid, reltoastidxid
+    SELECT relname, relkind, tc.oid as oid
     FROM   pg_class tc left outer join
            pg_attribute ta on (tc.oid = ta.attrelid)
     WHERE  ta.attrelid is NULL
@@ -2204,9 +2203,7 @@ def checkOwners():
       left join pg_appendonly ao on (c.oid = ao.segrelid or
                                      c.oid = ao.blkdirrelid or
                                      c.oid = ao.blkdiridxid)
-      left join pg_class t on (t.reltoastidxid = c.oid)
       left join pg_class o on (o.oid = ao.relid or
-                               o.reltoastrelid = t.oid or
                                o.reltoastrelid = c.oid)
       join pg_authid a on (a.oid = r.relowner)
       join pg_authid m on (m.oid = coalesce(o.relowner, c.relowner))


### PR DESCRIPTION
In the query in checkPGClass, AFAICS the reltoastrelid and reltoastidxid
fields were not used for anything, so just remove them from the query.
(To be honest, the whole query seems pretty pointless to me).

In the checkOwners() query, I also just removed the check for the toast
index. We have a regression test to check that the owner is set correctly
in ALTER TABLE commands, in the main test suite, in
'alter_distribution_policy' test, so it seems unlikely for that particular
problem to reappear. An index should always have the same owner as the
table itself, so perhaps adding a test for that more general case would be
useful, but I don't see much value in testing the toast index specifically.

pg_class.reltoastidxid field will be removed in PostgreSQL 9.4. Until
then, there's nothing wrong with these queries as such, but I wanted to
open a separate PR to get more eyeballs on the decisions.