### PR TITLE
Remove unnecessary debugging code, to reduce diff vs. upstream.

### DIFF
--- a/src/backend/storage/lmgr/lwlock.c
+++ b/src/backend/storage/lmgr/lwlock.c
@@ -848,7 +848,6 @@ LWLockRelease(LWLockId lockid)
 	PGPROC	   *head;
 	PGPROC	   *proc;
 	int			i;
-	bool		saveExclusive;
 
 	PRINT_LWDEBUG("LWLockRelease", lockid, lock);
 
@@ -863,13 +862,6 @@ LWLockRelease(LWLockId lockid)
 	}
 	if (i < 0)
 		elog(ERROR, "lock %d is not held", (int) lockid);
-
-	saveExclusive = held_lwlocks_exclusive[i];
-	if (InterruptHoldoffCount <= 0)
-		elog(PANIC, "upon entering lock release, the interrupt holdoff count is bad (%d) for release of lock %d (%s)", 
-			 InterruptHoldoffCount,
-			 (int)lockid,
-			 (saveExclusive ? "Exclusive" : "Shared"));
 
 	num_held_lwlocks--;
 	for (; i < num_held_lwlocks; i++)
@@ -993,11 +985,6 @@ LWLockRelease(LWLockId lockid)
 	/*
 	 * Now okay to allow cancel/die interrupts.
 	 */
-	if (InterruptHoldoffCount <= 0)
-		elog(PANIC, "upon exiting lock release, the interrupt holdoff count is bad (%d) for release of lock %d (%s)", 
-			 InterruptHoldoffCount,
-			 (int)lockid,
-			 (saveExclusive ? "Exclusive" : "Shared"));
 	RESUME_INTERRUPTS();
 }
 


### PR DESCRIPTION
RESUME_INTERRUPTS() contains this same check, so this is redundant. The
message from RESUME_INTERRUPTS() is more generic, but a PANIC prints a
backtrace in the log, and possibly a core dump, and all the extra
information in these messages should be evident from the backtrace, too.
Besides, this isn't a very common failure mode,  I don't remember ever
hitting this PANIC. These extra checks were added a very long time ago,
maybe there was a specific problem that the developers were trying to hunt
down back then, but they don't seem useful anymore.

The upcoming 9.4 merge would further complicate these, or make them even
less useful. In 9.4, LWLocks are no longer identified by a simple integer,
so all we have here is a pointer to the LWLock struct, and parsing that
into a human-readable message would require more effort. Or we could just
print the pointer value, which is pretty useless.