### PR TITLE
Use pg_get_expr() lookup instead of adsrc in gptransfer

### DIFF
--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -1953,7 +1953,7 @@ FROM (
                 and relkind='S'
                 and pg_class.oid in (
                     select
-                        substring(adsrc from '%%nextval#(''#"%%#"''::regclass#)' for '#')::regclass::oid
+                        substring(pg_catalog.pg_get_expr(adbin, adrelid) from '%%nextval#(''#"%%#"''::regclass#)' for '#')::regclass::oid
                     from pg_attrdef
                     where adrelid='%s.%s'::regclass
                         and adsrc like '%%nextval(%%'


### PR DESCRIPTION
Querying `pg_attrdef.adsrc` has been deprecated for some time (since PostgreSQL 8.0), due to it being prone to give wrong results as it doesn't track outside changes. The solution is to use `pg_get_expr()` and calculate the `adsrc` instead.

Bug reported by Ming Li and Eric Wong in Github issue #5173.