### PR TITLE
Update GPDB timezone files to tz 2018g

### DIFF
--- a/src/test/regress/expected/timetz.out
+++ b/src/test/regress/expected/timetz.out
@@ -134,8 +134,8 @@ SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as Sh
 -- Casablanca time has changed in new timezone db lets verify it
 set timezone = 'Africa/Casablanca';
 SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as Casablanca;
-          casablanca            
--------------------------------
- Sat Aug 09 01:52:00 2014 WEST
+          casablanca          
+------------------------------
+ Sat Aug 09 01:52:00 2014 +01
 (1 row)
 

--- a/src/timezone/README
+++ b/src/timezone/README
@@ -55,7 +55,7 @@ match properly on the old version.
 Time Zone code
 ==============
 
-The code in this directory is currently synced with tzcode release 2018f.
+The code in this directory is currently synced with tzcode release 2018g.
 There are many cosmetic (and not so cosmetic) differences from the
 original tzcode library, but diffs in the upstream version should usually
 be propagated to our version.  Here are some notes about that.
@@ -73,12 +73,17 @@ fixed that.)
 includes relying on configure's results rather than hand-hacked #defines,
 and not relying on <stdint.h> features that may not exist on old systems.
 (In particular this means using Postgres' definitions of the int32 and
-int64 typedefs, not int_fast32_t/int_fast64_t.)
+int64 typedefs, not int_fast32_t/int_fast64_t.  Likewise we use
+PG_INT32_MIN/MAX not INT32_MIN/MAX.)
 
 * Since Postgres is typically built on a system that has its own copy
 of the <time.h> functions, we must avoid conflicting with those.  This
 mandates renaming typedef time_t to pg_time_t, and similarly for most
 other exposed names.
+
+* zic.c's typedef "lineno" is renamed to "lineno_t", because having
+"lineno" in our typedefs list would cause unfortunate pgindent behavior
+in some other files where we have variables named that.
 
 * We have exposed the tzload() and tzparse() internal functions, and
 slightly modified the API of the former, in part because it now relies
@@ -108,8 +113,11 @@ to first run the tzcode source files through a sed filter like this:
         -e 's/\bregister[ \t]//g' \
         -e 's/int_fast32_t/int32/g' \
         -e 's/int_fast64_t/int64/g' \
+        -e 's/INT32_MIN/PG_INT32_MIN/g' \
+        -e 's/INT32_MAX/PG_INT32_MAX/g' \
         -e 's/struct[ \t]+tm\b/struct pg_tm/g' \
         -e 's/\btime_t\b/pg_time_t/g' \
