### PR TITLE
pg_upgrade: add a simple timing of pg_upgrade in test_upgrade.sh

### DIFF
--- a/concourse/scripts/test_upgrade.bash
+++ b/concourse/scripts/test_upgrade.bash
@@ -229,6 +229,7 @@ run_upgrade() {
 
     ssh -ttn "$hostname" '
         source '"${NEW_GPHOME}"'/greenplum_path.sh
+        export TIMEFORMAT=$'\'''"$hostname"'::'"$datadir"'\telapsed\t%3lR\tuser\t%3lU\tsys\t%3lS'\''
         time pg_upgrade '"${upgrade_opts}"' '"$*"' \
             -b '"${OLD_GPHOME}"'/bin/ -B '"${NEW_GPHOME}"'/bin/ \
             -d '"$datadir"' \


### PR DESCRIPTION
Add a simple seconds-based resolution of the time each pg_upgrade step takes, including the hostname and directory used.  Although this information is currently available from the log, its format is adhoc and requires assumptions about what is printed out.  This makes the performance simpler to parse, and takes a trivial amount of extra time.