### PR TITLE
    Simplify direct dispatch related code

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -291,8 +291,6 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 			{
 				long		curIndex = index;
 				int			hashCode;
-				ListCell	*lc;
-				bool		found = false;
 
 				/* hash the attribute values */
 				cdbhashinit(h);
@@ -320,14 +318,7 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 
 				hashCode = cdbhashreduce(h);
 
-				foreach(lc, result.dd.contentIds)
-				{
-					if (hashCode == lfirst_int(lc))
-						found = true;
-				}
-
-				if (!found)
-					result.dd.contentIds = lappend_int(result.dd.contentIds, hashCode);
+				result.dd.contentIds = list_append_unique_int(result.dd.contentIds, hashCode);
 			}
 		}
 		else

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -50,6 +50,7 @@
 #include "utils/fmgroids.h"
 #include "utils/sharedsnapshot.h"
 #include "utils/snapmgr.h"
+#include "utils/memutils.h"
 
 extern bool Test_print_direct_dispatch_info;
 
@@ -131,7 +132,7 @@ static void dumpRMOnlyDtx(HTAB *htab, StringInfoData *buff);
 
 static bool doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 							 char *gid, DistributedTransactionId gxid,
-							 bool *badGangs, bool raiseError, CdbDispatchDirectDesc *direct,
+							 bool *badGangs, bool raiseError, List *twophaseSegments,
 							 char *serializedDtxContextInfo, int serializedDtxContextInfoLen);
 static void doPrepareTransaction(void);
 static void doInsertForgetCommitted(void);
@@ -374,59 +375,6 @@ notifyCommittedDtxTransaction(void)
 	doNotifyingCommitPrepared();
 }
 
-static inline void
-copyDirectDispatchFromTransaction(CdbDispatchDirectDesc *dOut)
-{
-	if (currentGxact->directTransaction)
-	{
-		dOut->directed_dispatch = true;
-		dOut->count = 1;
-		dOut->content[0] = currentGxact->directTransactionContentId;
-	}
-	else
-	{
-		dOut->directed_dispatch = false;
-	}
-}
-
-static bool
-GetRootNodeIsDirectDispatch(PlannedStmt *stmt)
-{
-	if (stmt == NULL)
-		return false;
-
-	if (stmt->planTree == NULL)
-		return false;
-
-	return stmt->planTree->directDispatch.isDirectDispatch;
-}
-
-/**
- * note that the ability to look at the root node of a plan in order to determine
- *    direct dispatch overall depends on the way we assign direct dispatch.  Parent slices are
- *    never more directed than child slices.  This could be fixed with an iteration over all slices and
- *    combine from every slice.
- *
- * return true IFF the directDispatch data stored in n should be applied to the transaction
- */
-static bool
-GetPlannedStmtDirectDispatch_AndUsingNodeIsSufficient(PlannedStmt *stmt)
-{
-	if (!GetRootNodeIsDirectDispatch(stmt))
-		return false;
-
-	/*
-	 * now look at number initplans .. we do something simple.  ANY initPlans
-	 * means we don't do directDispatch at the dtm level.  It's technically
-	 * possible that the initPlan and the node share the same direct dispatch
-	 * set but we don't bother right now.
-	 */
-	if (stmt->nInitPlans > 0)
-		return false;
-
-	return true;
-}
-
 /*
  * @param needsTwoPhaseCommit if true then marks the current Distributed Transaction as needing to use the
  *       2 phase commit protocol.
@@ -435,92 +383,8 @@ void
 dtmPreCommand(const char *debugCaller, const char *debugDetail, PlannedStmt *stmt,
 			  bool needsTwoPhaseCommit, bool wantSnapshot, bool inCursor)
 {
-	bool		needsPromotionFromDirectDispatch = false;
-	const bool	rootNodeIsDirectDispatch = GetRootNodeIsDirectDispatch(stmt);
-	const bool	nodeSaysDirectDispatch = GetPlannedStmtDirectDispatch_AndUsingNodeIsSufficient(stmt);
-
 	Assert(debugCaller != NULL);
 	Assert(debugDetail != NULL);
-
-	/**
-	 * update the information about what segments are participating in the transaction
-	 */
-	if (currentGxact == NULL)
-	{
-		/* no open transaction so don't do anything */
-	}
-	else if (currentGxact->state == DTX_STATE_ACTIVE_NOT_DISTRIBUTED)
-	{
-		/* Can we direct this transaction to a single content-id ? */
-		if (nodeSaysDirectDispatch)
-		{
-			currentGxact->directTransaction = true;
-			currentGxact->directTransactionContentId = linitial_int(stmt->planTree->directDispatch.contentIds);
-
-			elog(DTM_DEBUG5,
-				 "dtmPreCommand going distributed (to content %d) for gid = %s (%s, detail = '%s')",
-				 currentGxact->directTransactionContentId, currentGxact->gid, debugCaller, debugDetail);
-		}
-		else
-		{
-			currentGxact->directTransaction = false;
-
-			if (rootNodeIsDirectDispatch)
-			{
-				/*
-				 * implicit write on the root, but some initPlan was to all
-				 * contents...so send explicit start
-				 */
-				needsPromotionFromDirectDispatch = true;
-			}
-
-			elog(DTM_DEBUG5,
-				 "dtmPreCommand going distributed (all gangs) for gid = %s (%s, detail = '%s')",
-				 currentGxact->gid, debugCaller, debugDetail);
-		}
-	}
-	else if (currentGxact->state == DTX_STATE_ACTIVE_DISTRIBUTED)
-	{
-		bool		wasDirected = currentGxact->directTransaction;
-		int			wasPromotedFromDirectDispatchContentId = wasDirected ? currentGxact->directTransactionContentId : -1;
-
-		/* Can we still direct this transaction to a single content-id ? */
-		if (currentGxact->directTransaction)
-		{
-			currentGxact->directTransaction = false;
-			/* turn off, but may be restored below */
-
-			if (nodeSaysDirectDispatch)
-			{
-				int			contentId = linitial_int(stmt->planTree->directDispatch.contentIds);
-
-				if (contentId == currentGxact->directTransactionContentId)
-				{
-					/*
-					 * it was the same content!  Stay in a single direct
-					 * transaction
-					 */
-					currentGxact->directTransaction = true;
-				}
-			}
-		}
-
-		if (currentGxact->directTransaction)
-		{
-			/** was not actually promoted */
-			wasPromotedFromDirectDispatchContentId = -1;
-		}
-
-		if (wasPromotedFromDirectDispatchContentId != -1)
-			needsPromotionFromDirectDispatch = true;
-
-		elog(DTM_DEBUG5,
-			 "dtmPreCommand gid = %s is already distributed (%s, detail = '%s'), (was %s : now %s)",
-			 currentGxact->gid, debugCaller, debugDetail,
-			 wasDirected ? "directed" : "all gangs",
-			 currentGxact->directTransaction ? "directed" : "all gangs"
-			);
-	}
 
 	/**
 	 * If two-phase commit then begin transaction.
@@ -545,38 +409,6 @@ dtmPreCommand(const char *debugCaller, const char *debugDetail, PlannedStmt *stm
 				 DtxStateToString(currentGxact->state), debugCaller, debugDetail);
 		}
 	}
-
-	/**
-	 * If promotion from direct-dispatch to whole-cluster dispatch was done then tell about it.
-	 *
-	 * FUTURE: note that this is only needed if the query we are going to run would not itself
-	 *   do this (that is, if the query we are going to run is a read-only one)
-	 */
-	if (currentGxact &&
-		currentGxact->state == DTX_STATE_ACTIVE_DISTRIBUTED &&
-		needsPromotionFromDirectDispatch)
-	{
-		CdbDispatchDirectDesc direct = default_dispatch_direct_desc;
-		char	   *serializedDtxContextInfo;
-		int			serializedDtxContextInfoLen;
-		bool		badGangs,
-					succeeded;
-
-		serializedDtxContextInfo = qdSerializeDtxContextInfo(&serializedDtxContextInfoLen, wantSnapshot, inCursor,
-															 mppTxnOptions(true), "promoteTransactionIn_dtmPreCommand");
-
-		succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_STAY_AT_OR_BECOME_IMPLIED_WRITER, /* flags */ 0,
-												 currentGxact->gid, currentGxact->gxid,
-												 &badGangs, /* raiseError */ false, &direct,
-												 serializedDtxContextInfo, serializedDtxContextInfoLen);
-
-		/* send a DTM command to others to tell them about the transaction */
-		if (!succeeded)
-		{
-			ereport(ERROR, (errmsg("Global transaction upgrade from single segment to entire cluster failed for gid = \"%s\" due to error",
-								   currentGxact->gid)));
-		}
-	}
 }
 
 
