### PR TITLE
Use max numsegments of subpaths for Append node.

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -332,6 +332,8 @@ SendTupleChunkToAMS(MotionLayerState *mlStates,
 		else
 		{
 			/* handle pt-to-pt message. Primary */
+			Assert(targetRoute >= 0);
+			Assert(targetRoute < pEntry->numConns);
 			conn = pEntry->conns + targetRoute;
 			/* only send to interested connections */
 			if (conn->stillActive)

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -1478,7 +1478,18 @@ doSendTuple(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot)
 		hval = evalHashKey(econtext, node->hashExpr,
 				motion->hashDataTypes, node->cdbhash);
 
-		Assert(hval < getgpsegmentCount() && "redistribute destination outside segment array");
+#ifdef USE_ASSERT_CHECKING
+		if (node->ps.state->es_plannedstmt->planGen == PLANGEN_PLANNER)
+		{
+			Assert(hval < node->ps.plan->flow->numsegments &&
+				   "redistribute destination outside segment array");
+		}
+		else
+		{
+			Assert(hval < getgpsegmentCount() &&
+				   "redistribute destination outside segment array");
+		}
+#endif /* USE_ASSERT_CHECKING */
 		
 		/* hashSegIdx takes our uint32 and maps it to an int, and here
 		 * we assign it to an int16. See below. */

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -84,8 +84,7 @@ analyze t1;
 --
 -- append node should use the max numsegments of all the subpaths
 begin;
-	truncate t1;
-	truncate t2;
+	-- insert enough data to ensure executors got reached on segments
 	insert into t1 select i from generate_series(1,100) i;
 	insert into t2 select i from generate_series(1,100) i;
 	:explain  select * from t2 a join t2 b using(c2)

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -80,6 +80,80 @@ abort;
 -- restore the analyze information
 analyze t1;
 --
+-- regression tests
+--
+-- append node should use the max numsegments of all the subpaths
+begin;
+	truncate t1;
+	truncate t2;
+	insert into t1 select i from generate_series(1,100) i;
+	insert into t2 select i from generate_series(1,100) i;
+	:explain  select * from t2 a join t2 b using(c2)
+	union all select * from t1 c join t1 d using(c2) ;
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=6.25..17.52 rows=14 width=28) (actual time=2.573..2.573 rows=0 loops=2)
+   ->  Append  (cost=6.25..17.52 rows=5 width=28) (actual time=0.000..4.405 rows=0 loops=1)
+         ->  Hash Join  (cost=6.25..11.69 rows=3 width=28) (actual time=0.000..3.522 rows=0 loops=1)
+               Hash Cond: (a.c2 = b.c2)
+               Extra Text: (seg0)   Hash chain length 0.0 avg, 0 max, using 0 of 262144 buckets.
+               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..5.00 rows=50 width=16) (never executed)
+                     Hash Key: a.c2
+                     ->  Seq Scan on t2 a  (cost=0.00..3.00 rows=34 width=16) (actual time=0.010..0.019 rows=28 loops=2)
+               ->  Hash  (cost=5.00..5.00 rows=34 width=16) (actual time=0.000..1.184 rows=0 loops=1)
+                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..5.00 rows=50 width=16) (actual time=0.018..0.585 rows=50 loops=2)
+                           Hash Key: b.c2
+                           ->  Seq Scan on t2 b  (cost=0.00..3.00 rows=34 width=16) (actual time=0.007..0.015 rows=28 loops=2)
+         ->  Hash Join  (cost=3.25..5.69 rows=3 width=28) (actual time=0.000..1.404 rows=0 loops=1)
+               Hash Cond: (c.c2 = d.c2)
+               Extra Text: (seg0)   Hash chain length 0.0 avg, 0 max, using 0 of 262144 buckets.
+               ->  Seq Scan on t1 c  (cost=0.00..2.00 rows=34 width=16) (actual time=0.012..0.012 rows=0 loops=2)
+               ->  Hash  (cost=2.00..2.00 rows=34 width=16) (actual time=0.000..0.056 rows=0 loops=1)
+                     ->  Seq Scan on t1 d  (cost=0.00..2.00 rows=34 width=16) (actual time=0.009..0.022 rows=50 loops=2)
+ Planning time: 1.964 ms
+   (slice0)    Executor memory: 518K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 3244K bytes avg x 2 workers, 4270K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Execution time: 9.956 ms
+(26 rows)
+
+	:explain  select * from t1 a join t1 b using(c2)
+	union all select * from t2 c join t2 d using(c2) ;
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3.25..17.52 rows=14 width=28) (actual time=1.483..1.483 rows=0 loops=2)
+   ->  Append  (cost=3.25..17.52 rows=5 width=28) (actual time=0.000..2.279 rows=0 loops=1)
+         ->  Hash Join  (cost=3.25..5.69 rows=3 width=28) (actual time=0.000..0.827 rows=0 loops=1)
+               Hash Cond: (a.c2 = b.c2)
+               Extra Text: (seg0)   Hash chain length 0.0 avg, 0 max, using 0 of 262144 buckets.
+               ->  Seq Scan on t1 a  (cost=0.00..2.00 rows=34 width=16) (actual time=0.006..0.006 rows=0 loops=2)
+               ->  Hash  (cost=2.00..2.00 rows=34 width=16) (actual time=0.000..0.043 rows=0 loops=1)
+                     ->  Seq Scan on t1 b  (cost=0.00..2.00 rows=34 width=16) (actual time=0.004..0.015 rows=50 loops=2)
+         ->  Hash Join  (cost=6.25..11.69 rows=3 width=28) (actual time=0.000..2.221 rows=0 loops=1)
+               Hash Cond: (c.c2 = d.c2)
+               Extra Text: (seg0)   Hash chain length 0.0 avg, 0 max, using 0 of 262144 buckets.
+               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..5.00 rows=50 width=16) (never executed)
+                     Hash Key: c.c2
+                     ->  Seq Scan on t2 c  (cost=0.00..3.00 rows=34 width=16) (actual time=0.010..0.018 rows=28 loops=2)
+               ->  Hash  (cost=5.00..5.00 rows=34 width=16) (actual time=0.000..0.915 rows=0 loops=1)
+                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..5.00 rows=50 width=16) (actual time=0.266..0.449 rows=50 loops=2)
+                           Hash Key: d.c2
+                           ->  Seq Scan on t2 d  (cost=0.00..3.00 rows=34 width=16) (actual time=0.006..0.013 rows=28 loops=2)
+ Planning time: 1.493 ms
+   (slice0)    Executor memory: 518K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 3232K bytes avg x 2 workers, 4258K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: legacy query optimizer
+ Execution time: 3.839 ms
+(26 rows)
+
+abort;
+--
 -- create table
 --
 create temp table t (like t1);

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -54,6 +54,24 @@ abort;
 analyze t1;
 
 --