+        -e 's/lineno/lineno_t/g' \
 
 and then run them through pgindent.  (The first three sed patterns deal
 with conversion of their block comment style to something pgindent

--- a/src/timezone/data/tzdata.zi
+++ b/src/timezone/data/tzdata.zi
@@ -1,4 +1,4 @@
-# version 2018f
+# version 2018g
 # This zic input file is in the public domain.
 R d 1916 o - Jun 14 23s 1 S
 R d 1916 1919 - O Sun>=1 23s 0 -
@@ -143,67 +143,56 @@ R MU 2008 o - O lastSun 2 1 -
 R MU 2009 o - Mar lastSun 2 0 -
 Z Indian/Mauritius 3:50 - LMT 1907
 4 MU +04/+05
-R M 1939 o - S 12 0 1 S
+R M 1939 o - S 12 0 1 -
 R M 1939 o - N 19 0 0 -
-R M 1940 o - F 25 0 1 S
+R M 1940 o - F 25 0 1 -
 R M 1945 o - N 18 0 0 -
-R M 1950 o - Jun 11 0 1 S
+R M 1950 o - Jun 11 0 1 -
 R M 1950 o - O 29 0 0 -
-R M 1967 o - Jun 3 12 1 S
+R M 1967 o - Jun 3 12 1 -
 R M 1967 o - O 1 0 0 -
-R M 1974 o - Jun 24 0 1 S
+R M 1974 o - Jun 24 0 1 -
 R M 1974 o - S 1 0 0 -
-R M 1976 1977 - May 1 0 1 S
+R M 1976 1977 - May 1 0 1 -
 R M 1976 o - Au 1 0 0 -
 R M 1977 o - S 28 0 0 -
-R M 1978 o - Jun 1 0 1 S
+R M 1978 o - Jun 1 0 1 -
 R M 1978 o - Au 4 0 0 -
-R M 2008 o - Jun 1 0 1 S
+R M 2008 o - Jun 1 0 1 -
 R M 2008 o - S 1 0 0 -
-R M 2009 o - Jun 1 0 1 S
+R M 2009 o - Jun 1 0 1 -
 R M 2009 o - Au 21 0 0 -
-R M 2010 o - May 2 0 1 S
+R M 2010 o - May 2 0 1 -
 R M 2010 o - Au 8 0 0 -
-R M 2011 o - Ap 3 0 1 S
+R M 2011 o - Ap 3 0 1 -
 R M 2011 o - Jul 31 0 0 -
-R M 2012 2013 - Ap lastSun 2 1 S
+R M 2012 2013 - Ap lastSun 2 1 -
 R M 2012 o - Jul 20 3 0 -
-R M 2012 o - Au 20 2 1 S
+R M 2012 o - Au 20 2 1 -
 R M 2012 o - S 30 3 0 -
 R M 2013 o - Jul 7 3 0 -
-R M 2013 o - Au 10 2 1 S
-R M 2013 ma - O lastSun 3 0 -
-R M 2014 2021 - Mar lastSun 2 1 S
+R M 2013 o - Au 10 2 1 -
+R M 2013 2018 - O lastSun 3 0 -
+R M 2014 2018 - Mar lastSun 2 1 -
 R M 2014 o - Jun 28 3 0 -
-R M 2014 o - Au 2 2 1 S
+R M 2014 o - Au 2 2 1 -
 R M 2015 o - Jun 14 3 0 -
-R M 2015 o - Jul 19 2 1 S
+R M 2015 o - Jul 19 2 1 -
 R M 2016 o - Jun 5 3 0 -
-R M 2016 o - Jul 10 2 1 S
+R M 2016 o - Jul 10 2 1 -
 R M 2017 o - May 21 3 0 -
-R M 2017 o - Jul 2 2 1 S
+R M 2017 o - Jul 2 2 1 -
 R M 2018 o - May 13 3 0 -
-R M 2018 o - Jun 17 2 1 S
-R M 2019 o - May 5 3 0 -
-R M 2019 o - Jun 9 2 1 S
-R M 2020 o - Ap 19 3 0 -
-R M 2020 o - May 24 2 1 S
-R M 2021 o - Ap 11 3 0 -
-R M 2021 o - May 16 2 1 S
-R M 2022 o - May 8 2 1 S
-R M 2023 o - Ap 23 2 1 S
-R M 2024 o - Ap 14 2 1 S
-R M 2025 o - Ap 6 2 1 S
-R M 2026 ma - Mar lastSun 2 1 S
-R M 2036 o - O 19 3 0 -
-R M 2037 o - O 4 3 0 -
+R M 2018 o - Jun 17 2 1 -
 Z Africa/Casablanca -0:30:20 - LMT 1913 O 26
-0 M WE%sT 1984 Mar 16
-1 - CET 1986
-0 M WE%sT
+0 M +00/+01 1984 Mar 16
+1 - +01 1986
+0 M +00/+01 2018 O 27
+1 - +01
 Z Africa/El_Aaiun -0:52:48 - LMT 1934
 -1 - -01 1976 Ap 14
-0 M WE%sT
+0 M +00/+01 2018 O 27
+1 - +01
 Z Africa/Maputo 2:10:20 - LMT 1903 Mar
 2 - CAT
 Li Africa/Maputo Africa/Blantyre
@@ -2433,6 +2422,15 @@ R s 1976 1977 - S lastSun 1 0 -
 R s 1977 o - Ap 2 23 1 S
 R s 1978 o - Ap 2 2s 1 S
 R s 1978 o - O 1 2s 0 -
+R Sp 1967 o - Jun 3 12 1 S
+R Sp 1967 o - O 1 0 0 -
+R Sp 1974 o - Jun 24 0 1 S
+R Sp 1974 o - S 1 0 0 -
+R Sp 1976 1977 - May 1 0 1 S
+R Sp 1976 o - Au 1 0 0 -
+R Sp 1977 o - S 28 0 0 -
+R Sp 1978 o - Jun 1 0 1 S
+R Sp 1978 o - Au 4 0 0 -
 Z Europe/Madrid -0:14:44 - LMT 1900 D 31 23:45:16
 0 s WE%sT 1940 Mar 16 23
 1 s CE%sT 1979
@@ -2443,7 +2441,7 @@ Z Africa/Ceuta -0:21:16 - LMT 1900 D 31 23:38:44
 0 - WET 1924
 0 s WE%sT 1929
 0 - WET 1967
-0 M WE%sT 1984 Mar 16
+0 Sp WE%sT 1984 Mar 16
 1 - CET 1986
 1 E CE%sT
 Z Atlantic/Canary -1:1:36 - LMT 1922 Mar
@@ -2695,9 +2693,7 @@ Z America/Adak 12:13:22 - LMT 1867 O 19 12:44:35
 Z Pacific/Honolulu -10:31:26 - LMT 1896 Ja 13 12
 -10:30 - HST 1933 Ap 30 2
 -10:30 1 HDT 1933 May 21 12
--10:30 - HST 1942 F 9 2
--10:30 1 HDT 1945 S 30 2
--10:30 - HST 1947 Jun 8 2
+-10:30 u H%sT 1947 Jun 8 2
 -10 - HST
 Z America/Phoenix -7:28:18 - LMT 1883 N 18 11:31:42
 -7 u M%sT 1944 Ja 1 0:1

--- a/src/timezone/zic.c
+++ b/src/timezone/zic.c
@@ -174,9 +174,11 @@ PERCENT_Z_LEN_BOUND = sizeof "+995959" - 1};
    QTBUG-53071 <https://bugreports.qt.io/browse/QTBUG-53071>.  This
    workaround will no longer be needed when Qt 5.6.1 and earlier are
    obsolete, say in the year 2021.  */
