### PR TITLE
Fix ZSTD compression error "dst buffer too small"

### DIFF
--- a/configure
+++ b/configure
@@ -13158,13 +13158,21 @@ fi
 
 fi
 
-# Check for zstd.h
+# Check for zstd.h and zstd_errors.h
 if test "$with_zstd" = yes; then
   ac_fn_c_check_header_mongrel "$LINENO" "zstd.h" "ac_cv_header_zstd_h" "$ac_includes_default"
 if test "x$ac_cv_header_zstd_h" = xyes; then :
 
 else
   as_fn_error $? "header file <zstd.h> is required for zstd support" "$LINENO" 5
+fi
+
+
+  ac_fn_c_check_header_mongrel "$LINENO" "zstd_errors.h" "ac_cv_header_zstd_errors_h" "$ac_includes_default"
+if test "x$ac_cv_header_zstd_errors_h" = xyes; then :
+
+else
+  as_fn_error $? "header file <zstd_errors.h> is required for zstd support" "$LINENO" 5
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -1542,6 +1542,7 @@ fi
 # Check for zstd.h
 if test "$with_zstd" = yes; then
   AC_CHECK_HEADER(zstd.h, [], [AC_MSG_ERROR([header file <zstd.h> is required for zstd support])])
+  AC_CHECK_HEADER(zstd_errors.h, [], [AC_MSG_ERROR([header file <zstd_errors.h> is required for zstd support])])
 fi
 
 if test "$with_gssapi" = yes ; then
@@ -1648,7 +1649,7 @@ fi
 
 if test "$PORTNAME" = "win32" ; then
    AC_CHECK_HEADERS(crtdefs.h)
-fi 
+fi
 
 # OpenBSD requires libexecinfo from ports for backtrace() as it's a glibc addition
 if test "$PORTNAME" = "openbsd"; then

--- a/gpcontrib/zstd/Makefile
+++ b/gpcontrib/zstd/Makefile
@@ -20,10 +20,12 @@ endif
 # Install into cdb_init.d, so that the catalog changes performed by initdb,
 # and the compressor is available in all databases.
 .PHONY: install-data
+
 install-data:
 	$(INSTALL_DATA) zstd_compression.sql '$(DESTDIR)$(datadir)/cdb_init.d/zstd_compression.sql'
 
 install: install-data
+
 
 .PHONY: uninstall-data
 
@@ -31,4 +33,13 @@ uninstall-data:
 	rm -f '$(DESTDIR)$(datadir)/cdb_init.d/zstd_compression.sql'
 
 uninstall: uninstall-data
+
+
+.PHONY: unittest-check unittest-clean
+
+unittest-check:
+	$(MAKE) -C test check
+
+unittest-clean:
+	$(MAKE) -C test clean
 

--- a/gpcontrib/zstd/test/Makefile
+++ b/gpcontrib/zstd/test/Makefile
@@ -1,0 +1,8 @@
+subdir=gpcontrib/zstd/test
+top_builddir=../../..
+
+include $(top_builddir)/src/Makefile.global
+
+TARGETS= zstd_compression
+
+include $(top_builddir)/src/backend/mock.mk

--- a/gpcontrib/zstd/test/mock/zstd_mock.c
+++ b/gpcontrib/zstd/test/mock/zstd_mock.c
@@ -1,6 +1,6 @@
 /* mock functions for zstd.h */
 size_t
-ZSTD_compressCCtx(ZSTD_CCtx * ctx, void * dst, size_t dstCapacity, const void * src, size_t srcSize, int compressionLevel)
+ZSTD_compressCCtx(ZSTD_CCtx * ctx, void *dst, size_t dstCapacity, const void *src, size_t srcSize, int compressionLevel)
 {
-	return (size_t)-ZSTD_error_dstSize_tooSmall;
+	return (size_t) -ZSTD_error_dstSize_tooSmall;
 }

--- a/gpcontrib/zstd/test/mock/zstd_mock.c
+++ b/gpcontrib/zstd/test/mock/zstd_mock.c
@@ -1,0 +1,6 @@
+/* mock functions for zstd.h */
+size_t
+ZSTD_compressCCtx(ZSTD_CCtx * ctx, void * dst, size_t dstCapacity, const void * src, size_t srcSize, int compressionLevel)
+{
+	return (size_t)-ZSTD_error_dstSize_tooSmall;
+}

