### PR TITLE
ExecSupportsMarkRestore Seqscan should return false

### DIFF
--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -493,7 +493,6 @@ ExecSupportsMarkRestore(NodeTag plantype)
 {
 	switch (plantype)
 	{
-		case T_SeqScan:
 		case T_IndexScan:
 		case T_IndexOnlyScan:
 		case T_TidScan:

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -532,3 +532,45 @@ explain select * from t5370 a , t5370_2 b where a.name=b.name;
 
 drop table t5370;
 drop table t5370_2;
+-- github issue 6215 cases
+-- When executing the following plan
+-- ```
+--  Gather Motion 1:1  (slice1; segments: 1)
+--    ->  Merge Full Join
+--         ->  Seq Scan on int4_tbl a
+--         ->  Seq Scan on int4_tbl b
+--```
+-- Greenplum will raise an Assert Fail.
+-- We force adding a material node for
+-- merge full join on true.
+drop table if exists t6215;
+create table t6215(f1 int4) distributed replicated;
+insert into t6215(f1) values (1), (2), (3);
+set enable_material = off;
+-- The plan still have Material operator
+explain (costs off) select * from t6215 a full join t6215 b on true;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Merge Full Join
+         ->  Seq Scan on t6215 a
+         ->  Materialize
+               ->  Seq Scan on t6215 b
+ Optimizer: legacy query optimizer
+(6 rows)
+
+select * from t6215 a full join t6215 b on true;
+ f1 | f1 
+----+----
+  1 |  1
+  1 |  2
+  1 |  3
+  2 |  1
+  2 |  2
+  2 |  3
+  3 |  1
+  3 |  2
+  3 |  3
+(9 rows)
+
+drop table t6215;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -563,3 +563,60 @@ explain select * from t5370 a , t5370_2 b where a.name=b.name;
 
 drop table t5370;
 drop table t5370_2;
+-- github issue 6215 cases
+-- When executing the following plan
+-- ```
+--  Gather Motion 1:1  (slice1; segments: 1)
+--    ->  Merge Full Join
+--         ->  Seq Scan on int4_tbl a
+--         ->  Seq Scan on int4_tbl b
+--```
+-- Greenplum will raise an Assert Fail.
+-- We force adding a material node for
+-- merge full join on true.
+drop table if exists t6215;
+create table t6215(f1 int4) distributed replicated;
+insert into t6215(f1) values (1), (2), (3);
+set enable_material = off;
+-- The plan still have Material operator
+explain (costs off) select * from t6215 a full join t6215 b on true;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Result
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:0)
+                     ->  Materialize
+                           ->  Table Scan on t6215 t6215_1
+               ->  Sequence
+                     ->  Shared Scan (share slice:id 1:1)
+                           ->  Materialize
+                                 ->  Table Scan on t6215
+                     ->  Append
+                           ->  Nested Loop Left Join
+                                 Join Filter: true
+                                 ->  Shared Scan (share slice:id 1:0)
+                                 ->  Shared Scan (share slice:id 1:1)
+                           ->  Result
+                                 ->  Nested Loop Anti Join
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 1:1)
+                                       ->  Shared Scan (share slice:id 1:0)
+ Optimizer: PQO version 3.9.0
+(21 rows)
+
+select * from t6215 a full join t6215 b on true;
+ f1 | f1 
+----+----
+  1 |  1
+  1 |  2
+  1 |  3
+  2 |  1
+  2 |  2
+  2 |  3
+  3 |  1
+  3 |  2
+  3 |  3
+(9 rows)
+
+drop table t6215;


### PR DESCRIPTION
This commit fixes the Github issue #6215.

When executing the following plan
```
 Gather Motion 1:1  (slice1; segments: 1)
   ->  Merge Full Join
         ->  Seq Scan on int4_tbl a
         ->  Seq Scan on int4_tbl b
```
Greenplum will raise an Assert Fail. The root cause is
we poorly support mark/restore in `heapam`. We decided
not to touch the code there because later version Postgres
has removed them.

We simply force a material node for the above plan.

Co-authored-by: Shujie Zhang shzhang@pivotal.io
Co-authored-by: Zhenghua Lyu zlv@pivotal.io