### PR TITLE
Fix the errors when reshuffle replicated table

### DIFF
--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -6142,14 +6142,14 @@ ExecInitExpr(Expr *node, PlanState *parent)
 			break;
 
         case T_ReshuffleExpr:
-            {
+			{
 				ReshuffleExpr *sr = (ReshuffleExpr *) node;
 				ReshuffleExprState *exprstate = makeNode(ReshuffleExprState);
-                exprstate->hashKeys = ExecInitExpr(sr->hashKeys, parent);
-                exprstate->hashTypes = sr->hashTypes;
-                exprstate->xprstate.evalfunc = (ExprStateEvalFunc) ExecEvalReshuffleExpr;
+				exprstate->hashKeys = (List*) ExecInitExpr((Expr *) sr->hashKeys, parent);
+				exprstate->hashTypes = sr->hashTypes;
+				exprstate->xprstate.evalfunc = (ExprStateEvalFunc) ExecEvalReshuffleExpr;
 				state = (ExprState*)exprstate;
-            }
+			}
 		    break;
 
 		default:

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1594,6 +1594,8 @@ ExecModifyTable(ModifyTableState *node)
 	/*
 	 * Prevent replicated tables being updated on segments outside
 	 * the [0, numsegments-1] range.
+	 *
+	 * FIXME: This piece of code maybe remove once we adjusted the gang size
 	 */
 	if (Gp_role == GP_ROLE_EXECUTE &&
 		!mt->isReshuffle &&

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1549,6 +1549,7 @@ ExecModifyTable(ModifyTableState *node)
 	ItemPointerData tuple_ctid;
 	HeapTupleData oldtupdata;
 	HeapTuple	oldtuple;
+	ModifyTable *mt = (ModifyTable *) node->ps.plan;
 
 	/*
 	 * This should NOT get called during EvalPlanQual; we should have passed a
@@ -1593,10 +1594,9 @@ ExecModifyTable(ModifyTableState *node)
 	/*
 	 * Prevent replicated tables being updated on segments outside
 	 * the [0, numsegments-1] range.
-	 *
-	 * FIXME: remove this once the flexible gang size feature is ready.
 	 */
 	if (Gp_role == GP_ROLE_EXECUTE &&
+		!mt->isReshuffle &&
 		resultRelInfo->ri_RelationDesc->rd_cdbpolicy->ptype == POLICYTYPE_REPLICATED &&
 		(GpIdentity.segindex >=
 		 resultRelInfo->ri_RelationDesc->rd_cdbpolicy->numsegments))

--- a/src/backend/executor/nodeReshuffle.c
+++ b/src/backend/executor/nodeReshuffle.c
@@ -292,7 +292,7 @@ ExecReshuffle(ReshuffleState *node)
 		int segIdx;
 
 		/* For replicated tables*/
-		if (GpIdentity.segindex >= reshuffle->oldSegs >=
+		if (GpIdentity.segindex + reshuffle->oldSegs >=
 			getgpsegmentCount())
 			return NULL;
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -316,6 +316,7 @@ _copyModifyTable(const ModifyTable *from)
 	COPY_NODE_FIELD(action_col_idxes);
 	COPY_NODE_FIELD(ctid_col_idxes);
 	COPY_NODE_FIELD(oid_col_idxes);
+	COPY_SCALAR_FIELD(isReshuffle);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -464,6 +464,7 @@ _outModifyTable(StringInfo str, const ModifyTable *node)
 	WRITE_NODE_FIELD(action_col_idxes);
 	WRITE_NODE_FIELD(ctid_col_idxes);
 	WRITE_NODE_FIELD(oid_col_idxes);
+	WRITE_BOOL_FIELD(isReshuffle);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2903,6 +2903,7 @@ _readModifyTable(void)
 	READ_NODE_FIELD(action_col_idxes);
 	READ_NODE_FIELD(ctid_col_idxes);
 	READ_NODE_FIELD(oid_col_idxes);
+	READ_BOOL_FIELD(isReshuffle);
 
 	READ_DONE();
 }

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6461,6 +6461,7 @@ make_modifytable(PlannerInfo *root,
 	node->action_col_idxes = NIL;
 	node->ctid_col_idxes = NIL;
 	node->oid_col_idxes = NIL;
+	node->isReshuffle = false;
 
 	adjust_modifytable_flow(root, node, is_split_updates);
 
@@ -6775,10 +6776,11 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 					 * if need reshuffle, add the Reshuffle node onto the
 					 * SplitUpdate node and Specify the explicit motion
 					 */
-                    if(qry->needReshuffle)
+					if(qry->needReshuffle)
 					{
 						new_subplan = (Plan *) make_reshuffle(root, new_subplan, rte, rti);
 						request_explicit_motion(new_subplan, rti, root->glob->finalrtable);
+						((ModifyTable *)node)->isReshuffle = true;
 					}
 					else
 					{
@@ -6851,6 +6853,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 					new_subplan = (Plan *) make_splitupdate(root, (ModifyTable *) node, subplan, rte);
 					new_subplan = (Plan *) make_reshuffle(root, new_subplan, rte, rti);
 					request_explicit_motion(new_subplan, rti, root->glob->finalrtable);
+					((ModifyTable *)node)->isReshuffle = true;
 
 					lcp->data.ptr_value = new_subplan;
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -362,6 +362,7 @@ typedef struct ModifyTable
 	List	   *action_col_idxes;
 	List	   *ctid_col_idxes;
 	List	   *oid_col_idxes;
+	bool		isReshuffle;
 } ModifyTable;
 
 /* ----------------


### PR DESCRIPTION
This PR is used to solve some errors which are introduced by the f4f4bdcc8b7327faccbda8e12721b2c6b943aed7 :
* Fix compiler warning for three-way comparison
* Fix an error, when reshuffle the replicated table, the tuple cannot insert correctly.

We assume that there are 3 segments(seg#0, seg#1, seg#2) in the cluster and the numsegments of a replicated table is 2.

In the common UPDATE, when we insert the tuple to this replicated table, It should not insert into the seg#2 because the replicated table only store data in the first 2 segments(seg#0, seg#1).

In the UPDATE with reshuffle flag (This UPDATE cannot use directly, it only can be composed by ALTER TABLE XXX SET WITH (RESHUFFLE = true)), we assume that there are 2 old segments(seg#0, seg#1) and 1 new segment(seg#2), the replicated table is in the first 2 segment. When we reshuffle the replicated table, it will insert new tuple to the seg#2, then ModifyTable operator prohibits the tuple insert into seg#2 because it thinks seg#2 is out of the range.

We add a new flag to the ModifyTable struct, it can distinguish between common UPDATE and RESHUFFLE. I suppose that we need to change the GANG size according to the numsegments, and then the isReshuffle flag can be removed.