### PR TITLE
Replace PathKey with new DistributionKey struct, in CdbPathLocus.

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -518,7 +518,7 @@ cdb_grouping_planner(PlannerInfo *root,
 		 */
 		if (has_groups &&
 			pathkeys_contained_in(root->group_pathkeys, group_context->best_path->pathkeys) &&
-			cdbpathlocus_collocates(root, group_context->best_path->locus, root->group_pathkeys, false /* exact_match */ ))
+			cdbpathlocus_collocates_pathkeys(root, group_context->best_path->locus, root->group_pathkeys, false /* exact_match */ ))
 		{
 			input_path = group_context->best_path;
 		}
@@ -542,7 +542,7 @@ cdb_grouping_planner(PlannerInfo *root,
 	else if (has_groups)		/* and not single or replicated */
 	{
 		if (root->group_pathkeys != NULL &&
-			cdbpathlocus_collocates(root, plan_1p.input_locus, root->group_pathkeys, false /* exact_match */ ))
+			cdbpathlocus_collocates_pathkeys(root, plan_1p.input_locus, root->group_pathkeys, false /* exact_match */ ))
 		{
 			plan_1p.group_prep = MPP_GRP_PREP_NONE;
 			plan_1p.output_locus = plan_1p.input_locus; /* may be less
@@ -566,7 +566,8 @@ cdb_grouping_planner(PlannerInfo *root,
 			else if (gp_hash_safe_grouping(root))
 			{
 				plan_1p.group_prep = MPP_GRP_PREP_HASH_GROUPS;
-				CdbPathLocus_MakeHashed(&plan_1p.output_locus, root->group_pathkeys,
+				CdbPathLocus_MakeHashed(&plan_1p.output_locus,
+										cdbpathlocus_get_distkeys_for_pathkeys(root->group_pathkeys),
 										CdbPathLocus_NumSegments(plan_1p.input_locus));
 			}
 			else
@@ -764,7 +765,8 @@ cdb_grouping_planner(PlannerInfo *root,
 				CdbPathLocus_MakeGeneral(&plan_2p.output_locus,
 										 CdbPathLocus_NumSegments(plan_2p.input_locus));
 			else
-				CdbPathLocus_MakeHashed(&plan_2p.output_locus, root->group_pathkeys,
+				CdbPathLocus_MakeHashed(&plan_2p.output_locus,
+										cdbpathlocus_get_distkeys_for_pathkeys(root->group_pathkeys),
 										CdbPathLocus_NumSegments(plan_2p.input_locus));
 		}
 		else
@@ -776,24 +778,26 @@ cdb_grouping_planner(PlannerInfo *root,
 
 		if (consider_agg & AGG_2PHASE_DQA)
 		{
-			PathKey    *distinct_pathkey;
-			List	   *l;
-
 			/* Either have DQA or not! */
 			Assert(!(consider_agg & AGG_2PHASE));
 
 			Insist(IsA(agg_costs->dqaArgs, List) &&
 				   list_length((List *) agg_costs->dqaArgs) == 1);
-			distinct_pathkey = cdb_make_pathkey_for_expr(root,
-														 linitial(agg_costs->dqaArgs),
-														 list_make1(makeString("=")));
-			l = list_make1(distinct_pathkey);
 
-			if (!cdbpathlocus_collocates(root, plan_2p.input_locus, l, false /* exact_match */ ))
+			if (!cdbpathlocus_collocates_expressions(root, plan_2p.input_locus, agg_costs->dqaArgs, false /* exact_match */ ))
 			{
+				DistributionKey *distinct_distkey;
+				List	   *l;
+
+				distinct_distkey = cdb_make_distkey_for_expr(root,
+															 linitial(agg_costs->dqaArgs),
+															 list_make1(makeString("=")));
+				l = list_make1(distinct_distkey);
+
 				plan_2p.group_prep = MPP_GRP_PREP_HASH_DISTINCT;
 				CdbPathLocus_MakeHashed(&plan_2p.input_locus, l,
 										CdbPathLocus_NumSegments(plan_2p.input_locus));
+				list_free(l);
 			}
 			else
 			{
@@ -801,8 +805,6 @@ cdb_grouping_planner(PlannerInfo *root,
 				plan_2p.output_locus = plan_2p.input_locus;
 				plan_2p.distinctkey_collocate = true;
 			}
-
-			list_free(l);
 		}
 	}
 
@@ -818,7 +820,8 @@ cdb_grouping_planner(PlannerInfo *root,
 				CdbPathLocus_MakeGeneral(&plan_3p.output_locus,
 										 CdbPathLocus_NumSegments(plan_3p.input_locus));
 			else
-				CdbPathLocus_MakeHashed(&plan_3p.output_locus, root->group_pathkeys,
+				CdbPathLocus_MakeHashed(&plan_3p.output_locus,
+										cdbpathlocus_get_distkeys_for_pathkeys(root->group_pathkeys),
 										CdbPathLocus_NumSegments(plan_3p.input_locus));
 		}
 		else
@@ -882,26 +885,18 @@ cdb_grouping_planner(PlannerInfo *root,
 		 */
 		for (i = 0; i < ctx.numDistinctCols; i++)
 		{
-			PathKey    *distinct_pathkey;
-			List	   *l;
-
 			set_coplan_strategies(root, &ctx, &ctx.dqaArgs[i], plan_3p.input_path);
 
 			/*
 			 * Determine if the input plan already collocates on the distinct
 			 * key.
 			 */
-			distinct_pathkey = cdb_make_pathkey_for_expr(root,
-														 ctx.dqaArgs[i].distinctExpr,
-														 list_make1(makeString("=")));
-			l = list_make1(distinct_pathkey);
-
-			if (cdbpathlocus_collocates(root, plan_3p.input_locus, l, false /* exact_match */ ))
+			if (cdbpathlocus_collocates_expressions(root, plan_3p.input_locus,
+													list_make1(ctx.dqaArgs[i].distinctExpr),
+													false /* exact_match */ ))
 			{
 				ctx.dqaArgs[i].distinctkey_collocate = true;
 			}
-
-			list_free(l);
 		}
 	}
 
@@ -1958,7 +1953,7 @@ make_plan_for_one_dqa(PlannerInfo *root, MppGroupContext *ctx, int dqa_index,
 				n;
 	DqaInfo    *dqaArg = &ctx->dqaArgs[dqa_index];
 	bool		sort_coplans = (ctx->join_strategy == DqaJoinMerge);
-	bool		groupkeys_collocate = cdbpathlocus_collocates(root, ctx->input_locus, root->group_pathkeys, false /* exact_match */ );
+	bool		groupkeys_collocate = cdbpathlocus_collocates_pathkeys(root, ctx->input_locus, root->group_pathkeys, false /* exact_match */ );
 	bool		need_inter_agg = false;
 	bool		dqaduphazard = false;
 	bool		stream_bottom_agg = root->config->gp_hashagg_streambottom;	/* Take hint */
@@ -2985,7 +2980,7 @@ generate_subquery_tlist(Index varno, List *input_tlist,
 
 
 /*
- * Function: cdbpathlocus_collocates
+ * Function: cdbpathlocus_collocates_pathkeys
  *
  * Is a relation with the given locus guaranteed to collocate tuples with
  * non-distinct values of the key.  The key is a list of PathKeys.
@@ -2998,8 +2993,8 @@ generate_subquery_tlist(Index varno, List *input_tlist,
  * on a range since these cannot occur at the moment (MPP 2.3).
  */
 bool
-cdbpathlocus_collocates(PlannerInfo *root, CdbPathLocus locus, List *pathkeys,
-						bool exact_match)
+cdbpathlocus_collocates_pathkeys(PlannerInfo *root, CdbPathLocus locus, List *pathkeys,
+								 bool exact_match)
 {
 	ListCell   *i;
 	List	   *pk_eclasses;
@@ -3017,7 +3012,7 @@ cdbpathlocus_collocates(PlannerInfo *root, CdbPathLocus locus, List *pathkeys,
 		return false;
 	}
 
-	if (exact_match && list_length(pathkeys) != list_length(locus.partkey_h))
+	if (exact_match && list_length(pathkeys) != list_length(locus.distkey))
 		return false;
 
 	/*
@@ -3043,6 +3038,42 @@ cdbpathlocus_collocates(PlannerInfo *root, CdbPathLocus locus, List *pathkeys,
 	 * value everywhere, so it doesn't affect collocation.
 	 */
 	return cdbpathlocus_is_hashed_on_eclasses(locus, pk_eclasses, true);
+}
+
+
+/*
+ * Function: cdbpathlocus_collocates_expressions
+ *
+ * Like cdbpathlocus_collocates_pathkeys, but the key list is given as a list
+ * of plain expressions, instead of PathKeys.
+ */
+bool
+cdbpathlocus_collocates_expressions(PlannerInfo *root, CdbPathLocus locus, List *exprs,
+								   bool exact_match)
+{
+	if (CdbPathLocus_IsBottleneck(locus))
+		return true;
+
+	if (!CdbPathLocus_IsHashed(locus))
+	{
+		/*
+		 * Note: HashedOJ can *not* be used for grouping. In HashedOJ, NULL
+		 * values can be located on any segment, so we would end up with
+		 * multiple NULL groups.
+		 */
+		return false;
+	}
+
+	if (exact_match && list_length(exprs) != list_length(locus.distkey))
+		return false;
+
+	/*
+	 * Check for containment of locus in pk_eclasses.
+	 *
+	 * We ignore constants in the locus hash key. A constant has the same
+	 * value everywhere, so it doesn't affect collocation.
+	 */
+	return cdbpathlocus_is_hashed_on_exprs(locus, exprs, true);
 }
 
 
@@ -5694,7 +5725,7 @@ add_motion_to_dqa_child(Plan *plan, PlannerInfo *root, bool *motion_added)
 										plan->flow->numsegments);
 	}
 
-	if (!cdbpathlocus_collocates(root, locus, pathkeys, true /* exact_match */ ))
+	if (!cdbpathlocus_collocates_pathkeys(root, locus, pathkeys, true /* exact_match */ ))
 	{
 		/*
 		 * MPP-22413: join requires exact distribution match for collocation

--- a/src/backend/cdb/cdbpathtoplan.c
+++ b/src/backend/cdb/cdbpathtoplan.c
@@ -59,7 +59,7 @@ cdbpathtoplan_create_flow(PlannerInfo *root,
 			 CdbPathLocus_IsHashedOJ(locus))
 	{
 		flow = makeFlow(FLOW_PARTITIONED, locus.numsegments);
-		flow->hashExpr = cdbpathlocus_get_partkey_exprs(locus,
+		flow->hashExpr = cdbpathlocus_get_distkey_exprs(locus,
 														relids,
 														plan->targetlist);
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2378,6 +2378,20 @@ _copyPathKey(const PathKey *from)
 }
 
 /*
+ * _copyDistributionKey
+ */
+static DistributionKey *
+_copyDistributionKey(const DistributionKey *from)
+{
+	DistributionKey    *newnode = makeNode(DistributionKey);
+
+	/* EquivalenceClasses are never moved, so just shallow-copy the pointer */
+	newnode->dk_eclasses = list_copy(from->dk_eclasses);
+
+	return newnode;
+}
+
+/*
  * _copyRestrictInfo
  */
 static RestrictInfo *
@@ -5467,6 +5481,9 @@ copyObject(const void *from)
 			break;
 		case T_PathKey:
 			retval = _copyPathKey(from);
+			break;
+		case T_DistributionKey:
+			retval = _copyDistributionKey(from);
 			break;
 		case T_RestrictInfo:
 			retval = _copyRestrictInfo(from);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1951,9 +1951,9 @@ _outFlow(StringInfo str, const Flow *node)
 static void
 _outCdbPathLocus(StringInfo str, const CdbPathLocus *node)
 {
-    WRITE_ENUM_FIELD(locustype, CdbLocusType);
-    WRITE_NODE_FIELD(partkey_h);
-    WRITE_NODE_FIELD(partkey_oj);
+	WRITE_ENUM_FIELD(locustype, CdbLocusType);
+	WRITE_NODE_FIELD(distkey);
+	WRITE_INT_FIELD(numsegments);
 }                               /* _outCdbPathLocus */
 
 
@@ -2398,6 +2398,16 @@ _outPathKey(StringInfo str, const PathKey *node)
 	WRITE_INT_FIELD(pk_strategy);
 	WRITE_BOOL_FIELD(pk_nulls_first);
 }
+
+#ifndef COMPILING_BINARY_FUNCS
+static void
+_outDistributionKey(StringInfo str, const DistributionKey *node)
+{
+	WRITE_NODE_TYPE("DISTRIBUTIONKEY");
+
+	WRITE_NODE_FIELD(dk_eclasses);
+}
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outParamPathInfo(StringInfo str, const ParamPathInfo *node)
@@ -5076,6 +5086,9 @@ _outNode(StringInfo str, const void *obj)
 				break;
 			case T_PathKey:
 				_outPathKey(str, obj);
+				break;
+			case T_DistributionKey:
+				_outDistributionKey(str, obj);
 				break;
 			case T_ParamPathInfo:
 				_outParamPathInfo(str, obj);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -7190,7 +7190,7 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 	else if (CdbPathLocus_IsHashed(path->path.locus) ||
 			 CdbPathLocus_IsHashedOJ(path->path.locus))
 	{
-		List	   *hashExpr = cdbpathlocus_get_partkey_exprs(path->path.locus,
+		List	   *hashExpr = cdbpathlocus_get_distkey_exprs(path->path.locus,
 															  path->path.parent->relids,
 															  subplan->targetlist);
 		if (!hashExpr)

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -1515,8 +1515,7 @@ plan_append_aggs_with_gather(PlannerInfo *root,
 	 * subplans to be used.
 	 */
 	context->subplan = gather_subplan;
-	context->path->locus.partkey_h = copyObject(context->input_locus.partkey_h);
-	context->path->locus.partkey_oj = copyObject(context->input_locus.partkey_oj);
+	context->path->locus.distkey = copyObject(context->input_locus.distkey);
 	context->pathkeys = NIL;
 
 	/* Compute how many number of subplans is needed. */
@@ -1639,8 +1638,7 @@ plan_append_aggs_with_rewrite(PlannerInfo *root,
 	 * subplans to be used.
 	 */
 	context->subplan = lefttree;
-	context->path->locus.partkey_h = copyObject(context->input_locus.partkey_h);
-	context->path->locus.partkey_oj = copyObject(context->input_locus.partkey_oj);
+	context->path->locus.distkey = copyObject(context->input_locus.distkey);
 	context->pathkeys = NIL;
 
 	/* Compute how many subplans is needed. */
@@ -2378,8 +2376,7 @@ plan_list_rollup_plans(PlannerInfo *root,
 	/* Generate the shared input subplans for all rollups. */
 	context->subplan = lefttree;
 	context->input_locus = context->path->locus;
-	context->input_locus.partkey_h = copyObject(context->path->locus.partkey_h);
-	context->input_locus.partkey_oj = copyObject(context->path->locus.partkey_oj);
+	context->input_locus.distkey = copyObject(context->path->locus.distkey);
 	context->pathkeys = NIL;
 
 	if (list_length(context->canonical_rollups) > 1)

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1303,6 +1303,7 @@ inheritance_planner(PlannerInfo *root)
 					case CdbLocusType_Hashed:
 					case CdbLocusType_HashedOJ:
 					case CdbLocusType_Strewn:
+						/* FIXME: is HashedOJ really OK here? */
 						/* MPP-2023: Among subplans, these loci are okay. */
 						break;
 					case CdbLocusType_SegmentGeneral:
@@ -1594,7 +1595,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	bool		tested_hashed_distinct = false;
 	double		numDistinct = 1;
 	List	   *distinctExprs = NIL;
-	List	   *distinct_dist_keys = NIL;
+	List	   *distinct_dist_pathkeys = NIL;
 	List	   *distinct_dist_exprs = NIL;
 	bool		must_gather;
 
@@ -2483,15 +2484,15 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 					need_gather_for_partitioning = false;
 				else
 				{
-					List	   *partition_dist_keys;
+					List	   *partition_dist_pathkeys;
 					List	   *partition_dist_exprs;
 
-					make_distribution_keys_for_groupclause(root,
-														   wc->partitionClause,
-														   tlist,
-														   &partition_dist_keys,
-														   &partition_dist_exprs);
-					if (!partition_dist_keys)
+					make_distribution_pathkeys_for_groupclause(root,
+															   wc->partitionClause,
+															   tlist,
+															   &partition_dist_pathkeys,
+															   &partition_dist_exprs);
+					if (!partition_dist_exprs)
 					{
 						/*
 						 * There is no PARTITION BY, or none of the PARTITION BY
@@ -2500,7 +2501,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 						 */
 						need_gather_for_partitioning = true;
 					}
-					else if (cdbpathlocus_collocates(root, current_locus, partition_dist_keys, false))
+					else if (cdbpathlocus_collocates_pathkeys(root, current_locus, partition_dist_pathkeys, false))
 					{
 						need_gather_for_partitioning = false;
 					}
@@ -2516,8 +2517,10 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 						 * Change current_locus based on the new distribution
 						 * pathkeys.
 						 */
-						CdbPathLocus_MakeHashed(&current_locus, partition_dist_keys,
-												CdbPathLocus_NumSegments(current_locus));
+						CdbPathLocus_MakeHashed(&current_locus,
+												cdbpathlocus_get_distkeys_for_pathkeys(partition_dist_pathkeys),
+												result_plan->flow->numsegments);
+
 						need_gather_for_partitioning = false;
 					}
 				}
@@ -2749,11 +2752,11 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		 * the cost of an extra Redistribute-Sort-Unique on the pre-uniqued
 		 * (reduced) input.
 		 */
-		make_distribution_keys_for_groupclause(root,
-											   parse->distinctClause,
-											   result_plan->targetlist,
-											   &distinct_dist_keys,
-											   &distinct_dist_exprs);
+		make_distribution_pathkeys_for_groupclause(root,
+												   parse->distinctClause,
+												   result_plan->targetlist,
+												   &distinct_dist_pathkeys,
+												   &distinct_dist_exprs);
 
 		distinctExprs = get_sortgrouplist_exprs(parse->distinctClause,
 												result_plan->targetlist);
@@ -2764,8 +2767,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		{
 			bool		needMotion;
 
-			needMotion = !cdbpathlocus_collocates(root, current_locus,
-												  distinct_dist_keys, false /* exact_match */ );
+			needMotion = !cdbpathlocus_collocates_pathkeys(root, current_locus,
+														   distinct_dist_pathkeys, false /* exact_match */ );
 
 			/* Apply the preunique optimization, if enabled and worthwhile. */
 			/* GPDB_84_MERGE_FIXME: pre-unique for hash distinct not implemented. */

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1826,7 +1826,7 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 
 	/* Repartition first if duplicates might be on different QEs. */
 	if (!CdbPathLocus_IsBottleneck(subpath->locus) &&
-		!cdbpathlocus_is_hashed_on_exprs(subpath->locus, uniq_exprs))
+		!cdbpathlocus_is_hashed_on_exprs(subpath->locus, uniq_exprs, false))
 	{
 		/*
 		 * We want to use numsegments from rel->cdbpolicy, however it might

--- a/src/include/cdb/cdbgroup.h
+++ b/src/include/cdb/cdbgroup.h
@@ -30,7 +30,10 @@ extern Plan *cdb_grouping_planner(PlannerInfo* root,
 					 AggClauseCosts *agg_costs,
 					 GroupContext *group_context);
 
-extern bool cdbpathlocus_collocates(PlannerInfo *root, CdbPathLocus locus, List *pathkeys, bool exact_match);
+extern bool cdbpathlocus_collocates_pathkeys(PlannerInfo *root, CdbPathLocus locus, List *pathkeys, bool exact_match);
+extern bool cdbpathlocus_collocates_expressions(PlannerInfo *root, CdbPathLocus locus, List *exprs,
+											   bool exact_match);
+
 extern CdbPathLocus cdbpathlocus_from_flow(Flow *flow);
 extern void generate_three_tlists(List *tlist,
 								  bool twostage,

--- a/src/include/cdb/cdbpullup.h
+++ b/src/include/cdb/cdbpullup.h
@@ -78,7 +78,7 @@ bool
 cdbpullup_exprHasSubplanRef(Expr *expr);
 
 
-extern Expr *cdbpullup_findPathKeyExprInTargetList(PathKey *item, List *targetlist);
+extern Expr *cdbpullup_findEclassInTargetList(EquivalenceClass *eclass, List *targetlist);
 
 extern List *cdbpullup_truncatePathKeysForTargetList(List *pathkeys, List *targetlist);
 

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -340,6 +340,7 @@ typedef enum NodeTag
     T_CdbMotionPath = 580,
 	T_PartitionSelectorPath,
     T_CdbRelColumnInfo,
+	T_DistributionKey,
 
 	/*
 	 * TAGS FOR MEMORY NODES (memnodes.h)

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -831,6 +831,27 @@ typedef struct PathKey
 	bool		pk_nulls_first; /* do NULLs come before normal values? */
 } PathKey;
 
+/*
+ * DistributionKeys
+ *
+ * Like PathKey, but is used to represent data distribution by hash across
+ * segments (DISTRIBUTED BY), rather than sort ordering.
+ */
+typedef struct DistributionKey
+{
+	NodeTag		type;
+
+	List	   *dk_eclasses;	/* the value that is distributed */
+} DistributionKey;
+
+/*
+ * CdbEquivClassIsConstant
+ *      is true if the equivalence class represents a pseudo-constant
+ *
+ * This is copied from MUST_BE_REDUNDANT in pathkeys.c
+ */
+#define CdbEquivClassIsConstant(eclass)						\
+	((eclass)->ec_has_const && !(eclass)->ec_below_outer_join)
 
 /*
  * ParamPathInfo
@@ -854,25 +875,6 @@ typedef struct ParamPathInfo
 	double		ppi_rows;		/* estimated number of result tuples */
 	List	   *ppi_clauses;	/* join clauses available from outer rels */
 } ParamPathInfo;
-
-
-/*
- * CdbEquivClassIsConstant
- *      is true if the equivalence class represents a pseudo-constant
- *
- * This is copied from MUST_BE_REDUNDANT in pathkeys.c
- */
-#define CdbEquivClassIsConstant(eclass)						\
-	((eclass)->ec_has_const && !(eclass)->ec_below_outer_join)
-
-/*
- * CdbPathkeyEqualsConstant
- *      is true if there is a constant expr in a given set of
- *      equijoin-equivalent exprs represented by a PathKey
- */
-#define CdbPathkeyEqualsConstant(_pathkey) \
-    ((_pathkey) != NULL && \
-	 CdbEquivClassIsConstant((_pathkey)->pk_eclass))
 
 
 /*

--- a/src/include/optimizer/paths.h
+++ b/src/include/optimizer/paths.h
@@ -185,13 +185,13 @@ extern List *build_join_pathkeys(PlannerInfo *root,
 					JoinType jointype,
 					List *outer_pathkeys);
 
-PathKey *
-cdb_make_pathkey_for_expr(PlannerInfo  *root,
+extern DistributionKey *
+cdb_make_distkey_for_expr(PlannerInfo  *root,
                           Node     *expr,
                           List     *eqopname);
-PathKey *
-cdb_pull_up_pathkey(PlannerInfo    *root,
-                    PathKey        *pathkey,
+extern EquivalenceClass *
+cdb_pull_up_eclass(PlannerInfo    *root,
+					EquivalenceClass *eclass,
                     Relids          relids,
                     List           *targetlist,
                     List           *newvarlist,
@@ -206,9 +206,10 @@ extern List *make_pathkeys_for_groupclause_noncanonical(PlannerInfo *root,
 extern List *make_pathkeys_for_sortclauses(PlannerInfo *root,
 							  List *sortclauses,
 							  List *tlist);
-extern void make_distribution_keys_for_groupclause(PlannerInfo *root, List *groupclause, List *tlist,
-									   List **partition_dist_keys,
-									   List **partition_dist_exprs);
+extern void make_distribution_pathkeys_for_groupclause(PlannerInfo *root,
+										   List *groupclause, List *tlist,
+										   List **partition_dist_pathkeys,
+										   List **partition_dist_exprs);
 extern void initialize_mergeclause_eclasses(PlannerInfo *root,
 								RestrictInfo *restrictinfo);
 extern void update_mergeclause_eclasses(PlannerInfo *root,


### PR DESCRIPTION
In PostgreSQL, a PathKey represents sort ordering, but we have been using
it in GPDB to also represent the distribution keys of hash-distributed
data in the planner. (i.e. the keys in DISTRIBUTED BY of a table, but also
when data is redistributed by some other key on the fly). That's been
convenient, and there's some precedent for that, since PostgreSQL also
uses PathKey to represent GROUP BY columns, which is quite similar to
DISTRIBUTED BY.
    
However, there are some differences. The opfamily, strategy and nulls_first
fields in PathKey are not applicable to distribution keys. Using the same
struct to represent ordering and hash distribution is sometimes convenient,
for example when we need to test whether the sort order or grouping is
"compatible" with the distribution. But at other times, it's confusing.

To clarify that, introduce a new DistributionKey struct, to represent
a hashed distribution. While we're at it, simplify the representation of
HashedOJ locus types, by including a List of EquivalenceClasses in
DistributionKey, rather than just one EC like a PathKey has. CdbPathLocus
now has only one 'distkey' list that is used for both Hashed and HashedOJ
locus, and it's a list of DistributionKeys. Each DistributionKey in turn
can contain multiple EquivalenceClasses.

Looking ahead, I'm working on a patch to generalize the "cdbhash"
mechanism, so that we'd use the normal Postgres hash opclasses for
distribution keys, instead of hard-coding support for specific datatypes.
With that, the hash operator class or family will be an important part of
the distribution key, in addition to the datatype. The plan is to store
that also in DistributionKey.