### PR TITLE
pg_upgrade: quick fix to demoprot_untrusted2 CI redness

### DIFF
--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -60,6 +60,7 @@ DROP TABLE IF EXISTS public.newpart CASCADE;
 -- This view definition changes after upgrade.
 DROP VIEW IF EXISTS v_xpect_triangle_de CASCADE;
 
--- The dump location for this protocol changes sporadically and causes a false
+-- The dump locations for these protocols change sporadically and cause a false
 -- negative. This may indicate a bug in pg_dump's sort priority for PROTOCOLs.
 DROP PROTOCOL IF EXISTS demoprot_untrusted;
+DROP PROTOCOL IF EXISTS demoprot_untrusted2;


### PR DESCRIPTION
The `demoprot_untrusted` protocol was already being dropped because of a sporadic sort order change after upgrade. The `demoprot_untrusted2` protocol, added recently in d4d4a16cc, is failing now, and should be dropped for the same reason.

It looks like a sort bug in pg_dump prevented this from showing up until now; b5078cc71 fixed that bug and exposed this problem again.