### PR TITLE
Add EXPLAIN formatting to MemAccounting

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -123,10 +123,6 @@ static void ExplainProperty(const char *qlabel, const char *value,
 static void ExplainPropertyStringInfo(const char *qlabel, ExplainState *es,
 									  const char *fmt,...)
 									  __attribute__((format(PG_PRINTF_ATTRIBUTE, 3, 4)));
-static void ExplainOpenGroup(const char *objtype, const char *labelname,
-				 bool labeled, ExplainState *es);
-static void ExplainCloseGroup(const char *objtype, const char *labelname,
-				  bool labeled, ExplainState *es);
 static void ExplainDummyGroup(const char *objtype, const char *labelname,
 				  ExplainState *es);
 static void ExplainXMLTag(const char *tagname, int flags, ExplainState *es);
@@ -3297,7 +3293,7 @@ ExplainPropertyFloat(const char *qlabel, double value, int ndigits,
  * If labeled is true, the group members will be labeled properties,
  * while if it's false, they'll be unlabeled objects.
  */
-static void
+void
 ExplainOpenGroup(const char *objtype, const char *labelname,
 				 bool labeled, ExplainState *es)
 {
@@ -3360,7 +3356,7 @@ ExplainOpenGroup(const char *objtype, const char *labelname,
  * Close a group of related objects.
  * Parameters must match the corresponding ExplainOpenGroup call.
  */
-static void
+void
 ExplainCloseGroup(const char *objtype, const char *labelname,
 				  bool labeled, ExplainState *es)
 {

--- a/src/include/commands/explain.h
+++ b/src/include/commands/explain.h
@@ -97,4 +97,9 @@ extern void ExplainPropertyLong(const char *qlabel, long value,
 extern void ExplainPropertyFloat(const char *qlabel, double value, int ndigits,
 					 ExplainState *es);
 
-#endif   /* EXPLAIN_H */
+extern void ExplainOpenGroup(const char *objtype, const char *labelname,
+				 bool labeled, ExplainState *es);
+extern void ExplainCloseGroup(const char *objtype, const char *labelname,
+				  bool labeled, ExplainState *es);
+
+#endif							/* EXPLAIN_H */

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -217,8 +217,9 @@ extern uint64
 MemoryAccounting_GetGlobalPeak(void);
 
 extern void
-MemoryAccounting_CombinedAccountArrayToString(void *accountArrayBytes,
-		MemoryAccountIdType accountCount, StringInfoData *str, uint32 indentation);
+MemoryAccounting_CombinedAccountArrayToExplain(void *accountArrayBytes,
+											  MemoryAccountIdType accountCount,
+											  void *es);
 
 extern void
 MemoryAccounting_SaveToFile(int currentSliceId);


### PR DESCRIPTION
This adds support for the structured formats in EXPLAIN (format ..) to the MemAccounting code, which previously only supported string output. The walker code is updated to take the ExplainState and make decisions oun output format rather then just the buffer.

As the PrettyPrinting debug function was using the ToString walker, it was removed in this commit since there are no callsites actually using it. The unittests for PrettyPrint and ToString were also removed, while they can be mocked to continue to work it's now only partially testing the code, and a normal pg_regress test could be devised to cover the output if we feel the string concatenation is important to test.

Also tidies up the header includes to be in alphabetical order as per how the code is usually structured.

The memaccounting patch relies on `ExplainOpenGroup()` being exposed in the `explain.h` API, so the corresponding commit from upstream is cherrypicked into this PR.