### PR TITLE
Fix data lost during data reorganization.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3666,7 +3666,8 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 
 	dist = (DistributedBy *)into->distributedBy;
 
-	dist->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+	if (dist->numsegments < 0)
+		dist->numsegments = GP_POLICY_ALL_NUMSEGMENTS;
 
 	/*
 	 * We have a DISTRIBUTED BY column list specified by the user

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -31,6 +31,54 @@ select localoid::regclass, attrnums, policytype, numsegments
  r2       |          | p          |           2
 (6 rows)
 
+analyze t1;
+analyze d1;
+analyze r1;
+analyze t2;
+analyze d2;
+analyze r2;
+--
+-- regression tests
+--
+-- a temp table is created during reorganization, its numsegments should be
+-- the same with original table, otherwise some data will be lost after the
+-- reorganization.
+begin;
+	insert into t1 select i, i from generate_series(1,10) i;
+	select gp_segment_id, * from t1;
+ gp_segment_id | c1 | c2 | c3 | c4 
+---------------+----+----+----+----
+             0 |  1 |  1 |    |   
+             0 |  2 |  2 |    |   
+             0 |  3 |  3 |    |   
+             0 |  4 |  4 |    |   
+             0 |  5 |  5 |    |   
+             0 |  6 |  6 |    |   
+             0 |  7 |  7 |    |   
+             0 |  8 |  8 |    |   
+             0 |  9 |  9 |    |   
+             0 | 10 | 10 |    |   
+(10 rows)
+
+	alter table t1 set with (reorganize=true) distributed by (c1);
+	select gp_segment_id, * from t1;
+ gp_segment_id | c1 | c2 | c3 | c4 
+---------------+----+----+----+----
+             0 |  1 |  1 |    |   
+             0 |  2 |  2 |    |   
+             0 |  3 |  3 |    |   
+             0 |  4 |  4 |    |   
+             0 |  5 |  5 |    |   
+             0 |  6 |  6 |    |   
+             0 |  7 |  7 |    |   
+             0 |  8 |  8 |    |   
+             0 |  9 |  9 |    |   
+             0 | 10 | 10 |    |   
+(10 rows)
+
+abort;
+-- restore the analyze information
+analyze t1;
 --
 -- create table
 --

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -30,6 +30,29 @@ select localoid::regclass, attrnums, policytype, numsegments
 		't1'::regclass, 'd1'::regclass, 'r1'::regclass,
 		't2'::regclass, 'd2'::regclass, 'r2'::regclass);
 
+analyze t1;
+analyze d1;
+analyze r1;
+analyze t2;
+analyze d2;
+analyze r2;
+
+--
+-- regression tests
+--
+
+-- a temp table is created during reorganization, its numsegments should be
+-- the same with original table, otherwise some data will be lost after the
+-- reorganization.
+begin;
+	insert into t1 select i, i from generate_series(1,10) i;
+	select gp_segment_id, * from t1;
+	alter table t1 set with (reorganize=true) distributed by (c1);
+	select gp_segment_id, * from t1;
+abort;
+-- restore the analyze information
+analyze t1;
+
 --
 -- create table
 --


### PR DESCRIPTION
A temp table is created during data reorganization, its numsegments must
be the same with the original table, otherwise some data will be lost
after the reorganization.