### PR TITLE
Ensure preassigned Oids aren't reused during upgrade

### DIFF
--- a/contrib/pg_upgrade/function.c
+++ b/contrib/pg_upgrade/function.c
@@ -97,6 +97,12 @@ install_support_functions_in_new_db(const char *db_name)
 							  "RETURNS VOID "
 							  "AS '$libdir/pg_upgrade_support' "
 							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.set_preassigned_oids(oid[]) "
+							  "RETURNS VOID "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
 
 	PQfinish(conn);
 }

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -45,24 +45,18 @@
  * nodes when the DDL command is dispatched, and for the QE nodes to use the
  * same, pre-assigned, OIDs for the objects.
  *
- * This same mechanism can be used to preserve OIDs during pg_upgrade. In
- * PostgreSQL, pg_upgrade only needs to preserve the OIDs of a few objects,
- * like types, but in GPDB we need to preserve most OIDs, because they need
- * to be kept in sync between the nodes. (Strictly speaking, we only need to
- * ensure that all the nodes use the same OIDs in the upgraded clusters, but
- * they wouldn't need to be the same as before upgrade. However, the most
- * straightforward way to achieve that is to use the same OIDs as before
- * upgrade.)
+ * This same mechanism is used to preserve OIDs when upgrading a GPDB cluster
+ * using pg_upgrade. pg_upgrade in PostgreSQL is using a set of global vars to
+ * communicate the next OID for an object during upgrade, a strategy GPDB
+ * doesn't employ due to the need for multiple OIDs for auxiliary objects.
+ * pg_upgrade records the OIDs from the old cluster and inserts them into the
+ * same 'preassigned_ods' list to restore them, that we use to assign specific
+ * OIDs in a QE node at dispatch. Additionally, to ensure that object creation
+ * that isn't bound by preassigned OIDs isn't consuming an OID that will later
+ * in the restore process be preassigned, a separate list of all such OIDs is
+ * maintained and queried before assigning a new non-preassigned OID.
  *
- * pg_upgrade has its own mechanism to record the OIDs from the old cluster
- * but when restoring the schema in the new cluster, it uses the same
- * 'preassigned_oids' list to restore them, that we use to assign specific
- * OIDs in a QE node at dispatch.
- *
- * (XXX: All the pg_upgrade code described above is to-be-done, as of
- * this writing),
- *
- * Portions Copyright 2016 Pivotal Software, Inc.
+ * Portions Copyright 2016-Present Pivotal Software, Inc.
  * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
@@ -148,6 +142,12 @@ static List *preassigned_oids = NIL;
  */
 static List *dispatch_oids = NIL;
 
+/*
+ * These will be used by the schema restoration process during binary upgrade,
+ * so any new object must not use any Oid on this list or else there will be
+ * collisions.
+ */
+static List *binary_upgrade_preassigned_oids = NIL;
 
 /*
  * Create an OidAssignment struct, for a catalog table tuple.
@@ -449,7 +449,7 @@ CreateKeyFromCatalogTuple(Relation catalogrel, HeapTuple tuple,
 			*exempt = true;
 			 break;
 
-		 /* Event triggers are only stored and fired in the QD. */
+		/* Event triggers are only stored and fired in the QD. */
 		case EventTriggerRelationId:
 			*exempt = true;
 			break;
