### PR TITLE
Ensure target clean shutdown at beginning of pg_rewind

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6668,12 +6668,6 @@ StartupXLOG(void)
 	else if (ControlFile->state != DB_SHUTDOWNED)
 		InRecovery = true;
 
-	if (InRecovery && !IsUnderPostmaster)
-	{
-		ereport(FATAL,
-				(errmsg("Database must be shutdown cleanly when using single backend start")));
-	}
-
 	/* Recovery from xlog */
 	if (InRecovery)
 	{

--- a/src/bin/pg_rewind/Makefile
+++ b/src/bin/pg_rewind/Makefile
@@ -26,7 +26,7 @@ OBJS	= pg_rewind.o parsexlog.o xlogreader.o datapagemap.o timeline.o \
 
 EXTRA_CLEAN = xlogreader.c compact.c
 
-REGRESS = basictest extrafiles databases pg_xlog_symlink
+REGRESS = basictest extrafiles databases pg_xlog_symlink unclean_shutdown
 REGRESS_OPTS=--use-existing --launcher=./launcher
 
 all: pg_rewind

--- a/src/bin/pg_rewind/expected/unclean_shutdown.out
+++ b/src/bin/pg_rewind/expected/unclean_shutdown.out
@@ -1,0 +1,12 @@
+Master initialized.
+Master running.
+Standby initialized and running.
+Standby promoted.
+Running pg_rewind...
+Old master restarted after rewind.
+SELECT state FROM pg_stat_replication
+   state   
+-----------
+ streaming
+(1 row)
+

--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -75,6 +75,7 @@ STANDBY_PSQL="psql -a --no-psqlrc -p $PORT_STANDBY"
 PG_CTL_COMMON_OPTIONS="--gp_dbid=2 --gp_contentid=0"
 MASTER_PG_CTL_OPTIONS="-p ${PORT_MASTER} $PG_CTL_COMMON_OPTIONS"
 STANDBY_PG_CTL_OPTIONS="-p ${PORT_STANDBY} $PG_CTL_COMMON_OPTIONS"
+MASTER_PG_CTL_STOP_MODE="fast"
 
 function wait_until_standby_is_promoted {
    retry=50

--- a/src/bin/pg_rewind/sql/run_test.sh
+++ b/src/bin/pg_rewind/sql/run_test.sh
@@ -93,7 +93,7 @@ echo "Standby promoted."
 after_promotion
 
 # Stop the master and be ready to perform the rewind
-pg_ctl -w -D $TEST_MASTER stop -m fast >>$log_path 2>&1
+pg_ctl -w -D $TEST_MASTER stop -m $MASTER_PG_CTL_STOP_MODE >>$log_path 2>&1
 
 # For a local test, source node need to be stopped as well.
 if [ $TEST_SUITE == "local" ]; then

--- a/src/bin/pg_rewind/sql/unclean_shutdown.sql
+++ b/src/bin/pg_rewind/sql/unclean_shutdown.sql
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This file has the .sql extension, but it is actually launched as a shell
+# script. This contortion is necessary because pg_regress normally uses
+# psql to run the input scripts, and requires them to have the .sql
+# extension, but we use a custom launcher script that runs the scripts using
+# a shell instead.
+
+TESTNAME=basictest
+
+. sql/config_test.sh
+
+MASTER_PG_CTL_STOP_MODE="immediate"
+
+# Nothing to do here
+function before_master
+{
+:
+}
+
+# Nothing to do here
+function before_standby
+{
+:
+}
+
+# Nothing to do here
+function standby_following_master
+{
+:
+}
+
+# Nothing to do here
+function after_promotion
+{
+:
+}
+
+# The old master was stopped with immediate mode which will cause unclean
+# shutdown and leave "in production" in the control file. At the beginning of
+# pg_rewind, a single-user mode postgres session should have been run to ensure
+# clean shutdown on the target instance.
+function after_rewind
+{
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "SELECT state FROM pg_stat_replication"
+}
+
+# Run the test
+. sql/run_test.sh


### PR DESCRIPTION
At the beginning of pg_rewind, we should launch a quick single-user mode
postgres session to the target instance to ensure the target has completed crash
recovery and logs a clean shutdown in its pg_control file.

Co-authored-by: Paul Guo <pguo@pivotal.io>

This has been tested manually and works fine as implementation replacement for open PR #6138.