### PR TITLE
Fix comment on EXTERNAL TABLE in pg_dump

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7848,6 +7848,8 @@ dumpTableComment(Archive *fout, TableInfo *tbinfo,
 		if (objsubid == 0)
 		{
 			resetPQExpBuffer(target);
+			if (strcmp(reltypename, "EXTERNAL TABLE") == 0)
+				reltypename = "TABLE";
 			appendPQExpBuffer(target, "%s %s.", reltypename,
 							  fmtId(tbinfo->dobj.namespace->dobj.name));
 			appendPQExpBuffer(target, "%s ", fmtId(tbinfo->dobj.name));


### PR DESCRIPTION
To create or alter an EXTERNAL TABLE, the syntax requires e.g.
CREATE EXTERNAL TABLE foo ... or ALTER EXTERNAL TABLE ...
But the syntax for a comment on an EXTERNAL TABLE is just:
COMMENT ON TABLE foo ...