### PR TITLE
correct ao table relfile operations for unlink, copy and upgrade

### DIFF
--- a/contrib/pg_upgrade/Makefile
+++ b/contrib/pg_upgrade/Makefile
@@ -12,7 +12,7 @@ OBJS = check.o controldata.o dump.o exec.o file.o function.o info.o \
 
 # Source files specific to Greenplum
 OBJS += aotable.o gpdb4_heap_convert.o version_gp.o \
-        check_gp.o file_gp.o reporting.o
+        check_gp.o file_gp.o reporting.o aomd_filehandler.o
 
 PG_CPPFLAGS  = -DFRONTEND -DDLSUFFIX=\"$(DLSUFFIX)\" -I$(srcdir) -I$(libpq_srcdir)
 PG_LIBS = $(libpq_pgport)
@@ -22,7 +22,7 @@ EXTRA_CLEAN = analyze_new_cluster.sh delete_old_cluster.sh log/ tmp_check/ \
               pg_upgrade_dump_*.custom pg_upgrade_*.log
 
 EXTRA_CLEAN += clusterConfigPostgresAddonsFile clusterConfigFile gpdemo-env.sh \
-              hostfile regression.diffs
+              hostfile regression.diffs aomd_filehandler.c
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config
@@ -33,6 +33,9 @@ subdir = contrib/pg_upgrade
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
+
+aomd_filehandler.c: % : $(top_srcdir)/src/backend/access/appendonly/%
+	rm -f $@ && $(LN_S) $< .
 
 # If ONLINE_EXPAND is set, the job should not contain any test cases with
 # restarting cluster operation, so this check should be disabled.

--- a/src/backend/access/appendonly/Makefile
+++ b/src/backend/access/appendonly/Makefile
@@ -13,7 +13,8 @@ override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 OBJS = appendonlyam.o aosegfiles.o aomd.o appendonlywriter.o appendonlytid.o \
 	   appendonlyblockdirectory.o appendonly_visimap.o \
 	   appendonly_visimap_entry.o appendonly_visimap_store.o \
-	   appendonly_compaction.o appendonly_visimap_udf.o
+	   appendonly_compaction.o appendonly_visimap_udf.o \
+	   aomd_filehandler.o
 
 include $(top_srcdir)/src/backend/common.mk
 

