### PR TITLE
Fix typos in comments and one internal error message.

### DIFF
--- a/src/backend/access/appendonly/README.md
+++ b/src/backend/access/appendonly/README.md
@@ -92,10 +92,10 @@ the visibility map used for heaps in PostgreSQL 8.4 and above!
 
 The AO visibility map is used to implement `DELETEs` and `UPDATEs`. An
 `UPDATE` in PostgreSQL is like `DELETE+INSERT`. In heap tables, the ctid
-field is used to implement update-chain-following when updates are
-done in in `READ COMMITTED` mode, but AO tables don't store that
-information, so an update of a recently updated row in read committed
-mode behaves as if the row was deleted.
+field is used to implement update-chain-following when updates are done
+in `READ COMMITTED` mode, but AO tables don't store that information, so
+an update of a recently updated row in read committed mode behaves as if
+the row was deleted.
 
 The AO visiblity map works as an overlay, over the data. When a row
 is `DELETEd` from an AO table, the original tuple is not modified. Instead,

--- a/src/backend/access/appendonly/appendonly_visimap_entry.c
+++ b/src/backend/access/appendonly/appendonly_visimap_entry.c
@@ -146,7 +146,7 @@ AppendOnlyVisiMapEnty_ReadData(
 
 	if (BitmapDecompress_HasError(&decompressState))
 	{
-		elog(ERROR, "error occured during visimap bitmap decompression");
+		elog(ERROR, "error occurred during visimap bitmap decompression");
 	}
 
 	bms_free(visiMapEntry->bitmap);

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -347,7 +347,7 @@ _bitmap_findnexttids(BMBatchWords *words, BMIterateResult *result,
 /*
  * _bitmap_intesect() is dead code because streaming intersects
  * PagetableEntry structures, not raw batch words. It's possible we may
- * want to intersect batches later though -- it would definately improve
+ * want to intersect batches later though -- it would definitely improve
  * streaming of intersections.
  */
 

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -876,7 +876,7 @@ externalgettup_defined(FileScanDesc scan)
 		PG_CATCH();
 		{
 			/*
-			 * got here? encoding conversion error occured on the
+			 * got here? encoding conversion error occurred on the
 			 * header line (first row).
 			 */
 			if (pstate->errMode == ALL_OR_NOTHING)

--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -541,7 +541,7 @@ GRANT SELECT ON TABLE gp_toolkit.gp_pgdatabase_invalid TO public;
 --        gp_toolkit.gp_skew_details_t
 --
 -- @doc:
---        Type to accomodate skew details
+--        Type to accommodate skew details
 --
 --------------------------------------------------------------------------------
 CREATE TYPE gp_toolkit.gp_skew_details_t
@@ -642,7 +642,7 @@ GRANT EXECUTE ON FUNCTION gp_toolkit.gp_skew_details(oid) TO public;
 --        gp_toolkit.gp_skew_analysis_t
 --
 -- @doc:
---        Type to accomodate skew analysis
+--        Type to accommodate skew analysis
 --
 --------------------------------------------------------------------------------
 CREATE TYPE gp_toolkit.gp_skew_analysis_t

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -129,7 +129,7 @@ FtsIsSegmentUp(CdbComponentDatabaseInfo *dBInfo)
 	 * initialized yet, just return positively back.  This is mainly to avoid
 	 * queries incorrectly failing just after QD restarts if FTS process is yet
 	 * to start and complete initializing the cached status.  We shouldn't be
-	 * checking against uninitialzed variable.
+	 * checking against an uninitialized variable.
 	 */
 	return ftsProbeInfo->fts_statusVersion ?
 		FTS_STATUS_IS_UP(ftsProbeInfo->fts_status[dBInfo->dbid]) :

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -268,7 +268,7 @@ typedef struct ParallelizeCorrelatedPlanWalkerContext
 } ParallelizeCorrelatedPlanWalkerContext;
 
 /**
- * Context information to map vars occuring in the Result node's targetlist
+ * Context information to map vars occurring in the Result node's targetlist
  * and quals to what is produced by the underlying SeqScan node.
  */
 typedef struct MapVarsMutatorContext
@@ -863,8 +863,8 @@ prescan_walker(Node *node, PlanProfile *context)
 				}
 
 				/*
-				 * Init plan and main plan are dispatched seperately,
-				 * so we need to set DISPATCH_PARALLEL flag seperately
+				 * Init plan and main plan are dispatched separately,
+				 * so we need to set DISPATCH_PARALLEL flag separately
 				 * for them.
 				 *
 				 * save the parallel state of main plan. init plan

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2163,9 +2163,9 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates,
 		 * kernel sending buffer may be lost on some platform if sender close the
 		 * connection totally.
 		 *
-		 * The correct way is sender blocks on the connection until recievers
+		 * The correct way is sender blocks on the connection until receivers
 		 * get the EOS packets and close the peer, then it's safe for sender to
-		 * the connection totally.
+		 * close the connection totally.
 		 *
 		 * If some errors are happening, senders can skip this step to avoid hung
 		 * issues, QD will take care of the error handling.

--- a/src/backend/libpq/test/pqcomm_test.c
+++ b/src/backend/libpq/test/pqcomm_test.c
@@ -33,7 +33,7 @@ static int test_accept_socket;
  *    - errno is not changed
  */
 void
-test__internal_flush_succesfulSend(void **state)
+test__internal_flush_successfulSend(void **state)
 {
 	int			result;
 
@@ -165,7 +165,7 @@ test__StreamConnection_set_SNDTIMEO_AF_INET(void **state)
 	struct timeval timeout;
 	int timeout_len = sizeof(timeout);
 	result = getsockopt(port->sock, SOL_SOCKET, SO_SNDTIMEO, &timeout, &timeout_len);
-	/* Check that getsockopt ran succesfully */
+	/* Check that getsockopt ran successfully */
 	assert_int_equal(result, 0);
 	/* Check that the timeout is actually set */
 	assert_int_equal(timeout.tv_sec, SOCKET_TIMEOUT_SECONDS);
@@ -194,7 +194,7 @@ test__StreamConnection_set_SNDTIMEO_AF_UNIX(void **state)
 	int timeout_len = sizeof(timeout);
 	result = getsockopt(port->sock, SOL_SOCKET, SO_SNDTIMEO, &timeout, &timeout_len);
 
-	/* Check that getsockopt ran succesfully */
+	/* Check that getsockopt ran successfully */
 	assert_int_equal(result, 0);
 	/* Check that the timeout is actually set */
 	assert_int_equal(timeout.tv_sec, SOCKET_TIMEOUT_SECONDS);
@@ -224,7 +224,7 @@ test__StreamConnection_set_SNDTIMEO_segment(void **state)
 	int timeout_len = sizeof(timeout);
 	result = getsockopt(port->sock, SOL_SOCKET, SO_SNDTIMEO, &timeout, &timeout_len);
 
-	/* Check that getsockopt ran succesfully */
+	/* Check that getsockopt ran successfully */
 	assert_int_equal(result, 0);
 	/* Check that the timeout is NOT actually set */
 	assert_int_equal(timeout.tv_sec, 0);
@@ -239,7 +239,7 @@ main(int argc, char* argv[])
 	cmockery_parse_arguments(argc, argv);
 
 	const UnitTest tests[] = {
-		unit_test(test__internal_flush_succesfulSend),
+		unit_test(test__internal_flush_successfulSend),
 		unit_test(test__internal_flush_failedSendEINTR),
 		unit_test(test__internal_flush_failedSendEPIPE),
 		unit_test(test__StreamConnection_set_SNDTIMEO_AF_INET),

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2112,9 +2112,9 @@ check_output_expressions(Query *subquery, bool *unsafeColumns)
 
 		/* MPP-19244:
 		 * if subquery has WINDOW clause, it is safe to push-down quals that
-		 * use columns included in in the Partition-By clauses of every OVER
+		 * use columns included in the Partition-By clauses of every OVER
 		 * clause in the subquery
-		 * */
+		 */
 		if (subquery->windowClause != NIL)
 		{
 			ListCell   *lc;

--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -39,7 +39,7 @@
  * In PostgreSQL, this is a dynamically loaded module, because PostgreSQL
  * doesn't want to link libpq statically into the backend.  In GPDB, we have
  * a statically linked copy of libpq in the backend, anyway, so this is
- * compiled and linked diretly as part of the postgres binary, like any
+ * compiled and linked directly as part of the postgres binary, like any
  * other backend .c file.
  */
 

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -1803,7 +1803,7 @@ ProcSendSignal(int pid)
  *	This is merely a version of ProcSleep modified for resource locks.
  *	The logic here could have been merged into ProcSleep, however it was
  *	requested to keep as much as possible of this resource lock code 
- *	seperate from its standard lock relatives - in the interest of not
+ *	separate from its standard lock relatives - in the interest of not
  *	introducing new bugs or performance regressions into the lock code.
  */
 int

--- a/src/backend/utils/hyperloglog/hyperloglog.c
+++ b/src/backend/utils/hyperloglog/hyperloglog.c
@@ -584,7 +584,7 @@ hll_compress_dense(HLLCounter hloglog)
     }
 
     /* lz_compress the normalized array and copy that data into hloglog->data
-     * if any compression was acheived */
+     * if any compression was achieved */
     pglz_compress(data,m,dest,PGLZ_strategy_always);
     if (VARSIZE_ANY(dest) >= (m * hloglog->binbits /8) ){
 	/* free allocated memory and return unaltered array */
@@ -643,7 +643,7 @@ hll_compress_dense_unpacked(HLLCounter hloglog)
 
 
 	/* lz_compress the normalized array and copy that data into hloglog->data
-	* if any compression was acheived */
+	* if any compression was achieved */
 	pglz_compress(hloglog->data, m, dest, PGLZ_strategy_always);
 	if (VARSIZE_ANY(dest) >= (m * hloglog->binbits / 8)){
 		/* free allocated memory and return unaltered array */

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -259,7 +259,7 @@ static ResGroupProcData *self = &__self;
 /* If we are waiting on a group, this points to the associated group */
 static ResGroupData *groupAwaited = NULL;
 
-/* the resource group self is running in in bypass mode */
+/* the resource group self is running in bypass mode */
 static ResGroupData *bypassedGroup = NULL;
 /* a fake slot used in bypass mode */
 static ResGroupSlotData bypassedSlot;

--- a/src/backend/utils/resscheduler/README
+++ b/src/backend/utils/resscheduler/README
@@ -126,9 +126,9 @@ interrupts, sleeping and wait queue removal:
 
 Deadlocks between standard and resource locks are possible, and are handled
 by the deadlock detector. We pass the lock mode as ExclusiveLock - which
-results in overly agressive detection and rollback of deadlocks. However, safety
-is the *initial* goal! More sophisticated detection logic is an obvious next
-step.
+results in overly aggressive detection and rollback of deadlocks. However,
+safety is the *initial* goal! More sophisticated detection logic is an obvious
+next step.
 
 Also deadlocks with oneself are possible, usually only achievable with several
 open cursors:

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -2633,7 +2633,8 @@ tuplesort_rescan(Tuplesortstate *state)
 }
 
 /*
- * Put pos at the begining of the tuplesort.  Create pos->work_tape if necessary
+ * Put pos at the beginning of the tuplesort.  Create pos->work_tape if
+ * necessary.
  */
 void
 tuplesort_rescan_pos(Tuplesortstate *state, TuplesortPos *pos)

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2552,7 +2552,8 @@ dumptuples_mk(Tuplesortstate_mk *state, bool alltuples)
 }
 
 /*
- * Put pos at the begining of the tuplesort.  Create pos->work_tape if necessary
+ * Put pos at the beginning of the tuplesort.  Create pos->work_tape if
+ * necessary.
  */
 void
 tuplesort_rescan_pos_mk(Tuplesortstate_mk *state, TuplesortPos_mk *pos)

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -44,7 +44,7 @@ extern Oid MyQueueId; /* resource queue for current role. */
  * Data structures
  *
  * TODO:
- * To add a equivalent of locallock to handle extensions to proclock
+ * To add an equivalent of locallock to handle extensions to proclock
  * and back out the changes to it.
  */
 

--- a/src/test/fsync/expected/bgwriter_checkpoint.out
+++ b/src/test/fsync/expected/bgwriter_checkpoint.out
@@ -28,7 +28,7 @@ $$
             where oid=$1);
 $$ language sql;
 -- Wait until number of dirty buffers for the specified relfiles drops
--- to 0 or timeout occurs.  Returns false if timeout occured.
+-- to 0 or timeout occurs.  Returns false if timeout occurred.
 create function wait_for_bgwriter(
    relid oid,
    timeout int)

--- a/src/test/fsync/sql/bgwriter_checkpoint.sql
+++ b/src/test/fsync/sql/bgwriter_checkpoint.sql
@@ -29,7 +29,7 @@ $$
 $$ language sql;
 
 -- Wait until number of dirty buffers for the specified relfiles drops
--- to 0 or timeout occurs.  Returns false if timeout occured.
+-- to 0 or timeout occurs.  Returns false if timeout occurred.
 create function wait_for_bgwriter(
    relid oid,
    timeout int)

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -404,7 +404,7 @@ class SQLIsolationTestCase:
         executing transactions. This is mainly used to test isolation behavior.
 
         [<#>[flag]:] <sql> | ! <shell scripts or command>
-        #: either an integer indicating an unique session, or a content-id if
+        #: either an integer indicating a unique session, or a content-id if
            followed by U (for utility-mode connections). In 'U' mode, the
            content-id can alternatively be an asterisk '*' to perform a
            utility-mode query on the master and all primaries.

--- a/src/test/walrep/expected/walreceiver.out
+++ b/src/test/walrep/expected/walreceiver.out
@@ -10,7 +10,7 @@ SELECT test_disconnect();
 (1 row)
 
 -- Wait until number of replication sessions drop to 0 or timeout
--- occurs. Returns false if timeout occured.
+-- occurs. Returns false if timeout occurred.
 create function check_and_wait_for_replication(
    timeout int)
 returns boolean as

--- a/src/test/walrep/sql/walreceiver.sql
+++ b/src/test/walrep/sql/walreceiver.sql
@@ -4,7 +4,7 @@ SELECT test_send();
 SELECT test_disconnect();
 
 -- Wait until number of replication sessions drop to 0 or timeout
--- occurs. Returns false if timeout occured.
+-- occurs. Returns false if timeout occurred.
 create function check_and_wait_for_replication(
    timeout int)
 returns boolean as


### PR DESCRIPTION
Daniel Gustafsson pointed offlist at the "diretly" typo in my last
libpqwalreceiver refactoring commit. I got a bit carried away and grepped
for other common misspellings.