### PR TITLE
 Fix restore of AO auxiliary tables in pg_upgrade

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -146,32 +146,26 @@ main(int argc, char **argv)
 	/* New now using xids of the old system */
 
 	/* -- NEW -- */
+	start_postmaster(&new_cluster, true);
+
 	if (user_opts.segment_mode == DISPATCHER)
 	{
-		start_postmaster(&new_cluster, true);
-
 		prepare_new_databases();
 
 		create_new_objects();
-
-		stop_postmaster(false);
 	}
-	else
-	{
-		/*
-		 * In a segment, the data directory already contains all the objects,
-		 * because the segment is initialized by taking a physical copy of the
-		 * upgraded QD data directory. The auxiliary AO tables - containing
-		 * information about the segment files, are different in each server,
-		 * however. So we still need to restore those separately on each
-		 * server.
-		 */
-		start_postmaster(&new_cluster, true);
 
-		restore_aosegment_tables();
+	/*
+	 * In a segment, the data directory already contains all the objects,
+	 * because the segment is initialized by taking a physical copy of the
+	 * upgraded QD data directory. The auxiliary AO tables - containing
+	 * information about the segment files, are different in each server,
+	 * however. So we still need to restore those separately on each
+	 * server.
+	 */
+	restore_aosegment_tables();
 
-		stop_postmaster(false);
-	}
+	stop_postmaster(false);
 
 	/*
 	 * Most failures happen in create_new_objects(), which has completed at

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -156,6 +156,22 @@ main(int argc, char **argv)
 
 		stop_postmaster(false);
 	}
+	else
+	{
+		/*
+		 * In a segment, the data directory already contains all the objects,
+		 * because the segment is initialized by taking a physical copy of the
+		 * upgraded QD data directory. The auxiliary AO tables - containing
+		 * information about the segment files, are different in each server,
+		 * however. So we still need to restore those separately on each
+		 * server.
+		 */
+		start_postmaster(&new_cluster, true);
+
+		restore_aosegment_tables();
+
+		stop_postmaster(false);
+	}
 
 	/*
 	 * Most failures happen in create_new_objects(), which has completed at
@@ -569,8 +585,6 @@ create_new_objects(void)
 
 	end_progress_output();
 	check_ok();
-
-	restore_aosegment_tables();
 
 	/*
 	 * We don't have minmxids for databases or relations in pre-9.3


### PR DESCRIPTION
Follow up to #5569. In addition to Heikki's fix, `TRUNCATE` the aux tables that have been copied over from master so that we don't get stale data, and execute `restore_aosegment_tables()` on both master and segments.