### PR TITLE
Fix bug: reshuffle should work with table with OIDs.

### DIFF
--- a/src/backend/optimizer/prep/preptlist.c
+++ b/src/backend/optimizer/prep/preptlist.c
@@ -406,10 +406,15 @@ expand_targetlist(PlannerInfo *root, List *tlist, int command_type,
 			}
 		}
 
-		if (key_col_updated)
+		if (key_col_updated || root->parse->needReshuffle)
 		{
 			/*
 			 * Yes, this is a split update.
+			 * Updating a hash column is a split update, of course.
+			 * We should note that current reshuffle implementation
+			 * is based on split-update, so if the query is a reshuffle
+			 * query, it is also a split-update even if we are reshuffling
+			 * a random distributed table.
 			 *
 			 * For each column that was changed, add the original column value
 			 * to the target list, if it's not there already.

--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -196,6 +196,55 @@ select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::re
 (1 row)
 
 drop table t1_reshuffle;
+Create table t1_reshuffle(a int, b int, c int) with OIDS distributed by (a,b);
+NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
+update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle'::regclass;
+insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update t1_reshuffle set c = gp_segment_id;
+Select count(*) from t1_reshuffle where gp_segment_id=0;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) from t1_reshuffle where gp_segment_id=1;
+ count 
+-------
+     0
+(1 row)
+
+Select count(*) from t1_reshuffle where gp_segment_id=2;
+ count 
+-------
+     0
+(1 row)
+
+Alter table t1_reshuffle set with (reshuffle);
+Select count(*) from t1_reshuffle where gp_segment_id=0;
+ count 
+-------
+    31
+(1 row)
+
+Select count(*) from t1_reshuffle where gp_segment_id=1;
+ count 
+-------
+    35
+(1 row)
+
+Select count(*) from t1_reshuffle where gp_segment_id=2;
+ count 
+-------
+    34
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
+drop table t1_reshuffle;
 -- Test NULLs.
 Create table t1_reshuffle(a int, b int, c int) distributed by (a,b,c);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle'::regclass;
@@ -358,6 +407,31 @@ Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
 drop table t1_reshuffle;
 -- Random distributed tables
 Create table r1_reshuffle(a int, b int, c int) distributed randomly;
+update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle'::regclass;
+insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update r1_reshuffle set c = gp_segment_id;
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Alter table r1_reshuffle set with (reshuffle);
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+drop table r1_reshuffle;
+Create table r1_reshuffle(a int, b int, c int) with OIDS distributed randomly;
+NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
 update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle'::regclass;
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
 Update r1_reshuffle set c = gp_segment_id;
@@ -557,6 +631,54 @@ Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
 
 drop table r1_reshuffle;
 Create table r1_reshuffle(a int, b int, c int) distributed replicated;
+update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
+select update_on_segment('r1_reshuffle', 0, 2);
+ update_on_segment 
+-------------------
+ t
+(1 row)
+
+select update_on_segment('r1_reshuffle', 1, 2);
+ update_on_segment 
+-------------------
+ t
+(1 row)
+
+select update_on_segment('r1_reshuffle', 2, 2);
+ update_on_segment 
+-------------------
+ t
+(1 row)
+
+insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+ select_on_segment 
+-------------------
+                 0
+(1 row)
+
+Alter table r1_reshuffle set with (reshuffle);
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+ select_on_segment 
+-------------------
+               100
+(1 row)
+
+drop table r1_reshuffle;
+Create table r1_reshuffle(a int, b int, c int) with OIDS distributed replicated;
+NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
 select update_on_segment('r1_reshuffle', 0, 2);
  update_on_segment 

--- a/src/test/regress/sql/reshuffle.sql
+++ b/src/test/regress/sql/reshuffle.sql
@@ -57,6 +57,21 @@ Select count(*) from t1_reshuffle where gp_segment_id=2;
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
 drop table t1_reshuffle;
 
+Create table t1_reshuffle(a int, b int, c int) with OIDS distributed by (a,b);
+update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle'::regclass;
+insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update t1_reshuffle set c = gp_segment_id;
+Select count(*) from t1_reshuffle where gp_segment_id=0;
+Select count(*) from t1_reshuffle where gp_segment_id=1;
+Select count(*) from t1_reshuffle where gp_segment_id=2;
+Alter table t1_reshuffle set with (reshuffle);
+Select count(*) from t1_reshuffle where gp_segment_id=0;
+Select count(*) from t1_reshuffle where gp_segment_id=1;
+Select count(*) from t1_reshuffle where gp_segment_id=2;
+select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
+drop table t1_reshuffle;
+
+
 -- Test NULLs.
 Create table t1_reshuffle(a int, b int, c int) distributed by (a,b,c);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle'::regclass;
@@ -125,9 +140,18 @@ Select count(*) from t1_reshuffle;
 Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
 drop table t1_reshuffle;
 
-
 -- Random distributed tables
 Create table r1_reshuffle(a int, b int, c int) distributed randomly;
+update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle'::regclass;
+insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update r1_reshuffle set c = gp_segment_id;
+Select count(*) from r1_reshuffle;
+Alter table r1_reshuffle set with (reshuffle);
+Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+drop table r1_reshuffle;
+
+Create table r1_reshuffle(a int, b int, c int) with OIDS distributed randomly;
 update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle'::regclass;
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
 Update r1_reshuffle set c = gp_segment_id;
@@ -227,6 +251,19 @@ Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
 drop table r1_reshuffle;
 
 Create table r1_reshuffle(a int, b int, c int) distributed replicated;
+update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
+select update_on_segment('r1_reshuffle', 0, 2);
+select update_on_segment('r1_reshuffle', 1, 2);
+select update_on_segment('r1_reshuffle', 2, 2);
+insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select count(*) from r1_reshuffle;
+Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+Alter table r1_reshuffle set with (reshuffle);
+Select count(*) from r1_reshuffle;
+Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+drop table r1_reshuffle;
+
+Create table r1_reshuffle(a int, b int, c int) with OIDS distributed replicated;
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
 select update_on_segment('r1_reshuffle', 0, 2);
 select update_on_segment('r1_reshuffle', 1, 2);


### PR DESCRIPTION
Current reshuffle implementation is based on split-update.
Previously, We mark a query split-update if the query is an
UPDATE and it updates some of the table's hash distribution
columns. We should also mark the query split-update when it is
a reshuffle, even if it's not a hash-distributed table.

This PR fixes the issue: https://github.com/greenplum-db/gpdb/issues/6136.