### PR TITLE
Add pg_rewind to gprecoverseg incremental recovery

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -677,6 +677,7 @@ class Command(object):
         self.exec_context = createExecutionContext(ctxt, remoteHost, stdin=stdin, nakedExecutionInfo=nakedExecutionInfo,
                                                    gphome=gphome)
         self.remoteHost = remoteHost
+        self.logger = gplog.get_default_logger()
 
     def __str__(self):
         if self.results:
@@ -693,6 +694,7 @@ class Command(object):
             return self.exec_context.proc
 
     def run(self, validateAfter=False):
+        self.logger.debug("Running Command: %s" % self.cmdStr)
         faultPoint = os.getenv('GP_COMMAND_FAULT_POINT')
         if not faultPoint or (self.name and not self.name.startswith(faultPoint)):
             self.exec_context.execute(self)
@@ -748,6 +750,7 @@ class Command(object):
     def validate(self, expected_rc=0):
         """Plain vanilla validation which expects a 0 return code."""
         if self.results.rc != expected_rc:
+            self.logger.debug(self.results)
             raise ExecutionError("non-zero rc: %d" % self.results.rc, self)
 
 

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -414,7 +414,8 @@ class SegmentRewind(Command):
     """
 
     def __init__(self, name, target_host, target_datadir,
-                 source_host, source_port, ctxt=REMOTE):
+                 source_host, source_port,
+                 verbose=False, ctxt=REMOTE):
 
         # Construct the source server libpq connection string
         source_server = "host=%s port=%s dbname=template1" % (source_host, source_port)
@@ -423,6 +424,9 @@ class SegmentRewind(Command):
         # file exists in target data directory because the target instance can
         # be started up normally as a mirror for WAL replication catch up.
         rewind_cmd = '[ -f %s/recovery.conf ] || PGOPTIONS="-c gp_session_role=utility" $GPHOME/bin/pg_rewind --write-recovery-conf --source-server="%s" --target-pgdata=%s' % (target_datadir, source_server, target_datadir)
+
+        if verbose:
+            rewind_cmd = rewind_cmd + ' --progress'
 
         self.cmdStr = rewind_cmd + ' 2>&1'
 

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -155,11 +155,13 @@ class Segment:
         """
         Construct a printable string representation of a Segment
         """
-        return "%s:%s:content=%s:dbid=%s:mode=%s:status=%s" % (
+        return "%s:%s:content=%s:dbid=%s:role=%s:preferred_role=%s:mode=%s:status=%s" % (
             self.hostname,
             self.datadir,
             self.content,
             self.dbid,
+            self.role,
+            self.preferred_role,
             self.mode,
             self.status
             )

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -320,9 +320,11 @@ class GpMirrorListToBuild:
                                    targetSegment.getSegmentHostName(),
                                    targetSegment.getSegmentDataDirectory(),
                                    sourceHostName,
-                                   sourcePort)
+                                   sourcePort,
+                                   verbose=gplog.logging_is_verbose())
             try:
                 cmd.run(True)
+                self.__logger.debug('pg_rewind results: %s' % cmd.results)
             except base.ExecutionError as e:
                 self.__logger.debug("pg_rewind failed for target directory %s." % targetSegment.getSegmentDataDirectory())
                 self.__logger.warning("Incremental recovery failed for dbid %s. You must use gprecoverseg -F to recover the segment." % targetSegment.getSegmentDbId())

--- a/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
+++ b/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
@@ -85,7 +85,7 @@ class GpSegmentRebalanceOperation:
                 self.logger.info("=============================START ANOTHER RECOVER=========================================")
                 # import here because GpRecoverSegmentProgram and GpSegmentRebalanceOperation have a circular dependency
                 from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
-                sys.argv = ['gprecoverseg', '-aF']
+                sys.argv = ['gprecoverseg', '-a']
                 local_parser = GpRecoverSegmentProgram.createParser()
                 local_options, args = local_parser.parse_args()
                 cmd = GpRecoverSegmentProgram.createProgram(local_options, args)
@@ -95,7 +95,7 @@ class GpSegmentRebalanceOperation:
                 if e.code != 0:
                     self.logger.error("Failed to start the synchronization step of the segment rebalance.")
                     self.logger.error("Check the gprecoverseg log file, correct any problems, and re-run")
-                    self.logger.error("'gprecoverseg -aF'.")
+                    self.logger.error("'gprecoverseg -a'.")
                     raise Exception("Error synchronizing.\nError: %s" % str(e))
             finally:
                 if cmd:

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -126,7 +126,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
         result = self.buildMirrorSegs._GpMirrorListToBuild__startAll(Mock(), [Mock(), Mock()], [])
         self.assertFalse(result)
         self.logger.warn.assert_any_call('Failed to start segment.  The fault prober will shortly mark it as down. '
-                                         'Segment: sdw1:/data/primary0:content=0:dbid=2:mode=s:status=u: REASON: reason')
+                                         'Segment: sdw1:/data/primary0:content=0:dbid=2:role=p:preferred_role=p:mode=s:status=u: REASON: reason')
 
     @patch('gppylib.operations.buildMirrorSegments.dbconn.connect')
     @patch('gppylib.operations.buildMirrorSegments.dbconn.execSQL')

--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -103,7 +103,7 @@ select role, preferred_role, mode from gp_segment_configuration where content = 
 
 -- The remaining steps are to bring back the cluster to original state.
 -- start_ignore
-\! gprecoverseg -aF
+\! gprecoverseg -a
 -- end_ignore
 -- loop while segments come in sync
 do $$

--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -45,7 +45,7 @@ select role, preferred_role, mode from gp_segment_configuration where content = 
 
 -- The remaining steps are to bring back the cluster to original state.
 -- start_ignore
-\! gprecoverseg -aF
+\! gprecoverseg -a
 -- end_ignore
 
 -- loop while segments come in sync


### PR DESCRIPTION
Now that pg_rewind is available, we can use it to incrementally recover a failed
primary segment that will be transitioning to mirror. Incremental recovery with
pg_rewind has a big performance advantage over full recovery. We also change
rebalance to use pg_rewind incremental recovery. However, if pg_rewind fails
during gprecoverseg, the user must run full recovery (gprecoverseg -F).

Co-authored-by: Paul Guo <pguo@pivotal.io>

This PR depends on the following 4 PRs being merged in first:
#6143 
#6158 
#6159 
#6160 

As those PRs get merged in, we will rebase this PR.