### PR TITLE
Ensure to return the Oid of the new extension

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -1270,7 +1270,7 @@ CreateExtension(CreateExtensionStmt *stmt)
 			case CREATE_EXTENSION_END:		/* Mark creating_extension flag = false */
 				creating_extension = false;
 				CurrentExtensionObject = InvalidOid;
-				return InvalidOid;		/* GPDB_93_MERGE_FIXME: can we get the real OID from somewhere? Do we need it? */
+				return get_extension_oid(stmt->extname, true);
 
 			default:
 				elog(ERROR, "unrecognized create_ext_state: %d",


### PR DESCRIPTION
On the QE's, make sure to keep the API property of CreateExtension() by returning the Oid of the newly created extension object.  There are no callsites that use the return value currently, so this has little effect, but in case we start using it we may as well get it right from the start.