### PR TITLE
Add a new reserved attribute in the GP_DISTRIBUTION_POLICY

### DIFF
--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -389,8 +389,8 @@ GpPolicyStore(Oid tbloid, const GpPolicy *policy)
 
 	ArrayType  *attrnums;
 
-	bool		nulls[4];
-	Datum		values[4];
+	bool		nulls[5];
+	Datum		values[5];
 
 	Insist(policy->ptype != POLICYTYPE_ENTRY);
 
@@ -398,6 +398,7 @@ GpPolicyStore(Oid tbloid, const GpPolicy *policy)
 	nulls[1] = false;
 	nulls[2] = false;
 	nulls[3] = false;
+	nulls[4] = true; /* reserved attribute */
 	values[0] = ObjectIdGetDatum(tbloid);
 	values[3] = Int32GetDatum(policy->numsegments);
 
@@ -465,9 +466,9 @@ GpPolicyReplace(Oid tbloid, const GpPolicy *policy)
 	SysScanDesc scan;
 	ScanKeyData skey;
 	ArrayType  *attrnums;
-	bool		nulls[4];
-	Datum		values[4];
-	bool		repl[4];
+	bool		nulls[5];
+	Datum		values[5];
+	bool		repl[5];
 
 	Insist(!GpPolicyIsEntry(policy));
 
@@ -475,6 +476,7 @@ GpPolicyReplace(Oid tbloid, const GpPolicy *policy)
 	nulls[1] = false;
 	nulls[2] = false;
 	nulls[3] = false;
+	nulls[4] = true; /* reserved attribute */
 	values[0] = ObjectIdGetDatum(tbloid);
 	values[3] = Int32GetDatum(policy->numsegments);
 
@@ -521,6 +523,7 @@ GpPolicyReplace(Oid tbloid, const GpPolicy *policy)
 	repl[1] = true;
 	repl[2] = true;
 	repl[3] = true;
+	repl[4] = false;
 
 
 	/*

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -34,16 +34,21 @@ CATALOG(gp_distribution_policy,5002) BKI_WITHOUT_OIDS
 	int16		attrnums[1];
 	char		policytype; /* distribution policy type */
 	int32		numsegments;
+
+#ifdef CATALOG_VARLEN			/* variable-length fields start here */
+	text		policyoptions[1];	/* reserved attribute */
+#endif
 } FormData_gp_policy;
 
 /* GPDB added foreign key definitions for gpcheckcat. */
 FOREIGN_KEY(localoid REFERENCES pg_class(oid));
 
-#define Natts_gp_policy		4
+#define Natts_gp_policy		5
 #define Anum_gp_policy_localoid	1
 #define Anum_gp_policy_attrnums	2
 #define Anum_gp_policy_type	3
 #define Anum_gp_policy_numsegments	4
+#define Anum_gp_policy_options 5
 
 /*
  * Symbolic values for Anum_gp_policy_type column


### PR DESCRIPTION
We can only change the catalog when upgrading the major version,
it may block some work when we want to change it in the mid-term,
so we add a reserved attribute for future features.