### PR TITLE
 Refactor and rename fts_statusVersion used by dispatcher 

### DIFF
--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -79,7 +79,7 @@ FtsShmemInit(void)
 		shared->ControlLock = LWLockAssign();
 		ftsControlLock = shared->ControlLock;
 
-		shared->fts_probe_info.fts_statusVersion = 0;
+		shared->fts_probe_info.segment_failover_occurrence = 0;
 	}
 }
 
@@ -156,5 +156,5 @@ FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor **segdbDesc, int size)
 uint8
 getFtsVersion(void)
 {
-	return ftsProbeInfo->fts_statusVersion;
+	return ftsProbeInfo->segment_failover_occurrence;
 }

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -154,7 +154,7 @@ FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor **segdbDesc, int size)
 }
 
 uint8
-getFtsVersion(void)
+getFtsSegmentFailoverOccurrence(void)
 {
 	return ftsProbeInfo->segment_failover_occurrence;
 }

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -538,7 +538,7 @@ cdbcomponent_cleanupIdleQEs(bool includeWriter)
 void
 cdbcomponent_updateCdbComponents(void)
 {
-	uint8 ftsVersion= getFtsVersion();
+	uint8 ftsSegmentFailoverOccurrence = getFtsSegmentFailoverOccurrence();
 	int expandVersion = GetGpExpandVersion();
 
 	PG_TRY();
@@ -546,10 +546,10 @@ cdbcomponent_updateCdbComponents(void)
 		if (cdb_component_dbs == NULL)
 		{
 			cdb_component_dbs = getCdbComponentInfo(true);
-			cdb_component_dbs->fts_version = ftsVersion;
+			cdb_component_dbs->fts_segment_failover_occurrence = ftsSegmentFailoverOccurrence;
 			cdb_component_dbs->expand_version = GetGpExpandVersion();
 		}
-		else if ((cdb_component_dbs->fts_version != ftsVersion ||
+		else if ((cdb_component_dbs->fts_segment_failover_occurrence != ftsSegmentFailoverOccurrence ||
 				 cdb_component_dbs->expand_version != expandVersion))
 		{
 			if (TempNamespaceOidIsValid())
@@ -564,7 +564,7 @@ cdbcomponent_updateCdbComponents(void)
 				ELOG_DISPATCHER_DEBUG("FTS rescanned, get new component databases info.");
 				cdbcomponent_destroyCdbComponents();
 				cdb_component_dbs = getCdbComponentInfo(true);
-				cdb_component_dbs->fts_version = ftsVersion;
+				cdb_component_dbs->fts_segment_failover_occurrence = ftsSegmentFailoverOccurrence;
 				cdb_component_dbs->expand_version = expandVersion;
 			}
 		}
@@ -595,7 +595,7 @@ cdbcomponent_getCdbComponents(bool DNSLookupAsError)
 		if (cdb_component_dbs == NULL)
 		{
 			cdb_component_dbs = getCdbComponentInfo(DNSLookupAsError);
-			cdb_component_dbs->fts_version = getFtsVersion();
+			cdb_component_dbs->fts_segment_failover_occurrence = getFtsSegmentFailoverOccurrence();
 			cdb_component_dbs->expand_version = GetGpExpandVersion();
 		}
 	}

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -389,7 +389,7 @@ checkDispatchResult(CdbDispatcherState *ds,
 	int			timeout = 0;
 	bool		sentSignal = false;
 	struct pollfd *fds;
-	uint8 ftsVersion = 0;
+	uint8 ftsSegmentFailoverOccurrence = 0;
 
 	db_count = pParms->dispatchCount;
 	fds = (struct pollfd *) palloc(db_count * sizeof(struct pollfd));
@@ -534,9 +534,9 @@ checkDispatchResult(CdbDispatcherState *ds,
 			 * explicitly in this case because this happens every
 			 * DISPATCH_WAIT_TIMEOUT_MSEC.
 			 */
-			if (ftsVersion == 0 || ftsVersion != getFtsVersion())
+			if (ftsSegmentFailoverOccurrence == 0 || ftsSegmentFailoverOccurrence != getFtsSegmentFailoverOccurrence())
 			{
-				ftsVersion = getFtsVersion();
+				ftsSegmentFailoverOccurrence = getFtsSegmentFailoverOccurrence();
 				checkSegmentAlive(pParms);
 			}
 

--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -642,7 +642,7 @@ test_processResponse_for_FtsIsActive_false(void **state)
  * state changed.
  */
 void
-test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
+test_PrimaryUpMirrorUpNotInSync_to_PrimaryUpMirrorUpNotInSync(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		2, true, GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
@@ -680,7 +680,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
  * current primary needs to stay marked as up.
  */
 void
-test_PrimayUpMirrorUpNotInSync_to_PrimaryDown(void **state)
+test_PrimaryUpMirrorUpNotInSync_to_PrimaryDown(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		2, true, GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
@@ -717,7 +717,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryDown(void **state)
  * 2 segments, content 0 mirror is updated as down
  */
 void
-test_PrimayUpMirrorUpNotInSync_to_PrimaryUpMirrorDownNotInSync(void **state)
+test_PrimaryUpMirrorUpNotInSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		2, true, GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
@@ -768,7 +768,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryUpMirrorDownNotInSync(void **state)
  * 3 segments, content 0 mirror is down and probe response is mirror up
  */
 void
-test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpNotInSync(void **state)
+test_PrimaryUpMirrorDownNotInSync_to_PrimaryUpMirrorUpNotInSync(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		3, true, GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
@@ -973,7 +973,7 @@ test_processResponse_multiple_segments(void **state)
  * 1 segment, primary and mirror will be marked not in sync
  */
 void
-test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync(void **state)
+test_PrimaryUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		1, true, GP_SEGMENT_CONFIGURATION_MODE_INSYNC);
@@ -1019,7 +1019,7 @@ test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync(void **state)
  * for first primary mirror pair
  */
 void
-test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync(void **state)
+test_PrimaryUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		2, true, GP_SEGMENT_CONFIGURATION_MODE_INSYNC);
@@ -1079,7 +1079,7 @@ test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync(void **state)
  * both will be marked not in sync, then FTS promote mirror
  */
 void
-test_PrimayUpMirrorUpSync_to_PrimaryDown_to_MirrorPromote(void **state)
+test_PrimaryUpMirrorUpSync_to_PrimaryDown_to_MirrorPromote(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		1, true, GP_SEGMENT_CONFIGURATION_MODE_INSYNC);
@@ -1127,7 +1127,7 @@ test_PrimayUpMirrorUpSync_to_PrimaryDown_to_MirrorPromote(void **state)
  * 1 segment, primary and mirror will be marked in sync
  */
 void
-test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpSync(void **state)
+test_PrimaryUpMirrorUpNotInSync_to_PrimaryUpMirrorUpSync(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		1, true, GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
@@ -1173,7 +1173,7 @@ test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpSync(void **state)
  * updated to SYNC
  */
 void
-test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
+test_PrimaryUpMirrorDownNotInSync_to_PrimaryUpMirrorUpSync(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		1, true, GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
@@ -1225,7 +1225,7 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
  * 1 segment, segment_failover is false because there is no status or mode change.
  */
 void
-test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorDownNotInSync(void **state)
+test_PrimaryUpMirrorDownNotInSync_to_PrimaryUpMirrorDownNotInSync(void **state)
 {
 	CdbComponentDatabases *cdbs = InitTestCdb(
 		1, true, GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC);
@@ -1376,18 +1376,18 @@ main(int argc, char* argv[])
 		unit_test(test_processResponse_for_zero_segment),
 		unit_test(test_processResponse_for_FtsIsActive_false),
 		unit_test(test_processResponse_multiple_segments),
-		unit_test(test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync),
-		unit_test(test_PrimayUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync),
-		unit_test(test_PrimayUpMirrorUpSync_to_PrimaryDown_to_MirrorPromote),
+		unit_test(test_PrimaryUpMirrorUpSync_to_PrimaryUpMirrorUpNotInSync),
+		unit_test(test_PrimaryUpMirrorUpSync_to_PrimaryUpMirrorDownNotInSync),
+		unit_test(test_PrimaryUpMirrorUpSync_to_PrimaryDown_to_MirrorPromote),
 
-		unit_test(test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpSync),
-		unit_test(test_PrimayUpMirrorUpNotInSync_to_PrimayUpMirrorUpNotInSync),
-		unit_test(test_PrimayUpMirrorUpNotInSync_to_PrimaryUpMirrorDownNotInSync),
-		unit_test(test_PrimayUpMirrorUpNotInSync_to_PrimaryDown),
+		unit_test(test_PrimaryUpMirrorUpNotInSync_to_PrimaryUpMirrorUpSync),
+		unit_test(test_PrimaryUpMirrorUpNotInSync_to_PrimaryUpMirrorUpNotInSync),
+		unit_test(test_PrimaryUpMirrorUpNotInSync_to_PrimaryUpMirrorDownNotInSync),
+		unit_test(test_PrimaryUpMirrorUpNotInSync_to_PrimaryDown),
 
-		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync),
-		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpNotInSync),
-		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorDownNotInSync),
+		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimaryUpMirrorUpSync),
+		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimaryUpMirrorUpNotInSync),
+		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimaryUpMirrorDownNotInSync),
 		unit_test(test_PrimaryUpMirrorDownNotInSync_to_PrimaryDown),
 		unit_test(test_probeTimeout),
 		/*-----------------------------------------------------------------------*/

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -32,7 +32,7 @@
 
 typedef struct FtsProbeInfo
 {
-	volatile uint8		fts_statusVersion;
+	volatile uint8		segment_failover_occurrence;
 	volatile uint8      probeTick;
 	volatile uint8		fts_status[FTS_MAX_DBS];
 } FtsProbeInfo;

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -57,5 +57,5 @@ extern bool verifyFtsSyncCount(void);
 extern void ftsLock(void);
 extern void ftsUnlock(void);
 extern void FtsNotifyProber(void);
-extern uint8 getFtsVersion(void);
+extern uint8 getFtsSegmentFailoverOccurrence(void);
 #endif   /* CDBFTS_H */

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -112,7 +112,7 @@ struct CdbComponentDatabases
 	int			my_dbid;		/* the dbid of this database */
 	int			my_segindex;	/* the content of this database */
 	bool		my_isprimary;	/* the isprimary flag of this database */
-	uint8		fts_version;	/* the version of fts */
+	uint8		fts_segment_failover_occurrence;	/* the segment_failover_occurrence of fts */
 	int			expand_version;
 	int			numActiveQEs;
 	int			numIdleQEs;

--- a/src/include/postmaster/ftsprobe.h
+++ b/src/include/postmaster/ftsprobe.h
@@ -92,5 +92,6 @@ typedef struct
 	fts_segment_info *perSegInfos;
 } fts_context;
 
-extern bool FtsWalRepMessageSegments(CdbComponentDatabases *context);
+extern bool segment_failover_occurred(void);
+extern void FtsWalRepMessageSegments(CdbComponentDatabases *context);
 #endif


### PR DESCRIPTION
FTS maintains a variable called fts_statusVersion. When a change to
gp_segment_configuration is made, FTS would increment the fts_statusVersion to
notify the dispatcher to reset existing gangs. This works as expected in the
scenario where a primary dies and its corresponding mirror gets promoted.
However, a simple desynchronization of a primary/mirror which would update the
gp_segment_configuration catalog (update from sync to not-in-sync) would also
increment the fts_statusVersion. This would result in the dispatcher taking the
unnecessary action of recreating all existing gangs.

We should only recreate gangs during segment failover. This patch refactors
fts_statusVersion to change its assumed usages and makes it more clear on what
is actually happening by removing some complicated variable passing through 3
layers of function calls. We also rename it to segment_failover_occurence to
make it match better with its purpose.