### PR TITLE
5X: Support equijoin on relabeled distribution keys

### DIFF
--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3043,3 +3043,38 @@ AND ft.id = dt1.id;
      4
 (1 row)
 
+-- Test colocated equijoins on coerced distribution keys
+CREATE TABLE coercejoin (a varchar(10), b varchar(10)) DISTRIBUTED BY (a);
+-- Positive test, the join should be colocated as the implicit cast from the
+-- parse rewrite is a relabeling (varchar::text).
+EXPLAIN SELECT * FROM coercejoin a, coercejoin b WHERE a.a=b.a;
+                 QUERY PLAN
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((a.a)::text = (b.a)::text)
+         ->  Seq Scan on coercejoin a
+         ->  Hash
+               ->  Seq Scan on coercejoin b
+ Optimizer: legacy query optimizer
+(7 rows)
+
+-- Negative test, the join should not be colocated since the cast is a coercion
+-- which cannot guarantee that the coerced value would hash to the same segment
+-- as the uncoerced tuple.
+EXPLAIN SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=b.a::numeric;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((a.a)::numeric = (b.a)::numeric)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (a.a)::numeric
+               ->  Seq Scan on coercejoin a
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (b.a)::numeric
+                     ->  Seq Scan on coercejoin b
+ Optimizer: legacy query optimizer
+(11 rows)
+

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3043,3 +3043,36 @@ AND ft.id = dt1.id;
      4
 (1 row)
 
+-- Test colocated equijoins on coerced distribution keys
+CREATE TABLE coercejoin (a varchar(10), b varchar(10)) DISTRIBUTED BY (a);
+-- Positive test, the join should be colocated as the implicit cast from the
+-- parse rewrite is a relabeling (varchar::text).
+EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a=b.a;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((coercejoin.a)::text = (coercejoin_1.a)::text)
+         ->  Table Scan on coercejoin
+         ->  Hash
+               ->  Table Scan on coercejoin coercejoin_1
+(7 rows)
+
+-- Negative test, the join should not be colocated since the cast is a coercion
+-- which cannot guarantee that the coerced value would hash to the same segment
+-- as the uncoerced tuple.
+EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=b.a::numeric;
+                                 QUERY PLAN                                    
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((coercejoin.a)::numeric = (coercejoin_1.a)::numeric)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (coercejoin.a)::numeric
+               ->  Table Scan on coercejoin
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (coercejoin_1.a)::numeric
+                     ->  Table Scan on coercejoin coercejoin_1
+(11 rows)
+

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3047,32 +3047,34 @@ AND ft.id = dt1.id;
 CREATE TABLE coercejoin (a varchar(10), b varchar(10)) DISTRIBUTED BY (a);
 -- Positive test, the join should be colocated as the implicit cast from the
 -- parse rewrite is a relabeling (varchar::text).
-EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a=b.a;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Join
-         Hash Cond: ((coercejoin.a)::text = (coercejoin_1.a)::text)
-         ->  Table Scan on coercejoin
-         ->  Hash
-               ->  Table Scan on coercejoin coercejoin_1
+EXPLAIN SELECT * FROM coercejoin a, coercejoin b WHERE a.a=b.a;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=36)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=36)
+         Hash Cond: public.coercejoin.a::text = public.coercejoin.a::text
+         ->  Table Scan on coercejoin  (cost=0.00..431.00 rows=1 width=18)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=18)
+               ->  Table Scan on coercejoin  (cost=0.00..431.00 rows=1 width=18)
+ Optimizer status: PQO version 3.2.0
 (7 rows)
 
 -- Negative test, the join should not be colocated since the cast is a coercion
 -- which cannot guarantee that the coerced value would hash to the same segment
 -- as the uncoerced tuple.
-EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=b.a::numeric;
-                                 QUERY PLAN                                    
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
-   ->  Hash Join
-         Hash Cond: ((coercejoin.a)::numeric = (coercejoin_1.a)::numeric)
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: (coercejoin.a)::numeric
-               ->  Table Scan on coercejoin
-         ->  Hash
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: (coercejoin_1.a)::numeric
-                     ->  Table Scan on coercejoin coercejoin_1
+EXPLAIN SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=b.a::numeric;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=36)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=36)
+         Hash Cond: public.coercejoin.a::numeric = public.coercejoin.a::numeric
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=18)
+               Hash Key: public.coercejoin.a::numeric
+               ->  Table Scan on coercejoin  (cost=0.00..431.00 rows=1 width=18)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=18)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=18)
+                     Hash Key: public.coercejoin.a::numeric
+                     ->  Table Scan on coercejoin  (cost=0.00..431.00 rows=1 width=18)
+ Optimizer status: PQO version 3.2.0
 (11 rows)
 


### PR DESCRIPTION
Distribution key joins on pathkeys where the parser invokes an implicit cast via a RelabelType node would introduce a redistribution motion due to the join not being recognized as a colocated equijoin.

As an example, consider the following relation

    create table test (a varchar(10), b varchar(10)) distributed by (a);

The below query will introduce an implicit cast on a.a and b.a to TEXT by the parser. This means that the pathkey EquivalenceClass is on VARCHAR but the RestrictInfo ECs are for TEXT.

    select * from test a, test b where a.a=b.a;

Fix by following the EC members to their basetypes to allow for colocated equijoins in these cases.

Affected testfiles updated, and one affected testcase slightly tweaked to ignore less and generate less uninteresting output in the .out file.

This is a backport of 75af5e5a296bf9f2dfe3f2e838ddc3a2e4f7f03d from master, with additional logic to ensure that the right EC is exposed at decision time. The canonicalization logic is in turn a partial backport of commit b310b6e on upstream.