### PR TITLE
Align transaction log manager a little more with upstream

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1423,7 +1423,7 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
      * Check for recovery control file, and if so set up state for offline
      * recovery
      */
-    XLogReadRecoveryCommandFile(DEBUG5);
+	readRecoveryCommandFile();
 
     /* Now we can determine the list of expected TLIs */
     expectedTLIs = readTimeLineHistory(ThisTimeLineID);

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -812,9 +812,7 @@ static XLogRecPtr XLogInsert_Internal(RmgrId rmid, uint8 info, XLogRecData *rdat
 static void CheckRecoveryConsistency(void);
 static XLogRecord *ReadCheckpointRecord(XLogReaderState *xlogreader,
 					 XLogRecPtr RecPtr, int whichChkpti, bool report);
-#if 0
 static bool rescanLatestTimeLine(void);
-#endif
 static void WriteControlFile(void);
 static void ReadControlFile(void);
 static char *str_time(pg_time_t tnow);
@@ -5164,7 +5162,7 @@ str_time(pg_time_t tnow)
  * The file is parsed using the main configuration parser.
  */
 void
-XLogReadRecoveryCommandFile(int emode)
+readRecoveryCommandFile(void)
 {
 	FILE	   *fd;
 	TimeLineID	rtli = 0;
@@ -5183,10 +5181,6 @@ XLogReadRecoveryCommandFile(int emode)
 				 errmsg("could not open recovery command file \"%s\": %m",
 						RECOVERY_COMMAND_FILE)));
 	}
-
-	ereport(emode,
-			(errmsg("Found recovery.conf file, checking appropriate parameters "
-					" for recovery in standby mode")));
 
 	/*
 	 * Since we're asking ParseConfigFp() to report errors as FATAL, there's
@@ -6303,7 +6297,7 @@ StartupXLOG(void)
 	 * Check for recovery control file, and if so set up state for offline
 	 * recovery
 	 */
-	XLogReadRecoveryCommandFile(LOG);
+	readRecoveryCommandFile();
 
 	if (StandbyModeRequested)
 	{

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2012,14 +2012,14 @@ initMasks(fd_set *rmask)
 }
 
 /*
- * XXX check to see if we're a mirror.  And if we are: (1) Assume that we
- * are running as super user. (2) No data pages need to be accessed by this
- * backend - no snapshot / transaction needed.
+ * Check to see if we're a mirror, and if we are: (1) Assume that we are
+ * running as superuser; (2) No data pages need to be accessed by this backend
+ * - no snapshot / transaction needed.
  *
  * The recovery.conf file is renamed to recovery.done at the end of xlog
  * replay.  Normal backends can be created thereafter.
  */
-bool
+static bool
 IsRoleMirror(void)
 {
 	struct stat stat_buf;

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -403,25 +403,12 @@ extern void do_pg_abort_backup(void);
 #define BACKUP_LABEL_FILE		"backup_label"
 #define BACKUP_LABEL_OLD		"backup_label.old"
 
-extern void xlog_print_redo_lsn_application(
-		RelFileNode		*rnode,
-		BlockNumber 	blkno,
-		void			*page,
-		XLogRecPtr		lsn,
-		const char		*funcName);
-
-extern void XLogReadRecoveryCommandFile(int emode);
-
+/* Greenplum additions */
+extern void readRecoveryCommandFile(void);
 extern List *XLogReadTimeLineHistory(TimeLineID targetTLI);
-
-extern TimeLineID GetRecoveryTargetTLI(void);
-
 extern bool IsStandbyMode(void);
 extern DBState GetCurrentDBState(void);
-extern bool IsRoleMirror(void);
-
-extern XLogRecPtr
-last_xlog_replay_location(void);
-
+extern XLogRecPtr last_xlog_replay_location(void);
 extern void wait_for_mirror(void);
+
 #endif   /* XLOG_H */


### PR DESCRIPTION
Rename `readRecoveryCommandFile()` back to the name used in upstream, and remove the `emode` parameter and associated log entry.  Also tidy up the `xlog.h` header by removing stale entries and making functions only used in a single context static with associated small cleanups.

@ashwinstar do you think the logging that I propose removing is useful? I can't really get excited about it..