### PR TITLE
Don't store total relpages/reltuples in root partition's pg_class.

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1513,18 +1513,6 @@ vac_update_relstats_from_list(List *updated_stats)
 			stats->rel_tuples = stats->rel_tuples / rel->rd_cdbpolicy->numsegments;
 			stats->relallvisible = stats->relallvisible / rel->rd_cdbpolicy->numsegments;
 		}
-		/*
-		 * If the relation is a partition root, we wont have any statistics
-		 * to update with as we've looked at the root in isolation. Avoid
-		 * resetting the statistics to zero. This means that the root won't
-		 * have the correct aggregate statistics until it has been ANALYZEd.
-		 */
-		else if (rel_is_partitioned(stats->relid))
-		{
-			stats->rel_pages = rel->rd_rel->relpages;
-			stats->rel_tuples = rel->rd_rel->reltuples;
-			stats->relallvisible = rel->rd_rel->relallvisible;
-		}
 
 		/*
 		 * Pass 'false' for isvacuum, so that the stats are

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2381,24 +2381,6 @@ gpdb::RelationExists
 }
 
 void
-gpdb::EstimateRelationSize
-	(
-	Relation rel,
-	int32 *attr_widths,
-	BlockNumber *pages,
-	double *tuples,
-	double *allvisfrac
-	)
-{
-	GP_WRAP_START;
-	{
-		estimate_rel_size(rel, attr_widths, pages, tuples, allvisfrac);
-		return;
-	}
-	GP_WRAP_END;
-}
-
-void
 gpdb::CdbEstimateRelationSize
 	(
 	RelOptInfo   *relOptInfo,
@@ -2413,6 +2395,20 @@ gpdb::CdbEstimateRelationSize
 	{
 		cdb_estimate_rel_size(relOptInfo, rel, attr_widths, pages, tuples, allvisfrac);
 		return;
+	}
+	GP_WRAP_END;
+}
+
+double
+gpdb::CdbEstimatePartitionedNumTuples
+	(
+	Relation rel,
+	bool *stats_missing_p
+	)
+{
+	GP_WRAP_START;
+	{
+		return cdb_estimate_partitioned_numtuples(rel, stats_missing_p);
 	}
 	GP_WRAP_END;
 }

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -49,6 +49,7 @@
 #include "cdb/cdbrelsize.h"
 #include "catalog/pg_appendonly_fn.h"
 #include "catalog/pg_exttable.h"
+#include "catalog/pg_inherits_fn.h"
 
 
 /* GUC parameter */
@@ -559,6 +560,86 @@ cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 
 	elog(DEBUG2, "cdb_estimate_rel_size estimated %g tuples, %d pages, and"
 		" %f allvisfrac", *tuples, (int) *pages, *allvisfrac);