@@ -465,12 +465,12 @@ CreateKeyFromCatalogTuple(Relation catalogrel, HeapTuple tuple,
 			break;
 
 		 /*
-		  * These objects need to have their OIDs synchronized, but there is bespoken
-		  * code to deal with it.
+		  * These objects need to have their OIDs synchronized, but there is
+		  * bespoken code to deal with it.
 		  */
 		case TriggerRelationId:
 			*exempt = true;
-			 break;
+			break;
 
 		default:
 			*recognized = false;
@@ -632,10 +632,11 @@ GetPreassignedOidForTuple(Relation catalogrel, HeapTuple tuple)
 	if ((oid = GetPreassignedOid(&searchkey)) == InvalidOid)
 	{
 		/*
-		 * When binary-upgrading the QD node, we must preserve the OIDs of
-		 * types, relations and enums from the old cluster, so we should have
-		 * pre-assigned OIDs for them.  For now we don't enforce the OIDs for
-		 * these objects here, consider that a future TODO.
+		 * During normal operation, all OIDs are preassigned unless the object
+		 * type is exempt (in which case we should never reach here). During
+		 * upgrades we do however allow objects to be created with new OIDs
+		 * since objects may be created in new cluster which didn't exist in
+		 * the old cluster.
 		 */
 		if (!IsBinaryUpgrade)
 			elog(ERROR, "no pre-assigned OID for %s tuple \"%s\" (namespace:%u keyOid1:%u keyOid2:%u)",
@@ -733,6 +734,36 @@ GetPreassignedOidForType(Oid namespaceOid, const char *typname,
  * Functions for use in binary-upgrade mode
  * ----------------------------------------------------------------
  */
+
+/*
+ * Remember an Oid which will be used in schema restoration during binary
+ * upgrade, such that we can prohibit any new object to consume Oids which
+ * will lead to collision.
+ */
+void
+MarkOidPreassignedFromBinaryUpgrade(Oid oid)
+{
+	MemoryContext		oldcontext;
+
+	if (!IsBinaryUpgrade)
+		elog(ERROR, "MarkOidPreassignedFromBinaryUpgrade called, but not in binary upgrade mode");
+
+	if (oid == InvalidOid)
+		return;
+
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+
+	/*
+	 * A list is hardly the best data structure for this as the number of OIDs
+	 * kept here can be quite high for a large schema. Implementing a better
+	 * store which enables quick lookups is a TODO for now.
+	 */
+	binary_upgrade_preassigned_oids =
+		lappend_oid(binary_upgrade_preassigned_oids, oid);
+
+	MemoryContextSwitchTo(oldcontext);
+}
+
 
 /*
  * Remember an OID which is set from loading a database dump performed
@@ -936,5 +967,5 @@ IsOidAcceptable(Oid oid)
 			return false;
 	}
 
-	return true;
+	return !(list_member_oid(binary_upgrade_preassigned_oids, oid));
 }

--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -50,6 +50,7 @@ static DumpableObject **oprinfoindex;
 static DumpableObject **collinfoindex;
 static DumpableObject **nspinfoindex;
 static DumpableObject **extinfoindex;
+static DumpableObject **binaryupgradeinfoindex;
 static int	numTables;
 static int	numTypes;
 static int	numFuncs;
@@ -80,7 +81,7 @@ static int	strInArray(const char *pattern, char **arr, int arr_size);
  *	  Collect information about all potentially dumpable objects
  */
 TableInfo *
-getSchemaData(Archive *fout, int *numTablesPtr)
+getSchemaData(Archive *fout, int *numTablesPtr, int binary_upgrade)
 {
 	TableInfo  *tblinfo;
 	TypeInfo   *typinfo;
@@ -109,6 +110,17 @@ getSchemaData(Archive *fout, int *numTablesPtr)
 
 	/* GPDB specific variables */
 	int			numExtProtocols;
+
+	if (binary_upgrade)
+	{
+		BinaryUpgradeInfo *binfo;
+
+		if (g_verbose)
+			write_msg(NULL, "identifying required binary upgrade calls\n");
+
+		binfo = getBinaryUpgradeObjects();
+		binaryupgradeinfoindex = buildIndexArray(binfo, 1, sizeof(BinaryUpgradeInfo));
+	}
 
 	/*
 	 * We must read extensions and extension membership info first, because

--- a/src/bin/pg_dump/pg_backup.h
+++ b/src/bin/pg_dump/pg_backup.h
@@ -181,6 +181,8 @@ extern void ArchiveEntry(Archive *AHX,
 			 const DumpId *deps, int nDeps,
 			 DataDumperPtr dumpFn, void *dumpArg);
 
+extern void AmendArchiveEntry(Archive *AHX, DumpId dumpId, const char *defn);
+
 /* Called to write *data* to the archive */
 extern void WriteData(Archive *AH, const void *data, size_t dLen);
 

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -112,12 +112,14 @@ typedef enum
 	DO_DEFAULT_ACL,
 	DO_BLOB,
 	DO_BLOB_DATA,
-	DO_EXTPROTOCOL,
-	DO_TYPE_STORAGE_OPTIONS,
 	DO_PRE_DATA_BOUNDARY,
 	DO_POST_DATA_BOUNDARY,
 	DO_EVENT_TRIGGER,
-	DO_REFRESH_MATVIEW
+	DO_REFRESH_MATVIEW,
+
+	DO_EXTPROTOCOL,
+	DO_TYPE_STORAGE_OPTIONS,
+	DO_BINARY_UPGRADE
 } DumpableObjectType;
 
 typedef struct _dumpableObject
@@ -133,6 +135,11 @@ typedef struct _dumpableObject
 	int			nDeps;			/* number of valid dependencies */
 	int			allocDeps;		/* allocated size of dependencies[] */
 } DumpableObject;
+
+typedef struct _binaryupgradeinfo
+{
+	DumpableObject dobj;
+} BinaryUpgradeInfo;
 
 typedef struct _namespaceInfo
 {
@@ -561,7 +568,7 @@ extern const char *EXT_PARTITION_NAME_POSTFIX;
 struct Archive;
 typedef struct Archive Archive;
 
-extern TableInfo *getSchemaData(Archive *, int *numTablesPtr);
+extern TableInfo *getSchemaData(Archive *, int *numTablesPtr, int binary_upgrade);
 
 typedef enum _OidOptions
 {
@@ -649,6 +656,7 @@ extern EventTriggerInfo *getEventTriggers(Archive *fout, int *numEventTriggers);
 /* START MPP ADDITION */
 extern TypeStorageOptions *getTypeStorageOptions(Archive *fout, int *numTypes);
 extern ExtProtInfo *getExtProtocols(Archive *fout, int *numExtProtocols);
+extern BinaryUpgradeInfo *getBinaryUpgradeObjects(void);
 
 extern bool	testExtProtocolSupport(Archive *fout);
 /* END MPP ADDITION */

--- a/src/bin/pg_dump/pg_dump_sort.c
+++ b/src/bin/pg_dump/pg_dump_sort.c
@@ -122,7 +122,8 @@ static const int newObjectTypePriority[] =
 	22,							/* DO_PRE_DATA_BOUNDARY */
 	25,							/* DO_POST_DATA_BOUNDARY */
 	32,							/* DO_EVENT_TRIGGER */
-	33							/* DO_REFRESH_MATVIEW */
+	33,							/* DO_REFRESH_MATVIEW */
+	1							/* DO_BINARY_UPGRADE */
 };
 
 static DumpId preDataBoundId;
@@ -1424,6 +1425,11 @@ describeDumpableObject(DumpableObject *obj, char *buf, int bufsize)
 		case DO_POST_DATA_BOUNDARY:
 			snprintf(buf, bufsize,
 					 "POST-DATA BOUNDARY  (ID %d)",
+					 obj->dumpId);
+			return;
+		case DO_BINARY_UPGRADE:
+			snprintf(buf, bufsize,
+					 "BINARY UPGRADE  (ID %d)",
 					 obj->dumpId);
 			return;
 	}

--- a/src/include/catalog/oid_dispatch.h
+++ b/src/include/catalog/oid_dispatch.h
@@ -32,6 +32,7 @@ extern Oid GetPreassignedOidForDatabase(const char *datname);
 
 /* Functions used in binary upgrade */
 extern bool IsOidAcceptable(Oid oid);
+extern void MarkOidPreassignedFromBinaryUpgrade(Oid oid);
 
 extern void AtEOXact_DispatchOids(bool isCommit);
 


### PR DESCRIPTION
During an upgrade, there are numerous new objects created in the new cluster which either doesn't have an Oids preallocated from the old, or which never existed in the old cluster to begin with. These objects are assigned Oids in the new cluster which may collide with Oids which are preassigned from the old cluster, but which hasn't yet been used in the restore process. This is because the restore process is doing the preallocation just before the object creation.

To avoid collisions, the Oids which will be preassigned are tracked during schema dump, and are injected into the Oid dispatch machinery before any object is restored such that the list can be queried. This requires a new mode of dumping in pg_dump where an object is recorded first in the dependency chain but is dumped last. To support this, a new API for amending ArchiveEntry objects has been added. Currently it only supports changing the definition but it can easily be extended to cover future usecases.

The performance of this patch is a TODO, passing all the Oids in an array in a single call is unlikely to scale to real-world scenarios but it's better to subject this to a wider audience sooner rather than later.

@jchampio What do you think about this approach? It's halfway going back to when we did blanket preallocations of everything, but in a bit more lightweight fashion. 