### PR TITLE
 Fix auto_explain to handle Greenplum EXPLAIN handling

### DIFF
--- a/contrib/auto_explain/auto_explain.c
+++ b/contrib/auto_explain/auto_explain.c
@@ -26,7 +26,7 @@ static bool auto_explain_log_analyze = false;
 static bool auto_explain_log_verbose = false;
 static bool auto_explain_log_buffers = false;
 static bool auto_explain_log_triggers = false;
-static bool auto_explain_log_timing = false;
+static bool auto_explain_log_timing = true;
 static int	auto_explain_log_format = EXPLAIN_FORMAT_TEXT;
 static bool auto_explain_log_nested_statements = false;
 
@@ -200,8 +200,6 @@ explain_ExecutorStart(QueryDesc *queryDesc, int eflags)
 				queryDesc->instrument_options |= INSTRUMENT_TIMER;
 			else
 				queryDesc->instrument_options |= INSTRUMENT_ROWS;
-
-
 			if (auto_explain_log_buffers)
 				queryDesc->instrument_options |= INSTRUMENT_BUFFERS;
 		}
@@ -302,6 +300,7 @@ explain_ExecutorEnd(QueryDesc *queryDesc)
 			es.analyze = (queryDesc->instrument_options && auto_explain_log_analyze);
 			es.verbose = auto_explain_log_verbose;
 			es.buffers = (es.analyze && auto_explain_log_buffers);
+			es.timing = (es.analyze && auto_explain_log_timing);
 			es.format = auto_explain_log_format;
 
 			ExplainBeginOutput(&es);

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -711,8 +711,12 @@ ExplainPrintPlan(ExplainState *es, QueryDesc *queryDesc)
 	/* CDB: Find slice table entry for the root slice. */
 	es->currentSlice = getCurrentSlice(estate, LocallyExecutingSliceIndex(estate));
 
-	/* Get local stats if root slice was executed here in the qDisp. */
-	if (es->analyze)
+	/*
+	 * Get local stats if root slice was executed here in the qDisp, as long
+	 * as we haven't already gathered the statistics. This can happen when an
+	 * executor hook generates EXPLAIN output.
+	 */
+	if (es->analyze && !es->showstatctx->stats_gathered)
 	{
 		if (!es->currentSlice || sliceRunsOnQD(es->currentSlice))
 			cdbexplain_localExecStats(queryDesc->planstate, es->showstatctx);

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -240,6 +240,7 @@ typedef struct CdbExplain_ShowStatCtx
 	double		workmemused_max;
 	double		workmemwanted_max;
 
+	bool		stats_gathered;
 	/* Per-slice statistics are deposited in this SliceSummary array */
 	int			nslice;			/* num of slots in slices array */
 	CdbExplain_SliceSummary *slices;	/* -> array[0..nslice-1] of
@@ -772,6 +773,9 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 
 	/* Transfer worker counts to SliceSummary. */
 	showstatctx->slices[sliceIndex].dispatchSummary = ds;
+
+	/* Signal that we've gathered all the statistics */
+	showstatctx->stats_gathered = true;
 
 	/* Clean up. */
 	if (ctx.msgptrs)
@@ -1877,6 +1881,21 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 	}
 }								/* cdbexplain_showExecStats */
 
+/*
+ *	ExplainPrintExecStatsEnd
+ *			External API wrapper for cdbexplain_showExecStatsEnd
+ *
+ * This is an externally exposed wrapper for cdbexplain_showExecStatsEnd such
+ * that extensions, such as auto_explain, can leverage the Greenplum specific
+ * parts of the EXPLAIN machiner.
+ */
+void
+ExplainPrintExecStatsEnd(ExplainState *es, QueryDesc *queryDesc)
+{
+	cdbexplain_showExecStatsEnd(queryDesc->plannedstmt,
+								queryDesc->showstatctx,
+								queryDesc->estate, es);
+}
 
 /*
  * cdbexplain_showExecStatsEnd

--- a/src/include/commands/explain.h
+++ b/src/include/commands/explain.h
@@ -97,4 +97,6 @@ extern void ExplainPropertyLong(const char *qlabel, long value,
 extern void ExplainPropertyFloat(const char *qlabel, double value, int ndigits,
 					 ExplainState *es);
 
+extern void ExplainPrintExecStatsEnd(ExplainState *es, QueryDesc *queryDesc);
+
 #endif   /* EXPLAIN_H */


### PR DESCRIPTION
When running EXPLAIN ANALYZE queries, the showstat context was being populated twice which led to an assertion failure. Fix by adding a flag to the struct to signal that the stats gathering has already
been performed. Also add the Greenplum Executor end statistics to the printing and properly set CDB instrumentation.

This is a re-working of #6085 done through the review process.