### PR TITLE
Rewrite WAL-logging of bitmap AM insertion.

### DIFF
--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -1425,6 +1425,19 @@ _bitmap_write_new_bitmapwords(Relation rel,
 			 BufferGetBlockNumber(lovBuffer), lovOffset,
 			 lovItem->bm_last_setbit, lovItem->bm_last_tid_location);
 
+
+	/*
+	 * WAL consistency checking
+	 */
+#if 0
+	_dump_page("insert", XactLastRecEnd, &rel->rd_node, lovBuffer);
+	foreach(lcb, perpage_buffers)
+	{
+		_dump_page("insert", XactLastRecEnd, &rel->rd_node, (Buffer) lfirst_int(lcb));
+		Assert(PageSizeIsValid(PageGetPageSize((BufferGetPage((Buffer) lfirst_int(lcb))))));
+	}
+#endif
+
 	/* release all bitmap buffers. */
 	foreach(lcb, perpage_buffers)
 	{

--- a/src/backend/access/bitmap/bitmappages.c
+++ b/src/backend/access/bitmap/bitmappages.c
@@ -139,15 +139,11 @@ _bitmap_init_lovpage(Relation rel __attribute__((unused)), Buffer buf)
  * _bitmap_init_bitmappage() -- initialize a new page to store the bitmap.
  */
 void
-_bitmap_init_bitmappage(Relation rel __attribute__((unused)), Buffer buf)
+_bitmap_init_bitmappage(Page page)
 {
-	Page			page;
 	BMBitmapOpaque	opaque;
 
-	page = (Page) BufferGetPage(buf);
-
-	if(PageIsNew(page))
-		PageInit(page, BufferGetPageSize(buf), sizeof(BMBitmapOpaqueData));
+	PageInit(page, BLCKSZ, sizeof(BMBitmapOpaqueData));
 
 	/* even though page may not be new, reset all values */
 	opaque = (BMBitmapOpaque) PageGetSpecialPointer(page);

--- a/src/backend/access/bitmap/bitmapxlog.c
+++ b/src/backend/access/bitmap/bitmapxlog.c
@@ -376,6 +376,18 @@ _bitmap_xlog_insert_bitmapwords(XLogRecPtr lsn, XLogRecord *record)
 		}
 	}
 
+	/*
+	 * WAL consistency checking
+	 */
+#if 0
+	_dump_page("redo", lsn, &xlrec->bm_node, lovBuffer);
+	for (bmpageno = 0; bmpageno < xlrec->bm_num_pages; bmpageno++)
+	{
+		if (BufferIsValid(bitmapBuffers[bmpageno]))
+			_dump_page("redo", lsn, &xlrec->bm_node, bitmapBuffers[bmpageno]);
+	}
+#endif
+
 	/* Release buffers */
 	UnlockReleaseBuffer(lovBuffer);
 	for (bmpageno = 0; bmpageno < xlrec->bm_num_pages; bmpageno++)

--- a/src/include/access/bitmap.h
+++ b/src/include/access/bitmap.h
@@ -806,6 +806,8 @@ extern void _bitmap_log_updatewords(Relation rel,
 						bool new_lastpage);
 extern void _bitmap_log_updateword(Relation rel, Buffer bitmapBuffer, int word_no);
 
+extern void _dump_page(char *file, XLogRecPtr recptr, RelFileNode *relfilenode, Buffer buf);
+
 /* bitmapsearch.c */
 extern bool _bitmap_first(IndexScanDesc scan, ScanDirection dir);
 extern bool _bitmap_next(IndexScanDesc scan, ScanDirection dir);

--- a/src/include/access/rmgrlist.h
+++ b/src/include/access/rmgrlist.h
@@ -43,6 +43,6 @@ PG_RMGR(RM_GIST_ID, "Gist", gist_redo, gist_desc, gist_xlog_startup, gist_xlog_c
 PG_RMGR(RM_SEQ_ID, "Sequence", seq_redo, seq_desc, NULL, NULL)
 PG_RMGR(RM_SPGIST_ID, "SPGist", spg_redo, spg_desc, spg_xlog_startup, spg_xlog_cleanup)
 
-PG_RMGR(RM_BITMAP_ID, "Bitmap", bitmap_redo, bitmap_desc, bitmap_xlog_startup, bitmap_xlog_cleanup)
+PG_RMGR(RM_BITMAP_ID, "Bitmap", bitmap_redo, bitmap_desc, NULL, NULL)
 PG_RMGR(RM_DISTRIBUTEDLOG_ID, "DistributedLog", DistributedLog_redo, DistributedLog_desc, NULL, NULL)
 PG_RMGR(RM_APPEND_ONLY_ID, "Appendonly", appendonly_redo, appendonly_desc, NULL, NULL)


### PR DESCRIPTION
There were a couple of issues with the old code:

1. It was extending the relation, and doing palloc's, while in critical
   section. Those can fail, if you run out of disk space or memory, which
   would lead to a PANIC. Out of disk space could be rather nasty, because
   after WAL replay, we would try to finish the incomplete insertion, which
   would be quite likely to run out of disk space again.

2. The "incomplete actions" mechanism, including the bm_safe_restartpoint()
   rmgr API function, are going away in PostgreSQL 9.4. As we merge with
   9.4, we will need to come up with a different way to deal with them.

After this patch, the insertion is performed in one atomic operation, with
a single WAL record. The XLOG_BITMAP_INSERT_WORDS WAL record format is
changed, so that it can represent the insertion on several bitmap pages in
one record.
