### PR TITLE
Fix bitmap index bug.

### DIFF
--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -12,7 +12,13 @@ select count(*) from bm_test where i=1;
     10
 (1 row)
 
-select count(*) from bm_test where i in(1, 3);
+select count(*) from bm_test where i in(1, 2);
+ count 
+-------
+    20
+(1 row)
+
+select count(*) from bm_test where i in(1, 8); -- tuple with i = 1 and i = 8 is on different segments
  count 
 -------
     20

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -12,7 +12,13 @@ select count(*) from bm_test where i=1;
     10
 (1 row)
 
-select count(*) from bm_test where i in(1, 3);
+select count(*) from bm_test where i in(1, 2);
+ count 
+-------
+    20
+(1 row)
+
+select count(*) from bm_test where i in(1, 8); -- tuple with i = 1 and i = 8 is on different segments
  count 
 -------
     20

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -6,7 +6,8 @@ create table bm_test (i int, t text);
 insert into bm_test select i % 10, (i % 10)::text  from generate_series(1, 100) i;
 create index bm_test_idx on bm_test using bitmap (i);
 select count(*) from bm_test where i=1;
-select count(*) from bm_test where i in(1, 3);
+select count(*) from bm_test where i in(1, 2);
+select count(*) from bm_test where i in(1, 8); -- tuple with i = 1 and i = 8 is on different segments
 select * from bm_test where i > 10;
 reindex index bm_test_idx;
 select count(*) from bm_test where i in(1, 3);


### PR DESCRIPTION
This commit fix github issue: #5353. If bmgetbimap
cannot acquire a bitmap, it return an empty TIDBITMAP.
This will cause an error in the next time loop in
MultiExecBitmapIndexScan.

An example is shown here:
```sql
SET enable_seqscan = OFF;
SET enable_indexscan = ON;
SET enable_bitmapscan = ON;

create table bm_test (i int, t text);
insert into bm_test select i % 10, (i % 10)::text  from generate_series(1, 100) i;
create index bm_test_idx on bm_test using bitmap (i);
select count(*) from bm_test where i=1;
select count(*) from bm_test where i in(1, 8);
```
The tuple with `i = 1` and the tuple with `i=8` is on different segments.

When we execute the expr `i in (1,8)`, we do the following  work on each segment:
  loop the array `(1, 8)` to get two bitmaps and merge them using OR. (See function
  `MultiExecBitmapIndexScan`)

Suppose on the segment where `i=8` is, it first tries to get bitmap for `i=1`.
Since there is no bitmap for `i=1` on this segment, it will return an empty
TIDBitmap(see function `bmgetbitmap`). Then the next time, we could find
`i=8`'s bitmap, but its type is `StreamBitmap`, we cannot merge it with
the previous TIDBitmap. That is the bug's root cause.

In this commit, we fix this by returning an empty TIDbitmap in the function
bmgetbitmap and correctly process the accumulated process of bitmap. And we
also improve the code in `MultiExecBitmapIndexScan` to process bitmap correctly.

A test case has been added also.

Co-authored-by: Shujie Zhang <shzhang@pivotal.io>
Co-authored-by: Zhenghua Lyu <zlv@pivotal.io>

---------

Previous PR is here:  https://github.com/greenplum-db/gpdb/pull/5354
Let's reopen it to fix it first.