### PR TITLE
New GUCs to specify default numsegments when creating tables.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -28,6 +28,7 @@
 #include "optimizer/var.h"
 #include "parser/parse_relation.h"
 #include "utils/fmgroids.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/datum.h"
 #include "utils/syscache.h"
@@ -277,10 +278,10 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 
 				/*
 				 * In CTAS the source distribution policy is not inherited,
-				 * always set numsegments to ALL unless a DISTRIBUTED BY clause
-				 * is specified.
+				 * always set numsegments to DEFAULT unless a DISTRIBUTED BY
+				 * clause is specified.
 				 */
-				numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+				numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 
 				if (query->intoPolicy != NULL)
 				{

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -56,6 +56,7 @@
 #include "optimizer/clauses.h"
 #include "optimizer/tlist.h"
 #include "parser/parse_func.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
 
 
@@ -3666,7 +3667,7 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 
 	dist = (DistributedBy *)into->distributedBy;
 
-	dist->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+	dist->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 
 	/*
 	 * We have a DISTRIBUTED BY column list specified by the user

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1672,7 +1672,7 @@ transformCreateExternalStmt(CreateExternalStmt *stmt, const char *queryString)
 			stmt->distributedBy = makeNode(DistributedBy);
 			stmt->distributedBy->ptype = POLICYTYPE_PARTITIONED;
 			stmt->distributedBy->keys = NIL;
-			stmt->distributedBy->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+			stmt->distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 		}
 		else
 		{
@@ -1725,7 +1725,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 	ListCell	*keys = NULL;
 	List		*distrkeys = NIL;
 	/* By default tables should be distributed on ALL segments */
-	int			numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+	int			numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 	ListCell   *lc;
 
 	/*
@@ -1738,7 +1738,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 	if (distributedBy &&
 		(distributedBy->ptype == POLICYTYPE_PARTITIONED && distributedBy->keys == NIL))
 	{
-		distributedBy->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+		distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 		return distributedBy;
 	}
 
@@ -1750,7 +1750,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("INHERITS clause cannot be used with DISTRIBUTED REPLICATED clause")));
 
-		distributedBy->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+		distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 		return distributedBy;
 	}
 
@@ -1969,7 +1969,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 		/*
 		 * Create with default distribution policy and numsegments.
 		 */
-		numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+		numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 
 		distributedBy = makeNode(DistributedBy);
 		distributedBy->ptype = POLICYTYPE_PARTITIONED;
@@ -2079,7 +2079,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 			/*
 			 * Create with default distribution policy and numsegments.
 			 */
-			numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+			numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 
 			distributedBy = makeNode(DistributedBy);
 			distributedBy->ptype = POLICYTYPE_PARTITIONED;

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -64,6 +64,45 @@ FOREIGN_KEY(localoid REFERENCES pg_class(oid));
 #define GP_POLICY_ALL_NUMSEGMENTS			Max(1, getgpsegmentCount())
 
 /*
+ * Minimal set of segments.
+ */
+#define GP_POLICY_MINIMAL_NUMSEGMENTS		1
+
+/*
+ * A random set of segments, the value is different on each call.
+ */
+#define GP_POLICY_RANDOM_NUMSEGMENTS		\
+	cdb_randint(GP_POLICY_ALL_NUMSEGMENTS, GP_POLICY_MINIMAL_NUMSEGMENTS)
+
+/*
+ * Default set of segments, the value is controlled by the GUC
+ * gp_create_table_default_numsegments, and when its 'ANY' it's further
+ * controlled by the GUC gp_create_table_any_numsegments.
+ */
+#define GP_POLICY_DEFAULT_NUMSEGMENTS		\
+( gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_FULL    ? GP_POLICY_ALL_NUMSEGMENTS \
+: gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_RANDOM  ? GP_POLICY_RANDOM_NUMSEGMENTS \
+: gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_MINIMAL ? GP_POLICY_MINIMAL_NUMSEGMENTS \
+: gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_ANY     ? gp_create_table_any_numsegments \
+: __GP_POLICY_EVIL_NUMSEGMENTS )
+
+/*
+ * The the default numsegments policies when creating a table.
+ *
+ * - FULL: all the segments;
+ * - RANDOM: pick a random set of segments each time;
+ * - MINIMAL: the minimal set of segments;
+ * - ANY: use the segments specified by gp_create_table_any_numsegments;
+ */
+enum
+{
+	GP_DEFAULT_NUMSEGMENTS_FULL,
+	GP_DEFAULT_NUMSEGMENTS_RANDOM,
+	GP_DEFAULT_NUMSEGMENTS_MINIMAL,
+	GP_DEFAULT_NUMSEGMENTS_ANY,
+};
+
+/*
  * The segments suitable for Entry locus, which include both master and all
  * the segments.
  *

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -278,6 +278,8 @@ extern bool gp_startup_integrity_checks;
 extern bool Debug_resource_group;
 extern bool gp_crash_recovery_suppress_ao_eof;
 extern bool gp_create_table_random_default_distribution;
+extern int	gp_create_table_default_numsegments;
+extern int	gp_create_table_any_numsegments;
 extern bool gp_allow_non_uniform_partitioning_ddl;
 extern bool gp_enable_exchange_default_partition;
 extern int  dtx_phase2_retry_count;

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -3,20 +3,85 @@
 -- TODO: ao tables
 -- TODO: tables and temp tables
 \set explain 'explain analyze'
-set allow_system_table_mods to true;
+drop schema if exists test_partial_table;
+NOTICE:  schema "test_partial_table" does not exist, skipping
+create schema test_partial_table;
+set search_path='test_partial_table';
+--
+-- verify the debugging GUCs
+--
+set gp_create_table_default_numsegments to full;
+create table t (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           3
+(1 row)
+
+drop table t;
+set gp_create_table_default_numsegments to minimal;
+create table t (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           1
+(1 row)
+
+drop table t;
+set gp_create_table_default_numsegments to 'any';
+set gp_create_table_any_numsegments to 1;
+create table t (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           1
+(1 row)
+
+drop table t;
+set gp_create_table_any_numsegments to 2;
+create table t (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           2
+(1 row)
+
+drop table t;
+set gp_create_table_any_numsegments to 3;
+create table t (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           3
+(1 row)
+
+drop table t;
+-- error: out of range [1, 3]
+set gp_create_table_any_numsegments to -1;
+ERROR:  -1 is outside the valid range for parameter "gp_create_table_any_numsegments" (1 .. 2147483647)
+set gp_create_table_any_numsegments to 0;
+ERROR:  0 is outside the valid range for parameter "gp_create_table_any_numsegments" (1 .. 2147483647)
+set gp_create_table_any_numsegments to 4;
+ERROR:  4 is outside the valid range for parameter "gp_create_table_any_numsegments" (1 .. 3)
+reset gp_create_table_default_numsegments;
 --
 -- prepare kinds of tables
 --
-create temp table t1 (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
-create temp table d1 (c1 int, c2 int, c3 int, c4 int) distributed replicated;
-create temp table r1 (c1 int, c2 int, c3 int, c4 int) distributed randomly;
-create temp table t2 (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
-create temp table d2 (c1 int, c2 int, c3 int, c4 int) distributed replicated;
-create temp table r2 (c1 int, c2 int, c3 int, c4 int) distributed randomly;
-update gp_distribution_policy set numsegments=1
-	where localoid in ('t1'::regclass, 'd1'::regclass, 'r1'::regclass);
-update gp_distribution_policy set numsegments=2
-	where localoid in ('t2'::regclass, 'd2'::regclass, 'r2'::regclass);
+set gp_create_table_default_numsegments to 'any';
+set gp_create_table_any_numsegments to 1;
+create table t1 (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+create table d1 (c1 int, c2 int, c3 int, c4 int) distributed replicated;
+create table r1 (c1 int, c2 int, c3 int, c4 int) distributed randomly;
+set gp_create_table_any_numsegments to 2;
+create table t2 (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+create table d2 (c1 int, c2 int, c3 int, c4 int) distributed replicated;
+create table r2 (c1 int, c2 int, c3 int, c4 int) distributed randomly;
+reset gp_create_table_default_numsegments;
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in (
 		't1'::regclass, 'd1'::regclass, 'r1'::regclass,
@@ -34,7 +99,7 @@ select localoid::regclass, attrnums, policytype, numsegments
 --
 -- create table
 --
-create temp table t (like t1);
+create table t (like t1);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
@@ -44,66 +109,71 @@ select localoid::regclass, attrnums, policytype, numsegments
 (1 row)
 
 drop table t;
-create temp table t as table t1;
+-- CTAS set numsegments with DEFAULT,
+-- let it be a fixed value to get stable output
+set gp_create_table_default_numsegments to 'any';
+set gp_create_table_any_numsegments to 2;
+create table t as table t1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1, c2' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
 ----------+----------+------------+-------------
- t        | {1,2}    | p          |           3
+ t        | {1,2}    | p          |           2
 (1 row)
 
 drop table t;
-create temp table t as select * from t1;
+create table t as select * from t1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1, c2' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
 ----------+----------+------------+-------------
- t        | {1,2}    | p          |           3
+ t        | {1,2}    | p          |           2
 (1 row)
 
 drop table t;
-create temp table t as select * from t1 distributed by (c1, c2);
+create table t as select * from t1 distributed by (c1, c2);
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
 ----------+----------+------------+-------------
- t        | {1,2}    | p          |           3
+ t        | {1,2}    | p          |           2
 (1 row)
 
 drop table t;
-create temp table t as select * from t1 distributed replicated;
+create table t as select * from t1 distributed replicated;
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
 ----------+----------+------------+-------------
- t        |          | r          |           3
+ t        |          | r          |           2
 (1 row)
 
 drop table t;
-create temp table t as select * from t1 distributed randomly;
+create table t as select * from t1 distributed randomly;
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
 ----------+----------+------------+-------------
- t        |          | p          |           3
+ t        |          | p          |           2
 (1 row)
 
 drop table t;
-select * into temp table t from t1;
+select * into table t from t1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1, c2' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
 ----------+----------+------------+-------------
- t        | {1,2}    | p          |           3
+ t        | {1,2}    | p          |           2
 (1 row)
 
 drop table t;
+reset gp_create_table_default_numsegments;
 --
 -- alter table
 --

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -44,9 +44,6 @@ test: icudp/gp_interconnect_queue_depth icudp/gp_interconnect_queue_depth_longti
 # event triggers cannot run concurrently with any test that runs DDL
 test: event_trigger_gp
 
-# test partially distributed tables
-test: partial_table
-
 # deadlock tests run separately - because we don't know which one gets stuck.
 test: deadlock
 
@@ -78,7 +75,7 @@ test: dtm_retry
 
 # The appendonly test cannot be run concurrently with tests that have
 # serializable transactions (may conflict with AO vacuum operations).
-test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish
+test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish partial_table
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.


### PR DESCRIPTION
Introduced two new GUCs to specify the default numsegments policies when
creating tables:

- gp_create_table_default_numsegments:
  - 'full': create on all segments, the default;
  - 'random': create on a random set of segments;
  - 'minimal': create on a minimal set of segements (one segment);
  - 'any': create on the segments specified by the other GUC
    gp_create_table_any_numsegments;

These GUCs are mainly for debugging and testing purpose.