### PR TITLE
Fix dispatching of mixed two-phase and one-phase queries.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1798,7 +1798,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 
 	char	   *dtxProtocolCommandStr = 0;
 
-	struct pg_result **results = NULL;
+	struct pg_result **results;
 
 	Assert(twophaseSegments != NIL);
 
@@ -1809,10 +1809,10 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 			 								dtxProtocolCommandStr,
 											segmentsToContentStr(twophaseSegments));
 
-	elog(DTM_DEBUG5,
-		 "dispatchDtxProtocolCommand: %d ('%s'), direct content #: %d",
-		 dtxProtocolCommand, dtxProtocolCommandStr,
-		 list_length(twophaseSegments) ? linitial_int(twophaseSegments) : -1);
+	ereport(DTM_DEBUG5,
+			(errmsg("dispatchDtxProtocolCommand: %d ('%s'), direct content #: %s",
+					dtxProtocolCommand, dtxProtocolCommandStr,
+					segmentsToContentStr(twophaseSegments))));
 
 	ErrorData *qeError;
 	results = CdbDispatchDtxProtocolCommand(dtxProtocolCommand, flags,
@@ -1901,7 +1901,7 @@ dispatchDtxCommand(const char *cmd)
 		return false;
 	}
 
-	CdbDispatchCommand(cmd, DF_NONE, &cdb_pgresults);
+	CdbDispatchCommand(cmd, DF_NEED_TWO_PHASE, &cdb_pgresults);
 
 	if (cdb_pgresults.numResults == 0)
 	{

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -97,12 +97,6 @@ cdbdisp_dispatchToGang(struct CdbDispatcherState *ds,
 	Assert(dispatchResults && dispatchResults->resultArray);
 
 	(pDispatchFuncs->dispatchToGang) (ds, gp, sliceIndex);
-
-	/*
-	 * If dtmPreCommand says we need two phase commit, record those segments
-	 * who actually get involved in current global transaction
-	 */
-	addToGxactTwophaseSegments(gp);
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -126,6 +126,7 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	cdbdisp_makeDispatchParams(ds, 1, queryText, queryTextLen);
 
 	cdbdisp_dispatchToGang(ds, primaryGang, -1);
+	addToGxactTwophaseSegments(primaryGang);
 
 	cdbdisp_waitDispatchFinish(ds);
 

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -3670,3 +3670,11 @@ insert into r2 (c1, c2) select c1, c2 from r2 returning c1, c2;
 (36 rows)
 
 rollback;
+--
+-- pg_relation_size() dispatches an internal query, to fetch the relation's
+-- size on each segment. The internal query doesn't need to be part of the
+-- distributed transactin. Test that we correctly issue two-phase commit in
+-- those segments that are affected by the INSERT, and that we don't try
+-- to perform distributed commit on the other segments.
+--
+insert into r1 (c4) values (pg_relation_size('r2'));

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -379,3 +379,12 @@ insert into r2 (c1, c2) select c1, c2 from d2 returning c1, c2;
 insert into r2 (c1, c2) select c1, c2 from r1 returning c1, c2;
 insert into r2 (c1, c2) select c1, c2 from r2 returning c1, c2;
 rollback;
+
+--
+-- pg_relation_size() dispatches an internal query, to fetch the relation's
+-- size on each segment. The internal query doesn't need to be part of the
+-- distributed transactin. Test that we correctly issue two-phase commit in
+-- those segments that are affected by the INSERT, and that we don't try
+-- to perform distributed commit on the other segments.
+--
+insert into r1 (c4) values (pg_relation_size('r2'));


### PR DESCRIPTION
Commit 576690f2ae added tracking of which segments have been enlisted in
a distributed transaction. However, it registered every query dispatched
with CdbDispatch*() in the distributed transaction, even if the query was
dispatched without the DF_NEED_TWO_PHASE flag to the segments. Without
DF_NEED_TWO_PHASE, the QE will believe it's not part of a distributed
transaction, and will throw an error when the QD tries to prepare it for
commit:

ERROR:  Distributed transaction 1542107193-0000000232 not found (cdbtm.c:3031)

This can occur if a command updates a partially distributed table (a table
with gp_distribution_policy.numsegments smaller than the cluster size),
and uses one of the backend functions, like pg_relation_size(), that
dispatches an internal query to all segments.

Fix the confusion, by only registering commands that are dispatched with
the DF_NEED_TWO_PHASE flag in the distributed transaction.