### PR TITLE
Stop connecting in utility mode on pg_dumpall

### DIFF
--- a/contrib/pg_upgrade/dump.c
+++ b/contrib/pg_upgrade/dump.c
@@ -23,6 +23,7 @@ generate_old_dump(void)
 
 	/* run new pg_dumpall binary for globals */
 	exec_prog(UTILITY_LOG_FILE, NULL, true,
+			  "PGOPTIONS='-c gp_session_role=utility' "
 			  "\"%s/pg_dumpall\" %s --schema-only --globals-only "
 			  "--quote-all-identifiers --binary-upgrade %s -f %s",
 			  new_cluster.bindir, cluster_conn_opts(&old_cluster),
@@ -53,6 +54,7 @@ generate_old_dump(void)
 		snprintf(log_file_name, sizeof(log_file_name), DB_DUMP_LOG_FILE_MASK, old_db->db_oid);
 
 		parallel_exec_prog(log_file_name, NULL,
+				   "PGOPTIONS='-c gp_session_role=utility' "
 				   "\"%s/pg_dump\" %s --schema-only --quote-all-identifiers "
 					  "--binary-upgrade --format=custom %s --file=\"%s\" %s",
 						 new_cluster.bindir, cluster_conn_opts(&old_cluster),

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -2134,7 +2134,7 @@ connectDatabase(const char *dbname, const char *connection_string,
 	 */
 	do
 	{
-		int			argcount = 6 + 1;	/* one extra GPDB option */
+		int			argcount = 6;
 		PQconninfoOption *conn_opt;
 		char	   *err_msg = NULL;
 		int			i = 0;
@@ -2217,10 +2217,6 @@ connectDatabase(const char *dbname, const char *connection_string,
 
 		keywords[i] = "fallback_application_name";
 		values[i] = progname;
-		i++;
-
-		keywords[i] = "options";
-		values[i] = "-c gp_session_role=utility";
 		i++;
 
 		new_pass = false;


### PR DESCRIPTION
Starting with the 9.3 merge the arguments for the global connection to master are being used to create the connections to all databases during pg_dump.  This is causing pg_dump to not retrieve any data present in the segments because we set utility mode on the global connection.

We reverted the utility mode change to align to upstream as we are not required to be in utility mode to retrieve the information that we need from master.

Now that pg_dumpall doesn't accidentally set utility mode for itself, we have to explicitly set it during pg_upgrade.