### PR TITLE
keep isolation2test for pg_upgrade testing but drop partition indexes

### DIFF
--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -3,48 +3,13 @@
 -- exist at the time of running upgrades. If objects are to be manipulated
 -- in other databases, make sure to change to the correct database first.
 
---should not need to drop isolation2test but interactions with
 --partition tables with indexes requires dropping for now
-DROP DATABASE IF EXISTS isolation2test;
+--NOTE: 'isolation2test' and 'regression' database must already exist
+\c isolation2test;
+\i test_gpdb_pre_drop_partition_indices.sql;
 
 \c regression;
-
--- Greenplum pg_upgrade doesn't support indexes on partitions since they can't
--- be reliably dump/restored in all situations. Drop all such indexes before
--- attempting the upgrade.
-CREATE OR REPLACE FUNCTION drop_indexes() RETURNS void AS $$
-DECLARE
-       part_indexes RECORD;
-BEGIN
-       FOR part_indexes IN
-       WITH partitions AS (
-           SELECT DISTINCT n.nspname,
-                  c.relname
-           FROM pg_catalog.pg_partition p
-                JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid)
-                JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
-           UNION
-           SELECT n.nspname,
-                  partitiontablename AS relname
-           FROM pg_catalog.pg_partitions p
-                JOIN pg_catalog.pg_class c ON (p.partitiontablename = c.relname)
-                JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
-       )
-       SELECT nspname,
-              relname,
-              indexname
-       FROM partitions
-            JOIN pg_catalog.pg_indexes ON (relname = tablename
-                                                                               AND nspname = schemaname)
-       LOOP
-               EXECUTE 'DROP INDEX IF EXISTS ' || quote_ident(part_indexes.nspname) || '.' || quote_ident(part_indexes.indexname);
-       END LOOP;
-       RETURN;
-END;
-$$ LANGUAGE plpgsql;
-
-SELECT drop_indexes();
-DROP FUNCTION drop_indexes();
+\i test_gpdb_pre_drop_partition_indices.sql;
 
 -- We currently have a bug where a heap partition that is exchanged out of the
 -- partition hierarchy is not given an array type. When this table is restored

--- a/contrib/pg_upgrade/test_gpdb_pre_drop_partition_indices.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre_drop_partition_indices.sql
@@ -1,0 +1,37 @@
+-- Greenplum pg_upgrade doesn't support indexes on partitions since they can't
+-- be reliably dump/restored in all situations. Drop all such indexes before
+-- attempting the upgrade.
+CREATE OR REPLACE FUNCTION drop_indexes() RETURNS void AS $$
+DECLARE
+       part_indexes RECORD;
+BEGIN
+       FOR part_indexes IN
+       WITH partitions AS (
+           SELECT DISTINCT n.nspname,
+                  c.relname
+           FROM pg_catalog.pg_partition p
+                JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid)
+                JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+           UNION
+           SELECT n.nspname,
+                  partitiontablename AS relname
+           FROM pg_catalog.pg_partitions p
+                JOIN pg_catalog.pg_class c ON (p.partitiontablename = c.relname)
+                JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+       )
+       SELECT nspname,
+              relname,
+              indexname
+       FROM partitions
+            JOIN pg_catalog.pg_indexes ON (relname = tablename
+                                                                               AND nspname = schemaname)
+       LOOP
+               EXECUTE 'DROP INDEX IF EXISTS ' || quote_ident(part_indexes.nspname) || '.' || quote_ident(part_indexes.indexname);
+       END LOOP;
+       RETURN;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT drop_indexes();
+DROP FUNCTION drop_indexes();
+


### PR DESCRIPTION
We also drop partition tables with indices for isolation2test, since pg_upgrade currently does not handle them.