### PR TITLE
Refactor reshufle regression test cases.

### DIFF
--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -1,193 +1,42 @@
 set allow_system_table_mods=true;
 -- Hash distributed tables
-Create table t1_reshuffle(a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+Create table t1_reshuffle(a int, b int, c int) distributed by (a);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle'::regclass;
 insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-    49
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
 
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-    51
-(1 row)
+begin;
+Alter table t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    40
+             0 |    32
+             2 |    28
+(3 rows)
 
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
 
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-    32
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-    40
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-    28
-(1 row)
-
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
- numsegments 
--------------
-           3
-(1 row)
-
-drop table t1_reshuffle;
-Create table t1_reshuffle(a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-   100
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-     0
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
-
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-    32
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-    40
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-    28
-(1 row)
-
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
- numsegments 
--------------
-           3
-(1 row)
-
-drop table t1_reshuffle;
-Create table t1_reshuffle(a int, b int, c int) distributed by (a,b);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-    51
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-    49
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
-
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-    31
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-    35
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-    34
-(1 row)
-
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
- numsegments 
--------------
-           3
-(1 row)
-
-drop table t1_reshuffle;
-Create table t1_reshuffle(a int, b int, c int) distributed by (a,b);
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-   100
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-     0
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
-
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-    31
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-    35
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-    34
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             1 |    40
+             2 |    28
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
  numsegments 
@@ -201,42 +50,37 @@ NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to
 update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle'::regclass;
 insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-   100
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-     0
-(1 row)
+begin;
+Alter table t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    31
+             1 |    35
+             2 |    34
+(3 rows)
 
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-     0
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-    31
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-    35
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-    34
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    31
+             2 |    34
+             1 |    35
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
  numsegments 
@@ -257,42 +101,39 @@ insert into t1_reshuffle values
   (null, 6,    null),
   (7,    null, null),
   (null, null, null);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-     4
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     4
+             0 |     4
+(2 rows)
 
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-     4
-(1 row)
+begin;
+Alter table t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |     3
+             1 |     3
+             0 |     2
+(3 rows)
 
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     4
+             0 |     4
+(2 rows)
 
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
- count 
--------
-     2
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=1;
- count 
--------
-     3
-(1 row)
-
-Select count(*) from t1_reshuffle where gp_segment_id=2;
- count 
--------
-     3
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |     3
+             0 |     2
+             1 |     3
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
  numsegments 
@@ -310,151 +151,46 @@ update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle'::regclass;
 insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
+(1 row)
+
+begin;
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle;
- count 
--------
-   100
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             2 |    28
+             1 |    40
+(3 rows)
+
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=1;
- ?column? 
-----------
- t
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table t1_reshuffle;
-Create table t1_reshuffle(a int, b int, c int) distributed by (a) partition by list(b) (partition t1_reshuffle_1 values(1), partition t1_reshuffle_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_t1_reshuffle_1" for table "t1_reshuffle"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_t1_reshuffle_2" for table "t1_reshuffle"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_other" for table "t1_reshuffle"
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_t1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_t1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle;
- count 
--------
-   100
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |    28
+             0 |    32
+             1 |    40
+(3 rows)
 
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table t1_reshuffle;
-Create table t1_reshuffle(a int, b int, c int) distributed by (a,b) partition by list(b) (partition t1_reshuffle_1 values(1), partition t1_reshuffle_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_t1_reshuffle_1" for table "t1_reshuffle"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_t1_reshuffle_2" for table "t1_reshuffle"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_other" for table "t1_reshuffle"
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_t1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_t1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=1;
- ?column? 
-----------
- t
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table t1_reshuffle;
-Create table t1_reshuffle(a int, b int, c int) distributed by (a,b) partition by list(b) (partition t1_reshuffle_1 values(1), partition t1_reshuffle_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_t1_reshuffle_1" for table "t1_reshuffle"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_t1_reshuffle_2" for table "t1_reshuffle"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_other" for table "t1_reshuffle"
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_t1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_t1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
- ?column? 
-----------
- t
+select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table t1_reshuffle;
 -- Random distributed tables
-Create table r1_reshuffle(a int, b int, c int) distributed randomly;
-update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle'::regclass;
-insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle set c = gp_segment_id;
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table r1_reshuffle;
-Create table r1_reshuffle(a int, b int, c int) with OIDS distributed randomly;
-NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
-update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle'::regclass;
-insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle set c = gp_segment_id;
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table r1_reshuffle;
 Create table r1_reshuffle(a int, b int, c int) distributed randomly;
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
@@ -465,6 +201,13 @@ Select count(*) from r1_reshuffle;
    100
 (1 row)
 
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
 Alter table r1_reshuffle set with (reshuffle);
 Select count(*) from r1_reshuffle;
  count 
@@ -476,18 +219,59 @@ Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table r1_reshuffle set with (reshuffle);
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle;
-Create table r1_reshuffle(a int, b int, c int) distributed randomly partition by list(b) (partition r1_reshuffle_1 values(1), partition r1_reshuffle_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_1_prt_r1_reshuffle_1" for table "r1_reshuffle"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_1_prt_r1_reshuffle_2" for table "r1_reshuffle"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_1_prt_other" for table "r1_reshuffle"
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_1_prt_r1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_1_prt_r1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle'::regclass;
+Create table r1_reshuffle(a int, b int, c int) with OIDS distributed randomly;
+NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
+update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update r1_reshuffle set c = gp_segment_id;
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
 Alter table r1_reshuffle set with (reshuffle);
 Select count(*) from r1_reshuffle;
  count 
@@ -495,16 +279,42 @@ Select count(*) from r1_reshuffle;
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle where gp_segment_id=1;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table r1_reshuffle set with (reshuffle);
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
 (1 row)
 
 Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle;
@@ -517,6 +327,19 @@ update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle'::regclass;
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
 Alter table r1_reshuffle set with (reshuffle);
 Select count(*) from r1_reshuffle;
  count 
@@ -524,16 +347,42 @@ Select count(*) from r1_reshuffle;
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle where gp_segment_id=1;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table r1_reshuffle set with (reshuffle);
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
 (1 row)
 
 Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle;
@@ -544,10 +393,8 @@ drop table r1_reshuffle;
 -- The case can only work under the assumption: it's running on 3-segment cluster
 -- in a single machine.
 -- start_ignore
-drop language plpythonu;
-ERROR:  language "plpythonu" does not exist
--- end_ignore
 create language plpythonu;
+-- end_ignore
 create function update_on_segment(tabname text, segid int, numseg int) returns boolean as
 $$
 import pygresql.pg as pg
@@ -616,45 +463,25 @@ Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
                  0
 (1 row)
 
+begin;
 Alter table r1_reshuffle set with (reshuffle);
-Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
- select_on_segment 
--------------------
-               100
-(1 row)
-
-Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
- select_on_segment 
--------------------
-               100
-(1 row)
-
-drop table r1_reshuffle;
-Create table r1_reshuffle(a int, b int, c int) distributed replicated;
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
-select update_on_segment('r1_reshuffle', 0, 2);
- update_on_segment 
--------------------
- t
-(1 row)
-
-select update_on_segment('r1_reshuffle', 1, 2);
- update_on_segment 
--------------------
- t
-(1 row)
-
-select update_on_segment('r1_reshuffle', 2, 2);
- update_on_segment 
--------------------
- t
-(1 row)
-
-insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
 Select count(*) from r1_reshuffle;
  count 
 -------
    100
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
+ select_on_segment 
+-------------------
+                 0
 (1 row)
 
 Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
@@ -670,10 +497,22 @@ Select count(*) from r1_reshuffle;
    100
 (1 row)
 
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
+ select_on_segment 
+-------------------
+               100
+(1 row)
+
 Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
  select_on_segment 
 -------------------
                100
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle;
@@ -705,6 +544,39 @@ Select count(*) from r1_reshuffle;
    100
 (1 row)
 
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
+ select_on_segment 
+-------------------
+               100
+(1 row)
+
+Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+ select_on_segment 
+-------------------
+                 0
+(1 row)
+
+begin;
+Alter table r1_reshuffle set with (reshuffle);
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
+ select_on_segment 
+-------------------
+               100
+(1 row)
+
 Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
  select_on_segment 
 -------------------
@@ -718,10 +590,22 @@ Select count(*) from r1_reshuffle;
    100
 (1 row)
 
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
+ select_on_segment 
+-------------------
+               100
+(1 row)
+
 Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
  select_on_segment 
 -------------------
                100
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle;

--- a/src/test/regress/expected/reshuffle_ao.out
+++ b/src/test/regress/expected/reshuffle_ao.out
@@ -1,47 +1,42 @@
 set allow_system_table_mods=true;
 -- Hash distributed tables
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_ao'::regclass;
 insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
- count 
--------
-    49
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
 
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
- count 
--------
-    51
-(1 row)
+begin;
+Alter table t1_reshuffle_ao set with (reshuffle);
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             2 |    28
+             1 |    40
+(3 rows)
 
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
 
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
- count 
--------
-    32
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
- count 
--------
-    40
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
- count 
--------
-    28
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             2 |    28
+             1 |    40
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
  numsegments 
@@ -50,48 +45,42 @@ select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao':
 (1 row)
 
 drop table t1_reshuffle_ao;
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed by (a,b);
+NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
 update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_ao'::regclass;
 insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
- count 
--------
-   100
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
- count 
--------
-     0
-(1 row)
+begin;
+Alter table t1_reshuffle_ao set with (reshuffle);
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    31
+             2 |    34
+             1 |    35
+(3 rows)
 
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
- count 
--------
-     0
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
- count 
--------
-    32
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
- count 
--------
-    40
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
- count 
--------
-    28
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    31
+             2 |    34
+             1 |    35
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
  numsegments 
@@ -100,94 +89,51 @@ select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao':
 (1 row)
 
 drop table t1_reshuffle_ao;
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b);
+-- Test NULLs.
+Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b,c);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
- count 
--------
-    51
-(1 row)
+insert into t1_reshuffle_ao values
+  (1,    1,    1   ),
+  (null, 2,    2   ),
+  (3,    null, 3   ),
+  (4,    4,    null),
+  (null, null, 5   ),
+  (null, 6,    null),
+  (7,    null, null),
+  (null, null, null);
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     4
+             0 |     4
+(2 rows)
 
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
- count 
--------
-    49
-(1 row)
+begin;
+Alter table t1_reshuffle_ao set with (reshuffle);
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |     2
+             2 |     3
+             1 |     3
+(3 rows)
 
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     4
+             0 |     4
+(2 rows)
 
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
- count 
--------
-    31
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
- count 
--------
-    35
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
- count 
--------
-    34
-(1 row)
-
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
- numsegments 
--------------
-           3
-(1 row)
-
-drop table t1_reshuffle_ao;
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b);
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
- count 
--------
-   100
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
- count 
--------
-     0
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
-
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
- count 
--------
-    31
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
- count 
--------
-    35
-(1 row)
-
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
- count 
--------
-    34
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |     2
+             1 |     3
+             2 |     3
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
  numsegments 
@@ -205,126 +151,46 @@ update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_a
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao'::regclass;
 insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
+(1 row)
+
+begin;
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao;
- count 
--------
-   100
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             1 |    40
+             2 |    28
+(3 rows)
+
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=1;
- ?column? 
-----------
- t
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table t1_reshuffle_ao;
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a) partition by list(b) (partition t1_reshuffle_ao_1 values(1), partition t1_reshuffle_ao_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1" for table "t1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2" for table "t1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_other" for table "t1_reshuffle_ao"
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |    28
+             1 |    40
+             0 |    32
+(3 rows)
 
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table t1_reshuffle_ao;
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b) partition by list(b) (partition t1_reshuffle_ao_1 values(1), partition t1_reshuffle_ao_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1" for table "t1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2" for table "t1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_other" for table "t1_reshuffle_ao"
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=1;
- ?column? 
-----------
- t
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table t1_reshuffle_ao;
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b) partition by list(b) (partition t1_reshuffle_ao_1 values(1), partition t1_reshuffle_ao_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1" for table "t1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2" for table "t1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_other" for table "t1_reshuffle_ao"
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=2;
- ?column? 
-----------
- t
+select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table t1_reshuffle_ao;
 -- Random distributed tables
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly;
-update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle_ao'::regclass;
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
-
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table r1_reshuffle_ao;
 Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly;
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
@@ -335,6 +201,13 @@ Select count(*) from r1_reshuffle_ao;
    100
 (1 row)
 
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
 Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
  count 
@@ -346,18 +219,59 @@ Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
  ?column? 
 ----------
  t
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle_ao;
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly partition by list(b) (partition r1_reshuffle_ao_1 values(1), partition r1_reshuffle_ao_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_ao_1_prt_r1_reshuffle_ao_1" for table "r1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_ao_1_prt_r1_reshuffle_ao_2" for table "r1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_ao_1_prt_other" for table "r1_reshuffle_ao"
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_ao_1_prt_r1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_ao_1_prt_r1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_ao'::regclass;
+Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed randomly;
+NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
+update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+Update r1_reshuffle_ao set c = gp_segment_id;
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
 Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
  count 
@@ -365,16 +279,42 @@ Select count(*) from r1_reshuffle_ao;
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=1;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
  ?column? 
 ----------
  t
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
 (1 row)
 
 Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
  ?column? 
 ----------
  t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle_ao;
@@ -387,17 +327,24 @@ update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_a
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao'::regclass;
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=1;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
  ?column? 
 ----------
- t
+ f
+(1 row)
+
+begin;
+Alter table r1_reshuffle_ao set with (reshuffle);
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
 (1 row)
 
 Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
@@ -406,10 +353,98 @@ Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
  t
 (1 row)
 
+abort;
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
 drop table r1_reshuffle_ao;
 -- Replicated tables
+-- We have to make sure replicated table successfully reshuffled.
+-- Currently we could only connect to the specific segments in utility mode
+-- to see if the data is consistent there. We create some python function here.
+-- The case can only work under the assumption: it's running on 3-segment cluster
+-- in a single machine.
+-- start_ignore
+create language plpythonu;
+ERROR:  language "plpythonu" already exists
+-- end_ignore
+create function update_on_segment_ao(tabname text, segid int, numseg int) returns boolean as
+$$
+import pygresql.pg as pg
+conn = pg.connect(dbname='regression')
+port = conn.query("select port from gp_segment_configuration where content = %d and role = 'p'" % segid).getresult()[0][0]
+conn.close()
+
+conn = pg.connect(dbname='regression', opt='-c gp_session_role=utility', port=port)
+conn.query("set allow_system_table_mods = true")
+conn.query("update gp_distribution_policy set numsegments = %d where localoid = '%s'::regclass" % (numseg, tabname))
+conn.close()
+
+return True
+$$
+LANGUAGE plpythonu;
+create function select_on_segment_ao(sql text, segid int) returns int as
+$$
+import pygresql.pg as pg
+conn = pg.connect(dbname='regression')
+port = conn.query("select port from gp_segment_configuration where content = %d and role = 'p'" % segid).getresult()[0][0]
+conn.close()
+
+conn = pg.connect(dbname='regression', opt='-c gp_session_role=utility', port=port)
+r = conn.query(sql).getresult()
+conn.close()
+
+return r[0][0]
+$$
+LANGUAGE plpythonu;
 Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed replicated;
 update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle_ao'::regclass;
+select update_on_segment_ao('r1_reshuffle_ao', 0, 1);
+ update_on_segment_ao 
+----------------------
+ t
+(1 row)
+
+select update_on_segment_ao('r1_reshuffle_ao', 1, 1);
+ update_on_segment_ao 
+----------------------
+ t
+(1 row)
+
+select update_on_segment_ao('r1_reshuffle_ao', 2, 1);
+ update_on_segment_ao 
+----------------------
+ t
+(1 row)
+
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
 Select count(*) from r1_reshuffle_ao;
  count 
@@ -417,16 +452,92 @@ Select count(*) from r1_reshuffle_ao;
    100
 (1 row)
 
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+ select_on_segment_ao 
+----------------------
+                    0
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+ select_on_segment_ao 
+----------------------
+                    0
+(1 row)
+
+begin;
 Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
  count 
 -------
    100
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+ select_on_segment_ao 
+----------------------
+                    0
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+ select_on_segment_ao 
+----------------------
+                    0
+(1 row)
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+ select_on_segment_ao 
+----------------------
+                  100
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+ select_on_segment_ao 
+----------------------
+                  100
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle_ao;
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed replicated;
+Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed replicated;
+NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
+select update_on_segment_ao('r1_reshuffle_ao', 0, 2);
+ update_on_segment_ao 
+----------------------
+ t
+(1 row)
+
+select update_on_segment_ao('r1_reshuffle_ao', 1, 2);
+ update_on_segment_ao 
+----------------------
+ t
+(1 row)
+
+select update_on_segment_ao('r1_reshuffle_ao', 2, 2);
+ update_on_segment_ao 
+----------------------
+ t
+(1 row)
+
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
 Select count(*) from r1_reshuffle_ao;
  count 
@@ -434,11 +545,68 @@ Select count(*) from r1_reshuffle_ao;
    100
 (1 row)
 
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+ select_on_segment_ao 
+----------------------
+                  100
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+ select_on_segment_ao 
+----------------------
+                    0
+(1 row)
+
+begin;
 Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
  count 
 -------
    100
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+ select_on_segment_ao 
+----------------------
+                  100
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+ select_on_segment_ao 
+----------------------
+                    0
+(1 row)
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+Select count(*) from r1_reshuffle_ao;
+ count 
+-------
+   100
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+ select_on_segment_ao 
+----------------------
+                  100
+(1 row)
+
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+ select_on_segment_ao 
+----------------------
+                  100
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle_ao;

--- a/src/test/regress/expected/reshuffle_aoco.out
+++ b/src/test/regress/expected/reshuffle_aoco.out
@@ -1,47 +1,42 @@
 set allow_system_table_mods=true;
 -- Hash distributed tables
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_aoco'::regclass;
 insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
- count 
--------
-    49
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
 
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
- count 
--------
-    51
-(1 row)
+begin;
+Alter table t1_reshuffle_aoco set with (reshuffle);
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             1 |    40
+             2 |    28
+(3 rows)
 
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
 
 Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
- count 
--------
-    32
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
- count 
--------
-    40
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
- count 
--------
-    28
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             2 |    28
+             1 |    40
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
  numsegments 
@@ -50,144 +45,51 @@ select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco
 (1 row)
 
 drop table t1_reshuffle_aoco;
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
- count 
--------
-   100
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
- count 
--------
-     0
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
-
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
- count 
--------
-    32
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
- count 
--------
-    40
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
- count 
--------
-    28
-(1 row)
-
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
- numsegments 
--------------
-           3
-(1 row)
-
-drop table t1_reshuffle_aoco;
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b);
+-- Test NULLs.
+Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b,c);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
- count 
--------
-    51
-(1 row)
+insert into t1_reshuffle_aoco values
+  (1,    1,    1   ),
+  (null, 2,    2   ),
+  (3,    null, 3   ),
+  (4,    4,    null),
+  (null, null, 5   ),
+  (null, 6,    null),
+  (7,    null, null),
+  (null, null, null);
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     4
+             0 |     4
+(2 rows)
 
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
- count 
--------
-    49
-(1 row)
+begin;
+Alter table t1_reshuffle_aoco set with (reshuffle);
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |     2
+             2 |     3
+             1 |     3
+(3 rows)
 
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     4
+             0 |     4
+(2 rows)
 
 Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
- count 
--------
-    31
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
- count 
--------
-    35
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
- count 
--------
-    34
-(1 row)
-
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
- numsegments 
--------------
-           3
-(1 row)
-
-drop table t1_reshuffle_aoco;
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b);
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
- count 
--------
-   100
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
- count 
--------
-     0
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
- count 
--------
-     0
-(1 row)
-
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
- count 
--------
-    31
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
- count 
--------
-    35
-(1 row)
-
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
- count 
--------
-    34
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     3
+             2 |     3
+             0 |     2
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
  numsegments 
@@ -205,126 +107,46 @@ update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_a
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco'::regclass;
 insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
+(1 row)
+
+begin;
 Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco;
- count 
--------
-   100
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |    28
+             0 |    32
+             1 |    40
+(3 rows)
+
+abort;
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=1;
- ?column? 
-----------
- t
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table t1_reshuffle_aoco;
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a) partition by list(b) (partition t1_reshuffle_aoco_1 values(1), partition t1_reshuffle_aoco_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1" for table "t1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2" for table "t1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_other" for table "t1_reshuffle_aoco"
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
 Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco;
- count 
--------
-   100
-(1 row)
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             1 |    40
+             2 |    28
+(3 rows)
 
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table t1_reshuffle_aoco;
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b) partition by list(b) (partition t1_reshuffle_aoco_1 values(1), partition t1_reshuffle_aoco_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1" for table "t1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2" for table "t1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_other" for table "t1_reshuffle_aoco"
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=1;
- ?column? 
-----------
- t
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table t1_reshuffle_aoco;
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b) partition by list(b) (partition t1_reshuffle_aoco_1 values(1), partition t1_reshuffle_aoco_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1" for table "t1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2" for table "t1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_other" for table "t1_reshuffle_aoco"
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=2;
- ?column? 
-----------
- t
+select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table t1_reshuffle_aoco;
 -- Random distributed tables
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly;
-update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from r1_reshuffle_aoco;
- count 
--------
-   100
-(1 row)
-
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
- count 
--------
-   100
-(1 row)
-
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
- ?column? 
-----------
- t
-(1 row)
-
-drop table r1_reshuffle_aoco;
 Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly;
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_aoco'::regclass;
 insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
@@ -335,6 +157,13 @@ Select count(*) from r1_reshuffle_aoco;
    100
 (1 row)
 
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
 Alter table r1_reshuffle_aoco set with (reshuffle);
 Select count(*) from r1_reshuffle_aoco;
  count 
@@ -348,16 +177,19 @@ Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
  t
 (1 row)
 
-drop table r1_reshuffle_aoco;
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly partition by list(b) (partition r1_reshuffle_aoco_1 values(1), partition r1_reshuffle_aoco_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_1" for table "r1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_2" for table "r1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_aoco_1_prt_other" for table "r1_reshuffle_aoco"
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
+abort;
+Select count(*) from r1_reshuffle_aoco;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
 Alter table r1_reshuffle_aoco set with (reshuffle);
 Select count(*) from r1_reshuffle_aoco;
  count 
@@ -365,16 +197,16 @@ Select count(*) from r1_reshuffle_aoco;
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=1;
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
- ?column? 
-----------
- t
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle_aoco;
@@ -387,17 +219,24 @@ update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_a
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco'::regclass;
 insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Alter table r1_reshuffle_aoco set with (reshuffle);
 Select count(*) from r1_reshuffle_aoco;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=1;
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
  ?column? 
 ----------
- t
+ f
+(1 row)
+
+begin;
+Alter table r1_reshuffle_aoco set with (reshuffle);
+Select count(*) from r1_reshuffle_aoco;
+ count 
+-------
+   100
 (1 row)
 
 Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
@@ -406,15 +245,142 @@ Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
  t
 (1 row)
 
+abort;
+Select count(*) from r1_reshuffle_aoco;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table r1_reshuffle_aoco set with (reshuffle);
+Select count(*) from r1_reshuffle_aoco;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
 drop table r1_reshuffle_aoco;
 -- Replicated tables
+-- We have to make sure replicated table successfully reshuffled.
+-- Currently we could only connect to the specific segments in utility mode
+-- to see if the data is consistent there. We create some python function here.
+-- The case can only work under the assumption: it's running on 3-segment cluster
+-- in a single machine.
+-- start_ignore
+create language plpythonu;
+ERROR:  language "plpythonu" already exists
+-- end_ignore
+create function update_on_segment_aoco(tabname text, segid int, numseg int) returns boolean as
+$$
+import pygresql.pg as pg
+conn = pg.connect(dbname='regression')
+port = conn.query("select port from gp_segment_configuration where content = %d and role = 'p'" % segid).getresult()[0][0]
+conn.close()
+
+conn = pg.connect(dbname='regression', opt='-c gp_session_role=utility', port=port)
+conn.query("set allow_system_table_mods = true")
+conn.query("update gp_distribution_policy set numsegments = %d where localoid = '%s'::regclass" % (numseg, tabname))
+conn.close()
+
+return True
+$$
+LANGUAGE plpythonu;
+create function select_on_segment_aoco(sql text, segid int) returns int as
+$$
+import pygresql.pg as pg
+conn = pg.connect(dbname='regression')
+port = conn.query("select port from gp_segment_configuration where content = %d and role = 'p'" % segid).getresult()[0][0]
+conn.close()
+
+conn = pg.connect(dbname='regression', opt='-c gp_session_role=utility', port=port)
+r = conn.query(sql).getresult()
+conn.close()
+
+return r[0][0]
+$$
+LANGUAGE plpythonu;
 Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed replicated;
 update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle_aoco'::regclass;
+select update_on_segment_aoco('r1_reshuffle_aoco', 0, 1);
+ update_on_segment_aoco 
+------------------------
+ t
+(1 row)
+
+select update_on_segment_aoco('r1_reshuffle_aoco', 1, 1);
+ update_on_segment_aoco 
+------------------------
+ t
+(1 row)
+
+select update_on_segment_aoco('r1_reshuffle_aoco', 2, 1);
+ update_on_segment_aoco 
+------------------------
+ t
+(1 row)
+
 insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
 Select count(*) from r1_reshuffle_aoco;
  count 
 -------
    100
+(1 row)
+
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 1);
+ select_on_segment_aoco 
+------------------------
+                      0
+(1 row)
+
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 2);
+ select_on_segment_aoco 
+------------------------
+                      0
+(1 row)
+
+begin;
+Alter table r1_reshuffle_aoco set with (reshuffle);
+Select count(*) from r1_reshuffle_aoco;
+ count 
+-------
+   100
+(1 row)
+
+abort;
+Select count(*) from r1_reshuffle_aoco;
+ count 
+-------
+   100
+(1 row)
+
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 1);
+ select_on_segment_aoco 
+------------------------
+                      0
+(1 row)
+
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 2);
+ select_on_segment_aoco 
+------------------------
+                      0
 (1 row)
 
 Alter table r1_reshuffle_aoco set with (reshuffle);
