### PR TITLE
Header file cleanup to avoid need for postgres.h in frontend code.

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -90,6 +90,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/tqual.h"
+#include "utils/timestamp.h"
 
 #include "cdb/cdbpartition.h"
 #include "cdb/cdbsreh.h"

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -42,6 +42,7 @@
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/bytea.h"
+#include "utils/timestamp.h"
 
 static void PreprocessByteaData(char *src);
 static void ErrorLogWrite(CdbSreh *cdbsreh);

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -39,7 +39,7 @@
 #include "miscadmin.h"
 #include "commands/sequence.h"
 #include "access/xact.h"
-
+#include "utils/timestamp.h"
 #define DISPATCH_WAIT_TIMEOUT_MSEC 2000
 
 /*

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -83,6 +83,7 @@
 #include "commands/user.h"
 #include "miscadmin.h"
 #include "postmaster/bgwriter.h"
+#include "storage/bufmgr.h"
 #include "storage/fd.h"
 #include "storage/lmgr.h"
 #include "storage/standby.h"

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -60,7 +60,7 @@
 #include "catalog/gp_segment_config.h"
 
 #include "storage/backendid.h"
-
+#include "storage/bufmgr.h"
 #include "executor/spi.h"
 
 #include "tcop/tcopprot.h" /* quickdie() */
@@ -241,7 +241,7 @@ ftsMain(int argc, char *argv[])
 	BaseInit();
 
 	/* See InitPostgres()... */
-	InitProcess();	
+	InitProcess();
 	InitBufferPoolBackend();
 	InitXLOGAccess();
 

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -16,6 +16,7 @@
 #include "cdb/cdbvars.h"
 #include "replication/gp_replication.h"
 #include "replication/walreceiver.h"
+#include "replication/walsender.h"
 #include "replication/walsender_private.h"
 #include "utils/builtins.h"
 

--- a/src/backend/tcop/idle_resource_cleaner.c
+++ b/src/backend/tcop/idle_resource_cleaner.c
@@ -13,6 +13,8 @@
  */
 #include "postgres.h"
 
+#include <signal.h>
+
 #include "cdb/cdbgang.h"
 #include "commands/async.h"
 #include "storage/sinval.h"

--- a/src/backend/utils/adt/timestamp.c
+++ b/src/backend/utils/adt/timestamp.c
@@ -32,6 +32,7 @@
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/datetime.h"
+#include "utils/timestamp.h"
 
 /*
  * gcc's -ffast-math switch breaks routines that expect exact results from

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -27,6 +27,7 @@
 #include "storage/procarray.h"
 #include "storage/procsignal.h"
 #include "storage/backendid.h"
+#include "storage/bufmgr.h"
 #include "storage/sinvaladt.h"
 #include "tcop/tcopprot.h"
 #include "utils/gdd.h"

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -20,9 +20,7 @@
 #include "storage/buf.h"
 #include "utils/pg_crc.h"
 #include "utils/relcache.h"
-#include "utils/timestamp.h"
 #include "cdb/cdbpublic.h"
-#include "replication/walsender.h"
 #include "datatype/timestamp.h"
 
 /*

--- a/src/include/storage/bufpage.h
+++ b/src/include/storage/bufpage.h
@@ -16,9 +16,14 @@
 
 #include "access/xlogdefs.h"
 #include "storage/block.h"
-#include "storage/bufmgr.h"
 #include "storage/item.h"
 #include "storage/off.h"
+#include "miscadmin.h"
+
+#ifndef FRONTEND
+/* Needed by PageGetLSN(), only for asserts in backend code */
+#include "storage/bufmgr.h"
+#endif
 
 /*
  * A postgres disk page is an abstraction layered on top of a postgres
@@ -364,7 +369,7 @@ typedef PageHeaderData *PageHeader;
 static inline XLogRecPtr
 PageGetLSN(Page page)
 {
-#ifdef USE_ASSERT_CHECKING
+#if defined (USE_ASSERT_CHECKING) && !defined(FRONTEND)
 	extern PGDLLIMPORT char *BufferBlocks; /* duplicates bufmgr.h */
 	char *pagePtr = page;
 
@@ -379,7 +384,6 @@ PageGetLSN(Page page)
 		Assert(LWLockHeldByMe(hdr->content_lock));
 	}
 #endif
-
 	return PageXLogRecPtrGet(((PageHeader) (page))->pd_lsn);
 }
 

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -49,6 +49,7 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/resource_manager.h"
+#include "utils/timestamp.h"
 
 /* table_functions test */
 extern Datum multiset_example(PG_FUNCTION_ARGS);

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -15,6 +15,7 @@
 #include "libpq/pqformat.h"
 #include "utils/builtins.h"
 #include "utils/pg_lsn.h"
+#include "utils/timestamp.h"
 
 PG_MODULE_MAGIC;
 


### PR DESCRIPTION
This PR is fall out of work to add `pg_rewind` to gpdb. As part of the same need for including `postgres.h` was flagged due to gpdb's difference in including `bufmgr.h` in `bufpage.h`. Eliminated the need by moving the function `PageGetLSN()` to `bugmgr.c` file. Another cleanup avoids inclusion of `utils/timestamp.h`.