### PR TITLE
Fix Travis compilation error by updating Travis configuration to match new orafce location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,20 +67,15 @@ env:
 
 ## ----------------------------------------------------------------------
 ## Perform build:
-##   GPDB
-##   orafce
 ## ----------------------------------------------------------------------
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --disable-orca --disable-gpcloud --enable-pxf --enable-mapreduce --with-perl --enable-snmp
+  - ./configure --with-openssl --with-ldap --with-libcurl --prefix=${TRAVIS_BUILD_DIR}/gpsql --disable-orca --disable-gpcloud --enable-pxf --enable-mapreduce --with-perl --enable-snmp --enable-orafce
 
   - make
   - make install
   - source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
-  - cd ${TRAVIS_BUILD_DIR}/gpAux/extensions/orafce
-  - make install USE_PGXS=1
-  - cd ${TRAVIS_BUILD_DIR}/
   - make unittest-check
   - postgres --version
   - initdb --version


### PR DESCRIPTION
The orafce extension was moved from gpAux/extensions to gpcontrib/ in commit 8c65f888e8, but the Travis configuration wasn't updated to match the new way of building.