### PR TITLE
Don't request AO blkdir on matview creation

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -245,7 +245,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	 * will be gone).
 	 */
 	OIDNewHeap = make_new_heap(matviewOid, tableSpace, concurrent,
-							   ExclusiveLock, true /* GPDB_93_MERGE_FIXME Is true? */);
+							   ExclusiveLock, false);
 	LockRelationOid(OIDNewHeap, AccessExclusiveLock);
 	dest = CreateTransientRelDestReceiver(OIDNewHeap);
 


### PR DESCRIPTION
Materialized views are not backed by append-only tables, so calling `make_new_heap()` requesting an AO blockdir will only cause an extra lookup on the relstorage for no purpose.