### PR TITLE
Add EXPLAIN formatting to allstats

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1398,7 +1398,7 @@ cdbexplain_formatMemory(char *outbuf, int bufsize, double bytes)
  *		seconds: [input] a value representing no. of seconds to be written to outbuf
  */
 static void
-cdbexplain_formatSeconds(char *outbuf, int bufsize, double seconds)
+cdbexplain_formatSeconds(char *outbuf, int bufsize, double seconds, bool unit)
 {
 	Assert(outbuf != NULL && "CDBEXPLAIN: char buffer is null");
 	Assert(bufsize > 0 && "CDBEXPLAIN: size of char buffer is zero");
@@ -1408,9 +1408,9 @@ cdbexplain_formatSeconds(char *outbuf, int bufsize, double seconds)
 #ifdef USE_ASSERT_CHECKING
 	int			nchars_written =
 #endif							/* USE_ASSERT_CHECKING */
-	snprintf(outbuf, bufsize, "%.*f ms",
+	snprintf(outbuf, bufsize, "%.*f%s",
 			 (ms < 10.0 && ms != 0.0 && ms > -10.0) ? 3 : 0,
-			 ms);
+			 ms, (unit ? " ms" : ""));
 
 	Assert(nchars_written < bufsize &&
 		   "CDBEXPLAIN:  size of char buffer is smaller than the required number of chars");
@@ -1817,11 +1817,6 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 	 */
 	if (gp_enable_explain_allstat && ns->segindex0 >= 0 && ns->ninst > 0)
 	{
-
-		/*
-		 * FIXME: Only displyed on TEXT format
-		 * [#159443819]
-		 */
 		if (es->format == EXPLAIN_FORMAT_TEXT)
 		{
 			/*
@@ -1831,22 +1826,27 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 			appendStringInfoSpaces(es->str, es->indent * 2);
 			appendStringInfoString(es->str,
 								   "allstat: seg_firststart_total_ntuples");
+		}
+		else
+			ExplainOpenGroup("Allstat", "Allstat", true, es);
 
-			for (i = 0; i < ns->ninst; i++)
+		for (i = 0; i < ns->ninst; i++)
+		{
+			CdbExplain_StatInst *nsi = &ns->insts[i];
+
+			if (INSTR_TIME_IS_ZERO(nsi->firststart))
+				continue;
+
+			/* Time from start of query on qDisp to worker's first result row */
+			INSTR_TIME_SET_ZERO(timediff);
+			INSTR_TIME_ACCUM_DIFF(timediff, nsi->firststart, ctx->querystarttime);
+
+			if (es->format == EXPLAIN_FORMAT_TEXT)
 			{
-				CdbExplain_StatInst *nsi = &ns->insts[i];
-
-				if (INSTR_TIME_IS_ZERO(nsi->firststart))
-				{
-					continue;
-				}
-
-				/* Time from start of query on qDisp to worker's first result row */
-				INSTR_TIME_SET_ZERO(timediff);
-				INSTR_TIME_ACCUM_DIFF(timediff, nsi->firststart, ctx->querystarttime);
-				cdbexplain_formatSeconds(startbuf, sizeof(startbuf), INSTR_TIME_GET_DOUBLE(timediff));
-				cdbexplain_formatSeconds(totalbuf, sizeof(totalbuf), nsi->total);
-
+				cdbexplain_formatSeconds(startbuf, sizeof(startbuf),
+										 INSTR_TIME_GET_DOUBLE(timediff), true);
+				cdbexplain_formatSeconds(totalbuf, sizeof(totalbuf),
+										 nsi->total, true);
 				appendStringInfo(es->str,
 								 "/seg%d_%s_%s_%.0f",
 								 ns->segindex0 + i,
@@ -1854,8 +1854,26 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 								 totalbuf,
 								 nsi->ntuples);
 			}
-			appendStringInfoString(es->str, "//end\n");
+			else
+			{
+				cdbexplain_formatSeconds(startbuf, sizeof(startbuf),
+										 INSTR_TIME_GET_DOUBLE(timediff), false);
+				cdbexplain_formatSeconds(totalbuf, sizeof(totalbuf),
+										 nsi->total, false);
+
+				ExplainOpenGroup("Segment", NULL, false, es);
+				ExplainPropertyInteger("Segment index", ns->segindex0 + i, es);
+				ExplainPropertyText("Time To First Result", startbuf, es);
+				ExplainPropertyText("Time To Total Result", totalbuf, es);
+				ExplainPropertyFloat("Tuples", nsi->ntuples, 1, es);
+				ExplainCloseGroup("Segment", NULL, false, es);
+			}
 		}
+
+		if (es->format == EXPLAIN_FORMAT_TEXT)
+			appendStringInfoString(es->str, "//end\n");
+		else
+			ExplainCloseGroup("Allstat", "Allstat", true, es);
 	}
 }								/* cdbexplain_showExecStats */
 


### PR DESCRIPTION
This adds support for the structured formats in EXPLAIN to allstats printing.