### PR TITLE
Fix num_distinct calculation in relcache translator

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2457,7 +2457,7 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 	if (form_pg_stats->stadistinct < 0)
 	{
 		GPOS_ASSERT(form_pg_stats->stadistinct > -1.01);
-		num_distinct = num_rows * CDouble(-form_pg_stats->stadistinct);
+		num_distinct = num_rows * (1 - null_freq ) * CDouble(-form_pg_stats->stadistinct);
 	}
 	else
 	{
@@ -2597,9 +2597,9 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 		// there will be remaining tuples if the merged histogram and the NULLS do not cover
 		// the total number of distinct values
 		if ((1 - CStatistics::Epsilon > num_freq_buckets + null_freq) &&
-			(0 < num_distinct - num_ndv_buckets - null_ndv))
+			(0 < num_distinct - num_ndv_buckets))
 		{
-			distinct_remaining = std::max(CDouble(0.0), (num_distinct - num_ndv_buckets - null_ndv));
+			distinct_remaining = std::max(CDouble(0.0), (num_distinct - num_ndv_buckets));
 			freq_remaining = std::max(CDouble(0.0), (1 - num_freq_buckets - null_freq));
 		}
 	}


### PR DESCRIPTION
Related to https://github.com/greenplum-db/gpdb/issues/5981.

In pg_statistic catalog table, stadistinct indicates the (approximate)
number of distinct non-null data values in the column. When < 0, it
holds the negative of multiplier for number of rows.

In the relcache translator, stadistinct is used to calculate
num_distinct, which is the absolute (approx) number of non-null values.
But, the formula used num_rows directly, without discounting for null
values. This would occasionally trip an assertion in ORCA for bool
column types, as it would appear there are 3 distinct bool values, since
it would include the NULL values in num_distinct.

We ran 256G non-part perf runs to compare this commit (1) with one on master right 
before the first fix (2). There are no plan difference between (1) and (2). The execution
times are also very similar.