### PR TITLE
Avoid freeing memory in error path

### DIFF
--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -296,8 +296,6 @@ url_execute_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	if (file->handle->pid == -1)
 	{
 		errno = save_errno;
-		pfree(file->common.url);
-		pfree(file);
 		ereport(ERROR,
 				(errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
 						errmsg("cannot start external table command: %m"),

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -4031,15 +4031,9 @@ merge_leaf_stats(VacAttrStatsP stats,
 		}
 		else
 		{
-			// Else error out due to incompatible leaf HLL counter merge
-			pfree(hllcounters);
-			pfree(hllcounters_fullscan);
-			pfree(hllcounters_copy);
-			pfree(nDistincts);
-			pfree(nMultiples);
-			pfree(nUniques);
+			/* Else error out due to incompatible leaf HLL counter merge */
 			ereport(ERROR,
-					 (errmsg("ANALYZE cannot merge since not all non-empty leaf partitions have consistent hyperloglog statistics for merge"),
+					(errmsg("ANALYZE cannot merge since not all non-empty leaf partitions have consistent hyperloglog statistics for merge"),
 					 errhint("Re-run ANALYZE or ANALYZE FULLSCAN")));
 		}
 	}

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -7570,7 +7570,6 @@ open_program_pipes(char *command, bool forwrite)
 	if (program_pipes->pid == -1)
 	{
 		errno = save_errno;
-		pfree(program_pipes);
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
 				 errmsg("can not start command: %s", command)));

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -156,12 +156,12 @@ checkIODataDirectory(void)
 				errmsg("could not unlink file \"%s\": %m", FTS_PROBE_FILE_NAME)));
 		}
 	}
-	pfree(data);
 
 	if (failure)
 		ereport(ERROR,
 				(errmsg("disk IO check during FTS probe failed.")));
 
+	pfree(data);
 	return failure;
 }
 


### PR DESCRIPTION
Erroring out via ereport(ERROR ..) will clean up resources allocated during execution, so explicitly freeing right before is not useful (unless the allocation is the in TopMemoryContext).  Remove pfree() calls for lower allocations, and reorder one to happen just after a conditional ereport instead to make for slightly easier debugging when breaking on the error.