### PR TITLE
Temporary workaround to make qp_dml_joins deterministic

### DIFF
--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -3125,6 +3125,14 @@ SELECT SUM(b) FROM dml_heap_pt_r;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
+-- Temporary workaround to make the error reported by the following
+-- update statement deterministic.  Without the savepoint, a QE reader
+-- may continue performing its part of the plan even after its writer
+-- has finished aborting the transaction.  This would lead to
+-- occasional "relation not found for OID ..." errors because the
+-- default partition would have been dropped as part of writer's abort
+-- processing.
+SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
 ERROR:  cross-partition or multi-update to a row  (seg1 10.152.10.75:25433 pid=28939)
 SELECT SUM(a) FROM dml_heap_pt_r;
@@ -3278,6 +3286,14 @@ SELECT * FROM dml_heap_pt_r WHERE a = 1;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
+-- Temporary workaround to make the error reported by the following
+-- update statement deterministic.  Without the savepoint, a QE reader
+-- may continue performing its part of the plan even after its writer
+-- has finished aborting the transaction.  This would lead to
+-- occasional "relation not found for OID ..." errors because the
+-- default partition would have been dropped as part of writer's abort
+-- processing.
+SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
 ERROR:  cross-partition or multi-update to a row  (seg2 10.152.10.75:25434 pid=14697)
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -3129,6 +3129,14 @@ SELECT SUM(b) FROM dml_heap_pt_r;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
+-- Temporary workaround to make the error reported by the following
+-- update statement deterministic.  Without the savepoint, a QE reader
+-- may continue performing its part of the plan even after its writer
+-- has finished aborting the transaction.  This would lead to
+-- occasional "relation not found for OID ..." errors because the
+-- default partition would have been dropped as part of writer's abort
+-- processing.
+SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum 
@@ -3289,6 +3297,14 @@ SELECT * FROM dml_heap_pt_r WHERE a = 1;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
+-- Temporary workaround to make the error reported by the following
+-- update statement deterministic.  Without the savepoint, a QE reader
+-- may continue performing its part of the plan even after its writer
+-- has finished aborting the transaction.  This would lead to
+-- occasional "relation not found for OID ..." errors because the
+-- default partition would have been dropped as part of writer's abort
+-- processing.
+SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
 ERROR:  cross-partition or multi-update to a row
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -1352,6 +1352,16 @@ begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
 SELECT SUM(b) FROM dml_heap_pt_r;
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
+
+-- Temporary workaround to make the error reported by the following
+-- update statement deterministic.  Without the savepoint, a QE reader
+-- may continue performing its part of the plan even after its writer
+-- has finished aborting the transaction.  This would lead to
+-- occasional "relation not found for OID ..." errors because the
+-- default partition would have been dropped as part of writer's abort
+-- processing.
+SAVEPOINT sp1;
+
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
 SELECT SUM(a) FROM dml_heap_pt_r;
 SELECT SUM(b) FROM dml_heap_pt_r;
@@ -1417,6 +1427,16 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;
 SELECT dml_heap_pt_s.a + 10 FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a ORDER BY 1 LIMIT 1;
 SELECT * FROM dml_heap_pt_r WHERE a = 1;
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
+
+-- Temporary workaround to make the error reported by the following
+-- update statement deterministic.  Without the savepoint, a QE reader
+-- may continue performing its part of the plan even after its writer
+-- has finished aborting the transaction.  This would lead to
+-- occasional "relation not found for OID ..." errors because the
+-- default partition would have been dropped as part of writer's abort
+-- processing.
+SAVEPOINT sp1;
+
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;


### PR DESCRIPTION
The test occasionally fails due to a different than expected error. The expected error is the one reported by QE writer.  However, occasionally a race condition exists where a QE reader will continue
executing its part of the plan even after the QE writer has already aborted the transaction.  If the reader also encounters an error, depending on the order of messages received, the dispatcher may choose to report the reader's error instead.  This would lead to diffs such as the following:

```
   -ERROR:  cross-partition or multi-update to a row
   +ERROR:  relation not found (OID ...)
```

The "cross-partition or multi-update ... " is the expected error, which is thrown by the QE writer.  The test adds a new default partition in the same transaction.  When the QE writer aborts the
transaction, the default partition relation is also removed.  If a QE reader then attepmts to open that relation, it no longer exists and will throw the "relation not found ..." error.

In order to prevent the QE reader from throwing relation not found error, this patch runs the update statement in its own subtransaction. The abort processing of this subtransaction will no longer include removing the default partition, thereby avoiding the "relation not found ..." error.

This is a temporary workaround.  A proper fix is needed to ensure that readers do not continue executing a query after the writer has aborted the transaction.