### PR TITLE
gpaddmirrors test: Cleanup cluster at end of each test.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -13,6 +13,7 @@ Feature: Tests for gpaddmirrors
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And the user runs "gpstop -aqM fast"
 
     Scenario: gpaddmirrors puts mirrors on the same hosts when there is a standby configured
         Given a working directory of the test as '/tmp/gpaddmirrors'
@@ -27,6 +28,7 @@ Feature: Tests for gpaddmirrors
         Then gpinitstandby should return a return code of 0
         And gpaddmirrors adds mirrors
         Then mirror hostlist matches the one saved in context
+        And the user runs "gpstop -aqM fast"
 
     # This test requires a bigger cluster than the other gpaddmirrors tests.
     @gpaddmirrors_spread
@@ -36,6 +38,7 @@ Feature: Tests for gpaddmirrors
         And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2, sdw3"
         And gpaddmirrors adds mirrors in spread configuration
         Then verify the database has mirrors in spread configuration
+        And the user runs "gpstop -aqM fast"
 
     Scenario: gpaddmirrors with a default master data directory
         Given a working directory of the test as '/tmp/gpaddmirrors'
@@ -43,6 +46,7 @@ Feature: Tests for gpaddmirrors
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And gpaddmirrors adds mirrors
         Then verify the database has mirrors
+        And the user runs "gpstop -aqM fast"
 
     @gpaddmirrors_temp_directory
     Scenario: gpaddmirrors with a given master data directory [-d <master datadir>]
@@ -51,6 +55,7 @@ Feature: Tests for gpaddmirrors
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And gpaddmirrors adds mirrors with temporary data dir
         Then verify the database has mirrors
+        And the user runs "gpstop -aqM fast"
 
     @gpaddmirrors_workload
     Scenario: gpaddmirrors when the primaries have data
@@ -69,3 +74,4 @@ Feature: Tests for gpaddmirrors
         Then verify that there is a "heap" table "public.heap_table" in "gptest" with "100" rows
         Then verify that there is a "ao" table "public.ao_table" in "gptest" with "100" rows
         Then verify that there is a "co" table "public.co_table" in "gptest" with "100" rows
+        And the user runs "gpstop -aqM fast"


### PR DESCRIPTION
We have observed intermittent failures in gpaddmirrors test with the error:
`pg_basebackup: could not connect to server: FATAL:  number of requested standby
connections exceeds max_wal_senders (currently 1)`.

This implies that a there was a connection to the Wal Sender process when the
pg_basebakeup is initiated for the new mirror.

Looking at the gpaddmirror tests, we see that when creating a new cluster, the
tests don't cleanup all the segments/hosts of the previous test.  Thus leaving
mirrors around that do try to connect to the primary of the new cluster.
However, the Wal Sender of the new primary sends the following error to the old
mirror:

```
... "ERROR","XX000","database system identifier differs between the primary
and standby (libpqwalreceiver.c:162)","The primary's identifier is
6613767102099215083, the standby's identifier is
6613766724142160379.",,,,,,0,,"libpqwalreceiver.c",162,"Stack trace: '''
```

During the small window that the Wal Sender is connected to the old mirror, a
pg_basebackup from the new mirror would get the FATAL error that we are seeing
in our test output.

More evidence that this is occuring is that during a green test, as in one that
has had pg_basebackup connnect successfully, we see the "orphaned" mirror
attempting to connect and failing.

This commit has each scenario stop its own database.