@@ -588,7 +420,6 @@ dtmPreCommand(const char *debugCaller, const char *debugDetail, PlannedStmt *stm
 bool
 doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType)
 {
-	CdbDispatchDirectDesc direct = default_dispatch_direct_desc;
 	char	   *serializedDtxContextInfo = NULL;
 	int			serializedDtxContextInfoLen = 0;
 	bool		badGangs,
@@ -614,7 +445,8 @@ doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType)
 	succeeded = doDispatchDtxProtocolCommand(
 											 cmdType, /* flags */ 0,
 											 currentGxact->gid, currentGxact->gxid,
-											 &badGangs, /* raiseError */ true, &direct,
+											 &badGangs, /* raiseError */ true,
+											 cdbcomponent_getCdbComponentsList(),
 											 serializedDtxContextInfo, serializedDtxContextInfoLen);
 
 	/* send a DTM command to others to tell them about the transaction */
@@ -659,7 +491,6 @@ static void
 doPrepareTransaction(void)
 {
 	bool		succeeded;
-	CdbDispatchDirectDesc direct = default_dispatch_direct_desc;
 
 	CHECK_FOR_INTERRUPTS();
 
@@ -672,16 +503,16 @@ doPrepareTransaction(void)
 	 */
 	HOLD_INTERRUPTS();
 
-	copyDirectDispatchFromTransaction(&direct);
-
 	Assert(currentGxact->state == DTX_STATE_ACTIVE_DISTRIBUTED);
 	setCurrentGxactState(DTX_STATE_PREPARING);
 
 	elog(DTM_DEBUG5, "doPrepareTransaction moved to state = %s", DtxStateToString(currentGxact->state));
 
+	Assert(currentGxact->twophaseSegments != NIL);
 	succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_PREPARE, /* flags */ 0,
 											 currentGxact->gid, currentGxact->gxid,
-											 &currentGxact->badPrepareGangs, /* raiseError */ true, &direct, NULL, 0);
+											 &currentGxact->badPrepareGangs, /* raiseError */ true,
+											 currentGxact->twophaseSegments, NULL, 0);
 
 	/*
 	 * Now we've cleaned up our dispatched statement, cancels are allowed
@@ -778,11 +609,7 @@ doNotifyingCommitPrepared(void)
 	volatile int savedInterruptHoldoffCount;
 	MemoryContext oldcontext = CurrentMemoryContext;;
 
-	CdbDispatchDirectDesc direct = default_dispatch_direct_desc;
-
 	elog(DTM_DEBUG5, "doNotifyingCommitPrepared entering in state = %s", DtxStateToString(currentGxact->state));
-
-	copyDirectDispatchFromTransaction(&direct);
 
 	Assert(currentGxact->state == DTX_STATE_INSERTED_COMMITTED);
 	setCurrentGxactState(DTX_STATE_NOTIFYING_COMMIT_PREPARED);
@@ -794,12 +621,13 @@ doNotifyingCommitPrepared(void)
 	SIMPLE_FAULT_INJECTOR(DtmBroadcastCommitPrepared);
 	savedInterruptHoldoffCount = InterruptHoldoffCount;
 
+	Assert(currentGxact->twophaseSegments != NIL);
 	PG_TRY();
 	{
 		succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_COMMIT_PREPARED, /* flags */ 0,
 												 currentGxact->gid, currentGxact->gxid,
 												 &badGangs, /* raiseError */ true,
