### PR TITLE
Set dbname and username when MyProcPort is not initialized when setup…

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -357,6 +357,7 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 		 * get database name from MyDatabaseId, which is initialized
 		 * in InitPostgres()
 		 */
+		Assert(MyDatabaseId != InvalidOid);
 		values[nkeywords] = get_database_name(MyDatabaseId);
 	}
 	nkeywords++;

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -15,6 +15,7 @@
  */
 #include "postgres.h"
 
+#include "commands/dbcommands.h"
 #include "libpq-fe.h"
 #include "libpq-int.h"
 #include "miscadmin.h"
@@ -345,16 +346,34 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 	values[nkeywords] = portstr;
 	nkeywords++;
 
-	if (MyProcPort->database_name)
+	keywords[nkeywords] = "dbname";
+	if(MyProcPort && MyProcPort->database_name)
 	{
-		keywords[nkeywords] = "dbname";
-		values[nkeywords] = MyProcPort->database_name;
-		nkeywords++;
+		values[nkeywords] = MyProcPort->database_name;	
 	}
+	else
+	{
+		/*
+		 * get database name from MyDatabaseId, which is initialized
+		 * in InitPostgres()
+		 */
+		values[nkeywords] = get_database_name(MyDatabaseId);
+	}
+	nkeywords++;
 
-	Assert(MyProcPort->user_name);
 	keywords[nkeywords] = "user";
-	values[nkeywords] = MyProcPort->user_name;
+	if (MyProcPort && MyProcPort->user_name)
+	{
+		values[nkeywords] = MyProcPort->user_name;
+	}
+	else
+	{
+		/*
+		 * get user name from AuthenticatedUserId which is initialized
+		 * in InitPostgres()
+		 */
+		values[nkeywords] = GetUserNameFromId(GetAuthenticatedUserId());
+	}
 	nkeywords++;
 
 	keywords[nkeywords] = NULL;


### PR DESCRIPTION
… connection.

InitPostgres() in GPDB needs to recover DTM, and will setup connection
from QD to QE by calling cdbconn_doConnectStart(), cdbconn_doConnectStart()
uses MyProcPort to get username and dbname currently. But for background
worker, MyProcPort is not set. Set MyProcPort before InitPostgres() is not
appropriate since catalog is not initialized. We could use MyDatabaseId and
AuthenticatedUserId instead, which are initialized in InitPostgres() for
background worker.