### PR TITLE
Add encoding option as condition of finding reusable table

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2297,7 +2297,7 @@ class gpload:
 
         encodingCode = None
         encodingStr = self.getconfig('gpload:input:encoding', unicode, None)
-        if encodingStr == None:
+        if encodingStr is None:
             result = self.db.query("SHOW SERVER_ENCODING".encode('utf-8')).getresult()
             if len(result) > 0:
                 encodingStr = result[0][0]

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1997,7 +1997,7 @@ class gpload:
     # This function will return the SQL to run in order to find out whether
     # such a table exists.
     #
-    def get_reuse_exttable_query(self, formatType, formatOpts, limitStr, from_cols, schemaName, log_errors):
+    def get_reuse_exttable_query(self, formatType, formatOpts, limitStr, from_cols, schemaName, log_errors, encodingCode):
         sqlFormat = """select attrelid::regclass
                  from (
                         select
@@ -2057,6 +2057,9 @@ class gpload:
         else:
             sql += "and pgext.rejectlimit IS NULL "
 
+        if encodingCode:
+            sql += "and pgext.encoding = %s " % encodingCode
+
         sql+= "group by attrelid "
 
         sql+= """having
@@ -2083,7 +2086,7 @@ class gpload:
     # This function will return the SQL to run in order to find out whether
     # such a table exists. The results of this SQl are table names without schema
     #