@@ -424,21 +390,22 @@ Select count(*) from r1_reshuffle_aoco;
    100
 (1 row)
 
-drop table r1_reshuffle_aoco;
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed replicated;
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Select count(*) from r1_reshuffle_aoco;
- count 
--------
-   100
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 1);
+ select_on_segment_aoco 
+------------------------
+                    100
 (1 row)
 
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
- count 
--------
-   100
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 2);
+ select_on_segment_aoco 
+------------------------
+                    100
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
+ numsegments 
+-------------
+           3
 (1 row)
 
 drop table r1_reshuffle_aoco;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -14,6 +14,8 @@
 #   to the segments, and therefore has to run in smaller groups to avoid
 #   hitting max_connections limit on segments.
 #
+# test reshuffle
+test: reshuffle reshuffle_ao reshuffle_aoco
 
 # enable query metrics cluster GUC
 test: instr_in_shmem_setup

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -166,6 +166,3 @@ test: returning
 # GUCs stats_block_level and stats_row_level, which have been removed from
 # GPDB.
 #test: stats
-
-test: reshuffle reshuffle_ao reshuffle_aoco
-

--- a/src/test/regress/sql/reshuffle.sql
+++ b/src/test/regress/sql/reshuffle.sql
@@ -1,76 +1,48 @@
 set allow_system_table_mods=true;
 
 -- Hash distributed tables
