### PR TITLE
Do not double count null values into buckets

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2463,7 +2463,7 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 	{
 		num_distinct = CDouble(form_pg_stats->stadistinct);
 	}
-	num_distinct = num_distinct.Ceil();
+	num_distinct = num_distinct.Ceil() - null_ndv;
 
 	BOOL is_dummy_stats = false;
 	// most common values and their frequencies extracted from the pg_statistic
@@ -2594,12 +2594,13 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 		CUtils::AddRefAppend(dxl_stats_bucket_array, dxl_stats_bucket_array_transformed);
 		dxl_stats_bucket_array_transformed->Release();
 
+		CDouble uncounted_distinct = num_distinct - num_ndv_buckets;
 		// there will be remaining tuples if the merged histogram and the NULLS do not cover
 		// the total number of distinct values
 		if ((1 - CStatistics::Epsilon > num_freq_buckets + null_freq) &&
-			(0 < num_distinct - num_ndv_buckets - null_ndv))
+			(0 < uncounted_distinct))
 		{
-			distinct_remaining = std::max(CDouble(0.0), (num_distinct - num_ndv_buckets - null_ndv));
+			distinct_remaining = std::max(CDouble(0.0), uncounted_distinct);
 			freq_remaining = std::max(CDouble(0.0), (1 - num_freq_buckets - null_freq));
 		}
 	}

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -495,26 +495,25 @@ ANALYZE test_join_card1;
 ANALYZE test_join_card2;
 ANALYZE test_join_card3;
 EXPLAIN SELECT * FROM test_join_card1 t1, test_join_card2 t2, test_join_card3 t3 WHERE t1.b = t2.b and t3.b = t2.b;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1297.58 rows=5999 width=22)
-   ->  Hash Join  (cost=0.00..1297.09 rows=2000 width=22)
-         Hash Cond: test_join_card2.b::text = test_join_card3.b::text
-         ->  Hash Join  (cost=0.00..864.43 rows=2000 width=14)
-               Hash Cond: test_join_card1.b::text = test_join_card2.b::text
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.48 rows=6667 width=10)
-                     Hash Key: test_join_card1.b::text
-                     ->  Table Scan on test_join_card1  (cost=0.00..431.15 rows=6667 width=10)
-               ->  Hash  (cost=431.08..431.08 rows=2000 width=4)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.08 rows=2000 width=4)
-                           Hash Key: test_join_card2.b
-                           ->  Table Scan on test_join_card2  (cost=0.00..431.04 rows=2000 width=4)
-         ->  Hash  (cost=431.20..431.20 rows=3334 width=8)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.20 rows=3334 width=8)
-                     Hash Key: test_join_card3.b::text
-                     ->  Table Scan on test_join_card3  (cost=0.00..431.07 rows=3334 width=8)
- Optimizer: PQO version 2.56.0
-(17 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1296.50 rows=1 width=22)
+   ->  Hash Join  (cost=0.00..1296.50 rows=1 width=22)
+         Hash Cond: ((test_join_card1.b)::text = (test_join_card2.b)::text)
+         ->  Table Scan on test_join_card1  (cost=0.00..431.15 rows=6667 width=10)
+         ->  Hash  (cost=864.03..864.03 rows=1 width=12)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..864.03 rows=1 width=12)
+                     ->  Hash Join  (cost=0.00..864.03 rows=1 width=12)
+                           Hash Cond: ((test_join_card3.b)::text = (test_join_card2.b)::text)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.20 rows=3334 width=8)
+                                 Hash Key: (test_join_card3.b)::text
+                                 ->  Table Scan on test_join_card3  (cost=0.00..431.07 rows=3334 width=8)
+                           ->  Hash  (cost=431.09..431.09 rows=2000 width=4)
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.09 rows=2000 width=4)
+                                       Hash Key: test_join_card2.b
+                                       ->  Table Scan on test_join_card2  (cost=0.00..431.04 rows=2000 width=4)
+ Optimizer: PQO version 3.2.0
+(16 rows)
 
 -- start_ignore
 DROP TABLE IF EXISTS test_join_card1;


### PR DESCRIPTION
Related to https://github.com/greenplum-db/gpdb/issues/5981

In the relcache translator we incorrectly count the distinct because of
the null value into the histogram. This makes an assert fail inside
GPORCA.

No test added since the issue was discovered during an existing tests.