--- a/src/backend/access/appendonly/aomd_filehandler.c
+++ b/src/backend/access/appendonly/aomd_filehandler.c
@@ -1,0 +1,101 @@
+/*-------------------------------------------------------------------------
+ *
+ * aomd_filehandler.c
+ *	  Code in this file would have been in aomd.c but is needed in contrib,
+ * so we separate it out here.
+ *
+ * Portions Copyright (c) 2008, Greenplum Inc.
+ * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	    src/backend/access/appendonly/aomd_filehandler.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "access/aomd.h"
+#include "access/appendonlytid.h"
+#include "access/appendonlywriter.h"
+
+/*
+ * Ideally the logic works even for heap tables, but is only used
+ * currently for AO and AOCS tables to avoid merge conflicts.
+ *
+ * There are different rules for the naming of the files, depending on
+ * the type of table:
+ *
+ *   Heap Tables: contiguous extensions, no upper bound
+ *   AO Tables: non contiguous extensions [.1 - .127]
+ *   CO Tables: non contiguous extensions
+ *          [  .1 - .127] for first column;  .0 reserved for utility and alter
+ *          [.129 - .255] for second column; .128 reserved for utility and alter
+ *          [.257 - .283] for third column;  .256 reserved for utility and alter
+ *          etc
+ *
+ *  Algorithm is coded with the assumption for CO tables that for a given
+ *  concurrency level, the relfiles exist OR stop existing for all columns thereafter.
+ *  For instance, if .2 exists, then .(2 + 128N) MIGHT exist for N=1.  But if it does
+ *  not exist for N=1, then it doesn't exist for N>=2.
+ *
+ *  We can think of this function as operating on a two-dimensional array:
+ *     column index x concurrency level.  The operation is broken up into two
+ *     steps:
+ *
+ *  1) Finds for which concurrency levels the table has files using [.1 - .127].
+ *      Concurrency level 0 is always checked as its corresponding segno file
+ *      must always exist.  However, the caller is expected to handle the that
+ *      file.
+ *  2) Iterates over present concurrency levels and uses the above assumption to
+ *     stop and proceed to the next concurrency level.
+ *
+ *  Graphically, showing the step above that can possibly operate on each
+ *  segment file:
+ *                                 column
+ *                              1    2    3    4 ---   MaxHeapAttributeNumber
+ *  concurrency 0               x    2)   2)   2)                 2)
+ *              1               1)   2)   2)   2)                 2)
+ *              2               1)   2)   2)   2)                 2)
+ *              3               1)   2)   2)   2)                 2)
+ *              |
+ *   (MAX_AOREL_CONCURRENCY-1)  1)   2)   2)   2)                 2)
+ */
+void
+ao_foreach_extent_file(ao_extent_callback callback, void *ctx)
+{
+    int segno;
+    int colnum;
+    int concurrency[AOTupleId_MaxSegmentFileNum];
+    int concurrencySize;
+
+    /*
+     * We always check concurrency level 0 here as the 0 based extensions such
+     * as .128, .256, ... for CO tables are created by ALTER table or utility
+     * mode insert. These also need to be copied. Column 0 concurrency level 0
+     * file is always present and, as noted above, handled by our caller.
+     */
+    concurrency[0] = 0;
+    concurrencySize = 1;
+
+    /* discover any remaining concurrency levels */
+    for (segno = 1; segno < MAX_AOREL_CONCURRENCY; segno++)
+    {
+        if (!callback(segno, ctx))
+            continue;
+        concurrency[concurrencySize] = segno;
+        concurrencySize++;
+    }
+
+    for (int index = 0; index < concurrencySize; index++)
+    {
+        for (colnum = 1; colnum < MaxHeapAttributeNumber; colnum++)
+        {
+            segno = colnum * AOTupleId_MultiplierSegmentFileNum + concurrency[index];
+            if (!callback(segno, ctx))
+                break;
+        }
+    }
+}

--- a/src/backend/access/appendonly/test/Makefile
+++ b/src/backend/access/appendonly/test/Makefile
@@ -2,7 +2,8 @@ subdir=src/backend/access/appendonly
 top_builddir=../../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=aomd appendonly_visimap appendonlywriter appendonly_visimap_entry
+TARGETS=aomd appendonly_visimap appendonlywriter appendonly_visimap_entry \
+	aomd_filehandler
 
 include $(top_builddir)/src/backend/mock.mk
 
@@ -14,6 +15,12 @@ appendonly_visimap.t: \
 
 appendonlywriter.t: \
 	$(MOCK_DIR)/backend/utils/hash/dynahash_mock.o
+
+# use the file to "mock itself" as the current testing infrastructure
+#  uses mock.mk above to replace the file under test with a mock one.
+#  In our case, we don't want to mock.
+aomd_filehandler.t: \
+	$(top_builddir)/src/backend/access/appendonly/aomd_filehandler.o
 
 appendonly_visimap_entry.t:
 

