### PR TITLE
Fix gp_distribution_policy for NULLs and non-first distribution keys.

### DIFF
--- a/gpcontrib/gp_distribution_policy/input/gp_distribution_policy.source
+++ b/gpcontrib/gp_distribution_policy/input/gp_distribution_policy.source
@@ -10,13 +10,21 @@ CREATE EXTENSION gp_distribution_policy;
 CREATE TABLE APPENDONLY_TABLE(id int, some_data int) WITH (appendonly = true);
 CREATE TABLE some_table(id int, some_data int);
 INSERT INTO APPENDONLY_TABLE (SELECT gen_id, gen_data from generate_series(1, 10000) gen_id, generate_series(100000, 20000) gen_data);
+INSERT INTO APPENDONLY_TABLE VALUES (NULL, 123);
 INSERT INTO some_table (SELECT gen_id, gen_data from generate_series(100000, 20000) gen_id, generate_series(1, 10000) gen_data);
+INSERT INTO some_table VALUES (NULL, 123);
+
+CREATE TABLE nonfirst_distkey_table (id int4, t text) DISTRIBUTED BY (t);
+INSERT INTO nonfirst_distkey_table SELECT g, g::text FROM generate_series(1, 100) g;
 
 -- Check that AO Tables throw error when checked
 SELECT gp_heap_distribution_check('appendonly_table');
 
 -- Check partitioned table returns something
 SELECT gp_heap_distribution_check('some_table');
+
+-- Check that table with non-first key column also works
+SELECT gp_heap_distribution_check('nonfirst_distkey_table');
 
 -- Check that a table with the wrong distribution correctly displays a false
 CREATE TABLE some_other_table(id int, some_other_data int) distributed by (id);

--- a/gpcontrib/gp_distribution_policy/output/gp_distribution_policy.source
+++ b/gpcontrib/gp_distribution_policy/output/gp_distribution_policy.source
@@ -13,7 +13,11 @@ CREATE TABLE some_table(id int, some_data int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO APPENDONLY_TABLE (SELECT gen_id, gen_data from generate_series(1, 10000) gen_id, generate_series(100000, 20000) gen_data);
+INSERT INTO APPENDONLY_TABLE VALUES (NULL, 123);
 INSERT INTO some_table (SELECT gen_id, gen_data from generate_series(100000, 20000) gen_id, generate_series(1, 10000) gen_data);
+INSERT INTO some_table VALUES (NULL, 123);
+CREATE TABLE nonfirst_distkey_table (id int4, t text) DISTRIBUTED BY (t);
+INSERT INTO nonfirst_distkey_table SELECT g, g::text FROM generate_series(1, 100) g;
 -- Check that AO Tables throw error when checked
 SELECT gp_heap_distribution_check('appendonly_table');
 ERROR:  input relation is not a heap table (gp_distribution_policy.c:180)  (seg0 slice1 127.0.1.1:25432 pid=10683) (gp_distribution_policy.c:180)
@@ -25,6 +29,15 @@ SELECT gp_heap_distribution_check('some_table');
  (2,t)
  (0,t)
  (1,t)
+(3 rows)
+
+-- Check that table with non-first key column also works
+SELECT gp_heap_distribution_check('nonfirst_distkey_table');
+ gp_heap_distribution_check 
+----------------------------
+ (0,t)
+ (1,t)
+ (2,t)
 (3 rows)
 
 -- Check that a table with the wrong distribution correctly displays a false


### PR DESCRIPTION
Two bugs:

1. NULLs were not hashed correctly.

2. The code to fetch the attribute's datatype was wrong. It fetched the
   datatype of the table's nth attribute, instead of the nth distribution
   key column's.

Both of these would lead to false report of wrong distribution, or errors.