### PR TITLE
Ensure ccache config file exists before conan compilation 

### DIFF
--- a/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+++ b/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
@@ -6,6 +6,8 @@ TRANSFER_DIR_ABSOLUTE_PATH=$(pwd)/${TRANSFER_DIR}
 COMPILED_BITS_FILENAME=${COMPILED_BITS_FILENAME:="compiled_bits_ubuntu16.tar.gz"}
 
 function build_external_depends() {
+    # fix the /root/.ccache missing issue during build
+    mkdir -p /root/.ccache && touch  /root/.ccache/ccache.conf
     pushd gpdb_src/depends
     ./configure
     make

--- a/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+++ b/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
@@ -9,28 +9,28 @@ function build_external_depends() {
     # fix the /root/.ccache missing issue during build
     mkdir -p /root/.ccache && touch  /root/.ccache/ccache.conf
     pushd gpdb_src/depends
-    ./configure
-    make
+        ./configure
+        make
     popd
 }
 
 function install_external_depends() {
     pushd gpdb_src/depends
-    make install
+        make install
     popd
 }
 
 function build_gpdb() {
     build_external_depends
     pushd gpdb_src
-    CWD=$(pwd)
-    LD_LIBRARY_PATH=${CWD}/depends/build/lib CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --with-gssapi --with-perl --with-libxml \
-      --with-python \
-      --with-libraries=${CWD}/depends/build/lib \
-      --with-includes=${CWD}/depends/build/include \
-      --prefix=${GREENPLUM_INSTALL_DIR}
-    make -j4
-    LD_LIBRARY_PATH=${CWD}/depends/build/lib make install
+        CWD=$(pwd)
+        LD_LIBRARY_PATH=${CWD}/depends/build/lib CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --with-gssapi --with-perl --with-libxml \
+          --with-python \
+          --with-libraries=${CWD}/depends/build/lib \
+          --with-includes=${CWD}/depends/build/include \
+          --prefix=${GREENPLUM_INSTALL_DIR}
+        make -j4
+        LD_LIBRARY_PATH=${CWD}/depends/build/lib make install
     popd
     install_external_depends
 }


### PR DESCRIPTION
When running parallel compilations with ccache, the existence of the ccache.conf configuration file can be subject to a race condition, causing occasional failures in pipelines.

To fix this, we ensure the configuration file exists before starting the compilation.

Master branch PR: #6012