### PR TITLE
Re-commit all commits of "escaping single quote format of shell command

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -34,6 +34,7 @@
 #include "postgres.h"
 
 #include <fstream/gfile.h>
+#include <tcop/tcopprot.h>
 
 #include "funcapi.h"
 #include "access/fileam.h"
@@ -2305,6 +2306,7 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 	extvar->GP_HADOOP_CONN_JARDIR = gp_hadoop_connector_jardir;
 	extvar->GP_HADOOP_CONN_VERSION = gp_hadoop_connector_version;
 	extvar->GP_HADOOP_HOME = gp_hadoop_home;
+	extvar->GP_QUERY_STRING = (char *)debug_query_string;
 
 	if (NULL != params)
 	{

--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -213,6 +213,7 @@ make_command(const char *cmd, extvar_t *ev)
 	make_export("GP_SEG_PORT", ev->GP_SEG_PORT, &buf);
 	make_export("GP_SESSION_ID", ev->GP_SESSION_ID, &buf);
 	make_export("GP_SEGMENT_COUNT", ev->GP_SEGMENT_COUNT, &buf);
+	make_export("GP_QUERY_STRING", ev->GP_QUERY_STRING, &buf);
 
 	/* hadoop env var */
 	make_export("GP_HADOOP_CONN_JARDIR", ev->GP_HADOOP_CONN_JARDIR, &buf);

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -7355,6 +7355,7 @@ open_program_pipes(char *command, bool forwrite)
 	/* Restore the SIGPIPE handler */
 	pqsignal(SIGPIPE, save_SIGPIPE);
 
+	elog(DEBUG5, "COPY ... PROGRAM command: %s", program_pipes->shexec);
 	if (program_pipes->pid == -1)
 	{
 		errno = save_errno;

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -69,6 +69,7 @@ typedef struct extvar_t
  	/* EOL vars */
  	char* GP_LINE_DELIM_STR;
  	char GP_LINE_DELIM_LENGTH[8];
+	char *GP_QUERY_STRING;
 } extvar_t;
 
 

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -88,6 +88,8 @@ DROP EXTERNAL TABLE IF EXISTS exttab_txs_2;
 DROP EXTERNAL TABLE IF EXISTS exttab_udfs_1;
 DROP EXTERNAL TABLE IF EXISTS exttab_udfs_2;
 DROP EXTERNAL TABLE IF EXISTS exttab_views_3;
+DROP EXTERNAL WEB TABLE IF EXISTS table_env;
+DROP EXTERNAL WEB TABLE IF EXISTS table_qry;
 
 DROP VIEW IF EXISTS exttab_views_3;
 
@@ -110,6 +112,19 @@ drop external table check_ps;
 drop external table check_env;
 
 -- end_ignore
+-- table to get shell command "env" output which list all environment variable
+CREATE EXTERNAL WEB TABLE table_env (val TEXT)
+  EXECUTE E'env' ON SEGMENT 0
+  FORMAT 'TEXT' (ESCAPE 'OFF');
+SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%' ORDER BY val ASC;
+SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%\%' ESCAPE '&' ORDER BY val ASC;
+
+-- echo will behave differently on different platforms, force to use bash with -E option
+CREATE EXTERNAL WEB TABLE table_qry (val TEXT)
+  EXECUTE E'/usr/bin/env bash -c ''echo -E "$GP_QUERY_STRING"''' ON SEGMENT 0
+  FORMAT 'TEXT' (ESCAPE 'OFF');
+SELECT * FROM table_qry WHERE val LIKE '%\\%' ORDER BY val ASC;
+SELECT * FROM table_qry WHERE val LIKE '%\%' ESCAPE '&' ORDER BY val ASC;
 -- --------------------------------------
 -- some negative tests
 -- --------------------------------------

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1250,3 +1250,23 @@ copy broken_type_test to '/tmp/g';
 -- Don't leave behind a table that you can't dump.
 drop table broken_type_test;
 drop type broken_int4 cascade; -- drops the I/O functions, too.
+
+-- GPDB makes the database name, and many other things, available
+-- as environment variables to the program. Test those.
+--
+-- Perform these tests in a funnily named database, to test
+-- escaping
+set client_min_messages='warning';
+DROP DATABASE IF EXISTS "funny copy""db'with\\quotes";
+reset client_min_messages;
+CREATE DATABASE "funny copy""db'with\\quotes";
+
+\c "funny copy""db'with\\quotes"
+-- echo will behave differently on different platforms, force to use bash with -E option
+COPY (SELECT 'data1') TO PROGRAM 'cat > /tmp/gpcopyenvtest; /usr/bin/env bash -c ''echo -E database in COPY TO: $GP_DATABASE >> /tmp/gpcopyenvtest '' ' ESCAPE 'OFF';
+
+CREATE TABLE foo (t text);
+COPY foo FROM PROGRAM 'cat /tmp/gpcopyenvtest' ESCAPE 'OFF';
+COPY foo FROM PROGRAM '/usr/bin/env bash -c ''echo -E database in COPY FROM: $GP_DATABASE''' ESCAPE 'OFF';
+
+select * from foo;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -81,6 +81,7 @@ select * from check_env;
  GP_HADOOP_CONN_VERSION=CE_1.0.0.0
  GP_MASTER_HOST=127.0.0.1
  GP_MASTER_PORT=5432
+ GP_QUERY_STRING=select * from check_env;
  GP_SEGMENT_COUNT=2
  GP_SEGMENT_ID=0
  GP_SEG_DATADIR=/Users/@gpcurusername@/greenplum-db-data/dbfast1/gpseg0

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -128,6 +128,38 @@ select * from check_env;
 (55 rows)
 
 -- end_ignore
+-- table to get shell command "env" output which list all environment variable
+CREATE EXTERNAL WEB TABLE table_env (val TEXT)
+  EXECUTE E'env' ON SEGMENT 0
+  FORMAT 'TEXT' (ESCAPE 'OFF');
+SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%' ORDER BY val ASC;
+                                         val                                          
+--------------------------------------------------------------------------------------
+ GP_QUERY_STRING=SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%' ORDER BY val ASC;
+(1 row)
+
+SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%\%' ESCAPE '&' ORDER BY val ASC;
+                                                val                                                
+---------------------------------------------------------------------------------------------------
+ GP_QUERY_STRING=SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%\%' ESCAPE '&' ORDER BY val ASC;
+(1 row)
+
+-- echo will behave differently on different platforms, force to use bash with -E option
+CREATE EXTERNAL WEB TABLE table_qry (val TEXT)
+  EXECUTE E'/usr/bin/env bash -c ''echo -E "$GP_QUERY_STRING"''' ON SEGMENT 0
+  FORMAT 'TEXT' (ESCAPE 'OFF');
+SELECT * FROM table_qry WHERE val LIKE '%\\%' ORDER BY val ASC;
+                               val                               
+-----------------------------------------------------------------
+ SELECT * FROM table_qry WHERE val LIKE '%\\%' ORDER BY val ASC;
+(1 row)
+
+SELECT * FROM table_qry WHERE val LIKE '%\%' ESCAPE '&' ORDER BY val ASC;
+                                    val                                    
+---------------------------------------------------------------------------
+ SELECT * FROM table_qry WHERE val LIKE '%\%' ESCAPE '&' ORDER BY val ASC;
+(1 row)
+
 -- --------------------------------------
 -- some negative tests
 -- --------------------------------------

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1454,3 +1454,26 @@ drop type broken_int4 cascade; -- drops the I/O functions, too.
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to function broken_int4in(cstring)
 drop cascades to function broken_int4out(broken_int4)
+-- GPDB makes the database name, and many other things, available
+-- as environment variables to the program. Test those.
+--
+-- Perform these tests in a funnily named database, to test
+-- escaping
+set client_min_messages='warning';
+DROP DATABASE IF EXISTS "funny copy""db'with\\quotes";
+reset client_min_messages;
+CREATE DATABASE "funny copy""db'with\\quotes";
+\c "funny copy""db'with\\quotes"
+-- echo will behave differently on different platforms, force to use bash with -E option
+COPY (SELECT 'data1') TO PROGRAM 'cat > /tmp/gpcopyenvtest; /usr/bin/env bash -c ''echo -E database in COPY TO: $GP_DATABASE >> /tmp/gpcopyenvtest '' ' ESCAPE 'OFF';
+CREATE TABLE foo (t text);
+COPY foo FROM PROGRAM 'cat /tmp/gpcopyenvtest' ESCAPE 'OFF';
+COPY foo FROM PROGRAM '/usr/bin/env bash -c ''echo -E database in COPY FROM: $GP_DATABASE''' ESCAPE 'OFF';
+select * from foo;
+                         t                         
+---------------------------------------------------
+ data1
+ database in COPY FROM: funny copy"db'with\\quotes
+ database in COPY TO: funny copy"db'with\\quotes
+(3 rows)
+


### PR DESCRIPTION
This PR is the latest update for below PRs which have been reverted for CI failure:
https://github.com/greenplum-db/gpdb/pull/5974
https://github.com/greenplum-db/gpdb/pull/6058
https://github.com/greenplum-db/gpdb/pull/5927

Notes in testcase about backslash escaping:
    - Need to add ESCAPE 'OFF' to EXTERNAL WEB TABLE
    - Need to add ESCAPE 'OFF' to COPY ... PROGRAM
    - Need to add ESCAPE '&' for LIKE predicate
    - Command echo will behaves differently on different platforms, force to use bash shell with -E option.
    - For shell 'env' output, don't seperate to 2 columns because CI env has funny char
      in variable value. e.g.
        "LS_OPTIONS=-N --color=tty -T 0" and
        "LESSOPEN=||/usr/bin/lesspipe.sh %s"