--- a/src/backend/access/appendonly/test/aomd_filehandler_test.c
+++ b/src/backend/access/appendonly/test/aomd_filehandler_test.c
@@ -1,0 +1,271 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+
+#include "postgres.h"
+#include "utils/memutils.h"
+#include "access/aomd.h"
+#include "access/appendonlytid.h"
+#include "access/appendonlywriter.h"
+
+/*
+ * ACHTUNG  This module is trickier than you might initially have expected
+ *  because not all combinations of present files are in fact valid GPDB
+ *  ao tables.  See the comment in ao_foreach_extent_file() to understand
+ *  what valid combinations are.  We do NOT attempt to test invalid
+ *  combinations here as that is a higher-level test than this unit test.
+ */
+
+#define MAX_SEGNO_FILES (MAX_AOREL_CONCURRENCY * MaxHeapAttributeNumber)
+typedef struct {
+	bool present[MAX_SEGNO_FILES];
+	bool call_result[MAX_SEGNO_FILES];
+	bool call_expected[MAX_SEGNO_FILES];
+	int num_called;
+} aomd_filehandler_callback_ctx;
+
+static void
+setup_test_structures(aomd_filehandler_callback_ctx *ctx)
+{
+	memset(ctx->present, false, sizeof(ctx->present));
+	memset(ctx->call_result, false, sizeof(ctx->call_result));
+	memset(ctx->call_expected, false, sizeof(ctx->call_expected));
+	ctx->num_called = 0;
+
+    /* these files get checked for presence in the foreach() */
+    ctx->call_expected[AOTupleId_MultiplierSegmentFileNum] = true;
+    for (int segno = 1; segno < MAX_AOREL_CONCURRENCY; segno++)
+        ctx->call_expected[segno] = true;
+}
+
+/*
+ * This is meant to be called in sorted order from lowest segno to
+ *  highest segno.  Since [.0,.127] is called by foreach(), we need
+ *  not set call_expected on the called in segno, just the next one.
+ *  This is because, for instance, .129 can only be called if .1 is present.
+ */
+static void
+set_ctx_for_present_file(aomd_filehandler_callback_ctx *ctx, int segno)
+{
+	ctx->present[segno] = true;
+	if (segno < (MAX_SEGNO_FILES - MAX_AOREL_CONCURRENCY))
+		ctx->call_expected[segno + MAX_AOREL_CONCURRENCY] = true;
+}
+
+static int
+compareSegnoFiles(bool *expected, bool *result)
+{
+	size_t numDiffer = 0;
+	bool printedOneDiff = false;
+
+	/*
+	 * We had two choices for the initialization value of segno:
+	 *   A). 0 since ao tables have a 0 segno file
+	 *   B). 1 since the foreach() function we are testing here does not
+	 *              actually touch segno 0.
+	 * We opt for A). since callers of foreach() need to handle that case
+	 *  properly, so we want our tests to model that.
+	 */
+	for (size_t segno=0;segno<MAX_SEGNO_FILES;segno++) {
+		if (expected[segno] != result[segno]) {
+			numDiffer++;
+			/* print only the first error to avoid printing thousands of them */
+			if (!printedOneDiff) {
+				printedOneDiff = true;
+				print_error("MISMATCH for segno: %ld expected: %d got: %d (%s)\n",
+							(long)segno, expected[segno], result[segno],
+							result[segno] ? "called but should not have been" :
+							"not called but should have been");
+			}
+		}
+	}
+
+	return numDiffer;
+}
+
+static bool
+file_callback(int segno, void *ctx) {
+	aomd_filehandler_callback_ctx *myctx = ctx;
+
+	assert_true(segno < MAX_SEGNO_FILES);
+
+	myctx->num_called++;
+	myctx->call_result[segno] = true;
+
+	return myctx->present[segno];
+}
+
+static void
+test_no_files_present(void **state)
+{
+    aomd_filehandler_callback_ctx ctx;
+    setup_test_structures(&ctx);
+
+    ao_foreach_extent_file(file_callback, &ctx);
+
+    assert_int_equal(ctx.num_called, MAX_AOREL_CONCURRENCY);
+    assert_int_equal(compareSegnoFiles(ctx.call_expected, ctx.call_result), 0);
+}
+
+/* concurrency = 1 num_columns = 1 */
+static void
+test_co_1_column_1_concurrency(void **state)
+{
+    aomd_filehandler_callback_ctx ctx;
+    setup_test_structures(&ctx);
+
+    for (int col = 0; col < 1; col++)
+        set_ctx_for_present_file(&ctx, 1 + col * AOTupleId_MultiplierSegmentFileNum);
+
+    ao_foreach_extent_file(file_callback, &ctx);
+
+    assert_int_equal(ctx.num_called, MAX_AOREL_CONCURRENCY + 1*1);
+    assert_int_equal(compareSegnoFiles(ctx.call_expected, ctx.call_result), 0);
+}
+
+/* concurrency = 1 num_columns = 4 */
+static void
+test_co_4_columns_1_concurrency(void **state)
+{
+    aomd_filehandler_callback_ctx ctx;
+    setup_test_structures(&ctx);
+
+    for (int col = 0; col < 4; col++)
+        set_ctx_for_present_file(&ctx, 1 + col * AOTupleId_MultiplierSegmentFileNum);
+
+    ao_foreach_extent_file(file_callback, &ctx);
+
+    assert_int_equal(ctx.num_called, MAX_AOREL_CONCURRENCY + 4*1);
+    assert_int_equal(compareSegnoFiles(ctx.call_expected, ctx.call_result), 0);
+}
+
+/* concurrency = 1,5 num_columns = 3 */
+static void
+test_co_3_columns_2_concurrency(void **state)
+{
+    aomd_filehandler_callback_ctx ctx;
+    setup_test_structures(&ctx);
+
+    for (int col = 0; col < 3; col++)
+    {
+        set_ctx_for_present_file(&ctx, 1 + col * AOTupleId_MultiplierSegmentFileNum);
+        set_ctx_for_present_file(&ctx, 5 + col * AOTupleId_MultiplierSegmentFileNum);
+    }
+
+    ao_foreach_extent_file(file_callback, &ctx);
+
+    assert_int_equal(ctx.num_called, MAX_AOREL_CONCURRENCY + 3*2);
+    assert_int_equal(compareSegnoFiles(ctx.call_expected, ctx.call_result), 0);
+}
+
+/* concurrency = [1,127] num_columns = 1 */
+static void
+test_co_1_column_127_concurrency(void **state)
+{
+    aomd_filehandler_callback_ctx ctx;
+    setup_test_structures(&ctx);
+
+    for (int concurrency = 1; concurrency < MAX_AOREL_CONCURRENCY; concurrency++)
+        set_ctx_for_present_file(&ctx, concurrency);
+
+    ao_foreach_extent_file(file_callback, &ctx);
+
+    assert_int_equal(ctx.num_called, MAX_AOREL_CONCURRENCY + 1*127);
+    assert_int_equal(compareSegnoFiles(ctx.call_expected, ctx.call_result), 0);
+}
+
+/* concurrency = 0 num_columns = MaxHeapAttributeNumber  */
+static void
+test_co_max_columns_0th_concurrency(void **state)
+{
+    aomd_filehandler_callback_ctx ctx;
+    setup_test_structures(&ctx);
+
+    for (int col = 0; col < MaxHeapAttributeNumber; col++)
+        set_ctx_for_present_file(&ctx, col * MAX_AOREL_CONCURRENCY);
+
+    ao_foreach_extent_file(file_callback, &ctx);
+
+    /* 0th file already acccounted for, hence the -1 */
+    assert_int_equal(ctx.num_called, (MAX_AOREL_CONCURRENCY-1) + (MaxHeapAttributeNumber * 1 - 1));
+    assert_int_equal(compareSegnoFiles(ctx.call_expected, ctx.call_result), 0);
+}
+
+/* concurrency = 1 num_columns = (MaxHeapAttributeNumber + 1) */
+static void
+test_co_max_columns_0_1_concurrency(void **state)
+{
+    aomd_filehandler_callback_ctx ctx;
+    setup_test_structures(&ctx);
+
+    for (int col = 0; col < MaxHeapAttributeNumber; col++) {
+        set_ctx_for_present_file(&ctx, col * MAX_AOREL_CONCURRENCY);
+        set_ctx_for_present_file(&ctx, col * MAX_AOREL_CONCURRENCY + 1);
+    }
+
+    ao_foreach_extent_file(file_callback, &ctx);
+
+    /* 0th file already acccount for, hence the -1 */
+    assert_int_equal(ctx.num_called, (MAX_AOREL_CONCURRENCY-1) + (MaxHeapAttributeNumber - 1) * 2);
+    assert_int_equal(compareSegnoFiles(ctx.call_expected, ctx.call_result), 0);
+}
+
+static void
+test_different_number_of_columns_per_concurrency_level(void **state)
+{
+    aomd_filehandler_callback_ctx ctx;
+    setup_test_structures(&ctx);
+
+    set_ctx_for_present_file(&ctx, 1);
+    set_ctx_for_present_file(&ctx, 129);
+    set_ctx_for_present_file(&ctx, 2);
+    set_ctx_for_present_file(&ctx, 130);
+    set_ctx_for_present_file(&ctx, 258);
+
+    ao_foreach_extent_file(file_callback, &ctx);
+
+    assert_int_equal(ctx.num_called, MAX_AOREL_CONCURRENCY + 5);
+    assert_int_equal(compareSegnoFiles(ctx.call_expected, ctx.call_result), 0);
+}
+
+static void
+test_all_files_present(void **state)
+{
+	aomd_filehandler_callback_ctx ctx;
+	setup_test_structures(&ctx);
+
+	memset(ctx.present, true, sizeof(ctx.present));
+	memset(ctx.call_expected, true, sizeof(ctx.call_expected));
+
+	ctx.call_expected[0] = false;  /* caller must deal with .0 file */
+	ao_foreach_extent_file(file_callback, &ctx);
+
+	assert_int_equal(ctx.num_called, MAX_SEGNO_FILES - 1);
+	assert_int_equal(compareSegnoFiles(ctx.call_expected, ctx.call_result), 0);
+
+	return;
+}
+
+int
+main(int argc, char *argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const		UnitTest tests[] = {
+		unit_test(test_no_files_present),
+        unit_test(test_co_1_column_1_concurrency),
+        unit_test(test_co_4_columns_1_concurrency),
+        unit_test(test_co_3_columns_2_concurrency),
+        unit_test(test_co_1_column_127_concurrency),
+        unit_test(test_co_max_columns_0th_concurrency),
+        unit_test(test_co_max_columns_0_1_concurrency),
+        unit_test(test_different_number_of_columns_per_concurrency_level),
+		unit_test(test_all_files_present),
+	};
+
+	MemoryContextInit();
+
+	return run_tests(tests);
+}