-												 &direct, NULL, 0);
+												 currentGxact->twophaseSegments, NULL, 0);
 	}
 	PG_CATCH();
 	{
@@ -849,7 +677,7 @@ doNotifyingCommitPrepared(void)
 													 DTX_PROTOCOL_COMMAND_RETRY_COMMIT_PREPARED, /* flags */ 0,
 													 currentGxact->gid, currentGxact->gxid,
 													 &badGangs, /* raiseError */ true,
-													 &direct, NULL, 0);
+													 currentGxact->twophaseSegments, NULL, 0);
 		}
 		PG_CATCH();
 		{
@@ -885,8 +713,6 @@ retryAbortPrepared(void)
 	volatile int savedInterruptHoldoffCount;
 	MemoryContext oldcontext = CurrentMemoryContext;;
 
-	CdbDispatchDirectDesc direct = default_dispatch_direct_desc;
-
 	while (!succeeded && dtx_phase2_retry_count > retry++)
 	{
 		/*
@@ -912,7 +738,7 @@ retryAbortPrepared(void)
 													 DTX_PROTOCOL_COMMAND_RETRY_ABORT_PREPARED, /* flags */ 0,
 													 currentGxact->gid, currentGxact->gxid,
 													 &badGangs, /* raiseError */ true,
-													 &direct, NULL, 0);
+													 cdbcomponent_getCdbComponentsList(), NULL, 0);
 			if (!succeeded)
 				elog(WARNING, "the distributed transaction 'Abort' broadcast "
 					 "failed to one or more segments for gid = %s.  "
@@ -947,24 +773,25 @@ doNotifyingAbort(void)
 	volatile int savedInterruptHoldoffCount;
 	MemoryContext oldcontext = CurrentMemoryContext;
 
-	CdbDispatchDirectDesc direct = default_dispatch_direct_desc;
-
 	elog(DTM_DEBUG5, "doNotifyingAborted entering in state = %s", DtxStateToString(currentGxact->state));
 
 	Assert(currentGxact->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED ||
 		   currentGxact->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
 		   currentGxact->state == DTX_STATE_NOTIFYING_ABORT_PREPARED);
 
-	copyDirectDispatchFromTransaction(&direct);
-
 	if (currentGxact->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED)
 	{
-		if (!currentGxact->writerGangLost)
+		/*
+		 * In some cases, dtmPreCommand said two phase commit is needed, but some errors
+		 * occur before the command is actually dispatched, no need to dispatch DTX for
+		 * such cases.
+		 */ 
+		if (!currentGxact->writerGangLost && currentGxact->twophaseSegments)
 		{
 			succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED, /* flags */ 0,
 													 currentGxact->gid, currentGxact->gxid,
 													 &badGangs, /* raiseError */ false,
-													 &direct, NULL, 0);
+													 currentGxact->twophaseSegments, NULL, 0);
 			if (!succeeded)
 			{
 				elog(WARNING, "The distributed transaction 'Abort' broadcast failed to one or more segments for gid = %s.",
@@ -1024,7 +851,7 @@ doNotifyingAbort(void)
 			succeeded = doDispatchDtxProtocolCommand(dtxProtocolCommand, /* flags */ 0,
 													 currentGxact->gid, currentGxact->gxid,
 													 &badGangs, /* raiseError */ true,
-													 &direct, NULL, 0);
+													 currentGxact->twophaseSegments, NULL, 0);
 		}
 		PG_CATCH();
 		{
@@ -1065,13 +892,11 @@ doNotifyCommittedInDoubt(char *gid)
 	bool		succeeded;
 	bool		badGangs;
 
-	CdbDispatchDirectDesc direct = default_dispatch_direct_desc;
-
 	/* UNDONE: Pass real gxid instead of InvalidDistributedTransactionId. */
 	succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_RECOVERY_COMMIT_PREPARED, /* flags */ 0,
 											 gid, InvalidDistributedTransactionId,
 											 &badGangs, /* raiseError */ false,
-											 &direct, NULL, 0);
+											 cdbcomponent_getCdbComponentsList(), NULL, 0);
 	if (!succeeded)
 	{
 		elog(FATAL, "Crash recovery broadcast of the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = %s.", gid);
@@ -1090,13 +915,11 @@ doAbortInDoubt(char *gid)
 	bool		succeeded;
 	bool		badGangs;
 
-	CdbDispatchDirectDesc direct = default_dispatch_direct_desc;
-
 	/* UNDONE: Pass real gxid instead of InvalidDistributedTransactionId. */
 	succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_RECOVERY_ABORT_PREPARED, /* flags */ 0,
 											 gid, InvalidDistributedTransactionId,
 											 &badGangs, /* raiseError */ false,
-											 &direct, NULL, 0);
+											 cdbcomponent_getCdbComponentsList(), NULL, 0);
 	if (!succeeded)
 	{
 		elog(FATAL, "Crash recovery retry of the distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid = %s.  System will retry again later", gid);
@@ -1965,7 +1788,7 @@ static bool
 doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 							 char *gid, DistributedTransactionId gxid,
 							 bool *badGangs, bool raiseError,
-							 CdbDispatchDirectDesc *direct,
+							 List *twophaseSegments,
 							 char *serializedDtxContextInfo,
 							 int serializedDtxContextInfoLen)
 {
@@ -1977,11 +1800,13 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 
 	struct pg_result **results = NULL;
 
+	Assert(twophaseSegments != NIL);
+
 	dtxProtocolCommandStr = DtxProtocolCommandToString(dtxProtocolCommand);
 
 	if (Test_print_direct_dispatch_info)
 	{
-		if (direct->directed_dispatch)
+		if (list_length(twophaseSegments) == 1)
 			elog(INFO, "Distributed transaction command '%s' to SINGLE content", dtxProtocolCommandStr);
 		else
 			elog(INFO, "Distributed transaction command '%s' to ALL contents", dtxProtocolCommandStr);
@@ -1989,13 +1814,13 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 	elog(DTM_DEBUG5,
 		 "dispatchDtxProtocolCommand: %d ('%s'), direct content #: %d",
 		 dtxProtocolCommand, dtxProtocolCommandStr,
-		 direct->directed_dispatch ? direct->content[0] : -1);
+		 list_length(twophaseSegments) ? linitial_int(twophaseSegments) : -1);
 
 	ErrorData *qeError;
 	results = CdbDispatchDtxProtocolCommand(dtxProtocolCommand, flags,
 											dtxProtocolCommandStr,
 											gid, gxid,
-											&qeError, &resultCount, badGangs, direct,
+											&qeError, &resultCount, badGangs, twophaseSegments,
 											serializedDtxContextInfo, serializedDtxContextInfoLen);
 
 	if (qeError)
@@ -2146,9 +1971,9 @@ initGxact(TMGXACT *gxact)
 
 	gxact->badPrepareGangs = false;
 
-	gxact->directTransaction = false;
-	gxact->directTransactionContentId = 0;
 	gxact->writerGangLost = false;
+	gxact->twophaseSegmentsMap = NULL;
+	gxact->twophaseSegments = NIL;
 }
 
 bool
