### PR TITLE
Fix memory leak in eval_part_qual

### DIFF
--- a/src/backend/cdb/partitionselection.c
+++ b/src/backend/cdb/partitionselection.c
@@ -70,16 +70,12 @@ eval_propagation_expression(PartitionSelectorState *node, Oid part_oid)
  * ----------------------------------------------------------------
  */
 static bool
-eval_part_qual(ExprState *exprstate, PartitionSelectorState *node, TupleTableSlot *inputTuple)
+eval_part_qual(ExprContext *econtext, TupleTableSlot *inputTuple, List *qualList)
 {
-	/* evaluate generalPredicate */
-	ExprContext *econtext = node->ps.ps_ExprContext;
-
+	/* evaluate predicate */
 	ResetExprContext(econtext);
 	econtext->ecxt_outertuple = inputTuple;
 	econtext->ecxt_scantuple = inputTuple;
-
-	List	   *qualList = list_make1(exprstate);
 
 	return ExecQual(qualList, econtext, false /* result is not for null */ );
 }
@@ -165,9 +161,9 @@ partition_rules_for_general_predicate(PartitionSelectorState *node, int level,
 		node->levelPartRules[level] = rule;
 
 		/* evaluate generalPredicate */
-		ExprState  *exprstate = (ExprState *) lfirst(list_nth_cell(node->levelExprStates, level));
+		List  *qualList = (List *) lfirst(list_nth_cell(node->levelExprStateLists, level));
 
-		if (eval_part_qual(exprstate, node, inputTuple))
+		if (eval_part_qual(node->ps.ps_ExprContext, inputTuple, qualList))
 		{
 			result = lappend(result, rule);
 		}
@@ -182,9 +178,9 @@ partition_rules_for_general_predicate(PartitionSelectorState *node, int level,
 		node->levelPartRules[level] = parentNode->default_part;
 
 		/* evaluate generalPredicate */
-		ExprState  *exprstate = (ExprState *) lfirst(list_nth_cell(node->levelExprStates, level));
+		List  *qualList = (List *) lfirst(list_nth_cell(node->levelExprStateLists, level));
 
-		if (eval_part_qual(exprstate, node, inputTuple))
+		if (eval_part_qual(node->ps.ps_ExprContext, inputTuple, qualList))
 		{
 			result = lappend(result, parentNode->default_part);
 		}
@@ -358,9 +354,7 @@ processLevel(PartitionSelectorState *node, int level, TupleTableSlot *inputTuple
 			if (NULL != ps->residualPredicate)
 			{
 				/* evaluate residualPredicate */
-				ExprState  *exprstate = node->residualPredicateExprState;
-
-				shouldPropagate = eval_part_qual(exprstate, node, inputTuple);
+				shouldPropagate = eval_part_qual(node->ps.ps_ExprContext, inputTuple, node->residualPredicateExprStateList);
 			}
 
 			if (shouldPropagate)
@@ -435,14 +429,14 @@ initPartitionSelection(PartitionSelector *node, EState *estate)
 	{
 		Expr	   *generalExpr = (Expr *) lfirst(lc);
 
-		psstate->levelExprStates = lappend(psstate->levelExprStates,
-										   ExecInitExpr(generalExpr, (PlanState *) psstate));
+		ExprState *generalExprState = ExecInitExpr(generalExpr, (PlanState *) psstate);
+		psstate->levelExprStateLists = lappend(psstate->levelExprStateLists, list_make1(generalExprState));
 	}
 
-	psstate->residualPredicateExprState = ExecInitExpr((Expr *) node->residualPredicate,
-													   (PlanState *) psstate);
-	psstate->propagationExprState = ExecInitExpr((Expr *) node->propagationExpression,
-												 (PlanState *) psstate);
+	ExprState *residualPredicateExprState = ExecInitExpr((Expr *) node->residualPredicate,
+														 (PlanState *) psstate);
+	psstate->residualPredicateExprStateList = list_make1(residualPredicateExprState);
+	psstate->propagationExprState = ExecInitExpr((Expr *) node->propagationExpression, (PlanState *) psstate);
 
 	psstate->ps.targetlist = (List *) ExecInitExpr((Expr *) node->plan.targetlist,
 												   (PlanState *) psstate);

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2996,8 +2996,8 @@ typedef struct PartitionSelectorState
 	PartitionAccessMethods *accessMethods;              /* Access method for partition */
 	struct PartitionRule **levelPartRules; 				/* accepted partitions for all levels */
 	List *levelEqExprStates;                            /* ExprState for equality expressions for all levels */
-	List *levelExprStates;                              /* ExprState for general expressions for all levels */
-	ExprState *residualPredicateExprState;              /* ExprState for evaluating residual predicate */
+	List *levelExprStateLists;                          /* ExprState list for general expressions for all levels */
+	List *residualPredicateExprStateList;               /* ExprState list for evaluating residual predicate */
 	ExprState *propagationExprState;                    /* ExprState for evaluating propagation expression */
 
 	TupleDesc	partTabDesc;

--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -12,11 +12,11 @@ insert into test select i, i % 100 from generate_series(1,1000) as i;
 -- start_ignore
 create language plpythonu;
 -- end_ignore
-create or replace function sum_alien_consumption(query text) returns int as
+create or replace function sum_owner_consumption(query text, owner text) returns int as
 $$
 import re
 rv = plpy.execute('EXPLAIN ANALYZE '+ query)
-search_text = 'X_Alien'
+search_text = owner
 total_consumption = 0
 count = 0
 comp_regex = re.compile("[^0-9]+(\d+)\/(\d+).+")
@@ -31,14 +31,14 @@ for i in range(len(rv)):
 return total_consumption
 $$
 language plpythonu;
-select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j') = 0;
+select sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien') = 0;
  ?column? 
 ----------
  t
 (1 row)
 
 set execute_pruned_plan=off;
-select sum_alien_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j') > 0;
+select sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien') > 0;
  ?column? 
 ----------
  t
@@ -234,5 +234,54 @@ select has_account_type('select oneoff_plan_func(i) from all_tuples_on_seg0', 'E
  has_account_type 
 ------------------
                 3
+(1 row)
+
+-- The memory consumption for X_PartitionSelector should not go above 1 MB
+-- total on all 3 segments -- It was around 7 MB before the bug in eval_part_qual was
+-- fixed. Although, It was max around .07MB after the fix, but have kept a small buffer.
+set explain_memory_verbosity=detail;
+-- start_ignore
+drop table if exists bar_part;
+NOTICE:  table "bar_part" does not exist, skipping
+drop table if exists foo;
+NOTICE:  table "foo" does not exist, skipping
+-- end_ignore
+create table bar_part (a int, b int) distributed by (b) partition by range(b) (start(1) end (2) every(1));
+NOTICE:  CREATE TABLE will create partition "bar_part_1_prt_1" for table "bar_part"
+create table foo (a int, b int) distributed by (b);
+insert into bar_part select 1, 1 from generate_series(1,100000)i;
+insert into foo select 1, 1 from generate_series(1,80000)i;
+analyze foo;
+analyze bar_part;
+select sum_owner_consumption('select * from bar_part where exists (select 1 from foo where foo.b = bar_part.b and bar_part.b > 0);', 'X_PartitionSelector') between 1 and 1000000;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- We expect, one slice in the plan for the top Gather Motion. Corresponding to
+-- each segment, there will be 1 instance of the slice, thus total 3 Executor
+-- accounts for 3 segments
+select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0', 'Executor');
+ has_account_type 
+------------------
+                3
+(1 row)
+
+-- Inserting even more data does not cause the memory usage to go high as it
+-- should be independent of the tuples. However, before the fix, it increased with
+-- more rows. Check the memory for X_PartitionSelector owner does not go above 1 MB.
+insert into foo select 1, 1 from generate_series(1,80000)i;
+select sum_owner_consumption('select * from bar_part where exists (select 1 from foo where foo.b = bar_part.b and bar_part.b > 0);', 'X_PartitionSelector') between 1 and 1000000;
+ ?column? 
+----------
+ t
+(1 row)
+
+insert into foo select 1, 1 from generate_series(1,80000)i;
+select sum_owner_consumption('select * from bar_part where exists (select 1 from foo where foo.b = bar_part.b and bar_part.b > 0);', 'X_PartitionSelector') between 1 and 1000000;
+ ?column? 
+----------
+ t
 (1 row)
 


### PR DESCRIPTION
Whenever `eval_part_qual` is invoked, a new qualList object is allocated
and is executed to evaluate a bool result. Once, the qualList is used,
we should free the memory, else we leak memory and can run into OOM
errors for queries on partitioned tables which uses general predicate to
evaluate the partition rule to select.

However, its ideal to perform the memory allocation in `ExecInitPartitionSelector`, so move the allocation to it.

Repro (On my MAC with 1 segment)
```
DROP TABLE IF EXISTS foo;
CREATE TABLE foo (col2 text, col5_date date) DISTRIBUTED BY (col2);

DROP TABLE IF EXISTS bar_partitioned;
CREATE TABLE bar_partitioned (col2 text, col5_date date)
WITH (appendonly=true) DISTRIBUTED BY (col2) PARTITION BY RANGE(col5_date)
  ( START ('2017-10-01'::date) END ('2018-11-02'::date) EVERY (INTERVAL '1 day'));
insert into foo select i::text,'2018-11-01' from generate_series(1,512000)i;
insert into bar_partitioned select i::text,'2018-11-01' from generate_series(1,512000)i;

DELETE FROM bar_partitioned T1 WHERE EXISTS
    (SELECT 1 FROM foo T2
     WHERE T1.col5_date = T2.col5_date
       AND T1.col2 = T2.col2
       AND T1.col5_date <= CAST('2018-11-03' AS DATE)
       AND T1.col5_date > CAST('2018-11-03' AS DATE) + interval '- 10 day' );
ERROR:  Canceling query because of high VMEM usage. Used: 7375MB, available 817MB, red zone: 7372MB (runaway_cleaner.c:189)  (seg0 127.0.0.1:25432 pid=65863) (runaway_cleaner.c:189)
Time: 98692.938 ms
```

Please see the attached trace showing the memory allocated in `eval_part_qual` method.
<img width="1454" alt="screen shot 2018-11-10 at 9 48 04 am" src="https://user-images.githubusercontent.com/10293569/48304804-c68b0780-e4d4-11e8-8671-9272cb744770.png">
For `ExecPartitionSelector`, the peak was around 7298.45MB, i.e `7.29GB`, almost the same for the query, indicating most of the memory was allocated in `ExecPartitionSelector`. The query failed with OOM.

After the fix, the peak it went for the query was around `45MB`, also the query finished successfully.
<img width="1428" alt="screen shot 2018-11-10 at 10 48 49 am" src="https://user-images.githubusercontent.com/10293569/48304880-5c736200-e4d6-11e8-94f3-438c1f36bfc0.png">
 and especially in `ExecPartitionSelector` the max was 37KB

Note: Running Pipeline to verify the change and will try to identify what test case can we add for it.