### PR TITLE
Make Greenplum tablespaces work with gprecoverseg -F

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -700,7 +700,9 @@ def copy_master_datadir_to_standby(options, array, standby_datadir):
                        host=array.master.getSegmentHostName(),
                        port=str(array.master.getSegmentPort()),
                        ctxt=base.REMOTE,
-                       remoteHost=options.standby_host)
+                       remoteHost=options.standby_host,
+                       forceoverwrite=True,
+                       target_gp_dbid=array.standbyMaster.dbid)
     try:
         cmd.run(validateAfter=True)
     except Exception, ex:

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -173,7 +173,7 @@ class PgControlData(Command):
         return self.datadir
 
 class PgBaseBackup(Command):
-    def __init__(self, pgdata, host, port, excludePaths=[], ctxt=LOCAL, remoteHost=None, forceoverwrite=False):
+    def __init__(self, pgdata, host, port, excludePaths=[], ctxt=LOCAL, remoteHost=None, forceoverwrite=False, target_gp_dbid=0):
         cmd_tokens = ['pg_basebackup',
                            '-x', '-R',
                            '-c', 'fast']
@@ -186,6 +186,10 @@ class PgBaseBackup(Command):
 
         if forceoverwrite:
             cmd_tokens.append('--force-overwrite')
+
+        # This is needed to handle Greenplum tablespaces
+        cmd_tokens.append('--target-gp-dbid')
+        cmd_tokens.append(str(target_gp_dbid))
 
         # We exclude certain unnecessary directories from being copied as they will greatly
         # slow down the speed of gpinitstandby if containing a lot of data

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -129,7 +129,8 @@ class ConfExpSegCmd(Command):
                         cmd = PgBaseBackup(pgdata=self.datadir,
                                            host=self.syncWithSegmentHostname,
                                            port=str(self.syncWithSegmentPort),
-                                           forceoverwrite=self.forceoverwrite)
+                                           forceoverwrite=self.forceoverwrite,
+                                           target_gp_dbid=self.dbid)
                         try:
                             cmd.run(validateAfter=True)
                             self.set_results(CommandResult(0, '', '', True, False))

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -160,10 +160,25 @@ content|preferred_role|role|status|mode
 1       
 (1 row)
 
+-- create tablespace to test if it works with gprecoverseg -F (pg_basebackup)
+!\retcode mkdir /tmp/mirror_promotion_tablespace_loc;
+(exited with code 0)
+create tablespace mirror_promotion_tablespace location '/tmp/mirror_promotion_tablespace_loc';
+CREATE
+create table mirror_promotion_tblspc_heap_table (a int) tablespace mirror_promotion_tablespace;
+CREATE
+
 -- -- now, let's fully recover the mirror
 !\retcode gprecoverseg -aF;
 -- start_ignore
 -- end_ignore
+(exited with code 0)
+
+drop table mirror_promotion_tblspc_heap_table;
+DROP
+drop tablespace mirror_promotion_tablespace;
+DROP
+!\retcode rm -rf /tmp/mirror_promotion_tablespace_loc;
 (exited with code 0)
 
 -- loop while segments come in sync

--- a/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
@@ -102,8 +102,17 @@ where content = 0;
 -- -- wait for content 0 (earlier mirror, now primary) to finish the promotion
 0U: select 1;
 
+-- create tablespace to test if it works with gprecoverseg -F (pg_basebackup)
+!\retcode mkdir /tmp/mirror_promotion_tablespace_loc;
+create tablespace mirror_promotion_tablespace location '/tmp/mirror_promotion_tablespace_loc';
+create table mirror_promotion_tblspc_heap_table (a int) tablespace mirror_promotion_tablespace;
+
 -- -- now, let's fully recover the mirror
 !\retcode gprecoverseg -aF;
+
+drop table mirror_promotion_tblspc_heap_table;
+drop tablespace mirror_promotion_tablespace;
+!\retcode rm -rf /tmp/mirror_promotion_tablespace_loc;
 
 -- loop while segments come in sync
 do $$


### PR DESCRIPTION
Greenplum tablespaces are very different from upstream Postgres. It creates a
subdirectory under the tablespace location path. When running pg_basebackup with
existing user-defined tablespaces, it will error out because the tablespace root
path already exists. For Greenplum, it should check the correct subdirectory in
the tablespace path instead.

To do this, we introduce --target-gp-dbid flag to pg_basebackup and introduce
logic for user-defined tablespace. Then we change utilities to use the new option.

Co-authored-by: Jinbao Chen <jinchen@pivotal.io>