### PR TITLE
[5X] Inferring quals on left outer joins incorrectly

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -176,7 +176,7 @@ gen_implied_qual(PlannerInfo *root,
 		return;
 
 	/* No inferences may be performed across an outer join */
-	if (old_rinfo->ojscope_relids && !bms_is_subset(new_qualscope, old_rinfo->ojscope_relids))
+	if (old_rinfo->ojscope_relids)
 		return;
 
 	/*

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3172,3 +3172,59 @@ EXPLAIN SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=b.a::numeric
  Optimizer: legacy query optimizer
 (11 rows)
 
+-- Do not push down any implied predicates to the Left Outer Join
+DROP TABLE IF EXISTS member;
+DROP TABLE IF EXISTS member_group;
+DROP TABLE IF EXISTS member_subgroup;
+DROP TABLE IF EXISTS region;
+CREATE TABLE member(member_id int NOT NULL, group_id int NOT NULL) DISTRIBUTED BY(member_id);
+CREATE TABLE member_group(group_id int NOT NULL) DISTRIBUTED BY(group_id);
+CREATE TABLE region(region_id char(4), county_name varchar(25)) DISTRIBUTED BY(region_id);
+CREATE TABLE member_subgroup(subgroup_id int NOT NULL, group_id int NOT NULL, subgroup_name text) DISTRIBUTED RANDOMLY;
+INSERT INTO region SELECT i, i FROM generate_series(1, 200) i;
+INSERT INTO member_group SELECT i FROM generate_series(1, 15) i;
+INSERT INTO member SELECT i, i%15 FROM generate_series(1, 10000) i;
+--start_ignore
+ANALYZE member;
+ANALYZE member_group;
+ANALYZE region;
+ANALYZE member_subgroup;
+--end_ignore
+EXPLAIN SELECT member.member_id
+FROM member
+INNER JOIN member_group
+ON member.group_id = member_group.group_id
+INNER JOIN member_subgroup
+ON member_group.group_id = member_subgroup.group_id
+LEFT OUTER JOIN region
+ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=16.89..154.82 rows=14 width=4)
+   ->  Hash Left Join  (cost=16.89..154.82 rows=5 width=4)
+         Hash Cond: member_subgroup.subgroup_name = region.county_name::text
+         Join Filter: member_group."group_id" = ANY ('{12,13,14,15}'::integer[])
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=5.39..143.13 rows=5 width=40)
+               Hash Key: member_subgroup.subgroup_name
+               ->  Hash Join  (cost=5.39..142.86 rows=5 width=40)
+                     Hash Cond: member."group_id" = member_group."group_id"
+                     ->  Hash Join  (cost=1.08..138.29 rows=5 width=44)
+                           Hash Cond: member."group_id" = member_subgroup."group_id"
+                           ->  Seq Scan on member  (cost=0.00..112.00 rows=3334 width=8)
+                           ->  Hash  (cost=1.04..1.04 rows=1 width=36)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.04 rows=1 width=36)
+                                       ->  Seq Scan on member_subgroup  (cost=0.00..1.00 rows=1 width=36)
+                     ->  Hash  (cost=3.75..3.75 rows=15 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.75 rows=15 width=4)
+                                 ->  Seq Scan on member_group  (cost=0.00..3.15 rows=5 width=4)
+         ->  Hash  (cost=9.00..9.00 rows=67 width=3)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..9.00 rows=67 width=3)
+                     Hash Key: region.county_name
+                     ->  Seq Scan on region  (cost=0.00..5.00 rows=67 width=3)
+ Optimizer: legacy query optimizer
+(23 rows)
+
+DROP TABLE member;
+DROP TABLE member_group;
+DROP TABLE member_subgroup;
+DROP TABLE region;

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3172,3 +3172,60 @@ EXPLAIN SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=b.a::numeric
  Optimizer status: PQO version 3.2.0
 (11 rows)
 
+-- Do not push down any implied predicates to the Left Outer Join
+DROP TABLE IF EXISTS member;
+DROP TABLE IF EXISTS member_group;
+DROP TABLE IF EXISTS member_subgroup;
+DROP TABLE IF EXISTS region;
+CREATE TABLE member(member_id int NOT NULL, group_id int NOT NULL) DISTRIBUTED BY(member_id);
+CREATE TABLE member_group(group_id int NOT NULL) DISTRIBUTED BY(group_id);
+CREATE TABLE region(region_id char(4), county_name varchar(25)) DISTRIBUTED BY(region_id);
+CREATE TABLE member_subgroup(subgroup_id int NOT NULL, group_id int NOT NULL, subgroup_name text) DISTRIBUTED RANDOMLY;
+INSERT INTO region SELECT i, i FROM generate_series(1, 200) i;
+INSERT INTO member_group SELECT i FROM generate_series(1, 15) i;
+INSERT INTO member SELECT i, i%15 FROM generate_series(1, 10000) i;
+--start_ignore
+ANALYZE member;
+ANALYZE member_group;
+ANALYZE region;
+ANALYZE member_subgroup;
+--end_ignore
+EXPLAIN SELECT member.member_id
+FROM member
+INNER JOIN member_group
+ON member.group_id = member_group.group_id
+INNER JOIN member_subgroup
+ON member_group.group_id = member_subgroup.group_id
+LEFT OUTER JOIN region
+ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1724.73 rows=1 width=4)
+   ->  Hash Left Join  (cost=0.00..1724.73 rows=1 width=4)
+         Hash Cond: member_subgroup.subgroup_name = region.county_name::text
+         Join Filter: member_group."group_id" = ANY ('{12,13,14,15}'::integer[])
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1293.72 rows=1 width=16)
+               Hash Key: member_subgroup.subgroup_name
+               ->  Hash Join  (cost=0.00..1293.72 rows=1 width=16)
+                     Hash Cond: member."group_id" = member_group."group_id" AND member_subgroup."group_id" = member_group."group_id"
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.72 rows=1 width=20)
+                           Hash Key: member."group_id"
+                           ->  Hash Join  (cost=0.00..862.72 rows=1 width=20)
+                                 Hash Cond: member."group_id" = member_subgroup."group_id"
+                                 ->  Table Scan on member  (cost=0.00..431.07 rows=3334 width=8)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                             ->  Table Scan on member_subgroup  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Hash  (cost=431.00..431.00 rows=5 width=4)
+                           ->  Table Scan on member_group  (cost=0.00..431.00 rows=5 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=67 width=3)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=67 width=3)
+                     Hash Key: region.county_name::text
+                     ->  Table Scan on region  (cost=0.00..431.00 rows=67 width=3)
+ Optimizer status: PQO version 3.6.0
+(23 rows)
+
+DROP TABLE member;
+DROP TABLE member_group;
+DROP TABLE member_subgroup;
+DROP TABLE region;

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -211,3 +211,38 @@ EXPLAIN SELECT * FROM coercejoin a, coercejoin b WHERE a.a=b.a;
 -- which cannot guarantee that the coerced value would hash to the same segment
 -- as the uncoerced tuple.
 EXPLAIN SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=b.a::numeric;
+
+-- Do not push down any implied predicates to the Left Outer Join
+DROP TABLE IF EXISTS member;
+DROP TABLE IF EXISTS member_group;
+DROP TABLE IF EXISTS member_subgroup;
+DROP TABLE IF EXISTS region;
+
+CREATE TABLE member(member_id int NOT NULL, group_id int NOT NULL) DISTRIBUTED BY(member_id);
+CREATE TABLE member_group(group_id int NOT NULL) DISTRIBUTED BY(group_id);
+CREATE TABLE region(region_id char(4), county_name varchar(25)) DISTRIBUTED BY(region_id);
+CREATE TABLE member_subgroup(subgroup_id int NOT NULL, group_id int NOT NULL, subgroup_name text) DISTRIBUTED RANDOMLY;
+
+INSERT INTO region SELECT i, i FROM generate_series(1, 200) i;
+INSERT INTO member_group SELECT i FROM generate_series(1, 15) i;
+INSERT INTO member SELECT i, i%15 FROM generate_series(1, 10000) i;
+--start_ignore
+ANALYZE member;
+ANALYZE member_group;
+ANALYZE region;
+ANALYZE member_subgroup;
+--end_ignore
+EXPLAIN SELECT member.member_id
+FROM member
+INNER JOIN member_group
+ON member.group_id = member_group.group_id
+INNER JOIN member_subgroup
+ON member_group.group_id = member_subgroup.group_id
+LEFT OUTER JOIN region
+ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
+
+
+DROP TABLE member;
+DROP TABLE member_group;
+DROP TABLE member_subgroup;
+DROP TABLE region;


### PR DESCRIPTION
The function `generate_implied_quals` was inferring quals and trying
to push them down inside the non Nullable side of the LEFT OUTER JOIN
and that behavior was incorrect. This was bubbling up in the following
error while trying to set join references(`set_join_references`):
`ERROR: variable not found in subplan target lists (setrefs.c:2085)`

This commit check if it is an outer join and if so will not try to infer
any predicates

Signed-off-by: Joao Pereira <jdealmeidapereira@pivotal.io>