### PR TITLE
Fix simple_no_rewind_required pg_rewind intermittent test failure

### DIFF
--- a/src/bin/pg_rewind/expected/simple_no_rewind_required.out
+++ b/src/bin/pg_rewind/expected/simple_no_rewind_required.out
@@ -9,10 +9,10 @@ SELECT state FROM pg_stat_replication;
 
 Running pg_rewind...
 Old master restarted after rewind.
+no rewind required
 SELECT state FROM pg_stat_replication;
    state   
 -----------
  streaming
 (1 row)
 
-no rewind required

--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -86,3 +86,13 @@ function wait_until_standby_is_promoted {
       sleep 0.2
    done
 }
+
+function wait_until_standby_streaming_state {
+   retry=150
+   until [ $retry -le 0 ]
+   do
+      PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "SELECT state FROM pg_stat_replication;" | grep 'streaming' > /dev/null && break
+      retry=$[$retry-1]
+      sleep 0.2
+   done
+}

--- a/src/bin/pg_rewind/sql/simple_no_rewind_required.sql
+++ b/src/bin/pg_rewind/sql/simple_no_rewind_required.sql
@@ -6,7 +6,7 @@
 # extension, but we use a custom launcher script that runs the scripts using
 # a shell instead.
 
-TESTNAME=norewind
+TESTNAME=simple_no_rewind_required
 STOP_MASTER_BEFORE_PROMOTE=true
 
 . sql/config_test.sh
@@ -40,8 +40,9 @@ PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "SELECT state FROM pg_stat_repli
 # promoted mirror's new timeline history file.
 function after_rewind
 {
-PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "SELECT state FROM pg_stat_replication;"
 grep "no rewind required" $log_path
+wait_until_standby_streaming_state
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "SELECT state FROM pg_stat_replication;"
 }
 
 # Run the test


### PR DESCRIPTION
The old master can be slow to restart its WAL stream with promoted standby as
part of automatic timeline switch for the new timeline after finishing old
timeline catchup. The SELECT query on pg_stat_replication was executed too fast
and the entry would show state STARTUP which is the default state for timeline
switching. To make the test more deterministic, loop the check on
pg_stat_replication for STREAMING state with timeout 30 seconds.