### PR TITLE
Workaround flaky test udf_exception_blocks_panic_scenarios

### DIFF
--- a/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
+++ b/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
@@ -39,6 +39,25 @@
 -- m/transaction -\d+/
 -- s/transaction -\d+/transaction/
 -- end_matchsubs
+
+-- skip FTS probes always
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
+(1 row)
+SELECT gp_request_fts_probe_scan();
+gp_request_fts_probe_scan
+-------------------------
+t                        
+(1 row)
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
 CREATE OR REPLACE FUNCTION test_excep (arg INTEGER) RETURNS INTEGER AS $$ DECLARE res INTEGER; /* in func */ BEGIN /* in func */ res := 100 / arg; /* in func */ RETURN res; /* in func */ EXCEPTION /* in func */ WHEN division_by_zero /* in func */ THEN  RETURN 999; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE
 
@@ -222,3 +241,9 @@ select * from employees;
 ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;
                       ^
+
+SELECT gp_inject_fault('fts_probe', 'reset', 1);
+gp_inject_fault
+---------------
+t              
+(1 row)

--- a/src/test/isolation2/sql/udf_exception_blocks_panic_scenarios.sql
+++ b/src/test/isolation2/sql/udf_exception_blocks_panic_scenarios.sql
@@ -39,6 +39,12 @@
 -- m/transaction -\d+/
 -- s/transaction -\d+/transaction/
 -- end_matchsubs
+
+-- skip FTS probes always
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
+SELECT gp_request_fts_probe_scan();
+select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 CREATE OR REPLACE FUNCTION test_excep (arg INTEGER) RETURNS INTEGER
 AS $$
     DECLARE res INTEGER; /* in func */
@@ -167,3 +173,5 @@ select test_protocol_allseg(1, 2,'f');
 0U: select 1;
 0Uq:
 select * from employees;
+
+SELECT gp_inject_fault('fts_probe', 'reset', 1);


### PR DESCRIPTION
Test exhibits unexpected behavior which seems to cause a gang reset and
lost `debug_dtm_*` GUC settings. We noticed that FTS probe led to gang
reset whenever we fail with following diff:

```
DROP TABLE IF EXISTS employees;
 DROP
  select test_protocol_allseg(1, 2,'f');
  -ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed
  -CONTEXT:  PL/pgSQL function
  test_protocol_allseg(integer,integer,character) line 18 during
  exception cleanup
  +test_protocol_allseg
  +--------------------
  +
  +(1 row)
```

We believe this is due to interactions between FTS and frequent UDF
execeptions. Until a more solid fix is identified, a simple workaround
is to turn off FTS during this test since FTS is not required to
exercise the original intent behind this test.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>