### PR TITLE
Unify the way to fetch/manage the number of segments

### DIFF
--- a/gpMgmt/bin/README.gpexpand.md
+++ b/gpMgmt/bin/README.gpexpand.md
@@ -36,27 +36,20 @@ added to the cluster.
 ### Add the new segments into the cluster:
 The general workflow is as below:
 - add the new segments into `gp_segment_configuration` with status 'u';
-- notify FTS about the changes and wait for FTS to finish the scan:
-  - FTS check the status of the new segments;
-  - FTS record the status in shared memory;
-- once FTS finished its scan notify other processes in the cluster about the
-  new segments via `gpstop -u`, `pg_hba.conf` and `postgres.conf` will be
-  reloaded at proper time by those processes;
+- bump the expand version so other backends can get newest `gp_segment_
+  confiuration`;
 - unlock catalog updates on master;
 
 New segments can't and shouldn't be visible to other processes (user
-connections and auxiliary processes) until:
-1. they are added to `gp_segment_configuration` so others can know about their
-   existance and information;
-2. they are scaned by FTS and their status are recorded in shared memory so
-   others can know about their status;
+connections and auxiliary processes) until they are added to `gp_segment_
+configuration` so others can know about their existance and information;
 
-After above 2 steps the new segments are ready to be used in any newly created
-transactions, but for existing transactions they will still work on old
-segments.  In other words, if a transaction begins with N segments then it
-will only see these N segments during the transaction.
-The gang-size is determined by GpIdentity.numsegment, it will be updated on QD
-main loop only when there is no active transaction.
+Each global transaction will fetch or update a snapshot of `gp_segment_
+configuration` at the beginning of transaction, so new segments can be used
+any newly created transactions, but for transactions that have got snapshot
+of `gp_segment_configuration` they will still work on old segments. In other
+words, if a transaction begins with N segments then it will only see these N
+segments during the transaction.
 
 ### Data reorganization
 

