### PR TITLE
Remove memory context argument from GpPolicyFetch and friends.

### DIFF
--- a/gpcontrib/gp_distribution_policy/gp_distribution_policy.c
+++ b/gpcontrib/gp_distribution_policy/gp_distribution_policy.c
@@ -106,7 +106,7 @@ set_distribution_policy (Datum array_distribution, Datum numsegments)
 	 * the distribution policy of the relation, we set the EVIL numbers for the
 	 * segment count simply, it need to be fixed in the future.
 	 */
-	policy = makeGpPolicy(NULL, POLICYTYPE_PARTITIONED, nattrs,
+	policy = makeGpPolicy(POLICYTYPE_PARTITIONED, nattrs,
 						  DatumGetInt32(numsegments));
 	
 	for (int i = 0; i < nattrs; i++)

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1781,8 +1781,13 @@ heap_create_with_catalog(const char *relname,
 			 Gp_role == GP_ROLE_EXECUTE ||
 			 IsBinaryUpgrade))
 	{
+		MemoryContext oldcontext;
+
 		Assert(relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW);
-		new_rel_desc->rd_cdbpolicy = GpPolicyCopy(GetMemoryChunkContext(new_rel_desc), policy);
+
+		oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(new_rel_desc));
+		new_rel_desc->rd_cdbpolicy = GpPolicyCopy(policy);
+		MemoryContextSwitchTo(oldcontext);
 		GpPolicyStore(relid, policy);
 	}
 

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -146,12 +146,11 @@ cdbCopyStart(CdbCopy *c, CopyStmt *stmt, struct GpPolicy *policy)
 
 	if (policy)
 	{
-		stmt->policy = GpPolicyCopy(CurrentMemoryContext, policy);
+		stmt->policy = GpPolicyCopy(policy);
 	}
 	else
 	{
-		stmt->policy = createRandomPartitionedPolicy(NULL,
-													 GP_POLICY_ALL_NUMSEGMENTS);
+		stmt->policy = createRandomPartitionedPolicy(GP_POLICY_ALL_NUMSEGMENTS);
 	}
 
 	flags = DF_WITH_SNAPSHOT | DF_CANCEL_ON_ERROR;

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -262,7 +262,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 
 		Assert(rte->rtekind == RTE_RELATION);
 
-		targetPolicy = GpPolicyFetch(CurrentMemoryContext, rte->relid);
+		targetPolicy = GpPolicyFetch(rte->relid);
 		targetPolicyType = targetPolicy->ptype;
 	}
 