@@ -3383,4 +3208,42 @@ bool
 currentGxactWriterGangLost(void)
 {
 	return currentGxact == NULL ? false : currentGxact->writerGangLost;
+}
+
+/*
+ * Record which segment involved in the two phase commit.
+ */
+void
+addToGxactTwophaseSegments(Gang *gang)
+{
+	SegmentDatabaseDescriptor *segdbDesc;
+	MemoryContext oldContext;
+	int segindex;
+	int i;
+
+	if (currentGxact && currentGxact->state == DTX_STATE_ACTIVE_DISTRIBUTED)
+	{
+		oldContext = MemoryContextSwitchTo(TopTransactionContext);
+		for (i = 0; i < gang->size; i++)
+		{
+			segdbDesc = gang->db_descriptors[i];
+			Assert(segdbDesc);
+			segindex = segdbDesc->segindex;
+
+			/* entry db is just a reader, will not involve in two phase commit */
+			if (segindex == -1)
+				continue;
+
+			/* skip if record already */
+			if (bms_is_member(segindex, currentGxact->twophaseSegmentsMap))
+				continue;
+
+			currentGxact->twophaseSegmentsMap =
+					bms_add_member(currentGxact->twophaseSegmentsMap, segindex);
+
+			currentGxact->twophaseSegments =
+					lappend_int(currentGxact->twophaseSegments, segindex);
+		}
+		MemoryContextSwitchTo(oldContext);
+	}
 }

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1805,14 +1805,10 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 	dtxProtocolCommandStr = DtxProtocolCommandToString(dtxProtocolCommand);
 
 	if (Test_print_direct_dispatch_info)