-Create table t1_reshuffle(a int, b int, c int);
+Create table t1_reshuffle(a int, b int, c int) distributed by (a);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle'::regclass;
 insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
+
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
+begin;
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
+Alter table t1_reshuffle set with (reshuffle);
+
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
 drop table t1_reshuffle;
 
-Create table t1_reshuffle(a int, b int, c int);
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
-drop table t1_reshuffle;
-
-Create table t1_reshuffle(a int, b int, c int) distributed by (a,b);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
-drop table t1_reshuffle;
-
-Create table t1_reshuffle(a int, b int, c int) distributed by (a,b);
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
-drop table t1_reshuffle;
 
 Create table t1_reshuffle(a int, b int, c int) with OIDS distributed by (a,b);
 update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle'::regclass;
 insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle set c = gp_segment_id;
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
+
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
+begin;
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
+Alter table t1_reshuffle set with (reshuffle);
+
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
 drop table t1_reshuffle;
-
 
 -- Test NULLs.
 Create table t1_reshuffle(a int, b int, c int) distributed by (a,b,c);
@@ -84,13 +56,19 @@ insert into t1_reshuffle values
   (null, 6,    null),
   (7,    null, null),
   (null, null, null);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
+begin;
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle where gp_segment_id=0;
-Select count(*) from t1_reshuffle where gp_segment_id=1;
-Select count(*) from t1_reshuffle where gp_segment_id=2;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
+Alter table t1_reshuffle set with (reshuffle);
+
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
 drop table t1_reshuffle;
 
