### PR TITLE
Remove "Rows Out" processing in test explain parsing

### DIFF
--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -36,9 +36,7 @@ EXPLAIN ANALYZE SELECT * FROM explaintest;
                                                                QUERY PLAN                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4)
-   Rows out:  10 rows at destination with 0.332 ms to first row, 0.345 ms to end, start offset by 0.283 ms.
    ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4)
-         Rows out:  Avg 3.3 rows x 3 workers.  Max 5 rows (seg1) with 0.015 ms to first row, 0.018 ms to end, start offset by 0.543 ms.
  Slice statistics:
    (slice0)    Executor memory: 318K bytes.
    (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).

--- a/src/test/regress/expected/instr_in_shmem.out
+++ b/src/test/regress/expected/instr_in_shmem.out
@@ -109,29 +109,17 @@ EXPLAIN ANALYZE SELECT count(*) FROM a a1, a a2, a a3;
                                                                          QUERY PLAN                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=23614.53..23614.54 rows=1 width=8)
-   Rows out:  1 rows with 16 ms to end.
    ->  Gather Motion 9:1  (slice3; segments: 9)  (cost=23614.41..23614.51 rows=1 width=8)
-         Rows out:  9 rows at destination with 11 ms to first row, 16 ms to end.
          ->  Aggregate  (cost=23614.41..23614.42 rows=1 width=8)
-               Rows out:  Avg 1.0 rows x 9 workers.  Max 1 rows (seg0) with 12 ms to end.
                ->  Nested Loop  (cost=29.90..22989.40 rows=13889 width=0)
-                     Rows out:  Avg 13888.9 rows x 9 workers.  Max 17500 rows (seg6) with 3.320 ms to first row, 11 ms to end.
                      ->  Nested Loop  (cost=14.95..474.45 rows=278 width=0)
-                           Rows out:  Avg 277.8 rows x 9 workers.  Max 350 rows (seg6) with 0.250 ms to first row, 0.618 ms to end.
                            ->  Seq Scan on a a1  (cost=0.00..9.50 rows=6 width=0)
-                                 Rows out:  Avg 5.6 rows x 9 workers.  Max 7 rows (seg6) with 0.052 ms to first row, 0.064 ms to end.
                            ->  Materialize  (cost=14.95..19.45 rows=50 width=0)
-                                 Rows out:  Avg 277.8 rows x 9 workers.  Max 350 rows (seg6) with 0.165 ms to first row, 0.351 ms to end of 7 scans.
                                  ->  Broadcast Motion 9:9  (slice1; segments: 9)  (cost=0.00..14.50 rows=50 width=0)
-                                       Rows out:  Avg 50.0 rows x 9 workers at destination.  Max 50 rows (seg0) with 0.044 ms to first row, 0.117 ms to end.
                                        ->  Seq Scan on a a3  (cost=0.00..9.50 rows=6 width=0)
-                                             Rows out:  Avg 5.6 rows x 9 workers.  Max 7 rows (seg6) with 0.238 ms to first row, 0.246 ms to end.
                      ->  Materialize  (cost=14.95..19.45 rows=50 width=0)
-                           Rows out:  Avg 13889.9 rows x 9 workers.  Max 17501 rows (seg6) with 3.060 ms to first row, 5.964 ms to end of 351 scans.
                            ->  Broadcast Motion 9:9  (slice2; segments: 9)  (cost=0.00..14.50 rows=50 width=0)
-                                 Rows out:  Avg 50.0 rows x 9 workers at destination.  Max 50 rows (seg0) with 0.129 ms to first row, 2.538 ms to end.
                                  ->  Seq Scan on a a2  (cost=0.00..9.50 rows=6 width=0)
