### PR TITLE
pg_upgrade: don't run ANALYZE at all on segments

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -432,13 +432,20 @@ prepare_new_cluster(void)
 	 * It would make more sense to freeze after loading the schema, but that
 	 * would cause us to lose the frozenids restored by the load. We use
 	 * --analyze so autovacuum doesn't update statistics later
+	 *
+	 * GPDB: after we've copied the master data directory to the segments,
+	 * AO tables can't be analyzed because their aoseg tuple counts don't match
+	 * those on disk. We therefore skip this step for segments.
 	 */
-	prep_status("Analyzing all rows in the new cluster");
-	exec_prog(UTILITY_LOG_FILE, NULL, true,
-			  "PGOPTIONS='-c gp_session_role=utility' \"%s/vacuumdb\" %s --all --analyze %s",
-			  new_cluster.bindir, cluster_conn_opts(&new_cluster),
-			  log_opts.verbose ? "--verbose" : "");
-	check_ok();
+	if (user_opts.segment_mode == DISPATCHER)
+	{
+		prep_status("Analyzing all rows in the new cluster");
+		exec_prog(UTILITY_LOG_FILE, NULL, true,
+				  "PGOPTIONS='-c gp_session_role=utility' \"%s/vacuumdb\" %s --all --analyze %s",
+				  new_cluster.bindir, cluster_conn_opts(&new_cluster),
+				  log_opts.verbose ? "--verbose" : "");
+		check_ok();
+	}
 
 	/*
 	 * We do freeze after analyze so pg_statistic is also frozen. template0 is


### PR DESCRIPTION
Before freezing tuples in the new target cluster, pg_upgrade performs an `ANALYZE` to update pg_statistic. During segment upgrade, we have already copied (master versions of the) AO auxiliary tables to the segment by the time we reach this step, and the append-only analyze logic can't
deal with aoseg tuple counts that don't match the data on disk. Therefore, we skip the `ANALYZE` step for segments.

Note that the incorrect master-only auxiliary table contents will be overwritten later in the upgrade.