### PR TITLE
Remove unused 'caller' arguments from functions in twophase.c.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7621,7 +7621,7 @@ CreateCheckPoint(int flags)
 
 	prepared_transaction_agg_state *p = NULL;
 
-	getTwoPhasePreparedTransactionData(&p, "CreateCheckPoint");
+	getTwoPhasePreparedTransactionData(&p);
 	rdata[5].data = (char*)p;
 	rdata[5].buffer = InvalidBuffer;
 	rdata[5].len = PREPARED_TRANSACTION_CHECKPOINT_BYTES(p->count);

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -100,10 +100,9 @@ extern void TwoPhaseAddPreparedTransaction(
                  prepared_transaction_agg_state **ptas
 		 , int                           *maxCount
                  , TransactionId                  xid
-		 , XLogRecPtr                    *xlogPtr
-		 , char                          *caller);
+		 , XLogRecPtr                    *xlogPtr);
 
-extern void getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **ptas, char *caller);
+extern void getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **ptas);
 
 extern void SetupCheckpointPreparedTransactionList(prepared_transaction_agg_state *ptas);
 


### PR DESCRIPTION
Unnecessary cruft.