--- a/gpcontrib/zstd/test/zstd_compression_test.c
+++ b/gpcontrib/zstd/test/zstd_compression_test.c
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#define UNIT_TESTING
+
+/* Include unit under test */
+#include "../zstd_compression.c"
+
+#include "mock/zstd_mock.c"
+
+
+/*
+ * Test compression failure when compressed data is larger than uncompressed
+ */
+void
+test_uncompressed_sz_equals_compressed_sz(void **state)
+{
+    int32 uncompressed_size = 42;
+    int32 compressed_size = 0;
+
+    DirectFunctionCall6(
+        zstd_compress,
+        PointerGetDatum(NULL),
+        Int32GetDatum(uncompressed_size),
+        PointerGetDatum(NULL),
+        Int32GetDatum(uncompressed_size),
+        PointerGetDatum(&compressed_size),
+        PointerGetDatum(NULL)
+    );
+
+    assert_int_equal(compressed_size, uncompressed_size);
+}
+
+int
+main(int argc, char *argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_uncompressed_sz_equals_compressed_sz),
+	};
+
+	MemoryContextInit();
+
+	return run_tests(tests);
+}

--- a/gpcontrib/zstd/test/zstd_compression_test.c
+++ b/gpcontrib/zstd/test/zstd_compression_test.c
@@ -27,6 +27,7 @@
 /* Include unit under test */
 #include "../zstd_compression.c"
 
+/* Include mock functions for zstd.h */
 #include "mock/zstd_mock.c"
 
 

--- a/gpcontrib/zstd/test/zstd_compression_test.c
+++ b/gpcontrib/zstd/test/zstd_compression_test.c
@@ -36,20 +36,20 @@
 void
 test_uncompressed_sz_equals_compressed_sz(void **state)
 {
-    int32 uncompressed_size = 42;
-    int32 compressed_size = 0;
+	int32		uncompressed_size = 42;
+	int32		compressed_size = 0;
 
-    DirectFunctionCall6(
-        zstd_compress,
-        PointerGetDatum(NULL),
-        Int32GetDatum(uncompressed_size),
-        PointerGetDatum(NULL),
-        Int32GetDatum(uncompressed_size),
-        PointerGetDatum(&compressed_size),
-        PointerGetDatum(NULL)
-    );
+	DirectFunctionCall6(
+						zstd_compress,
+						PointerGetDatum(NULL),
+						Int32GetDatum(uncompressed_size),
+						PointerGetDatum(NULL),
+						Int32GetDatum(uncompressed_size),
+						PointerGetDatum(&compressed_size),
+						PointerGetDatum(NULL)
+		);
 
-    assert_int_equal(compressed_size, uncompressed_size);
+	assert_int_equal(compressed_size, uncompressed_size);
 }
 
 int
