### PR TITLE
Fix overwriting of pg_class statistics during VACUUM

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1494,6 +1494,12 @@ vac_update_relstats_from_list(List *updated_stats)
 {
 	ListCell *lc;
 
+	/*
+	 * This function is only called in the context of the QD, so let's be
+	 * explicit about that given the assumptions taken.
+	 */
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+
 	foreach (lc, updated_stats)
 	{
 		VPgClassStats *stats = (VPgClassStats *) lfirst(lc);
@@ -1508,17 +1514,13 @@ vac_update_relstats_from_list(List *updated_stats)
 			stats->relallvisible = stats->relallvisible / rel->rd_cdbpolicy->numsegments;
 		}
 
-		/*
-		 * Pass 'false' for isvacuum, so that the stats are
-		 * actually updated.
-		 */
 		vac_update_relstats(rel,
 							stats->rel_pages, stats->rel_tuples,
 							stats->relallvisible,
 							rel->rd_rel->relhasindex,
 							InvalidTransactionId,
 							InvalidMultiXactId,
-							false /* isvacuum */);
+							true /* isvacuum */);
 		relation_close(rel, AccessShareLock);
 	}
 }

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -287,3 +287,27 @@ VACUUM ANALYZE s_priv_test.t_priv_table;
 DROP SCHEMA s_priv_test CASCADE;
 NOTICE:  drop cascades to table s_priv_test.t_priv_table
 DROP ROLE r_priv_test;
+-- Ensure that VACUUM doesn't reset the statistics on the parent table
+CREATE TABLE pt (a int, b int) DISTRIBUTED BY (a) PARTITION BY range (b) (END(5), START(5));
+INSERT INTO pt SELECT 0, 6 FROM generate_series(1, 12);
+ANALYZE pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+ reltuples 
+-----------
+        12
+(1 row)
+
+VACUUM pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+ reltuples 
+-----------
+        12
+(1 row)
+
+VACUUM ANALYZE pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+ reltuples 
+-----------
+        12
+(1 row)
+

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -188,3 +188,13 @@ ALTER TABLE s_priv_test.t_priv_table OWNER TO r_priv_test;
 VACUUM ANALYZE s_priv_test.t_priv_table;
 DROP SCHEMA s_priv_test CASCADE;
 DROP ROLE r_priv_test;
+
+-- Ensure that VACUUM doesn't reset the statistics on the parent table
+CREATE TABLE pt (a int, b int) DISTRIBUTED BY (a) PARTITION BY range (b) (END(5), START(5));
+INSERT INTO pt SELECT 0, 6 FROM generate_series(1, 12);
+ANALYZE pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+VACUUM pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+VACUUM ANALYZE pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';


### PR DESCRIPTION
vac_update_relstats_from_list is only called on the QD during lazy
VACUUMing (it used to have several callsites), and thus we need to
set isvacuum to true to avoid that it overwrites the statistics in
pg_class with bogus values from the QD.

This reported as resetting reltupes for parent tables in partition
hierarchies, so add a testcase to ensure reltuples are maintained.

Also add an assertion on QD operation to the function to indicate
when reading code that this function may make assumptins that are
only valid on the QD.