+-- regression tests
+--
+
+-- append node should use the max numsegments of all the subpaths
+begin;
+	truncate t1;
+	truncate t2;
+	insert into t1 select i from generate_series(1,100) i;
+	insert into t2 select i from generate_series(1,100) i;
+
+	:explain  select * from t2 a join t2 b using(c2)
+	union all select * from t1 c join t1 d using(c2) ;
+
+	:explain  select * from t1 a join t1 b using(c2)
+	union all select * from t2 c join t2 d using(c2) ;
+abort;
+
+--
 -- create table
 --
 

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -59,8 +59,7 @@ analyze t1;
 
 -- append node should use the max numsegments of all the subpaths
 begin;
-	truncate t1;
-	truncate t2;
+	-- insert enough data to ensure executors got reached on segments
 	insert into t1 select i from generate_series(1,100) i;
 	insert into t2 select i from generate_series(1,100) i;
 


### PR DESCRIPTION
Suppose t1 has numsegments=1 and t2 has numsegments=2, then below query
will have incorrect plan:

    explain (costs off) select * from t2 a join t2 b using(c2)
              union all select * from t1 c join t1 d using(c2);
                                   QUERY PLAN
    ------------------------------------------------------------------------
     Gather Motion 1:1  (slice3; segments: 1)
       ->  Append
             ->  Hash Join
                   Hash Cond: (a.c2 = b.c2)
                   ->  Redistribute Motion 2:2  (slice1; segments: 2)
                         Hash Key: a.c2
                         ->  Seq Scan on t2 a
                   ->  Hash
                         ->  Redistribute Motion 2:2  (slice2; segments: 2)
                               Hash Key: b.c2
                               ->  Seq Scan on t2 b
             ->  Hash Join
                   Hash Cond: (c.c2 = d.c2)
                   ->  Seq Scan on t1 c
                   ->  Hash
                         ->  Seq Scan on t1 d
     Optimizer: legacy query optimizer
    (17 rows)

slice2 has a 2:2 redistribute motion to slice3, however slice3 only has
1 segment, this is due to Append's numsegments is decided from the last
subpath.

To fix the issue we should use max numsegments of subpaths for Append.