@@ -57,7 +57,7 @@ main(int argc, char *argv[])
 {
 	cmockery_parse_arguments(argc, argv);
 
-	const UnitTest tests[] = {
+	const		UnitTest tests[] = {
 		unit_test(test_uncompressed_sz_equals_compressed_sz),
 	};
 

--- a/gpcontrib/zstd/zstd_compression.c
+++ b/gpcontrib/zstd/zstd_compression.c
@@ -22,11 +22,11 @@
 PG_MODULE_MAGIC;
 #endif
 
-Datum zstd_constructor(PG_FUNCTION_ARGS);
-Datum zstd_destructor(PG_FUNCTION_ARGS);
-Datum zstd_compress(PG_FUNCTION_ARGS);
-Datum zstd_decompress(PG_FUNCTION_ARGS);
-Datum zstd_validator(PG_FUNCTION_ARGS);
+Datum		zstd_constructor(PG_FUNCTION_ARGS);
+Datum		zstd_destructor(PG_FUNCTION_ARGS);
+Datum		zstd_compress(PG_FUNCTION_ARGS);
+Datum		zstd_decompress(PG_FUNCTION_ARGS);
+Datum		zstd_validator(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(zstd_constructor);
 PG_FUNCTION_INFO_V1(zstd_destructor);
@@ -42,7 +42,7 @@ typedef struct zstd_state
 	bool		compress;		/* Compress if true, decompress otherwise */
 	ZSTD_CCtx  *zstd_compress_context;	/* ZSTD compression context */
 	ZSTD_DCtx  *zstd_decompress_context;	/* ZSTD decompression context */
-} zstd_state;
+}			zstd_state;
 
 Datum
 zstd_constructor(PG_FUNCTION_ARGS)
@@ -108,11 +108,12 @@ zstd_compress(PG_FUNCTION_ARGS)
 
 	if (ZSTD_isError(dst_length_used))
 	{
-		if (ZSTD_getErrorCode(dst_length_used) == ZSTD_error_dstSize_tooSmall) {
+		if (ZSTD_getErrorCode(dst_length_used) == ZSTD_error_dstSize_tooSmall)
+		{
 			/*
 			 * This error is returned when "compressed" output is bigger than
-			 * uncompressed input.
-			 * The caller can detect this by checking dst_used >= src_size
+			 * uncompressed input. The caller can detect this by checking
+			 * dst_used >= src_size
 			 */
 			dst_length_used = src_sz;
 		}
@@ -163,4 +164,3 @@ zstd_validator(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_VOID();
 }
-

--- a/gpcontrib/zstd/zstd_compression.c
+++ b/gpcontrib/zstd/zstd_compression.c
@@ -16,6 +16,7 @@
 #include "utils/builtins.h"
 
 #include <zstd.h>
+#include <zstd_errors.h>
 
 Datum zstd_constructor(PG_FUNCTION_ARGS);
 Datum zstd_destructor(PG_FUNCTION_ARGS);
@@ -104,7 +105,16 @@ zstd_compress(PG_FUNCTION_ARGS)
 
 	if (ZSTD_isError(dst_length_used))
 	{
-		elog(ERROR, "%s", ZSTD_getErrorName(dst_length_used));
+		if (ZSTD_getErrorCode(dst_length_used) == ZSTD_error_dstSize_tooSmall) {
+			/*
+			 * This error is returned when "compressed" output is bigger than
+			 * uncompressed input.
+			 * The caller can detect this by checking dst_used >= src_size
+			 */
+			dst_length_used = src_sz;
+		}
+		else
+			elog(ERROR, "%s", ZSTD_getErrorName(dst_length_used));
 	}
 
 	*dst_used = (int32) dst_length_used;

--- a/gpcontrib/zstd/zstd_compression.c
+++ b/gpcontrib/zstd/zstd_compression.c
@@ -87,6 +87,12 @@ zstd_destructor(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
+/*
+ * zstd compression implementation
+ *
+ * Note that when compression fails due to algorithm inefficiency,
+ * dst_used is set so src_sz, but the output buffer contents are left unchanged
+ */
 Datum
 zstd_compress(PG_FUNCTION_ARGS)
 {

--- a/gpcontrib/zstd/zstd_compression.c
+++ b/gpcontrib/zstd/zstd_compression.c
@@ -18,6 +18,10 @@
 #include <zstd.h>
 #include <zstd_errors.h>
 
+#ifndef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
 Datum zstd_constructor(PG_FUNCTION_ARGS);
 Datum zstd_destructor(PG_FUNCTION_ARGS);
 Datum zstd_compress(PG_FUNCTION_ARGS);
@@ -30,7 +34,6 @@ PG_FUNCTION_INFO_V1(zstd_compress);
 PG_FUNCTION_INFO_V1(zstd_decompress);
 PG_FUNCTION_INFO_V1(zstd_validator);
 
-PG_MODULE_MAGIC;
 
 /* Internal state for zstd */
 typedef struct zstd_state

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -81,7 +81,7 @@ comptype_to_name(char *comptype)
 	len = strlen(comptype);
 	dct = asc_tolower(comptype, len);
 	len = strlen(dct);
-	
+
 	memcpy(&(NameStr(compname)), dct, len);
 	NameStr(compname)[len] = '\0';
 	pfree(dct);


### PR DESCRIPTION
This closes #6200.

When ZSTD compression is used for AO CO tables, insert operations may cause an error "Destination buffer is too small". This happens when compressed output is larger than uncompressed input.

Output buffer is now left unchanged, and `dst_used` passed to `zstd_compress` is set to `src_sz`. The caller (e.g., `cdbappendonlystoragewrite.c`) is able to handle this; it copies data from input to output buffer itself and sets header bytes accordingly, preventing the future decompression call.

A new header file, `zstd_errors.h`, is required; its check is added to `configure.in`. The header file itself is present in ZSTD library.