### PR TITLE
Remove dead LWLock for file space

### DIFF
--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -138,9 +138,8 @@ extern PGDLLIMPORT LWLockPadded *MainLWLockArray;
 #define ErrorLogLock				(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 6].lock)
 #define SessionStateLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 8].lock)
 #define RelfilenodeGenLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 9].lock)
-#define TablespaceHashLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 10].lock)
-#define GpReplicationConfigFileLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 11].lock)
-#define GP_NUM_INDIVIDUAL_LWLOCKS		11
+#define GpReplicationConfigFileLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 10].lock)
+#define GP_NUM_INDIVIDUAL_LWLOCKS		10
 
 /*
  * It would probably be better to allocate separate LWLock tranches


### PR DESCRIPTION
The lock `TablespaceHashLock` was added during 5.0 development in commit
677c3eaca06. With the removal of filespace this lock effectively became
dead code. This is made more obvious by commit fe12fd8c6c6, which
removed the vestigial references to this lock.

I noticed this while glancing over lwlock.h as part of reviewing
greenplum-db/gpdb#6057 .