### PR TITLE
Drop functions with dependencies not shipped to customers at end of ICW

### DIFF
--- a/concourse/scripts/drop_functions_with_dependencies_not_shipped_to_customers.sql
+++ b/concourse/scripts/drop_functions_with_dependencies_not_shipped_to_customers.sql
@@ -1,0 +1,53 @@
+CREATE TEMP TABLE probins_not_shipped AS (
+  SELECT probin
+    FROM pg_catalog.pg_proc
+   WHERE probin IS NOT NULL
+     AND probin NOT LIKE '$libdir%'
+) DISTRIBUTED RANDOMLY;
+
+INSERT INTO probins_not_shipped
+  VALUES ('$libdir/gp_replica_check')
+       , ('$libdir/gpformatter.so')
+       , ('$libdir/gpextprotocol.so')
+       , ('$libdir/gppc_test')
+       , ('$libdir/gppc_demo')
+       , ('$libdir/tabfunc_gppc_demo');
+
+CREATE TEMP TABLE functions_to_be_dropped AS (
+  SELECT proname
+       , pg_catalog.pg_get_function_arguments(oid) AS args
+    FROM pg_catalog.pg_proc
+   WHERE probin IN (SELECT * FROM probins_not_shipped)
+) DISTRIBUTED RANDOMLY;
+
+\echo "List all the functions that we plan on dropping:"
+SELECT * FROM functions_to_be_dropped;
+
+-- The functions that have probin = $libdir/gp_replica_check are part of an extension,
+-- therefore DROP the extension explicitly
+DROP EXTENSION gp_replica_check;
+
+CREATE OR REPLACE FUNCTION drop_functions_with_dependencies_not_shipped_to_customers() RETURNS void AS $$
+DECLARE
+       function RECORD;
+       sql text;
+BEGIN
+       FOR function IN
+            SELECT * FROM functions_to_be_dropped
+       LOOP
+            sql := 'DROP FUNCTION IF EXISTS ' || quote_ident(function.proname) || '(' || function.args || ') CASCADE';
+            RAISE NOTICE '%', sql;
+            EXECUTE sql;
+       END LOOP;
+       RETURN;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT drop_functions_with_dependencies_not_shipped_to_customers();
+DROP FUNCTION drop_functions_with_dependencies_not_shipped_to_customers();
+
+\echo "Now there should be no functions left."
+
+SELECT proname
+  FROM pg_catalog.pg_proc
+ WHERE probin IN (SELECT * FROM probins_not_shipped);

--- a/concourse/scripts/dumpdb.bash
+++ b/concourse/scripts/dumpdb.bash
@@ -1,8 +1,30 @@
 #!/bin/bash
+set -e
+set -u
 
 source /usr/local/greenplum-db-devel/greenplum_path.sh
 source /opt/gcc_env.sh
 source ./gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+
 gpstart -a
+
+psql \
+    -X \
+    -c "select datname from pg_database where datname != 'template0'" \
+    --set ON_ERROR_STOP=on \
+    --no-align \
+    -t \
+    --field-separator ' ' \
+    --quiet \
+    template1 | while read -r database ; do
+
+    echo "-----------------------------------------------------------------"
+    echo "Drop objects not shipped to customers from DATABASE: ${database}."
+    echo "-----------------------------------------------------------------"
+    psql "${database}" -f ./gpdb_src/concourse/scripts/drop_functions_with_dependencies_not_shipped_to_customers.sql
+    echo ""
+    echo ""
+done
+
 pg_dumpall -f ./sqldump/dump.sql
 xz -z ./sqldump/dump.sql


### PR DESCRIPTION
The sql dump that is generated from the `icw_gporca_centos6` job can't be fully loaded into the test cluster for the `pg_upgrade` and `gpexpand` jobs because those clusters are missing some required libraries and extensions which would have been installed during ICW.  However all of the missing pieces are not compiled objects that we ship.  We do not expect a sql dump file to be restore these compiled objects.  Therefore we are going to drop the objects from the database that depend on bits we don' ship.

Ask for extra attention from reviewers: We looked into attempting to programmatically figure out what `probin`s are being built and installed during ICW only, and are not part of the normal build and distribution (for example `$libdir/tabfunc_gppc_demo`).  All the methods we explored seemed to add more complexity than we were comfortable with and were not particularly robust, but hardcoding the list means we won't protect against future additional ICW testing targets.  Thoughts on this tradeoff would be appreciated.