### PR TITLE
GPDB_94_MERGE_FIXME: GPDB have special case YYYYMMDDHH24MISS

### DIFF
--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -2726,27 +2726,26 @@ DecodeNumberField(int len, char *str, int fmask,
 	/* No decimal point and no complete date yet? */
 	if ((fmask & DTK_DATE_M) != DTK_DATE_M && !have_frac)
 	{
-		/* GPDB_94_MERGE_FIXME: Why does GPDB have this special case for this case? */
-		/* yyyymmddhhmmss? */
-		if ((fmask & DTK_DATE_M) != DTK_DATE_M && 
+		/* GPDB have this special case for YYYYMMDDHH24MISS case */
+		if ((fmask & DTK_DATE_M) != DTK_DATE_M &&
 			(fmask & DTK_TIME_M) != DTK_TIME_M &&
 			len == 14)
 		{
-            *tmask = DTK_DATE_M | DTK_TIME_M; 
+			*tmask = DTK_DATE_M | DTK_TIME_M;
 
-            tm->tm_sec = atoi(str + 12); 
-            *(str + 12) = '\0'; 
-            tm->tm_min = atoi(str + 10); 
-            *(str + 10) = '\0'; 
-            tm->tm_hour = atoi(str + 8); 
-            *(str + 8) = '\0'; 
-            tm->tm_mday = atoi(str + 6); 
-            *(str + 6) = '\0'; 
-            tm->tm_mon = atoi(str + 4); 
-            *(str + 4) = '\0'; 
-            tm->tm_year = atoi(str + 0); 
-            return DTK_DATE; 
-        } 
+			tm->tm_sec = atoi(str + 12);
+			*(str + 12) = '\0';
+			tm->tm_min = atoi(str + 10);
+			*(str + 10) = '\0';
+			tm->tm_hour = atoi(str + 8);
+			*(str + 8) = '\0';
+			tm->tm_mday = atoi(str + 6);
+			*(str + 6) = '\0';
+			tm->tm_mon = atoi(str + 4);
+			*(str + 4) = '\0';
+			tm->tm_year = atoi(str + 0);
+			return DTK_DATE;
+		}
 		if (len >= 6)
 		{
 			*tmask = DTK_DATE_M;


### PR DESCRIPTION
This code block is GPDB special, because it can turn YYYYMMDDHH24MISS to right time while 9.4 postgres cannot.

I also delete extra space at end of line, and turns space to tablespace

In GPDB
```
postgres=# select '20081225132424'::timestamp;
      timestamp
---------------------
 2008-12-25 13:24:24
(1 row)
```
while in postgres 9.4 :
```
postgres=# select '20081225130000'::timestamp;
ERROR:  date/time field value out of range: "20081225130000"
LINE 1: select '20081225130000'::timestamp;
               ^
HINT:  Perhaps you need a different "datestyle" setting.
```

The original reason is in MPP_5665, a customer says
```
Without this automatic conversion, external table definition cannot define the field as timestamp. Instead, it must be defined as text, and during load, a separate conversion operator (to_timestamp(field, 'YYYYMMDDHHMI24SS') has to inserted to do the conversion.

This slows down load, and also disabled SREH for the field.
```