### PR TITLE
Squeeze the gap in MainLWLockArray

### DIFF
--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -136,10 +136,10 @@ extern PGDLLIMPORT LWLockPadded *MainLWLockArray;
 #define ResQueueLock				(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 4].lock)
 #define ResGroupLock				(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 5].lock)
 #define ErrorLogLock				(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 6].lock)
-#define SessionStateLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 8].lock)
-#define RelfilenodeGenLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 9].lock)
-#define GpReplicationConfigFileLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 10].lock)
-#define GP_NUM_INDIVIDUAL_LWLOCKS		10
+#define SessionStateLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 7].lock)
+#define RelfilenodeGenLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 8].lock)
+#define GpReplicationConfigFileLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 9].lock)
+#define GP_NUM_INDIVIDUAL_LWLOCKS		9
 
 /*
  * It would probably be better to allocate separate LWLock tranches


### PR DESCRIPTION
I noticed this after committing 7581b5370d7, that there's a gap between
`ErrorLogLock` and `SessionStateLock` in the main LWLock array. After a bit
of digging, seems the 7th (missing) lock was intended for
`FirstWorkfileMgrLock`, which got re-arranged to after the individual
Greenplum locks, but we forgot to squeeze out the gap while resolving
conflicts during the merge with Postgres 9.4.

Eliminate that gap now.