### PR TITLE
QE writer should cancel QE readers before aborting

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -5492,6 +5492,7 @@ AbortSubTransaction(void)
 		AtEOSubXact_LargeObject(false, s->subTransactionId,
 								s->parent->subTransactionId);
 		AtSubAbort_Notify();
+		AtAbort_Readers();
 
 		/* Advertise the fact that we aborted in pg_clog. */
 		(void) RecordTransactionAbort(true);

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -4185,7 +4185,6 @@ PostmasterStateMachine(void)
 	}
 }
 
-
 /*
  * Send a signal to a postmaster child process
  *

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -60,6 +60,7 @@
 #include "access/aosegfiles.h"
 #include "access/aocssegfiles.h"
 #include "cdb/cdbappendonlyam.h"
+#include "cdb/cdbvars.h"
 #include "utils/timestamp.h"
 
 
@@ -531,6 +532,15 @@ ReadBuffer_common(SMgrRelation smgr, char relpersistence, ForkNumber forkNum,
 	}
 	else
 	{
+		/*
+		 * QE reader should not bring in a shared buffer from disk if its
+		 * writer has already aborted the transaction.  Check for interrupts
+		 * allows the reader to determine if the writer has sent a cancel
+		 * signal.
+		 */
+		if (!Gp_is_writer)
+			CHECK_FOR_INTERRUPTS();
+
 		/*
 		 * Read in the page, unless the caller intends to overwrite it and
 		 * just wants us to allocate a buffer.

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1548,6 +1548,7 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo, Snapshot snapshot, cha
 	SharedLocalSnapshotSlot->QDxid = dtxContextInfo->distributedXid;
 		
 	SharedLocalSnapshotSlot->ready = true;
+	SharedLocalSnapshotSlot->writerSentCancel = false;
 
 	SharedLocalSnapshotSlot->segmateSync = dtxContextInfo->segmateSync;
 
@@ -4861,6 +4862,40 @@ ListAllGxid(void)
 	LWLockRelease(ProcArrayLock);
 
 	return gxids;
+}
+
+void
+CancelMyReaders(void)
+{
+	int numProcs;
+	int i;
+	int pid_index = 0;
+	ProcArrayStruct *arrayP = procArray;
+
+	pid_t *reader_pids = (pid_t *) palloc(arrayP->maxProcs * sizeof(pid_t));
+
+	Assert(Gp_is_writer);
+
+	LWLockAcquire(ProcArrayLock, LW_SHARED);
+	numProcs = arrayP->numProcs;
+	for (i = 0; i < numProcs; i++)
+	{
+		volatile PGPROC *proc = &allProcs[arrayP->pgprocnos[i]];
+		if (proc->mppSessionId == MyProc->mppSessionId &&
+			proc->pid != MyProcPid)
+		{
+			Assert(!proc->mppIsWriter);
+			Assert(proc->databaseId == MyDatabaseId);
+			reader_pids[pid_index++] = proc->pid;
+		}
+	}
+	LWLockRelease(ProcArrayLock);
+
+	while (--pid_index >= 0)
+	{
+		kill(reader_pids[pid_index], SIGINT); /* ignore error */
+		SIMPLE_FAULT_INJECTOR(CancelledReaderDuringAbort);
+	}
 }
 
 /*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -94,6 +94,7 @@
 #include "cdb/cdbgang.h"
 #include "cdb/ml_ipc.h"
 #include "utils/guc.h"
+#include "utils/sharedsnapshot.h"
 #include "access/twophase.h"
 #include "postmaster/backoff.h"
 #include "utils/resource_manager.h"
@@ -236,6 +237,7 @@ static bool RecoveryConflictRetryable = true;
 static ProcSignalReason RecoveryConflictReason;
 
 static DtxContextInfo TempDtxContextInfo = DtxContextInfo_StaticInit;
+static bool HandlingWriterCancelRequest = false;
 
 extern void CheckForQDMirroringWork(void);
 
@@ -1052,7 +1054,7 @@ exec_mpp_query(const char *query_string,
 	QueryDispatchDesc *ddesc = NULL;
 	CmdType		commandType = CMD_UNKNOWN;
 	SliceTable *sliceTable = NULL;
-	Slice      *slice = NULL;
+	Slice      *currentSlice = NULL;
 	ParamListInfo paramLI = NULL;
 
 	Assert(Gp_role == GP_ROLE_EXECUTE);
@@ -1146,14 +1148,14 @@ exec_mpp_query(const char *query_string,
 			/* Identify slice to execute */
 			foreach(lc, sliceTable->slices)
 			{
-				slice = (Slice *)lfirst(lc);
-				if (bms_is_member(qe_identifier, slice->processesMap))
+				currentSlice = (Slice *)lfirst(lc);
+				if (bms_is_member(qe_identifier, currentSlice->processesMap))
 					break;
 			}
 
