### PR TITLE
Resynchronize dumpable objects and their sortorder

### DIFF
--- a/src/bin/pg_dump/pg_dump_sort.c
+++ b/src/bin/pg_dump/pg_dump_sort.c
@@ -117,15 +117,12 @@ static const int newObjectTypePriority[] =
 	31,							/* DO_DEFAULT_ACL */
 	21,							/* DO_BLOB */
 	24,							/* DO_BLOB_DATA */
+	8,							/* DO_EXTPROTOCOL */
+	21,							/* DO_TYPE_STORAGE_OPTIONS */
 	22,							/* DO_PRE_DATA_BOUNDARY */
 	25,							/* DO_POST_DATA_BOUNDARY */
 	32,							/* DO_EVENT_TRIGGER */
 	33							/* DO_REFRESH_MATVIEW */
-
-	,
-	/* GPDB_84_MERGE_FIXME: Are these priorities sensible? */
-	8,							/* DO_EXTPROTOCOL */
-	22							/* DO_TYPE_STORAGE_OPTIONS */
 };
 
 static DumpId preDataBoundId;


### PR DESCRIPTION
The DumpableObjectType enum and newObjectTypePriority array must be kept in perfect sync since the array index is mimicking the enum key wrt lookups. The Greenplum specific options had been placed last to avoid merge conflicts, but thats not a re-ordering we can do since it breaks the synchronization. Re-order the array, and also fix the sort orders and remove the FIXME (placing DO_TYPE_STORAGE_OPTIONS before the PRE_DATA_BOUNDARY to ensure it's in the right section).