@@ -100,87 +78,72 @@ update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle'::regclass;
 insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle;
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=1;
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
-drop table t1_reshuffle;
 
-Create table t1_reshuffle(a int, b int, c int) distributed by (a) partition by list(b) (partition t1_reshuffle_1 values(1), partition t1_reshuffle_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_t1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_t1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle;
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
-drop table t1_reshuffle;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
 
-Create table t1_reshuffle(a int, b int, c int) distributed by (a,b) partition by list(b) (partition t1_reshuffle_1 values(1), partition t1_reshuffle_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_t1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_t1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
+begin;
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle;
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=1;
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
-drop table t1_reshuffle;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+abort;
 
-Create table t1_reshuffle(a int, b int, c int) distributed by (a,b) partition by list(b) (partition t1_reshuffle_1 values(1), partition t1_reshuffle_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_t1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_t1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle'::regclass;
-insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
 Alter table t1_reshuffle set with (reshuffle);
-Select count(*) from t1_reshuffle;
-Select count(*) > 0 from t1_reshuffle where gp_segment_id=2;
+
+Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
+
+select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
 drop table t1_reshuffle;
 
 -- Random distributed tables
 Create table r1_reshuffle(a int, b int, c int) distributed randomly;
-update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle'::regclass;
-insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle set c = gp_segment_id;
-Select count(*) from r1_reshuffle;
-Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
-Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
-drop table r1_reshuffle;
-
-Create table r1_reshuffle(a int, b int, c int) with OIDS distributed randomly;
-update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle'::regclass;
-insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle set c = gp_segment_id;
-Select count(*) from r1_reshuffle;
-Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
-Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
-drop table r1_reshuffle;
-
-Create table r1_reshuffle(a int, b int, c int) distributed randomly;
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
 Update r1_reshuffle set c = gp_segment_id;
+
 Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+
+begin;
 Alter table r1_reshuffle set with (reshuffle);
 Select count(*) from r1_reshuffle;
 Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+abort;
+
+Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+
+Alter table r1_reshuffle set with (reshuffle);
+
+Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
 drop table r1_reshuffle;
 
-Create table r1_reshuffle(a int, b int, c int) distributed randomly partition by list(b) (partition r1_reshuffle_1 values(1), partition r1_reshuffle_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_1_prt_r1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_1_prt_r1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle'::regclass;
+Create table r1_reshuffle(a int, b int, c int) with OIDS distributed randomly;
+update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update r1_reshuffle set c = gp_segment_id;
+
+Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+
+begin;
 Alter table r1_reshuffle set with (reshuffle);
 Select count(*) from r1_reshuffle;
-Select count(*) > 0 from r1_reshuffle where gp_segment_id=1;
 Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+abort;
+
+Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+
+Alter table r1_reshuffle set with (reshuffle);
+
+Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
 drop table r1_reshuffle;
 
 Create table r1_reshuffle(a int, b int, c int) distributed randomly partition by list(b) (partition r1_reshuffle_1 values(1), partition r1_reshuffle_2 values(2), default partition other);
@@ -189,10 +152,25 @@ update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle'::regclass;
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
+
+Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+
+begin;
 Alter table r1_reshuffle set with (reshuffle);
 Select count(*) from r1_reshuffle;
-Select count(*) > 0 from r1_reshuffle where gp_segment_id=1;
 Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+abort;
+
+Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+
+Alter table r1_reshuffle set with (reshuffle);
+
+Select count(*) from r1_reshuffle;
+Select count(*) > 0 from r1_reshuffle where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
 drop table r1_reshuffle;
 
 -- Replicated tables
@@ -202,9 +180,8 @@ drop table r1_reshuffle;
 -- The case can only work under the assumption: it's running on 3-segment cluster
 -- in a single machine.
 -- start_ignore
-drop language plpythonu;
--- end_ignore
 create language plpythonu;
+-- end_ignore
 create function update_on_segment(tabname text, segid int, numseg int) returns boolean as
 $$
 import pygresql.pg as pg
@@ -242,25 +219,27 @@ select update_on_segment('r1_reshuffle', 0, 1);
 select update_on_segment('r1_reshuffle', 1, 1);
 select update_on_segment('r1_reshuffle', 2, 1);
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
-Select count(*) from r1_reshuffle;
-Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
-Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
-Alter table r1_reshuffle set with (reshuffle);
-Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
-Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
-drop table r1_reshuffle;
 
-Create table r1_reshuffle(a int, b int, c int) distributed replicated;
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle'::regclass;
-select update_on_segment('r1_reshuffle', 0, 2);
-select update_on_segment('r1_reshuffle', 1, 2);
-select update_on_segment('r1_reshuffle', 2, 2);
-insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
 Select count(*) from r1_reshuffle;
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
 Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+
+begin;
 Alter table r1_reshuffle set with (reshuffle);
 Select count(*) from r1_reshuffle;
+abort;
+
+Select count(*) from r1_reshuffle;
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
 Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+
+Alter table r1_reshuffle set with (reshuffle);
+
+Select count(*) from r1_reshuffle;
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
+Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
 drop table r1_reshuffle;
 
 Create table r1_reshuffle(a int, b int, c int) with OIDS distributed replicated;
@@ -269,11 +248,27 @@ select update_on_segment('r1_reshuffle', 0, 2);
 select update_on_segment('r1_reshuffle', 1, 2);
 select update_on_segment('r1_reshuffle', 2, 2);
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
+
 Select count(*) from r1_reshuffle;
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
 Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+
+begin;
 Alter table r1_reshuffle set with (reshuffle);
 Select count(*) from r1_reshuffle;
+abort;
+
+Select count(*) from r1_reshuffle;
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
 Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+
+Alter table r1_reshuffle set with (reshuffle);
+
+Select count(*) from r1_reshuffle;
+Select select_on_segment('Select count(*) from r1_reshuffle;', 1);
+Select select_on_segment('Select count(*) from r1_reshuffle;', 2);
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
 drop table r1_reshuffle;
 
 -- table with update triggers on distributed key column

--- a/src/test/regress/sql/reshuffle_ao.sql
+++ b/src/test/regress/sql/reshuffle_ao.sql
@@ -1,59 +1,74 @@
 set allow_system_table_mods=true;
 
 -- Hash distributed tables
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true);
+Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_ao'::regclass;
 insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
+
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
+begin;
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
+Alter table t1_reshuffle_ao set with (reshuffle);
+
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
 drop table t1_reshuffle_ao;
 
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true);
+
+Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed by (a,b);
 update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_ao'::regclass;
 insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
+
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
+begin;
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
+Alter table t1_reshuffle_ao set with (reshuffle);
+
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
 drop table t1_reshuffle_ao;
 
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b);
+-- Test NULLs.
+Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b,c);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
-drop table t1_reshuffle_ao;
+insert into t1_reshuffle_ao values
+  (1,    1,    1   ),
+  (null, 2,    2   ),
+  (3,    null, 3   ),
+  (4,    4,    null),
+  (null, null, 5   ),
+  (null, 6,    null),
+  (7,    null, null),
+  (null, null, null);
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
 
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b);
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
+begin;
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao where gp_segment_id=0;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) from t1_reshuffle_ao where gp_segment_id=2;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
+Alter table t1_reshuffle_ao set with (reshuffle);
+
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
 drop table t1_reshuffle_ao;
 
