### PR TITLE
Allow registering for compaction drop for segment files in compactedSegmentFileList.

### DIFF
--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -779,9 +779,6 @@ RegisterSegnoForCompactionDrop(Oid relid, List *compactedSegmentFileList)
 
 			appendOnlyInsertXact = true;
 			segfilestat->xid = CurrentXid;
-			elogif(segfilestat->state != COMPACTED_AWAITING_DROP,
-				   ERROR, "expected segno (%d) from AO relid %d in state COMPACTED_AWAITING_DROP but found in state %d",
-				   i, relid, segfilestat->state);
 			segfilestat->state = DROP_USE;
 		}
 	}

--- a/src/test/isolation2/output/uao/insert_should_not_use_awaiting_drop.source
+++ b/src/test/isolation2/output/uao/insert_should_not_use_awaiting_drop.source
@@ -118,7 +118,7 @@ gp_inject_fault
 t              
 (1 row)
 2<:  <... completed>
-ERROR:  expected segno (1) from AO relid 41063 in state COMPACTED_AWAITING_DROP but found in state 1 (appendonlywriter.c:768)
+VACUUM
 
 -- Then inserts into test table should be visible
 select count(1) from test_table_@orientation@;


### PR DESCRIPTION
When there are many concurrent operations on AO tables, it is possible
the aoentry fetched during RegisterSegnoForCompactionDrop is a brand
new entry that does not contain information about the current vacuum
of the relation. In this case, compactedSegmentFileList contains the
accurate list of segment files that have been compacted.

Remove the `elogif` that assumes the aoentry is accurate.

Note: The aoentry will not be evicted again after RegisterSegnoForCompactionDrop
because the entry is marked as 'in use'.