### PR TITLE
Reshuffle support policy change from random to hash

### DIFF
--- a/src/backend/executor/nodeReshuffle.c
+++ b/src/backend/executor/nodeReshuffle.c
@@ -266,8 +266,6 @@ ExecReshuffle(ReshuffleState *node)
 									  nulls,
 									  reshuffle->policyAttrs,
 									  node->oldcdbhash));
-
-				Assert(oldSegID == newSegID);
 			}
 		}
 

--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -957,3 +957,72 @@ DETAIL:  drop cascades to table inherit_t1_reshuffle_p2
 drop cascades to table inherit_t1_reshuffle_p4
 drop cascades to table inherit_t1_reshuffle_p3
 drop cascades to table inherit_t1_reshuffle_p5
+-- test reshuffle from full random to full hash distributed
+create table t1_reshuffle_full_random (c1 int, c2 int) distributed randomly;
+insert into t1_reshuffle_full_random select * from generate_series(1, 10);
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 't1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+          | p          |           3
+(1 row)
+
+begin;
+alter table t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+select gp_segment_id, count(*) from t1_reshuffle_full_random group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     5
+             0 |     3
+             2 |     2
+(3 rows)
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 't1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+ {1}      | p          |           3
+(1 row)
+
+abort;
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 't1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+          | p          |           3
+(1 row)
+
+alter table t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+select gp_segment_id, count(*) from t1_reshuffle_full_random group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |     3
+             2 |     2
+             1 |     5
+(3 rows)
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 't1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+ {1}      | p          |           3
+(1 row)
+
+-- test fail cases
+begin;
+alter table t1_reshuffle_full_random set with(reshuffle) distributed by (c2);
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+begin;
+alter table t1_reshuffle_full_random set with(reshuffle) distributed randomly;
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+begin;
+alter table t1_reshuffle_full_random set with(reshuffle) distributed replicated;
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+DROP TABLE t1_reshuffle_full_random;
+create table t1_reshuffle_full_random (c1 int, c2 int) distributed randomly;
+update gp_distribution_policy set numsegments = 1 where localoid = 't1_reshuffle_full_random'::regclass;
+insert into t1_reshuffle_full_random select * from generate_series(1, 20);
+begin;
+alter table t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+DROP TABLE t1_reshuffle_full_random;

--- a/src/test/regress/expected/reshuffle_ao.out
+++ b/src/test/regress/expected/reshuffle_ao.out
@@ -794,3 +794,72 @@ Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
 (3 rows)
 
 drop table part_ao_t1_reshuffle;
+-- test reshuffle from full random to full hash distributed
+create table ao_t1_reshuffle_full_random (c1 int, c2 int) with (appendonly=true) distributed randomly;
+insert into ao_t1_reshuffle_full_random select * from generate_series(1, 10);
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+          | p          |           3
+(1 row)
+
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+select gp_segment_id, count(*) from ao_t1_reshuffle_full_random group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             2 |     2
+             1 |     5
+             0 |     3
+(3 rows)
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+ {1}      | p          |           3
+(1 row)
+
+abort;
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+          | p          |           3
+(1 row)
+
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+select gp_segment_id, count(*) from ao_t1_reshuffle_full_random group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |     3
+             2 |     2
+             1 |     5
+(3 rows)
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+ {1}      | p          |           3
+(1 row)
+
+-- test fail cases
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed by (c2);
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed randomly;
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed replicated;
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+DROP TABLE ao_t1_reshuffle_full_random;
+create table ao_t1_reshuffle_full_random (c1 int, c2 int) with (appendonly=true) distributed randomly;
+update gp_distribution_policy set numsegments = 1 where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+insert into ao_t1_reshuffle_full_random select * from generate_series(1, 20);
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+DROP TABLE ao_t1_reshuffle_full_random;

--- a/src/test/regress/expected/reshuffle_aoco.out
+++ b/src/test/regress/expected/reshuffle_aoco.out
@@ -637,3 +637,72 @@ Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_i
 (3 rows)
 
 drop table part_aoco_t1_reshuffle;
+-- test reshuffle from full random to full hash distributed
+create table aoco_t1_reshuffle_full_random (c1 int, c2 int) with (appendonly=true, orientation=column) distributed randomly;
+insert into aoco_t1_reshuffle_full_random select * from generate_series(1, 10);
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+          | p          |           3
+(1 row)
+
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+select gp_segment_id, count(*) from aoco_t1_reshuffle_full_random group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     5
+             2 |     2
+             0 |     3
+(3 rows)
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+ {1}      | p          |           3
+(1 row)
+
+abort;
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+          | p          |           3
+(1 row)
+
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+select gp_segment_id, count(*) from aoco_t1_reshuffle_full_random group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |     5
+             0 |     3
+             2 |     2
+(3 rows)
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+ attrnums | policytype | numsegments 
+----------+------------+-------------
+ {1}      | p          |           3
+(1 row)
+
+-- test fail cases
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed by (c2);
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed randomly;
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed replicated;
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+DROP TABLE aoco_t1_reshuffle_full_random;
+create table aoco_t1_reshuffle_full_random (c1 int, c2 int) with (appendonly=true, orientation=column) distributed randomly;
+update gp_distribution_policy set numsegments = 1 where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+insert into aoco_t1_reshuffle_full_random select * from generate_series(1, 20);
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+ERROR:  reshuffle with distributed by only supported from random full to hash full
+abort;
+DROP TABLE aoco_t1_reshuffle_full_random;

