### PR TITLE
5X_STABLE: Backport stable function folding for simple expressions

### DIFF
--- a/src/test/modules/Makefile
+++ b/src/test/modules/Makefile
@@ -1,0 +1,9 @@
+# src/test/modules/Makefile
+
+subdir = src/test/modules
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+
+SUBDIRS = test_planner
+
+$(recurse)

--- a/src/test/modules/test_planner/expected/test_planner.out
+++ b/src/test/modules/test_planner/expected/test_planner.out
@@ -15,6 +15,8 @@ INFO:  Success test_window_function_with_subquery_has_correct_extparams - integr
 INFO:  Success test_window_function_with_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:26
 INFO:  Success test_window_function_with_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:29
 INFO:  Success test_window_function_with_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:32
+INFO:  Success test_stable_function_in_subquery_is_evaluated_to_const - integration_tests/planner_integration_tests.c:70
+INFO:  Success test_stable_function_in_simple_query_is_not_evaluated_in_planner - integration_tests/planner_integration_tests.c:83
  test_planner 
 --------------
  

--- a/src/test/modules/test_planner/expected/test_planner.out
+++ b/src/test/modules/test_planner/expected/test_planner.out
@@ -1,25 +1,23 @@
 -- start_matchsubs
---
--- # Ignore drop failures
--- m/.*extension \"test_planner\" does not exist/
--- s/(.*)//
--- 
 -- # Remove all successful
--- m/INFO:  Success.*/
--- s/(.*)//
---
+-- m/INFO:  Success.*\.c:\d+/
+-- s/\d+/###/
 -- end_matchsubs
-DROP EXTENSION test_planner;
-
+--start_ignore
 CREATE EXTENSION test_planner;
+--end_ignore
 SELECT test_planner();
-
-
-
-
- test_planner
+INFO:  Success test_vanilla_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:48
+INFO:  Success test_vanilla_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:51
+INFO:  Success test_vanilla_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:54
+INFO:  Success test_vanilla_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:57
+INFO:  Success test_window_function_with_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:23
+INFO:  Success test_window_function_with_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:26
+INFO:  Success test_window_function_with_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:29
+INFO:  Success test_window_function_with_subquery_has_correct_extparams - integration_tests/planner_integration_tests.c:32
+ test_planner 
 --------------
-
+ 
 (1 row)
 
 DROP EXTENSION test_planner;

--- a/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
+++ b/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
@@ -57,9 +57,40 @@ test_vanilla_subquery_has_correct_extparams()
 		is_equal_to(0));
 }
 
+static void
+test_stable_function_in_subquery_is_evaluated_to_const()
+{
+	const char *query_string = "select * from (select now()) a;";
+
+	Query *query = make_query(query_string);
+	PlannedStmt *plannedstmt = planner(query, 0, NULL);
+
+	TargetEntry *tle = get_target_entry_from_root_plan_node(plannedstmt);
+
+	assert_that_bool(IsA(tle->expr, Const), is_equal_to(true));
+}
+
+static void
+test_stable_function_in_simple_query_is_not_evaluated_in_planner()
+{
+	const char *query_string = "select now();";
+
+	Query *query = make_query(query_string);
+	PlannedStmt *plannedstmt = planner(query, 0, NULL);
+
+	TargetEntry *tle = get_target_entry_from_root_plan_node(plannedstmt);
+
+	assert_that_bool(IsA(tle->expr, FuncExpr), is_equal_to(true));
+}
+
 void
 run_planner_integration_test_suite(void)
 {
+	/*
+	 * Tests that are generic between planner and optimizer
+	 */
 	test_vanilla_subquery_has_correct_extparams();
 	test_window_function_with_subquery_has_correct_extparams();
+	test_stable_function_in_subquery_is_evaluated_to_const();
+	test_stable_function_in_simple_query_is_not_evaluated_in_planner();
 }

--- a/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
+++ b/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
@@ -6,7 +6,8 @@
 #include "src/assertions.h"
 #include "src/planner_test_helpers.h"
 
-static void test_window_function_with_subquery_has_correct_extparams()
+static void
+test_window_function_with_subquery_has_correct_extparams()
 {
 	const char *query_string = "select ( \
 							       SELECT min(1) OVER() \
@@ -31,7 +32,8 @@ static void test_window_function_with_subquery_has_correct_extparams()
 		is_equal_to(0));
 }
 