+#ifndef WORK_AROUND_QTBUG_53071
 enum
 {
 WORK_AROUND_QTBUG_53071 = true};
+#endif
 
 static int	charcnt;
 static bool errors;
@@ -1919,12 +1921,6 @@ atcomp(const void *avp, const void *bvp)
 	return (a < b) ? -1 : (a > b);
 }
 
-static bool
-is32(const zic_t x)
-{
-	return x == ((zic_t) ((int32) x));
-}
-
 static void
 swaptypes(int i, int j)
 {
@@ -1978,7 +1974,12 @@ writezone(const char *const name, const char *const string, char version,
 	zic_t		one = 1;
 	zic_t		y2038_boundary = one << 31;
 	ptrdiff_t	nats = timecnt + WORK_AROUND_QTBUG_53071;
-	zic_t	   *ats = emalloc(size_product(nats, sizeof *ats + 1));
+
+	/*
+	 * Allocate the ATS and TYPES arrays via a single malloc, as this is a bit
+	 * faster.
+	 */
+	zic_t	   *ats = emalloc(MAXALIGN(size_product(nats, sizeof *ats + 1)));
 	void	   *typesptr = ats + nats;
 	unsigned char *types = typesptr;
 
@@ -2037,20 +2038,6 @@ writezone(const char *const name, const char *const string, char version,
 	}
 
 	/*
-	 * Work around QTBUG-53071 for timestamps less than y2038_boundary - 1, by
-	 * inserting a no-op transition at time y2038_boundary - 1. This works
-	 * only for timestamps before the boundary, which should be good enough in
-	 * practice as QTBUG-53071 should be long-dead by 2038.
-	 */
-	if (WORK_AROUND_QTBUG_53071 && timecnt != 0
-		&& ats[timecnt - 1] < y2038_boundary - 1 && strchr(string, '<'))
-	{
-		ats[timecnt] = y2038_boundary - 1;
-		types[timecnt] = types[timecnt - 1];
-		timecnt++;
-	}
-
-	/*
 	 * Correct for leap seconds.
 	 */
 	for (i = 0; i < timecnt; ++i)
@@ -2065,31 +2052,47 @@ writezone(const char *const name, const char *const string, char version,
 	}
 
 	/*
+	 * Work around QTBUG-53071 for timestamps less than y2038_boundary - 1, by
+	 * inserting a no-op transition at time y2038_boundary - 1. This works
+	 * only for timestamps before the boundary, which should be good enough in
+	 * practice as QTBUG-53071 should be long-dead by 2038.  Do this after
+	 * correcting for leap seconds, as the idea is to insert a transition just
+	 * before 32-bit pg_time_t rolls around, and this occurs at a slightly
+	 * different moment if transitions are leap-second corrected.
+	 */
+	if (WORK_AROUND_QTBUG_53071 && timecnt != 0
+		&& ats[timecnt - 1] < y2038_boundary - 1 && strchr(string, '<'))
+	{
+		ats[timecnt] = y2038_boundary - 1;
+		types[timecnt] = types[timecnt - 1];
+		timecnt++;
+	}
+
+	/*
 	 * Figure out 32-bit-limited starts and counts.
 	 */
 	timecnt32 = timecnt;
 	timei32 = 0;
 	leapcnt32 = leapcnt;
 	leapi32 = 0;
-	while (timecnt32 > 0 && !is32(ats[timecnt32 - 1]))
+	while (0 < timecnt32 && PG_INT32_MAX < ats[timecnt32 - 1])
 		--timecnt32;
-	while (timecnt32 > 0 && !is32(ats[timei32]))
+	while (1 < timecnt32 && ats[timei32] < PG_INT32_MIN
+		   && ats[timei32 + 1] <= PG_INT32_MIN)
 	{
+		/*
+		 * Discard too-low transitions, except keep any last too-low
+		 * transition if no transition is exactly at PG_INT32_MIN. The kept
+		 * transition will be output as an PG_INT32_MIN "transition"
+		 * appropriate for buggy 32-bit clients that do not use time type 0
+		 * for timestamps before the first transition; see below.
+		 */
 		--timecnt32;
 		++timei32;
 	}
-
-	/*
-	 * Output an INT32_MIN "transition" if appropriate; see below.
-	 */
-	if (timei32 > 0 && ats[timei32] > PG_INT32_MIN)
-	{
-		--timei32;
-		++timecnt32;
-	}
-	while (leapcnt32 > 0 && !is32(trans[leapcnt32 - 1]))
+	while (0 < leapcnt32 && PG_INT32_MAX < trans[leapcnt32 - 1])
 		--leapcnt32;
-	while (leapcnt32 > 0 && !is32(trans[leapi32]))
+	while (0 < leapcnt32 && trans[leapi32] < PG_INT32_MIN)
 	{
 		--leapcnt32;
 		++leapi32;
@@ -2322,7 +2325,8 @@ writezone(const char *const name, const char *const string, char version,
 			if (pass == 1)
 
 				/*
-				 * Output an INT32_MIN "transition" if appropriate; see above.
+				 * Output an PG_INT32_MIN "transition" if appropriate; see
+				 * above.
 				 */
 				puttzcode(((ats[i] < PG_INT32_MIN) ?
 						   PG_INT32_MIN : ats[i]), fp);


### PR DESCRIPTION
Cherry-picks of tz 2018g release files:

```
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Wed Oct 31 09:47:53 2018 -0400

    Sync our copy of the timezone library with IANA release tzcode2018g.
    
    This patch absorbs an upstream fix to "zic" for a recently-introduced
    bug that made it output data that some 32-bit clients couldn't read.
    Given the current source data, the bug only manifests in zones with
    leap seconds, which we don't generate, so that there's no actual
    change in our installed timezone data files from this.  Still, in
    case somebody uses our copy of "zic" to do something else, it seems
    best to apply the fix promptly.
    
    Also, update the README's notes about converting upstream code to
    our conventions.
```
```
commit 3b0d51aaa7a5caf6a381221fddd9313f1a2378e6
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Wed Oct 31 08:35:50 2018 -0400

    Update time zone data files to tzdata release 2018g.
    
    DST law changes in Morocco (with, effectively, zero notice).
    Historical corrections for Hawaii.
```