### PR TITLE
Pass type OIDs in makeCdbHash() call.

### DIFF
--- a/gpcontrib/gp_distribution_policy/gp_distribution_policy.c
+++ b/gpcontrib/gp_distribution_policy/gp_distribution_policy.c
@@ -52,10 +52,6 @@ extract_INT2OID_array(Datum array_datum, int *lenp, int16 **vecp);
 static GpPolicy *
 set_distribution_policy (Datum array_distribution, Datum numsegments);
 
-/* Get base type OID */
-static Oid
-get_base_dataType(Oid att_datatype);
-
 
 /*
  * Extract len and pointer to buffer from an int16[] (vector) Datum
@@ -118,37 +114,6 @@ set_distribution_policy (Datum array_distribution, Datum numsegments)
 }
 
 /* 
- * Get base data type from complex data types (e.g. Arrays) 
- */
-static Oid
-get_base_dataType(Oid att_datatype)
-{
-	Oid att_type = att_datatype;
-	
-	if (get_typtype(att_type) == 'd')
-	{
-		att_type = getBaseType(att_type);
-	}
-	
-	switch (att_type)
-	{
-		case INT2ARRAYOID:
-		case INT4ARRAYOID:
-		case INT8ARRAYOID:
-		case FLOAT4ARRAYOID:
-		case FLOAT8ARRAYOID:
-		case REGTYPEARRAYOID:
-			att_type = ANYARRAYOID;
-			/* Fall through */
-			break;
-		default:
-			break;
-	}
-	
-	return att_type;
-}
-
-/* 
  * Verifies the correct data distribution (given a GpPolicy) 
  * of a heap table in a segment. 
  */
@@ -162,6 +127,7 @@ gp_distribution_policy_heap_table_check(PG_FUNCTION_ARGS)
 	Oid relOid = PG_GETARG_OID(0);
 	Datum  array_distribution = PG_GETARG_DATUM(1);
 	Datum  numsegments = PG_GETARG_DATUM(2);
+	Oid		   *typeoids;
 
 	Assert(array_distribution);
 
@@ -184,30 +150,35 @@ gp_distribution_policy_heap_table_check(PG_FUNCTION_ARGS)
 	HeapTuple    tuple = heap_getnext(scandesc, ForwardScanDirection);
 	TupleDesc	desc = RelationGetDescr(rel);
 
+	/* Initialize hash function and structure */
+	CdbHash *hash;
+
+	typeoids = palloc(policy->nattrs * sizeof(Oid));
+	for(int i = 0; i < policy->nattrs; i++)
+	{
+		AttrNumber	attnum = policy->attrs[i];
+		Oid			att_type = desc->attrs[attnum]->atttypid;
+
+		typeoids[i] = att_type;
+	}
+	hash = makeCdbHash(policy->numsegments, policy->nattrs, typeoids);
+
 	while (HeapTupleIsValid(tuple))
 	{
 		CHECK_FOR_INTERRUPTS();
 
-		/* Initialize hash function and structure */
-		CdbHash *hash = makeCdbHash(policy->numsegments);
 		cdbhashinit(hash);
 
 		/* Add every attribute in the distribution policy to the hash */
-		for(int i = 0; i < policy->nattrs; i++)
+		for (int i = 0; i < policy->nattrs; i++)
 		{
 			int			attnum = policy->attrs[i];
 			bool		isNull;
 			Datum		attr;
-			Oid			att_type;
 
 			attr = heap_getattr(tuple, attnum, desc, &isNull);
 
-			att_type = get_base_dataType(desc->attrs[attnum - 1]->atttypid);
-
-			if (isNull)
-				cdbhashnull(hash);
-			else
-				cdbhash(hash, attr, att_type);
+			cdbhash(hash, i + 1, attr, isNull);
 		}
 
 		/* End check if one tuple is in the wrong segment */
@@ -216,7 +187,7 @@ gp_distribution_policy_heap_table_check(PG_FUNCTION_ARGS)
 			result = false;
 			break;
 		}
-		
+
 		tuple = heap_getnext(scandesc, ForwardScanDirection);
 	}
 

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2806,7 +2806,7 @@ gpdb::CdbHashRandom
 {
 	GP_WRAP_START;
 	{
-		CdbHash    *pcdbhash = makeCdbHash(num_segments);
+		CdbHash    *pcdbhash = makeCdbHash(num_segments, 0, NULL);
 
 		cdbhashinit(pcdbhash);
 

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -15,6 +15,8 @@
 #ifndef CDBHASH_H
 #define CDBHASH_H
 
+#include "utils/rel.h"
+
 /*
  * Hash Method
  * if change here, please also change pg_database.h
@@ -44,13 +46,15 @@ typedef struct CdbHash
 	CdbHashReduce reducealg;	/* the algorithm used for reducing to buckets		*/
 	uint32		rrindex;		/* round robin index for empty policy tables		*/
 
+	int			natts;
+	Oid			typeoids[FLEXIBLE_ARRAY_MEMBER];
 } CdbHash;
 
 /*
  * Create and initialize a CdbHash in the current memory context.
- * Parameter numsegs - number of segments in Greenplum Database.
  */
-extern CdbHash *makeCdbHash(int numsegs);
+extern CdbHash *makeCdbHash(int numsegs, int natts, Oid *typeoids);
+extern CdbHash *makeCdbHashForRelation(Relation rel);
 
 /*
  * Initialize CdbHash for hashing the next tuple values.
@@ -60,12 +64,7 @@ extern void cdbhashinit(CdbHash *h);
 /*
  * Add an attribute to the hash calculation.
  */
-extern void cdbhash(CdbHash *h, Datum val, Oid typid);
-
-/*
- * Add a NULL attribute to the hash calculation.
- */
-extern void cdbhashnull(CdbHash *h);
+extern void cdbhash(CdbHash *h, int attno, Datum datum, bool isnull);
 
 /*
  * Hash a tuple for a relation with an empty (no hash keys) partitioning policy.
@@ -86,16 +85,5 @@ extern bool isGreenplumDbHashable(Oid typid);
  * Return true if the operator Oid is hashable internally in Greenplum Database.
  */
 extern bool isGreenplumDbOprRedistributable(Oid oprid);
-
-/*
- * Return true if the Oid is an array type.  This can be used prior
- *   to hashing the datum because array typeoids are expected to
- *   have been converted to any array oid.
- */
-extern bool typeIsArrayType(Oid typeoid);
-
-extern bool typeIsEnumType(Oid typeoid);
-
-extern bool typeIsRangeType(Oid typeoid);
 
 #endif   /* CDBHASH_H */


### PR DESCRIPTION
Avoids looking through domains, array types, etc. on every call. That
seems like a more sensible API, since the data types don't change during
the lifetime of a CdbHash.

Make cdbhash() more convenient for callers, by handling NULLs within the
function. This way the callers don't need to do the NULL check and call
either cdbhash() or cdbhashnull().

This also fixes the performance issue caused by the syscache lookups
reported in https://github.com/greenplum-db/gpdb/issues/5961. The type's
type is now checked only once, when the CdbHash object is initialized,
instead of every row.