### PR TITLE
Fix memory leak in eval_part_qual

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2674,8 +2674,8 @@ typedef struct PartitionSelectorState
 	PartitionAccessMethods *accessMethods;              /* Access method for partition */
 	struct PartitionRule **levelPartRules; 				/* accepted partitions for all levels */
 	List *levelEqExprStates;                            /* ExprState for equality expressions for all levels */
-	List *levelExprStates;                              /* ExprState for general expressions for all levels */
-	ExprState *residualPredicateExprState;              /* ExprState for evaluating residual predicate */
+	List *levelExprStateLists;                          /* ExprState list for general expressions for all levels */
+	List *residualPredicateExprStateList;               /* ExprState list for evaluating residual predicate */
 	ExprState *propagationExprState;                    /* ExprState for evaluating propagation expression */
 
 	TupleDesc	partTabDesc;


### PR DESCRIPTION
Fix memory leak in eval_part_qual

Whenever `eval_part_qual` is invoked, a new qualList object is allocated
and is executed to evaluate a bool result. Once, the qualList is used,
the memory is not freed, and we continue allocating memory for qualList
for all the levels. This can lead to OOM errors.

Instead of allocating the memory in `eval_part_qual`, its better to
initialize it in `ExecInitPartitionSelector` to avoid such leaks.

This PR is a backport of https://github.com/greenplum-db/gpdb/commit/6722118deeebcc119de0ec414f80025774a5b464 from master. However, since have added one additional commit to disable planner for 1 the new test added, creating this PR to get consensus to get it in. 

Signed-off-by: Hans Zeller <hzeller@pivotal.io>