### PR TITLE
Remove restriction to INSERT/UPDATE/DELETE foreign relations

### DIFF
--- a/contrib/file_fdw/output/file_fdw.source
+++ b/contrib/file_fdw/output/file_fdw.source
@@ -243,7 +243,7 @@ SET ROLE file_fdw_user;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_text WHERE a > 0;
  Foreign Scan on public.agg_text
    Output: a, b
-   Filter: agg_text.a > 0
+   Filter: (agg_text.a > 0)
    Foreign File: @abs_srcdir@/data/agg.data
  Optimizer: legacy query optimizer
 

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -364,14 +364,6 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 				 errmsg("permission denied: \"%s\" is a system catalog",
 						 RelationGetRelationName(pstate->p_target_relation))));
 
-	/* special check for DML on foreign relations */
-	if(RelationIsForeign(pstate->p_target_relation))
-		ereport(ERROR,
-				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-				 errmsg("foreign tables are read only. cannot change \"%s\"",
-						 RelationGetRelationName(pstate->p_target_relation))));
-
-
 	/* special check for DML on external relations */
 	if(RelationIsExternal(pstate->p_target_relation))
 	{


### PR DESCRIPTION
While spiking on implementing PXF using FDW,
we noticed that error messages for file_fdw
were different from upstream error messages
when updating a file_fdw. GPDB introduced a
check in `setTargetTable` for foreign relations
that might have not been cleaned up during
merge. This PR removes the check in `setTargetTable`
and fixes the expected output in file_fdw.
Running make installcheck on file_fdw, now
succeeds, as we are matching the upstream
error message "updates aren't supported".

Lifting this restriction will also unblock us in the
development for consuming FDW routines for
updating foreign tables.

Authored-by: Francisco Guerrero <aguerrero@pivotal.io>