-    def get_fast_match_exttable_query(self, formatType, formatOpts, limitStr, schemaName, log_errors):
+    def get_fast_match_exttable_query(self, formatType, formatOpts, limitStr, schemaName, log_errors, encodingCode):
 
         sqlFormat = """select relname from pg_class
                     join
@@ -2129,6 +2132,9 @@ class gpload:
             sql += "and pgext.rejectlimit = %s " % limitStr
         else:
             sql += "and pgext.rejectlimit IS NULL "
+
+        if encodingCode:
+            sql += "and pgext.encoding = %s " % encodingCode
 
         sql+= "limit 1;"
 
@@ -2289,7 +2295,18 @@ class gpload:
                     self.control_file_error("gpload:input:force_not_null must be a YAML sequence of strings")
             self.formatOpts += "force not null %s " % ','.join(force_not_null_columns)
 
+        encodingCode = None
         encodingStr = self.getconfig('gpload:input:encoding', unicode, None)
+        if encodingStr == None:
+            result = self.db.query("SHOW SERVER_ENCODING".encode('utf-8')).getresult()
+            if len(result) > 0:
+                encodingStr = result[0][0]
+
+        if encodingStr:
+            sql = "SELECT pg_char_to_encoding('%s')" % encodingStr
+            result = self.db.query(sql.encode('utf-8')).getresult()
+            if len(result) > 0:
+                encodingCode = result[0][0]
 
         limitStr = self.getconfig('gpload:input:error_limit',int, None)
         if self.log_errors and not limitStr:
@@ -2342,10 +2359,10 @@ class gpload:
                 self.formatOpts = self.formatOpts.replace("E'\\''","'\''")
                 if self.fast_match:
                     sql = self.get_fast_match_exttable_query(formatType, self.formatOpts,
-                        limitStr, self.extSchemaName, self.log_errors)
+                        limitStr, self.extSchemaName, self.log_errors, encodingCode)
                 else:
                     sql = self.get_reuse_exttable_query(formatType, self.formatOpts,
-                        limitStr, from_cols, self.extSchemaName, self.log_errors)
+                        limitStr, from_cols, self.extSchemaName, self.log_errors, encodingCode)
 
                 resultList = self.db.query(sql.encode('utf-8')).getresult()
                 if len(resultList) > 0:

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -95,7 +95,7 @@ d = mkpath('config')
 if not os.path.exists(d):
     os.mkdir(d)
 
-def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None,staging_table=None,fast_match='false'):
+def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None,staging_table=None,fast_match='false', encoding=None):
 
     f = open(mkpath('config/config_file'),'w')
     f.write("VERSION: 1.0.0.1")
@@ -138,6 +138,8 @@ def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',
         f.write("\n    - ERROR_LIMIT: " + error_limit)
     if delimiter:
         f.write("\n    - DELIMITER: "+delimiter)
+    if encoding:
+        f.write("\n    - ENCODING: "+encoding)
     if escape:
         f.write("\n    - ESCAPE: "+escape)
     if quote:
@@ -426,7 +428,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_00_gpload_formatOpts_setup(self):
         "0  gpload setup"
-        for num in range(1,34):
+        for num in range(1,38):
            f = open(mkpath('query%d.sql' % num),'w')
            f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n"+"\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
            f.close()
@@ -697,6 +699,34 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         copy_data('external_file_04.txt','data_file.txt')
         write_config_file(mode='merge',reuse_flag='true',fast_match='true',file='data_file.txt',externalSchema='test')
         self.doTest(33)
+    def test_34_gpload_reuse_table_merge_mode_with_fast_match_and_encoding(self):
+        "34  gpload merge mode with fast match and encoding GBK"
+        file = mkpath('setup.sql')
+        runfile(file)
+        copy_data('external_file_04.txt','data_file.txt')
+        write_config_file(mode='merge',reuse_flag='true',fast_match='true',file='data_file.txt',encoding='GBK')
+        self.doTest(34)
+
+    def test_35_gpload_reuse_table_merge_mode_with_fast_match_default_encoding(self):
+        "35  gpload does not reuse table when encoding is setted from GBK to empty"
+        write_config_file(mode='merge',reuse_flag='true',fast_match='true',file='data_file.txt')
+        self.doTest(35)
+
+    def test_36_gpload_reuse_table_merge_mode_default_encoding(self):
+        "36  gpload merge mode with encoding GBK"
+        file = mkpath('setup.sql')
+        runfile(file)
+        copy_data('external_file_04.txt','data_file.txt')
+        write_config_file(mode='merge',reuse_flag='true',fast_match='false',file='data_file.txt',encoding='GBK')
+        self.doTest(36)
+
+    def test_37_gpload_reuse_table_merge_mode_invalid_encoding(self):
+        "37  gpload merge mode with invalid encoding"
+        file = mkpath('setup.sql')
+        runfile(file)
+        copy_data('external_file_04.txt','data_file.txt')
+        write_config_file(mode='merge',reuse_flag='true',fast_match='false',file='data_file.txt',encoding='xxxx')
+        self.doTest(37)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(GPLoad_FormatOpts_TestCase)

--- a/gpMgmt/bin/gpload_test/gpload2/init_file
+++ b/gpMgmt/bin/gpload_test/gpload2/init_file
@@ -15,6 +15,8 @@
 -- s/staging_gpload_reusable_\w+/STAGING_GPLOAD_REUSABLE/
 -- m/started gpfdist/
 -- s/started gpfdist -p \d* -P \d* -f .*/ports/
+-- m/gpfdist:/
+-- s#gpfdist://\d*.\d*.\d*.\d*:\d*//\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*data_file.txt#LOCATION#
 -- m/data_file.tbl/
 -- s/(").*data_file.tbl(")/data/
 -- m/cmdtime/

--- a/gpMgmt/bin/gpload_test/gpload2/query34.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query34.ans
@@ -1,0 +1,20 @@
+2018-11-05 19:14:10|INFO|gpload session started 2018-11-05 19:14:10
+2018-11-05 19:14:10|INFO|setting schema 'public' for table 'texttable'
+2018-11-05 19:14:10|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-11-05 19:14:10|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 19:14:11|INFO|did not find an external table to reuse. creating ext_gpload_reusable_eb932982_e0eb_11e8_9c10_00505698a2d7
+2018-11-05 19:14:11|INFO|running time: 0.57 seconds
+2018-11-05 19:14:11|INFO|rows Inserted          = 16
+2018-11-05 19:14:11|INFO|rows Updated           = 0
+2018-11-05 19:14:11|INFO|data formatting errors = 0
+2018-11-05 19:14:11|INFO|gpload succeeded
+2018-11-05 19:14:11|INFO|gpload session started 2018-11-05 19:14:11
+2018-11-05 19:14:11|INFO|setting schema 'public' for table 'texttable'
+2018-11-05 19:14:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-11-05 19:14:11|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 19:14:11|INFO|reusing external table ext_gpload_reusable_eb932982_e0eb_11e8_9c10_00505698a2d7
+2018-11-05 19:14:12|INFO|running time: 0.50 seconds
+2018-11-05 19:14:12|INFO|rows Inserted          = 0
+2018-11-05 19:14:12|INFO|rows Updated           = 16
+2018-11-05 19:14:12|INFO|data formatting errors = 0
+2018-11-05 19:14:12|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query35.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query35.ans
@@ -1,0 +1,20 @@
+2018-11-05 19:39:49|INFO|gpload session started 2018-11-05 19:39:49
+2018-11-05 19:39:49|INFO|setting schema 'public' for table 'texttable'
+2018-11-05 19:39:49|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-11-05 19:39:49|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 19:39:49|INFO|did not find an external table to reuse. creating ext_gpload_reusable_8098fb6c_e0ef_11e8_a796_00505698a2d7
+2018-11-05 19:39:50|INFO|running time: 0.58 seconds
+2018-11-05 19:39:50|INFO|rows Inserted          = 0
+2018-11-05 19:39:50|INFO|rows Updated           = 16
+2018-11-05 19:39:50|INFO|data formatting errors = 0
+2018-11-05 19:39:50|INFO|gpload succeeded
+2018-11-05 19:39:50|INFO|gpload session started 2018-11-05 19:39:50
+2018-11-05 19:39:50|INFO|setting schema 'public' for table 'texttable'
+2018-11-05 19:39:50|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-11-05 19:39:50|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 19:39:50|INFO|reusing external table ext_gpload_reusable_8098fb6c_e0ef_11e8_a796_00505698a2d7
+2018-11-05 19:39:50|INFO|running time: 0.51 seconds
+2018-11-05 19:39:50|INFO|rows Inserted          = 0
+2018-11-05 19:39:50|INFO|rows Updated           = 16
+2018-11-05 19:39:50|INFO|data formatting errors = 0
+2018-11-05 19:39:50|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query36.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query36.ans
@@ -1,0 +1,20 @@
+2018-11-05 22:49:40|INFO|gpload session started 2018-11-05 22:49:40
+2018-11-05 22:49:40|INFO|setting schema 'public' for table 'texttable'
+2018-11-05 22:49:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-11-05 22:49:40|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 22:49:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_06670f3a_e10a_11e8_af7b_00505698a2d7
+2018-11-05 22:49:41|INFO|running time: 0.64 seconds
+2018-11-05 22:49:41|INFO|rows Inserted          = 16
+2018-11-05 22:49:41|INFO|rows Updated           = 0
+2018-11-05 22:49:41|INFO|data formatting errors = 0
+2018-11-05 22:49:41|INFO|gpload succeeded
+2018-11-05 22:49:41|INFO|gpload session started 2018-11-05 22:49:41
+2018-11-05 22:49:41|INFO|setting schema 'public' for table 'texttable'
+2018-11-05 22:49:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-11-05 22:49:41|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 22:49:41|INFO|reusing external table ext_gpload_reusable_06670f3a_e10a_11e8_af7b_00505698a2d7
+2018-11-05 22:49:42|INFO|running time: 0.55 seconds
+2018-11-05 22:49:42|INFO|rows Inserted          = 0
+2018-11-05 22:49:42|INFO|rows Updated           = 16
+2018-11-05 22:49:42|INFO|data formatting errors = 0
+2018-11-05 22:49:42|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query37.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query37.ans
@@ -1,0 +1,22 @@
+2018-11-05 22:52:11|INFO|gpload session started 2018-11-05 22:52:11
+2018-11-05 22:52:11|INFO|setting schema 'public' for table 'texttable'
+2018-11-05 22:52:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 22:52:11|INFO|did not find an external table to reuse. creating ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7
+2018-11-05 22:52:11|ERROR|could not run SQL "create external table ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+
+2018-11-05 22:52:11|INFO|rows Inserted          = 0
+2018-11-05 22:52:11|INFO|rows Updated           = 0
+2018-11-05 22:52:11|INFO|data formatting errors = 0
+2018-11-05 22:52:11|INFO|gpload failed
+2018-11-05 22:52:11|INFO|gpload session started 2018-11-05 22:52:11
+2018-11-05 22:52:11|INFO|setting schema 'public' for table 'texttable'
+2018-11-05 22:52:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 22:52:12|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7
+2018-11-05 22:52:12|ERROR|could not run SQL "create external table ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+
+2018-11-05 22:52:12|INFO|rows Inserted          = 0
+2018-11-05 22:52:12|INFO|rows Updated           = 0
+2018-11-05 22:52:12|INFO|data formatting errors = 0
+2018-11-05 22:52:12|INFO|gpload failed

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
@@ -48,7 +48,7 @@ class GpLoadTestCase(unittest.TestCase):
         gploader.locations = [ 'gpfdist://localhost:8080/test' ]
         rejectLimit = '9999'
 
-        sql = gploader.get_reuse_exttable_query('csv', 'header', None, {}, None, False)
+        sql = gploader.get_reuse_exttable_query('csv', 'header', None, {}, None, False, None)
         self.assertTrue('pgext.fmterrtbl IS NULL' in sql)
         self.assertTrue('pgext.rejectlimit IS NULL' in sql)
 


### PR DESCRIPTION

Get database default encoding if ENCODING is not set in config file.
Find encoding code by encoding string and then add encoding code as one of
conditions of finding reusable table.