### PR TITLE
Catch the cstate->md_error to prevent the crash happening.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -7040,6 +7040,12 @@ void CopyExtractRowMetaData(CopyState cstate)
 
 	/* look for the second delimiter, and extract line_buf_converted */
 	COPY_FIND_MD_DELIM;
+	if(cstate->md_error)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+				 errmsg("COPY metadata not found. This probably means that there is a "
+						"mixture of newline types in the data. Use the NEWLINE keyword "
+						"in order to resolve this reliably.")));
 	Assert(*line_start == '0' || *line_start == '1'); 
 	cstate->line_buf_converted = atoi(line_start);
 	

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -7026,9 +7026,9 @@ void CopyExtractRowMetaData(CopyState cstate)
 	if(cstate->md_error)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
-				 errmsg("COPY metadata not found. This probably means that there is a "
-						"mixture of newline types in the data. Use the NEWLINE keyword "
-						"in order to resolve this reliably.")));
+				 errmsg("COPY metadata cur_lineno not found. This probably means that "
+						"there is a mixture of newline types in the data. Use the NEWLINE"
+						"keyword in order to resolve this reliably.")));
 
 	cstate->cur_lineno = atoi(line_start);
 
@@ -7043,9 +7043,9 @@ void CopyExtractRowMetaData(CopyState cstate)
 	if(cstate->md_error)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
-				 errmsg("COPY metadata not found. This probably means that there is a "
-						"mixture of newline types in the data. Use the NEWLINE keyword "
-						"in order to resolve this reliably.")));
+				 errmsg("COPY metadata line_buf_converted not found. This probably means "
+						"that there is a mixture of newline types in the data. Use the "
+						"NEWLINE keyword in order to resolve this reliably.")));
 	Assert(*line_start == '0' || *line_start == '1'); 
 	cstate->line_buf_converted = atoi(line_start);
 	

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -580,13 +580,25 @@ DROP TABLE copy_regression_newline;
 -- <MD>xxx\r
 -- xxx\n
 -- We lost the prefix <MD> and get a panic
- CREATE TABLE copy_regression_detect(a text) distributed by(a);
+CREATE TABLE copy_regression_detect(a text) distributed by(a);
+-- negative
 COPY copy_regression_detect FROM stdin;
 1
 12
 \.
 
 COPY copy_regression_detect FROM stdin;
+1
+12^22
+\.
+
+-- positive
+COPY copy_regression_detect FROM stdin WITH NEWLINE 'LF';
+1
+12
+\.
+
+COPY copy_regression_detect FROM stdin WITH NEWLINE 'LF';
 1
 12^22
 \.

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -565,6 +565,34 @@ COPY copy_regression_newline to stdout with delimiter '|' newline 'blah';
 
 DROP TABLE copy_regression_newline;
 
