### PR TITLE
Docs: Port date/time/interval type info

### DIFF
--- a/gpdb-doc/dita/ref_guide/data_types.xml
+++ b/gpdb-doc/dita/ref_guide/data_types.xml
@@ -172,10 +172,10 @@
               <entry colname="col5">usual choice for integer</entry>
             </row>
             <row>
-              <entry colname="col1">interval [ (p) ]</entry>
+              <entry colname="col1">interval [ <varname>fields</varname> ] [ (p) ]</entry>
               <entry colname="col2"/>
-              <entry colname="col3">12 bytes</entry>
-              <entry colname="col4">-178000000 years - 178000000 years</entry>
+              <entry colname="col3">16 bytes</entry>
+              <entry colname="col4">-178000000 years to 178000000 years</entry>
               <entry colname="col5">time span</entry>
             </row>
             <row>

--- a/gpdb-doc/dita/ref_guide/datatype-datetime.xml
+++ b/gpdb-doc/dita/ref_guide/datatype-datetime.xml
@@ -1,0 +1,997 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dita PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<dita>
+  <topic id="topic_abq_gfk_qfb">
+    <title>Date/Time Types</title>
+    <body><section id="datatype-datetime">
+   
+
+   <p>Greenplum supports the full set of SQL date and time types, shown in <xref
+      href="#topic_abq_gfk_qfb/datatype-datetime-table" format="dita"/>. The operations available on
+     these data types are described in <xref
+      href="https://www.postgresql.org/docs/9.4/static/functions-datetime.html" format="html"
+      scope="external">Date/Time Functions and Operators</xref> in the PostgreSQL documentation.
+     Dates are counted according to the Gregorian calendar, even in years before that calendar was
+     introduced (see <xref
+      href="https://www.postgresql.org/docs/9.4/static/datetime-units-history.html" format="html"
+      scope="external">History of Units</xref> in the PostgreSQL documentation for more
+     information).</p>
+
+    <table id="datatype-datetime-table">
+     <title>Date/Time Types</title>
+     <tgroup cols="6">
+      <thead>
+       <row>
+        <entry>Name</entry>
+        <entry>Storage Size</entry>
+        <entry>Description</entry>
+        <entry>Low Value</entry>
+        <entry>High Value</entry>
+        <entry>Resolution</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>timestamp [ (<varname>p</varname>) ] [ without time zone ]</entry>
+        <entry>8 bytes</entry>
+        <entry>both date and time (no time zone)</entry>
+        <entry>4713 BC</entry>
+        <entry>294276 AD</entry>
+        <entry>1 microsecond / 14 digits</entry>
+       </row>
+       <row>
+        <entry>timestamp [ (<varname>p</varname>) ] with time zone</entry>
+        <entry>8 bytes</entry>
+        <entry>both date and time, with time zone</entry>
+        <entry>4713 BC</entry>
+        <entry>294276 AD</entry>
+        <entry>1 microsecond / 14 digits</entry>
+       </row>
+       <row>
+        <entry>date</entry>
+        <entry>4 bytes</entry>
+        <entry>date (no time of day)</entry>
+        <entry>4713 BC</entry>
+        <entry>5874897 AD</entry>
+        <entry>1 day</entry>
+       </row>
+       <row>
+        <entry>time [ (<varname>p</varname>) ] [ without time zone ]</entry>
+        <entry>8 bytes</entry>
+        <entry>time of day (no date)</entry>
+        <entry>00:00:00</entry>
+        <entry>24:00:00</entry>
+        <entry>1 microsecond / 14 digits</entry>
+       </row>
+       <row>
+        <entry>time [ (<varname>p</varname>) ] with time zone</entry>
+        <entry>12 bytes</entry>
+        <entry>times of day only, with time zone</entry>
+        <entry>00:00:00+1459</entry>
+        <entry>24:00:00-1459</entry>
+        <entry>1 microsecond / 14 digits</entry>
+       </row>
+       <row>
+        <entry>interval [ <varname>fields</varname> ] [ (<varname>p</varname>) ]</entry>
+        <entry>16 bytes</entry>
+        <entry>time interval</entry>
+        <entry>-178000000 years</entry>
+        <entry>178000000 years</entry>
+        <entry>1 microsecond / 14 digits</entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+
+   <note>The SQL standard requires that writing just <codeph>timestamp</codeph> be equivalent to
+      <codeph>timestamp without time zone</codeph>, and Greenplum honors that behavior.
+      <codeph>timestamptz</codeph> is accepted as an abbreviation for <codeph>timestamp with time
+      zone</codeph>; this is a PostgreSQL extension. </note>
+
+   <p><codeph>time</codeph>, <codeph>timestamp</codeph>, and <codeph>interval</codeph> accept an
+     optional precision value <varname>p</varname> which specifies the number of fractional digits
+     retained in the seconds field. By default, there is no explicit bound on precision. The allowed
+     range of <varname>p</varname> is from 0 to 6 for the <codeph>timestamp</codeph> and
+      <codeph>interval</codeph> types.</p>
+
+   <note>When <codeph>timestamp</codeph> values are stored as eight-byte integers (currently the
+     default), microsecond precision is available over the full range of values. When
+      <codeph>timestamp</codeph> values are stored as double precision floating-point numbers
+     instead (a deprecated compile-time option), the effective limit of precision might be less than
+     6. <codeph>timestamp</codeph> values are stored as seconds before or after midnight 2000-01-01.
+     When <codeph>timestamp</codeph> values are implemented using floating-point numbers,
+     microsecond precision is achieved for dates within a few years of 2000-01-01, but the precision
+     degrades for dates further away. Note that using floating-point datetimes allows a larger range
+     of <codeph>timestamp</codeph> values to be represented than shown above: from 4713 BC up to
+     5874897 AD. <p>The same compile-time option also determines whether <codeph>time</codeph> and
+       <codeph>interval</codeph> values are stored as floating-point numbers or eight-byte integers.
+      In the floating-point case, large <codeph>interval</codeph> values degrade in precision as the
+      size of the interval increases.</p></note>
+
+   <p>For the <codeph>time</codeph> types, the allowed range of
+    <varname>p</varname> is from 0 to 6 when eight-byte integer
+    storage is used, or from 0 to 10 when floating-point storage is used.</p>
+
+   <p>The <codeph>interval</codeph> type has an additional option, which is
+    to restrict the set of stored fields by writing one of these phrases:
+<codeblock>
+YEAR
+MONTH
+DAY
+HOUR
+MINUTE
+SECOND
+YEAR TO MONTH
+DAY TO HOUR
+DAY TO MINUTE
+DAY TO SECOND
+HOUR TO MINUTE
+HOUR TO SECOND
+MINUTE TO SECOND
+</codeblock>
+    Note that if both <varname>fields</varname> and
+    <varname>p</varname> are specified, the
+    <varname>fields</varname> must include <codeph>SECOND</codeph>,
+    since the precision applies only to the seconds.</p>
+
+   <p>The type <codeph>time with time zone</codeph> is defined by the SQL
+    standard, but the definition exhibits properties which lead to
+    questionable usefulness. In most cases, a combination of
+    <codeph>date</codeph>, <codeph>time</codeph>, <codeph>timestamp without time
+    zone</codeph>, and <codeph>timestamp with time zone</codeph> should
+    provide a complete range of date/time functionality required by
+    any application.</p>
+
+   <p>The types <codeph>abstime</codeph>
+    and <codeph>reltime</codeph> are lower precision types which are used internally.
+    You are discouraged from using these types in
+    applications;  these internal types
+    might disappear in a future release.</p>
+
+    </section>
+   <section id="datatype-datetime-input">
+    <title>Date/Time Input</title>
+
+    <p>Date and time input is accepted in almost any reasonable format, including ISO 8601,
+     SQL-compatible, traditional POSTGRES, and others. For some formats, ordering of day, month, and
+     year in date input is ambiguous and there is support for specifying the expected ordering of
+     these fields. Set the <xref href="config_params/guc-list.xml#DateStyle"/> parameter to
+      <codeph>MDY</codeph> to select month-day-year interpretation, <codeph>DMY</codeph> to select
+     day-month-year interpretation, or <codeph>YMD</codeph> to select year-month-day interpretation.</p>
+
+    <p>Greenplum is more flexible in handling date/time input than the SQL standard requires. See
+      <xref href="https://www.postgresql.org/docs/9.4/static/datetime-appendix.html" format="html"
+      scope="external">Appendix B. Date/Time Support</xref> in the PostgreSQL documentation for the
+     exact parsing rules of date/time input and for the recognized text fields including months,
+     days of the week, and time zones.</p>
+
+    <p>Remember that any date or time literal input needs to be enclosed in single quotes, like
+     text strings. SQL requires the following syntax
+     <codeblock>
+<varname>type</varname> [ (<varname>p</varname>) ] '<varname>value</varname>'
+</codeblock>
+     where <varname>p</varname> is an optional precision specification giving the number of
+     fractional digits in the seconds field. Precision can be specified for <codeph>time</codeph>,
+      <codeph>timestamp</codeph>, and <codeph>interval</codeph> types. The allowed values are
+     mentioned above. If no precision is specified in a constant specification, it defaults to the
+     precision of the literal value.</p>
+
+   </section>
+    <section>
+    <title>Dates</title>
+
+    <p><xref href="#topic_abq_gfk_qfb/table_owm_dfr_qfb" format="dita"/> shows some possible inputs
+     for the <codeph>date</codeph> type.</p>
+
+     <table id="table_owm_dfr_qfb">
+     <title>Date Input</title>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>Example</entry>
+        <entry>Description</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>1999-01-08</entry>
+        <entry>ISO 8601; January 8 in any mode (recommended format)</entry>
+       </row>
+       <row>
+        <entry>January 8, 1999</entry>
+        <entry>unambiguous in any <varname>datestyle</varname> input mode</entry>
+       </row>
+       <row>
+        <entry>1/8/1999</entry>
+        <entry>January 8 in <codeph>MDY</codeph> mode; August 1 in <codeph>DMY</codeph> mode</entry>
+       </row>
+       <row>
+        <entry>1/18/1999</entry>
+        <entry>January 18 in <codeph>MDY</codeph> mode; rejected in other modes</entry>
+       </row>
+       <row>
+        <entry>01/02/03</entry>
+        <entry>January 2, 2003 in <codeph>MDY</codeph> mode; February 1, 2003 in
+          <codeph>DMY</codeph> mode; February 3, 2001 in <codeph>YMD</codeph> mode </entry>
+       </row>
+       <row>
+        <entry>1999-Jan-08</entry>
+        <entry>January 8 in any mode</entry>
+       </row>
+       <row>
+        <entry>Jan-08-1999</entry>
+        <entry>January 8 in any mode</entry>
+       </row>
+       <row>
+        <entry>08-Jan-1999</entry>
+        <entry>January 8 in any mode</entry>
+       </row>
+       <row>
+        <entry>99-Jan-08</entry>
+        <entry>January 8 in <codeph>YMD</codeph> mode, else error</entry>
+       </row>
+       <row>
+        <entry>08-Jan-99</entry>
+        <entry>January 8, except error in <codeph>YMD</codeph> mode</entry>
+       </row>
+       <row>
+        <entry>Jan-08-99</entry>
+        <entry>January 8, except error in <codeph>YMD</codeph> mode</entry>
+       </row>
+       <row>
+        <entry>19990108</entry>
+        <entry>ISO 8601; January 8, 1999 in any mode</entry>
+       </row>
+       <row>
+        <entry>990108</entry>
+        <entry>ISO 8601; January 8, 1999 in any mode</entry>
+       </row>
+       <row>
+        <entry>1999.008</entry>
+        <entry>year and day of year</entry>
+       </row>
+       <row>
+        <entry>J2451187</entry>
+        <entry>Julian date</entry>
+       </row>
+       <row>
+        <entry>January 8, 99 BC</entry>
+        <entry>year 99 BC</entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+    </section>
+
+    <section>
+     <title>Times</title>
+
+     <p>The time-of-day types are <codeph>time [
+      (<varname>p</varname>) ] without time zone</codeph> and
+      <codeph>time [ (<varname>p</varname>) ] with time
+      zone</codeph>.  <codeph>time</codeph> alone is equivalent to
+      <codeph>time without time zone</codeph>.</p>
+
+     <p>Valid input for these types consists of a time of day followed by an optional time zone.
+     (See <xref href="#topic_abq_gfk_qfb/datatype-datetime-time-table" format="dita"/> and <xref
+      href="#topic_abq_gfk_qfb/datatype-timezone-table" format="dita"/>.) If a time zone is
+     specified in the input for <codeph>time without time zone</codeph>, it is silently ignored. You
+     can also specify a date but it will be ignored, except when you use a time zone name that
+     involves a daylight-savings rule, such as <codeph>America/New_York</codeph>. In this case
+     specifying the date is required in order to determine whether standard or daylight-savings time
+     applies. The appropriate time zone offset is recorded in the <codeph>time with time
+      zone</codeph> value.</p>
+
+      <table id="datatype-datetime-time-table">
+       <title>Time Input</title>
+       <tgroup cols="2">
+        <thead>
+         <row>
+          <entry>Example</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry><codeph>04:05:06.789</codeph></entry>
+          <entry>ISO 8601</entry>
+         </row>
+         <row>
+          <entry><codeph>04:05:06</codeph></entry>
+          <entry>ISO 8601</entry>
+         </row>
+         <row>
+          <entry><codeph>04:05</codeph></entry>
+          <entry>ISO 8601</entry>
+         </row>
+         <row>
+          <entry><codeph>040506</codeph></entry>
+          <entry>ISO 8601</entry>
+         </row>
+         <row>
+          <entry><codeph>04:05 AM</codeph></entry>
+          <entry>same as 04:05; AM does not affect value</entry>
+         </row>
+         <row>
+          <entry><codeph>04:05 PM</codeph></entry>
+          <entry>same as 16:05; input hour must be &lt;= 12</entry>
+         </row>
+         <row>
+          <entry><codeph>04:05:06.789-8</codeph></entry>
+          <entry>ISO 8601</entry>
+         </row>
+         <row>
+          <entry><codeph>04:05:06-08:00</codeph></entry>
+          <entry>ISO 8601</entry>
+         </row>
+         <row>
+          <entry><codeph>04:05-08:00</codeph></entry>
+          <entry>ISO 8601</entry>
+         </row>
+         <row>
+          <entry><codeph>040506-08</codeph></entry>
+          <entry>ISO 8601</entry>
+         </row>
+         <row>
+          <entry><codeph>04:05:06 PST</codeph></entry>
+          <entry>time zone specified by abbreviation</entry>
+         </row>
+         <row>
+          <entry><codeph>2003-04-12 04:05:06 America/New_York</codeph></entry>
+          <entry>time zone specified by full name</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+
+      <table id="datatype-timezone-table">
+       <title>Time Zone Input</title>
+       <tgroup cols="2">
+        <thead>
+         <row>
+          <entry>Example</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry><codeph>PST</codeph></entry>
+          <entry>Abbreviation (for Pacific Standard Time)</entry>
+         </row>
+         <row>
+          <entry><codeph>America/New_York</codeph></entry>
+          <entry>Full time zone name</entry>
+         </row>
+         <row>
+          <entry><codeph>PST8PDT</codeph></entry>
+          <entry>POSIX-style time zone specification</entry>
+         </row>
+         <row>
+          <entry><codeph>-8:00</codeph></entry>
+          <entry>ISO-8601 offset for PST</entry>
+         </row>
+         <row>
+          <entry><codeph>-800</codeph></entry>
+          <entry>ISO-8601 offset for PST</entry>
+         </row>
+         <row>
+          <entry><codeph>-8</codeph></entry>
+          <entry>ISO-8601 offset for PST</entry>
+         </row>
+         <row>
+          <entry><codeph>zulu</codeph></entry>
+          <entry>Military abbreviation for UTC</entry>
+         </row>
+         <row>
+          <entry><codeph>z</codeph></entry>
+          <entry>Short form of <codeph>zulu</codeph></entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+
+     <p>Refer to <xref href="#topic_abq_gfk_qfb/datatype-timezones" format="dita"/> for more
+     information on how to specify time zones.</p>
+    </section>
+
+    <section>
+    <title>Time Stamps</title>
+
+     <p>Valid input for the time stamp types consists of the concatenation
+      of a date and a time, followed by an optional time zone,
+      followed by an optional <codeph>AD</codeph> or <codeph>BC</codeph>.
+      (Alternatively, <codeph>AD</codeph>/<codeph>BC</codeph> can appear
+      before the time zone, but this is not the preferred ordering.)
+      Thus:
+
+<codeph>
+1999-01-08 04:05:06
+</codeph>
+      and:
+<codeph>
+1999-01-08 04:05:06 -8:00
+</codeph>
+
+      are valid values, which follow the ISO 8601
+      standard.  In addition, the common format:
+<codeph>
+January 8 04:05:06 1999 PST
+</codeph>
+      is supported.</p>
+
+     <p>The SQL standard differentiates <codeph>timestamp without time zone</codeph> and
+      <codeph>timestamp with time zone</codeph> literals by the presence of a <codeph>+</codeph> or
+      <codeph>-</codeph> symbol and time zone offset after the time. Hence, according to the
+     standard, <codeph>TIMESTAMP '2004-10-19 10:23:54'</codeph> is a <codeph>timestamp without time
+      zone</codeph>, while <codeph>TIMESTAMP '2004-10-19 10:23:54+02'</codeph> is a
+      <codeph>timestamp with time zone</codeph>. Greenplum never examines the content of a literal
+     string before determining its type, and therefore will treat both of the above as
+      <codeph>timestamp without time zone</codeph>. To ensure that a literal is treated as
+      <codeph>timestamp with time zone</codeph>, give it the correct explicit type:
+      <codeph>TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'</codeph> In a literal that has been
+     determined to be <codeph>timestamp without time zone</codeph>, Greenplum will silently ignore
+     any time zone indication. That is, the resulting value is derived from the date/time fields in
+     the input value, and is not adjusted for time zone.</p>
+
+     <p>For <codeph>timestamp with time zone</codeph>, the internally stored value is always in UTC
+     (Universal Coordinated Time, traditionally known as Greenwich Mean Time, GMT). An input value
+     that has an explicit time zone specified is converted to UTC using the appropriate offset for
+     that time zone. If no time zone is stated in the input string, then it is assumed to be in the
+     time zone indicated by the system's <codeph>TimeZone</codeph> parameter, and is converted to
+     UTC using the offset for the <varname>timezone</varname> zone.</p>
+
+     <p>When a <codeph>timestamp with time zone</codeph> value is output, it is always converted
+     from UTC to the current <varname>timezone</varname> zone, and displayed as local time in that
+     zone. To see the time in another time zone, either change <varname>timezone</varname> or use
+     the <codeph>AT TIME ZONE</codeph> construct (see <xref
+      href="https://www.postgresql.org/docs/9.4/static/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT"
+      format="html" scope="external">AT TIME ZONE</xref> in the PostgreSQL documentation).</p>
+
+     <p>Conversions between <codeph>timestamp without time zone</codeph> and
+      <codeph>timestamp with time zone</codeph> normally assume that the
+      <codeph>timestamp without time zone</codeph> value should be taken or given
+      as <varname>timezone</varname> local time.  A different time zone can
+      be specified for the conversion using <codeph>AT TIME ZONE</codeph>.</p>
+    </section>
+
+    <section>
+     <title>Special Values</title>
+
+     <p>Greenplum supports several special date/time input values for convenience, as shown in <xref
+      href="#topic_abq_gfk_qfb/datatype-datetime-special-table" format="dita"/>. The values
+      <codeph>infinity</codeph> and <codeph>-infinity</codeph> are specially represented inside the
+     system and will be displayed unchanged; but the others are simply notational shorthands that
+     will be converted to ordinary date/time values when read. (In particular, <codeph>now</codeph>
+     and related strings are converted to a specific time value as soon as they are read.) All of
+     these values need to be enclosed in single quotes when used as constants in SQL commands.</p>
+
+      <table id="datatype-datetime-special-table">
+       <title>Special Date/Time Inputs</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Input String</entry>
+          <entry>Valid Types</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry><codeph>epoch</codeph></entry>
+          <entry><codeph>date</codeph>, <codeph>timestamp</codeph></entry>
+          <entry>1970-01-01 00:00:00+00 (Unix system time zero)</entry>
+         </row>
+         <row>
+          <entry><codeph>infinity</codeph></entry>
+          <entry><codeph>date</codeph>, <codeph>timestamp</codeph></entry>
+          <entry>later than all other time stamps</entry>
+         </row>
+         <row>
+          <entry><codeph>-infinity</codeph></entry>
+          <entry><codeph>date</codeph>, <codeph>timestamp</codeph></entry>
+          <entry>earlier than all other time stamps</entry>
+         </row>
+         <row>
+          <entry><codeph>now</codeph></entry>
+          <entry><codeph>date</codeph>, <codeph>time</codeph>, <codeph>timestamp</codeph></entry>
+          <entry>current transaction's start time</entry>
+         </row>
+         <row>
+          <entry><codeph>today</codeph></entry>
+          <entry><codeph>date</codeph>, <codeph>timestamp</codeph></entry>
+          <entry>midnight today</entry>
+         </row>
+         <row>
+          <entry><codeph>tomorrow</codeph></entry>
+          <entry><codeph>date</codeph>, <codeph>timestamp</codeph></entry>
+          <entry>midnight tomorrow</entry>
+         </row>
+         <row>
+          <entry><codeph>yesterday</codeph></entry>
+          <entry><codeph>date</codeph>, <codeph>timestamp</codeph></entry>
+          <entry>midnight yesterday</entry>
+         </row>
+         <row>
+          <entry><codeph>allballs</codeph></entry>
+          <entry><codeph>time</codeph></entry>
+          <entry>00:00:00.00 UTC</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+
+     <p>The following SQL-compatible functions can also be used to obtain the current time value
+     for the corresponding data type: <codeph>CURRENT_DATE</codeph>, <codeph>CURRENT_TIME</codeph>,
+      <codeph>CURRENT_TIMESTAMP</codeph>, <codeph>LOCALTIME</codeph>,
+      <codeph>LOCALTIMESTAMP</codeph>. The latter four accept an optional subsecond precision
+     specification. (See <xref
+      href="https://www.postgresql.org/docs/9.4/static/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT"
+      format="html" scope="external">Current Date/Time</xref> in the PostgreSQL documentation.) Note
+     that these are SQL functions and are <i>not</i> recognized in data input strings.</p>
+
+    </section>
+   
+
+   <section id="datatype-datetime-output">
+    <title>Date/Time Output</title>
+
+    
+    <p>The output format of the date/time types can be set to one of the four styles ISO 8601, SQL
+     (Ingres), traditional POSTGRES (Unix <codeph>date</codeph> format), or German. The default is
+     the ISO format. (The SQL standard requires the use of the ISO 8601 format. The name of the
+      <codeph>SQL</codeph> output format is a historical accident.) <xref
+      href="#topic_abq_gfk_qfb/datatype-datetime-output-table" format="dita"/> shows examples of
+     each output style. The output of the <codeph>date</codeph> and <codeph>time</codeph> types is
+     generally only the date or time part in accordance with the given examples. However, the
+     POSTGRES style outputs date-only values in ISO format.</p>
+
+     <table id="datatype-datetime-output-table">
+      <title>Date/Time Output Styles</title>
+      <tgroup cols="3">
+       <thead>
+        <row>
+         <entry>Style Specification</entry>
+         <entry>Description</entry>
+         <entry>Example</entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry><codeph>ISO</codeph></entry>
+         <entry>ISO 8601, SQL standard</entry>
+         <entry><codeph>1997-12-17 07:37:16-08</codeph></entry>
+        </row>
+        <row>
+         <entry><codeph>SQL</codeph></entry>
+         <entry>traditional style</entry>
+         <entry><codeph>12/17/1997 07:37:16.00 PST</codeph></entry>
+        </row>
+        <row>
+         <entry><codeph>Postgres</codeph></entry>
+         <entry>original style</entry>
+         <entry><codeph>Wed Dec 17 07:37:16 1997 PST</codeph></entry>
+        </row>
+        <row>
+         <entry><codeph>German</codeph></entry>
+         <entry>regional style</entry>
+         <entry><codeph>17.12.1997 07:37:16.00 PST</codeph></entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </table>
+
+    <note> ISO 8601 specifies the use of uppercase letter <codeph>T</codeph> to separate the date
+     and time. Greenplum accepts that format on input, but on output it uses a space rather than
+      <codeph>T</codeph>, as shown above. This is for readability and for consistency with RFC 3339
+     as well as some other database systems. </note>
+
+    <p>In the SQL and POSTGRES styles, day appears before month if DMY field ordering has been
+     specified, otherwise month appears before day. (See <xref
+      href="#topic_abq_gfk_qfb/table_owm_dfr_qfb" format="dita"/> for how this setting also affects
+     interpretation of input values.) <xref
+      href="#topic_abq_gfk_qfb/datatype-datetime-output2-table" format="dita"/> shows examples.</p>
+
+     <table id="datatype-datetime-output2-table">
+      <title>Date Order Conventions</title>
+      <tgroup cols="3">
+       <thead>
+        <row>
+         <entry><varname>datestyle</varname> Setting</entry>
+         <entry>Input Ordering</entry>
+         <entry>Example Output</entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry><codeph>SQL, DMY</codeph></entry>
+         <entry><varname>day</varname>/<varname>month</varname>/<varname>year</varname></entry>
+         <entry><codeph>17/12/1997 15:37:16.00 CET</codeph></entry>
+        </row>
+        <row>
+         <entry><codeph>SQL, MDY</codeph></entry>
+         <entry><varname>month</varname>/<varname>day</varname>/<varname>year</varname></entry>
+         <entry><codeph>12/17/1997 07:37:16.00 PST</codeph></entry>
+        </row>
+        <row>
+         <entry><codeph>Postgres, DMY</codeph></entry>
+         <entry><varname>day</varname>/<varname>month</varname>/<varname>year</varname></entry>
+         <entry><codeph>Wed 17 Dec 07:37:16 1997 PST</codeph></entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </table>
+
+    <p>The date/time style can be selected by the user using the <codeph>SET datestyle</codeph>
+     command, the <codeph>DateStyle</codeph> parameter in the <codeph>postgresql.conf</codeph>
+     configuration file, or the <codeph>PGDATESTYLE</codeph> environment variable on the server or
+     client.</p>
+
+    <p>The formatting function <codeph>to_char</codeph> (see <xref
+      href="https://www.postgresql.org/docs/9.4/static/functions-formatting.html" format="html"
+      scope="external">Data Type Formatting Functions</xref>) is also available as a more flexible
+     way to format date/time output.</p>
+   </section>
+
+   <section id="datatype-timezones">
+    <title>Time Zones</title>
+
+    
+
+   <p>Time zones, and time-zone conventions, are influenced by political decisions, not just earth
+     geometry. Time zones around the world became somewhat standardized during the 1900s, but
+     continue to be prone to arbitrary changes, particularly with respect to daylight-savings rules.
+     Greenplum uses the widely-used IANA (Olson) time zone database for information about historical
+     time zone rules. For times in the future, the assumption is that the latest known rules for a
+     given time zone will continue to be observed indefinitely far into the future.</p>
+
+    <p>Greenplum endeavors to be compatible with the SQL standard definitions for typical usage.
+     However, the SQL standard has an odd mix of date and time types and capabilities. Two obvious
+     problems are: <ol>
+      <li>Although the <codeph>date</codeph> type cannot have an associated time zone, the
+        <codeph>time</codeph> type can. Time zones in the real world have little meaning unless
+       associated with a date as well as a time, since the offset can vary through the year with
+       daylight-saving time boundaries. </li>
+      <li>The default time zone is specified as a constant numeric offset from UTC. It is therefore
+       impossible to adapt to daylight-saving time when doing date/time arithmetic across DST
+       boundaries. </li>
+     </ol></p>
+
+    <p>To address these difficulties, we recommend using date/time types that contain both date and
+     time when using time zones. We do <i>not</i> recommend using the type <codeph>time with time
+      zone</codeph> (though it is supported by Greenplum for legacy applications and for compliance
+     with the SQL standard). Greenplum assumes your local time zone for any type containing only
+     date or time.</p>
+
+    <p>All timezone-aware dates and times are stored internally in UTC. They are converted to local
+     time in the zone specified by the <codeph>TimeZone</codeph> configuration parameter before
+     being displayed to the client.</p>
+
+    <p>Greenplum allows you to specify time zones in three different forms: <ol>
+      <li>A full time zone name, for example <codeph>America/New_York</codeph>. The recognized time
+       zone names are listed in the <codeph>pg_timezone_names</codeph> view. Greenplum uses the
+       widely-used IANA time zone data for this purpose, so the same time zone names are also
+       recognized by much other software. </li>
+      <li>A time zone abbreviation, for example <codeph>PST</codeph>. Such a specification merely
+       defines a particular offset from UTC, in contrast to full time zone names which can imply a
+       set of daylight savings transition-date rules as well. The recognized abbreviations are
+       listed in the <codeph>pg_timezone_abbrevs</codeph> view. You cannot set the configuration
+       parameters <xref href="config_params/guc-list.xml#TimeZone"/> or <xref
+        href="config_params/guc-list.xml#log_timezone"/> to a time zone abbreviation, but you can
+       use abbreviations in date/time input values and with the <codeph>AT TIME ZONE</codeph>
+       operator. </li>
+      <li>In addition to the timezone names and abbreviations, Greenplum will accept POSIX-style
+       time zone specifications of the form <varname>STD</varname><varname>offset</varname> or
+        <varname>STD</varname><varname>offset</varname><varname>DST</varname>, where
+        <varname>STD</varname> is a zone abbreviation, <varname>offset</varname> is a numeric offset
+       in hours west from UTC, and <varname>DST</varname> is an optional daylight-savings zone
+       abbreviation, assumed to stand for one hour ahead of the given offset. For example, if
+        <codeph>EST5EDT</codeph> were not already a recognized zone name, it would be accepted and
+       would be functionally equivalent to United States East Coast time. In this syntax, a zone
+       abbreviation can be a string of letters, or an arbitrary string surrounded by angle brackets
+        (<codeph>&lt;&gt;</codeph>). When a daylight-savings zone abbreviation is present, it is
+       assumed to be used according to the same daylight-savings transition rules used in the IANA
+       time zone database's entry. In a standard Greenplum installation, is the same as
+        <codeph>US/Eastern</codeph>, so that POSIX-style time zone specifications follow USA
+       daylight-savings rules. If needed, you can adjust this behavior by replacing the file. </li>
+     </ol> In short, this is the difference between abbreviations and full names: abbreviations
+     represent a specific offset from UTC, whereas many of the full names imply a local
+     daylight-savings time rule, and so have two possible UTC offsets. As an example,
+      <codeph>2014-06-04 12:00 America/New_York</codeph> represents noon local time in New York,
+     which for this particular date was Eastern Daylight Time (UTC-4). So <codeph>2014-06-04 12:00
+      EDT</codeph> specifies that same time instant. But <codeph>2014-06-04 12:00 EST</codeph>
+     specifies noon Eastern Standard Time (UTC-5), regardless of whether daylight savings was
+     nominally in effect on that date.</p>
+
+    <p>To complicate matters, some jurisdictions have used the same timezone abbreviation to mean
+     different UTC offsets at different times; for example, in Moscow <codeph>MSK</codeph> has meant
+     UTC+3 in some years and UTC+4 in others. Greenplum interprets such abbreviations according to
+     whatever they meant (or had most recently meant) on the specified date; but, as with the
+      <codeph>EST</codeph> example above, this is not necessarily the same as local civil time on
+     that date.</p>
+
+    <p>One should be wary that the POSIX-style time zone feature can lead to silently accepting
+     bogus input, since there is no check on the reasonableness of the zone abbreviations. For
+     example, <codeph>SET TIMEZONE TO FOOBAR0</codeph> will work, leaving the system effectively
+     using a rather peculiar abbreviation for UTC. Another issue to keep in mind is that in POSIX
+     time zone names, positive offsets are used for locations of Greenwich. Everywhere else,
+     Greenplum follows the ISO-8601 convention that positive timezone offsets are of Greenwich.</p>
+
+    <p>In all cases, timezone names and abbreviations are recognized case-insensitively.</p>
+
+    <p>Neither timezone names nor abbreviations are hard-wired into the server; they are obtained
+     from configuration files<ph otherprops="pivotal"> (see <xref
+       href="../install_guide/localization.xml">Configuring Localization Settings</xref>)</ph>.</p>
+
+    <p>The <codeph>TimeZone</codeph> configuration parameter can be set in the file , or in any of
+     the other standard ways for setting configuration parameters. There are also some special ways
+     to set it: <ol>
+      <li>The SQL command <codeph>SET TIME ZONE</codeph> sets the time zone for the session. This is
+       an alternative spelling of <codeph>SET TIMEZONE TO</codeph> with a more SQL-spec-compatible
+       syntax. </li>
+      <li>The <codeph>PGTZ</codeph> environment variable is used by <codeph>libpq</codeph> clients
+       to send a <codeph>SET TIME ZONE</codeph> command to the server upon connection. </li>
+     </ol></p>
+   </section>
+
+   <section id="datatype-interval-input">
+    <title>Interval Input</title>
+
+     <p><codeph>interval</codeph> values can be written using the following verbose syntax:
+     <codeblock>
+<varname>@</varname> <varname>quantity</varname> <varname>unit</varname> <varname>quantity</varname> <varname>unit</varname>... <varname>direction</varname>
+</codeblock>
+     where <varname>quantity</varname> is a number (possibly signed); <varname>unit</varname> is
+      <codeph>microsecond</codeph>, <codeph>millisecond</codeph>, <codeph>second</codeph>,
+      <codeph>minute</codeph>, <codeph>hour</codeph>, <codeph>day</codeph>, <codeph>week</codeph>,
+      <codeph>month</codeph>, <codeph>year</codeph>, <codeph>decade</codeph>,
+      <codeph>century</codeph>, <codeph>millennium</codeph>, or abbreviations or plurals of these
+     units; <varname>direction</varname> can be <codeph>ago</codeph> or empty. The at sign
+      (<codeph>@</codeph>) is optional noise. The amounts of the different units are implicitly
+     added with appropriate sign accounting. <codeph>ago</codeph> negates all the fields. This
+     syntax is also used for interval output, if <xref
+      href="config_params/guc-list.xml#IntervalStyle"/> is set to <codeph>postgres_verbose</codeph>.</p>
+
+    <p>Quantities of days, hours, minutes, and seconds can be specified without
+     explicit unit markings.  For example, <codeph>'1 12:59:10'</codeph> is read
+     the same as <codeph>'1 day 12 hours 59 min 10 sec'</codeph>.  Also,
+     a combination of years and months can be specified with a dash;
+     for example <codeph>'200-10'</codeph> is read the same as <codeph>'200 years
+     10 months'</codeph>.  (These shorter forms are in fact the only ones allowed
+     by the SQL standard, and are used for output when
+     <varname>IntervalStyle</varname> is set to <codeph>sql_standard</codeph>.)</p>
+
+    <p>Interval values can also be written as ISO 8601 time intervals, using either the
+      <codeph>format with designators</codeph> of the standard's section 4.4.3.2 or the
+      <codeph>alternative format</codeph> of section 4.4.3.3. The format with designators looks like
+     this:
+     <codeblock>
+P <varname>quantity</varname> <varname>unit</varname> <varname>quantity</varname> <varname>unit</varname> ...  T  <varname>quantity</varname> <varname>unit</varname> ...
+</codeblock>
+     The string must start with a <codeph>P</codeph>, and may include a <codeph>T</codeph> that
+     introduces the time-of-day units. The available unit abbreviations are given in <xref
+      href="#topic_abq_gfk_qfb/datatype-interval-iso8601-units" format="dita"/>. Units may be
+     omitted, and may be specified in any order, but units smaller than a day must appear after
+      <codeph>T</codeph>. In particular, the meaning of <codeph>M</codeph> depends on whether it is
+     before or after <codeph>T</codeph>.</p>
+
+     <table id="datatype-interval-iso8601-units">
+      <title>ISO 8601 Interval Unit Abbreviations</title>
+     <tgroup cols="2">
+       <thead>
+        <row>
+         <entry>Abbreviation</entry>
+         <entry>Meaning</entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry>Y</entry>
+         <entry>Years</entry>
+        </row>
+        <row>
+         <entry>M</entry>
+         <entry>Months (in the date part)</entry>
+        </row>
+        <row>
+         <entry>W</entry>
+         <entry>Weeks</entry>
+        </row>
+        <row>
+         <entry>D</entry>
+         <entry>Days</entry>
+        </row>
+        <row>
+         <entry>H</entry>
+         <entry>Hours</entry>
+        </row>
+        <row>
+         <entry>M</entry>
+         <entry>Minutes (in the time part)</entry>
+        </row>
+        <row>
+         <entry>S</entry>
+         <entry>Seconds</entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </table>
+
+     <p>In the alternative format:
+<codeblock>
+P  <varname>years</varname>-<varname>months</varname>-<varname>days</varname>   T <varname>hours</varname>:<varname>minutes</varname>:<varname>seconds</varname> 
+</codeblock>
+      the string must begin with <codeph>P</codeph>, and a
+      <codeph>T</codeph> separates the date and time parts of the interval.
+      The values are given as numbers similar to ISO 8601 dates.</p>
+
+    <p>When writing an interval constant with a <varname>fields</varname>
+     specification, or when assigning a string to an interval column that was
+     defined with a <varname>fields</varname> specification, the interpretation of
+     unmarked quantities depends on the <varname>fields</varname>.  For
+     example <codeph>INTERVAL '1' YEAR</codeph> is read as 1 year, whereas
+     <codeph>INTERVAL '1'</codeph> means 1 second.  Also, field values
+     <codeph>to the right</codeph> of the least significant field allowed by the
+     <varname>fields</varname> specification are silently discarded.  For
+     example, writing <codeph>INTERVAL '1 day 2:03:04' HOUR TO MINUTE</codeph>
+     results in dropping the seconds field, but not the day field.</p>
+
+    <p>According to the SQL standard all fields of an interval value must have the same sign, so a
+     leading negative sign applies to all fields; for example the negative sign in the interval
+     literal <codeph>'-1 2:03:04'</codeph> applies to both the days and hour/minute/second parts.
+     Greenplum allows the fields to have different signs, and traditionally treats each field in the
+     textual representation as independently signed, so that the hour/minute/second part is
+     considered positive in this example. If <varname>IntervalStyle</varname> is set to
+      <codeph>sql_standard</codeph> then a leading sign is considered to apply to all fields (but
+     only if no additional signs appear). Otherwise the traditional Greenplum interpretation is
+     used. To avoid ambiguity, it's recommended to attach an explicit sign to each field if any
+     field is negative.</p>
+
+    <p>In the verbose input format, and in some fields of the more compact
+     input formats, field values can have fractional parts; for example
+     <codeph>'1.5 week'</codeph> or <codeph>'01:02:03.45'</codeph>.  Such input is
+     converted to the appropriate number of months, days, and seconds
+     for storage.  When this would result in a fractional number of
+     months or days, the fraction is added to the lower-order fields
+     using the conversion factors 1 month = 30 days and 1 day = 24 hours.
+     For example, <codeph>'1.5 month'</codeph> becomes 1 month and 15 days.
+     Only seconds will ever be shown as fractional on output.</p>
+
+    <p><xref href="#topic_abq_gfk_qfb/datatype-interval-input-examples" format="dita"/> shows some
+     examples of valid <codeph>interval</codeph> input.</p>
+
+     <table id="datatype-interval-input-examples">
+      <title>Interval Input</title>
+      <tgroup cols="2">
+       <thead>
+        <row>
+         <entry>Example</entry>
+         <entry>Description</entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry>1-2</entry>
+         <entry>SQL standard format: 1 year 2 months</entry>
+        </row>
+        <row>
+         <entry>3 4:05:06</entry>
+         <entry>SQL standard format: 3 days 4 hours 5 minutes 6 seconds</entry>
+        </row>
+        <row>
+         <entry>1 year 2 months 3 days 4 hours 5 minutes 6 seconds</entry>
+         <entry>Traditional Postgres format: 1 year 2 months 3 days 4 hours 5 minutes 6 seconds</entry>
+        </row>
+        <row>
+         <entry>P1Y2M3DT4H5M6S</entry>
+         <entry>ISO 8601 <codeph>format with designators</codeph>: same meaning as above</entry>
+        </row>
+        <row>
+         <entry>P0001-02-03T04:05:06</entry>
+         <entry>ISO 8601 <codeph>alternative format</codeph>: same meaning as above</entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </table>
+
+    <p>Internally <codeph>interval</codeph> values are stored as months, days,
+     and seconds. This is done because the number of days in a month
+     varies, and a day can have 23 or 25 hours if a daylight savings
+     time adjustment is involved.  The months and days fields are integers
+     while the seconds field can store fractions.  Because intervals are
+     usually created from constant strings or <codeph>timestamp</codeph> subtraction,
+     this storage method works well in most cases, but can cause unexpected
+     results:
+
+<codeph>
+SELECT EXTRACT(hours from '80 minutes'::interval);
+ date_part
+-----------
+         1
+
+SELECT EXTRACT(days from '80 hours'::interval);
+ date_part
+-----------
+         0
+</codeph>
+
+     Functions <codeph>justify_days</codeph> and
+     <codeph>justify_hours</codeph> are available for adjusting days
+     and hours that overflow their normal ranges.</p>
+
+   </section>
+
+   <section id="datatype-interval-output">
+    <title>Interval Output</title>
+
+
+    <p>The output format of the interval type can be set to one of the four styles
+      <codeph>sql_standard</codeph>, <codeph>postgres</codeph>, <codeph>postgres_verbose</codeph>,
+     or <codeph>iso_8601</codeph>, using the command <codeph>SET intervalstyle</codeph>. The default
+     is the <codeph>postgres</codeph> format. <xref
+      href="#topic_abq_gfk_qfb/interval-style-output-table" format="dita"/> shows examples of each
+     output style.</p>
+
+    <p>The <codeph>sql_standard</codeph> style produces output that conforms to
+     the SQL standard's specification for interval literal strings, if
+     the interval value meets the standard's restrictions (either year-month
+     only or day-time only, with no mixing of positive
+     and negative components).  Otherwise the output looks like a standard
+     year-month literal string followed by a day-time literal string,
+     with explicit signs added to disambiguate mixed-sign intervals.</p>
+
+    <p>The output of the <codeph>postgres</codeph> style matches the output of PostgreSQL releases
+     prior to 8.4 when the <xref href="config_params/guc-list.xml#DateStyle"/> parameter was set to
+      <codeph>ISO</codeph>.</p>
+
+    <p>The output of the <codeph>postgres_verbose</codeph> style matches the output of
+     PostgreSQL releases prior to 8.4 when the
+     <varname>DateStyle</varname> parameter was set to non-<codeph>ISO</codeph> output.</p>
+
+    <p>The output of the <codeph>iso_8601</codeph> style matches the <codeph>format
+     with designators</codeph> described in section 4.4.3.2 of the
+     ISO 8601 standard.</p>
+
+     <table id="interval-style-output-table">
+       <title>Interval Output Style Examples</title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Style Specification</entry>
+          <entry>Year-Month Interval</entry>
+          <entry>Day-Time Interval</entry>
+          <entry>Mixed Interval</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry><codeph>sql_standard</codeph></entry>
+          <entry>1-2</entry>
+          <entry>3 4:05:06</entry>
+          <entry>-1-2 +3 -4:05:06</entry>
+         </row>
+         <row>
+          <entry><codeph>postgres</codeph></entry>
+          <entry>1 year 2 mons</entry>
+          <entry>3 days 04:05:06</entry>
+          <entry>-1 year -2 mons +3 days -04:05:06</entry>
+         </row>
+         <row>
+          <entry><codeph>postgres_verbose</codeph></entry>
+          <entry>@ 1 year 2 mons</entry>
+          <entry>@ 3 days 4 hours 5 mins 6 secs</entry>
+          <entry>@ 1 year 2 mons -3 days 4 hours 5 mins 6 secs ago</entry>
+         </row>
+         <row>
+          <entry><codeph>iso_8601</codeph></entry>
+          <entry>P1Y2M</entry>
+          <entry>P3DT4H5M6S</entry>
+          <entry>P-1Y-2M3DT-4H-5M-6S</entry>
+         </row>
+        </tbody>
+       </tgroup>
+    </table>
+
+   </section>
+    </body>
+  </topic>
+</dita>

--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -260,6 +260,7 @@
 		<topicref href="gp_toolkit.ditamap" format="ditamap"/>
 		<topicref href="gpperfmon/gpperfmon.ditamap" format="ditamap"/>
 		<topicref href="data_types.xml" navtitle="Greenplum Database Data Types" id="data_types">
+			<topicref href="datatype-datetime.xml"/>
 			<topicref href="datatype-pseudo.xml"/>
 			<topicref href="datatype-textsearch.xml"/>
 		</topicref>


### PR DESCRIPTION
@Eulerizeit @hlinnaka - It seems to make sense to port over the [Date/Time Types](http://docs-yozie-datetime.cfapps.io/docs/600/ref_guide/datatype-datetime.html) docs for 6.0, at least in order to show the differences in interval handling.  Is it ok to include this new info as-is, or are there differences in the Greenplum implementation that need to be called out?