### PR TITLE
Remove early exit in RequestXLogStreaming

### DIFF
--- a/src/backend/replication/walreceiverfuncs.c
+++ b/src/backend/replication/walreceiverfuncs.c
@@ -249,18 +249,6 @@ RequestXLogStreaming(TimeLineID tli, XLogRecPtr recptr, const char *conninfo,
 	pg_time_t	now = (pg_time_t) time(NULL);
 
 	/*
-	 * If it's not stopped, nothing to do.
-	 */
-	if (walrcv->walRcvState != WALRCV_STOPPED)
-	{
-		elogif(debug_xlog_record_read, LOG,
-			   "request streaming -- walreceiver state is %s. Hence, no need "
-			   "to request streaming.", WalRcvGetStateString(walrcv->walRcvState));
-
-		return;
-	}
-
-	/*
 	 * We always start at the beginning of the segment. That prevents a broken
 	 * segment (i.e., with no records in the first half of a segment) from
 	 * being created by XLOG streaming, which might cause trouble later on if


### PR DESCRIPTION
When WalRcv's walRcvState is not WALRCV_STOPPED, we do early exit. This early
exit is not in upstream Postgres and is legacy Greenplum code. This prevented
timeline switch scenario from happening correctly because WAL receiver's state
is set to WALRCV_WAITING expecting to wake itself up with SetLatch or
PMSIGNAL_START_WALRECEIVER signal call at the end of RequestXLogStreaming()
call.

Co-authored-by: Paul Guo <pguo@pivotal.io>