+-- test automatic detect newline
+-- the problem lies in the way we (and postgresql) handle newlines. We 
+-- automatically detect the newline type (LF, CR or CRLF) by looking at
+-- the first row of data, and assume that the rest of the data has the 
+-- same newline type. This happens on the master and then on each segment
+-- all over again. That can be confusing. For example, 
+-- the original data xxxxxx\nxxxx\rxxx\n
+-- QD detect the newline and add prefix <MD> 
+-- <MD>xxxxxx\n
+-- <MD>xxx\rxxx\n
+-- QE detect the newline type again and split line to 
+-- <MD>xxxxxx\n
+-- <MD>xxx\r
+-- xxx\n
+-- We lost the prefix <MD> and get a panic
+ CREATE TABLE copy_regression_detect(a text) distributed by(a);
+COPY copy_regression_detect FROM stdin;
+1
+12
+\.
+
+COPY copy_regression_detect FROM stdin;
+1
+12^22
+\.
+
+DROP TABLE copy_regression_detect;
+
 -- Test that FORCE QUOTE option works with the fastpath for integers and
 -- numerics
 COPY (

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -527,7 +527,8 @@ DROP TABLE copy_regression_newline;
 -- <MD>xxx\r
 -- xxx\n
 -- We lost the prefix <MD> and get a panic
- CREATE TABLE copy_regression_detect(a text) distributed by(a);
+CREATE TABLE copy_regression_detect(a text) distributed by(a);
+-- negative
 COPY copy_regression_detect FROM stdin;
 ERROR:  COPY metadata cur_lineno not found. This probably means that there is a mixture of newline types in the data. Use the NEWLINEkeyword in order to resolve this reliably.  (seg1 127.0.0.1:25433 pid=7977)
 CONTEXT:  COPY copy_regression_detect, line 2: "2
@@ -536,6 +537,9 @@ COPY copy_regression_detect FROM stdin;
 ERROR:  COPY metadata line_buf_converted not found. This probably means that there is a mixture of newline types in the data. Use the NEWLINE keyword in order to resolve this reliably.  (seg2 127.0.0.1:25434 pid=7978)
 CONTEXT:  COPY copy_regression_detect, line 2: "2^22
 "
+-- positive
+COPY copy_regression_detect FROM stdin WITH NEWLINE 'LF';
+COPY copy_regression_detect FROM stdin WITH NEWLINE 'LF';
 DROP TABLE copy_regression_detect;
 -- Test that FORCE QUOTE option works with the fastpath for integers and
 -- numerics

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -512,6 +512,31 @@ HINT:  valid options are: 'LF', 'CRLF', 'CR'
 COPY copy_regression_newline to stdout with delimiter '|' newline 'blah';
 ERROR:  newline currently available for data loading only, not unloading
 DROP TABLE copy_regression_newline;
+-- test automatic detect newline
+-- the problem lies in the way we (and postgresql) handle newlines. We 
+-- automatically detect the newline type (LF, CR or CRLF) by looking at
+-- the first row of data, and assume that the rest of the data has the 
+-- same newline type. This happens on the master and then on each segment
+-- all over again. That can be confusing. For example, 
+-- the original data xxxxxx\nxxxx\rxxx\n
+-- QD detect the newline and add prefix <MD> 
+-- <MD>xxxxxx\n
+-- <MD>xxx\rxxx\n
+-- QE detect the newline type again and split line to 
+-- <MD>xxxxxx\n
+-- <MD>xxx\r
+-- xxx\n
+-- We lost the prefix <MD> and get a panic
+ CREATE TABLE copy_regression_detect(a text) distributed by(a);
+COPY copy_regression_detect FROM stdin;
+ERROR:  COPY metadata cur_lineno not found. This probably means that there is a mixture of newline types in the data. Use the NEWLINEkeyword in order to resolve this reliably.  (seg1 127.0.0.1:25433 pid=7977)
+CONTEXT:  COPY copy_regression_detect, line 2: "2
+"
+COPY copy_regression_detect FROM stdin;
+ERROR:  COPY metadata line_buf_converted not found. This probably means that there is a mixture of newline types in the data. Use the NEWLINE keyword in order to resolve this reliably.  (seg2 127.0.0.1:25434 pid=7978)
+CONTEXT:  COPY copy_regression_detect, line 2: "2^22
+"
+DROP TABLE copy_regression_detect;
 -- Test that FORCE QUOTE option works with the fastpath for integers and
 -- numerics
 COPY (


### PR DESCRIPTION
the problem lies in the way we (and postgresql) handle newlines. We
automatically detect the newline type (LF, CR or CRLF) by looking at
the first row of data, and assume that the rest of the data has the
same newline type. This happens on the master and then on each
segment all over again. That can be confusing. For example,
the original data xxxxxx\nxxxx\rxxx\n
QD detect the newline and add prefix <MD>
   <MD>xxxxxx\n
   <MD>xxx\rxxx\n
QE detect the newline type again and split line to
   <MD>xxxxxx\n
   <MD>xxx\r
   xxx\n
We lost the prefix <MD> and get a panic

We add a check and print error log, so we can stop the crash. but Using automatic detect in text containing both cr and lf still causes error. Performing auto detect twice on QD and QE is the root cause of the problem. 

We believe that in the case of mixed CR and LF, the automatic detect function is difficult to make a correct judgment. So just output the error log and then remind the user to use the newline keyword to specify a newline.