-static void test_vanilla_subquery_has_correct_extparams()
+static void
+test_vanilla_subquery_has_correct_extparams()
 {
 	const char *subquery_string = "select ( \
 								    select 1 from pg_class \
@@ -55,7 +57,9 @@ static void test_vanilla_subquery_has_correct_extparams()
 		is_equal_to(0));
 }
 
-void run_planner_integration_test_suite(void) {
+void
+run_planner_integration_test_suite(void)
+{
 	test_vanilla_subquery_has_correct_extparams();
 	test_window_function_with_subquery_has_correct_extparams();
 }

--- a/src/test/modules/test_planner/sql/test_planner.sql
+++ b/src/test/modules/test_planner/sql/test_planner.sql
@@ -1,17 +1,12 @@
 -- start_matchsubs
---
--- # Ignore drop failures
--- m/.*extension \"test_planner\" does not exist/
--- s/(.*)//
---
 -- # Remove all successful
--- m/INFO:  Success.*/
--- s/(.*)//
---
+-- m/INFO:  Success.*\.c:\d+/
+-- s/\d+/###/
 -- end_matchsubs
 
-DROP EXTENSION test_planner;
+--start_ignore
 CREATE EXTENSION test_planner;
+--end_ignore
 
 SELECT test_planner();
 DROP EXTENSION test_planner;

--- a/src/test/modules/test_planner/src/assertions.c
+++ b/src/test/modules/test_planner/src/assertions.c
@@ -2,22 +2,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-char *int_to_bool_string(int value) {
+char *
+int_to_bool_string(int value)
+{
 	if (value == 0) return "false";
 	return "true";
 }
 
-char *int_to_int_string(int value) {
+char *
+int_to_int_string(int value)
+{
 	char *buffer = malloc(sizeof(char*));
 	sprintf(buffer, "%d", value);
 	return buffer;
 }
 
-void test_succeeded(
+void
+test_succeeded(
 	const char* test_function_name,
 	const char* test_file_name,
-	int test_line_number) {
-
+	int test_line_number)
+{
 	elog(
 		INFO,
 		"Success %s - %s:%d",
@@ -26,13 +31,14 @@ void test_succeeded(
 		test_line_number);
 }
 
-void test_failed(
+void
+test_failed(
 	char *expected,
 	char *actual,
 	const char *test_function_name,
 	const char *test_file_name,
-	int test_line_number) {
-
+	int test_line_number)
+{
 	elog(
 		WARNING,
 		"expected %s, was %s in %s - %s:%d",

--- a/src/test/modules/test_planner/src/planner_test_helpers.c
+++ b/src/test/modules/test_planner/src/planner_test_helpers.c
@@ -32,3 +32,11 @@ get_first_subplan(PlannedStmt *plannedStmt)
 {
 	return (Plan *)list_nth(plannedStmt->subplans, 0);
 }
+
+TargetEntry *
+get_target_entry_from_root_plan_node(PlannedStmt *plannedstmt)
+{
+	Result *result_node = (Result*) plannedstmt->planTree;
+	List *tlist = result_node->plan.targetlist;
+	return list_nth(tlist, 0);
+}

--- a/src/test/modules/test_planner/src/planner_test_helpers.c
+++ b/src/test/modules/test_planner/src/planner_test_helpers.c
@@ -3,27 +3,32 @@
 #include "optimizer/planmain.h"
 #include "tcop/tcopprot.h"
 
-static Node *get_parsetree_for(const char *query_string) {
+static Node *
+get_parsetree_for(const char *query_string)
+{
 	List *parsetree_list = pg_parse_query(query_string);
 	ListCell *parsetree_item = list_head(parsetree_list);
 	return (Node *)lfirst(parsetree_item);
 }
 
 static Query *
-get_query_for_parsetree(Node *parsetree, const char *query_string) {
+get_query_for_parsetree(Node *parsetree, const char *query_string)
+{
 	List *querytree_list = pg_analyze_and_rewrite(parsetree, query_string, NULL, 0);
 	ListCell *querytree = list_head(querytree_list);
 	return (Query *)lfirst(querytree);
 }
 
 Query *
-make_query(const char *query_string) {
+make_query(const char *query_string)
+{
 	Node *parsetree = get_parsetree_for(query_string);
 
 	return get_query_for_parsetree(parsetree, query_string);
 }
 
 Plan *
-get_first_subplan(PlannedStmt *plannedStmt) {
+get_first_subplan(PlannedStmt *plannedStmt)
+{
 	return (Plan *)list_nth(plannedStmt->subplans, 0);
 }

--- a/src/test/modules/test_planner/src/planner_test_helpers.h
+++ b/src/test/modules/test_planner/src/planner_test_helpers.h
@@ -8,5 +8,6 @@
 
 extern Query *make_query(const char *query_string);
 extern Plan *get_first_subplan(PlannedStmt *plannedStmt);
+extern TargetEntry *get_target_entry_from_root_plan_node(PlannedStmt *plannedstmt);
 
 #endif //PLANNER_TEST_HELPERS_H

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -299,6 +299,60 @@ NOTICE:  stabletestfunc executed
   1
 (1 row)
 
+-- Test that pl/pgsql simple expressions are not considered a
+-- oneoffPlan.  We validate this by ensuring that a simple expression
+-- involving a stable function is planned only once and the same plan
+-- is re-executed for each tuple.  The NOTICE in the immutable
+-- function allows us to detect when it is executed.  We assume that
+-- the planner folds immutablefunc() into a const.
+CREATE FUNCTION immutablefunc() RETURNS int2
+LANGUAGE plpgsql IMMUTABLE STRICT AS
+$$
+BEGIN
+	raise notice 'immutablefunc executed';
+	return 42;
+END
+$$;
+CREATE FUNCTION stablenow (dummy int2) RETURNS timestamp
+LANGUAGE plpgsql STABLE STRICT AS
+$fn$
+BEGIN
+	return now();
+END
+$fn$;
+CREATE FUNCTION volatilefunc(a int) RETURNS int
+LANGUAGE plpgsql VOLATILE STRICT AS
+$fn$
+DECLARE
+  t timestamp;
+BEGIN
+	t := stablenow(immutablefunc());
+	if date_part('month', t) > a then
+		return 0;
+	else
+		return 1;
+	end if;
+END
+$fn$;
+CREATE TABLE oneoffplantest (a int) distributed by (a);
+INSERT INTO oneoffplantest VALUES (0), (0), (0);
+-- Plan for the following query should be cached such that the call to
+-- immutablefun() is folded into a const.  Note that all the
+-- statements within volatilefunc() are pl/pgsql simple expressions.
+-- Their plans should NOT be classified as oneoffPlan and should be
+-- cached.  So we expect the NOTICE to be printed only once,
+-- regardless of the number of tuples in the table.
+select volatilefunc(a) from oneoffplantest;
+NOTICE:  immutablefunc executed  (seg0 slice1 127.0.1.1:25432 pid=6257)
+CONTEXT:  SQL statement "SELECT stablenow(immutablefunc())"
+PL/pgSQL function "volatilefunc" line 4 at assignment
+ volatilefunc 
+--------------
+            0
+            0
+            0
+(3 rows)
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -655,7 +655,7 @@ alter function myfunc(int) reset all;
 select myfunc(0), current_setting('regex_flavor');
   myfunc  | current_setting 
 ----------+-----------------
- extended | advanced
+ extended | extended
 (1 row)
 
 set regex_flavor = advanced;
@@ -670,18 +670,7 @@ set regex_flavor = basic;
 select myfunc(0), current_setting('regex_flavor');
   myfunc  | current_setting 
 ----------+-----------------
- extended | advanced
-(1 row)
-
--- In GPDB, the plan looks somewhat different from what you get on
--- PostgreSQL, so that the current_setting() in previous query is
--- evaluated before myfunc(0), and therefore it shows 'advanced'.
--- Query again to show that the myfunc(0) call actually changed
--- the setting.
-select current_setting('regex_flavor');
- current_setting 
------------------
- extended
+ extended | extended
 (1 row)
 
 set regex_flavor = advanced;
@@ -707,6 +696,6 @@ select current_setting('regex_flavor');
 select myfunc(1), current_setting('regex_flavor');
   myfunc  | current_setting 
 ----------+-----------------
- extended | advanced
+ extended | extended
 (1 row)
 

--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -187,3 +187,52 @@ select has_account_type('select * from (select simple_sql_function(i) from all_t
                12
 (1 row)
 
+create or replace function oneoff_plan_func(a integer)
+returns integer AS
+$$
+BEGIN
+if date_part('month', now()) + 1 > a then
+   return 0;
+else
+   return 1;
+end if;
+END
+$$ LANGUAGE 'plpgsql' stable;
+-- The oneoff_plan_func calls the stable function "now()".  Normally,
+-- GPDB will agressively evaluate stable functions in the planner, at
+-- the cost of being required to regenerate a plan during every
+-- execution.  The benefit of this is partition elimination because
+-- partition elimination is done inside the planner, by evaluating
+-- stable functions we can avoid costly full table scans on tables
+-- that will yield no tuples.  However, in the case of simple
+-- expressions in pl/pgsql the resulting plan will never do partition
+-- elimination.  In cases where we will end up with simple
+-- expressions, we can prevent the planner from evaluating stable
+-- functions in order for it to create a reusable plan.  A reusable
+-- plan will be cached and reused for subsequent executions of
+-- oneoff_plan_func.
+-- Two planners, one for each evaluated statement block in oneoff_plan_func will
+-- be executed on seg0.  Because seg0 is the only segment having tuples, no
+-- other segment will create a plan.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Planner');
+ has_account_type 
+------------------
+                2
+(1 row)
+
+-- Both plans will have been cached during previous executions will be reused,
+-- therefore, we expect the output to be 0.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Planner');
+ has_account_type 
+------------------
+                0
+(1 row)
+
+-- We expect only three Executor accounts, one per segment, because
+-- simple expressions in pl/pgsql should not need a full executor.
+select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -195,6 +195,52 @@ execute myprep;
 execute myprep;
 execute myprep;
 
+-- Test that pl/pgsql simple expressions are not considered a
+-- oneoffPlan.  We validate this by ensuring that a simple expression
+-- involving a stable function is planned only once and the same plan
+-- is re-executed for each tuple.  The NOTICE in the immutable
+-- function allows us to detect when it is executed.  We assume that
+-- the planner folds immutablefunc() into a const.
+CREATE FUNCTION immutablefunc() RETURNS int2
+LANGUAGE plpgsql IMMUTABLE STRICT AS
+$$
+BEGIN
+	raise notice 'immutablefunc executed';
+	return 42;
+END
+$$;
+CREATE FUNCTION stablenow (dummy int2) RETURNS timestamp
+LANGUAGE plpgsql STABLE STRICT AS
+$fn$
+BEGIN
+	return now();
+END
+$fn$;
+
+CREATE FUNCTION volatilefunc(a int) RETURNS int
+LANGUAGE plpgsql VOLATILE STRICT AS
+$fn$
+DECLARE
+  t timestamp;
+BEGIN
+	t := stablenow(immutablefunc());
+	if date_part('month', t) > a then
+		return 0;
+	else
+		return 1;
+	end if;
+END
+$fn$;
+CREATE TABLE oneoffplantest (a int) distributed by (a);
+INSERT INTO oneoffplantest VALUES (0), (0), (0);
+
+-- Plan for the following query should be cached such that the call to
+-- immutablefun() is folded into a const.  Note that all the
+-- statements within volatilefunc() are pl/pgsql simple expressions.
+-- Their plans should NOT be classified as oneoffPlan and should be
+-- cached.  So we expect the NOTICE to be printed only once,
+-- regardless of the number of tuples in the table.
+select volatilefunc(a) from oneoffplantest;
 
 -- start_ignore
 drop table if exists bfv_planner_x;

--- a/src/test/regress/sql/guc.sql
+++ b/src/test/regress/sql/guc.sql
@@ -236,13 +236,6 @@ set regex_flavor = basic;
 
 select myfunc(0), current_setting('regex_flavor');
 
--- In GPDB, the plan looks somewhat different from what you get on
--- PostgreSQL, so that the current_setting() in previous query is
--- evaluated before myfunc(0), and therefore it shows 'advanced'.
--- Query again to show that the myfunc(0) call actually changed
--- the setting.
-select current_setting('regex_flavor');
-
 set regex_flavor = advanced;
 
 -- it should roll back on error, though


### PR DESCRIPTION
This patch set backports the changes in PR #5971 to the 5X_STABLE branch.

Stable functions need not be folded in case the query is simple enough (e.g. pl/pgsql simple expression, or "select foo()").

Without this patch, every time a simple expression is evaluated, a new plan and a new ExprState are generated. Because we only clean up the expression states created for simple expressions at the end of transaction, this will result in millions of expression states, one per tuple, being generated that are not reused after they are initially created.