### PR TITLE
Fix building the coverity pipeline in Concourse

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -224,7 +224,7 @@ BLD_CURL_CONFIG=CURL_CONFIG=$(BLD_THIRDPARTY_BIN_DIR)/curl-config
 endif
 # ...and do not include the authlibs on Windows or AIX
 ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_64 win32 win64)" ""
-CONFIGFLAGS+= --with-openssl --with-pam --with-krb5 --with-ldap $(BLD_CURL_CONFIG) $(APR_CONFIG)
+CONFIGFLAGS+= --with-openssl --with-pam --with-ldap $(BLD_CURL_CONFIG) $(APR_CONFIG)
 endif
 
 # ...but do include some of the authlibs on AIX
@@ -276,7 +276,6 @@ $(GPPGDIR)/GNUmakefile : $(GPPGDIR)/configure  env.sh
                      CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL) \
                      ./configure $(CONFIGFLAGS)               \
                          --prefix=$(INSTLOC)                  \
-                         --with-docdir=$(INSTLOC)/doc         \
                          --mandir=$(INSTLOC)/man
 
 Debug/GNUmakefile : $(GPPGDIR)/configure  env.sh
@@ -286,7 +285,6 @@ Debug/GNUmakefile : $(GPPGDIR)/configure  env.sh
                 CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL)     \
                 ./configure $(CONFIGFLAGS)                   \
                     --prefix=$(INSTLOC)                      \
-                    --with-docdir=$(INSTLOC)/doc             \
                     --mandir=$(INSTLOC)/man
 
 Release/GNUmakefile : $(GPPGDIR)/configure  env.sh
@@ -296,7 +294,6 @@ Release/GNUmakefile : $(GPPGDIR)/configure  env.sh
                   CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL)  \
                   ./configure $(CONFIGFLAGS)                \
                       --prefix=$(INSTLOC)                   \
-                      --with-docdir=$(INSTLOC)/doc          \
                       --mandir=$(INSTLOC)/man
 
 #---------------------------------------------------------------------

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -447,7 +447,7 @@ devel : INSTLOC=$(DEVPATH)
 devel : CLIENTINSTLOC=$(CLIENTDEVPATH)
 devel : LOADERSINSTLOC=$(LOADERSDEVPATH)
 devel : GPPKGINSTLOC=$(GPPKGDEVPATH)
-devel : CONFIGFLAGS+= --enable-cassert --enable-debug --enable-testutils --enable-depend
+devel : CONFIGFLAGS+= --enable-cassert --enable-debug --enable-depend
 ifdef ENABLE_VPATH_BUILD
 devel : BUILDDIR=Debug
 devel : ISCONFIG=$(BUILDDIR)/GNUmakefile
@@ -482,7 +482,6 @@ dist_prof : INSTCFLAGS=$(PROFFLAGS)
 dist_prof : INSTLOC=$(DISTPATH)
 dist_prof : CLIENTINSTLOC=$(CLIENTDISTPATH)
 dist_prof : LOADERSINSTLOC=$(LOADERSDISTPATH)
-dist_prof : CONFIGFLAGS+= --enable-testutils
 ifdef ENABLE_VPATH_BUILD
 dist_prof : BUILDDIR=Release
 dist_prof : ISCONFIG=$(BUILDDIR)/GNUmakefile
@@ -495,7 +494,6 @@ endif
 
 dist_faultinj : CLIENTINSTLOC=$(CLIENTDISTPATH)
 dist_faultinj : LOADERSINSTLOC=$(LOADERSDISTPATH)
-dist_faultinj : CONFIGFLAGS+= --enable-testutils
 ifdef ENABLE_VPATH_BUILD
 dist_faultinj : BUILDDIR=Release
 dist_faultinj : ISCONFIG=$(BUILDDIR)/GNUmakefile

--- a/src/include/utils/palloc.h
+++ b/src/include/utils/palloc.h
@@ -55,7 +55,13 @@
 #define CDB_PALLOC_CALLER_ID
 */
 
-// GPDB_93_MERGE_FIXME: This mechanism got broken.
+/*
+ * GPDB_93_MERGE_FIXME: This mechanism got broken. If this is resurrected and
+ * and made working the --enable-testutils invocations should be readded to
+ * gpAux/Makefile. For reference to where, the commit adding this comment has
+ * the removal so reverting this will get us back where we were before the
+ * merge.
+ */
 #ifdef USE_ASSERT_CHECKING
 //#define CDB_PALLOC_TAGS
 #endif


### PR DESCRIPTION
The --enable-testutils mechanism was broken in the 9.3 merge, with fixing it left as a FIXME. Remove the invocation of the option from gpAux targets as they otherwise fail to compile the tree. This also expands the comment of the FIXME to indicate that these should be turned on again when fixed.

Also fix an unrelated warning on unused options spotted when looking at the log.