### PR TITLE
Autogenerate recovery.conf file at the end of pg_rewind

### DIFF
--- a/src/bin/pg_rewind/fetch.h
+++ b/src/bin/pg_rewind/fetch.h
@@ -43,4 +43,7 @@ extern void copy_executeFileMap(filemap_t *map);
 typedef void (*process_file_callback_t) (const char *path, file_type_t type, size_t size, const char *link_target);
 extern void traverse_datadir(const char *datadir, process_file_callback_t callback);
 
+extern void GenerateRecoveryConf(void);
+extern void WriteRecoveryConf(void);
+
 #endif   /* FETCH_H */

--- a/src/bin/pg_rewind/pg_rewind.h
+++ b/src/bin/pg_rewind/pg_rewind.h
@@ -27,6 +27,8 @@ extern bool debug;
 extern bool showprogress;
 extern bool dry_run;
 
+extern const char *progname;
+
 /* in parsexlog.c */
 extern void extractPageMap(const char *datadir, XLogRecPtr startpoint,
 			   TimeLineID tli, XLogRecPtr endpoint);


### PR DESCRIPTION
Like pg_basebackup, we should generate recovery.conf file at the end of
pg_rewind so that utilities do not have to take care of that step. This is
required in Greenplum mainly because users will not use pg_rewind manually. Note
that we only autogenerate recovery.conf file if pg_rewind is called with source
server because we utilize the libpq connection information. We expect pg_rewind
usage to only be through gprecoverseg.

Co-authored-by: Paul Guo <pguo@pivotal.io>