+}
+
+/*
+ * Get the total size of a partitioned table, including all partitions.
+ *
+ * Only used with ORCA, currently. This is slightly different from
+ * cdb_estimate_rel_size(), in that if the relation is a partitioned table
+ * (or general inherited table, but ORCA doesn't deal with general general
+ * inheritance), this sums up the estimates from the child tables. Also, if
+ * gp_enable_relsize_collection is off, and none of the partitions have been
+ * analyzed, this returns 0 rather than the default constant estimate.
+ */
+double
+cdb_estimate_partitioned_numtuples(Relation rel, bool *stats_missing)
+{
+	List	   *inheritors;
+	ListCell   *lc;
+	double		totaltuples;
+
+	*stats_missing = false;
+
+	if (rel->rd_rel->reltuples > 0)
+		return rel->rd_rel->reltuples;
+
+	inheritors = find_all_inheritors(RelationGetRelid(rel),
+									 NoLock,
+									 NULL);
+	totaltuples = 0;
+	foreach(lc, inheritors)
+	{
+		Oid			childid = lfirst_oid(lc);
+		Relation	childrel;
+		double		childtuples;
+
+		if (childid != RelationGetRelid(rel))
+			childrel = try_heap_open(childid, NoLock, false);
+		else
+			childrel = rel;
+
+		childtuples = childrel->rd_rel->reltuples;
+
+		/*
+		 * relpages == 0 means stats are missing. There's a special
+		 * case in ANALYZE/VACUUM, to set relpages to 1 even if the
+		 * table is completely empty, so relpages is zero only if the
+		 * table hasn't been analyzed yet.
+		 */
+		if (childrel->rd_rel->relpages == 0)
+		{
+			/*
+			 * In the root partition of a partitioned table, though,
+			 * it's expected.
+			 */
+			if (childrel != rel)
+				*stats_missing = true;
+		}
+
+		if (gp_enable_relsize_collection && childtuples == 0)
+		{
+			RelOptInfo *dummy_reloptinfo;
+			BlockNumber	numpages;
+			double		allvisfrac;
+
+			dummy_reloptinfo = makeNode(RelOptInfo);
+			dummy_reloptinfo->cdbpolicy = rel->rd_cdbpolicy;
+
+			cdb_estimate_rel_size(dummy_reloptinfo,
+								  childrel,
+								  NULL,
+								  &numpages,
+								  &childtuples,
+								  &allvisfrac);
+			pfree(dummy_reloptinfo);
+		}
+		totaltuples += childtuples;
+
+		if (childrel != rel)
+			heap_close(childrel, NoLock);
+	}
+	return totaltuples;
 }
 
 

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -514,8 +514,8 @@ namespace gpdb {
 	bool RelationExists(Oid oid);
 
 	// estimate the relation size using the real number of blocks and tuple density
-	void EstimateRelationSize(Relation rel,	int32 *attr_widths,	BlockNumber *pages,	double *tuples, double *allvisfrac);
 	void CdbEstimateRelationSize (RelOptInfo *relOptInfo, Relation rel, int32 *attr_widths, BlockNumber *pages, double *tuples, double *allvisfrac);
+	double CdbEstimatePartitionedNumTuples (Relation rel, bool *stats_missing);
 
 	// close the given relation
 	void CloseRelation(Relation rel);

--- a/src/include/optimizer/plancat.h
+++ b/src/include/optimizer/plancat.h
@@ -39,6 +39,7 @@ extern void cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 							  BlockNumber  *pages,
 							  double       *tuples,
 							  double       *allvisfrac);
+extern double cdb_estimate_partitioned_numtuples(Relation rel, bool *stats_missing);
 
 extern int32 get_relation_data_width(Oid relid, int32 *attr_widths);
 

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -26,7 +26,7 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
@@ -175,7 +175,7 @@ analyze;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
@@ -283,7 +283,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
@@ -428,7 +428,7 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
@@ -484,7 +484,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
@@ -535,20 +535,20 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
- p3_sales_1_prt_2                                                |         2 |        1
- p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
@@ -601,7 +601,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
@@ -652,7 +652,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
@@ -703,20 +703,20 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        1
- p3_sales_1_prt_2                                                |         2 |        1
- p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
@@ -764,7 +764,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -513,18 +513,6 @@ CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select Ta.a , Ta.b , Ta.c  from public.dd_singlecol_part_bitmap_idx_1_prt_extra as Ta  limit 30000 "
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145124"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145100"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145104"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145108"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145112"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145116"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145096"
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
@@ -747,18 +735,6 @@ CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select Ta.a , Ta.b , Ta.c  from public.dd_singlecol_part_idx_1_prt_extra as Ta  limit 30000 "
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145180"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145159"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145163"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145167"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145171"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145175"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145155"
 analyze dd_singlecol_part_idx2;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -779,18 +755,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145189"
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select Ta.a , Ta.b , Ta.c  from public.dd_singlecol_part_idx2_1_prt_extra as Ta  limit 30000 "
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145214"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145193"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145197"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145201"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145205"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145209"
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=145189"
 -- indexes on partitioned tables

