### PR TITLE
Add alternate output for gp_xml for unsupported feature

### DIFF
--- a/src/test/regress/expected/gp_xml_1.out
+++ b/src/test/regress/expected/gp_xml_1.out
@@ -1,0 +1,8 @@
+SELECT XMLPARSE(CONTENT '<abc>x</abc>'::text STRIP WHITESPACE) AS "xmlparse";
+ERROR:  unsupported XML feature
+DETAIL:  This functionality requires the server to be built with libxml support.
+HINT:  You need to rebuild PostgreSQL using --with-libxml.
+SELECT XMLPARSE(CONTENT '<abc>x</abc>'::text PRESERVE WHITESPACE) AS "xmlparse";
+ERROR:  unsupported XML feature
+DETAIL:  This functionality requires the server to be built with libxml support.
+HINT:  You need to rebuild PostgreSQL using --with-libxml.


### PR DESCRIPTION
After the discussion in #6237 I mustered the energy to figure out why I was getting `FAILED` on the `gp_xml` test in my builds without libxml. Turns out the alternate output file was simply missing. This + #6237 will make sure that ICW can run green on a build without XML.

Commit c20e5c4e488be added the gp_xml testsuite for GPDB XML tests in order to not pollute the upstrean xml testsuite, it however failed to add the alternative output for clusters compiled with out support for XML.