### PR TITLE
Fixes wrong result with correlated queries (#6074)

### DIFF
--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -144,9 +144,7 @@ ExecResult(ResultState *node)
 
 		node->rs_checkqual = false;
 		if (!qualResult)
-		{
 			return NULL;
-		}
 	}
 
 	TupleTableSlot *outputSlot = NULL;

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -145,15 +145,6 @@ ExecResult(ResultState *node)
 		node->rs_checkqual = false;
 		if (!qualResult)
 		{
-			/*
-			 * CDB: We'll read no more from outer subtree. To keep our
-			 * sibling QEs from being starved, tell source QEs not to clog
-			 * up the pipeline with our never-to-be-consumed data.
-			 */
-			PlanState *outerPlan = outerPlanState(node);	
-			if (outerPlan)
-				ExecSquelchNode(outerPlan);	
-
 			return NULL;
 		}
 	}

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -242,7 +242,22 @@ struct MotionConn
 
 	int			tupleCount;
 
+	/*
+	 * false means 1) received a stop message and has handled it. 2) received
+	 * EOS message or sent out EOS message 3) received a QueryFinishPending
+	 * notify and has handled it.
+	 */
 	bool		stillActive;
+	/*
+	 * used both by motion sender and motion receiver
+	 *
+	 * sender: true means receiver don't need to consume tuples any more, sender
+	 * is also responsible to send stop message to its senders.
+	 *
+	 * receiver: true means have sent out a stop message to its senders. The stop
+	 * message might be lost, stopRequested can also tell sender that no more
+	 * data needed in the ack message.
+	 */
 	bool		stopRequested;
 
     MotionConnState state;

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -453,6 +453,22 @@ select * from foo where foo.a = (select min(bar.c) from bar where foo.b || bar.d
 
 drop table foo, bar;
 --
+-- Test subquery with rescan of RESULT node
+--
+create table foo_rescan_result(a, b) as (values (1, 2), (1, 1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'column1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar_rescan_result(a, b) as (values (1, 1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'column1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select * from foo_rescan_result t1
+where (select count(*) from bar_rescan_result where t1.a=t1.b) > 0;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+--
 -- subqueries with unnest in projectlist
 --
 -- start_ignore

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -448,6 +448,22 @@ select * from foo where foo.a = (select min(bar.c) from bar where foo.b || bar.d
 
 drop table foo, bar;
 --
+-- Test subquery with rescan of RESULT node
+--
+create table foo_rescan_result(a, b) as (values (1, 2), (1, 1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'column1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar_rescan_result(a, b) as (values (1, 1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'column1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select * from foo_rescan_result t1
+where (select count(*) from bar_rescan_result where t1.a=t1.b) > 0;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+--
 -- subqueries with unnest in projectlist
 --
 -- start_ignore

--- a/src/test/regress/expected/ic.out
+++ b/src/test/regress/expected/ic.out
@@ -504,3 +504,28 @@ NOTICE:  Success:
  t
 (1 row)
 
+-- Use WITH RECURSIVE to construct a one-time filter result node that executed
+-- on QD, meanwhile, let the result node has a outer node which contain motion.
+-- It's used to test that result node on QD can send a stop message to sender in
+-- one-time filter case.
+RESET gp_interconnect_snd_queue_depth;
+RESET gp_interconnect_queue_depth;
+CREATE TABLE recursive_table_ic (a INT) DISTRIBUTED BY (a);
+-- Insert enough data so interconnect sender don't quit earlier.
+INSERT INTO recursive_table_ic SELECT * FROM generate_series(20, 30000);
+WITH RECURSIVE
+r(i) AS (
+       SELECT 1
+),
+y(i) AS (
+       SELECT 1
+       UNION ALL
+       SELECT i + 1 FROM y, recursive_table_ic WHERE NOT EXISTS (SELECT * FROM r LIMIT 10)
+)
+SELECT * FROM y LIMIT 10;
+ i 
+---
+ 1
+(1 row)
+
+DROP TABLE recursive_table_ic;

--- a/src/test/regress/expected/ic.out
+++ b/src/test/regress/expected/ic.out
@@ -504,28 +504,3 @@ NOTICE:  Success:
  t
 (1 row)
 
--- Use WITH RECURSIVE to construct a one-time filter result node that executed
--- on QD, meanwhile, let the result node has a outer node which contain motion.
--- It's used to test that result node on QD can send a stop message to sender in
--- one-time filter case.
-RESET gp_interconnect_snd_queue_depth;
-RESET gp_interconnect_queue_depth;
-CREATE TABLE recursive_table_ic (a INT) DISTRIBUTED BY (a);
--- Insert enough data so interconnect sender don't quit earlier.
-INSERT INTO recursive_table_ic SELECT * FROM generate_series(20, 30000);
-WITH RECURSIVE
-r(i) AS (
-	SELECT 1
-),
-y(i) AS (
-	SELECT 1
-	UNION ALL
-	SELECT i + 1 FROM y, recursive_table_ic WHERE NOT EXISTS (SELECT * FROM r LIMIT 10)
-)
-SELECT * FROM y LIMIT 10;
- i 
----
- 1
-(1 row)
-
-DROP TABLE recursive_table_ic;

--- a/src/test/regress/sql/bfv_subquery.sql
+++ b/src/test/regress/sql/bfv_subquery.sql
@@ -271,6 +271,14 @@ select * from foo where foo.a = (select min(bar.c) from bar where foo.b || bar.d
 drop table foo, bar;
 
 --
+-- Test subquery with rescan of RESULT node
+--
+create table foo_rescan_result(a, b) as (values (1, 2), (1, 1));
+create table bar_rescan_result(a, b) as (values (1, 1));
+
+select * from foo_rescan_result t1
+where (select count(*) from bar_rescan_result where t1.a=t1.b) > 0;
+--
 -- subqueries with unnest in projectlist
 --
 -- start_ignore

--- a/src/test/regress/sql/ic.sql
+++ b/src/test/regress/sql/ic.sql
@@ -214,24 +214,3 @@ SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 1);
 SELECT * FROM a;
 DROP TABLE a;
 SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 1);
-
--- Use WITH RECURSIVE to construct a one-time filter result node that executed
--- on QD, meanwhile, let the result node has a outer node which contain motion.
--- It's used to test that result node on QD can send a stop message to sender in
--- one-time filter case.
-RESET gp_interconnect_snd_queue_depth;
-RESET gp_interconnect_queue_depth;
-CREATE TABLE recursive_table_ic (a INT) DISTRIBUTED BY (a);
--- Insert enough data so interconnect sender don't quit earlier.
-INSERT INTO recursive_table_ic SELECT * FROM generate_series(20, 30000);
-WITH RECURSIVE
-r(i) AS (
-	SELECT 1
-),
-y(i) AS (
-	SELECT 1
-	UNION ALL
-	SELECT i + 1 FROM y, recursive_table_ic WHERE NOT EXISTS (SELECT * FROM r LIMIT 10)
-)
-SELECT * FROM y LIMIT 10;
-DROP TABLE recursive_table_ic;

--- a/src/test/regress/sql/ic.sql
+++ b/src/test/regress/sql/ic.sql
@@ -214,3 +214,24 @@ SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 1);
 SELECT * FROM a;
 DROP TABLE a;
 SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 1);
+
+-- Use WITH RECURSIVE to construct a one-time filter result node that executed
+-- on QD, meanwhile, let the result node has a outer node which contain motion.
+-- It's used to test that result node on QD can send a stop message to sender in
+-- one-time filter case.
+RESET gp_interconnect_snd_queue_depth;
+RESET gp_interconnect_queue_depth;
+CREATE TABLE recursive_table_ic (a INT) DISTRIBUTED BY (a);
+-- Insert enough data so interconnect sender don't quit earlier.
+INSERT INTO recursive_table_ic SELECT * FROM generate_series(20, 30000);
+WITH RECURSIVE
+r(i) AS (
+       SELECT 1
+),
+y(i) AS (
+       SELECT 1
+       UNION ALL
+       SELECT i + 1 FROM y, recursive_table_ic WHERE NOT EXISTS (SELECT * FROM r LIMIT 10)
+)
+SELECT * FROM y LIMIT 10;
+DROP TABLE recursive_table_ic;


### PR DESCRIPTION


    This commit fixes wrong results with correlated queries (#6074),
    the issue is introduced by commit 2c011ce in which it made a bad
    decision to call ExecSquelchNode() in RESULT node.

    The original thought in 2c011ce is, once the one-time filter qual
    of a RESULT node is evaluated to be false, we no longer need to
    fetch tuple from child node, so it's safe to send a stop message
    to source QE senders. Then if the RESULT node is rescanned,
    one-time filter is revaluated to be true, RESULT node need to fetch
    tuple from child node, however, the QE senders has been stopped and
    some tuples are missed. So the first step is reverting the changes
    in 2c011ce and then add a new test case.