### PR TITLE
FIXME: Remove NULL guards from pg_dump to align with upstream

### DIFF
--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -912,18 +912,14 @@ ArchiveEntry(Archive *AHX,
 	newToc->dumpId = dumpId;
 	newToc->section = section;
 
-/*
- * GPDB_92_MERGE_FIXEME: can owner or dropStmt be NULL??  upstream pg_dump
- * doesn't guard against NULL pointer in owner nor dropStmt
- */
 	newToc->tag = pg_strdup(tag);
 	newToc->namespace = namespace ? pg_strdup(namespace) : NULL;
 	newToc->tablespace = tablespace ? pg_strdup(tablespace) : NULL;
-	newToc->owner = owner ? pg_strdup(owner) : NULL;
+	newToc->owner = owner;
 	newToc->withOids = withOids;
 	newToc->desc = pg_strdup(desc);
 	newToc->defn = pg_strdup(defn);
-	newToc->dropStmt = dropStmt ? pg_strdup(dropStmt) : NULL;
+	newToc->dropStmt = dropStmt;
 	newToc->copyStmt = copyStmt ? pg_strdup(copyStmt) : NULL;
 
 	if (nDeps > 0)


### PR DESCRIPTION
To answer the question raised in the removed FIXME comment: owner is not allowed to be NULL, it may be omitted if `--no-owner` it passed but each `ArchiveEntry` should have an owner set; `dropStmt` is allowed to be empty but not `NULL`, the pattern for not setting a dropStmt is to pass `""` in the `ArchiveEntry()` call.

While these guards didn't really hurt, every non-essential divergence from upstream can cause conflicts when merging so we might as well keep aligned. If we want changes along these lines we should submit them upstream.