@@ -292,8 +292,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 				}
 				else if (gp_create_table_random_default_distribution)
 				{
-					targetPolicy = createRandomPartitionedPolicy(NULL,
-																 numsegments);
+					targetPolicy = createRandomPartitionedPolicy(numsegments);
 					ereport(NOTICE,
 							(errcode(ERRCODE_SUCCESSFUL_COMPLETION),
 							 errmsg("Using default RANDOM distribution since no distribution was specified."),
@@ -414,7 +413,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 						}
 					}
 
-					targetPolicy = createHashPartitionedPolicy(NULL, policykeys,
+					targetPolicy = createHashPartitionedPolicy(policykeys,
 															   numsegments);
 
 					if (query->intoPolicy == NULL)

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -8275,7 +8275,7 @@ is_exchangeable(Relation rel, Relation oldrel, Relation newrel, bool throw)
 		{
 			int			i;
 
-			adjpol = GpPolicyCopy(CurrentMemoryContext, parpol);
+			adjpol = GpPolicyCopy(parpol);
 
 			for (i = 0; i < adjpol->nattrs; i++)
 			{

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2179,7 +2179,7 @@ analyzeEstimateReltuplesRelpages(Oid relationOid, float4 *relTuples, float4 *rel
 
 		initStringInfo(&sqlstmt);
 
-		policy = GpPolicyFetch(CurrentMemoryContext, singleOid);
+		policy = GpPolicyFetch(singleOid);
 
 		if (policy->ptype == POLICYTYPE_ENTRY)
 		{
@@ -2254,7 +2254,7 @@ analyzeEstimateIndexpages(Relation onerel, Relation indrel, BlockNumber *indexPa
 
 	initStringInfo(&sqlstmt);
 
-	policy = GpPolicyFetch(CurrentMemoryContext, RelationGetRelid(onerel));
+	policy = GpPolicyFetch(RelationGetRelid(onerel));
 
 	if (policy->ptype == POLICYTYPE_ENTRY)
 	{

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4512,7 +4512,7 @@ FillSliceTable_walker(Node *node, void *context)
 			Oid			reloid = getrelid(idx, stmt->rtable);
 			GpPolicyType policyType;
 
-			policyType = GpPolicyFetch(CurrentMemoryContext, reloid)->ptype;
+			policyType = GpPolicyFetch(reloid)->ptype;
 
 #ifdef USE_ASSERT_CHECKING
 			{
@@ -4522,7 +4522,7 @@ FillSliceTable_walker(Node *node, void *context)
 					idx = lfirst_int(lc);
 					reloid = getrelid(idx, stmt->rtable);
 
-					if (policyType != GpPolicyFetch(CurrentMemoryContext, reloid)->ptype)
+					if (policyType != GpPolicyFetch(reloid)->ptype)
 						elog(ERROR, "ModifyTable mixes distributed and entry-only tables");
 
 				}
@@ -4547,7 +4547,7 @@ FillSliceTable_walker(Node *node, void *context)
 		Oid			reloid = getrelid(idx, stmt->rtable);
 		GpPolicyType policyType;
 
-		policyType = GpPolicyFetch(CurrentMemoryContext, reloid)->ptype;
+		policyType = GpPolicyFetch(reloid)->ptype;
 
 		if (policyType != POLICYTYPE_ENTRY)
 		{

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -3212,7 +3212,6 @@ gpdb::IsAbortRequested
 GpPolicy *
 gpdb::MakeGpPolicy
 		(
-			MemoryContext mcxt,
 			GpPolicyType ptype,
 			int nattrs,
 			int numsegments
@@ -3223,7 +3222,7 @@ gpdb::MakeGpPolicy
 		/*
 		 * FIXME_TABLE_EXPAND: it used by ORCA, help...
 		 */
-		return makeGpPolicy(mcxt, ptype, nattrs, numsegments);
+		return makeGpPolicy(ptype, nattrs, numsegments);
 	}
 	GP_WRAP_END;
 }

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5184,7 +5184,7 @@ CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy
 	}
 	
 	// always set numsegments to ALL for CTAS
-	GpPolicy *distr_policy = gpdb::MakeGpPolicy(NULL, POLICYTYPE_PARTITIONED,
+	GpPolicy *distr_policy = gpdb::MakeGpPolicy(POLICYTYPE_PARTITIONED,
 												num_of_distr_cols_alloc,
 												gpdb::GetGPSegmentCount());
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6570,7 +6570,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 
 			Assert(rte->rtekind == RTE_RELATION);
 
-			targetPolicy = GpPolicyFetch(CurrentMemoryContext, rte->relid);
+			targetPolicy = GpPolicyFetch(rte->relid);
 			targetPolicyType = targetPolicy->ptype;
 
 			if (numsegments >= 0)
@@ -6726,7 +6726,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 			Assert(rti > 0);
 			Assert(rte->rtekind == RTE_RELATION);
 
-			targetPolicy = GpPolicyFetch(CurrentMemoryContext, rte->relid);
+			targetPolicy = GpPolicyFetch(rte->relid);
 			targetPolicyType = targetPolicy->ptype;
 
 			if (numsegments >= 0)

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -467,7 +467,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 
 	result->nMotionNodes = top_plan->nMotionNodes;
 	result->nInitPlans = top_plan->nInitPlans;
-	result->intoPolicy = GpPolicyCopy(CurrentMemoryContext, parse->intoPolicy);
+	result->intoPolicy = GpPolicyCopy(parse->intoPolicy);
 	result->queryPartOids = NIL;
 	result->queryPartsMetadata = NIL;
 	result->numSelectorsPerScanId = NIL;
@@ -1160,7 +1160,7 @@ inheritance_planner(PlannerInfo *root)
 
 		if (!parentPolicy)
 		{
-			parentPolicy = GpPolicyFetch(NULL, appinfo->parent_reloid);
+			parentPolicy = GpPolicyFetch(appinfo->parent_reloid);
 			parentOid = appinfo->parent_reloid;
 
 			Assert(parentPolicy != NULL);

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -425,7 +425,7 @@ static bool QueryHasDistributedRelation(Query *q)
 		if (rte->relid != InvalidOid
 				&& rte->rtekind == RTE_RELATION)
 		{
-			GpPolicy *policy = GpPolicyFetch(CurrentMemoryContext, rte->relid);
+			GpPolicy *policy = GpPolicyFetch(rte->relid);
 			if (GpPolicyIsPartitioned(policy))
 			{
 				pfree(policy);

--- a/src/backend/optimizer/prep/preptlist.c
+++ b/src/backend/optimizer/prep/preptlist.c
@@ -391,7 +391,7 @@ expand_targetlist(PlannerInfo *root, List *tlist, int command_type,
 		bool		key_col_updated = false;
 
 		/* Was any distribution key column among the changed columns? */
-		targetPolicy = GpPolicyFetch(CurrentMemoryContext, RelationGetRelid(rel));
+		targetPolicy = GpPolicyFetch(RelationGetRelid(rel));
 		if (targetPolicy->ptype == POLICYTYPE_PARTITIONED)
 		{
 			int			i;

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -153,10 +153,9 @@ build_simple_rel(PlannerInfo *root, int relid, RelOptKind reloptkind)
 			/* if we've been asked to, force the dist-policy to be partitioned-randomly. */
 			if (rte->forceDistRandom)
 			{
-				GpPolicy   *origpolicy = GpPolicyFetch(NULL, rte->relid);
+				GpPolicy   *origpolicy = GpPolicyFetch(rte->relid);
 
-				rel->cdbpolicy = createRandomPartitionedPolicy(NULL,
-															   origpolicy->numsegments);
+				rel->cdbpolicy = createRandomPartitionedPolicy(origpolicy->numsegments);
 
 				/* Scribble the tuple number of rel to reflect the real size */
 				rel->tuples = rel->tuples * planner_segment_count(rel->cdbpolicy);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3679,7 +3679,7 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 						MaxPolicyAttributeNumber)));
 
 	if (dist->ptype == POLICYTYPE_REPLICATED)
-		qry->intoPolicy = createReplicatedGpPolicy(NULL, dist->numsegments);
+		qry->intoPolicy = createReplicatedGpPolicy(dist->numsegments);
 	else
 	{
 		List	*policykeys = NIL;
@@ -3701,7 +3701,7 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 			policykeys = lappend_int(policykeys, keyindex);
 		}
 
-		qry->intoPolicy = createHashPartitionedPolicy(NULL, policykeys,
+		qry->intoPolicy = createHashPartitionedPolicy(policykeys,
 													  dist->numsegments);
 	}
 }

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -422,7 +422,7 @@ transformExprRecurse(ParseState *pstate, Node *expr)
 
 				relid = pstate->p_target_rangetblentry->relid;
 
-				policy = GpPolicyFetch(CurrentMemoryContext, relid);
+				policy = GpPolicyFetch(relid);
 
 				/*
 				 * Now we can assume that the relation was locked because

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1846,8 +1846,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 		{
 			RangeVar   *parent = (RangeVar *) lfirst(entry);
 			Oid			relId = RangeVarGetRelid(parent, NoLock, false);
-			GpPolicy  *oldTablePolicy =
-				GpPolicyFetch(CurrentMemoryContext, relId);
+			GpPolicy  *oldTablePolicy = GpPolicyFetch(relId);
 
 			/*
 			 * Partitioned child must have partitioned parents. During binary
@@ -2321,7 +2320,7 @@ getPolicyForDistributedBy(DistributedBy *distributedBy, TupleDesc tupdesc)
 					elog(ERROR, "could not find DISTRIBUTED BY column \"%s\"", colname);
 			}
 
-			return createHashPartitionedPolicy(NULL, policykeys,
+			return createHashPartitionedPolicy(policykeys,
 											   distributedBy->numsegments);;
 
 		case POLICYTYPE_ENTRY:
@@ -2329,7 +2328,7 @@ getPolicyForDistributedBy(DistributedBy *distributedBy, TupleDesc tupdesc)
 			return NULL;
 
 		case POLICYTYPE_REPLICATED:
-			return createReplicatedGpPolicy(NULL, distributedBy->numsegments);
+			return createReplicatedGpPolicy(distributedBy->numsegments);
 	}
 	elog(ERROR, "unrecognized policy type %d", distributedBy->ptype);
 	return NULL;
@@ -4214,7 +4213,7 @@ getLikeDistributionPolicy(TableLikeClause *e)
 	GpPolicy*		oldTablePolicy;
 
 	relId = RangeVarGetRelid(e->relation, NoLock, false);
-	oldTablePolicy = GpPolicyFetch(CurrentMemoryContext, relId);
+	oldTablePolicy = GpPolicyFetch(relId);
 
 	if (oldTablePolicy != NULL && oldTablePolicy->ptype != POLICYTYPE_ENTRY)
 	{

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1018,9 +1018,13 @@ RelationBuildDesc(Oid targetRelId, bool insertIt)
      * initialize Greenplum Database partitioning info
      */
     if ((relation->rd_rel->relkind == RELKIND_RELATION &&
-        !IsSystemRelation(relation)) ||
+		 !IsSystemRelation(relation)) ||
 		relation->rd_rel->relkind == RELKIND_MATVIEW)
-        relation->rd_cdbpolicy = GpPolicyFetch(CacheMemoryContext, targetRelId);
+	{
+		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
+		relation->rd_cdbpolicy = GpPolicyFetch(targetRelId);
+		MemoryContextSwitchTo(oldcontext);
+	}
 
     relation->rd_cdbDefaultStatsWarningIssued = false;
 
@@ -3811,7 +3815,7 @@ CheckConstraintFetch(Relation relation)
 GpPolicy*
 RelationGetPartitioningKey(Relation relation)
 {
-    return GpPolicyCopy(CurrentMemoryContext, relation->rd_cdbpolicy);
+	return GpPolicyCopy(relation->rd_cdbpolicy);
 }                                       /* RelationGetPartitioningKey */
 
 

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -21,7 +21,6 @@
 #include "access/attnum.h"
 #include "catalog/genbki.h"
 #include "nodes/pg_list.h"
-#include "utils/palloc.h"
 
 /*
  * Defines for gp_policy
@@ -109,14 +108,14 @@ typedef struct GpPolicy
  *
  * The copy is palloc'ed in the specified context.
  */
-GpPolicy *GpPolicyCopy(MemoryContext mcxt, const GpPolicy *src);
+extern GpPolicy *GpPolicyCopy(const GpPolicy *src);
 
 /* GpPolicyEqual
  *
  * A field-by-field comparison just to facilitate comparing IntoClause
  * (which embeds this) in equalFuncs.c
  */
-bool GpPolicyEqual(const GpPolicy *lft, const GpPolicy *rgt);
+extern bool GpPolicyEqual(const GpPolicy *lft, const GpPolicy *rgt);
 
 /*
  * GpPolicyFetch
@@ -130,27 +129,27 @@ bool GpPolicyEqual(const GpPolicy *lft, const GpPolicy *rgt);
  * function does not check and assigns a policy of type POLICYTYPE_ENTRY
  * for any oid not found in gp_distribution_policy.
  */
-GpPolicy *GpPolicyFetch(MemoryContext mcxt, Oid tbloid);
+extern GpPolicy *GpPolicyFetch(Oid tbloid);
 
 /*
  * GpPolicyStore: sets the GpPolicy for a table.
  */
-void GpPolicyStore(Oid tbloid, const GpPolicy *policy);
+extern void GpPolicyStore(Oid tbloid, const GpPolicy *policy);
 
-void GpPolicyReplace(Oid tbloid, const GpPolicy *policy);
+extern void GpPolicyReplace(Oid tbloid, const GpPolicy *policy);
 
-void GpPolicyRemove(Oid tbloid);
+extern void GpPolicyRemove(Oid tbloid);
 
-bool GpPolicyIsRandomPartitioned(const GpPolicy *policy);
-bool GpPolicyIsHashPartitioned(const GpPolicy *policy);
-bool GpPolicyIsPartitioned(const GpPolicy *policy);
-bool GpPolicyIsReplicated(const GpPolicy *policy);
-bool GpPolicyIsEntry(const GpPolicy *policy);
+extern bool GpPolicyIsRandomPartitioned(const GpPolicy *policy);
+extern bool GpPolicyIsHashPartitioned(const GpPolicy *policy);
+extern bool GpPolicyIsPartitioned(const GpPolicy *policy);
+extern bool GpPolicyIsReplicated(const GpPolicy *policy);
+extern bool GpPolicyIsEntry(const GpPolicy *policy);
 
-extern GpPolicy *makeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs, int numsegments);
-extern GpPolicy *createReplicatedGpPolicy(MemoryContext mcxt, int numsegments);
-extern GpPolicy *createRandomPartitionedPolicy(MemoryContext mcxt, int numsegments);
-extern GpPolicy *createHashPartitionedPolicy(MemoryContext mcxt, List *keys, int numsegments);
+extern GpPolicy *makeGpPolicy(GpPolicyType ptype, int nattrs, int numsegments);
+extern GpPolicy *createReplicatedGpPolicy(int numsegments);
+extern GpPolicy *createRandomPartitionedPolicy(int numsegments);
+extern GpPolicy *createHashPartitionedPolicy(List *keys, int numsegments);
 
 extern bool IsReplicatedTable(Oid relid);
 

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -650,7 +650,7 @@ namespace gpdb {
 	// returns true if a query cancel is requested in GPDB
 	bool IsAbortRequested(void);
 
-	GpPolicy *MakeGpPolicy(MemoryContext mcxt, GpPolicyType ptype, int nattrs,
+	GpPolicy *MakeGpPolicy(GpPolicyType ptype, int nattrs,
 						   int numsegments);
 
 } //namespace gpdb


### PR DESCRIPTION
Most callers were passing CurrentMemoryContext, so this makes most callers
slightly simpler. The few places that needed to pass a different context
now switch to the correct one before calling the GpPolicy*() function.