-			sliceTable->localSlice = slice->sliceIndex;
+			sliceTable->localSlice = currentSlice->sliceIndex;
 
-			Assert(IsA(slice, Slice));
+			Assert(IsA(currentSlice, Slice));
 
 			/* Set global sliceid variable for elog. */
 			currentSliceId = sliceTable->localSlice;
@@ -1185,10 +1187,10 @@ exec_mpp_query(const char *query_string,
 
         commandType = plan->commandType;
 	}
-	if ( slice )
+	if ( currentSlice )
 	{
 		/* Non root slices don't need update privileges. */
-		if (sliceTable->localSlice != slice->rootIndex)
+		if (sliceTable->localSlice != currentSlice->rootIndex)
 		{
 			ListCell       *rtcell;
 			RangeTblEntry  *rte;
@@ -1303,6 +1305,21 @@ exec_mpp_query(const char *query_string,
 
 		/* Make sure we are in a transaction command */
 		start_xact_command();
+
+		/*
+		 * In a query plan there can be at the most one writer that executes
+		 * the root slice.  All other slices are executed by readers.  If
+		 * readers exist in our plan, we capture that information in the
+		 * transaction state, to be used later during abort.  In case of a
+		 * read-only command, no slice should have gangType as PRIMARY_WRITER.
+		 * We can skip the overhead of walking through proc array during abort
+		 * if the command is read-only.
+		 */
+		if (sliceTable && list_length(sliceTable->slices) > 1 && Gp_is_writer &&
+			currentSlice->gangType == GANGTYPE_PRIMARY_WRITER)
+			SetCurrentTransactionUsesReaders();
+		else
+			ResetCurrentTransactionUsesReaders();
 
 		/* If we got a cancel signal in parsing or prior command, quit */
 		CHECK_FOR_INTERRUPTS();
@@ -3871,9 +3888,23 @@ ProcessInterrupts(const char* filename, int lineno)
 			DisableCatchupInterrupt();
 
 			if (Gp_role == GP_ROLE_EXECUTE)
+			{
+				HandlingWriterCancelRequest =
+					!Gp_is_writer && SharedLocalSnapshotSlot &&
+					SharedLocalSnapshotSlot->writerSentCancel;
+				/*
+				 * Do not send the error message back to QD if the writer
+				 * asked us to cancel the query.  Otherwise, if QD receives
+				 * "canceling MPP operation" error before the error reported
+				 * by the writer, the writer's error will not be reported to
+				 * the client.
+				 */
+				if (HandlingWriterCancelRequest)
+					whereToSendOutput = DestNone;
 				ereport(ERROR,
 						(errcode(ERRCODE_GP_OPERATION_CANCELED),
 						 errmsg("canceling MPP operation")));
+			}
 			else if (HasCancelMessage())
 			{
 				char   *buffer = palloc0(MAX_CANCEL_MSG);
@@ -4967,6 +4998,16 @@ PostgresMain(int argc, char *argv[],
 
 		/* Report the error to the client and/or server log */
 		EmitErrorReport();
+		if (HandlingWriterCancelRequest)
+		{
+			/*
+			 * Restore CommandDest so that any error from now on will be
+			 * delivered back to QD.
+			 */
+			Assert(!Gp_is_writer);
+			whereToSendOutput = DestRemote;
+			HandlingWriterCancelRequest = false;
+		}
 
 		/*
 		 * Make sure debug_query_string gets reset before we possibly clobber

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -942,3 +942,26 @@ LogDistributedSnapshotInfo(Snapshot snapshot, const char *prefix)
 	elog(LOG, "%s", buf.data);
 	pfree(buf.data);
 }
+
+/*
+ * QE writer must let other QE readers participating in the same transaction
+ * know that the transaction must be canceled.  This reduces the window
+ * between a transaction being marked as aborted by the QE writer and QE
+ * readers cancel executing part of the transaction / plan.
+ */
+void
+AtAbort_Readers(void)
+{
+	/*
+	 * Walk the procArray only if the current transaction made any writes and
+	 * there are readers
+	 */
+	if (Gp_is_writer && TransactionIdIsValid(GetCurrentTransactionIdIfAny()) &&
+		GetCurrentTransactionUsesReaders())
+	{
+		Assert(SharedLocalSnapshotSlot != NULL);
+		SharedLocalSnapshotSlot->writerSentCancel = true;
+		CancelMyReaders();
+	}
+	/* TODO: how to ensure that the readers have acted upon the signal? */
+}

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -292,6 +292,9 @@ extern void UnregisterSubXactCallback(SubXactCallback callback, void *arg);
 extern void RecordDistributedForgetCommitted(struct TMGXACT_LOG *gxact_log);
 
 extern int	xactGetCommittedChildren(TransactionId **ptr);
+extern void SetCurrentTransactionUsesReaders(void);
+extern bool GetCurrentTransactionUsesReaders(void);
+extern void ResetCurrentTransactionUsesReaders(void);
 
 extern void xact_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
 extern void xact_desc(StringInfo buf, XLogRecord *record);

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -96,6 +96,7 @@ extern void GetSlotTableDebugInfo(void **snapshotArray, int *maxSlots);
 extern void getDtxCheckPointInfo(char **result, int *result_size);
 
 extern List *ListAllGxid(void);
+extern void CancelMyReaders(void);
 extern int GetPidByGxid(DistributedTransactionId gxid);
 
 extern void ProcArraySetReplicationSlotXmin(TransactionId xmin,

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -255,6 +255,8 @@ FI_IDENT(CreateGangInProgress, "create_gang_in_progress")
 FI_IDENT(DecreaseToastMaxChunkSize, "decrease_toast_max_chunk_size")
 /* inject fault to let cleanupGang return false */
 FI_IDENT(CleanupQE, "cleanup_qe")
+/* inject fault after a writer has cancelled a reader during abort transaction */
+FI_IDENT(CancelledReaderDuringAbort, "cancelled_reader_during_abort")
 #endif
 
 /*

--- a/src/include/utils/sharedsnapshot.h
+++ b/src/include/utils/sharedsnapshot.h
@@ -36,6 +36,7 @@ typedef struct SharedSnapshotSlot
 	ComboCidKeyData combocids[MaxComboCids];
 	SnapshotData	snapshot;
 	LWLockId        slotLock;
+	bool            writerSentCancel;
 } SharedSnapshotSlot;
 
 extern volatile SharedSnapshotSlot *SharedLocalSnapshotSlot;
@@ -53,6 +54,7 @@ extern void dumpSharedLocalSnapshot_forCursor(void);
 extern void readSharedLocalSnapshot_forCursor(Snapshot snapshot);
 
 extern void AtEOXact_SharedSnapshot(void);
+extern void AtAbort_Readers(void);
 
 #define NUM_SHARED_SNAPSHOT_SLOTS (2 * max_prepared_xacts)
 

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -3125,14 +3125,6 @@ SELECT SUM(b) FROM dml_heap_pt_r;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
 ERROR:  cross-partition or multi-update to a row  (seg1 10.152.10.75:25433 pid=28939)
 SELECT SUM(a) FROM dml_heap_pt_r;
@@ -3286,14 +3278,6 @@ SELECT * FROM dml_heap_pt_r WHERE a = 1;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
 ERROR:  cross-partition or multi-update to a row  (seg2 10.152.10.75:25434 pid=14697)
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -3129,14 +3129,6 @@ SELECT SUM(b) FROM dml_heap_pt_r;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum 
@@ -3297,14 +3289,6 @@ SELECT * FROM dml_heap_pt_r WHERE a = 1;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
 ERROR:  cross-partition or multi-update to a row
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;

--- a/src/test/regress/expected/writer_aborts_reader.out
+++ b/src/test/regress/expected/writer_aborts_reader.out
@@ -1,0 +1,165 @@
+-- Tests to validate that in a multi-slice query a QE writer signals QE readers
+-- to cancel query execution before marking the transaction as aborted.
+-- The tests make use of a "skip" fault to determine if the control reached a
+-- specific location of interest.  In this case, the location of the fault
+-- "cancelled_reader_during_abort" is right after a writer sends SIGINT to
+-- corresponding readers.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+create table writer_aborts_before_reader_a(i int, j int) distributed by (i);
+alter table writer_aborts_before_reader_a add constraint check_j check (j > 0);
+insert into writer_aborts_before_reader_a select 4,i from generate_series(1,12) i;
+create table writer_aborts_before_reader_b (like writer_aborts_before_reader_a) distributed by (i);
+insert into writer_aborts_before_reader_b select * from writer_aborts_before_reader_a;
+-- first test: one writer with one or more readers
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=51789)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+begin;
+-- Make a write in this transaction so that a TransactionId will be assigned.
+insert into writer_aborts_before_reader_a values (4, 4);
+-- This multi-slice update is aborted because QE writer encounters constraint
+-- failure.  The writer must send cancel signal to the readers before aborting the
+-- transaction.  The fault, therefore, is expected to hit at least once.
+update writer_aborts_before_reader_a set j = -1 from writer_aborts_before_reader_b;
+ERROR:  new row for relation "writer_aborts_before_reader_a" violates check constraint "check_j"  (seg0 127.0.0.1:25432 pid=51789)
+DETAIL:  Failing row contains (4, -1).
+end;
+select gp_wait_until_triggered_fault('cancelled_reader_during_abort', 1, dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=51789)
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t
+(1 row)
+
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=51789)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- second test: one writer with no readers
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=51789)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+begin;
+-- Make a write in this transaction so that a TransactionId will be assigned.
+insert into writer_aborts_before_reader_a values (4, 4);
+-- No reader gangs. This is a single slice update.  The writer aborts the
+-- transaction because of constraint failure.
+update writer_aborts_before_reader_a set j = -1;
+ERROR:  new row for relation "writer_aborts_before_reader_a" violates check constraint "check_j"  (seg0 127.0.0.1:25432 pid=51789)
+DETAIL:  Failing row contains (4, -1).
+end;
+-- The writer from the previous update statement is not expceted to walk the
+-- proc array and look for readers because that was a single-slice statement.
+-- Therefore, hit count for the fault should be 0.
+select gp_inject_fault('cancelled_reader_during_abort', 'status', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success: fault name:'cancelled_reader_during_abort' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'set'  num times hit:'0'  (seg0 127.0.0.1:25432 pid=51789)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=51789)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- third test: writer and reader, but the transaction does not write
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=51789)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+begin;
+-- This is a non-colocated join, with two slices.
+select count(*) from writer_aborts_before_reader_a, writer_aborts_before_reader_b
+where writer_aborts_before_reader_a.i = writer_aborts_before_reader_b.j;
+ count 
+-------
+    12
+(1 row)
+
+abort;
+-- The previous abort should cause the QE writer to go through abort workflow.
+-- But the writer should not walk the proc array and look for readers because the
+-- transaction did not make any writes.  Therefore, the fault status is expected
+-- to return hit count as 0.
+select gp_inject_fault('cancelled_reader_during_abort', 'status', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success: fault name:'cancelled_reader_during_abort' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'set'  num times hit:'0'  (seg0 127.0.0.1:25432 pid=51789)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=51789)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- fourth test: the transaction does write but the last command before
+-- abort is read-only
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=1390)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+begin;
+-- Make a write in this transaction so that a TransactionId will be assigned.
+insert into writer_aborts_before_reader_a values (4, 4);
+-- Both the slices in this query plan have gangType PRIMARY_READER
+select count(*) from writer_aborts_before_reader_a, writer_aborts_before_reader_b
+where writer_aborts_before_reader_a.i = writer_aborts_before_reader_b.j;
+ count 
+-------
+    13
+(1 row)
+
+abort;
+-- QE writer should not walk through proc array during abort to look
+-- for readers because none of the slices in the last command had
+-- gangType PRIMARY_WRITER.  Hit count reported by the status should
+-- therefore be 0.
+select gp_inject_fault('cancelled_reader_during_abort', 'status', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success: fault name:'cancelled_reader_during_abort' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'set'  num times hit:'0'  (seg0 127.0.1.1:25432 pid=1390)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=1390)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+

--- a/src/test/regress/expected/writer_aborts_reader.out
+++ b/src/test/regress/expected/writer_aborts_reader.out
@@ -163,3 +163,55 @@ NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=1390)
  t
 (1 row)
 
+-- fifth test: a multi-slice query is aborted in a subtransaction
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=18853)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+begin;
+-- Make a write in this transaction so that a TransactionId will be
+-- assigned to the top transaction.
+insert into writer_aborts_before_reader_a values (4, 4);
+savepoint sp1;
+-- Make a write so that a TransactionId will be assigned to this
+-- subtranaction.
+insert into writer_aborts_before_reader_a values (4, 4);
+-- The QE writer should hit an error and walk through proc array to
+-- signal all readers before marking the transaction aborted.
+update writer_aborts_before_reader_a set j = -1 from writer_aborts_before_reader_b;
+ERROR:  new row for relation "writer_aborts_before_reader_a" violates check constraint "check_j"  (seg0 127.0.1.1:25432 pid=18853)
+DETAIL:  Failing row contains (4, -1).
+rollback to sp1;
+-- The top transaction should remain in-progress, even after the
+-- readers were signaled to cancel.  Verify that by executing a query.
+select count(*) from writer_aborts_before_reader_a, writer_aborts_before_reader_b
+where writer_aborts_before_reader_a.i = writer_aborts_before_reader_b.j;
+ count 
+-------
+    13
+(1 row)
+
+commit;
+-- The fault should be hit during subtransaction abort because the
+-- writer should wait for readers before marking the subtransaction as
+-- aborted.
+select gp_inject_fault('cancelled_reader_during_abort', 'status', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success: fault name:'cancelled_reader_during_abort' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'  (seg0 127.0.1.1:25432 pid=18853)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=18853)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -142,7 +142,7 @@ test: catalog
 test: bfv_catalog bfv_index bfv_olap bfv_aggregate bfv_partition bfv_partition_plans DML_over_joins gporca bfv_statistic
 # NOTE: gporca_faults uses gp_fault_injector - so do not add to a parallel group
 test: gporca_faults
- 
+
 test: aggregate_with_groupingsets 
 
 test: nested_case_null sort bb_mpph
@@ -247,4 +247,10 @@ test: autovacuum-template0
 
 # Online expand introduce the partial tables, check them if they can run correctly
 test: gangsize
+# This test uses fault injectors in abort transaction workflow.  It
+# may be run in parallel with other tests as long as they don't abort
+# a transaction where mult-slice query was executed and the writer was
+# assigned a transaction ID.
+test: writer_aborts_reader
+
 # end of tests

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -1352,16 +1352,6 @@ begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
 SELECT SUM(b) FROM dml_heap_pt_r;
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
-
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
-
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
 SELECT SUM(a) FROM dml_heap_pt_r;
 SELECT SUM(b) FROM dml_heap_pt_r;
@@ -1427,16 +1417,6 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;
 SELECT dml_heap_pt_s.a + 10 FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a ORDER BY 1 LIMIT 1;
 SELECT * FROM dml_heap_pt_r WHERE a = 1;
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
-
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
-
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;

--- a/src/test/regress/sql/writer_aborts_reader.sql
+++ b/src/test/regress/sql/writer_aborts_reader.sql
@@ -1,0 +1,97 @@
+-- Tests to validate that in a multi-slice query a QE writer signals QE readers
+-- to cancel query execution before marking the transaction as aborted.
+-- The tests make use of a "skip" fault to determine if the control reached a
+-- specific location of interest.  In this case, the location of the fault
+-- "cancelled_reader_during_abort" is right after a writer sends SIGINT to
+-- corresponding readers.
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+create table writer_aborts_before_reader_a(i int, j int) distributed by (i);
+alter table writer_aborts_before_reader_a add constraint check_j check (j > 0);
+insert into writer_aborts_before_reader_a select 4,i from generate_series(1,12) i;
+
+create table writer_aborts_before_reader_b (like writer_aborts_before_reader_a) distributed by (i);
+insert into writer_aborts_before_reader_b select * from writer_aborts_before_reader_a;
+
+-- first test: one writer with one or more readers
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+begin;
+-- Make a write in this transaction so that a TransactionId will be assigned.
+insert into writer_aborts_before_reader_a values (4, 4);
+-- This multi-slice update is aborted because QE writer encounters constraint
+-- failure.  The writer must send cancel signal to the readers before aborting the
+-- transaction.  The fault, therefore, is expected to hit at least once.
+update writer_aborts_before_reader_a set j = -1 from writer_aborts_before_reader_b;
+end;
+
+select gp_wait_until_triggered_fault('cancelled_reader_during_abort', 1, dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+-- second test: one writer with no readers
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+begin;
+-- Make a write in this transaction so that a TransactionId will be assigned.
+insert into writer_aborts_before_reader_a values (4, 4);
+-- No reader gangs. This is a single slice update.  The writer aborts the
+-- transaction because of constraint failure.
+update writer_aborts_before_reader_a set j = -1;
+end;
+
+-- The writer from the previous update statement is not expceted to walk the
+-- proc array and look for readers because that was a single-slice statement.
+-- Therefore, hit count for the fault should be 0.
+select gp_inject_fault('cancelled_reader_during_abort', 'status', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+-- third test: writer and reader, but the transaction does not write
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+begin;
+-- This is a non-colocated join, with two slices.
+select count(*) from writer_aborts_before_reader_a, writer_aborts_before_reader_b
+where writer_aborts_before_reader_a.i = writer_aborts_before_reader_b.j;
+abort;
+
+-- The previous abort should cause the QE writer to go through abort workflow.
+-- But the writer should not walk the proc array and look for readers because the
+-- transaction did not make any writes.  Therefore, the fault status is expected
+-- to return hit count as 0.
+select gp_inject_fault('cancelled_reader_during_abort', 'status', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+-- fourth test: the transaction does write but the last command before
+-- abort is read-only
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+begin;
+-- Make a write in this transaction so that a TransactionId will be assigned.
+insert into writer_aborts_before_reader_a values (4, 4);
+-- Both the slices in this query plan have gangType PRIMARY_READER
+select count(*) from writer_aborts_before_reader_a, writer_aborts_before_reader_b
+where writer_aborts_before_reader_a.i = writer_aborts_before_reader_b.j;
+abort;
+
+-- QE writer should not walk through proc array during abort to look
+-- for readers because none of the slices in the last command had
+-- gangType PRIMARY_WRITER.  Hit count reported by the status should
+-- therefore be 0.
+select gp_inject_fault('cancelled_reader_during_abort', 'status', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;

--- a/src/test/regress/sql/writer_aborts_reader.sql
+++ b/src/test/regress/sql/writer_aborts_reader.sql
@@ -95,3 +95,33 @@ gp_segment_configuration where role = 'p' and content = 0;
 
 select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
 gp_segment_configuration where role = 'p' and content = 0;
+
+-- fifth test: a multi-slice query is aborted in a subtransaction
+select gp_inject_fault('cancelled_reader_during_abort', 'skip', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+
+begin;
+-- Make a write in this transaction so that a TransactionId will be
+-- assigned to the top transaction.
+insert into writer_aborts_before_reader_a values (4, 4);
+savepoint sp1;
+-- Make a write so that a TransactionId will be assigned to this
+-- subtranaction.
+insert into writer_aborts_before_reader_a values (4, 4);
+-- The QE writer should hit an error and walk through proc array to
+-- signal all readers before marking the transaction aborted.
+update writer_aborts_before_reader_a set j = -1 from writer_aborts_before_reader_b;
+rollback to sp1;
+-- The top transaction should remain in-progress, even after the
+-- readers were signaled to cancel.  Verify that by executing a query.
+select count(*) from writer_aborts_before_reader_a, writer_aborts_before_reader_b
+where writer_aborts_before_reader_a.i = writer_aborts_before_reader_b.j;
+commit;
+
+-- The fault should be hit during subtransaction abort because the
+-- writer should wait for readers before marking the subtransaction as
+-- aborted.
+select gp_inject_fault('cancelled_reader_during_abort', 'status', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;
+select gp_inject_fault('cancelled_reader_during_abort', 'reset', dbid) from
+gp_segment_configuration where role = 'p' and content = 0;


### PR DESCRIPTION
If a QE writer marks the transaction as aborted while a reader is still
executing the query the reader affect shared memory state. In order to
prevent this the writer walks procArray to find the readers and sends
SIGINT to them.

This is WIP because:

- [ ]  The writer needs to be sure that the readers have cancelled the
execution.

- [x] The test needs to be debugged. It fails because the newly added fault
is hit unexpectedly in one case.  When the same case was run manually,
things work as expected.

- [x]  Add test to greenplum schedule file

- [x] The reader should perform CHECK_FOR_INTERRUPTS just before allocating
a shared buffer as suggested by Ashwin.

- [x]  Remove the temporary workaround b6dd73a4c2242b236cf4bbb399d7253d85042be1

- [x] Handle subtransactions

Discussion:
https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/S2WL1FtJEJ0/Wh6DfJ-RBwAJ
