### PR TITLE
Fix HINT on ALTER TABLE ... DISTRIBUTION KEY.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14067,8 +14067,7 @@ static void checkUniqueIndexCompatible(Relation rel, GpPolicy *pol)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("UNIQUE INDEX and DISTRIBUTED BY definitions incompatible"),
-						 errhint("the DISTRIBUTED BY columns must be equal to "
-								 "or a left-subset of the UNIQUE INDEX columns.")));
+						 errhint("the DISTRIBUTED BY columns must be a subset of the UNIQUE INDEX columns.")));
 			}
 
 			bms_free(indbm);

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1367,7 +1367,7 @@ ALTER TABLE public.distrib_part_test SET with (reorganize=false) DISTRIBUTED RAN
 CREATE TABLE t_dist1(col1 INTEGER, col2 INTEGER, CONSTRAINT pk_t_dist1 PRIMARY KEY(col2)) DISTRIBUTED BY(col2);
 ALTER TABLE t_dist1 SET DISTRIBUTED BY(col1);
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  the DISTRIBUTED BY columns must be a subset of the UNIQUE INDEX columns.
 -- case 2
 CREATE TABLE t_dist2(col1 INTEGER, col2 INTEGER, col3 INTEGER, col4 INTEGER) DISTRIBUTED BY(col1);
 CREATE UNIQUE INDEX idx1_t_dist2 ON t_dist2(col1, col2);
@@ -1380,13 +1380,13 @@ ALTER TABLE t_dist2 SET DISTRIBUTED BY(col2);
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col1, col2);
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col1, col2, col3);
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  the DISTRIBUTED BY columns must be a subset of the UNIQUE INDEX columns.
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col3);
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  the DISTRIBUTED BY columns must be a subset of the UNIQUE INDEX columns.
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col4);
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  the DISTRIBUTED BY columns must be a subset of the UNIQUE INDEX columns.
 -- Altering distribution policy for subpartitioned tables
 CREATE TABLE mpp6489
 (


### PR DESCRIPTION
The DISTRIBUTED BY doesn't need to be a left-subset of the UNIQUE
indexes. Any subset will do. That has been true at least since e572af54e4,
although the check here has been the same even longer, so I suspect that
we allowed that for ALTER TABLE even before that.