--- a/src/backend/access/appendonly/test/aomd_test.c
+++ b/src/backend/access/appendonly/test/aomd_test.c
@@ -9,11 +9,9 @@
 #include "catalog/pg_tablespace.h"
 
 #define PATH_TO_DATA_FILE "/tmp/md_test/1234"
-/*
- * Note (MaxHeapAttributeNumber + 1) represents the maximum number of columns
- * we can have in a table.
- */
-static bool file_present[MAX_AOREL_CONCURRENCY * (MaxHeapAttributeNumber + 1)];
+
+#define MAX_SEGNO_FILES (MAX_AOREL_CONCURRENCY * MaxHeapAttributeNumber)
+static bool file_present[MAX_SEGNO_FILES];
 static int num_unlink_called = 0;
 static bool unlink_passing = true;
 
@@ -221,10 +219,10 @@ test_mdunlink_co_all_columns_full_concurrency(void **state)
 	mdunlink_ao(PATH_TO_DATA_FILE);
 
 	/*
-	 * note num_unlink_called is one less than total files because .0 is NOT unlinked
-	 *    by mdunlink_ao()
+	 * Note num_unlink_called is one less than total files because .0 is NOT unlinked
+	 * by mdunlink_ao()
 	 */
-	assert_true(num_unlink_called == (MAX_AOREL_CONCURRENCY * (MaxHeapAttributeNumber + 1)) - 1);
+	assert_true(num_unlink_called == (MAX_SEGNO_FILES - 1));
 	assert_true(unlink_passing);
 	return;
 }

--- a/src/include/access/aomd.h
+++ b/src/include/access/aomd.h
@@ -15,6 +15,7 @@
 #ifndef AOMD_H
 #define AOMD_H
 
+#include "htup_details.h"
 #include "storage/fd.h"
 #include "utils/rel.h"
 
@@ -49,6 +50,18 @@ TruncateAOSegmentFile(File fd,
 
 extern void
 mdunlink_ao(const char *path);
+
 extern void
 copy_append_only_data(RelFileNode src, RelFileNode dst, BackendId backendid, char relpersistence);
+
+/*
+ * return value should be true if the callback was able to find the given
+ * segment number on disk and false otherwise. Failures during operation should
+ * be handled out of band, either with a PG_THROW/elog/etc., or through the
+ * passed user context.
+ */
+typedef bool (*ao_extent_callback)(int segno, void *ctx);
+
+extern void ao_foreach_extent_file(ao_extent_callback callback, void *ctx);
+
 #endif							/* AOMD_H */


### PR DESCRIPTION
Previously these three operations were incorrectly stoppings
on the first non-existent segno file.  The previous code operated under
the assumption that segno files existed for all concurrency levels for
all columns.  For ADD COLUMN on a co table, this assumption may
not be valid.