--- a/gpMgmt/bin/README.gpexpand.md
+++ b/gpMgmt/bin/README.gpexpand.md
@@ -45,7 +45,7 @@ connections and auxiliary processes) until they are added to `gp_segment_
 configuration` so others can know about their existance and information;
 
 Each global transaction will fetch or update a snapshot of `gp_segment_
-configuration` at the beginning of transaction, so new segments can be used
+configuration` at the beginning of transaction, so new segments can be used in
 any newly created transactions, but for transactions that have got snapshot
 of `gp_segment_configuration` they will still work on old segments. In other
 words, if a transaction begins with N segments then it will only see these N

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1523,13 +1523,10 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
         dbconn.execSQL(self.conn, "CHECKPOINT")
         self.conn.close()
 
-        # Trigger FTS to rescan the segments status
-        self.conn = dbconn.connect(self.dburl, encoding='UTF8')
-        dbconn.execSQL(self.conn, "SELECT gp_request_fts_probe_scan()")
+        # increase expand version 
+        self.conn = dbconn.connect(self.dburl, utility=True, encoding='UTF8')
+        dbconn.execSQL(self.conn, "select gp_expand_bump_version()")
         self.conn.close()
-
-        cmd = GpStop('Notify all backends about the new segments', reload=True)
-        cmd.run(validateAfter=False)
 
         self.statusLogger.set_status('UPDATE_CATALOG_DONE')
 

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -305,7 +305,6 @@ Feature: expand the cluster by adding more segments
         And user has created test table
         And 20 rows are inserted into table "test" in schema "public" with column type list "int"
         And a long-run read-only transaction exists on "test"
-        And gp_num_contents_in_cluster in the long-run transaction has been saved
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "mdw"
         And the user runs gpexpand interview to add 1 new segment and 0 new host "ignore.host"
@@ -316,8 +315,6 @@ Feature: expand the cluster by adding more segments
         And all the segments are running
         And verify that the master pid has not been changed
         And verify that long-run read-only transaction still exists on "test"
-        And verify that gp_num_contents_in_cluster is unchanged in the long-run transaction
-        And verify that gp_num_contents_in_cluster is 3 in a new transaction
 
     @gpexpand_no_mirrors
     @gpexpand_no_restart

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2217,36 +2217,6 @@ def impl(context, table_name):
                 xid(before %s, after %), result(before %s, after %s)"
         raise Exception(error_str % (context.long_run_select_only_xid, xid, context.long_run_select_only_data_result, data_result))
 
-@given('gp_num_contents_in_cluster in the long-run transaction has been saved')
-def impl(context):
-    dbname = 'gptest'
-    conn = context.long_run_select_only_conn
-
-    query = """show gp_num_contents_in_cluster"""
-    context.gp_num_contents_in_cluster = dbconn.execSQLForSingleton(conn, query)
-
-@then('verify that gp_num_contents_in_cluster is unchanged in the long-run transaction')
-def impl(context):
-    dbname = 'gptest'
-    conn = context.long_run_select_only_conn
-
-    query = """show gp_num_contents_in_cluster"""
-    gp_num_contents_in_cluster = dbconn.execSQLForSingleton(conn, query)
-
-    if context.gp_num_contents_in_cluster != gp_num_contents_in_cluster:
-        raise Exception("gp_num_contents_in_cluster has been changed in transaction.")
-
-@then('verify that gp_num_contents_in_cluster is {value} in a new transaction')
-def impl(context, value):
-    dbname = 'gptest'
-    conn = dbconn.connect(dbconn.DbURL(dbname=dbname))
-
-    query = """show gp_num_contents_in_cluster"""
-    gp_num_contents_in_cluster = dbconn.execSQLForSingleton(conn, query)
-
-    if int(value) != int(gp_num_contents_in_cluster):
-        raise Exception("gp_num_contents_in_cluster is not updated in a new transaction.")
-
 @given('a long-run transaction starts')
 def impl(context):
     dbname = 'gptest'
@@ -2272,7 +2242,7 @@ def impl(context, table_name):
     try:
         data_result = dbconn.execSQL(conn, query)
     except Exception, msg:
-        key_msg = "ERROR:  cluster size is changed"
+        key_msg = "FATAL:  cluster is expaneded"
         if key_msg not in msg.__str__():
             raise Exception("transaction not abort correctly, errmsg:%s" % msg)
     else:

--- a/gpcontrib/gpcloud/src/s3conf.cpp
+++ b/gpcontrib/gpcloud/src/s3conf.cpp
@@ -15,6 +15,7 @@ void write_log(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 extern "C" {
 #include "c.h"
 #include "cdb/cdbvars.h"
+extern int getgpsegmentCount(void);
 }
 #endif
 
@@ -35,7 +36,7 @@ S3Params InitConfig(const string& urlWithOptions) {
     s3ext_segnum = 1;
 #else
     s3ext_segid = GpIdentity.segindex;
-    s3ext_segnum = GpIdentity.numsegments;
+    s3ext_segnum = getgpsegmentCount();
 #endif
 
     if (s3ext_segid == -1 && s3ext_segnum > 0) {

--- a/gpcontrib/pxf/src/pxffragment.c
+++ b/gpcontrib/pxf/src/pxffragment.c
@@ -373,11 +373,12 @@ filter_fragments_for_segment(List *list)
 
 	int			index = 0;
 	int			frag_index = 1;
-	int32		shift = xid % GpIdentity.numsegments;
+	int			numsegments = getgpsegmentCount();
+	int32		shift = xid % numsegments;
 
 	for (current = list_head(list); current != NULL; index++)
 	{
-		if (GpIdentity.segindex == (index + shift) % GpIdentity.numsegments)
+		if (GpIdentity.segindex == (index + shift) % numsegments)
 		{
 			/*
 			 * current segment is the one that should process, keep the

--- a/gpcontrib/pxf/test/Makefile
+++ b/gpcontrib/pxf/test/Makefile
@@ -8,7 +8,8 @@ include $(top_builddir)/src/backend/mock.mk
 
 pxfheaders.t: $(MOCK_DIR)/backend/access/external/fileam_mock.o $(MOCK_DIR)/backend/catalog/pg_exttable_mock.o
 
-pxffragment.t: $(MOCK_DIR)/backend/cdb/cdbtm_mock.o $(top_builddir)/src/backend/utils/adt/json.o
+pxffragment.t: $(MOCK_DIR)/backend/cdb/cdbtm_mock.o $(top_builddir)/src/backend/utils/adt/json.o $(MOCK_DIR)/backend/cdb/cdbutil_mock.o
+
 
 pxfbridge.t: $(MOCK_DIR)/backend/cdb/cdbtm_mock.o
 

--- a/gpcontrib/pxf/test/pxffragment_test.c
+++ b/gpcontrib/pxf/test/pxffragment_test.c
@@ -192,6 +192,9 @@ test_list(int segindex, int segtotal, int xid, int fragtotal, char *expected[], 
 	/* prepare the input list */
 	List	   *list = prepare_fragment_list(fragtotal, segindex, segtotal, xid);
 
+	if (list && xid != InvalidDistributedTransactionId)
+		will_return(getgpsegmentCount, segtotal);
+
 	/* filter the list */
 	List	   *filtered = filter_fragments_for_segment(list);
 
@@ -219,7 +222,6 @@ static List *
 prepare_fragment_list(int fragtotal, int segindex, int segtotal, int xid)
 {
 	GpIdentity.segindex = segindex;
-	GpIdentity.numsegments = segtotal;
 
 	if (fragtotal > 0)
 		will_return(getDistributedTransactionId, xid);

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -573,7 +573,7 @@ external_insert_init(Relation rel)
 		Value	   *v;
 		char	   *uri_str;
 		int			segindex = GpIdentity.segindex;
-		int			num_segs = GpIdentity.numsegments;
+		int			num_segs = getgpsegmentCount();
 		int			num_urls = list_length(extentry->urilocations);
 		int			my_url = segindex % num_urls;
 
@@ -2289,7 +2289,7 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 	sprintf(extvar->GP_SEGMENT_ID, "%d", GpIdentity.segindex);
 	sprintf(extvar->GP_SEG_PORT, "%d", PostPortNumber);
 	sprintf(extvar->GP_SESSION_ID, "%d", gp_session_id);
-	sprintf(extvar->GP_SEGMENT_COUNT, "%d", GpIdentity.numsegments);
+	sprintf(extvar->GP_SEGMENT_COUNT, "%d", getgpsegmentCount());
 
 	/*
 	 * Hadoop Connector env var

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2494,6 +2494,14 @@ StartTransaction(void)
 	s->state = TRANS_INPROGRESS;
 
 	/*
+	 * update the snapshot of gp_segment_configuration, it's not changed
+	 * until the end of transaction, do this update inside a transaction
+	 * because it does a catalog lookup.
+	 */
+	if (DistributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE)
+		cdbcomponent_updateCdbComponents();
+
+	/*
 	 * Acquire a resource group slot.
 	 *
 	 * Slot is successfully acquired when AssignResGroupOnMaster() is returned.

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -158,15 +158,3 @@ getFtsVersion(void)
 {
 	return ftsProbeInfo->fts_statusVersion;
 }
-
-uint32
-FtsGetTotalSegments(void)
-{
-	/*
-	 * ftsProbeInfo is stored in shared memory, so check whether shared memory
-	 * has been initialized
-	 */
-	Assert(ftsProbeInfo);
-
-	return ftsProbeInfo->total_segments;
-}

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -176,8 +176,7 @@ FtsGetTotalSegments(void)
 	 * ftsProbeInfo is stored in shared memory, so check whether shared memory
 	 * has been initialized
 	 */
-	if (ftsProbeInfo)
-		return ftsProbeInfo->total_segment_dbs;
-	else
-		return GpIdentity.numsegments;
+	Assert(ftsProbeInfo);
+
+	return ftsProbeInfo->total_segments;
 }

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -117,23 +117,13 @@ FtsNotifyProber(void)
  * dispatcher: ONLY CALL THREADSAFE FUNCTIONS -- elog() is NOT threadsafe.
  */
 bool
-FtsIsSegmentUp(CdbComponentDatabaseInfo *dBInfo)
+FtsIsSegmentDown(CdbComponentDatabaseInfo *dBInfo)
 {
 	/* master is always reported as alive */
 	if (dBInfo->segindex == MASTER_SEGMENT_ID)
-		return true;
+		return false;
 
-	/*
-	 * If fullscan is not requested, caller is just trying to optimize on the
-	 * cached version of the segment status.  If the cached version is not
-	 * initialized yet, just return positively back.  This is mainly to avoid
-	 * queries incorrectly failing just after QD restarts if FTS process is yet
-	 * to start and complete initializing the cached status.  We shouldn't be
-	 * checking against an uninitialized variable.
-	 */
-	return ftsProbeInfo->fts_statusVersion ?
-		FTS_STATUS_IS_UP(ftsProbeInfo->fts_status[dBInfo->dbid]) :
-		true;
+	return FTS_STATUS_IS_DOWN(ftsProbeInfo->fts_status[dBInfo->dbid]);
 }
 
 /*
@@ -152,7 +142,7 @@ FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor **segdbDesc, int size)
 
 		elog(DEBUG2, "FtsTestSegmentDBIsDown: looking for real fault on segment dbid %d", (int) segInfo->dbid);
 
-		if (!FtsIsSegmentUp(segInfo))
+		if (FtsIsSegmentDown(segInfo))
 		{
 			ereport(LOG, (errmsg_internal("FTS: found fault with segment dbid %d. "
 										  "Reconfiguration is in progress", (int) segInfo->dbid)));

--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -434,7 +434,7 @@ FinalizeDirectDispatchDataForSlice(Node *node, ContentIdAssignmentData *data, bo
 
 				if (ddcr->dd.contentIds == NULL)
 				{
-					ddcr->dd.contentIds = list_make1_int(cdb_randint(GpIdentity.numsegments - 1, 0));
+					ddcr->dd.contentIds = list_make1_int(cdb_randint(getgpsegmentCount() - 1, 0));
 					if (ShouldPrintTestMessages())
 						elog(INFO, "DDCR learned no content dispatch is required");
 				}

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2188,9 +2188,6 @@ setCurrentGxact(void)
 	setCurrentGxactState(DTX_STATE_ACTIVE_NOT_DISTRIBUTED);
 
 	currentGxact->gxid = gxid;
-
-	/* update the snapshot of current segments info */
-	cdbcomponent_updateCdbComponents();
 }
 
 static void

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -50,7 +50,6 @@
 #include "utils/fmgroids.h"
 #include "utils/sharedsnapshot.h"
 #include "utils/snapmgr.h"
-#include "catalog/namespace.h"
 
 extern bool Test_print_direct_dispatch_info;
 
@@ -960,8 +959,7 @@ doNotifyingAbort(void)
 
 	if (currentGxact->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED)
 	{
-		if (!currentGxact->writerGangLost &&
-				currentGxact->gxidDispatched)
+		if (!currentGxact->writerGangLost)
 		{
 			succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED, /* flags */ 0,
 													 currentGxact->gid, currentGxact->gxid,
@@ -2151,7 +2149,6 @@ initGxact(TMGXACT *gxact)
 	gxact->directTransaction = false;
 	gxact->directTransactionContentId = 0;
 	gxact->writerGangLost = false;
-	gxact->gxidDispatched = false;
 }
 
 bool
@@ -2191,6 +2188,9 @@ setCurrentGxact(void)
 	setCurrentGxactState(DTX_STATE_ACTIVE_NOT_DISTRIBUTED);
 
 	currentGxact->gxid = gxid;
+
+	/* update the snapshot of current segments info */
+	cdbcomponent_updateCdbComponents();
 }
 
 static void
@@ -3386,33 +3386,4 @@ bool
 currentGxactWriterGangLost(void)
 {
 	return currentGxact == NULL ? false : currentGxact->writerGangLost;
-}
-
-bool
-isSafeToRecreateWriter(void)
-{
-	/*
-	 * Can not recycle current writer because temp files will be
-	 * dropped in the segement, dispatcher will inform the segment
-	 * is down and report an error and reset the session.
-	 */
-	if (TempNamespaceOidIsValid())
-		return false;
-
-	/*
-	 * Can not recycle current writer if current global transaction
-	 * has been dispatched to the writer, otherwise new created
-	 * writer will miss gxid info. 
-	 */
-	if (currentGxact && currentGxact->gxidDispatched)
-		return false;
-
-	return true;
-}
-
-void
-markCurrentGxactDispatched(void)
-{
-	if (currentGxact && currentGxact->state >= DTX_STATE_ACTIVE_DISTRIBUTED)
-		currentGxact->gxidDispatched = true;
 }

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -547,6 +547,7 @@ cdbcomponent_updateCdbComponents(void)
 		{
 			cdb_component_dbs = getCdbComponentInfo(true);
 			cdb_component_dbs->fts_version = ftsVersion;
+			cdb_component_dbs->expand_version = GetGpExpandVersion();
 		}
 		else if ((cdb_component_dbs->fts_version != ftsVersion ||
 				 cdb_component_dbs->expand_version != expandVersion))

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -45,6 +45,7 @@
 #include "cdb/cdbfts.h"
 #include "storage/ipc.h"
 #include "postmaster/fts.h"
+#include "catalog/namespace.h"
 
 #define MAX_CACHED_1_GANGS 1
 
@@ -73,6 +74,8 @@ static void getAddressesForDBid(CdbComponentDatabaseInfo *c, int elevel);
 static HTAB *hostSegsHashTableInit(void);
 
 static HTAB *segment_ip_cache_htab = NULL;
+
+int numsegmentsFromQD = -1;
 
 typedef struct SegIpEntry
 {
@@ -106,12 +109,6 @@ getCdbComponentInfo(bool DNSLookupAsError)
 	 */
 	int			segment_array_size = 500;
 	int			entry_array_size = 4;	/* we currently support a max of 2 */
-
-	/*
-	 * Count of primary and mirror segments.
-	 */
-	int			primary_count = 0;
-	int			mirror_count = 0;
 
 	/*
 	 * isNull and attr are used when getting the data for a specific column
@@ -228,28 +225,6 @@ getCdbComponentInfo(bool DNSLookupAsError)
 		 */
 		if (content >= 0)
 		{
-			/*
-			 * Only FTS can see all the segments, others can only see the old
-			 * segments during the transaction.  GpIdentity.numsegments is only
-			 * updated at beginning of a transaction, so we should see at most
-			 * GpIdentity.numsegments primaries / mirrors.
-			 */
-			if (!am_ftsprobe)
-			{
-				if (role == 'p')
-				{
-					if (primary_count == getgpsegmentCount())
-						continue; /* Ignore new primaries */
-					primary_count++;
-				}
-				else if (role == 'm')
-				{
-					if (mirror_count == getgpsegmentCount())
-						continue; /* Ignore new mirrors */
-					mirror_count++;
-				}
-			}
-
 			/*
 			 * if we have a dbid bigger than our array we'll have to grow the
 			 * array. (MPP-2104)
@@ -395,19 +370,6 @@ getCdbComponentInfo(bool DNSLookupAsError)
 	}
 
 	/*
-	 * Validate that gp_numsegments == segment_databases->total_segment_dbs
-	 * unless called by FTS.
-	 */
-	if (!am_ftsprobe &&
-		getgpsegmentCount() != component_databases->total_segments)
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_DATA_EXCEPTION),
-				 errmsg("Greenplum Database number of segments inconsistency: count is %d from pg_catalog.%s table, but %d from cdbcomponent_getCdbComponents()",
-						getgpsegmentCount(), GpIdRelationName, component_databases->total_segments)));
-	}
-
-	/*
 	 * Now validate that our identity is present in the entry databases
 	 */
 	for (i = 0; i < component_databases->total_entry_dbs; i++)
@@ -429,11 +391,11 @@ getCdbComponentInfo(bool DNSLookupAsError)
 
 	/*
 	 * Now validate that the segindexes for the segment databases are between
-	 * 0 and (GpIdentity.numsegments - 1) inclusive, and that we hit them all.
+	 * 0 and (numsegments - 1) inclusive, and that we hit them all.
 	 * Since it's sorted, this is relatively easy.
 	 */
 	x = 0;
-	for (i = 0; i < getgpsegmentCount(); i++)
+	for (i = 0; i < component_databases->total_segments; i++)
 	{
 		int			this_segindex = -1;
 
@@ -449,7 +411,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 				ereport(ERROR,
 						(errcode(ERRCODE_DATA_EXCEPTION),
 						 errmsg("Content values not valid in %s table.  They must be in the range 0 to %d inclusive",
-								GpSegmentConfigRelationName, getgpsegmentCount() - 1)));
+								GpSegmentConfigRelationName, component_databases->total_segments - 1)));
 			}
 		}
 		if (this_segindex != i)
@@ -457,7 +419,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_EXCEPTION),
 					 errmsg("Content values not valid in %s table.  They must be in the range 0 to %d inclusive",
-							GpSegmentConfigRelationName, getgpsegmentCount() - 1)));
+							GpSegmentConfigRelationName, component_databases->total_segments - 1)));
 		}
 	}
 
@@ -567,6 +529,53 @@ cdbcomponent_cleanupIdleQEs(bool includeWriter)
 	return;
 }
 
+/* 
+ * This function is called when current global transaction is set,
+ * the snapshot of segments info will not changed within a global
+ * transaction
+ */
+void
+cdbcomponent_updateCdbComponents(void)
+{
+	uint8 ftsVersion= getFtsVersion();
+
+	PG_TRY();
+	{
+		if (cdb_component_dbs == NULL)
+		{
+			cdb_component_dbs = getCdbComponentInfo(true);
+			cdb_component_dbs->fts_version = ftsVersion;
+		}
+		else if (cdb_component_dbs->fts_version != ftsVersion &&
+				 !TempNamespaceOidIsValid())
+		{
+			/*
+			 * A fts version change don't always means a segment is
+			 * down. A mirror InSync status change also change fts
+			 * version, so we need to be careful of destroying exist
+			 * cdb_component_dbs.
+			 *
+			 * Can not update current writer because temp files will be
+			 * dropped in the segement, dispatcher will inform the segment
+			 * is down and report an error and reset the session.
+			 */
+			ELOG_DISPATCHER_DEBUG("FTS rescanned, get new component databases info.");
+			cdbcomponent_destroyCdbComponents();
+			cdb_component_dbs = getCdbComponentInfo(true);
+			cdb_component_dbs->fts_version = ftsVersion;
+		}
+	}
+	PG_CATCH();
+	{
+		FtsNotifyProber();
+
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	Assert(cdb_component_dbs->numActiveQEs == 0);
+}
+
 /*
  * cdbcomponent_getCdbComponents 
  *
@@ -577,38 +586,13 @@ cdbcomponent_cleanupIdleQEs(bool includeWriter)
 CdbComponentDatabases *
 cdbcomponent_getCdbComponents(bool DNSLookupAsError)
 {
-	uint8	ftsVersion = getFtsVersion();
-
 	PG_TRY();
 	{
 		if (cdb_component_dbs == NULL)
 		{
 			cdb_component_dbs = getCdbComponentInfo(DNSLookupAsError);
-			cdb_component_dbs->fts_version = ftsVersion;
+			cdb_component_dbs->fts_version = getFtsVersion();
 		}
-		else if (cdb_component_dbs->fts_version != ftsVersion)
-		{
-			/*
-			 * A fts version change don't always means a segment is
-			 * down. A mirror InSync status change also change fts
-			 * version, so we need to be careful of destroying exist
-			 * cdb_component_dbs.
-			 *
-			 *
-			 * * A query should has a unique cdb_component_dbs between
-			 * 	 slices and inside slices. 
-			 * * If it's not safe to recycle current writer, use current
-			 *   cdb_component_dbs.
-			 */
-			if (cdb_component_dbs->numActiveQEs == 0 && isSafeToRecreateWriter())
-			{
-				ELOG_DISPATCHER_DEBUG("FTS rescanned, get new component databases info.");
-				cdbcomponent_destroyCdbComponents();
-				cdb_component_dbs = getCdbComponentInfo(DNSLookupAsError);
-				cdb_component_dbs->fts_version = ftsVersion;
-			}
-		}
-
 	}
 	PG_CATCH();
 	{
@@ -1503,28 +1487,6 @@ contentid_get_dbid(int16 contentid, char role, bool getPreferredRoleNotCurrentRo
 	return dbid;
 }
 
-/*
- * Returns the number of segments
- */
-int
-getgpsegmentCount(void)
-{
-	if (Gp_role == GP_ROLE_UTILITY)
-	{
-		if (GpIdentity.numsegments <= 0)
-		{
-			elog(DEBUG5, "getgpsegmentCount called when Gp_role == utility, returning zero segments.");
-			return 0;
-		}
-
-		elog(DEBUG1, "getgpsegmentCount called when Gp_role == utility, but is relying on gp_id info");
-	}
-
-	verifyGpIdentityIsSet();
-	Assert(GpIdentity.numsegments > 0);
-	return GpIdentity.numsegments;
-}
-
 List *
 cdbcomponent_getCdbComponentsList(void)
 {
@@ -1542,3 +1504,19 @@ cdbcomponent_getCdbComponentsList(void)
 	return segments;
 }
 
+/*
+ * return the number of total segments for current snapshot of
+ * segments info
+ */
+int
+getgpsegmentCount(void)
+{
+	int32 numsegments = -1;
+
+	if (Gp_role == GP_ROLE_DISPATCH)
+		numsegments = cdbcomponent_getCdbComponents(true)->total_segments;
+	else if (Gp_role == GP_ROLE_EXECUTE)
+		numsegments = numsegmentsFromQD;
+
+	return numsegments;
+}

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -336,7 +336,7 @@ bool		gp_cost_hashjoin_chainwalk = false;
  * Any code needing the "numsegments"
  * can simply #include cdbvars.h, and use GpIdentity.numsegments
  */
-GpId		GpIdentity = {UNINITIALIZED_GP_IDENTITY_VALUE, UNINITIALIZED_GP_IDENTITY_VALUE, UNINITIALIZED_GP_IDENTITY_VALUE};
+GpId		GpIdentity = {UNINITIALIZED_GP_IDENTITY_VALUE, UNINITIALIZED_GP_IDENTITY_VALUE};
 
 /*
  * Keep track of a few dispatch-related  statistics:

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -338,17 +338,6 @@ bool		gp_cost_hashjoin_chainwalk = false;
  */
 GpId		GpIdentity = {UNINITIALIZED_GP_IDENTITY_VALUE, UNINITIALIZED_GP_IDENTITY_VALUE, UNINITIALIZED_GP_IDENTITY_VALUE};
 
-void
-verifyGpIdentityIsSet(void)
-{
-	if (GpIdentity.numsegments == UNINITIALIZED_GP_IDENTITY_VALUE ||
-		GpIdentity.dbid == UNINITIALIZED_GP_IDENTITY_VALUE ||
-		GpIdentity.segindex == UNINITIALIZED_GP_IDENTITY_VALUE)
-	{
-		elog(ERROR, "GpIdentity is not set");
-	}
-}
-
 /*
  * Keep track of a few dispatch-related  statistics:
  */
@@ -766,48 +755,4 @@ Datum
 gp_execution_dbid(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_INT32(GpIdentity.dbid);
-}
-
-/*
- * Get new numsegments from Shared Memory and update GpIdentity
- * If the value has changed return true.
- * This function must only be called by QD or QE process.
- */
-bool
-updateGpIdentityNumsegments(void)
-{
-	/*
-	 * New segments can be added to the cluster when there are in-progress
-	 * transactions, however the new segments should not be visible to them.
-	 * So GpIdentity.numsegments should only be updated outside transactions.
-	 */
-	Assert(MyProc);
-	if (Gp_role == GP_ROLE_DISPATCH && MyProc->lxid == InvalidOid)
-	{
-		uint32 newnumsegments = FtsGetTotalSegments();
-		if (newnumsegments > GpIdentity.numsegments)
-		{
-			GpIdentity.numsegments = newnumsegments;
-			return true;
-		}
-	}
-	return false;
-}
-
-/*
- * Same as updateGpIdentityNumsegments, for system process.
- */
-bool
-updateSystemProcessGpIdentityNumsegments(void)
-{
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		uint32 newnumsegments = FtsGetTotalSegments();
-		if (newnumsegments > GpIdentity.numsegments)
-		{
-			GpIdentity.numsegments = newnumsegments;
-			return true;
-		}
-	}
-	return false;
 }

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -96,8 +96,6 @@ cdbdisp_dispatchToGang(struct CdbDispatcherState *ds,
 	Assert(dispatchResults && dispatchResults->resultArray);
 
 	(pDispatchFuncs->dispatchToGang) (ds, gp, sliceIndex);
-
-	markCurrentGxactDispatched();
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -794,7 +794,7 @@ checkSegmentAlive(CdbDispatchCmdAsync *pParms)
 		ELOG_DISPATCHER_DEBUG("FTS testing connection %d of %d (%s)",
 							  i + 1, pParms->dispatchCount, segdbDesc->whoami);
 
-		if (!FtsIsSegmentUp(segdbDesc->segment_database_info))
+		if (FtsIsSegmentDown(segdbDesc->segment_database_info))
 		{
 			char	   *msg = PQerrorMessage(segdbDesc->conn);
 

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -808,6 +808,7 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 	Oid			sessionUserId = GetSessionUserId();
 	Oid			outerUserId = GetOuterUserId();
 	Oid			currentUserId = GetUserId();
+	int32		numsegments = getgpsegmentCount();
 	StringInfoData resgroupInfo;
 
 	int			tmp,
@@ -861,7 +862,7 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 		plantree_len +
 		params_len +
 		sddesc_len +
-		sizeof(GpIdentity.numsegments) +
+		sizeof(numsegments) +
 		sizeof(resgroupInfo.len) +
 		resgroupInfo.len;
 
@@ -972,10 +973,9 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 		pos += sddesc_len;
 	}
 
-	/* FIXME: this could be retired with the per-table numsegments */
-	tmp = htonl(GpIdentity.numsegments);
-	memcpy(pos, &tmp, sizeof(GpIdentity.numsegments));
-	pos += sizeof(GpIdentity.numsegments);
+	tmp = htonl(numsegments);
+	memcpy(pos, &tmp, sizeof(numsegments));
+	pos += sizeof(numsegments);
 
 	tmp = htonl(resgroupInfo.len);
 	memcpy(pos, &tmp, sizeof(resgroupInfo.len));

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -823,7 +823,7 @@ GangOK(Gang *gp)
 
 		if (cdbconn_isBadConnection(segdbDesc))
 			return false;
-		if (!FtsIsSegmentUp(segdbDesc->segment_database_info))
+		if (FtsIsSegmentDown(segdbDesc->segment_database_info))
 			return false;
 	}
 

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -176,7 +176,6 @@ main(int argc, char *argv[])
 
 	CurrentResourceOwner = ResourceOwnerCreate(NULL, "gang test");
 	Gp_role = GP_ROLE_DISPATCH;
-	GpIdentity.numsegments = TOTOAL_SEGMENTS;
 	GpIdentity.dbid = 1;
 	GpIdentity.segindex = -1;
 

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -848,7 +848,7 @@ EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool flushCommLa
 	 */
 	if (pMNEntry->preserve_order && pMNEntry->ready_tuple_lists != NULL)
 	{
-		for (i = 0; i < GpIdentity.numsegments; i++)
+		for (i = 0; i < getgpsegmentCount(); i++)
 		{
 			pCSEntry = &pMNEntry->ready_tuple_lists[i];
 
@@ -1004,7 +1004,7 @@ getChunkSorterEntry(MotionLayerState *mlStates,
 	AssertArg(motNodeEntry != NULL);
 
 	Assert(srcRoute >= 0);
-	Assert(srcRoute < GpIdentity.numsegments);
+	Assert(srcRoute < getgpsegmentCount());
 
 	/* Do we have a sorter initialized ? */
 	if (motNodeEntry->ready_tuple_lists != NULL)
@@ -1017,7 +1017,7 @@ getChunkSorterEntry(MotionLayerState *mlStates,
 	oldCtxt = MemoryContextSwitchTo(mlStates->motion_layer_mctx);
 
 	if (motNodeEntry->ready_tuple_lists == NULL)
-		motNodeEntry->ready_tuple_lists = (ChunkSorterEntry *) palloc0(GpIdentity.numsegments * sizeof(ChunkSorterEntry));
+		motNodeEntry->ready_tuple_lists = (ChunkSorterEntry *) palloc0(getgpsegmentCount() * sizeof(ChunkSorterEntry));
 
 	chunkSorterEntry = &motNodeEntry->ready_tuple_lists[srcRoute];
 

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -346,7 +346,7 @@ InitMotionTCP(int *listenerSocketFd, uint16 *listenerPort)
 	tval.tv_usec = 500000;
 
 #ifdef pg_on_solaris
-	listenerBacklog = Min(1024, Max(GpIdentity.numsegments * 4, listenerBacklog));
+	listenerBacklog = Min(1024, Max(getgpsegmentCount() * 4, listenerBacklog));
 #endif
 
 	setupTCPListeningSocket(listenerBacklog, listenerSocketFd, listenerPort);

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -177,7 +177,7 @@ struct ConnHashTable
 	int			size;
 };
 
-#define DEFAULT_CONN_HTAB_SIZE (Max((GpIdentity.numsegments*Gp_interconnect_hash_multiplier), 16))
+#define DEFAULT_CONN_HTAB_SIZE 16
 #define CONN_HASH_VALUE(icpkt) ((uint32)((((icpkt)->srcPid ^ (icpkt)->dstPid)) + (icpkt)->dstContentId))
 #define CONN_HASH_MATCH(a, b) (((a)->motNodeId == (b)->motNodeId && \
 								(a)->dstContentId == (b)->dstContentId && \

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2737,7 +2737,7 @@ CopyTo(CopyState cstate)
 		/* For replicated table, choose only one segment to scan data */
 		if (Gp_role == GP_ROLE_EXECUTE && !cstate->on_segment &&
 				GpPolicyIsReplicated(cstate->rel->rd_cdbpolicy) &&
-				gp_session_id % GpIdentity.numsegments != GpIdentity.segindex)
+				gp_session_id % getgpsegmentCount() != GpIdentity.segindex)
 		{
 			MemoryContextDelete(cstate->rowcontext);
 			return 0;

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1794,7 +1794,7 @@ sliceCalculateNumSendingProcesses(Slice *slice)
 			if (slice->directDispatch.isDirectDispatch)
 				return list_length(slice->directDispatch.contentIds);
 			else
-				return getgpsegmentCount();
+				return slice->gangSize;
 
 		default:
 			Insist(false);

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -379,7 +379,6 @@ CdbComponentDatabases *readCdbComponentInfoAndUpdateStatus(MemoryContext probeCo
 	if (ftsProbeInfo->fts_statusVersion == 0)
 	{
 		ftsProbeInfo->fts_statusVersion++;
-		ftsProbeInfo->total_segments = cdbs->total_segments;
 	}
 
 	return cdbs;
@@ -564,10 +563,7 @@ void FtsLoop()
 
 			/* Bump the version if configuration was updated. */
 			if (updated_probe_state)
-			{
 				ftsProbeInfo->fts_statusVersion++;
-				ftsProbeInfo->total_segments = cdbs->total_segments;
-			}
 		}
 
 		/* free current components info and free ip addr caches */	

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -366,8 +366,8 @@ CdbComponentDatabases *readCdbComponentInfoAndUpdateStatus(MemoryContext probeCo
 		CdbComponentDatabaseInfo *segInfo = &cdbs->segment_db_info[i];
 		uint8	segStatus = 0;
 
-		if (SEGMENT_IS_ALIVE(segInfo))
-			FTS_STATUS_SET_UP(segStatus);
+		if (!SEGMENT_IS_ALIVE(segInfo))
+			FTS_STATUS_SET_DOWN(segStatus);
 
 		ftsProbeInfo->fts_status[segInfo->dbid] = segStatus;
 	}

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -377,9 +377,7 @@ CdbComponentDatabases *readCdbComponentInfoAndUpdateStatus(MemoryContext probeCo
 	 * shared memory for the first time after FTS startup.
 	 */
 	if (ftsProbeInfo->fts_statusVersion == 0)
-	{
 		ftsProbeInfo->fts_statusVersion++;
-	}
 
 	return cdbs;
 }

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -50,6 +50,7 @@
 #include "utils/rel.h"
 
 #include "cdb/cdbvars.h"
+#include "cdb/cdbutil.h"
 #include "catalog/gp_policy.h"
 #include "access/htup_details.h"
 #include "optimizer/clauses.h"
@@ -3664,6 +3665,8 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 	Assert(into->distributedBy != NULL);
 
 	dist = (DistributedBy *)into->distributedBy;
+
+	dist->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
 
 	/*
 	 * We have a DISTRIBUTED BY column list specified by the user

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4685,7 +4685,7 @@ DistributedBy:   DISTRIBUTED BY  '(' columnListUnique ')'
 			{
 				DistributedBy *distributedBy = makeNode(DistributedBy);
 				distributedBy->ptype = POLICYTYPE_PARTITIONED;
-				distributedBy->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+				distributedBy->numsegments = -1;
 				distributedBy->keys = $4;
 				$$ = (Node *)distributedBy;
 			}
@@ -4693,7 +4693,7 @@ DistributedBy:   DISTRIBUTED BY  '(' columnListUnique ')'
 			{
 				DistributedBy *distributedBy = makeNode(DistributedBy);
 				distributedBy->ptype = POLICYTYPE_PARTITIONED;
-				distributedBy->numsegments = Max(1, getgpsegmentCount());
+				distributedBy->numsegments = -1;
 				distributedBy->keys = NIL;
 				$$ = (Node *)distributedBy;
 			}
@@ -4701,7 +4701,7 @@ DistributedBy:   DISTRIBUTED BY  '(' columnListUnique ')'
 			{
 				DistributedBy *distributedBy = makeNode(DistributedBy);
 				distributedBy->ptype = POLICYTYPE_REPLICATED;
-				distributedBy->numsegments = Max(1, getgpsegmentCount());
+				distributedBy->numsegments = -1;
 				distributedBy->keys = NIL;
 				$$ = (Node *)distributedBy;
 			}

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1738,6 +1738,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 	if (distributedBy &&
 		(distributedBy->ptype == POLICYTYPE_PARTITIONED && distributedBy->keys == NIL))
 	{
+		distributedBy->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
 		return distributedBy;
 	}
 
@@ -1749,14 +1750,12 @@ transformDistributedBy(CreateStmtContext *cxt,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("INHERITS clause cannot be used with DISTRIBUTED REPLICATED clause")));
 
+		distributedBy->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
 		return distributedBy;
 	}
 
 	if (distributedBy)
-	{
 		distrkeys = distributedBy->keys;
-		numsegments = distributedBy->numsegments;
-	}
 
 	/*
 	 * If distributedBy is NIL, the user did not explicitly say what he

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2771,8 +2771,6 @@ SIGHUP_handler(SIGNAL_ARGS)
 
 	PG_SETMASK(&BlockSig);
 
-	updateSystemProcessGpIdentityNumsegments();
-
 	if (Shutdown <= SmartShutdown)
 	{
 		ereport(LOG,

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1041,15 +1041,6 @@ PostmasterMain(int argc, char *argv[])
              )));
 	}
 
-	if ( GpIdentity.numsegments < 0 )
-	{
-	    ereport(FATAL,
-            (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-             errmsg("numContentsInCluster (from -z option) is not specified or is invalid.  This value must be >= 0.  "
-                "The value to pass can be determined by determining the number of primary segments in the cluster."
-             )));
-	}
-
 	/*
 	 * Other one-time internal sanity checks can go here, if they are fast.
 	 * (Put any slow processing further down, after postmaster.pid creation.)

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -51,6 +51,7 @@
 #include "utils/resource_manager.h"
 #include "utils/faultinjector.h"
 #include "utils/sharedsnapshot.h"
+#include "utils/gpexpand.h"
 
 #include "libpq-fe.h"
 #include "libpq-int.h"
@@ -200,6 +201,9 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		/* size of Instrumentation slots */
 		size = add_size(size, InstrShmemSize());
 
+		/* size of expand version */
+		size = add_size(size, GpExpandVersionShmemSize());
+
 		elog(DEBUG3, "invoking IpcMemoryCreate(size=%zu)", size);
 
 		/*
@@ -344,6 +348,7 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	if (!IsUnderPostmaster)
 		InstrShmemInit();
 
+	GpExpandVersionShmemInit();
 #ifdef EXEC_BACKEND
 
 	/*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5181,14 +5181,6 @@ PostgresMain(int argc, char *argv[],
 		}
 
 		/*
-		 * (5.1) update GpIdentity.numsegments on QD to see newly added
-		 * segments, nothing will be changed if a transaction is already
-		 * started.
-		 */
-		if (updateGpIdentityNumsegments())
-			DisconnectAndDestroyAllGangs(false);
-
-		/*
 		 * (6) process the command.  But ignore it if we're skipping till
 		 * Sync.
 		 */
@@ -5316,7 +5308,8 @@ PostgresMain(int argc, char *argv[],
 					/*
 					 * Always use the same GpIdentity.numsegments with QD on QEs
 					 */
-					GpIdentity.numsegments = pq_getmsgint(&input_message, 4);
+					numsegmentsFromQD = pq_getmsgint(&input_message, 4);
+
 					resgroupInfoLen = pq_getmsgint(&input_message, 4);
 					if (resgroupInfoLen > 0)
 						resgroupInfoBuf = pq_getmsgbytes(&input_message, resgroupInfoLen);

--- a/src/backend/utils/misc/gpexpand.c
+++ b/src/backend/utils/misc/gpexpand.c
@@ -33,6 +33,7 @@
 #include "utils/relcache.h"
 #include "utils/gpexpand.h"
 
+extern uint8 getFtsVersion(void);
 
 /*
  * Catalog lock.
@@ -72,6 +73,7 @@ void
 gp_expand_protect_catalog_changes(Relation relation)
 {
 	LockAcquireResult	acquired;
+	CdbComponentDatabases *cdbs = NULL;
 
 	if (Gp_role != GP_ROLE_DISPATCH)
 		/* only lock catalog updates on qd */

--- a/src/backend/utils/misc/gpexpand.c
+++ b/src/backend/utils/misc/gpexpand.c
@@ -52,7 +52,7 @@ static LOCKTAG gp_expand_locktag =
 int
 GpExpandVersionShmemSize(void)
 {
-	return sizeof(gp_expand_version);
+	return sizeof(*gp_expand_version);
 }
 
 void
@@ -72,10 +72,18 @@ GetGpExpandVersion(void)
 	return *gp_expand_version;
 }
 
+/*
+ * Used by gpexpand to bump the gpexpand version once gpexpand started up
+ * new segments and updated the gp_segment_configuration.
+ *
+ * a gpexpand version change also prevent concurrent changes to catalog
+ * during gpexpand (see gp_expand_lock_catalog)
+ *
+ */
 Datum
 gp_expand_bump_version(PG_FUNCTION_ARGS)
 {
-	*gp_expand_version = *gp_expand_version + 1;
+	*gp_expand_version += 1;
 	PG_RETURN_VOID();
 }
 

--- a/src/backend/utils/misc/gpexpand.c
+++ b/src/backend/utils/misc/gpexpand.c
@@ -73,7 +73,6 @@ void
 gp_expand_protect_catalog_changes(Relation relation)
 {
 	LockAcquireResult	acquired;
-	CdbComponentDatabases *cdbs = NULL;
 
 	if (Gp_role != GP_ROLE_DISPATCH)
 		/* only lock catalog updates on qd */

--- a/src/backend/utils/misc/gpexpand.c
+++ b/src/backend/utils/misc/gpexpand.c
@@ -149,7 +149,7 @@ gp_expand_protect_catalog_changes(Relation relation)
 	oldVersion = cdbcomponent_getCdbComponents(true)->expand_version;
 	newVersion = GetGpExpandVersion();
 	if (oldVersion != newVersion)
-		ereport(ERROR,
+		ereport(FATAL,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("cluster is expaneded from version %d to %d, "
 						"catalog changes are disallowed",

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -68,6 +68,7 @@
 #define S_PER_D (60 * 60 * 24)
 #define MS_PER_D (1000 * 60 * 60 * 24)
 
+/* FIXME: remove this once gp_num_contents_in_cluster is retired */
 static int dummy_segments = -1;
 /*
  * Assign/Show hook functions defined in this module
@@ -3289,11 +3290,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		NULL, NULL, NULL
 	},
 
+	/*
+	 * FIXME: gp_num_contents_in_cluster take no effect already, can remove it.
+	 * add GUC_NO_SHOW_ALL to avoid gp_num_contents_in_cluster being used by
+	 * others like pg_settings
+	 */
 	{
 		{"gp_num_contents_in_cluster", PGC_POSTMASTER, PRESET_OPTIONS,
 			gettext_noop("Sets the number of segments in the cluster."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
 		},
 		&dummy_segments,
 		UNINITIALIZED_GP_IDENTITY_VALUE, INT_MIN, INT_MAX,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -68,6 +68,7 @@
 #define S_PER_D (60 * 60 * 24)
 #define MS_PER_D (1000 * 60 * 60 * 24)
 
+static int dummy_segments = -1;
 /*
  * Assign/Show hook functions defined in this module
  */
@@ -3294,7 +3295,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			NULL,
 			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
 		},
-		&GpIdentity.numsegments,
+		&dummy_segments,
 		UNINITIALIZED_GP_IDENTITY_VALUE, INT_MIN, INT_MAX,
 		NULL, NULL, NULL
 	},

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3479,8 +3479,6 @@ ResGroupDumpInfo(StringInfo str)
 	if (!IsResGroupEnabled())
 		return;
 
-	verifyGpIdentityIsSet();
-
 	appendStringInfo(str, "{\"segid\":%d,", GpIdentity.segindex);
 	/* dump fields in pResGroupControl. */
 	appendStringInfo(str, "\"segmentsOnMaster\":%d,", pResGroupControl->segmentsOnMaster);

--- a/src/include/catalog/pg_proc.sql
+++ b/src/include/catalog/pg_proc.sql
@@ -264,6 +264,8 @@
 
  CREATE FUNCTION gp_expand_lock_catalog() RETURNS void LANGUAGE internal VOLATILE AS 'gp_expand_lock_catalog' WITH (OID=5080, DESCRIPTION="Lock catalog changes for gpexpand");
 
+ CREATE FUNCTION gp_expand_bump_version() RETURNS void LANGUAGE internal VOLATILE AS 'gp_expand_bump_version' WITH (OID=5081, DESCRIPTION="bump gpexpand version");
+
  CREATE FUNCTION gp_remove_segment(int2) RETURNS bool LANGUAGE internal VOLATILE AS 'gp_remove_segment' WITH (OID=5051, DESCRIPTION="Remove a primary segment from the system catalog");
 
  CREATE FUNCTION gp_request_fts_probe_scan() RETURNS bool LANGUAGE internal VOLATILE AS 'gp_request_fts_probe_scan' EXECUTE ON MASTER WITH (OID=5035, DESCRIPTION="Request a FTS probe scan and wait for response");

--- a/src/include/catalog/pg_proc_gp.h
+++ b/src/include/catalog/pg_proc_gp.h
@@ -533,6 +533,10 @@ DESCR("Perform the catalog operations necessary for adding a new segment");
 DATA(insert OID = 5080 ( gp_expand_lock_catalog  PGNSP PGUID 12 1 0 0 0 f f f f f f v 0 0 2278 "" _null_ _null_ _null_ _null_ gp_expand_lock_catalog _null_ _null_ _null_ n a ));
 DESCR("Lock catalog changes for gpexpand");
 
+/* gp_expand_bump_version() => void */
+DATA(insert OID = 5081 ( gp_expand_bump_version  PGNSP PGUID 12 1 0 0 0 f f f f f f v 0 0 2278 "" _null_ _null_ _null_ _null_ gp_expand_bump_version _null_ _null_ _null_ n a ));
+DESCR("Bump gpexpand version");
+
 /* gp_remove_segment(int2) => bool */
 DATA(insert OID = 5051 ( gp_remove_segment  PGNSP PGUID 12 1 0 0 0 f f f f f f v 1 0 16 "21" _null_ _null_ _null_ _null_ gp_remove_segment _null_ _null_ _null_ n a ));
 DESCR("Remove a primary segment from the system catalog");

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -34,7 +34,6 @@ typedef struct FtsProbeInfo
 {
 	volatile uint8		fts_statusVersion;
 	volatile uint8      probeTick;
-	volatile uint32		total_segments; /* number of primary segments */
 	volatile uint8		fts_status[FTS_MAX_DBS];
 } FtsProbeInfo;
 

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -34,7 +34,7 @@ typedef struct FtsProbeInfo
 {
 	volatile uint8		fts_statusVersion;
 	volatile uint8      probeTick;
-	volatile uint32		total_segment_dbs; /* number of primary segments */
+	volatile uint32		total_segments; /* number of primary segments */
 	volatile uint8		fts_status[FTS_MAX_DBS];
 } FtsProbeInfo;
 

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -19,16 +19,16 @@
  * if segment is UP or not. So just have that, when needed for other states
  * this can be extended.
  */
-#define FTS_STATUS_UP				(1<<0)
+#define FTS_STATUS_DOWN				(1<<0)
 
 #define FTS_STATUS_TEST(status, flag) (((status) & (flag)) ? true : false)
-#define FTS_STATUS_IS_UP(status) FTS_STATUS_TEST((status), FTS_STATUS_UP)
+#define FTS_STATUS_IS_DOWN(status) FTS_STATUS_TEST((status), FTS_STATUS_DOWN)
 
 #define FTS_STATUS_SET(status, flag) ((status) |= (flag))
-#define FTS_STATUS_SET_UP(status) FTS_STATUS_SET((status), FTS_STATUS_UP)
+#define FTS_STATUS_SET_DOWN(status) FTS_STATUS_SET((status), FTS_STATUS_DOWN)
 
 #define FTS_STATUS_RESET(status, flag) ((status) &= ~(flag))
-#define FTS_STATUS_SET_DOWN(status) FTS_STATUS_RESET((status), FTS_STATUS_UP)
+#define FTS_STATUS_SET_UP(status) FTS_STATUS_RESET((status), FTS_STATUS_DOWN)
 
 typedef struct FtsProbeInfo
 {
@@ -51,7 +51,7 @@ extern volatile FtsProbeInfo *ftsProbeInfo;
 extern int	FtsShmemSize(void);
 extern void FtsShmemInit(void);
 
-extern bool FtsIsSegmentUp(CdbComponentDatabaseInfo *dBInfo);
+extern bool FtsIsSegmentDown(CdbComponentDatabaseInfo *dBInfo);
 extern bool FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor **, int);
 
 extern bool verifyFtsSyncCount(void);

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -235,7 +235,7 @@ typedef struct TMGXACT
 	bool						directTransaction;
 	uint16						directTransactionContentId;
 	bool						writerGangLost;
-	bool						gxidDispatched;
+
 }	TMGXACT;
 
 typedef struct TMGXACTSTATUS
@@ -352,6 +352,4 @@ extern void markCurrentGxactWriterGangLost(void);
 
 extern bool currentGxactWriterGangLost(void);
 
-extern bool isSafeToRecreateWriter(void);
-extern void markCurrentGxactDispatched(void);
 #endif   /* CDBTM_H */

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -156,6 +156,7 @@ extern void cdb_cleanup(int code, Datum arg  __attribute__((unused)) );
 CdbComponentDatabases * cdbcomponent_getCdbComponents(bool DNSLookupAsError);
 void cdbcomponent_destroyCdbComponents(void);
 
+void cdbcomponent_updateCdbComponents(void);
 /*
  * cdbcomponent_cleanupIdleQEs()
  *
@@ -206,10 +207,11 @@ extern int16 master_standby_dbid(void);
 extern CdbComponentDatabaseInfo *dbid_get_dbinfo(int16 dbid);
 extern int16 contentid_get_dbid(int16 contentid, char role, bool getPreferredRoleNotCurrentRole);
 
+extern int numsegmentsFromQD;
 /*
  * Returns the number of segments
  */
-extern int	getgpsegmentCount(void);
+extern int getgpsegmentCount(void);
 
 #define ELOG_DISPATCHER_DEBUG(...) do { \
        if (gp_log_gang >= GPVARS_VERBOSITY_DEBUG) elog(LOG, __VA_ARGS__); \

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -113,6 +113,7 @@ struct CdbComponentDatabases
 	int			my_segindex;	/* the content of this database */
 	bool		my_isprimary;	/* the isprimary flag of this database */
 	uint8		fts_version;	/* the version of fts */
+	int			expand_version;
 	int			numActiveQEs;
 	int			numIdleQEs;
 	int			qeCounter;

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -887,12 +887,8 @@ extern uint32 Gp_listener_port;
  */
 extern void write_log(const char *fmt,...) __attribute__((format(printf, 1, 2)));
 
-extern void verifyGpIdentityIsSet(void);
 
 extern void increment_command_count(void);
-
-extern bool updateGpIdentityNumsegments(void);
-extern bool updateSystemProcessGpIdentityNumsegments(void);
 
 /* default to RANDOM distribution for CREATE TABLE without DISTRIBUTED BY */
 extern bool gp_create_table_random_default_distribution;

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -863,7 +863,6 @@ extern int cdb_max_slices;
 
 typedef struct GpId
 {
-	int32		numsegments;	/* count of distinct segindexes */
 	int32		dbid;			/* the dbid of this database */
 	int32		segindex;		/* content indicator: -1 for entry database,
 								 * 0, ..., n-1 for segment database *

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -130,15 +130,6 @@ extern int ftsprobe_start(void);
 extern bool FtsIsActive(void);
 
 /*
- * Get the number of primary segments from FTS.
- *
- * This function should be declared in cdbfts.h, however that header file
- * include "cdbconn.h" which should not be included in some source files,
- * so we move this declaration here.
- */
-extern uint32 FtsGetTotalSegments(void);
-
-/*
  * Interface for WALREP specific checking
  */
 extern void HandleFtsMessage(const char* query_string);

--- a/src/include/utils/gpexpand.h
+++ b/src/include/utils/gpexpand.h
@@ -14,9 +14,16 @@
 #ifndef GPEXPAND_H
 #define GPEXPAND_H
 
+extern int GpExpandVersionShmemSize(void);
+extern void GpExpandVersionShmemInit(void);
+extern int GetGpExpandVersion(void);
+
 extern Datum gp_expand_lock_catalog(PG_FUNCTION_ARGS);
 
 extern void gp_expand_protect_catalog_changes(Relation relation);
+
+extern Datum gp_expand_bump_version(PG_FUNCTION_ARGS);
+
 
 #endif   /* GPEXPAND_H */
 


### PR DESCRIPTION
    Unify the way to fetch/manage the number of segments

    Commit e0b06678aa lets us expanding a GPDB cluster without a restart,
    the number of segments may changes during a transaction now, so we
    need to take care of the numsegments.

    We now have two way to get segments number, 1) from GpIdentity.numsegments
    2) from gp_segment_configuration (cdb_component_dbs) which dispatcher used
    to decide the segments range of dispatching. We did some hard work to
    update GpIdentity.numsegments correctly within e0b06678aa which made the
    management of segments more complicated, now we want to use an easier way
    to do it:

    1. We only allow getting segments info (include number of segments) through
    gp_segment_configuration, gp_segment_configuration has newest segments info,
    there is no need to update GpIdentity.numsegments, GpIdentity.numsegments is
    left only for debugging and can be removed totally in the future.

    2. Each global transaction fetches/updates the newest snapshot of
    gp_segment_configuration and never change it until the end of transaction
    unless a writer gang is lost, so a global transaction can see consistent
    state of segments. We used to use gxidDispatched to do the same thing, now
    it can be removed.