### PR TITLE
Fix compiler warning for three-way comparison

### DIFF
--- a/src/backend/executor/nodeReshuffle.c
+++ b/src/backend/executor/nodeReshuffle.c
@@ -292,8 +292,8 @@ ExecReshuffle(ReshuffleState *node)
 		int segIdx;
 
 		/* For replicated tables*/
-		if (GpIdentity.segindex >= reshuffle->oldSegs >=
-			getgpsegmentCount())
+		if (GpIdentity.segindex >= reshuffle->oldSegs &&
+			reshuffle->oldSegs >= getgpsegmentCount())
 			return NULL;
 
 		/*


### PR DESCRIPTION
GCC 7 reports a warning for expressions such as `(X <= Y <= Z)` as their mathematical meaning is not preserved.  The comparison translates to `((X <= Y) <= Z)` and the first `<=` returns bool.  Some compilers may be smart enough to preserve the mathematical meaning in generated code but why take chances?