### PR TITLE
Disable deprecated register warning for gpcloud

### DIFF
--- a/gpcontrib/gpcloud/src/gpcloud.cpp
+++ b/gpcontrib/gpcloud/src/gpcloud.cpp
@@ -1,6 +1,9 @@
 extern "C" {
 #include "postgres.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-register"
+
 #include "access/extprotocol.h"
 #include "access/xact.h"
 #include "catalog/pg_exttable.h"
@@ -12,6 +15,8 @@ extern "C" {
 #include "utils/builtins.h"
 #include "utils/memutils.h"
 #include "utils/resowner.h"
+
+#pragma clang diagnostic pop
 
 /* Do the module magic dance */
 PG_MODULE_MAGIC;


### PR DESCRIPTION
Including funcapi.h pulls in lwlock.h which use the register storage class for spinlocks. This causes a compiler warning fo deprecated storage class when used in C++ code, which gpcloud is.
```
../../src/include/storage/s_lock.h:220:2: warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]
        register slock_t _res = 1;
        ^~~~~~~~~
1 warning generated.
```
While this will go away as the register stored spinlock is removed in a future commit which we will get via merging upstream, having a pointless compiler warning in every buildlog which we all need to ignore is bad practice (no warning should ever be ignored) so remove it now via a pragma.

A similar pragma may be needed for GCC but I don't have a recent GCC handy to test with.