@@ -63,78 +78,72 @@ update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_a
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao'::regclass;
 insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao;
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=2;
-drop table t1_reshuffle_ao;
 
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a) partition by list(b) (partition t1_reshuffle_ao_1 values(1), partition t1_reshuffle_ao_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao;
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=2;
-drop table t1_reshuffle_ao;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
 
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b) partition by list(b) (partition t1_reshuffle_ao_1 values(1), partition t1_reshuffle_ao_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+begin;
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao;
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=1;
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=2;
-drop table t1_reshuffle_ao;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+abort;
 
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b) partition by list(b) (partition t1_reshuffle_ao_1 values(1), partition t1_reshuffle_ao_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
 Alter table t1_reshuffle_ao set with (reshuffle);
-Select count(*) from t1_reshuffle_ao;
-Select count(*) > 0 from t1_reshuffle_ao where gp_segment_id=2;
-drop table t1_reshuffle_ao;
 
+Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+
+select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
+drop table t1_reshuffle_ao;
 
 -- Random distributed tables
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly;
-update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle_ao'::regclass;
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from r1_reshuffle_ao;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
-drop table r1_reshuffle_ao;
-
 Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly;
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
 Update r1_reshuffle_ao set c = gp_segment_id;
+
 Select count(*) from r1_reshuffle_ao;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+
+begin;
 Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
 Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+abort;
+
+Select count(*) from r1_reshuffle_ao;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+
+Select count(*) from r1_reshuffle_ao;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
 drop table r1_reshuffle_ao;
 
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly partition by list(b) (partition r1_reshuffle_ao_1 values(1), partition r1_reshuffle_ao_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_ao_1_prt_r1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_ao_1_prt_r1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_ao'::regclass;
+Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed randomly;
+update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+Update r1_reshuffle_ao set c = gp_segment_id;
+
+Select count(*) from r1_reshuffle_ao;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+
+begin;
 Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=1;
 Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+abort;
+
+Select count(*) from r1_reshuffle_ao;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+
+Select count(*) from r1_reshuffle_ao;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
 drop table r1_reshuffle_ao;
 
 Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly partition by list(b) (partition r1_reshuffle_ao_1 values(1), partition r1_reshuffle_ao_2 values(2), default partition other);
@@ -143,28 +152,121 @@ update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_a
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao'::regclass;
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+
+Select count(*) from r1_reshuffle_ao;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+
+begin;
 Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=1;
 Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+abort;
+
+Select count(*) from r1_reshuffle_ao;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+
+Select count(*) from r1_reshuffle_ao;
+Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
 drop table r1_reshuffle_ao;
 
 -- Replicated tables
+-- We have to make sure replicated table successfully reshuffled.
+-- Currently we could only connect to the specific segments in utility mode
+-- to see if the data is consistent there. We create some python function here.
+-- The case can only work under the assumption: it's running on 3-segment cluster
+-- in a single machine.
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+create function update_on_segment_ao(tabname text, segid int, numseg int) returns boolean as
+$$
+import pygresql.pg as pg
+conn = pg.connect(dbname='regression')
+port = conn.query("select port from gp_segment_configuration where content = %d and role = 'p'" % segid).getresult()[0][0]
+conn.close()
+
+conn = pg.connect(dbname='regression', opt='-c gp_session_role=utility', port=port)
+conn.query("set allow_system_table_mods = true")
+conn.query("update gp_distribution_policy set numsegments = %d where localoid = '%s'::regclass" % (numseg, tabname))
+conn.close()
+
+return True
+$$
+LANGUAGE plpythonu;
+
+create function select_on_segment_ao(sql text, segid int) returns int as
+$$
+import pygresql.pg as pg
+conn = pg.connect(dbname='regression')
+port = conn.query("select port from gp_segment_configuration where content = %d and role = 'p'" % segid).getresult()[0][0]
+conn.close()
+
+conn = pg.connect(dbname='regression', opt='-c gp_session_role=utility', port=port)
+r = conn.query(sql).getresult()
+conn.close()
+
+return r[0][0]
+$$
+LANGUAGE plpythonu;
+
 Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed replicated;
 update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle_ao'::regclass;
+select update_on_segment_ao('r1_reshuffle_ao', 0, 1);
+select update_on_segment_ao('r1_reshuffle_ao', 1, 1);
+select update_on_segment_ao('r1_reshuffle_ao', 2, 1);
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+
 Select count(*) from r1_reshuffle_ao;
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+
+begin;
 Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
+abort;
+
+Select count(*) from r1_reshuffle_ao;
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+
+Select count(*) from r1_reshuffle_ao;
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
 drop table r1_reshuffle_ao;
 
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed replicated;
+Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed replicated;
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
+select update_on_segment_ao('r1_reshuffle_ao', 0, 2);
+select update_on_segment_ao('r1_reshuffle_ao', 1, 2);
+select update_on_segment_ao('r1_reshuffle_ao', 2, 2);
 insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+
 Select count(*) from r1_reshuffle_ao;
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+
+begin;
 Alter table r1_reshuffle_ao set with (reshuffle);
 Select count(*) from r1_reshuffle_ao;
+abort;
+
+Select count(*) from r1_reshuffle_ao;
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+
+Alter table r1_reshuffle_ao set with (reshuffle);
+
+Select count(*) from r1_reshuffle_ao;
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 1);
+Select select_on_segment_ao('Select count(*) from r1_reshuffle_ao;', 2);
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
 drop table r1_reshuffle_ao;
-
-
-

--- a/src/test/regress/sql/reshuffle_aoco.sql
+++ b/src/test/regress/sql/reshuffle_aoco.sql
@@ -1,59 +1,52 @@
 set allow_system_table_mods=true;
 
 -- Hash distributed tables
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column);
+Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_aoco'::regclass;
 insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
 Update t1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
