### PR TITLE
Mark External Protocol oclass for event triggers

### DIFF
--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -1009,9 +1009,11 @@ EventTriggerSupportsObjectClass(ObjectClass objclass)
 		case OCLASS_DEFACL:
 		case OCLASS_EXTENSION:
 			return true;
+
 		case OCLASS_EXTPROTOCOL:
+			return true;
 		case OCLASS_COMPRESSION:
-			return false;/*GPDB_93_MERGE_FIXME is these gp types support trigger? */
+			return false;
 
 		case MAX_OCLASS:
 

--- a/src/test/regress/expected/event_trigger_gp.out
+++ b/src/test/regress/expected/event_trigger_gp.out
@@ -16,6 +16,10 @@ CREATE OR REPLACE FUNCTION read_from_file() RETURNS integer as '$libdir/gpextpro
 NOTICE:  test_event_trigger: ddl_command_start CREATE FUNCTION
 CREATE PROTOCOL demoprot_event_trig_test (readfunc = 'read_from_file', writefunc = 'write_to_file');
 NOTICE:  test_event_trigger: ddl_command_start CREATE PROTOCOL
+CREATE WRITABLE EXTERNAL TABLE demoprot_w(a int) location('demoprot_event_trig_test://demoprotfile.txt') format 'text';
+NOTICE:  test_event_trigger: ddl_command_start CREATE EXTERNAL TABLE
+DROP EXTERNAL TABLE demoprot_w CASCADE;
+NOTICE:  test_event_trigger: ddl_command_start DROP EXTERNAL TABLE
 DROP PROTOCOL demoprot_event_trig_test;
 NOTICE:  test_event_trigger: ddl_command_start DROP PROTOCOL
 drop event trigger regress_event_trigger;

--- a/src/test/regress/sql/event_trigger_gp.sql
+++ b/src/test/regress/sql/event_trigger_gp.sql
@@ -15,6 +15,11 @@ CREATE OR REPLACE FUNCTION write_to_file() RETURNS integer as '$libdir/gpextprot
 CREATE OR REPLACE FUNCTION read_from_file() RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_import' LANGUAGE C STABLE NO SQL;
 
 CREATE PROTOCOL demoprot_event_trig_test (readfunc = 'read_from_file', writefunc = 'write_to_file');
+
+CREATE WRITABLE EXTERNAL TABLE demoprot_w(a int) location('demoprot_event_trig_test://demoprotfile.txt') format 'text';
+
+DROP EXTERNAL TABLE demoprot_w CASCADE;
+
 DROP PROTOCOL demoprot_event_trig_test;
 
 drop event trigger regress_event_trigger;


### PR DESCRIPTION
Support for event triggers on External Protocols was added in commit d920bf318553290ee but the oclass wasn't marked as supported for event triggers. This makes little difference in practice as the only codepath affected is operations on dependent objects, but none exists for external protocols. Also add a small addition to the testcase to use the protocol in WRITEABLE table.

In passing, also mark compression oclass as not supported, as we dont have operations for creating/dropping compression objects yet.