### PR TITLE
Pull up sublink of type "NOT OR (expr1) (expr2)".

### DIFF
--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -627,27 +627,14 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 														 jtlink1, available_rels1,
 														 jtlink2, available_rels2);
 		}
-		/*
-		 * GPDB_91_MERGE_FIXME: The below enters an infinite recursion with
-		 * this query from the 'qp_subquery' test:
-		 *
-		 * select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3)); -- expected: (5,6)
-		 *
-		 * That's because canonicalize_qual() was changed in 9.1, to not "push
-		 * down" NOTs into an OR chain (commit 220e45bf32). I'm not sure if
-		 * this is optimization is still worthwhile, and we should fix it,
-		 * or we can just remove it. Commented it out for now, to avoid the
-		 * crash.
-		 */
-#if 0
 		else if (or_clause(arg))
 		{
 			/* NOT OR (expr1) (expr2) => (expr1) AND (expr2) */
 			return (Node *) pull_up_sublinks_qual_recurse(root,
-														 (Node *) canonicalize_qual((Expr *) node),
-														 available_rels, jtlink);
+														 negate_clause(arg),
+														 jtlink1, available_rels1,
+														 jtlink2, available_rels2);
 		}
-#endif
 
 		/* Else return it unmodified */
 		return node;

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -955,6 +955,24 @@ select Tbl04.* from Tbl04 where (Tbl04.a,Tbl04.b) not in (select Tbl06.a,Tbl06.b
  5 | 6
 (1 row)
 
+explain (costs off)
+select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3));
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Left Anti Semi (Not-In) Join
+         Hash Cond: ((tbl04.a = i3.a) AND (tbl04.b = i3.b))
+         ->  Nested Loop Left Anti Semi (Not-In) Join
+               Join Filter: ((tbl04.a = tbl06.a) AND (tbl04.b = tbl06.b))
+               ->  Seq Scan on tbl04
+               ->  Materialize
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Seq Scan on tbl06
+         ->  Hash
+               ->  Seq Scan on i3
+ Optimizer: legacy query optimizer
+(12 rows)
+
 select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3)); -- expected: (5,6)
  a | b 
 ---+---

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -956,6 +956,24 @@ select Tbl04.* from Tbl04 where (Tbl04.a,Tbl04.b) not in (select Tbl06.a,Tbl06.b
  5 | 6
 (1 row)
 
+explain (costs off)
+select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3));
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Left Anti Semi (Not-In) Join
+         Hash Cond: ((tbl04.a = i3.a) AND (tbl04.b = i3.b))
+         ->  Nested Loop Left Anti Semi (Not-In) Join
+               Join Filter: ((tbl04.a = tbl06.a) AND (tbl04.b = tbl06.b))
+               ->  Seq Scan on tbl04
+               ->  Materialize
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Seq Scan on tbl06
+         ->  Hash
+               ->  Seq Scan on i3
+ Optimizer: legacy query optimizer
+(12 rows)
+
 select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3)); -- expected: (5,6)
  a | b 
 ---+---

--- a/src/test/regress/sql/qp_subquery.sql
+++ b/src/test/regress/sql/qp_subquery.sql
@@ -441,6 +441,8 @@ select Tbl04.* from Tbl04 where (Tbl04.a,Tbl04.b) not in ((1,2));
 
 select Tbl04.* from Tbl04 where (Tbl04.a,Tbl04.b) not in (select Tbl06.a,Tbl06.b from Tbl06) and (Tbl04.a,Tbl04.b) not in (select i3.a, i3.b from i3); -- expected: (5,6)
 
+explain (costs off)
+select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3));
 select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3)); -- expected: (5,6)
 
 -- single column in the target list should always give a HLASJ


### PR DESCRIPTION
This patch converts "(NOT (OR A B))" to "(AND (NOT A) (NOT B))". As a
result, it would enable pull-up for sublink of type "NOT OR".

For instance, for the query below:

```
select * from a where NOT
		( a.i in (select b.i from b) OR a.i in (select c.i from c) );
```

Previously, the scan of b and c would be two seperate SubPlans:
```
                               QUERY PLAN
-------------------------------------------------------------------------
 Gather Motion 3:1  (slice3; segments: 3)
   ->  Seq Scan on a
         Filter: ((NOT (hashed SubPlan 1)) AND (NOT (hashed SubPlan 2)))
         SubPlan 1  (slice3; segments: 3)
           ->  Materialize
                 ->  Broadcast Motion 3:3  (slice1; segments: 3)
                       ->  Seq Scan on b
         SubPlan 2  (slice3; segments: 3)
           ->  Materialize
                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
                       ->  Seq Scan on c
 Optimizer: legacy query optimizer
```

And now the scan of b and c would be converted into semi joins:
```
                             QUERY PLAN
---------------------------------------------------------------------
 Gather Motion 3:1  (slice3; segments: 3)
   ->  Hash Left Anti Semi (Not-In) Join
         Hash Cond: (a.i = c.i)
         ->  Hash Left Anti Semi (Not-In) Join
               Hash Cond: (a.i = b.i)
               ->  Seq Scan on a
               ->  Hash
                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
                           ->  Seq Scan on b
         ->  Hash
               ->  Broadcast Motion 3:3  (slice2; segments: 3)
                     ->  Seq Scan on c
 Optimizer: legacy query optimizer
(13 rows)
```