### PR TITLE
Correct behavior for reshuffling partition tables

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14662,7 +14662,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 					 */
 					targetRelPartStatus = rel_part_status(RelationGetRelid(rel));
 
-					if(PART_STATUS_ROOT == targetRelPartStatus ||
+					if(PART_STATUS_LEAF == targetRelPartStatus ||
 					   PART_STATUS_NONE == targetRelPartStatus)
 					{
 						ReshuffleRelationData(rel);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14649,27 +14649,44 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 				{
 					MemoryContext oldcontext;
 					GpPolicy *newPolicy;
+					PartStatus targetRelPartStatus;
 
 					if (NULL != lsecond(lprime))
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 										errmsg("Can not set Distribute By")));
 
-					ReshuffleRelationData(rel);
+					/*
+					 * We generate a UpdateStmt when the relation is non-partition
+					 * table or root-partition table.
+					 */
+					targetRelPartStatus = rel_part_status(RelationGetRelid(rel));
 
+					if(PART_STATUS_ROOT == targetRelPartStatus ||
+					   PART_STATUS_NONE == targetRelPartStatus)
+					{
+						ReshuffleRelationData(rel);
+					}
+
+					/* Generate a new policy and adjust the numsegments */
 					policy = rel->rd_cdbpolicy;
 					oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
 					newPolicy = GpPolicyCopy(policy);
 					MemoryContextSwitchTo(oldcontext);
+
 					newPolicy->numsegments = getgpsegmentCount();
 
+					/* Update the numsegments in gp_distribution_policy */
 					GpPolicyReplace(RelationGetRelid(rel), newPolicy);
 					oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
 					rel->rd_cdbpolicy = GpPolicyCopy(newPolicy);
 					MemoryContextSwitchTo(oldcontext);
-
 					heap_close(rel, NoLock);
 
+					/*
+					 * Save the policy in the CMD, it would be dispatched in
+					 * next step.
+					 */
 					lsecond(lprime) = makeNode(SetDistributionCmd);
 					/*
 					 * Notice: reshuffle can not specify (Distribute By), so

--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -782,6 +782,121 @@ select numsegments from gp_distribution_policy where localoid='part_t1_reshuffle
 (1 row)
 
 drop table part_t1_reshuffle;
+-- only alter leaf partition
+CREATE TABLE part_t1_reshuffle(a int, b int, c int, d int, e int)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b" for table "part_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c" for table "part_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_one" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_two" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_three" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_others_d" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2" for table "part_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_one" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_two" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_three" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3" for table "part_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_one" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_two" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_three" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_others_d" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2" for table "part_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c" for table "part_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_one" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_two" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_three" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_others_d" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2" for table "part_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_one" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_two" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_three" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_others_d" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3" for table "part_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_one" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_two" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_three" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_others_d" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_t1_reshuffle%');
+insert into part_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_t1_reshuffle set e = gp_segment_id;
+select gp_segment_id, * from part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 65 | 2 | 1 | 0 | 0
+             0 | 69 | 0 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+(7 rows)
+
+begin;
+alter table part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+select gp_segment_id, * from part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             2 | 65 | 2 | 1 | 0 | 0
+             2 | 69 | 0 | 1 | 4 | 0
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+(7 rows)
+
+abort;
+select gp_segment_id, * from part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 65 | 2 | 1 | 0 | 0
+             0 | 69 | 0 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+(7 rows)
+
+alter table part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+select gp_segment_id, * from part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             2 | 65 | 2 | 1 | 0 | 0
+             2 | 69 | 0 | 1 | 4 | 0
+(7 rows)
+
+-- try to reshuffle root partition, it will raise a notice
+Alter table part_t1_reshuffle set with (reshuffle);
+NOTICE:  Do not need to reshuffle public.part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             2 |    28
+             1 |    40
+(3 rows)
+
+drop table part_t1_reshuffle;
 -- inherits tables
 CREATE TABLE inherit_t1_reshuffle_p1(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -16,9 +16,9 @@ Alter table t1_reshuffle set with (reshuffle);
 Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             1 |    40
              0 |    32
              2 |    28
+             1 |    40
 (3 rows)
 
 abort;
@@ -33,9 +33,9 @@ Alter table t1_reshuffle set with (reshuffle);
 Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
+             2 |    28
              0 |    32
              1 |    40
-             2 |    28
 (3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
@@ -61,9 +61,9 @@ Alter table t1_reshuffle set with (reshuffle);
 Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             0 |    31
-             1 |    35
              2 |    34
+             1 |    35
+             0 |    31
 (3 rows)
 
 abort;
@@ -77,9 +77,9 @@ Alter table t1_reshuffle set with (reshuffle);
 Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             0 |    31
              2 |    34
              1 |    35
+             0 |    31
 (3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
@@ -113,9 +113,9 @@ Alter table t1_reshuffle set with (reshuffle);
 Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
+             0 |     2
              2 |     3
              1 |     3
-             0 |     2
 (3 rows)
 
 abort;
@@ -131,8 +131,8 @@ Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              2 |     3
-             0 |     2
              1 |     3
+             0 |     2
 (3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
@@ -146,10 +146,7 @@ Create table t1_reshuffle(a int, b int, c int) distributed by (a) partition by l
 NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_t1_reshuffle_1" for table "t1_reshuffle"
 NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_t1_reshuffle_2" for table "t1_reshuffle"
 NOTICE:  CREATE TABLE will create partition "t1_reshuffle_1_prt_other" for table "t1_reshuffle"
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_t1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_t1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle'::regclass;
+update gp_distribution_policy set numsegments = 1 where localoid in (select oid from pg_class where relname like 't1_reshuffle%');
 insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
 Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
@@ -162,9 +159,9 @@ Alter table t1_reshuffle set with (reshuffle);
 Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             0 |    32
              2 |    28
              1 |    40
+             0 |    32
 (3 rows)
 
 abort;
@@ -178,9 +175,9 @@ Alter table t1_reshuffle set with (reshuffle);
 Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
+             1 |    40
              2 |    28
              0 |    32
-             1 |    40
 (3 rows)
 
 select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::regclass;
@@ -322,10 +319,7 @@ Create table r1_reshuffle(a int, b int, c int) distributed randomly partition by
 NOTICE:  CREATE TABLE will create partition "r1_reshuffle_1_prt_r1_reshuffle_1" for table "r1_reshuffle"
 NOTICE:  CREATE TABLE will create partition "r1_reshuffle_1_prt_r1_reshuffle_2" for table "r1_reshuffle"
 NOTICE:  CREATE TABLE will create partition "r1_reshuffle_1_prt_other" for table "r1_reshuffle"
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1_prt_r1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1_prt_r1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle'::regclass;
+update gp_distribution_policy set numsegments = 2 where localoid in (select oid from pg_class where relname like 'r1_reshuffle%');
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
 Select count(*) from r1_reshuffle;
  count 
@@ -387,78 +381,45 @@ select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::re
 
 drop table r1_reshuffle;
 -- Replicated tables
--- We have to make sure replicated table successfully reshuffled.
 Create table r1_reshuffle(a int, b int, c int) distributed replicated;
-select update_numsegments_in_policy('r1_reshuffle', 1);
+select update_numsegments_in_policy('r1_reshuffle'::regclass, 1);
  update_numsegments_in_policy 
 ------------------------------
  
 (1 row)
 
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 0
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 0
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
 begin;
 Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |   100
+             2 |   100
+             0 |   100
+(3 rows)
 
 abort;
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 0
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 0
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
 Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |   100
+             1 |   100
+             0 |   100
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
  numsegments 
@@ -467,78 +428,47 @@ select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::re
 (1 row)
 
 drop table r1_reshuffle;
+--
 Create table r1_reshuffle(a int, b int, c int) with OIDS distributed replicated;
 NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
-select update_numsegments_in_policy('r1_reshuffle', 2);
+select update_numsegments_in_policy('r1_reshuffle'::regclass, 1);
  update_numsegments_in_policy 
 ------------------------------
  
 (1 row)
 
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 0
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
 begin;
 Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |   100
+             0 |   100
+             2 |   100
+(3 rows)
 
 abort;
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 0
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
 Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |   100
+             2 |   100
+             0 |   100
+(3 rows)
 
 select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
  numsegments 
@@ -650,3 +580,265 @@ select gp_segment_id, * from mix_base_tbl order by 2, 1;
              2 | 24 | 23
 (9 rows)
 
+-- multi-level partition tables
+CREATE TABLE part_t1_reshuffle(a int, b int, c int, d int, e int)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b" for table "part_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c" for table "part_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_one" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_two" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_three" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_others_d" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2" for table "part_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_one" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_two" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_three" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3" for table "part_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_one" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_two" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_three" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_others_d" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2" for table "part_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c" for table "part_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_one" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_two" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_three" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_others_d" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2" for table "part_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_one" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_two" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_three" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_others_d" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3" for table "part_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_one" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_two" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_three" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_others_d" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_t1_reshuffle%');
+insert into part_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_t1_reshuffle set e = gp_segment_id;
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
+
+begin;
+Alter table part_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |    28
+             1 |    40
+             0 |    32
+(3 rows)
+
+abort;
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
+
+Alter table part_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             2 |    28
+             1 |    40
+(3 rows)
+
+select numsegments from gp_distribution_policy where localoid='part_t1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
+drop table part_t1_reshuffle;
+--
+CREATE TABLE part_t1_reshuffle(a int, b int, c int, d int, e int)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b" for table "part_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c" for table "part_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_one" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_two" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_three" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_others_d" for table "part_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2" for table "part_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_one" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_two" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_three" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d" for table "part_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3" for table "part_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_one" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_two" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_three" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_others_d" for table "part_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2" for table "part_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c" for table "part_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_one" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_two" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_three" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_others_d" for table "part_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2" for table "part_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_one" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_two" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_three" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_2_3_prt_others_d" for table "part_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3" for table "part_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_one" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_two" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_three" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_t1_reshuffle_1_prt_2_2_prt_3_3_prt_others_d" for table "part_t1_reshuffle_1_prt_2_2_prt_3"
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_t1_reshuffle%');
+insert into part_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_t1_reshuffle set e = gp_segment_id;
+Select count(*) from part_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
+Alter table part_t1_reshuffle set with (reshuffle);
+Select count(*) from part_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+abort;
+Select count(*) from part_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table part_t1_reshuffle set with (reshuffle);
+Select count(*) from part_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='part_t1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
+drop table part_t1_reshuffle;
+-- inherits tables
+CREATE TABLE inherit_t1_reshuffle_p1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE inherit_t1_reshuffle_p2(a int, b int) INHERITS (inherit_t1_reshuffle_p1);
+NOTICE:  Table has parent, setting distribution columns to match parent table
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+CREATE TABLE inherit_t1_reshuffle_p3(a int, b int) INHERITS (inherit_t1_reshuffle_p1);
+NOTICE:  Table has parent, setting distribution columns to match parent table
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+CREATE TABLE inherit_t1_reshuffle_p4(a int, b int) INHERITS (inherit_t1_reshuffle_p2);
+NOTICE:  Table has parent, setting distribution columns to match parent table
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+CREATE TABLE inherit_t1_reshuffle_p5(a int, b int) INHERITS (inherit_t1_reshuffle_p3);
+NOTICE:  Table has parent, setting distribution columns to match parent table
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'inherit_t1_reshuffle%');
+insert into inherit_t1_reshuffle_p1 select i,i from generate_series(1,10) i;
+insert into inherit_t1_reshuffle_p2 select i,i from generate_series(1,10) i;
+insert into inherit_t1_reshuffle_p3 select i,i from generate_series(1,10) i;
+insert into inherit_t1_reshuffle_p4 select i,i from generate_series(1,10) i;
+insert into inherit_t1_reshuffle_p5 select i,i from generate_series(1,10) i;
+select count(*) > 0 from inherit_t1_reshuffle_p1 where gp_segment_id = 2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
+alter table inherit_t1_reshuffle_p1 set with(reshuffle);
+select count(*) > 0 from inherit_t1_reshuffle_p1 where gp_segment_id = 2;
+ ?column? 
+----------
+ t
+(1 row)
+
+abort;
+select count(*) > 0 from inherit_t1_reshuffle_p1 where gp_segment_id = 2;
+ ?column? 
+----------
+ f
+(1 row)
+
+alter table inherit_t1_reshuffle_p1 set with(reshuffle);
+select count(*) > 0 from inherit_t1_reshuffle_p1 where gp_segment_id = 2;
+ ?column? 
+----------
+ t
+(1 row)
+
+DROP TABLE inherit_t1_reshuffle_p1 CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table inherit_t1_reshuffle_p2
+drop cascades to table inherit_t1_reshuffle_p4
+drop cascades to table inherit_t1_reshuffle_p3
+drop cascades to table inherit_t1_reshuffle_p5

--- a/src/test/regress/expected/reshuffle_ao.out
+++ b/src/test/regress/expected/reshuffle_ao.out
@@ -1,10 +1,10 @@
 set allow_system_table_mods=true;
 -- Hash distributed tables
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_ao set c = gp_segment_id;
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Create table ao_t1_reshuffle(a int, b int, c int) with (appendonly=true) distributed by (a);
+update gp_distribution_policy  set numsegments=2 where localoid='ao_t1_reshuffle'::regclass;
+insert into ao_t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update ao_t1_reshuffle set c = gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              1 |    51
@@ -12,53 +12,53 @@ Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
 (2 rows)
 
 begin;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
+             1 |    40
              0 |    32
              2 |    28
-             1 |    40
 (3 rows)
 
 abort;
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              1 |    51
              0 |    49
 (2 rows)
 
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
+             1 |    40
              0 |    32
              2 |    28
-             1 |    40
 (3 rows)
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
+select numsegments from gp_distribution_policy where localoid='ao_t1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table t1_reshuffle_ao;
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed by (a,b);
+drop table ao_t1_reshuffle;
+Create table ao_t1_reshuffle(a int, b int, c int) with (appendonly=true, OIDS) distributed by (a,b);
 NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_ao set c = gp_segment_id;
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+update gp_distribution_policy  set numsegments=1 where localoid='ao_t1_reshuffle'::regclass;
+insert into ao_t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update ao_t1_reshuffle set c = gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |   100
 (1 row)
 
 begin;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |    31
@@ -67,32 +67,32 @@ Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
 (3 rows)
 
 abort;
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |   100
 (1 row)
 
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             0 |    31
              2 |    34
+             0 |    31
              1 |    35
 (3 rows)
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
+select numsegments from gp_distribution_policy where localoid='ao_t1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table t1_reshuffle_ao;
+drop table ao_t1_reshuffle;
 -- Test NULLs.
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b,c);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao values
+Create table ao_t1_reshuffle(a int, b int, c int) with (appendonly=true) distributed by (a,b,c);
+update gp_distribution_policy  set numsegments=2 where localoid='ao_t1_reshuffle'::regclass;
+insert into ao_t1_reshuffle values
   (1,    1,    1   ),
   (null, 2,    2   ),
   (3,    null, 3   ),
@@ -101,7 +101,7 @@ insert into t1_reshuffle_ao values
   (null, 6,    null),
   (7,    null, null),
   (null, null, null);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              1 |     4
@@ -109,441 +109,573 @@ Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
 (2 rows)
 
 begin;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             0 |     2
              2 |     3
+             0 |     2
              1 |     3
 (3 rows)
 
 abort;
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              1 |     4
              0 |     4
 (2 rows)
 
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |     2
-             1 |     3
              2 |     3
+             1 |     3
 (3 rows)
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
+select numsegments from gp_distribution_policy where localoid='ao_t1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table t1_reshuffle_ao;
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a) partition by list(b) (partition t1_reshuffle_ao_1 values(1), partition t1_reshuffle_ao_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1" for table "t1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2" for table "t1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_ao_1_prt_other" for table "t1_reshuffle_ao"
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+drop table ao_t1_reshuffle;
+Create table ao_t1_reshuffle(a int, b int, c int) with (appendonly=true) distributed by (a) partition by list(b) (partition ao_t1_reshuffle_1 values(1), partition ao_t1_reshuffle_2 values(2), default partition other);
+NOTICE:  CREATE TABLE will create partition "ao_t1_reshuffle_1_prt_ao_t1_reshuffle_1" for table "ao_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "ao_t1_reshuffle_1_prt_ao_t1_reshuffle_2" for table "ao_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "ao_t1_reshuffle_1_prt_other" for table "ao_t1_reshuffle"
+update gp_distribution_policy set numsegments = 1 where localoid in (select oid from pg_class where relname like 'ao_t1_reshuffle%');
+insert into ao_t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |   100
 (1 row)
 
 begin;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             0 |    32
-             1 |    40
              2 |    28
+             1 |    40
+             0 |    32
 (3 rows)
 
 abort;
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |   100
 (1 row)
 
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              2 |    28
-             1 |    40
              0 |    32
+             1 |    40
 (3 rows)
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
+select numsegments from gp_distribution_policy where localoid='ao_t1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table t1_reshuffle_ao;
+drop table ao_t1_reshuffle;
 -- Random distributed tables
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly;
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from r1_reshuffle_ao;
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true) distributed randomly;
+update gp_distribution_policy  set numsegments=2 where localoid='ao_r1_reshuffle'::regclass;
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update ao_r1_reshuffle set c = gp_segment_id;
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
 begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
 abort;
-Select count(*) from r1_reshuffle_ao;
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table r1_reshuffle_ao;
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed randomly;
+drop table ao_r1_reshuffle;
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true, OIDS) distributed randomly;
 NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_ao set c = gp_segment_id;
-Select count(*) from r1_reshuffle_ao;
+update gp_distribution_policy  set numsegments=2 where localoid='ao_r1_reshuffle'::regclass;
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update ao_r1_reshuffle set c = gp_segment_id;
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
 begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
 abort;
-Select count(*) from r1_reshuffle_ao;
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table r1_reshuffle_ao;
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly partition by list(b) (partition r1_reshuffle_ao_1 values(1), partition r1_reshuffle_ao_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_ao_1_prt_r1_reshuffle_ao_1" for table "r1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_ao_1_prt_r1_reshuffle_ao_2" for table "r1_reshuffle_ao"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_ao_1_prt_other" for table "r1_reshuffle_ao"
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao_1_prt_r1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao_1_prt_r1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao'::regclass;
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Select count(*) from r1_reshuffle_ao;
+drop table ao_r1_reshuffle;
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true) distributed randomly partition by list(b) (partition ao_r1_reshuffle_1 values(1), partition ao_r1_reshuffle_2 values(2), default partition other);
+NOTICE:  CREATE TABLE will create partition "ao_r1_reshuffle_1_prt_ao_r1_reshuffle_1" for table "ao_r1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "ao_r1_reshuffle_1_prt_ao_r1_reshuffle_2" for table "ao_r1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "ao_r1_reshuffle_1_prt_other" for table "ao_r1_reshuffle"
+update gp_distribution_policy set numsegments = 2 where localoid in (select oid from pg_class where relname like 'ao_r1_reshuffle%');
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
 begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
 abort;
-Select count(*) from r1_reshuffle_ao;
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select count(*) from ao_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table r1_reshuffle_ao;
+drop table ao_r1_reshuffle;
 -- Replicated tables
--- We have to make sure replicated table successfully reshuffled.
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed replicated;
-select update_numsegments_in_policy('r1_reshuffle_ao', 1);
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true) distributed replicated;
+select update_numsegments_in_policy('ao_r1_reshuffle'::regclass, 1);
  update_numsegments_in_policy 
 ------------------------------
  
 (1 row)
 
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 0
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 0
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
 begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
+             2 |   100
+             1 |   100
+(3 rows)
 
 abort;
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 0
-(1 row)
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
+             2 |   100
+             1 |   100
+(3 rows)
 
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 0
-(1 row)
-
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table r1_reshuffle_ao;
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed replicated;
+drop table ao_r1_reshuffle;
+--
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true, OIDS) distributed replicated;
 NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
-select update_numsegments_in_policy('r1_reshuffle_ao', 2);
+select update_numsegments_in_policy('ao_r1_reshuffle'::regclass, 1);
  update_numsegments_in_policy 
 ------------------------------
  
 (1 row)
 
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 0
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
 begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
+             2 |   100
+             1 |   100
+(3 rows)
 
 abort;
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
+             2 |   100
+             1 |   100
+(3 rows)
 
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 0
-(1 row)
-
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table r1_reshuffle_ao;
+drop table ao_r1_reshuffle;
+-- multi-level partition tables
+CREATE TABLE part_ao_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b" for table "part_ao_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c" for table "part_ao_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others__3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2" for table "part_ao_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3" for table "part_ao_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2" for table "part_ao_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c" for table "part_ao_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2" for table "part_ao_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3" for table "part_ao_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_ao_t1_reshuffle%');
+insert into part_ao_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_ao_t1_reshuffle set e = gp_segment_id;
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
+
+begin;
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             2 |    28
+             1 |    40
+(3 rows)
+
+abort;
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
+
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             2 |    28
+             1 |    40
+(3 rows)
+
+select numsegments from gp_distribution_policy where localoid='part_ao_t1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
+drop table part_ao_t1_reshuffle;
+--
+CREATE TABLE part_ao_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b" for table "part_ao_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c" for table "part_ao_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others__3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2" for table "part_ao_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3" for table "part_ao_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2" for table "part_ao_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c" for table "part_ao_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2" for table "part_ao_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3" for table "part_ao_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_ao_t1_reshuffle%');
+insert into part_ao_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_ao_t1_reshuffle set e = gp_segment_id;
+Select count(*) from part_ao_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_ao_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+Select count(*) from part_ao_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_ao_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+abort;
+Select count(*) from part_ao_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_ao_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+Select count(*) from part_ao_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_ao_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='part_ao_t1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
+drop table part_ao_t1_reshuffle;

--- a/src/test/regress/expected/reshuffle_ao.out
+++ b/src/test/regress/expected/reshuffle_ao.out
@@ -679,3 +679,118 @@ select numsegments from gp_distribution_policy where localoid='part_ao_t1_reshuf
 (1 row)
 
 drop table part_ao_t1_reshuffle;
+-- only reshuffle leaf partition
+CREATE TABLE part_ao_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b" for table "part_ao_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c" for table "part_ao_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others__3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2" for table "part_ao_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3" for table "part_ao_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2" for table "part_ao_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c" for table "part_ao_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2" for table "part_ao_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_2_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3" for table "part_ao_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_one" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_two" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_three" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_ao_t1_reshuffle_1_prt_2_2_prt_3_3_prt_others_d" for table "part_ao_t1_reshuffle_1_prt_2_2_prt_3"
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_ao_t1_reshuffle%');
+insert into part_ao_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_ao_t1_reshuffle set e = gp_segment_id;
+select gp_segment_id, * from part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 65 | 2 | 1 | 0 | 0
+             0 | 69 | 0 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+(7 rows)
+
+begin;
+Alter table part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+Select gp_segment_id, * from part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             2 | 65 | 2 | 1 | 0 | 0
+             2 | 69 | 0 | 1 | 4 | 0
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+(7 rows)
+
+abort;
+Select gp_segment_id, * from part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 65 | 2 | 1 | 0 | 0
+             0 | 69 | 0 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+(7 rows)
+
+Alter table part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+Select gp_segment_id, * from part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             2 | 65 | 2 | 1 | 0 | 0
+             2 | 69 | 0 | 1 | 4 | 0
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+(7 rows)
+
+-- try to reshuffle root partition, it will raise a notice
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+NOTICE:  Do not need to reshuffle public.part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |    28
+             0 |    32
+             1 |    40
+(3 rows)
+
+drop table part_ao_t1_reshuffle;

--- a/src/test/regress/expected/reshuffle_aoco.out
+++ b/src/test/regress/expected/reshuffle_aoco.out
@@ -1,10 +1,10 @@
 set allow_system_table_mods=true;
 -- Hash distributed tables
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_aoco set c = gp_segment_id;
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Create table aoco_t1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed by (a);
+update gp_distribution_policy  set numsegments=2 where localoid='aoco_t1_reshuffle'::regclass;
+insert into aoco_t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update aoco_t1_reshuffle set c = gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              1 |    51
@@ -12,43 +12,43 @@ Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
 (2 rows)
 
 begin;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Alter table aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |    32
-             1 |    40
              2 |    28
+             1 |    40
 (3 rows)
 
 abort;
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              1 |    51
              0 |    49
 (2 rows)
 
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Alter table aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             0 |    32
              2 |    28
              1 |    40
+             0 |    32
 (3 rows)
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
+select numsegments from gp_distribution_policy where localoid='aoco_t1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table t1_reshuffle_aoco;
+drop table aoco_t1_reshuffle;
 -- Test NULLs.
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b,c);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco values
+Create table aoco_t1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed by (a,b,c);
+update gp_distribution_policy  set numsegments=2 where localoid='aoco_t1_reshuffle'::regclass;
+insert into aoco_t1_reshuffle values
   (1,    1,    1   ),
   (null, 2,    2   ),
   (3,    null, 3   ),
@@ -57,7 +57,7 @@ insert into t1_reshuffle_aoco values
   (null, 6,    null),
   (7,    null, null),
   (null, null, null);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              1 |     4
@@ -65,297 +65,460 @@ Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
 (2 rows)
 
 begin;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Alter table aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |     2
-             2 |     3
              1 |     3
+             2 |     3
 (3 rows)
 
 abort;
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              1 |     4
              0 |     4
 (2 rows)
 
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Alter table aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             1 |     3
              2 |     3
+             1 |     3
              0 |     2
 (3 rows)
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
+select numsegments from gp_distribution_policy where localoid='aoco_t1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table t1_reshuffle_aoco;
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a) partition by list(b) (partition t1_reshuffle_aoco_1 values(1), partition t1_reshuffle_aoco_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1" for table "t1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2" for table "t1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "t1_reshuffle_aoco_1_prt_other" for table "t1_reshuffle_aoco"
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+drop table aoco_t1_reshuffle;
+Create table aoco_t1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed by (a) partition by list(b) (partition aoco_t1_reshuffle_1 values(1), partition aoco_t1_reshuffle_2 values(2), default partition other);
+NOTICE:  CREATE TABLE will create partition "aoco_t1_reshuffle_1_prt_aoco_t1_reshuffle_1" for table "aoco_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "aoco_t1_reshuffle_1_prt_aoco_t1_reshuffle_2" for table "aoco_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "aoco_t1_reshuffle_1_prt_other" for table "aoco_t1_reshuffle"
+update gp_distribution_policy set numsegments = 1 where localoid in (select oid from pg_class where relname like 'aoco_t1_reshuffle%');
+insert into aoco_t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |   100
 (1 row)
 
 begin;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Alter table aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             2 |    28
              0 |    32
+             2 |    28
              1 |    40
 (3 rows)
 
 abort;
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
              0 |   100
 (1 row)
 
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Alter table aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             0 |    32
-             1 |    40
              2 |    28
+             1 |    40
+             0 |    32
 (3 rows)
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
+select numsegments from gp_distribution_policy where localoid='aoco_t1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table t1_reshuffle_aoco;
+drop table aoco_t1_reshuffle;
 -- Random distributed tables
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly;
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_aoco set c = gp_segment_id;
-Select count(*) from r1_reshuffle_aoco;
+Create table aoco_r1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed randomly;
+update gp_distribution_policy  set numsegments=2 where localoid='aoco_r1_reshuffle'::regclass;
+insert into aoco_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update aoco_r1_reshuffle set c = gp_segment_id;
+Select count(*) from aoco_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
 begin;
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
+Alter table aoco_r1_reshuffle set with (reshuffle);
+Select count(*) from aoco_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
 abort;
-Select count(*) from r1_reshuffle_aoco;
+Select count(*) from aoco_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
+Alter table aoco_r1_reshuffle set with (reshuffle);
+Select count(*) from aoco_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
+select numsegments from gp_distribution_policy where localoid='aoco_r1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table r1_reshuffle_aoco;
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly partition by list(b) (partition r1_reshuffle_aoco_1 values(1), partition r1_reshuffle_aoco_2 values(2), default partition other);
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_1" for table "r1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_2" for table "r1_reshuffle_aoco"
-NOTICE:  CREATE TABLE will create partition "r1_reshuffle_aoco_1_prt_other" for table "r1_reshuffle_aoco"
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Select count(*) from r1_reshuffle_aoco;
+drop table aoco_r1_reshuffle;
+Create table aoco_r1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed randomly partition by list(b) (partition aoco_r1_reshuffle_1 values(1), partition aoco_r1_reshuffle_2 values(2), default partition other);
+NOTICE:  CREATE TABLE will create partition "aoco_r1_reshuffle_1_prt_aoco_r1_reshuffle_1" for table "aoco_r1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "aoco_r1_reshuffle_1_prt_aoco_r1_reshuffle_2" for table "aoco_r1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "aoco_r1_reshuffle_1_prt_other" for table "aoco_r1_reshuffle"
+update gp_distribution_policy set numsegments = 2 where localoid in (select oid from pg_class where relname like 'aoco_r1_reshuffle%');
+insert into aoco_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select count(*) from aoco_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
 begin;
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
+Alter table aoco_r1_reshuffle set with (reshuffle);
+Select count(*) from aoco_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
 abort;
-Select count(*) from r1_reshuffle_aoco;
+Select count(*) from aoco_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  f
 (1 row)
 
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
+Alter table aoco_r1_reshuffle set with (reshuffle);
+Select count(*) from aoco_r1_reshuffle;
  count 
 -------
    100
 (1 row)
 
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
  ?column? 
 ----------
  t
 (1 row)
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
+select numsegments from gp_distribution_policy where localoid='aoco_r1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table r1_reshuffle_aoco;
+drop table aoco_r1_reshuffle;
 -- Replicated tables
--- We have to make sure replicated table successfully reshuffled.
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed replicated;
-select update_numsegments_in_policy('r1_reshuffle_aoco', 1);
+Create table aoco_r1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed replicated;
+select update_numsegments_in_policy('aoco_r1_reshuffle'::regclass, 1);
  update_numsegments_in_policy 
 ------------------------------
  
 (1 row)
 
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Select count(*) from r1_reshuffle_aoco;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_aoco;');
- gp_execute_on_server 
-----------------------
- 0
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_aoco;');
- gp_execute_on_server 
-----------------------
- 0
+insert into aoco_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Select gp_segment_id, count(*) from gp_dist_random('aoco_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
 begin;
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
- count 
--------
-   100
-(1 row)
+Alter table aoco_r1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from gp_dist_random('aoco_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |   100
+             0 |   100
+             2 |   100
+(3 rows)
 
 abort;
-Select count(*) from r1_reshuffle_aoco;
- count 
--------
-   100
+Select gp_segment_id, count(*) from gp_dist_random('aoco_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
 (1 row)
 
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_aoco;');
- gp_execute_on_server 
-----------------------
- 0
-(1 row)
+Alter table aoco_r1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from gp_dist_random('aoco_r1_reshuffle') group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |   100
+             2 |   100
+             1 |   100
+(3 rows)
 
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_aoco;');
- gp_execute_on_server 
-----------------------
- 0
-(1 row)
-
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
- count 
--------
-   100
-(1 row)
-
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_aoco;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_aoco;');
- gp_execute_on_server 
-----------------------
- 100
-(1 row)
-
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
+select numsegments from gp_distribution_policy where localoid='aoco_r1_reshuffle'::regclass;
  numsegments 
 -------------
            3
 (1 row)
 
-drop table r1_reshuffle_aoco;
+drop table aoco_r1_reshuffle;
+-- multi-level partition tables
+CREATE TABLE part_aoco_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true, orientation=column)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b" for table "part_aoco_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c" for table "part_aoco_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_other_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2" for table "part_aoco_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3" for table "part_aoco_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2" for table "part_aoco_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c" for table "part_aoco_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2" for table "part_aoco_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3" for table "part_aoco_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_aoco_t1_reshuffle%');
+insert into part_aoco_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_aoco_t1_reshuffle set e = gp_segment_id;
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
+
+begin;
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |    32
+             2 |    28
+             1 |    40
+(3 rows)
+
+abort;
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
+
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |    28
+             0 |    32
+             1 |    40
+(3 rows)
+
+select numsegments from gp_distribution_policy where localoid='part_aoco_t1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
+drop table part_aoco_t1_reshuffle;
+--
+CREATE TABLE part_aoco_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true, orientation=column)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b" for table "part_aoco_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c" for table "part_aoco_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_other_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2" for table "part_aoco_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3" for table "part_aoco_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2" for table "part_aoco_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c" for table "part_aoco_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2" for table "part_aoco_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3" for table "part_aoco_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_aoco_t1_reshuffle%');
+insert into part_aoco_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_aoco_t1_reshuffle set e = gp_segment_id;
+Select count(*) from part_aoco_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_aoco_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+begin;
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+Select count(*) from part_aoco_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_aoco_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+abort;
+Select count(*) from part_aoco_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_aoco_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ f
+(1 row)
+
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+Select count(*) from part_aoco_t1_reshuffle;
+ count 
+-------
+   100
+(1 row)
+
+Select count(*) > 0 from part_aoco_t1_reshuffle where gp_segment_id=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+select numsegments from gp_distribution_policy where localoid='part_aoco_t1_reshuffle'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
+drop table part_aoco_t1_reshuffle;

--- a/src/test/regress/expected/reshuffle_aoco.out
+++ b/src/test/regress/expected/reshuffle_aoco.out
@@ -522,3 +522,118 @@ select numsegments from gp_distribution_policy where localoid='part_aoco_t1_resh
 (1 row)
 
 drop table part_aoco_t1_reshuffle;
+-- only reshuffle leaf partitions
+CREATE TABLE part_aoco_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true, orientation=column)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b" for table "part_aoco_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c" for table "part_aoco_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_other_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2" for table "part_aoco_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3" for table "part_aoco_t1_reshuffle_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2" for table "part_aoco_t1_reshuffle"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c" for table "part_aoco_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2" for table "part_aoco_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_2_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3" for table "part_aoco_t1_reshuffle_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_one" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_two" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_three" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "part_aoco_t1_reshuffle_1_prt_2_2_prt_3_3_prt_others_d" for table "part_aoco_t1_reshuffle_1_prt_2_2_prt_3"
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_aoco_t1_reshuffle%');
+insert into part_aoco_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_aoco_t1_reshuffle set e = gp_segment_id;
+select gp_segment_id, * from part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 65 | 2 | 1 | 0 | 0
+             0 | 69 | 0 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+(7 rows)
+
+begin;
+alter table part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+select gp_segment_id, * from part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+             2 | 65 | 2 | 1 | 0 | 0
+             2 | 69 | 0 | 1 | 4 | 0
+(7 rows)
+
+abort;
+select gp_segment_id, * from part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 65 | 2 | 1 | 0 | 0
+             0 | 69 | 0 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+(7 rows)
+
+alter table part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+select gp_segment_id, * from part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+ gp_segment_id | a  | b | c | d | e 
+---------------+----+---+---+---+---
+             2 | 65 | 2 | 1 | 0 | 0
+             2 | 69 | 0 | 1 | 4 | 0
+             0 | 29 | 2 | 1 | 4 | 0
+             0 | 89 | 2 | 1 | 4 | 0
+             1 |  5 | 2 | 1 | 0 | 1
+             1 |  9 | 0 | 1 | 4 | 1
+             1 | 45 | 0 | 1 | 0 | 1
+(7 rows)
+
+-- try to reshuffle root partition, it will raise a notice
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+NOTICE:  Do not need to reshuffle public.part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    40
+             2 |    28
+             0 |    32
+(3 rows)
+
+drop table part_aoco_t1_reshuffle;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -14,10 +14,6 @@
 #   to the segments, and therefore has to run in smaller groups to avoid
 #   hitting max_connections limit on segments.
 #
-# test reshuffle
-test: reshuffle_helper
-test: reshuffle reshuffle_ao reshuffle_aoco
-
 # enable query metrics cluster GUC
 test: instr_in_shmem_setup
 # run separately - because slot counter may influenced by other parallel queries
@@ -247,10 +243,14 @@ test: autovacuum-template0
 
 # Online expand introduce the partial tables, check them if they can run correctly
 test: gangsize
+
 # This test uses fault injectors in abort transaction workflow.  It
 # may be run in parallel with other tests as long as they don't abort
 # a transaction where mult-slice query was executed and the writer was
 # assigned a transaction ID.
 test: writer_aborts_reader
 
+# test reshuffle
+test: reshuffle_helper
+test: reshuffle reshuffle_ao reshuffle_aoco
 # end of tests

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -251,6 +251,7 @@ test: gangsize
 test: writer_aborts_reader
 
 # test reshuffle
+# It may affect the result of 'gp_explain', so keep it below the 'gp_explain'
 test: reshuffle_helper
 test: reshuffle reshuffle_ao reshuffle_aoco
 # end of tests

--- a/src/test/regress/sql/reshuffle.sql
+++ b/src/test/regress/sql/reshuffle.sql
@@ -343,6 +343,49 @@ Select count(*) > 0 from part_t1_reshuffle where gp_segment_id=2;
 select numsegments from gp_distribution_policy where localoid='part_t1_reshuffle'::regclass;
 drop table part_t1_reshuffle;
 
+-- only alter leaf partition
+CREATE TABLE part_t1_reshuffle(a int, b int, c int, d int, e int)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_t1_reshuffle%');
+insert into part_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_t1_reshuffle set e = gp_segment_id;
+
+select gp_segment_id, * from part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+
+begin;
+alter table part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+select gp_segment_id, * from part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+abort;
+
+select gp_segment_id, * from part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+
+alter table part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+
+select gp_segment_id, * from part_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+
+-- try to reshuffle root partition, it will raise a notice
+Alter table part_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+
+drop table part_t1_reshuffle;
+
+
 -- inherits tables
 CREATE TABLE inherit_t1_reshuffle_p1(a int, b int);
 CREATE TABLE inherit_t1_reshuffle_p2(a int, b int) INHERITS (inherit_t1_reshuffle_p1);

--- a/src/test/regress/sql/reshuffle.sql
+++ b/src/test/regress/sql/reshuffle.sql
@@ -73,10 +73,7 @@ select numsegments from gp_distribution_policy where localoid='t1_reshuffle'::re
 drop table t1_reshuffle;
 
 Create table t1_reshuffle(a int, b int, c int) distributed by (a) partition by list(b) (partition t1_reshuffle_1 values(1), partition t1_reshuffle_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_t1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_t1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle'::regclass;
+update gp_distribution_policy set numsegments = 1 where localoid in (select oid from pg_class where relname like 't1_reshuffle%');
 insert into t1_reshuffle select i,i,0 from generate_series(1,100) I;
 
 Select gp_segment_id, count(*) from t1_reshuffle group by gp_segment_id;
@@ -147,10 +144,7 @@ select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::re
 drop table r1_reshuffle;
 
 Create table r1_reshuffle(a int, b int, c int) distributed randomly partition by list(b) (partition r1_reshuffle_1 values(1), partition r1_reshuffle_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1_prt_r1_reshuffle_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1_prt_r1_reshuffle_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle'::regclass;
+update gp_distribution_policy set numsegments = 2 where localoid in (select oid from pg_class where relname like 'r1_reshuffle%');
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
 
 Select count(*) from r1_reshuffle;
@@ -174,56 +168,47 @@ select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::re
 drop table r1_reshuffle;
 
 -- Replicated tables
--- We have to make sure replicated table successfully reshuffled.
-
 Create table r1_reshuffle(a int, b int, c int) distributed replicated;
-select update_numsegments_in_policy('r1_reshuffle', 1);
+
+select update_numsegments_in_policy('r1_reshuffle'::regclass, 1);
+
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
 
-Select count(*) from r1_reshuffle;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
 
 begin;
 Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
 abort;
 
-Select count(*) from r1_reshuffle;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
 
 Alter table r1_reshuffle set with (reshuffle);
 
-Select count(*) from r1_reshuffle;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
 
 select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
 drop table r1_reshuffle;
 
+--
 Create table r1_reshuffle(a int, b int, c int) with OIDS distributed replicated;
-select update_numsegments_in_policy('r1_reshuffle', 2);
+
+select update_numsegments_in_policy('r1_reshuffle'::regclass, 1);
+
 insert into r1_reshuffle select i,i,0 from generate_series(1,100) I;
 
-Select count(*) from r1_reshuffle;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
 
 begin;
 Alter table r1_reshuffle set with (reshuffle);
-Select count(*) from r1_reshuffle;
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
 abort;
 
-Select count(*) from r1_reshuffle;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
 
 Alter table r1_reshuffle set with (reshuffle);
 
-Select count(*) from r1_reshuffle;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle;');
+Select gp_segment_id, count(*) from gp_dist_random('r1_reshuffle') group by gp_segment_id;
 
 select numsegments from gp_distribution_policy where localoid='r1_reshuffle'::regclass;
 drop table r1_reshuffle;
@@ -275,3 +260,115 @@ select gp_segment_id, * from mix_base_tbl order by 2, 1;
 -- segments
 Alter table mix_base_tbl set with (reshuffle);
 select gp_segment_id, * from mix_base_tbl order by 2, 1;
+
+-- multi-level partition tables
+CREATE TABLE part_t1_reshuffle(a int, b int, c int, d int, e int)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_t1_reshuffle%');
+insert into part_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_t1_reshuffle set e = gp_segment_id;
+
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+
+begin;
+Alter table part_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+
+Alter table part_t1_reshuffle set with (reshuffle);
+
+Select gp_segment_id, count(*) from part_t1_reshuffle group by gp_segment_id;
+
+select numsegments from gp_distribution_policy where localoid='part_t1_reshuffle'::regclass;
+drop table part_t1_reshuffle;
+
+--
+CREATE TABLE part_t1_reshuffle(a int, b int, c int, d int, e int)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_t1_reshuffle%');
+insert into part_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_t1_reshuffle set e = gp_segment_id;
+
+Select count(*) from part_t1_reshuffle;
+Select count(*) > 0 from part_t1_reshuffle where gp_segment_id=2;
+
+begin;
+Alter table part_t1_reshuffle set with (reshuffle);
+Select count(*) from part_t1_reshuffle;
+Select count(*) > 0 from part_t1_reshuffle where gp_segment_id=2;
+abort;
+
+Select count(*) from part_t1_reshuffle;
+Select count(*) > 0 from part_t1_reshuffle where gp_segment_id=2;
+
+Alter table part_t1_reshuffle set with (reshuffle);
+
+Select count(*) from part_t1_reshuffle;
+Select count(*) > 0 from part_t1_reshuffle where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='part_t1_reshuffle'::regclass;
+drop table part_t1_reshuffle;
+
+-- inherits tables
+CREATE TABLE inherit_t1_reshuffle_p1(a int, b int);
+CREATE TABLE inherit_t1_reshuffle_p2(a int, b int) INHERITS (inherit_t1_reshuffle_p1);
+CREATE TABLE inherit_t1_reshuffle_p3(a int, b int) INHERITS (inherit_t1_reshuffle_p1);
+CREATE TABLE inherit_t1_reshuffle_p4(a int, b int) INHERITS (inherit_t1_reshuffle_p2);
+CREATE TABLE inherit_t1_reshuffle_p5(a int, b int) INHERITS (inherit_t1_reshuffle_p3);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'inherit_t1_reshuffle%');
+
+insert into inherit_t1_reshuffle_p1 select i,i from generate_series(1,10) i;
+insert into inherit_t1_reshuffle_p2 select i,i from generate_series(1,10) i;
+insert into inherit_t1_reshuffle_p3 select i,i from generate_series(1,10) i;
+insert into inherit_t1_reshuffle_p4 select i,i from generate_series(1,10) i;
+insert into inherit_t1_reshuffle_p5 select i,i from generate_series(1,10) i;
+
+select count(*) > 0 from inherit_t1_reshuffle_p1 where gp_segment_id = 2;
+
+begin;
+alter table inherit_t1_reshuffle_p1 set with(reshuffle);
+select count(*) > 0 from inherit_t1_reshuffle_p1 where gp_segment_id = 2;
+abort;
+
+select count(*) > 0 from inherit_t1_reshuffle_p1 where gp_segment_id = 2;
+
+alter table inherit_t1_reshuffle_p1 set with(reshuffle);
+
+select count(*) > 0 from inherit_t1_reshuffle_p1 where gp_segment_id = 2;
+
+DROP TABLE inherit_t1_reshuffle_p1 CASCADE;

--- a/src/test/regress/sql/reshuffle_ao.sql
+++ b/src/test/regress/sql/reshuffle_ao.sql
@@ -294,3 +294,44 @@ Select count(*) > 0 from part_ao_t1_reshuffle where gp_segment_id=2;
 
 select numsegments from gp_distribution_policy where localoid='part_ao_t1_reshuffle'::regclass;
 drop table part_ao_t1_reshuffle;
+
+
+-- only reshuffle leaf partition
+CREATE TABLE part_ao_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_ao_t1_reshuffle%');
+insert into part_ao_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_ao_t1_reshuffle set e = gp_segment_id;
+
+select gp_segment_id, * from part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+
+begin;
+Alter table part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+Select gp_segment_id, * from part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+abort;
+
+Select gp_segment_id, * from part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+Alter table part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+Select gp_segment_id, * from part_ao_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+
+-- try to reshuffle root partition, it will raise a notice
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+
+drop table part_ao_t1_reshuffle;

--- a/src/test/regress/sql/reshuffle_ao.sql
+++ b/src/test/regress/sql/reshuffle_ao.sql
@@ -1,53 +1,53 @@
 set allow_system_table_mods=true;
 
 -- Hash distributed tables
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_ao set c = gp_segment_id;
+Create table ao_t1_reshuffle(a int, b int, c int) with (appendonly=true) distributed by (a);
+update gp_distribution_policy  set numsegments=2 where localoid='ao_t1_reshuffle'::regclass;
+insert into ao_t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update ao_t1_reshuffle set c = gp_segment_id;
 
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
-
-begin;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
-abort;
-
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
-
-Alter table t1_reshuffle_ao set with (reshuffle);
-
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
-
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
-drop table t1_reshuffle_ao;
-
-
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed by (a,b);
-update gp_distribution_policy  set numsegments=1 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_ao set c = gp_segment_id;
-
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 
 begin;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 abort;
 
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 
-Alter table t1_reshuffle_ao set with (reshuffle);
+Alter table ao_t1_reshuffle set with (reshuffle);
 
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
-drop table t1_reshuffle_ao;
+select numsegments from gp_distribution_policy where localoid='ao_t1_reshuffle'::regclass;
+drop table ao_t1_reshuffle;
+
+
+Create table ao_t1_reshuffle(a int, b int, c int) with (appendonly=true, OIDS) distributed by (a,b);
+update gp_distribution_policy  set numsegments=1 where localoid='ao_t1_reshuffle'::regclass;
+insert into ao_t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update ao_t1_reshuffle set c = gp_segment_id;
+
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
+
+begin;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
+
+Alter table ao_t1_reshuffle set with (reshuffle);
+
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
+
+select numsegments from gp_distribution_policy where localoid='ao_t1_reshuffle'::regclass;
+drop table ao_t1_reshuffle;
 
 -- Test NULLs.
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a,b,c);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao values
+Create table ao_t1_reshuffle(a int, b int, c int) with (appendonly=true) distributed by (a,b,c);
+update gp_distribution_policy  set numsegments=2 where localoid='ao_t1_reshuffle'::regclass;
+insert into ao_t1_reshuffle values
   (1,    1,    1   ),
   (null, 2,    2   ),
   (3,    null, 3   ),
@@ -56,174 +56,241 @@ insert into t1_reshuffle_ao values
   (null, 6,    null),
   (7,    null, null),
   (null, null, null);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 
 begin;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 abort;
 
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 
-Alter table t1_reshuffle_ao set with (reshuffle);
+Alter table ao_t1_reshuffle set with (reshuffle);
 
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
-drop table t1_reshuffle_ao;
+select numsegments from gp_distribution_policy where localoid='ao_t1_reshuffle'::regclass;
+drop table ao_t1_reshuffle;
 
-Create table t1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed by (a) partition by list(b) (partition t1_reshuffle_ao_1 values(1), partition t1_reshuffle_ao_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_t1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_ao'::regclass;
-insert into t1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+Create table ao_t1_reshuffle(a int, b int, c int) with (appendonly=true) distributed by (a) partition by list(b) (partition ao_t1_reshuffle_1 values(1), partition ao_t1_reshuffle_2 values(2), default partition other);
+update gp_distribution_policy set numsegments = 1 where localoid in (select oid from pg_class where relname like 'ao_t1_reshuffle%');
+insert into ao_t1_reshuffle select i,i,0 from generate_series(1,100) I;
 
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 
 begin;
-Alter table t1_reshuffle_ao set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Alter table ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 abort;
 
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 
-Alter table t1_reshuffle_ao set with (reshuffle);
+Alter table ao_t1_reshuffle set with (reshuffle);
 
-Select gp_segment_id, count(*) from t1_reshuffle_ao group by gp_segment_id;
+Select gp_segment_id, count(*) from ao_t1_reshuffle group by gp_segment_id;
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_ao'::regclass;
-drop table t1_reshuffle_ao;
+select numsegments from gp_distribution_policy where localoid='ao_t1_reshuffle'::regclass;
+drop table ao_t1_reshuffle;
 
 -- Random distributed tables
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly;
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_ao set c = gp_segment_id;
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true) distributed randomly;
+update gp_distribution_policy  set numsegments=2 where localoid='ao_r1_reshuffle'::regclass;
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update ao_r1_reshuffle set c = gp_segment_id;
 
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
-
-begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
-abort;
-
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
-
-Alter table r1_reshuffle_ao set with (reshuffle);
-
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
-
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
-drop table r1_reshuffle_ao;
-
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed randomly;
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_ao'::regclass;
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_ao set c = gp_segment_id;
-
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
 
 begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
 abort;
 
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
 
-Alter table r1_reshuffle_ao set with (reshuffle);
+Alter table ao_r1_reshuffle set with (reshuffle);
 
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
-drop table r1_reshuffle_ao;
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
+drop table ao_r1_reshuffle;
 
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed randomly partition by list(b) (partition r1_reshuffle_ao_1 values(1), partition r1_reshuffle_ao_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao_1_prt_r1_reshuffle_ao_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao_1_prt_r1_reshuffle_ao_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_ao'::regclass;
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true, OIDS) distributed randomly;
+update gp_distribution_policy  set numsegments=2 where localoid='ao_r1_reshuffle'::regclass;
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update ao_r1_reshuffle set c = gp_segment_id;
 
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
 
 begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
 abort;
 
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
 
-Alter table r1_reshuffle_ao set with (reshuffle);
+Alter table ao_r1_reshuffle set with (reshuffle);
 
-Select count(*) from r1_reshuffle_ao;
-Select count(*) > 0 from r1_reshuffle_ao where gp_segment_id=2;
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
-drop table r1_reshuffle_ao;
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
+drop table ao_r1_reshuffle;
+
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true) distributed randomly partition by list(b) (partition ao_r1_reshuffle_1 values(1), partition ao_r1_reshuffle_2 values(2), default partition other);
+update gp_distribution_policy set numsegments = 2 where localoid in (select oid from pg_class where relname like 'ao_r1_reshuffle%');
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
+
+begin;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
+abort;
+
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
+
+Alter table ao_r1_reshuffle set with (reshuffle);
+
+Select count(*) from ao_r1_reshuffle;
+Select count(*) > 0 from ao_r1_reshuffle where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
+drop table ao_r1_reshuffle;
 
 -- Replicated tables
--- We have to make sure replicated table successfully reshuffled.
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true) distributed replicated;
 
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true) distributed replicated;
-select update_numsegments_in_policy('r1_reshuffle_ao', 1);
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+select update_numsegments_in_policy('ao_r1_reshuffle'::regclass, 1);
 
-Select count(*) from r1_reshuffle_ao;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
 
 begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
 abort;
 
-Select count(*) from r1_reshuffle_ao;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
 
-Alter table r1_reshuffle_ao set with (reshuffle);
+Alter table ao_r1_reshuffle set with (reshuffle);
 
-Select count(*) from r1_reshuffle_ao;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
-drop table r1_reshuffle_ao;
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
+drop table ao_r1_reshuffle;
 
-Create table r1_reshuffle_ao(a int, b int, c int) with (appendonly = true, OIDS = true) distributed replicated;
-select update_numsegments_in_policy('r1_reshuffle_ao', 2);
-insert into r1_reshuffle_ao select i,i,0 from generate_series(1,100) I;
+--
+Create table ao_r1_reshuffle(a int, b int, c int) with (appendonly=true, OIDS) distributed replicated;
 
-Select count(*) from r1_reshuffle_ao;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
+select update_numsegments_in_policy('ao_r1_reshuffle'::regclass, 1);
+
+insert into ao_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
 
 begin;
-Alter table r1_reshuffle_ao set with (reshuffle);
-Select count(*) from r1_reshuffle_ao;
+Alter table ao_r1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
 abort;
 
-Select count(*) from r1_reshuffle_ao;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
 
-Alter table r1_reshuffle_ao set with (reshuffle);
+Alter table ao_r1_reshuffle set with (reshuffle);
 
-Select count(*) from r1_reshuffle_ao;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_ao;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_ao;');
+Select gp_segment_id, count(*) from gp_dist_random('ao_r1_reshuffle') group by gp_segment_id;
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_ao'::regclass;
-drop table r1_reshuffle_ao;
+select numsegments from gp_distribution_policy where localoid='ao_r1_reshuffle'::regclass;
+drop table ao_r1_reshuffle;
+
+-- multi-level partition tables
+CREATE TABLE part_ao_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_ao_t1_reshuffle%');
+insert into part_ao_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_ao_t1_reshuffle set e = gp_segment_id;
+
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+
+begin;
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+
+Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
+
+select numsegments from gp_distribution_policy where localoid='part_ao_t1_reshuffle'::regclass;
+drop table part_ao_t1_reshuffle;
+
+--
+CREATE TABLE part_ao_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_ao_t1_reshuffle%');
+insert into part_ao_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_ao_t1_reshuffle set e = gp_segment_id;
+
+Select count(*) from part_ao_t1_reshuffle;
+Select count(*) > 0 from part_ao_t1_reshuffle where gp_segment_id=2;
+
+begin;
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+Select count(*) from part_ao_t1_reshuffle;
+Select count(*) > 0 from part_ao_t1_reshuffle where gp_segment_id=2;
+abort;
+
+Select count(*) from part_ao_t1_reshuffle;
+Select count(*) > 0 from part_ao_t1_reshuffle where gp_segment_id=2;
+
+Alter table part_ao_t1_reshuffle set with (reshuffle);
+
+Select count(*) from part_ao_t1_reshuffle;
+Select count(*) > 0 from part_ao_t1_reshuffle where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='part_ao_t1_reshuffle'::regclass;
+drop table part_ao_t1_reshuffle;

--- a/src/test/regress/sql/reshuffle_aoco.sql
+++ b/src/test/regress/sql/reshuffle_aoco.sql
@@ -223,3 +223,44 @@ Select count(*) > 0 from part_aoco_t1_reshuffle where gp_segment_id=2;
 
 select numsegments from gp_distribution_policy where localoid='part_aoco_t1_reshuffle'::regclass;
 drop table part_aoco_t1_reshuffle;
+
+-- only reshuffle leaf partitions
+
+CREATE TABLE part_aoco_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true, orientation=column)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_aoco_t1_reshuffle%');
+insert into part_aoco_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_aoco_t1_reshuffle set e = gp_segment_id;
+
+select gp_segment_id, * from part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+
+begin;
+alter table part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+select gp_segment_id, * from part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+abort;
+
+select gp_segment_id, * from part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+alter table part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d set with (reshuffle);
+select gp_segment_id, * from part_aoco_t1_reshuffle_1_prt_other_b_2_prt_2_3_prt_others_d;
+
+-- try to reshuffle root partition, it will raise a notice
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+
+drop table part_aoco_t1_reshuffle;

--- a/src/test/regress/sql/reshuffle_aoco.sql
+++ b/src/test/regress/sql/reshuffle_aoco.sql
@@ -1,31 +1,31 @@
 set allow_system_table_mods=true;
 
 -- Hash distributed tables
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update t1_reshuffle_aoco set c = gp_segment_id;
+Create table aoco_t1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed by (a);
+update gp_distribution_policy  set numsegments=2 where localoid='aoco_t1_reshuffle'::regclass;
+insert into aoco_t1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update aoco_t1_reshuffle set c = gp_segment_id;
 
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 
 begin;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Alter table aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 abort;
 
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 
-Alter table t1_reshuffle_aoco set with (reshuffle);
+Alter table aoco_t1_reshuffle set with (reshuffle);
 
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
-drop table t1_reshuffle_aoco;
+select numsegments from gp_distribution_policy where localoid='aoco_t1_reshuffle'::regclass;
+drop table aoco_t1_reshuffle;
 
 -- Test NULLs.
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a,b,c);
-update gp_distribution_policy  set numsegments=2 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco values
+Create table aoco_t1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed by (a,b,c);
+update gp_distribution_policy  set numsegments=2 where localoid='aoco_t1_reshuffle'::regclass;
+insert into aoco_t1_reshuffle values
   (1,    1,    1   ),
   (null, 2,    2   ),
   (3,    null, 3   ),
@@ -34,123 +34,192 @@ insert into t1_reshuffle_aoco values
   (null, 6,    null),
   (7,    null, null),
   (null, null, null);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 
 begin;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Alter table aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 abort;
 
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 
-Alter table t1_reshuffle_aoco set with (reshuffle);
+Alter table aoco_t1_reshuffle set with (reshuffle);
 
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
-drop table t1_reshuffle_aoco;
+select numsegments from gp_distribution_policy where localoid='aoco_t1_reshuffle'::regclass;
+drop table aoco_t1_reshuffle;
 
-Create table t1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed by (a) partition by list(b) (partition t1_reshuffle_aoco_1 values(1), partition t1_reshuffle_aoco_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_t1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 1 where localoid='t1_reshuffle_aoco'::regclass;
-insert into t1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
+Create table aoco_t1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed by (a) partition by list(b) (partition aoco_t1_reshuffle_1 values(1), partition aoco_t1_reshuffle_2 values(2), default partition other);
+update gp_distribution_policy set numsegments = 1 where localoid in (select oid from pg_class where relname like 'aoco_t1_reshuffle%');
+insert into aoco_t1_reshuffle select i,i,0 from generate_series(1,100) I;
 
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 
 begin;
-Alter table t1_reshuffle_aoco set with (reshuffle);
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Alter table aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 abort;
 
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 
-Alter table t1_reshuffle_aoco set with (reshuffle);
+Alter table aoco_t1_reshuffle set with (reshuffle);
 
-Select gp_segment_id, count(*) from t1_reshuffle_aoco group by gp_segment_id;
+Select gp_segment_id, count(*) from aoco_t1_reshuffle group by gp_segment_id;
 
-select numsegments from gp_distribution_policy where localoid='t1_reshuffle_aoco'::regclass;
-drop table t1_reshuffle_aoco;
+select numsegments from gp_distribution_policy where localoid='aoco_t1_reshuffle'::regclass;
+drop table aoco_t1_reshuffle;
 
 -- Random distributed tables
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly;
-update gp_distribution_policy  set numsegments=2 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-Update r1_reshuffle_aoco set c = gp_segment_id;
+Create table aoco_r1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed randomly;
+update gp_distribution_policy  set numsegments=2 where localoid='aoco_r1_reshuffle'::regclass;
+insert into aoco_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+Update aoco_r1_reshuffle set c = gp_segment_id;
 
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
-
-begin;
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
-abort;
-
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
-
-Alter table r1_reshuffle_aoco set with (reshuffle);
-
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
-
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
-drop table r1_reshuffle_aoco;
-
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed randomly partition by list(b) (partition r1_reshuffle_aoco_1 values(1), partition r1_reshuffle_aoco_2 values(2), default partition other);
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_1'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco_1_prt_r1_reshuffle_aoco_2'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco_1_prt_other'::regclass;
-update gp_distribution_policy set numsegments = 2 where localoid='r1_reshuffle_aoco'::regclass;
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
-
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) from aoco_r1_reshuffle;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
 
 begin;
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Alter table aoco_r1_reshuffle set with (reshuffle);
+Select count(*) from aoco_r1_reshuffle;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
 abort;
 
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) from aoco_r1_reshuffle;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
 
-Alter table r1_reshuffle_aoco set with (reshuffle);
+Alter table aoco_r1_reshuffle set with (reshuffle);
 
-Select count(*) from r1_reshuffle_aoco;
-Select count(*) > 0 from r1_reshuffle_aoco where gp_segment_id=2;
+Select count(*) from aoco_r1_reshuffle;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
-drop table r1_reshuffle_aoco;
+select numsegments from gp_distribution_policy where localoid='aoco_r1_reshuffle'::regclass;
+drop table aoco_r1_reshuffle;
+
+Create table aoco_r1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed randomly partition by list(b) (partition aoco_r1_reshuffle_1 values(1), partition aoco_r1_reshuffle_2 values(2), default partition other);
+update gp_distribution_policy set numsegments = 2 where localoid in (select oid from pg_class where relname like 'aoco_r1_reshuffle%');
+insert into aoco_r1_reshuffle select i,i,0 from generate_series(1,100) I;
+
+Select count(*) from aoco_r1_reshuffle;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
+
+begin;
+Alter table aoco_r1_reshuffle set with (reshuffle);
+Select count(*) from aoco_r1_reshuffle;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
+abort;
+
+Select count(*) from aoco_r1_reshuffle;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
+
+Alter table aoco_r1_reshuffle set with (reshuffle);
+
+Select count(*) from aoco_r1_reshuffle;
+Select count(*) > 0 from aoco_r1_reshuffle where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='aoco_r1_reshuffle'::regclass;
+drop table aoco_r1_reshuffle;
 
 -- Replicated tables
--- We have to make sure replicated table successfully reshuffled.
+Create table aoco_r1_reshuffle(a int, b int, c int) with (appendonly=true, orientation=column) distributed replicated;
+select update_numsegments_in_policy('aoco_r1_reshuffle'::regclass, 1);
 
-Create table r1_reshuffle_aoco(a int, b int, c int) with (appendonly = true, orientation = column) distributed replicated;
-select update_numsegments_in_policy('r1_reshuffle_aoco', 1);
-insert into r1_reshuffle_aoco select i,i,0 from generate_series(1,100) I;
+insert into aoco_r1_reshuffle select i,i,0 from generate_series(1,100) I;
 
-Select count(*) from r1_reshuffle_aoco;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_aoco;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_aoco;');
+Select gp_segment_id, count(*) from gp_dist_random('aoco_r1_reshuffle') group by gp_segment_id;
 
 begin;
-Alter table r1_reshuffle_aoco set with (reshuffle);
-Select count(*) from r1_reshuffle_aoco;
+Alter table aoco_r1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from gp_dist_random('aoco_r1_reshuffle') group by gp_segment_id;
 abort;
 
-Select count(*) from r1_reshuffle_aoco;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_aoco;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_aoco;');
+Select gp_segment_id, count(*) from gp_dist_random('aoco_r1_reshuffle') group by gp_segment_id;
 
-Alter table r1_reshuffle_aoco set with (reshuffle);
+Alter table aoco_r1_reshuffle set with (reshuffle);
 
-Select count(*) from r1_reshuffle_aoco;
-Select gp_execute_on_server(1, 'Select count(*) from r1_reshuffle_aoco;');
-Select gp_execute_on_server(2, 'Select count(*) from r1_reshuffle_aoco;');
+Select gp_segment_id, count(*) from gp_dist_random('aoco_r1_reshuffle') group by gp_segment_id;
 
-select numsegments from gp_distribution_policy where localoid='r1_reshuffle_aoco'::regclass;
-drop table r1_reshuffle_aoco;
+select numsegments from gp_distribution_policy where localoid='aoco_r1_reshuffle'::regclass;
+drop table aoco_r1_reshuffle;
+
+-- multi-level partition tables
+CREATE TABLE part_aoco_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true, orientation=column)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_aoco_t1_reshuffle%');
+insert into part_aoco_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_aoco_t1_reshuffle set e = gp_segment_id;
+
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+
+begin;
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+abort;
+
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+
+Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
+
+select numsegments from gp_distribution_policy where localoid='part_aoco_t1_reshuffle'::regclass;
+drop table part_aoco_t1_reshuffle;
+
+--
+CREATE TABLE part_aoco_t1_reshuffle(a int, b int, c int, d int, e int) with (appendonly=true, orientation=column)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+update gp_distribution_policy  set numsegments=2 where localoid in (select oid from pg_class where relname like 'part_aoco_t1_reshuffle%');
+insert into part_aoco_t1_reshuffle select i,i%3,i%4,i%5,i from generate_series(1,100) I;
+Update part_aoco_t1_reshuffle set e = gp_segment_id;
+
+Select count(*) from part_aoco_t1_reshuffle;
+Select count(*) > 0 from part_aoco_t1_reshuffle where gp_segment_id=2;
+
+begin;
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+Select count(*) from part_aoco_t1_reshuffle;
+Select count(*) > 0 from part_aoco_t1_reshuffle where gp_segment_id=2;
+abort;
+
+Select count(*) from part_aoco_t1_reshuffle;
+Select count(*) > 0 from part_aoco_t1_reshuffle where gp_segment_id=2;
+
+Alter table part_aoco_t1_reshuffle set with (reshuffle);
+
+Select count(*) from part_aoco_t1_reshuffle;
+Select count(*) > 0 from part_aoco_t1_reshuffle where gp_segment_id=2;
+
+select numsegments from gp_distribution_policy where localoid='part_aoco_t1_reshuffle'::regclass;
+drop table part_aoco_t1_reshuffle;


### PR DESCRIPTION
The previous code makes UPDATE statement for root
and its children partitions when we reshuffle a partition
table. It not only involves redundant work but also will
lead to an error while reshuffling a two-level partition
table(because the mid-level partitions have no data). 

The commit does the following work:

* Only make UPDATE statement for leaf partition or 
   non-partition table.
* Fix a bug of inheriting AO table, because we need all
   OID of inherit table is needed by the Executor.
* Refactor the reshuffle test cases. We remove the
   python udf code and use `gp_execute_on_server`
   and `gp_dist_random` to test replicated table.

Co-authored-by: Shujie Zhang shzhang@pivotal.io
Co-authored-by: Zhenghua Lyu zlv@pivotal.io