-                                       Rows out:  Avg 5.6 rows x 9 workers.  Max 7 rows (seg6) with 0.121 ms to first row, 0.127 ms to end.
  Slice statistics:
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 248K bytes avg x 9 workers, 248K bytes max (seg0).

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -3128,11 +3128,9 @@ explain analyze select reltablespace  from pg_class where oid = (select reltoast
 ------------------------------------------------------------------------------------------------------------------------------------
  Index Scan using pg_class_oid_index on pg_class  (cost=200.27..400.54 rows=1 width=4)
    Index Cond: oid = $0
-   Rows out:  1 rows with 0.025 ms to first row, 0.026 ms to end, start offset by 0.042 ms.
    InitPlan 1 (returns $0)
      ->  Index Scan using pg_class_relname_nsp_index on pg_class pg_class_1  (cost=0.00..200.27 rows=1 width=4)
            Index Cond: relname = 'tbl_8205'::name
-           Rows out:  1 rows with 0.010 ms to first row, 0.012 ms to end of 2 scans, start offset by 0.044 ms.
  Slice statistics:
    (slice0)    Executor memory: 113K bytes.
    (slice1)    Executor memory: 113K bytes.
@@ -3823,14 +3821,10 @@ explain analyze select count(*) from qp_misc_jiras.test_heap;
                                                                          QUERY PLAN                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=1176.32..1176.33 rows=1 width=8)
-   Rows out:  1 rows with 16 ms to end, start offset by 0.333 ms.
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1176.25..1176.30 rows=1 width=8)
-         Rows out:  3 rows at destination with 16 ms to end, start offset by 0.334 ms.
          ->  Aggregate  (cost=1176.25..1176.26 rows=1 width=8)
-               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 15 ms to end, start offset by 0.621 ms.
                allstat: seg_firststart_total_ntuples/seg0_0.621 ms_15 ms_1/seg1_0.621 ms_15 ms_1/seg2_0.634 ms_15 ms_1//end
                ->  Seq Scan on test_heap  (cost=0.00..961.00 rows=28700 width=0)
-                     Rows out:  Avg 33333.7 rows x 3 workers.  Max 33350 rows (seg0) with 0.035 ms to first row, 7.878 ms to end, start offset by 0.622 ms.
                      allstat: seg_firststart_total_ntuples/seg0_0.622 ms_7.878 ms_33350/seg1_0.622 ms_7.850 ms_33336/seg2_0.634 ms_7.866 ms_33315//end
  Slice statistics:
    (slice0)    Executor memory: 382K bytes.
@@ -3956,26 +3950,21 @@ explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=25.50..73.50 rows=1000 width=16)
-   Rows out:  1000 rows at destination with 78 ms to first row, 127 ms to end, start offset by 0.204 ms.
    ->  Hash Join  (cost=25.50..73.50 rows=334 width=16)
          Hash Cond: s.b = r.a
-         Rows out:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 86 ms to first row, 126 ms to end, start offset by 0.434 ms.
          Executor memory:  11K bytes avg, 11K bytes max (seg1).
          Work_mem used:  11K bytes avg, 11K bytes max (seg1). Workfile: (0 spilling, 0 reused)
          (seg1)   Hash chain length 1.0 avg, 1 max, using 342 of 8388619 buckets.
          allstat: seg_firststart_total_ntuples/seg0_0.408 ms_116 ms_321/seg1_0.434 ms_126 ms_342/seg2_0.446 ms_119 ms_337//end
          ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..33.00 rows=334 width=8)
                Hash Key: s.b
-               Rows out:  Avg 333.3 rows x 3 workers at destination.  Max 342 rows (seg1) with 0.114 ms to first row, 0.177 ms to end, start offset by 86 ms.
                allstat: seg_firststart_total_ntuples/seg0_78 ms_0.142 ms_321/seg1_86 ms_0.177 ms_342/seg2_80 ms_0.135 ms_337//end
                ->  Seq Scan on s  (cost=0.00..13.00 rows=334 width=8)
-                     Rows out:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 1.982 ms to first row, 2.023 ms to end, start offset by 2.147 ms.
                      allstat: seg_firststart_total_ntuples/seg0_0.822 ms_2.413 ms_321/seg1_2.147 ms_2.023 ms_342/seg2_2.115 ms_1.947 ms_337//end
          ->  Hash  (cost=13.00..13.00 rows=334 width=8)
                Rows in:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 0.247 ms to end, start offset by 86 ms.
                allstat: seg_firststart_total_ntuples/seg0_78 ms_0.215 ms_321/seg1_86 ms_0.247 ms_342/seg2_80 ms_0.173 ms_337//end
                ->  Seq Scan on r  (cost=0.00..13.00 rows=334 width=8)