--- a/src/test/regress/expected/bfv_dd_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_optimizer.out
@@ -504,18 +504,6 @@ CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select Ta.a , Ta.b , Ta.c  from public.dd_singlecol_part_bitmap_idx_1_prt_extra as Ta  limit 30000 "
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139555"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139531"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139535"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139539"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139543"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139547"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139527"
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
@@ -734,18 +722,6 @@ CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select Ta.a , Ta.b , Ta.c  from public.dd_singlecol_part_idx_1_prt_extra as Ta  limit 30000 "
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139611"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139590"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139594"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139598"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139602"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139606"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139586"
 analyze dd_singlecol_part_idx2;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -766,18 +742,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139620"
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select Ta.a , Ta.b , Ta.c  from public.dd_singlecol_part_idx2_1_prt_extra as Ta  limit 30000 "
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139645"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139624"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139628"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139632"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139636"
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139640"
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 CONTEXT:  SQL statement "select pg_catalog.sum(pg_catalog.gp_statistics_estimate_reltuples_relpages_oid(c.oid))::pg_catalog.float4[] from gp_dist_random('pg_catalog.pg_class') c where c.oid=139620"
 -- indexes on partitioned tables

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1997,7 +1997,7 @@ SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_
 SELECT relname, relpages, reltuples FROM pg_class WHERE relname LIKE 'incr_analyze_test%' ORDER BY relname;
           relname          | relpages | reltuples 
 ---------------------------+----------+-----------
- incr_analyze_test         |        4 |      1001
+ incr_analyze_test         |        0 |         0
  incr_analyze_test_1_prt_1 |        1 |         1
  incr_analyze_test_1_prt_2 |        3 |      1000
  incr_analyze_test_1_prt_3 |        1 |         0

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -1691,7 +1691,7 @@ select relname, reltuples, relpages from pg_class where relname like 'tbl6833_an
 ------------------------+-----------+----------
  tbl6833_anl_1_prt_bb_1 |         0 |        1
  tbl6833_anl_1_prt_bb_2 |         0 |        1
- tbl6833_anl            |         0 |        1
+ tbl6833_anl            |         0 |        0
 (3 rows)
 
 create table qp_misc_jiras.tbl6833_vac(a int, b int, c int) distributed by (a) partition by range (b) (partition bb start (0) end (2) every (1));

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -1691,7 +1691,7 @@ select relname, reltuples, relpages from pg_class where relname like 'tbl6833_an
 ------------------------+-----------+----------
  tbl6833_anl_1_prt_bb_1 |         0 |        1
  tbl6833_anl_1_prt_bb_2 |         0 |        1
- tbl6833_anl            |         0 |        1
+ tbl6833_anl            |         0 |        0
 (3 rows)
 
 create table qp_misc_jiras.tbl6833_vac(a int, b int, c int) distributed by (a) partition by range (b) (partition bb start (0) end (2) every (1));

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -287,27 +287,44 @@ VACUUM ANALYZE s_priv_test.t_priv_table;
 DROP SCHEMA s_priv_test CASCADE;
 NOTICE:  drop cascades to table s_priv_test.t_priv_table
 DROP ROLE r_priv_test;
--- Ensure that VACUUM doesn't reset the statistics on the parent table
-CREATE TABLE pt (a int, b int) DISTRIBUTED BY (a) PARTITION BY range (b) (END(5), START(5));
-INSERT INTO pt SELECT 0, 6 FROM generate_series(1, 12);
-ANALYZE pt;
-SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
- reltuples 
------------
-        12
-(1 row)
+-- Check how reltuples/relpages are updated on a partitioned table, on
+-- VACUUM and ANALYZE.
+set gp_autostats_mode='none';
+CREATE TABLE vacuum_gp_pt (a int, b int) DISTRIBUTED BY (a) PARTITION BY range (b) (END(5), START(5));
+INSERT INTO vacuum_gp_pt SELECT 0, 6 FROM generate_series(1, 12);
+SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
+       relname        | reltuples | relpages 
+----------------------+-----------+----------
+ vacuum_gp_pt         |         0 |        0
+ vacuum_gp_pt_1_prt_1 |         0 |        0
+ vacuum_gp_pt_1_prt_2 |         0 |        0
+(3 rows)
 
-VACUUM pt;
-SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
- reltuples 
------------
-        12
-(1 row)
+ANALYZE vacuum_gp_pt;
+SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
+       relname        | reltuples | relpages 
+----------------------+-----------+----------
+ vacuum_gp_pt         |         0 |        0
+ vacuum_gp_pt_1_prt_1 |         0 |        1
+ vacuum_gp_pt_1_prt_2 |        12 |        1
+(3 rows)
 
