### PR TITLE
Simplify code to choose a segment in random, for DISTRIBUTED RANDOMLY.

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -401,7 +401,10 @@ FinalizeDirectDispatchDataForSlice(Node *node, ContentIdAssignmentData *data, bo
 
 				if (ddcr->dd.contentIds == NULL)
 				{
-					ddcr->dd.contentIds = list_make1_int(cdb_randint(getgpsegmentCount() - 1, 0));
+					int			random_segno;
+
+					random_segno = cdbhashrandomseg(getgpsegmentCount());
+					ddcr->dd.contentIds = list_make1_int(random_segno);
 					if (ShouldPrintTestMessages())
 						elog(INFO, "DDCR learned no content dispatch is required");
 				}

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -31,6 +31,7 @@
 #include "catalog/gp_id.h"
 #include "catalog/gp_segment_config.h"
 #include "catalog/indexing.h"
+#include "cdb/cdbhash.h"
 #include "cdb/cdbutil.h"
 #include "cdb/cdbmotion.h"
 #include "cdb/cdbvars.h"
@@ -1219,14 +1220,8 @@ makeRandomSegMap(int total_primaries, int total_to_skip)
 	{
 		/*
 		 * create a random int between 0 and (total_primaries - 1).
-		 *
-		 * NOTE that the lower and upper limits in cdb_randint() are inclusive
-		 * so we take them into account. In reality the chance of those limits
-		 * to get selected by the random generator is extremely small, so we
-		 * may want to find a better random generator some time (not critical
-		 * though).
 		 */
-		randint = cdb_randint(0, total_primaries - 1);
+		randint = cdbhashrandomseg(total_primaries);
 
 		/*
 		 * mark this random index 'true' in the skip map (marked to be

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -5256,12 +5256,13 @@ ExecEvalReshuffleExpr(ReshuffleExprState *astate,
 			/*
 			 * For random distributed tables
 			 *
-			 * We generate an random values [0, newSegs), when this
-			 * value is greater than oldSegs, it indicate that the
-			 * tuple need to reshuffle.
+			 * We generate a random value between[0, newSegs). When this
+			 * value is greater than oldSegs, it indicates that the tuple
+			 * needs to be reshuffled.
 			 */
-			int newSegs = getgpsegmentCount();
-			result = (cdb_randint((newSegs - 1), 0) >= sr->oldSegs);
+			int			newSegs = getgpsegmentCount();
+
+			result = (cdbhashrandomseg(newSegs) >= sr->oldSegs);
 		}
 	}
 	else if(sr->ptype == POLICYTYPE_REPLICATED)

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -44,7 +44,6 @@ typedef struct CdbHash
 	int			numsegs;		/* number of segments in Greenplum Database used for
 								 * partitioning  */
 	CdbHashReduce reducealg;	/* the algorithm used for reducing to buckets		*/
-	uint32		rrindex;		/* round robin index for empty policy tables		*/
 
 	int			natts;
 	Oid			typeoids[FLEXIBLE_ARRAY_MEMBER];
@@ -67,7 +66,8 @@ extern void cdbhashinit(CdbHash *h);
 extern void cdbhash(CdbHash *h, int attno, Datum datum, bool isnull);
 
 /*
- * Hash a tuple for a relation with an empty (no hash keys) partitioning policy.
+ * Pick a random hash value, for a tuple in a relation with an empty
+ * policy (i.e. DISTRIBUTED RANDOMLY).
  */
 extern void cdbhashnokey(CdbHash *h);
 
@@ -75,6 +75,11 @@ extern void cdbhashnokey(CdbHash *h);
  * Reduce the hash to a segment number.
  */
 extern unsigned int cdbhashreduce(CdbHash *h);
+
+/*
+ * Return a random segment number, for a randomly distributed policy.
+ */
+extern unsigned int cdbhashrandomseg(int numsegs);
 
 /*
  * Return true if Oid is hashable internally in Greenplum Database.

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -17,20 +17,8 @@
 #ifndef CDBUTIL_H
 #define CDBUTIL_H
 
-/*
- * Copied from geqo_random.h (deprecated)
- */
-
-#include <math.h>
 #include "catalog/gp_segment_config.h"
 #include "nodes/pg_list.h"
-
-/* cdb_rand returns a random float value between 0 and 1 inclusive */
-#define cdb_rand() ((double) random() / (double) MAX_RANDOM_VALUE)
-
-/* cdb_randint returns integer value between lower and upper inclusive */
-#define cdb_randint(upper,lower) \
-	( (int) floor( cdb_rand()*(((upper)-(lower))+0.999999) ) + (lower) )
 
 struct SegmentDatabaseDescriptor;
 


### PR DESCRIPTION
The definition of cdb_randint() was pretty hard to understand. Where did
the 0.999999 constant come from, for example? And the signature of
cdb_randint() was also surprising, with the upper bound as the first
argument, and lower bound second. The call in makeRandomSegMap() got that
backwards, but it still mostly worked (I think there was just a small bias
when called that way).

Also simplify the 'rrindex' mechanism used in cdbhash.c, to choose a
segment in random. The comment in makeCdbHash() that claimed that the
calling cdbhashnokey() repeatedly would behave in a round-robin fashion
was wrong: the 'rrindex' counter that was incremented on every call was
fed to a hash function, which meant that we were using the hash function
like a random number generator. Since we were using it like a random number
generator anyway, remove the 'rrindex' field and use a real random number
generator in cdbhashnokey() directly.