### PR TITLE
Fix spelling of disabled option descriptions in autoconf

### DIFF
--- a/configure
+++ b/configure
@@ -1531,8 +1531,8 @@ Optional Features:
   --disable-atomics       do not use atomic operations
   --disable-gpfdist       do not use gpfdist
   --disable-pxf           do not build pxf
-  --enable-gphdfs         do not build gphdfs
-  --enable-orafce         do not build Oracle compatability functions
+  --enable-gphdfs         build with gphdfs
+  --enable-orafce         build with Oracle compatability functions
   --enable-gpperfmon      build with gpperfmon
   --enable-debug          build with debugging symbols (-g)
   --enable-profiling      build with profiling enabled

--- a/configure.in
+++ b/configure.in
@@ -216,14 +216,14 @@ AC_SUBST(enable_pxf)
 # gphdfs
 #
 PGAC_ARG_BOOL(enable, gphdfs, no,
-             [do not build gphdfs])
+             [build with gphdfs])
 AC_SUBST(enable_gphdfs)
 
 #
 # orafce
 #
 PGAC_ARG_BOOL(enable, orafce, no,
-             [do not build Oracle compatability functions])
+             [build with Oracle compatability functions])
 AC_SUBST(enable_orafce)
 
 #


### PR DESCRIPTION
The --enable-orafce and --enable-gphdfs were both described as "do not build X", probably from copy/pasting another PGAC_OPTION_BOOL which defaults to true and thus becomes --disable-X.