-                     Rows out:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 0.048 ms to first row, 0.099 ms to end, start offset by 86 ms.
                      allstat: seg_firststart_total_ntuples/seg0_78 ms_0.073 ms_321/seg1_86 ms_0.099 ms_342/seg2_80 ms_0.065 ms_337//end
  Slice statistics:
    (slice0)    Executor memory: 267K bytes.

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -3153,11 +3153,9 @@ explain analyze select reltablespace  from pg_class where oid = (select reltoast
 -----------------------------------------------------------------------------------------------------------------------------------
  Index Scan using pg_class_oid_index on pg_class  (cost=200.27..400.54 rows=1 width=4)
    Index Cond: oid = $0
-   Rows out:  1 rows with 0.037 ms to first row, 0.038 ms to end, start offset by 0.047 ms.
    InitPlan 1 (returns $0)
      ->  Index Scan using pg_class_relname_nsp_index on pg_class pg_class_1  (cost=0.00..200.27 rows=1 width=4)
            Index Cond: relname = 'tbl_8205'::name
-           Rows out:  1 rows with 0.021 ms to first row, 0.023 ms to end of 2 scans, start offset by 0.049 ms.
  Slice statistics:
    (slice0)    Executor memory: 113K bytes.
    (slice1)    Executor memory: 113K bytes.
@@ -3855,14 +3853,10 @@ explain analyze select count(*) from qp_misc_jiras.test_heap;
                                                                          QUERY PLAN                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   Rows out:  1 rows with 10 ms to end, start offset by 0.342 ms.
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         Rows out:  3 rows at destination with 10 ms to end, start offset by 0.343 ms.
          ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 10 ms to end, start offset by 0.638 ms.
                allstat: seg_firststart_total_ntuples/seg0_0.638 ms_10 ms_1/seg1_0.636 ms_10 ms_1/seg2_0.637 ms_10 ms_1//end
                ->  Table Scan on test_heap  (cost=0.00..431.00 rows=1 width=1)
-                     Rows out:  Avg 33333.7 rows x 3 workers.  Max 33350 rows (seg0) with 0.039 ms to first row, 5.346 ms to end, start offset by 0.638 ms.
                      allstat: seg_firststart_total_ntuples/seg0_0.638 ms_5.346 ms_33350/seg1_0.636 ms_5.368 ms_33336/seg2_0.637 ms_5.264 ms_33315//end
  Slice statistics:
    (slice0)    Executor memory: 382K bytes.
@@ -3989,26 +3983,21 @@ explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
                                                                              QUERY PLAN                                                                             
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.26 rows=1000 width=16)
-   Rows out:  1000 rows at destination with 60 ms to first row, 87 ms to end, start offset by 0.252 ms.
    ->  Hash Join  (cost=0.00..862.20 rows=334 width=16)
          Hash Cond: r.a = s.b
-         Rows out:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 60 ms to first row, 86 ms to end, start offset by 0.527 ms.
          Executor memory:  11K bytes avg, 11K bytes max (seg1).
          Work_mem used:  11K bytes avg, 11K bytes max (seg1). Workfile: (0 spilling, 0 reused)
          (seg1)   Hash chain length 1.0 avg, 1 max, using 342 of 8388619 buckets.
          allstat: seg_firststart_total_ntuples/seg0_0.559 ms_86 ms_321/seg1_0.527 ms_86 ms_342/seg2_0.576 ms_86 ms_337//end
          ->  Table Scan on r  (cost=0.00..431.01 rows=334 width=8)
-               Rows out:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 0.019 ms to first row, 0.037 ms to end, start offset by 60 ms.
                allstat: seg_firststart_total_ntuples/seg0_61 ms_0.041 ms_321/seg1_60 ms_0.037 ms_342/seg2_61 ms_0.036 ms_337//end
          ->  Hash  (cost=431.02..431.02 rows=334 width=8)
                Rows in:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 0.131 ms to end, start offset by 60 ms.
                allstat: seg_firststart_total_ntuples/seg0_61 ms_0.135 ms_321/seg1_60 ms_0.131 ms_342/seg2_61 ms_0.176 ms_337//end
                ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.02 rows=334 width=8)
                      Hash Key: s.b
-                     Rows out:  Avg 333.3 rows x 3 workers at destination.  Max 342 rows (seg1) with 0.048 ms to first row, 0.081 ms to end, start offset by 60 ms.
                      allstat: seg_firststart_total_ntuples/seg0_61 ms_0.076 ms_321/seg1_60 ms_0.081 ms_342/seg2_61 ms_0.117 ms_337//end
                      ->  Table Scan on s  (cost=0.00..431.01 rows=334 width=8)
