### PR TITLE
COPY now correctly reports an error if it fails on a segment.

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1712,6 +1712,8 @@ appendonly_beginscan(Relation relation,
 	int			segfile_count;
 	FileSegInfo **seginfo;
 
+	SIMPLE_FAULT_INJECTOR(AppendOnlyBeginScan);
+
 	seginfo = GetAllFileSegInfo(relation,
 								appendOnlyMetaDataSnapshot, &segfile_count);
 

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -305,6 +305,7 @@ cdbCopyGetData(CdbCopy *c, bool copy_cancel, uint64 *rows_processed)
 					{
 						appendStringInfo(&(c->err_msg), "Error from segment %d: %s\n",
 										 source_seg, PQresultErrorMessage(res));
+						c->io_errors = true;
 						first_error = false;
 					}
 

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -148,6 +148,8 @@ FI_IDENT(AppendOnlyInsert, "appendonly_insert")
 FI_IDENT(AppendOnlyDelete, "appendonly_delete")
 /* inject fault before an append-only update */
 FI_IDENT(AppendOnlyUpdate, "appendonly_update")
+/* inject fault before an append-only beginscan */
+FI_IDENT(AppendOnlyBeginScan, "appendonly_beginscan")
 /* inject fault before creating an appendonly hash entry*/
 FI_IDENT(BeforeCreatingAnAOHashEntry, "before_creating_an_ao_hash_entry")
 /* inject fault in append-only compression function */

--- a/src/test/regress/expected/copy2.out
+++ b/src/test/regress/expected/copy2.out
@@ -309,3 +309,26 @@ DROP FUNCTION truncate_in_subxact();
 DROP TABLE x, y;
 DROP FUNCTION fn_x_before();
 DROP FUNCTION fn_x_after();
+create extension if not exists gp_inject_fault;
+create table copy2_test_segment_failure(a int, b int) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- insert data to only segment 1 to make the test stable
+insert into copy2_test_segment_failure select i,i from generate_series(4,4)i;
+-- inject fault to fail copy on segment 1
+select gp_inject_fault_infinite('appendonly_beginscan', 'error', 2);
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=38443)
+ gp_inject_fault_infinite 
+--------------------------
+ t
+(1 row)
+
+copy copy2_test_segment_failure (a, b) to STDOUT;
+ERROR:  Error from segment 0: ERROR:  fault triggered, fault name:'appendonly_beginscan' fault type:'error'
+select gp_inject_fault_infinite('appendonly_beginscan', 'reset', 2);
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=38443)
+ gp_inject_fault_infinite 
+--------------------------
+ t
+(1 row)
+


### PR DESCRIPTION
Previously, if COPY failed on a segment, it would silently "succeed"
but in reality failed.  That behavior would have been interpreted
by a user as "COPY passed but there was no data to COPY" whereas
in reality there was an error that occurred.  This commit fixes that
and adds a test using the fault injector..

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>