-	{
-		if (list_length(twophaseSegments) == 1)
-			elog(INFO, "Distributed transaction command '%s' to SINGLE content", dtxProtocolCommandStr);
-		else if (list_length(twophaseSegments) < getgpsegmentCount())
-			elog(INFO, "Distributed transaction command '%s' to PARTIAL contents", dtxProtocolCommandStr);
-		else
-			elog(INFO, "Distributed transaction command '%s' to ALL contents", dtxProtocolCommandStr);
-	}
+		elog(INFO, "Distributed transaction command '%s' to %s",
+			 								dtxProtocolCommandStr,
+											segmentsToContentStr(twophaseSegments));
+
 	elog(DTM_DEBUG5,
 		 "dispatchDtxProtocolCommand: %d ('%s'), direct content #: %d",
 		 dtxProtocolCommand, dtxProtocolCommandStr,

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1808,6 +1808,8 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 	{
 		if (list_length(twophaseSegments) == 1)
 			elog(INFO, "Distributed transaction command '%s' to SINGLE content", dtxProtocolCommandStr);
+		else if (list_length(twophaseSegments) < getgpsegmentCount())
+			elog(INFO, "Distributed transaction command '%s' to PARTIAL contents", dtxProtocolCommandStr);
 		else
 			elog(INFO, "Distributed transaction command '%s' to ALL contents", dtxProtocolCommandStr);
 	}

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -96,6 +96,12 @@ cdbdisp_dispatchToGang(struct CdbDispatcherState *ds,
 	Assert(dispatchResults && dispatchResults->resultArray);
 
 	(pDispatchFuncs->dispatchToGang) (ds, gp, sliceIndex);
+
+	/*
+	 * If dtmPreCommand says we need two phase commit, record those segments
+	 * who actually get involved in current global transaction
+	 */
+	addToGxactTwophaseSegments(gp);
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -587,3 +587,17 @@ cdbdisp_markNamedPortalGangsDestroyed(void)
 		head = head->next;
 	}
 }
+
+char*
+segmentsToContentStr(List *segments)
+{
+	int size = list_length(segments);
+	if (size == 0)
+		return "ALL contents";
+	else if (size == 1)
+		return "SINGLE content";
+	else if (size < getgpsegmentCount())
+		return "PARTIAL contents";
+	else
+		return "ALL contents";
+}

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -75,7 +75,7 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 							  ErrorData **qeError,
 							  int *numresults,
 							  bool *badGangs,
-							  CdbDispatchDirectDesc *direct,
+							  List *twophaseSegments,
 							  char *serializedDtxContextInfo,
 							  int serializedDtxContextInfoLen)
 {
@@ -88,11 +88,6 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	char	   *queryText = NULL;
 	int			queryTextLen = 0;
 	List		*segments;
-
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "CdbDispatchDtxProtocolCommand: %s for gid = %s, direct content #: %d",
-		 dtxProtocolCommandLoggingStr, gid,
-		 direct->directed_dispatch ? direct->content[0] : -1);
 
 	*badGangs = false;
 	*qeError = NULL;
@@ -109,10 +104,6 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	dtxProtocolParms.serializedDtxContextInfo = serializedDtxContextInfo;
 	dtxProtocolParms.serializedDtxContextInfoLen = serializedDtxContextInfoLen;
 
-	/* decide segments to dispatch */
-	segments = direct->directed_dispatch ?
-				list_make1_int(direct->content[0]) : cdbcomponent_getCdbComponentsList();
-
 	/*
 	 * Dispatch the command.
 	 */
@@ -120,7 +111,7 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 
 	queryText = buildGpDtxProtocolCommand(&dtxProtocolParms, &queryTextLen);
 
-	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, segments);
+	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, twophaseSegments);
 
 	Assert(primaryGang);
 

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -87,7 +87,6 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	Gang	   *primaryGang;
 	char	   *queryText = NULL;
 	int			queryTextLen = 0;
-	List		*segments;
 
 	*badGangs = false;
 	*qeError = NULL;

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1121,25 +1121,10 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		primaryGang = slice->primaryGang;
 		Assert(primaryGang != NULL);
 
-		if (slice->directDispatch.isDirectDispatch)
-		{
-			if (Test_print_direct_dispatch_info)
-			{
-				if (list_length(slice->directDispatch.contentIds) == 1)
-					elog(INFO, "Dispatch command to SINGLE content");
-				else if (list_length(slice->directDispatch.contentIds) < getgpsegmentCount())
-					elog(INFO, "Dispatch command to SINGLE content");
-				else
-					elog(INFO, "Dispatch command to SINGLE content");
-			}
-		}
-		else
-		{
-			if (Test_print_direct_dispatch_info)
-			{
-				elog(INFO, "Dispatch command to ALL contents");
-			}
-		}
+		if (Test_print_direct_dispatch_info)
+			elog(INFO, "Dispatch command to %s",
+				 		segmentsToContentStr(slice->directDispatch.isDirectDispatch ?
+											slice->directDispatch.contentIds : NULL));
 
 		/*
 		 * Bail out if already got an error or cancellation request.

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1125,7 +1125,12 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		{
 			if (Test_print_direct_dispatch_info)
 			{
-				elog(INFO, "Dispatch command to SINGLE content");
+				if (list_length(slice->directDispatch.contentIds) == 1)
+					elog(INFO, "Dispatch command to SINGLE content");
+				else if (list_length(slice->directDispatch.contentIds) < getgpsegmentCount())
+					elog(INFO, "Dispatch command to SINGLE content");
+				else
+					elog(INFO, "Dispatch command to SINGLE content");
 			}
 		}
 		else

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -893,7 +893,6 @@ show_dispatch_info(Slice *slice, ExplainState *es, Plan *plan)
 		{
 			if (slice->directDispatch.isDirectDispatch)
 			{
-				Assert(list_length(slice->directDispatch.contentIds) == 1);
 				segments = list_length(slice->directDispatch.contentIds);
 			}
 			else if (es->pstmt->planGen == PLANGEN_PLANNER)
@@ -1442,7 +1441,6 @@ ExplainNode(PlanState *planstate, List *ancestors,
 					if (slice->directDispatch.isDirectDispatch)
 					{
 						/* Special handling on direct dispatch */