+
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+
+begin;
 Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+
+Alter table t1_reshuffle_aoco set with (reshuffle);
+
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
 drop table t1_reshuffle_aoco;
 
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column);
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
-drop table t1_reshuffle_aoco;
-
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b);
+-- Test NULLs.
+Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b,c);
 update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
-drop table t1_reshuffle_aoco;
+insert into t1_reshuffle_aoco values
+  (1,    1,    1   ),
+  (null, 2,    2   ),
+  (3,    null, 3   ),
+  (4,    4,    null),
+  (null, null, 5   ),
+  (null, 6,    null),
+  (7,    null, null),
+  (null, null, null);
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
 
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b);
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
+begin;
 Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=0;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) from t1_reshuffle_aoco where gp_segment_id=2;
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+
+Alter table t1_reshuffle_aoco set with (reshuffle);
+
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
 drop table t1_reshuffle_aoco;
 
@@ -63,78 +56,47 @@ update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_a
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco'::regclass;
 insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco;
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=2;
-drop table t1_reshuffle_aoco;
 
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a) partition by list(b) (partition t1_reshuffle_aoco_1 values(1), partition t1_reshuffle_aoco_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco;
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=2;
-drop table t1_reshuffle_aoco;
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
 
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b) partition by list(b) (partition t1_reshuffle_aoco_1 values(1), partition t1_reshuffle_aoco_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
+begin;
 Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco;
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=1;
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=2;
-drop table t1_reshuffle_aoco;
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+abort;
 
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b) partition by list(b) (partition t1_reshuffle_aoco_1 values(1), partition t1_reshuffle_aoco_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+
 Alter table t1_reshuffle_aoco set with (reshuffle);
-Select count(*) from t1_reshuffle_aoco;
-Select count(*) > 0 from t1_reshuffle_aoco where gp_segment_id=2;
-drop table t1_reshuffle_aoco;
 
+Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+
+select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
+drop table t1_reshuffle_aoco;
 
 -- Random distributed tables
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly;
-update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from r1_reshuffle_aoco;
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
-drop table r1_reshuffle_aoco;
-
 Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly;
 update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_aoco'::regclass;
 insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
 Update r1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from r1_reshuffle_aoco;
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
-drop table r1_reshuffle_aoco;
 
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly partition by list(b) (partition r1_reshuffle_aoco_1 values(1), partition r1_reshuffle_aoco_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
+Select count(*) from r1_reshuffle_aoco;
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+
+begin;
 Alter table r1_reshuffle_aoco set with (reshuffle);
 Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=1;
 Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+abort;
+
+Select count(*) from r1_reshuffle_aoco;
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+
+Alter table r1_reshuffle_aoco set with (reshuffle);
+
+Select count(*) from r1_reshuffle_aoco;
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
 drop table r1_reshuffle_aoco;
 
 Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly partition by list(b) (partition r1_reshuffle_aoco_1 values(1), partition r1_reshuffle_aoco_2 values(2), default partition other);
@@ -143,28 +105,92 @@ update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_a
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco_1_prt_other'::regclass;
 update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco'::regclass;
 insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
+
+Select count(*) from r1_reshuffle_aoco;
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+
+begin;
 Alter table r1_reshuffle_aoco set with (reshuffle);
 Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=1;
 Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+abort;
+
+Select count(*) from r1_reshuffle_aoco;
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+
+Alter table r1_reshuffle_aoco set with (reshuffle);
+
+Select count(*) from r1_reshuffle_aoco;
+Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
 drop table r1_reshuffle_aoco;
 
 -- Replicated tables
+-- We have to make sure replicated table successfully reshuffled.
+-- Currently we could only connect to the specific segments in utility mode
+-- to see if the data is consistent there. We create some python function here.
+-- The case can only work under the assumption: it's running on 3-segment cluster
+-- in a single machine.
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+create function update_on_segment_aoco(tabname text, segid int, numseg int) returns boolean as
+$$
+import pygresql.pg as pg
+conn = pg.connect(dbname='regression')
+port = conn.query("select port from gp_segment_configuration where content = %d and role = 'p'" % segid).getresult()[0][0]
+conn.close()
+
+conn = pg.connect(dbname='regression', opt='-c gp_session_role=utility', port=port)
+conn.query("set allow_system_table_mods = true")
+conn.query("update gp_distribution_policy set numsegments = %d where localoid = '%s'::regclass" % (numseg, tabname))
+conn.close()
+
+return True
+$$
+LANGUAGE plpythonu;
+
+create function select_on_segment_aoco(sql text, segid int) returns int as
+$$
+import pygresql.pg as pg
+conn = pg.connect(dbname='regression')
+port = conn.query("select port from gp_segment_configuration where content = %d and role = 'p'" % segid).getresult()[0][0]
+conn.close()
+
+conn = pg.connect(dbname='regression', opt='-c gp_session_role=utility', port=port)
+r = conn.query(sql).getresult()
+conn.close()
+
+return r[0][0]
+$$
+LANGUAGE plpythonu;
+
 Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed replicated;
 update gp_distribution_policy  set numsegments=1 where localoid='r1_reshuffle_aoco'::regclass;
+select update_on_segment_aoco('r1_reshuffle_aoco', 0, 1);
+select update_on_segment_aoco('r1_reshuffle_aoco', 1, 1);
+select update_on_segment_aoco('r1_reshuffle_aoco', 2, 1);
 insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
+
 Select count(*) from r1_reshuffle_aoco;
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 1);
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 2);
+
+begin;
 Alter table r1_reshuffle_aoco set with (reshuffle);
 Select count(*) from r1_reshuffle_aoco;
-drop table r1_reshuffle_aoco;
+abort;
 
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed replicated;
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
 Select count(*) from r1_reshuffle_aoco;
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 1);
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 2);
+
 Alter table r1_reshuffle_aoco set with (reshuffle);
+
 Select count(*) from r1_reshuffle_aoco;
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 1);
+Select select_on_segment_aoco('Select count(*) from r1_reshuffle_aoco;', 2);
+
+select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
 drop table r1_reshuffle_aoco;
-
-
-


### PR DESCRIPTION
This commit does three things:
  - move reshufle tests to greenplum_schedule
  - add cases to test that reshuffle can correctly abort
  - remove some redundant cases(I think in this regress
    tests, it is enough to just test expanding from 2 to 3)