### PR TITLE
Fix gpsys1 memory reporting on macOS

### DIFF
--- a/gpMgmt/bin/gpsys1
+++ b/gpMgmt/bin/gpsys1
@@ -96,7 +96,7 @@ def getMemory():
 	return '?'
 
     if getPlatform() == 'darwin':
-	ok, out = run("sysctl hw.physmem")
+	ok, out = run("sysctl hw.memsize")
 	if not ok: return '?'
 	list = out.strip().split(' ')
 	val = int(list[1])


### PR DESCRIPTION
This utility was using the `hw.physmem` sysctl which is undocumented on macOS and most likely is a remnant from the FreeBSD origins of macOS. The supported way is to use `hw.memsize`.

Whether or not this util is actually used by anyone I don't know, but it should at least return the correct results.