-						Assert(list_length(slice->directDispatch.contentIds) == 1);
 						motion_snd = list_length(slice->directDispatch.contentIds);
 					}
 					else if (plan->lefttree->flow->flotype == FLOW_SINGLETON)

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -183,4 +183,8 @@ void cdbdisp_cleanupDispatcherHandle(const struct ResourceOwnerData * owner);
 void AtAbort_DispatcherState(void);
 
 void AtSubAbort_DispatcherState(void);
+
+char *
+segmentsToContentStr(List *segments);
+
 #endif   /* CDBDISP_H */

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -45,9 +45,6 @@ typedef struct CdbDispatchDirectDesc
 	uint16 content[1];
 } CdbDispatchDirectDesc;
 
-extern CdbDispatchDirectDesc default_dispatch_direct_desc;
-#define DEFAULT_DISP_DIRECT (&default_dispatch_direct_desc)
-
 typedef struct CdbDispatcherState
 {
 	bool isExtendedQuery;

--- a/src/include/cdb/cdbdisp_dtx.h
+++ b/src/include/cdb/cdbdisp_dtx.h
@@ -41,7 +41,7 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 							  ErrorData **qeError,
 							  int *resultCount,
 							  bool* badGangs,
-							  CdbDispatchDirectDesc *direct,
+							  List *twophaseSegments,
 							  char *argument, int argumentLength );
 
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -232,10 +232,10 @@ typedef struct TMGXACT
 
 	bool						badPrepareGangs;
 
-	bool						directTransaction;
-	uint16						directTransactionContentId;
 	bool						writerGangLost;
 
+	Bitmapset					*twophaseSegmentsMap;
+	List						*twophaseSegments;
 }	TMGXACT;
 
 typedef struct TMGXACTSTATUS
@@ -351,5 +351,7 @@ extern bool doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType);
 extern void markCurrentGxactWriterGangLost(void);
 
 extern bool currentGxactWriterGangLost(void);
+
+extern void addToGxactTwophaseSegments(struct Gang* gp);
 
 #endif   /* CDBTM_H */

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -121,7 +121,7 @@ INFO:  Dispatch command to ALL contents
 
 -- projections and disjunction
 select b from dd_singlecol_1 where a=1 or a=2;
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  b 
 ---
  1
@@ -154,7 +154,7 @@ INFO:  Dispatch command to ALL contents
 (2 rows)
 
 select * from dd_singlecol_1 where (a,b) in ((1,2),(2,3)); 
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b 
 ---+---
 (0 rows)
@@ -189,7 +189,7 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- disjunction with partitioned tables
 select * from dd_part_singlecol where a in (1,3,5);
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b  | c  
 ---+----+----
  3 |  6 |  9
@@ -198,7 +198,7 @@ INFO:  Dispatch command to ALL contents
 (3 rows)
 
 select * from dd_part_singlecol where a=1 or a=3 or a=5;
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b  | c  
 ---+----+----
  1 |  2 |  3
@@ -350,21 +350,21 @@ INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=1217208"
 -- disjunction with index scans
 select * from dd_singlecol_idx where (a=1 or a=2) and b<2;
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b | c 
 ---+---+---
  1 | 1 | 1
 (1 row)
 
 select 'one' from dd_singlecol_idx where (a=1 or a=2) and b=1;
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  ?column? 
 ----------
  one
 (1 row)
 
 select a, count(*) from dd_singlecol_idx where (a=1 or a=2) and b=1  group by a;
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | count 
 ---+-------
  1 |     1
@@ -407,21 +407,21 @@ INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=1217242"
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b<2;
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b | c 
 ---+---+---
  1 | 1 | 1
 (1 row)
 
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b=2 and c=2;
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b | c 
 ---+---+---
  2 | 2 | 2
 (1 row)
 
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and (b=2 or c=2);
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b | c 
 ---+---+---
  2 | 2 | 2
@@ -660,7 +660,7 @@ INFO:  Dispatch command to SINGLE content
 (1 row)
 
 select * from dd_multicol_idx where (a=1 or a=2) and (b=1 or b=5) and c=1;
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b | c 
 ---+---+---
  1 | 1 | 1

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -94,7 +94,7 @@ INFO:  Dispatch command to ALL contents
 
 -- single column distr key
 select * from dd_singlecol_1 where a in (1,3,5);
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to PARTIAL contents
  a | b 
 ---+---
  1 | 1
@@ -103,7 +103,7 @@ INFO:  Dispatch command to ALL contents
 (3 rows)
 
 select * from dd_singlecol_1 where a=1 or a=3 or a=5;
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to PARTIAL contents
  a | b 
 ---+---
  3 | 3
@@ -121,7 +121,7 @@ INFO:  Dispatch command to ALL contents
 
 -- projections and disjunction
 select b from dd_singlecol_1 where a=1 or a=2;
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  b 
 ---
  1
@@ -154,7 +154,7 @@ INFO:  Dispatch command to ALL contents
 (2 rows)
 
 select * from dd_singlecol_1 where (a,b) in ((1,2),(2,3)); 
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b 
 ---+---
 (0 rows)
@@ -189,7 +189,7 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- disjunction with partitioned tables
 select * from dd_part_singlecol where a in (1,3,5);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b  | c  
 ---+----+----
  3 |  6 |  9
@@ -198,7 +198,7 @@ INFO:  Dispatch command to SINGLE content
 (3 rows)
 
 select * from dd_part_singlecol where a=1 or a=3 or a=5;
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b  | c  
 ---+----+----
  1 |  2 |  3
