### PR TITLE
solve double free when gp_dump

### DIFF
--- a/src/backend/cdb/cdbbackup.c
+++ b/src/backend/cdb/cdbbackup.c
@@ -1248,7 +1248,6 @@ gp_write_backup_file__(PG_FUNCTION_ARGS)
 	nBytes = strlen(pszBackup);
 	if (nBytes != fwrite(pszBackup, 1, nBytes, f))
 	{
-		fclose(f);
 		ereport(ERROR,
 				(errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
 				 errmsg("Error writing Backup File %s", pszFileName)));


### PR DESCRIPTION
fd is open by fd.c:AllocateFile, fd.c will automatically close all files opened with AllocateFile at transaction commit or abort, so there is no necessary to call fclose(f) here. Otherwise it will cause double free.

The double free error log as follow:

2018-11-18 18:12:49.156747 CST,"gpadmincloud","t1",p30697,th-2019645376,"10.0.19.12","18217",2018-11-18 18:12:46 CST,0,con15928,cmd10,seg-1,,,,sx1,"LOG","00000","An exception was encountered during the execution of statement: SELECT * FROM gp_read_backup_file('/home/gpadmincloud/cos/db_dumps/20181118', '20181118181244', 1)",,,,,,,0,,,,
2018-11-18 18:12:49.156801 CST,,,p29298,th-2019645376,,,,0,,,seg-1,,,,,"LOG","00000","3rd party error log:
*** Error in `postgres: 40000, gpadmincloud t1 10.0.19.12(18217) con15928 cmd9 SELECT': double free or corruption (!prev): 0x0000000001eb1cc0 ***




