### PR TITLE
Adds src/test/modules to installcheck.

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -14,6 +14,6 @@ include $(top_builddir)/src/Makefile.global
 
 SUBDIRS = regress isolation
 
-SUBDIRS += fsync walrep heap_checksum isolation2 kerberos
+SUBDIRS += fsync walrep heap_checksum isolation2 kerberos modules
 
 $(recurse)

--- a/src/test/modules/test_planner/Makefile
+++ b/src/test/modules/test_planner/Makefile
@@ -26,5 +26,7 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
+installcheck: install
+
 test: clean all install
 	psql postgres -f sql/test_planner.sql 2>&1


### PR DESCRIPTION
Added src/test/modules to the full test suite. Install check seems like the appropriate place, as these tests are for the core server, not for a contrib module.