### PR TITLE
Concourse: Replace pivotaldata/ubuntu-gpdb-dev:16.04_gcc_6_3 with :16.04

### DIFF
--- a/concourse/pipelines/gpdb_master-generated.yml
+++ b/concourse/pipelines/gpdb_master-generated.yml
@@ -377,7 +377,7 @@ resources:
   type: docker-image
   source:
     repository: pivotaldata/ubuntu-gpdb-dev
-    tag: '16.04_gcc_6_3'
+    tag: '16.04'
 
 - name: ubuntu-gpdb-debian-dev-16
   type: docker-image

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -22,7 +22,7 @@ resources:
     type: docker-image
     source:
       repository: pivotaldata/ubuntu-gpdb-dev
-      tag: '16.04_gcc_6_3'
+      tag: '16.04'
 
 jobs:
   - name: compile_and_test_gpdb

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -496,7 +496,7 @@ resources:
   type: docker-image
   source:
     repository: pivotaldata/ubuntu-gpdb-dev
-    tag: '16.04_gcc_6_3'
+    tag: '16.04'
 
 - name: ubuntu-gpdb-debian-dev-16
   type: docker-image


### PR DESCRIPTION
The _gcc_6_3 tag had been updated to _gcc_6_4, but to avoid missing
updates in the future, instead of bumping the version here, the tag has
been renamed to simply :16.04

Co-authored-by: David Sharp <dsharp@pivotal.io>
Co-authored-by: Fei Yang <fyang@pivotal.io>