-VACUUM ANALYZE pt;
-SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
- reltuples 
------------
-        12
-(1 row)
+VACUUM vacuum_gp_pt;
+SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
+       relname        | reltuples | relpages 
+----------------------+-----------+----------
+ vacuum_gp_pt         |         0 |        1
+ vacuum_gp_pt_1_prt_1 |         0 |        1
+ vacuum_gp_pt_1_prt_2 |        12 |        1
+(3 rows)
 
+VACUUM ANALYZE vacuum_gp_pt;
+SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
+       relname        | reltuples | relpages 
+----------------------+-----------+----------
+ vacuum_gp_pt         |         0 |        1
+ vacuum_gp_pt_1_prt_1 |         0 |        1
+ vacuum_gp_pt_1_prt_2 |        12 |        1
+(3 rows)
+
+reset gp_autostats_mode;

--- a/src/test/regress/input/uao_ddl/alter_ao_part_tables_splitpartition.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_part_tables_splitpartition.source
@@ -35,6 +35,9 @@ insert into sto_alt_uao_part_splitpartition
  select i, ('2013-'||i||'-11')::date, i from generate_series(1,12)i;
 delete from sto_alt_uao_part_splitpartition where date < '2013-07-10';
 
+-- avoid warnings about missing stats with ORCA.
+ANALYZE sto_alt_uao_part_splitpartition;
+
 Insert into sto_alt_uao_part_splitpartition values
  (10,'2013-01-22',12.52), (11,'2013-02-22',13.53), (12,'2013-07-22',14.54);
 select * from sto_alt_uao_part_splitpartition;

--- a/src/test/regress/output/uao_ddl/alter_ao_part_tables_splitpartition.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_part_tables_splitpartition.source
@@ -52,6 +52,8 @@ visimapidxid is not NULL AND relid in (SELECT c.oid FROM pg_class c
 insert into sto_alt_uao_part_splitpartition
  select i, ('2013-'||i||'-11')::date, i from generate_series(1,12)i;
 delete from sto_alt_uao_part_splitpartition where date < '2013-07-10';
+-- avoid warnings about missing stats with ORCA.
+ANALYZE sto_alt_uao_part_splitpartition;
 Insert into sto_alt_uao_part_splitpartition values
  (10,'2013-01-22',12.52), (11,'2013-02-22',13.53), (12,'2013-07-22',14.54);
 select * from sto_alt_uao_part_splitpartition;

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -189,12 +189,16 @@ VACUUM ANALYZE s_priv_test.t_priv_table;
 DROP SCHEMA s_priv_test CASCADE;
 DROP ROLE r_priv_test;
 
--- Ensure that VACUUM doesn't reset the statistics on the parent table
-CREATE TABLE pt (a int, b int) DISTRIBUTED BY (a) PARTITION BY range (b) (END(5), START(5));
-INSERT INTO pt SELECT 0, 6 FROM generate_series(1, 12);
-ANALYZE pt;
-SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
-VACUUM pt;
-SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
-VACUUM ANALYZE pt;
-SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+-- Check how reltuples/relpages are updated on a partitioned table, on
+-- VACUUM and ANALYZE.
+set gp_autostats_mode='none';
+CREATE TABLE vacuum_gp_pt (a int, b int) DISTRIBUTED BY (a) PARTITION BY range (b) (END(5), START(5));
+INSERT INTO vacuum_gp_pt SELECT 0, 6 FROM generate_series(1, 12);
+SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
+ANALYZE vacuum_gp_pt;
+SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
+VACUUM vacuum_gp_pt;
+SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
+VACUUM ANALYZE vacuum_gp_pt;
+SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
+reset gp_autostats_mode;


### PR DESCRIPTION
For consistency with upstream. Sum up the child reltuples at planning
time in ORCA, instead. This adds some overhead to planning partitioned
tables with lots of partitions with ORCA, but we hardly care about the
startup time of ORCA, anyway..