### PR TITLE
docs - fix column width of several pxf tables (markdown)

### DIFF
--- a/gpdb-doc/markdown/pxf/about_pxf_dir.html.md.erb
+++ b/gpdb-doc/markdown/pxf/about_pxf_dir.html.md.erb
@@ -6,15 +6,15 @@ PXF is installed on your master node when you install Greenplum Database. You in
 
 The following PXF files and directories are installed in your Greenplum Database cluster. These files/directories are relative to the PXF installation directory `$GPHOME/pxf`:
 
-| Directory                      | Description                                                                                                                                                                                                                                |
+| Directory | Description                                                                                                                                                                                                                                |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `apache-tomcat`      | The PXF tomcat directory.  |
-| `bin`                 | The PXF script and executable directory.                                                                                                                                                                                                                       |
-| `conf`                | The PXF configuration directory. This directory contains the `pxf-env.sh`, `pxf-public.classpath`, `pxf-private.classpath` and `pxf-profiles.xml` configuration files. |
-| `conf-templates`                | Configuration templates for PXF. |
-| `lib`                 | The PXF library directory.                                                                                                                                                                                                                       |
-| `logs`, | The PXF log file directory. Includes `pxf-service.log` and Tomcat-related logs including `catalina.out`. The log directory and log files are readable only by the `gpadmin` user.
-| `pxf-service`         | After initializing PXF, the PXF service instance directory.                                                                                                                                                                                                              |
-| `run`         | After starting PXF, the PXF run directory. Includes a PXF catalina process id file.                                                                                                                                                                                                              |
-| `tomcat-templates` | Tomcat templates for PXF.                                                                          |
+| apache&#8209;tomcat/     | The PXF tomcat directory.  |
+| bin/                | The PXF script and executable directory.                                                                                                                                                                                                                       |
+| conf/                | The PXF configuration directory. This directory contains the `pxf-env.sh`, `pxf-public.classpath`, `pxf-private.classpath` and `pxf-profiles.xml` configuration files. |
+| conf&#8209;templates/                | Configuration templates for PXF. |
+| lib/                 | The PXF library directory.                                                                                                                                                                                                                       |
+| logs/ | The PXF log file directory. Includes `pxf-service.log` and Tomcat-related logs including `catalina.out`. The log directory and log files are readable only by the `gpadmin` user.
+| pxf&#8209;service/         | After initializing PXF, the PXF service instance directory.                                                                                                                                                                                                              |
+| run/         | After starting PXF, the PXF run directory. Includes a PXF catalina process id file.                                                                                                                                                                                                              |
+| tomcat&#8209;templates/ | Tomcat templates for PXF.                                                                          |
 

--- a/gpdb-doc/markdown/pxf/hbase_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hbase_pxf.html.md.erb
@@ -99,7 +99,7 @@ HBase connector-specific keywords and values used in the [CREATE EXTERNAL TABLE]
 
 | Keyword  | Value |
 |-------|-------------------------------------|
-| \<hbase-table-name\>    | The name of the HBase table. |
+| \<hbase&#8209;table&#8209;name\>    | The name of the HBase table. |
 | PROFILE    | The `PROFILE` keyword must specify `HBase`. |
 | FORMAT  | The `FORMAT` clause must specify `'CUSTOM' (formatter='pxfwritable_import')`.   |
 

