### PR TITLE
Fix crash when concurrent update a table contains varying length column

### DIFF
--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -834,6 +834,14 @@ ExecMaterializeSlot(TupleTableSlot *slot)
 	}
 
 	slot->PRIVATE_tts_heaptuple = htup;
+
+	/*
+	 * Mark extracted state invalid.  This is important because the slot is
+	 * not supposed to depend any more on the previous external data; we
+	 * mustn't leave any dangling pass-by-reference datums in PRIVATE_tts_values.
+	 */
+	slot->PRIVATE_tts_nvalid = 0;
+
 	return htup;
 }
 

--- a/src/test/isolation2/expected/concurrent_update.out
+++ b/src/test/isolation2/expected/concurrent_update.out
@@ -6,8 +6,12 @@ INSERT 1
 
 1: BEGIN;
 BEGIN
+1: SET optimizer=off;
+SET
 1: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
 UPDATE 1
+2: SET optimizer=off;
+SET
 2&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;  <waiting ...>
 1: END;
 END

--- a/src/test/isolation2/expected/concurrent_update.out
+++ b/src/test/isolation2/expected/concurrent_update.out
@@ -1,0 +1,23 @@
+-- Test concurrent update a table with a varying length type
+CREATE TABLE t_concurrent_update(a int, b int, c char(84));
+CREATE
+INSERT INTO t_concurrent_update VALUES(1,1,'test');
+INSERT 1
+
+1: BEGIN;
+BEGIN
+1: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+UPDATE 1
+2&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;  <waiting ...>
+1: END;
+END
+2<:  <... completed>
+UPDATE 1
+1: SELECT * FROM t_concurrent_update;
+a|b |c                                                                                   
+-+--+------------------------------------------------------------------------------------
+1|21|test                                                                                
+(1 row)
+
+DROP TABLE t_concurrent_update;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -165,3 +165,5 @@ test: reindex/vacuum_while_reindex_ao_bitmap reindex/vacuum_while_reindex_heap_b
 
 # Cancel test
 test: cancel_plpython
+
+test: concurrent_update

--- a/src/test/isolation2/sql/concurrent_update.sql
+++ b/src/test/isolation2/sql/concurrent_update.sql
@@ -1,0 +1,12 @@
+-- Test concurrent update a table with a varying length type
+CREATE TABLE t_concurrent_update(a int, b int, c char(84));
+INSERT INTO t_concurrent_update VALUES(1,1,'test');
+
+1: BEGIN;
+1: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+2&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+1: END;
+2<:
+1: SELECT * FROM t_concurrent_update;
+
+DROP TABLE t_concurrent_update;

--- a/src/test/isolation2/sql/concurrent_update.sql
+++ b/src/test/isolation2/sql/concurrent_update.sql
@@ -3,7 +3,9 @@ CREATE TABLE t_concurrent_update(a int, b int, c char(84));
 INSERT INTO t_concurrent_update VALUES(1,1,'test');
 
 1: BEGIN;
+1: SET optimizer=off;
 1: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+2: SET optimizer=off;
 2&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
 1: END;
 2<:


### PR DESCRIPTION
EvalPlanQual materializes the slot to a heap tuple, PRIVATE_tts_values point
to freed memory. We need to reset PRIVATE_tts_nvalid in ExecMaterializeSlot, to
prevent the following ExecFilterJunk from referencing the dangling pointer.