### PR TITLE
Fix the new bitmap AM insertion WAL record.

### DIFF
--- a/src/include/access/bitmap.h
+++ b/src/include/access/bitmap.h
@@ -806,6 +806,10 @@ extern void _bitmap_log_updatewords(Relation rel,
 						bool new_lastpage);
 extern void _bitmap_log_updateword(Relation rel, Buffer bitmapBuffer, int word_no);
 
+#ifdef DUMP_BITMAPAM_INSERT_RECORDS
+extern void _dump_page(char *file, XLogRecPtr recptr, RelFileNode *relfilenode, Buffer buf);
+#endif
+
 /* bitmapsearch.c */
 extern bool _bitmap_first(IndexScanDesc scan, ScanDirection dir);
 extern bool _bitmap_next(IndexScanDesc scan, ScanDirection dir);


### PR DESCRIPTION
I botched the WAL-logging of the content words in the
_bitmap_write_bitmapwords_on_page function. In The start position for
changed content words is kept in 'cwords' variable, not 'startWordNo'.
'startWordNo' is the starting position in the input buffer to copy from,
not the position in the target page to copy to.

Move the lines that record this information in the WAL record closer to
the corresponding memcpy()s that make the changes in the master. This makes
it easier to verify that we're recording the same changes in the WAL record
that we are making to the page.

I found this by running a patched version that wrote a full page image
after writing or replaying each XLOG_BITMAP_INSERT_WORDS record, with
the 'bitmap_index' regression test.  This hopefully explains the assertion
failure that Ashwin reported at
https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/TkoXWveDS6g
although I was not able to reproduce that.