-                           Rows out:  Avg 333.3 rows x 3 workers.  Max 342 rows (seg1) with 2.039 ms to first row, 2.069 ms to end, start offset by 2.265 ms.
                            allstat: seg_firststart_total_ntuples/seg0_2.222 ms_2.232 ms_321/seg1_2.265 ms_2.069 ms_342/seg2_2.286 ms_1.974 ms_337//end
  Slice statistics:
    (slice0)    Executor memory: 267K bytes.

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -2010,19 +2010,12 @@ explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hell
                                                                               QUERY PLAN                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=2.24..2.27 rows=1 width=36)
-   Rows out:  1 rows at destination with 2.808 ms to first row, 3.303 ms to end, start offset by 1.517 ms.
    ->  Table Function Scan on multiset_5  (cost=2.24..2.27 rows=1 width=36)
-         Rows out:  1 rows (seg1) with 0.093 ms to first row, 0.096 ms to end, start offset by 4.177 ms.
          ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.24..2.25 rows=1 width=36)
-               Rows out:  1 rows at destination (seg1) with 0.078 ms to first row, 0.079 ms to end, start offset by 4.183 ms.
                ->  Aggregate  (cost=2.24..2.25 rows=1 width=36)
-                     Rows out:  1 rows with 0.060 ms to end, start offset by 4.070 ms.
                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.13..2.23 rows=1 width=8)
-                           Rows out:  2 rows at destination with 0.031 ms to first row, 0.051 ms to end, start offset by 4.071 ms.
                            ->  Aggregate  (cost=2.13..2.14 rows=1 width=8)
-                                 Rows out:  Avg 1.0 rows x 2 workers.  Max 1 rows (seg0) with 0.687 ms to end, start offset by 2.106 ms.
                                  ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=0)
-                                       Rows out:  Avg 5.0 rows x 2 workers.  Max 5 rows (seg0) with 0.675 ms to first row, 0.679 ms to end, start offset by 2.106 ms.
  Slice statistics:
    (slice0)    Executor memory: 258K bytes.
    (slice1)    Executor memory: 210K bytes avg x 2 workers, 210K bytes max (seg0).

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -2011,19 +2011,12 @@ explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hell
                                                                               QUERY PLAN                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=2.24..2.27 rows=1 width=36)
-   Rows out:  1 rows at destination with 2.808 ms to first row, 3.303 ms to end, start offset by 1.517 ms.
    ->  Table Function Scan on multiset_5  (cost=2.24..2.27 rows=1 width=36)
-         Rows out:  1 rows (seg1) with 0.093 ms to first row, 0.096 ms to end, start offset by 4.177 ms.
          ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.24..2.25 rows=1 width=36)
-               Rows out:  1 rows at destination (seg1) with 0.078 ms to first row, 0.079 ms to end, start offset by 4.183 ms.
                ->  Aggregate  (cost=2.24..2.25 rows=1 width=36)
-                     Rows out:  1 rows with 0.060 ms to end, start offset by 4.070 ms.
                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.13..2.23 rows=1 width=8)
-                           Rows out:  2 rows at destination with 0.031 ms to first row, 0.051 ms to end, start offset by 4.071 ms.
                            ->  Aggregate  (cost=2.13..2.14 rows=1 width=8)
-                                 Rows out:  Avg 1.0 rows x 2 workers.  Max 1 rows (seg0) with 0.687 ms to end, start offset by 2.106 ms.
                                  ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=0)
-                                       Rows out:  Avg 5.0 rows x 2 workers.  Max 5 rows (seg0) with 0.675 ms to first row, 0.679 ms to end, start offset by 2.106 ms.
  Slice statistics:
    (slice0)    Executor memory: 258K bytes.
    (slice1)    Executor memory: 210K bytes avg x 2 workers, 210K bytes max (seg0).


### PR DESCRIPTION
The `Rows out..` output was removed from `EXPLAIN` in the recent merge with PostgreSQL 9.  This output remained in the expected testfiles though, and that worked due to the `explain` Perl module parsing out the offending line from the resulting diff operation. This removes the parsing and all the now-outdated rows from the expected files.

This PR contains a commit from #5985 on which it relies, and where the need for this cleanup was made obvious. Merging this PR relies on 5985 being in the tree first, such that the cherry-picked commit can be removed from here.