### PR TITLE
docs - Avoid redirects when linking to postgres documentation

### DIFF
--- a/gpdb-doc/dita/admin_guide/client_auth.xml
+++ b/gpdb-doc/dita/admin_guide/client_auth.xml
@@ -20,7 +20,7 @@
     <body>
       <p>Client access and authentication is controlled by the standard PostgreSQL host-based
         authentication file, <filepath>pg_hba.conf</filepath>. For detailed information about this
-        file, see <xref href="http://www.postgresql.org/docs/9.1/interactive/auth-pg-hba-conf.html"
+        file, see <xref href="https://www.postgresql.org/docs/9.1/static/auth-pg-hba-conf.html"
           scope="external" format="html">The pg_hba.conf File</xref> in the PostgreSQL
         documentation. </p>
       <p>In Greenplum Database, the <filepath>pg_hba.conf</filepath> file of the master instance
@@ -143,7 +143,7 @@
               <entry colname="col1">authentication-method</entry>
               <entry colname="col2">Specifies the authentication method to use when connecting.
                 Greenplum supports the <xref
-                  href="http://www.postgresql.org/docs/9.0/static/auth-methods.html"
+                  href="https://www.postgresql.org/docs/9.0/static/auth-methods.html"
                   scope="external" format="html">authentication methods</xref> supported by
                 PostgreSQL 9.0.</entry>
             </row>

--- a/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
@@ -512,7 +512,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="http://www.postgresql.org/docs/9.1/interactive/functions-xml.html"
+                                    href="https://www.postgresql.org/docs/9.1/static/functions-xml.html"
                                     scope="external">XML Functions</xref> and function-like
                                 expressions </entry>
                             <entry colname="col2"/>

--- a/gpdb-doc/dita/install_guide/env_var_ref.xml
+++ b/gpdb-doc/dita/install_guide/env_var_ref.xml
@@ -156,7 +156,7 @@ export MASTER_DATA_DIRECTORY</codeblock>
                                 <p>The name of the password file to use for lookups. If not set, it
                                         defaults to <codeph class="+ topic/ph pr-d/codeph "
                                                 >~/.pgpass</codeph>. See the topic about <xref
-                                                href="http://www.postgresql.org/docs/8.2/static/libpq-pgpass.html"
+                                                href="https://www.postgresql.org/docs/8.2/static/libpq-pgpass.html"
                                                 scope="external" format="html" class="- topic/xref "
                                                 >The Password File</xref> in the PostgreSQL
                                         documentation for more information.</p>

--- a/gpdb-doc/dita/ref_guide/function-summary.xml
+++ b/gpdb-doc/dita/ref_guide/function-summary.xml
@@ -203,7 +203,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="http://www.postgresql.org/docs/9.4/static/functions-matching.html"
+                  href="https://www.postgresql.org/docs/9.4/static/functions-matching.html"
                   scope="external">
                   <ph>Pattern Matching</ph>
                 </xref>
@@ -399,7 +399,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="http://www.postgresql.org/docs/9.1/interactive/functions-xml.html"
+                  href="https://www.postgresql.org/docs/9.1/static/functions-xml.html"
                   scope="external">XML Functions</xref> and function-like expressions </entry>
               <entry colname="col2"/>
               <entry colname="col3">

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -26,7 +26,7 @@
       <p>Client access and authentication is controlled by a configuration file named
           <codeph>pg_hba.conf</codeph> (the standard PostgreSQL host-based authentication file). For
         detailed information about this file, see <xref
-          href="http://www.postgresql.org/docs/9.1/interactive/auth-pg-hba-conf.html" format="html"
+          href="https://www.postgresql.org/docs/9.1/static/auth-pg-hba-conf.html" format="html"
           scope="external">The pg_hba.conf File</xref> in the PostgreSQL documentation. </p>
       <p>In Greenplum Database, the <codeph>pg_hba.conf</codeph> file of the master instance
         controls client access and authentication to your Greenplum system. The segments also have

--- a/gpdb-doc/dita/security-guide/topics/Encryption.xml
+++ b/gpdb-doc/dita/security-guide/topics/Encryption.xml
@@ -298,7 +298,7 @@ ssb   2048R/4FD2EFBB 2015-01-13</codeblock><p>2027CC30
             commands:<codeblock># gpg -a --export 4FD2EFBB &gt; public.key
 # gpg -a --export-secret-keys 2027CC30 &gt; secret.key</codeblock></li>
         </ol>
-        <p>See the <xref href="http://www.postgresql.org/docs/8.3/static/pgcrypto.html"
+        <p>See the <xref href="https://www.postgresql.org/docs/8.3/static/pgcrypto.html"
             format="html" scope="external">pgcrypto</xref> documentation for more information about
           PGP encryption functions. </p>
       </section>
@@ -467,7 +467,7 @@ key_used | 9D4D255F4FD2EFBB
             <note>Different keys may have the same ID. This is rare, but is a normal event. The
               client application should try to decrypt with each one to see which fits — like
               handling <codeph>ANYKEY</codeph>. See <xref
-                href="http://www.postgresql.org/docs/8.3/static/pgcrypto.html" format="html"
+                href="https://www.postgresql.org/docs/8.3/static/pgcrypto.html" format="html"
                 scope="external">pgp_key_id()</xref> in the pgcrypto documentation. </note>
           </li>
           <li>Decrypt the data using the private key.

--- a/gpdb-doc/dita/security-guide/topics/preface.xml
+++ b/gpdb-doc/dita/security-guide/topics/preface.xml
@@ -9,7 +9,7 @@
       structured query language (SQL) is helpful.</p>
     <p>Because Greenplum Database is based on PostgreSQL8.3.23, this guide assumes some familiarity
       with PostgreSQL. References to <xref
-        href="http://www.postgresql.org/docs/8.3/static/index.html" scope="external" format="html"
+        href="https://www.postgresql.org/docs/8.3/static/index.html" scope="external" format="html"
           ><ph>PostgreSQL documentation</ph></xref> are provided throughout this guide for features
       that are similar to those in Greenplum Database.</p>
     <p>This information is intended for system administrators responsible for administering a


### PR DESCRIPTION
The PostgreSQL documentation is only available over https, with a 307 redirect, so update all links to be https. Also remove interactive mode links as the documentation is all static these days.

This does not put any value judgment on whether we should link to such old versions, but I think it's pointless to address that before we have finished merging upstream for GPDB 6. Once we have settled on a version we can tailor the docs to match where we are at.