### PR TITLE
Fix bugs in FDWs and postgres_fdw.

### DIFF
--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -473,7 +473,8 @@ postgresGetForeignRelSize(PlannerInfo *root,
 													 fpinfo->local_conds,
 													 baserel->relid,
 													 JOIN_INNER,
-													 NULL);
+													 NULL,
+													 false);
 
 	cost_qual_eval(&fpinfo->local_conds_cost, fpinfo->local_conds, root);
 
@@ -1013,7 +1014,7 @@ postgresIterateForeignScan(ForeignScanState *node)
 	/*
 	 * Return the next tuple.
 	 */
-	ExecStoreTuple(fsstate->tuples[fsstate->next_tuple++],
+	ExecStoreHeapTuple(fsstate->tuples[fsstate->next_tuple++],
 				   slot,
 				   InvalidBuffer,
 				   false);
@@ -1759,7 +1760,8 @@ estimate_path_cost_size(PlannerInfo *root,
 										   local_join_conds,
 										   baserel->relid,
 										   JOIN_INNER,
-										   NULL);
+										   NULL,
+										   false);
 		local_sel *= fpinfo->local_conds_sel;
 
 		rows = clamp_row_est(rows * local_sel);
@@ -2268,7 +2270,7 @@ store_returning_result(PgFdwModifyState *fmstate,
 											fmstate->retrieved_attrs,
 											fmstate->temp_cxt);
 		/* tuple will be deleted when it is cleared from the slot */
-		ExecStoreTuple(newtup, slot, InvalidBuffer, true);
+		ExecStoreHeapTuple(newtup, slot, InvalidBuffer, true);
 	}
 	PG_CATCH();
 	{

--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -244,8 +244,14 @@ plan_tree_walker(Node *node,
 		case T_BitmapAppendOnlyScan:
 		case T_BitmapTableScan:
 		case T_WorkTableScan:
+			if (walk_scan_node_fields((Scan *) node, walker, context))
+				return true;
+			break;
+
 		case T_ForeignScan:
 			if (walk_scan_node_fields((Scan *) node, walker, context))
+				return true;
+			if (walker(((ForeignScan *) node)->fdw_exprs, context))
 				return true;
 			break;
 


### PR DESCRIPTION
* Replace ExecStoreTuple with ExecStoreHeapTuple in postgres_fdw, to make
  it compile

* Teach plan_tree_walker() to recurse into ForeignScan.fdw_exprs field.
  This fixes a crash in the postgres_fdw regression tests.

This is enough to make postgres_fdw compile, and not crash. It's still
failing a lot of regression tests, though. The failures need further
investigation, but this is a start.