### PR TITLE
5X: Fix overwriting of pg_class statistics during VACUUM

### DIFF
--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -291,3 +291,27 @@ VACUUM ANALYZE s_priv_test.t_priv_table;
 DROP SCHEMA s_priv_test CASCADE;
 NOTICE:  drop cascades to table s_priv_test.t_priv_table
 DROP ROLE r_priv_test;
+-- Ensure that VACUUM doesn't reset the statistics on the parent table
+CREATE TABLE pt (a int, b int) DISTRIBUTED BY (a) PARTITION BY range (b) (END(5), START(5));
+INSERT INTO pt SELECT 0, 6 FROM generate_series(1, 12);
+ANALYZE pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+ reltuples 
+-----------
+        12
+(1 row)
+
+VACUUM pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+ reltuples 
+-----------
+        12
+(1 row)
+
+VACUUM ANALYZE pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+ reltuples 
+-----------
+        12
+(1 row)
+

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -191,3 +191,13 @@ ALTER TABLE s_priv_test.t_priv_table OWNER TO r_priv_test;
 VACUUM ANALYZE s_priv_test.t_priv_table;
 DROP SCHEMA s_priv_test CASCADE;
 DROP ROLE r_priv_test;
+
+-- Ensure that VACUUM doesn't reset the statistics on the parent table
+CREATE TABLE pt (a int, b int) DISTRIBUTED BY (a) PARTITION BY range (b) (END(5), START(5));
+INSERT INTO pt SELECT 0, 6 FROM generate_series(1, 12);
+ANALYZE pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+VACUUM pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';
+VACUUM ANALYZE pt;
+SELECT reltuples FROM pg_catalog.pg_class WHERE relname = 'pt';


### PR DESCRIPTION
When VACUUM passes a partitioning root it will consider in isolation
in vacuum_rel, which will set the statistics to zero as there is no
data to be counted. This means that the root statistics were reset
on VACUUM which can cause unsuitable plans to be generated.

Rather than resetting, opt for retaining the statistics for root
partitions during VACUUM as it's all we can do, without breaking
the one-rel-at-time semantics of VACUUM.  This adds a testcase to
ensure reltuples are maintained.

Also add an assertion on QD operation to the function to indicate
when reading code that this function may make assumptions that are
only valid on the QD.

This is a backport from master PR #6221 .