--- a/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
@@ -108,12 +108,12 @@ The specific keywords and values used by the `pxf` protocol in the [CREATE EXTER
 
 | Keyword  | Value |
 |-------|-------------------------------------|
-| \<path-to-hdfs-file\>    | The absolute path to the directory or file in the HDFS data store. |
+| \<path&#8209;to&#8209;hdfs&#8209;file\>    | The absolute path to the directory or file in the HDFS data store. |
 | PROFILE    | The `PROFILE` keyword must specify one of the values `HdfsTextSimple`, `HdfsTextMulti`, `Avro`, or `Json`. |
-| \<custom-option\>  | \<custom-option\> is profile-specific. Profile-specific options are discussed in the relevant sections later in this topic.|
+| \<custom&#8209;option\>  | \<custom-option\> is profile-specific. Profile-specific options are discussed in the relevant sections later in this topic.|
 | FORMAT | Use `FORMAT` `'TEXT'` with the `HdfsTextSimple` profile when \<path-to-hdfs-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'`  with the `HdfsTextSimple` or `HdfsTextMulti` profile when \<path-to-hdfs-file\> references a comma-separated value data.  |
 | FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `Avro`, `Json`, and `Parquet` profiles. The `Avro`, `Json`, and `Parquet` `'CUSTOM'` `FORMAT`s also require the built-in `(formatter='pxfwritable_import')` \<formatting-property\> |
- \<formatting-properties\>    | \<formatting-properties\> are profile-specific. Profile-specific formatting options are identified in the relevant sections later in this topic. |
+ \<formatting&#8209;properties\>    | \<formatting-properties\> are profile-specific. Profile-specific formatting options are identified in the relevant sections later in this topic. |
 
 **Note**: When creating PXF external tables, you cannot use the `HEADER` option in your `FORMAT` specification.
 
@@ -123,7 +123,7 @@ Use the `HdfsTextSimple` profile when you read a plain text delimited or .csv da
 
 \<formatting-properties\> supported by the `HdfsTextSimple` profile include:
 
-| Keyword  | Syntax, Example(s) | Description |
+| Keyword  | &nbsp;&nbsp;Syntax,&nbsp;&nbsp;Example(s)&nbsp;&nbsp; | Description |
 |-------|--------------|-----------------------|
 | delimiter    | `(delimiter=E'\t')`<br>`(delimiter ':')` | The delimiter character in the data. For `FORMAT` `'CSV'`, the default value is a comma `,`. Preface the value with an `E` when the value is an escape sequence. |
 
@@ -207,7 +207,7 @@ Use the `HdfsTextMulti` profile to read plain text data with delimited single- o
 
 \<formatting-properties\> supported by the `HdfsTextMulti` profile include:
 
-| Keyword  | Syntax, Example(s) | Value |
+| Keyword  | &nbsp;&nbsp;Syntax,&nbsp;&nbsp;Example(s)&nbsp;&nbsp; | Value |
 |-------|--------------|-----------------------|
 | delimiter    | `(delimiter=E'\t')`<br>`(delimiter ':')` | The delimiter character in the data. For `FORMAT` `'CSV'`, the default value is a comma `,`. Preface the value with an `E` when the value is an escape sequence. |
 
@@ -639,7 +639,7 @@ Once the data is loaded to HDFS, you can use Greenplum Database and PXF to query
 
 PXF supports single- and multi- line JSON records. When you want to read multi-line JSON records, you must provide an `IDENTIFIER` \<custom-option\> and value. Use this \<custom-option\> to identify the member name of the first field in the JSON record object:
 
-| Keyword  | Syntax, Example(s) | Description |
+| Keyword  | &nbsp;&nbsp;Syntax,&nbsp;&nbsp;Example(s)&nbsp;&nbsp; | Description |
 |-------|--------------|-----------------------|
 | IDENTIFIER  | `&IDENTIFIER=<value>`<br>`&IDENTIFIER=created_at`| You must include the `IDENTIFIER` keyword and \<value\> in the `LOCATION` string only when you are accessing JSON data comprised of multi-line records. Use the \<value\> to identify the member name of the first field in the JSON record object. | 
 

--- a/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
@@ -57,11 +57,11 @@ The specific keywords and values used by the `pxf` protocol in the [CREATE EXTER
 
 | Keyword  | Value |
 |-------|-------------------------------------|
-| \<path-to-hdfs-dir\>    | The the absolute path to the directory in the HDFS data store. |
+| \<path&#8209;to&#8209;hdfs&#8209;dir\>    | The absolute path to the directory in the HDFS data store. |
 | PROFILE    | The `PROFILE` keyword must specify one of the values `HdfsTextSimple` or `SequenceWritable`. |
-| \<custom-option\>  | \<custom-option\> is profile-specific. Profile-specific options are discussed later in this topic.|
+| \<custom&#8209;option\>  | \<custom-option\> is profile-specific. Profile-specific options are discussed later in this topic.|
 | FORMAT | Use `FORMAT` `'TEXT'` with the `HdfsTextSimple` profile to write plain, delimited text to \<path-to-hdfs-dir\>.<br> Use `FORMAT` `'CSV'`  with the `HdfsTextSimple` profile to write comma-separated value text to \<path-to-hdfs-dir\>.<br> Use `FORMAT` '`CUSTOM`' with  the `SequenceWritable` profile. The `SequenceWritable` `'CUSTOM'` `FORMAT` supports only the built-in `(formatter='pxfwritable_export')` (write) and `(formatter='pxfwritable_import')` (read) \<formatting-properties\>. |
- \<formatting-properties\>    | \<formatting-properties\> are profile-specific. Profile-specific formatting options are identified later in this topic. |
+ \<formatting&#8209;properties\>    | \<formatting-properties\> are profile-specific. Profile-specific formatting options are identified later in this topic. |
 | DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
 
 **Note**: When creating PXF external tables, you cannot use the `HEADER` option in your `FORMAT` specification.
@@ -89,7 +89,7 @@ Writable external tables you create using the `HdfsTextSimple` profile can optio
 
 \<formatting-properties\> supported by the `HdfsTextSimple` profile when writing text data include:
 
-| Keyword  | Syntax, Example(s) | Description |
+| Keyword  | &nbsp;&nbsp;Syntax,&nbsp;&nbsp;Example(s)&nbsp;&nbsp; | Description |
 |-------|-----------------------|--------------|
 | delimiter    | `(delimiter=E'\t')`<br>`(delimiter ':')` | The delimiter character in the data. For `FORMAT` `'CSV'`, the default value is a comma `,`. Preface the value with an `E` when the value is an escape sequence. |
 

--- a/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
@@ -192,8 +192,8 @@ Hive connector-specific keywords and values used in the [CREATE EXTERNAL TABLE](
 
 | Keyword  | Value |
 |-------|-------------------------------------|
-| \<hive-db-name\>    | The name of the Hive database. If omitted, defaults to the Hive database named `default`. |
-| \<hive-table-name\>    | The name of the Hive table. |
+| \<hive&#8209;db&#8209;name\>    | The name of the Hive database. If omitted, defaults to the Hive database named `default`. |
+| \<hive&#8209;table&#8209;name\>    | The name of the Hive table. |
 | PROFILE    | The `PROFILE` keyword must specify one of the values `Hive`, `HiveText`, `HiveRC`, `HiveORC`, or `HiveVectorizedORC`. |
 | DELIMITER    | The custom options `DELIMITER` clause is required for both the `HiveText` and `HiveRC` profiles and identifies the field delimiter used in the Hive data set.  \<delim\> must be a single ascii character or specified in hexadecimal representation. |
 | FORMAT (`Hive`, `HiveORC`, and `HiveVectorizedORC` profiles)   | The `FORMAT` clause must specify `CUSTOM`. The `CUSTOM` format requires the built-in `pxfwritable_import` `formatter`.   |

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -73,9 +73,9 @@ The specific keywords and values used by the `pxf` protocol in the [CREATE EXTER
 
 | Keyword  | Value |
 |-------|-------------------------------------|
-| \<external-table-name\>    | The full name of the external table. Depends on the external SQL database, may include a schema name and a table name. |
+| \<external&#8209;table&#8209;name\>    | The full name of the external table. Depends on the external SQL database, may include a schema name and a table name. |
 | PROFILE    | The `PROFILE` keyword value must specify `Jdbc`. |
-| \<custom-option\>  | \<custom-option\> is profile-specific. `Jdbc` profile-specific options are discussed in the next section.|
+| \<custom&#8209;option\>  | \<custom-option\> is profile-specific. `Jdbc` profile-specific options are discussed in the next section.|
 | FORMAT 'CUSTOM' | The JDBC `CUSTOM` `FORMAT` supports the built-in `'pxfwritable_import'` `FORMATTER` function for read operations and the built-in `'pxfwritable_export'` function for write operations. |
 
 **Note**: You cannot use the `HEADER` option in your `FORMAT` specification when you create a PXF external table.

--- a/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
@@ -27,6 +27,10 @@ The Greenplum Platform Extension Framework (PXF) provides parallel, high through
 
     This topic describes the architecture of PXF and its integration with Greenplum Database.
 
+-   **[About the PXF Installation](about_pxf_dir.html)**
+
+    The PXF installation directories are identified in this topic.
+
 -   **[Configuring PXF](instcfg_pxf.html)**
 
     This topic details the PXF configuration, initialization, and startup procedures.

--- a/gpdb-doc/markdown/pxf/sdk/pxfapi.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/pxfapi.html.md.erb
@@ -8,7 +8,7 @@ The PXF API interfaces that you will implement or extend depend upon the externa
 
 The PXF API defines classes including the following:
 
-| Class Name       | Description                                |
+| Class&nbsp;Name       | Description                                |
 |------------------|--------------------------------------------|
 | `Plugin`       | The base class for all PXF plug-in types.    |
 | `Fragmenter`       | The abstract class that defines how to split data from an external source into fragments.    |

--- a/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
@@ -205,11 +205,11 @@ Greenplum Database passes the parameters in the `LOCATION` string as headers to 
 
 | Keyword               | Value and Description                                                                                                                                                                                                                                                          |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| \<path\-to\-data\>        | A directory, file name, wildcard pattern, table name, etc. The syntax of \<path-to-data\> is dependent upon the profile currently in use.                                                                                                                                                                                                                    |
+| \<path&#8209;to&#8209;data\>        | A directory, file name, wildcard pattern, table name, etc. The syntax of \<path-to-data\> is dependent upon the profile currently in use.                                                                                                                                                                                                                    |
 | PROFILE              | The profile PXF uses to access the data. PXF supports HBase, HDFS, Hive, and JDBC connectors that expose profiles named `HBase`, `HdfsTextSimple`, `HdfsTextMulti`, `Avro`, `Json`, `SequenceWritable`, `Hive`, `HiveText`, `HiveRC`, `HiveORC`, `HiveVectorizedORC`, and `Jdbc`.                                                                                                                                                                                   |
-| \<custom-option\>=\<value\> | Additional options and values supported by the profile.                                                                  |
-| FORMAT  \<value\>| PXF profiles support the '`TEXT`', '`CSV`', and '`CUSTOM`' `FORMAT`s.  |
-| \<formatting-properties\> | Formatting properties supported by the profile; for example, the `formatter` or `delimiter`.                                                                   |
+| \<custom&#8209;option\>=\<value\> | Additional options and values supported by the profile.                                                                  |
+| FORMAT&nbsp;\<value\>| PXF profiles support the '`TEXT`', '`CSV`', and '`CUSTOM`' `FORMAT`s.  |
+| \<formatting&#8209;properties\> | Formatting properties supported by the profile; for example, the `formatter` or `delimiter`.                                                                   |
 
 **Note:** When you create a PXF external table, you cannot use the `HEADER` option in your `FORMAT` specification.
 


### PR DESCRIPTION
no technical changes in this PR.

markdown does not provide much support for table formatting.  try to make tables in the PXF docs more presentable by using non-breaking spaces and hyphens.

doc review site link to some of the tables with improved formatting:
- http://docs-lisa-fixpxftbls.cfapps.io/600/pxf/about_pxf_dir.html
- http://docs-lisa-fixpxftbls.cfapps.io/600/pxf/hdfs_read_pxf.html#hdfs_queryextdata
- http://docs-lisa-fixpxftbls.cfapps.io/600/pxf/hdfs_read_pxf.html#profile_hdfstextsimple
- http://docs-lisa-fixpxftbls.cfapps.io/600/pxf/sdk/pxfapi.html
