### PR TITLE
Fix checking for duplicated columns in DISTRIBUTED BY

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4559,7 +4559,7 @@ columnList:
 
 columnListUnique:
 			columnElem								{ $$ = list_make1($1); }
-			| columnList ',' columnElem
+			| columnListUnique ',' columnElem
 				{
 					if (list_member($1, $3))
 						ereport(ERROR,

--- a/src/test/regress/expected/gp_create_table.out
+++ b/src/test/regress/expected/gp_create_table.out
@@ -194,6 +194,14 @@ create table foo (a int, b int) distributed by (c,C);
 ERROR:  duplicate column in DISTRIBUTED BY clause
 LINE 1: create table foo (a int, b int) distributed by (c,C);
                                                           ^
+create table foo (a int, b int, c int) distributed by (b, c, c);
+ERROR:  duplicate column in DISTRIBUTED BY clause
+LINE 1: ...te table foo (a int, b int, c int) distributed by (b, c, c);
+                                                                    ^
+create table foo (a int, b int, c int) distributed by (c, c, b);
+ERROR:  duplicate column in DISTRIBUTED BY clause
+LINE 1: ...te table foo (a int, b int, c int) distributed by (c, c, b);
+                                                                 ^
 create table foo ("I" int, i int) distributed by ("I",I);
 select attrnums from gp_distribution_policy where localoid='foo'::regclass;
  attrnums 

--- a/src/test/regress/sql/gp_create_table.sql
+++ b/src/test/regress/sql/gp_create_table.sql
@@ -124,6 +124,8 @@ create table foo (a int, b int) distributed by (a,aA,A);
 create table foo (a int, b int) distributed by (a,aA);
 create table foo (a int, b int) distributed by (b,a,aabb);
 create table foo (a int, b int) distributed by (c,C);
+create table foo (a int, b int, c int) distributed by (b, c, c);
+create table foo (a int, b int, c int) distributed by (c, c, b);
 create table foo ("I" int, i int) distributed by ("I",I);
 select attrnums from gp_distribution_policy where localoid='foo'::regclass;
 create table fooctas as select * from foo distributed by (i,i);


### PR DESCRIPTION
The check in the parser didn't recurse correctly, and therefore only
checked whether the last DISTRIBUTED BY column was the same as any previous
one. As long as the last column was unique, duplicates elsewhere in the
list were ignored.