### PR TITLE
drop isolation2test in pg_upgrade test due to interaction with partition indexes

### DIFF
--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -3,6 +3,10 @@
 -- exist at the time of running upgrades. If objects are to be manipulated
 -- in other databases, make sure to change to the correct database first.
 
+--should not need to drop isolation2test but interactions with
+--partition tables with indexes requires dropping for now
+DROP DATABASE IF EXISTS isolation2test;
+
 \c regression;
 
 -- Greenplum pg_upgrade doesn't support indexes on partitions since they can't


### PR DESCRIPTION
revert 399a05cd52444908e71db1bf6028a98bc24cf076 for partition indices