@@ -350,21 +350,21 @@ INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=1217208"
 -- disjunction with index scans
 select * from dd_singlecol_idx where (a=1 or a=2) and b<2;
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b | c 
 ---+---+---
  1 | 1 | 1
 (1 row)
 
 select 'one' from dd_singlecol_idx where (a=1 or a=2) and b=1;
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  ?column? 
 ----------
  one
 (1 row)
 
 select a, count(*) from dd_singlecol_idx where (a=1 or a=2) and b=1  group by a;
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | count 
 ---+-------
  1 |     1
@@ -407,21 +407,21 @@ INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=1217242"
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b<2;
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b | c 
 ---+---+---
  1 | 1 | 1
 (1 row)
 
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b=2 and c=2;
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b | c 
 ---+---+---
  2 | 2 | 2
 (1 row)
 
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and (b=2 or c=2);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b | c 
 ---+---+---
  2 | 2 | 2
@@ -660,7 +660,7 @@ INFO:  Dispatch command to SINGLE content
 (1 row)
 
 select * from dd_multicol_idx where (a=1 or a=2) and (b=1 or b=5) and c=1;
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b | c 
 ---+---+---
  1 | 1 | 1

--- a/src/test/regress/expected/bfv_dd_multicolumn.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn.out
@@ -54,7 +54,7 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- negative cases: composite distr key
 select * from dd_multicol_1 where a in (1,3) and b in (1,3);
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b 
 ---+---
  3 | 1
@@ -69,14 +69,14 @@ INFO:  Dispatch command to SINGLE content
 (1 row)
 
 select * from dd_multicol_1 where (a=1 and b=1) or (a=3 and b=3);
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b 
 ---+---
  1 | 1
 (1 row)
 
 select * from dd_multicol_1 where (a=1 or a=3) and (b=1 or b=3);
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b 
 ---+---
  1 | 1
@@ -100,14 +100,14 @@ INFO:  Dispatch command to ALL contents
 (0 rows)
 
 select * from dd_multicol_1 where (a,b) in ((1,2),(3,4)); 
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b 
 ---+---
 (0 rows)
 
 -- negative cases: composite distr key: projections 
 select b from dd_multicol_1 where (a=1 or a=3) and (b=1 or b=3);
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  b 
 ---
  1

--- a/src/test/regress/expected/bfv_dd_multicolumn.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn.out
@@ -54,7 +54,7 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- negative cases: composite distr key
 select * from dd_multicol_1 where a in (1,3) and b in (1,3);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b 
 ---+---
  3 | 1
@@ -69,14 +69,14 @@ INFO:  Dispatch command to SINGLE content
 (1 row)
 
 select * from dd_multicol_1 where (a=1 and b=1) or (a=3 and b=3);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b 
 ---+---
  1 | 1
 (1 row)
 
 select * from dd_multicol_1 where (a=1 or a=3) and (b=1 or b=3);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b 
 ---+---
  1 | 1
@@ -100,14 +100,14 @@ INFO:  Dispatch command to ALL contents
 (0 rows)
 
 select * from dd_multicol_1 where (a,b) in ((1,2),(3,4)); 
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  a | b 
 ---+---
 (0 rows)
 
 -- negative cases: composite distr key: projections 
 select b from dd_multicol_1 where (a=1 or a=3) and (b=1 or b=3);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
  b 
 ---
  1

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -3044,7 +3044,7 @@ WHERE unique1 IN (1,42,7)
 ORDER BY unique1;
                          QUERY PLAN                          
 -------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 2:1  (slice1; segments: 2)
    Merge Key: unique1
    ->  Index Only Scan using tenk1_unique1 on tenk1
          Index Cond: (unique1 = ANY ('{1,42,7}'::integer[]))

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -3065,7 +3065,7 @@ WHERE unique1 IN (1,42,7)
 ORDER BY unique1;
                          QUERY PLAN                          
 -------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 2:1  (slice1; segments: 2)
    Merge Key: unique1
    ->  Index Only Scan using tenk1_unique1 on tenk1
          Index Cond: (unique1 = ANY ('{1,42,7}'::integer[]))

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -400,14 +400,12 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 -- Known_opt_diff: MPP-21346
 delete from direct_dispatch_foo where id * id = (select max(id2) from direct_dispatch_bar where id1 = 5) AND id = 3;
-INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
 INFO:  Dispatch command to SINGLE content
 INFO:  Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- Known_opt_diff: MPP-21346
 delete from direct_dispatch_foo where id * id = (select max(id2) from direct_dispatch_bar) AND id = 3;
-INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
 INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -218,19 +218,19 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 --                hash all these values to the same content! (and so test would change)
 --
 update direct_test set value = 'pig' where key in (1,2,3,4,5);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to ALL contents
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 update direct_test_two_column set value = 'pig' where key1 = 100 and key2 in (1,2,3,4);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
 INFO:  Distributed transaction command 'Distributed Prepare' to PARTIAL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to PARTIAL contents
 update direct_test_two_column set value = 'pig' where key1 in (100,101,102,103,104) and key2 in (1);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
 INFO:  Distributed transaction command 'Distributed Prepare' to PARTIAL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to PARTIAL contents
 update direct_test_two_column set value = 'pig' where key1 in (100,101) and key2 in (1,2);
-INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to PARTIAL contents
 INFO:  Distributed transaction command 'Distributed Prepare' to PARTIAL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to PARTIAL contents
 -- Multiple row update, where clause lists values which all hash to same segment

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -218,21 +218,21 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 --                hash all these values to the same content! (and so test would change)
 --
 update direct_test set value = 'pig' where key in (1,2,3,4,5);
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 update direct_test_two_column set value = 'pig' where key1 = 100 and key2 in (1,2,3,4);
-INFO:  Dispatch command to ALL contents
-INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to PARTIAL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to PARTIAL contents
 update direct_test_two_column set value = 'pig' where key1 in (100,101,102,103,104) and key2 in (1);
-INFO:  Dispatch command to ALL contents
-INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to PARTIAL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to PARTIAL contents
 update direct_test_two_column set value = 'pig' where key1 in (100,101) and key2 in (1,2);
-INFO:  Dispatch command to ALL contents
-INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to PARTIAL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to PARTIAL contents
 -- Multiple row update, where clause lists values which all hash to same segment
 -- DO direct dispatch
 -- CAN'T IMPLEMENT THIS TEST BECAUSE THE # of segments changes again (unless we use a # of segments function, and exploit the simple nature of int4 hashing -- can we do that?)
@@ -391,6 +391,12 @@ INFO:  Dispatch command to SINGLE content
   1
 (1 row)
 
+-- main plan is direct dispatch and also has init plans
+update direct_dispatch_bar set id2 = 1 where id1 = 1 and exists (select * from direct_dispatch_foo where id = 2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to PARTIAL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to PARTIAL contents
 -- init plan to see how transaction escalation happens
 -- Known_opt_diff: MPP-21346
 delete from direct_dispatch_foo where id = (select max(id2) from direct_dispatch_bar where id1 = 5);
@@ -402,8 +408,8 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 delete from direct_dispatch_foo where id * id = (select max(id2) from direct_dispatch_bar where id1 = 5) AND id = 3;
 INFO:  Dispatch command to SINGLE content
 INFO:  Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to PARTIAL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to PARTIAL contents
 -- Known_opt_diff: MPP-21346
 delete from direct_dispatch_foo where id * id = (select max(id2) from direct_dispatch_bar) AND id = 3;
 INFO:  Dispatch command to ALL contents

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -390,6 +390,13 @@ INFO:  Dispatch command to SINGLE content
   1
 (1 row)
 
+-- main plan is direct dispatch and also has init plans
+update direct_dispatch_bar set id2 = 1 where id1 = 1 and exists (select * from direct_dispatch_foo where id = 2);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 -- init plan to see how transaction escalation happens
 -- Known_opt_diff: MPP-21346
 delete from direct_dispatch_foo where id = (select max(id2) from direct_dispatch_bar where id1 = 5);

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3732,7 +3732,7 @@ SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.
 EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1.05..3.12 rows=4 width=24)
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=1.05..3.12 rows=4 width=24)
    ->  Hash Join  (cost=1.05..3.12 rows=2 width=24)
          Hash Cond: qp_non_eq_a.i = qp_non_eq_b.i
          ->  Seq Scan on qp_non_eq_a  (cost=0.00..2.03 rows=1 width=12)
@@ -3741,7 +3741,7 @@ EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b
                ->  Seq Scan on qp_non_eq_b  (cost=0.00..1.03 rows=1 width=12)
                      Filter: i = ANY ('{1,2,3}'::integer[])
  Optimizer: legacy query optimizer
-(9 rows)
+(10 rows)
 
 SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
  i | f | i | f  

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -202,6 +202,9 @@ SELECT * from direct_dispatch_foo WHERE id * id = 1;
 SELECT * from direct_dispatch_foo WHERE id * id = 1 OR id = 1;
 SELECT * from direct_dispatch_foo where id * id = 1 AND id = 1;
 
+-- main plan is direct dispatch and also has init plans
+update direct_dispatch_bar set id2 = 1 where id1 = 1 and exists (select * from direct_dispatch_foo where id = 2);
+
 -- init plan to see how transaction escalation happens
 -- Known_opt_diff: MPP-21346
 delete from direct_dispatch_foo where id = (select max(id2) from direct_dispatch_bar where id1 = 5);


### PR DESCRIPTION
    This commit include two parts:
    * simplify direct-dispatch dispatching code
    * simplify direct-dispatch DTM related code

    Previously, cdbdisp_dispatchToGang need a CdbDispatchDirectDesc info,
    now gang only contain inuse segments, so direct-dispatch info is useless.

    Another thing is, we need to decide if DTM is available for direct-dispatch
    within dtmPreCommand, the logic is complex, you need to know if the main plan
    is direct-dispatch and if the init plan contain direct-dispatch.

    one example is:
    "update foo set foo.c2 = 2
    where foo.c1 = 1 and exists (select * from bar where bar.c1=4)"

    main plan can be direct dispatched to segment 1, init plan can be direct
    dispatched to segment 2, with the old logic, the DTM like PREPARE need to
    dispatched to all segments, so dtmPreCommand need to dispatch a DTM named
    'DTX_PROTOCOL_COMMAND_STAY_AT_OR_BECOME_IMPLIED' to all segment so those
    segments like segment 3 who didn't receive the plan can be ready for two
    phase commit.

    With the new gang API, we can simplify this process, we add a list in
    currentGxact to record which segments are actually get involved in a two
    phase commit, then we can dispatch DTM to them directly. This is also very
    usefully for queries on tables that are not fully expaneded yet.