### PR TITLE
catullus.pl: error if returns "record" with only one OUT parameter

### DIFF
--- a/src/include/catalog/catullus.pl
+++ b/src/include/catalog/catullus.pl
@@ -1091,6 +1091,15 @@ sub doprocs()
 		make_rettype($fndef);
 		make_allargs($fndef);
 
+		if (defined($fndef->{tuple}->{proargmodes}))
+		{
+			my $ocount = $fndef->{tuple}->{proargmodes} =~ tr/o/o/;
+			if ($ocount == 1 and $fndef->{tuple}->{prorettype} == get_typeoid("record"))
+			{
+				die ("OUT count must not be 1 because the result type is record")
+			}
+		}
+
 		# Fill in defaults for procost and prorows. (We have to do this
 		# after make_rettype, as we don't know if it's a set-returning function
 		# before that.


### PR DESCRIPTION
It generated a definition from the statement below successfully but failed when SELECT.
```
CREATE FUNCTION XXX(OUT XXX int4) RETURNS SETOF record LANGUAGE internal VOLATILE AS 'XXX' WITH (OID=XXX);
```
```
SELECT * FROM XXX();
ERROR:  a column definition list is required for functions returning "record"
```

Actually, not only Greenplum but also PostgreSQL doesn't allow such functions.
```
CREATE OR REPLACE FUNCTION foo(OUT c1 int4) RETURNS SETOF RECORD AS $$
BEGIN
  c1 = 1;
  RETURN NEXT;
  c1 = 3;
  RETURN NEXT;
  RETURN;
END;
$$ LANGUAGE plpgsql;

ERROR:  function result type must be integer because of OUT parameters
```

This commit checks while generating definitions and errors out if returns
"record" with only one OUT parameter.