### PR TITLE
Fix incorrect assertion within adjust_modifytable_flow

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14438,17 +14438,22 @@ ReshuffleRelationData(Relation rel)
 	Oid					relationOid = InvalidOid;
 	AutoStatsCmdType 	cmdType = AUTOSTATS_CMDTYPE_SENTINEL;
 
-	if (policy->numsegments >= getgpsegmentCount())
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("Do not need to reshuffle")));
-
 	stmt->needReshuffle = true;
 	stmt->targetList = NIL;
 
 	/* make an RangeVar to indicate the result relation */
 	prelname = pstrdup(RelationGetRelationName(rel));
 	namespace_name = get_namespace_name(rel->rd_rel->relnamespace);
+
+	if (policy->numsegments >= getgpsegmentCount())
+	{
+		ereport(NOTICE,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("Do not need to reshuffle %s.%s",
+							   namespace_name,prelname)));
+
+		return;
+	}
 
 	relation = makeRangeVar(namespace_name, prelname, -1);
 	stmt->relation = relation;

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1531,8 +1531,16 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 		}
 		else if (CdbPathLocus_IsPartitioned(pathnode->locus) &&
 				 CdbPathLocus_IsPartitioned(projectedlocus))
+		{
+			/*
+			 * subpaths have different distributed policy, mark it as random
+			 * distributed and set the numsegments to the maximum of all
+			 * subpaths to not missing any tuples.
+			 */
 			CdbPathLocus_MakeStrewn(&pathnode->locus,
-									CdbPathLocus_NumSegments(projectedlocus));
+									Max(CdbPathLocus_NumSegments(pathnode->locus),
+										CdbPathLocus_NumSegments(projectedlocus)));
+		}
 		else
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg_internal("cannot append paths with incompatible distribution")));

--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -764,3 +764,67 @@ select gp_segment_id, count(*) from table_with_update_trigger group by 1 order b
              2 |    28
 (3 rows)
 
+--
+-- Test reshuffle inheritance parent table, parent table has different numsegments with
+-- child tables.
+--
+create table mix_base_tbl (a int4, b int4) distributed by (a);
+update gp_distribution_policy  set numsegments=2 where localoid='mix_base_tbl'::regclass;
+insert into mix_base_tbl select g, g from generate_series(1, 3) g;
+create table mix_child_a (a int4, b int4) inherits (mix_base_tbl) distributed by (a);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+insert into mix_child_a select g, g from generate_series(11, 13) g;
+create table mix_child_b (a int4, b int4) inherits (mix_base_tbl) distributed by (b);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+update gp_distribution_policy  set numsegments=2 where localoid='mix_child_b'::regclass;
+insert into mix_child_b select g, g from generate_series(21, 23) g;
+select gp_segment_id, * from mix_base_tbl order by 2, 1;
+ gp_segment_id | a  | b  
+---------------+----+----
+             0 |  1 |  1
+             1 |  2 |  2
+             1 |  3 |  3
+             0 | 11 | 11
+             1 | 12 | 12
+             2 | 13 | 13
+             0 | 21 | 21
+             1 | 22 | 22
+             0 | 23 | 23
+(9 rows)
+
+-- update distributed column, numsegments does not change
+update mix_base_tbl set a=a+1;
+select gp_segment_id, * from mix_base_tbl order by 2, 1;
+ gp_segment_id | a  | b  
+---------------+----+----
+             1 |  2 |  1
+             1 |  3 |  2
+             0 |  4 |  3
+             1 | 12 | 11
+             2 | 13 | 12
+             2 | 14 | 13
+             0 | 22 | 21
+             1 | 23 | 22
+             0 | 24 | 23
+(9 rows)
+
+-- reshuffle the parent table, both parent and child table will be rebalanced to all
+-- segments
+Alter table mix_base_tbl set with (reshuffle);
+NOTICE:  Do not need to reshuffle public.mix_child_a
+select gp_segment_id, * from mix_base_tbl order by 2, 1;
+ gp_segment_id | a  | b  
+---------------+----+----
+             1 |  2 |  1
+             2 |  3 |  2
+             0 |  4 |  3
+             1 | 12 | 11
+             2 | 13 | 12
+             2 | 14 | 13
+             0 | 22 | 21
+             1 | 23 | 22
+             2 | 24 | 23
+(9 rows)
+


### PR DESCRIPTION
Previously, when we try to update a partition table or an inherited table,
we assume all parent table and child table should have the same number of
segments in gp_distribution_policy catalog, otherwise, we let the query
fail.

The assumption is incorrect, updating on mix size of target relations
can work actually, we only need to set the flow size of modifytable node
to the maxinum size of all target relations and take care of the output
size of motion for each target relations individually.

It's very common that parent table and child table has different number
of segments in gp_distribution_policy, gpexpand may expand the child
table first and then the parent table.