--- a/src/test/regress/sql/reshuffle_ao.sql
+++ b/src/test/regress/sql/reshuffle_ao.sql
@@ -335,3 +335,47 @@ Alter table part_ao_t1_reshuffle set with (reshuffle);
 Select gp_segment_id, count(*) from part_ao_t1_reshuffle group by gp_segment_id;
 
 drop table part_ao_t1_reshuffle;
+
+-- test reshuffle from full random to full hash distributed
+create table ao_t1_reshuffle_full_random (c1 int, c2 int) with (appendonly=true) distributed randomly;
+insert into ao_t1_reshuffle_full_random select * from generate_series(1, 10);
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+select gp_segment_id, count(*) from ao_t1_reshuffle_full_random group by gp_segment_id;
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+abort;
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+
+select gp_segment_id, count(*) from ao_t1_reshuffle_full_random group by gp_segment_id;
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+
+-- test fail cases
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed by (c2);
+abort;
+
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed randomly;
+abort;
+
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed replicated;
+abort;
+
+DROP TABLE ao_t1_reshuffle_full_random;
+
+create table ao_t1_reshuffle_full_random (c1 int, c2 int) with (appendonly=true) distributed randomly;
+update gp_distribution_policy set numsegments = 1 where localoid = 'ao_t1_reshuffle_full_random'::regclass;
+insert into ao_t1_reshuffle_full_random select * from generate_series(1, 20);
+
+begin;
+alter table ao_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+abort;
+
+DROP TABLE ao_t1_reshuffle_full_random;

--- a/src/test/regress/sql/reshuffle_aoco.sql
+++ b/src/test/regress/sql/reshuffle_aoco.sql
@@ -264,3 +264,47 @@ Alter table part_aoco_t1_reshuffle set with (reshuffle);
 Select gp_segment_id, count(*) from part_aoco_t1_reshuffle group by gp_segment_id;
 
 drop table part_aoco_t1_reshuffle;
+
+-- test reshuffle from full random to full hash distributed
+create table aoco_t1_reshuffle_full_random (c1 int, c2 int) with (appendonly=true, orientation=column) distributed randomly;
+insert into aoco_t1_reshuffle_full_random select * from generate_series(1, 10);
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+select gp_segment_id, count(*) from aoco_t1_reshuffle_full_random group by gp_segment_id;
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+abort;
+
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+
+select gp_segment_id, count(*) from aoco_t1_reshuffle_full_random group by gp_segment_id;
+select attrnums, policytype, numsegments from gp_distribution_policy where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+
+-- test fail cases
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed by (c2);
+abort;
+
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed randomly;
+abort;
+
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed replicated;
+abort;
+
+DROP TABLE aoco_t1_reshuffle_full_random;
+
+create table aoco_t1_reshuffle_full_random (c1 int, c2 int) with (appendonly=true, orientation=column) distributed randomly;
+update gp_distribution_policy set numsegments = 1 where localoid = 'aoco_t1_reshuffle_full_random'::regclass;
+insert into aoco_t1_reshuffle_full_random select * from generate_series(1, 20);
+
+begin;
+alter table aoco_t1_reshuffle_full_random set with(reshuffle) distributed by (c1);
+abort;
+
+DROP TABLE aoco_t1_reshuffle_full_random;


### PR DESCRIPTION
This commit implements a new syntax for reshuffle:
'alter table {tab} set with(reshuffle) distributed by (cols...)'
And this statement has some restriction:
  - the table being altered must be a random-partitioned table
  - the numsegments of the policy of the table being altered must
    be exactly the cluster size
  - must provide at least one distributed-by cols

This statement is supposed to be only used by the python scripts
of gpexpand' 2nd stage. When reshuffling a hash partition table that
has many partitions, an efficient way to do this is:
  1. change all the sub-tables to fully random-distributed
     and change the root table to fully hash-distributed
  2. reshuffle one leaf table by one and only lock the leaf table

This commit does not add test cases because we need to wait PR https://github.com/greenplum-db/gpdb/pull/6214 merge first. I have tested locally.

Will add test cases after PR https://github.com/greenplum-db/gpdb/pull/6214 is merged.