### PR TITLE
docs - pxf config refactor, misc edits

### DIFF
--- a/gpdb-doc/markdown/pxf/about_pxf_dir.html.md.erb
+++ b/gpdb-doc/markdown/pxf/about_pxf_dir.html.md.erb
@@ -37,6 +37,7 @@ Also during initialization, PXF populates a user configuration directory that yo
 | keytabs/  | The default location for the PXF service Kerberos principal keytab file.  |
 | lib/     | The default PXF user runtime library directory. |
 | logs/     | The PXF runtime log file directory. Includes `pxf-service.log` and the Tomcat-related log `catalina.out`. The `logs/` directory and log files are readable only by the `gpadmin` user. |
-| servers/  | The server configuration directory; each subdirectory identifies the name of a server. PXF supports a Hadoop server configuration named `default`. The `default/` directory includes template Hadoop configuration files. |
+| servers/  | The server configuration directory; each subdirectory identifies the name of a server. PXF supports a default Hadoop server configuration named `default`. |
+| templates/  | The Hadoop configuration template file directory. |
 
 Refer to [Initializing PXF](cfginitstart_pxf.html#init_pxf) and [Starting PXF](cfginitstart_pxf.html#start_pxf) for detailed information about the PXF initialization and startup commands and procedures.

--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -57,13 +57,6 @@ Perform the following procedure to initialize PXF on each segment host in your G
     seghost3
     ```
 
-3. If not already present, install the `unzip` package on the master and each Greenplum Database segment host. You must have operating system super user privileges to install packages. For example:
-
-    ``` shell
-    gpadmin@gpmaster$ sudo yum -y install unzip
-    gpadmin@gpmaster$ gpssh -e -v -f seghostfile "sudo yum -y install unzip"
-    ```
-
 4. Run the `pxf init` command to initialize the PXF service on the master and each segment host. For example, the following command specifies `/etc/pxf/usercfg` as the PXF user configuration directory for initialization. (Note that the `gpadmin` user must have permission to either create, or write to, the specified directory.)
 
     ``` shell
@@ -73,7 +66,7 @@ Perform the following procedure to initialize PXF on each segment host in your G
 
     The `init` command creates the PXF web application and initializes the internal PXF configuration. The `init` command also creates the `$PXF_CONF` user configuration directory if it does not exist, and populates the directory with user-customizable configuration templates.
 
-    **Note**: The PXF service runs only on the segment hosts. However, you must execute `pxf init` on the master to set up the PXF user configuration directories there.
+    **Note**: The PXF service runs only on the segment hosts. However, you execute `pxf init` on the Greenplum Database master to set up the PXF user configuration directories there.
 
 
 ## <a id="start_pxf"></a>Starting PXF

--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -4,13 +4,13 @@ title: Configuring PXF Hadoop Connectors (Optional)
 
 PXF is compatible with Cloudera, Hortonworks Data Platform, and generic Apache Hadoop distributions. This topic describes how configure the PXF Hadoop, Hive, and HBase connectors.
 
-*If you do not plan to use the Hadoop-related PXF connectors, you need not perform this procedure.*
+*If you do not want to use the Hadoop-related PXF connectors, then you do not need to perform this procedure.*
 
 ## <a id="client-pxf-prereq"></a>Prerequisites
 
 PXF bundles all of the JAR files on which it depends, including those for Hadoop services, and loads these JARs at runtime. Configuring PXF Hadoop connectors involves copying configuration files from your Hadoop cluster to each Greenplum Database segment host. Before you configure PXF Hadoop, Hive, and HBase connectors, ensure that you can copy configuration files from HDFS, Hive, and HBase hosts in your Hadoop cluster to the Greenplum Database master host.
 
-In this procedure, you copy Hadoop configuration files to the `$PXF_CONF/server/default` directory on each Greenplum Database segment host. PXF creates this directory when you run `pxf init`.
+In this procedure, you copy Hadoop configuration files to the `$PXF_CONF/servers/default` directory on each Greenplum Database segment host. PXF creates this directory when you run `pxf init`.
 
 ## <a id="client-pxf-config-steps"></a>Procedure
 
@@ -31,7 +31,7 @@ You will use the `gpssh` and `gpscp` utilities where possible to run a command o
     1. Copy the `core-site.xml`, `hdfs-site.xml`, `mapred-site.xml`, and `yarn-site.xml` Hadoop configuration files from your Hadoop cluster NameNode host to the current host using your tool of choice. For example, this command uses `scp` to copy the files:
 
         ``` shell
-        gpadmin@gpmaster$ cd $PXF_CONF/server/default
+        gpadmin@gpmaster$ cd $PXF_CONF/servers/default
         gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/core-site.xml .
         gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/hdfs-site.xml .
         gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/mapred-site.xml .

--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -4,18 +4,13 @@ title: Configuring PXF Hadoop Connectors (Optional)
 
 PXF is compatible with Cloudera, Hortonworks Data Platform, and generic Apache Hadoop distributions. This topic describes how configure the PXF Hadoop, Hive, and HBase connectors.
 
-*If you do not plan to use the Hadoop-related PXF connectors, or you already have Hadoop client installations on your Greenplum Database segments hosts, you need not perform this procedure.*
+*If you do not plan to use the Hadoop-related PXF connectors, you need not perform this procedure.*
 
 ## <a id="client-pxf-prereq"></a>Prerequisites
 
 PXF bundles all of the JAR files on which it depends, including those for Hadoop services, and loads these JARs at runtime. Configuring PXF Hadoop connectors involves copying configuration files from your Hadoop cluster to each Greenplum Database segment host. Before you configure PXF Hadoop, Hive, and HBase connectors, ensure that you can copy configuration files from HDFS, Hive, and HBase hosts in your Hadoop cluster to the Greenplum Database master host.
 
-In this procedure, you copy Hadoop configuration files to `/etc/<hadoop-service>/conf` directories on each Greenplum Database segment host. You must create these directories if they do not exist, and assign read and write access permissions to the `gpadmin` user. You need only create the directories for the Hadoop services that you plan to use. For example, to create the directories and assign permission:
-
-``` shell
-root@seghost$ mkdir -p /etc/hadoop/conf /etc/hive/conf /etc/hbase/conf
-root@seghost$ chown -R gpadmin:gpadmin /etc/hadoop/conf /etc/hive/conf /etc/hbase/conf
-```
+In this procedure, you copy Hadoop configuration files to the `$PXF_CONF/server/default` directory on each Greenplum Database segment host. PXF creates this directory when you run `pxf init`.
 
 ## <a id="client-pxf-config-steps"></a>Procedure
 
@@ -36,19 +31,20 @@ You will use the `gpssh` and `gpscp` utilities where possible to run a command o
     1. Copy the `core-site.xml`, `hdfs-site.xml`, `mapred-site.xml`, and `yarn-site.xml` Hadoop configuration files from your Hadoop cluster NameNode host to the current host using your tool of choice. For example, this command uses `scp` to copy the files:
 
         ``` shell
+        gpadmin@gpmaster$ cd $PXF_CONF/server/default
         gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/core-site.xml .
         gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/hdfs-site.xml .
         gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/mapred-site.xml .
         gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/yarn-site.xml .
         ```
         
-    2. Next, copy these Hadoop configuration files to each Greenplum Database segment host. For example:
+    2. Next, copy these Hadoop configuration files to each Greenplum Database segment host. For example, if `PXF_CONF=/etc/pxf/usercfg`:
 
         ``` shell
-        gpadmin@gpmaster$ gpscp -v -f seghostfile core-site.xml =:/etc/hadoop/conf/core-site.xml
-        gpadmin@gpmaster$ gpscp -v -f seghostfile hdfs-site.xml =:/etc/hadoop/conf/hdfs-site.xml
-        gpadmin@gpmaster$ gpscp -v -f seghostfile mapred-site.xml =:/etc/hadoop/conf/mapred-site.xml
-        gpadmin@gpmaster$ gpscp -v -f seghostfile yarn-site.xml =:/etc/hadoop/conf/yarn-site.xml
+        gpadmin@gpmaster$ gpscp -v -f seghostfile core-site.xml =:/etc/pxf/usercfg/servers/default/core-site.xml
+        gpadmin@gpmaster$ gpscp -v -f seghostfile hdfs-site.xml =:/etc/pxf/usercfg/servers/default/hdfs-site.xml
+        gpadmin@gpmaster$ gpscp -v -f seghostfile mapred-site.xml =:/etc/pxf/usercfg/servers/default/mapred-site.xml
+        gpadmin@gpmaster$ gpscp -v -f seghostfile yarn-site.xml =:/etc/pxf/usercfg/servers/default/yarn-site.xml
         ```
 
 2. If you plan to use the PXF Hive connector to access Hive table data, similarly copy Hive configuration to each Greenplum Database segment host.
@@ -62,7 +58,7 @@ You will use the `gpssh` and `gpscp` utilities where possible to run a command o
     2. Next, copy the `hive-site.xml` configuration file to each Greenplum Database segment host. For example:
 
         ``` shell
-        gpadmin@gpmaster$ gpscp -v -f seghostfile hive-site.xml =:/etc/hive/conf/hive-site.xml
+        gpadmin@gpmaster$ gpscp -v -f seghostfile hive-site.xml =:/etc/pxf/usercfg/servers/default/hive-site.xml
         ```
 
 3. If you plan to use the PXF HBase connector to access HBase table data, similarly copy HBase configuration to each Greenplum Database segment host.
@@ -76,7 +72,7 @@ You will use the `gpssh` and `gpscp` utilities where possible to run a command o
     2. Next, copy the `hbase-site.xml` configuration file to each Greenplum Database segment host. For example:
 
         ``` shell
-        gpadmin@gpmaster$ gpscp -v -f seghostfile hbase-site.xml =:/etc/hbase/conf/hbase-site.xml
+        gpadmin@gpmaster$ gpscp -v -f seghostfile hbase-site.xml =:/etc/pxf/usercfg/servers/default/hbase-site.xml
         ```
 
 4. PXF accesses Hadoop services on behalf of Greenplum Database end users. By default, PXF tries to access HDFS, Hive, and HBase using the identity of the Greenplum Database user account that logs into Greenplum Database. In order to support this functionality, you must configure proxy settings for Hadoop, as well as for Hive and HBase if you intend to use those PXF connectors. Follow procedures in [Configuring User Impersonation and Proxying](pxfuserimpers.html) to configure user impersonation and proxying for Hadoop services, or to turn off PXF user impersonation.

--- a/gpdb-doc/markdown/pxf/hbase_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hbase_pxf.html.md.erb
@@ -12,6 +12,8 @@ This section describes how to use the PXF HBase connector.
 
 Before working with HBase table data, ensure that you have:
 
+- Configured the PXF Hadoop and HBase Connectors on each Greenplum Database segment host. Refer to [Configuring PXF Hadoop Connectors](client_instcfg.html) for instructions.
+
 - Copied `$GPHOME/pxf/lib/pxf-hbase-*.jar` to each node in your HBase cluster, and that the location of this PXF JAR file is in the `$HBASE_CLASSPATH`. This configuration is required for the PXF HBase connector to support filter pushdown.
 
 - Initialized PXF on your Greenplum Database segment hosts, and started PXF on each host. See [Initializing and Managing PXF](cfginitstart_pxf.html) for PXF initialization and startup information.

--- a/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_read_pxf.html.md.erb
@@ -29,7 +29,7 @@ This section describes how to use PXF to access HDFS data, including how to crea
 
 Before working with HDFS data using PXF, ensure that:
 
-- You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions. If you plan to access JSON format data stored in a Cloudera Hadoop cluster, PXF requires a Cloudera version 5.8 or later Hadoop distribution.
+- You have configured the PXF Hadoop Connector on each Greenplum Database segment host. Refer to [Configuring PXF Hadoop Connectors](client_instcfg.html) for instructions. If you plan to access JSON format data stored in a Cloudera Hadoop cluster, PXF requires a Cloudera version 5.8 or later Hadoop distribution.
 - You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Initializing and Managing PXF](cfginitstart_pxf.html) for PXF initialization and startup information.
 - If user impersonation is enabled (the default), you have granted read permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database to each Greenplum Database user/role name that will access the HDFS files and directories. If user impersonation is not enabled, you must grant this permission to the `gpadmin` user.
 

--- a/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_write_pxf.html.md.erb
@@ -31,7 +31,7 @@ This section describes how to use PXF to write HDFS data, including how to creat
 
 Before writing HDFS data using PXF, ensure that:
 
--  You have installed and configured a Hadoop client on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
+-  You have configured the PXF Hadoop connector on each Greenplum Database segment host. Refer to [Configuring PXF Hadoop Connectors](client_instcfg.html) for instructions.
 - You have initialized and started PXF on your Greenplum Database segment hosts. See [Initializing and Managing PXF](cfginitstart_pxf.html) for PXF initialization and startup information.
 - You have granted both *read and write* permissions to the HDFS directories that will be accessed as external tables in Greenplum Database. If user impersonation is enabled (the default), you must grant these permissions to each Greenplum Database user/role name that will use external tables that reference the HDFS files. If user impersonation is not enabled, you must grant this permission to the `gpadmin` user.
 

--- a/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
@@ -29,7 +29,7 @@ The PXF Hive connector reads data stored in a Hive table. This section describes
 
 Before working with Hive table data using PXF, ensure that:
 
-- You have installed and configured a Hive client on each Greenplum Database segment host. Refer to [Installing and Configuring Hadoop Clients for PXF](client_instcfg.html) for instructions.
+- You have configured the PXF Hadoop and Hive connectors on each Greenplum Database segment host. Refer to [Configuring PXF Hadoop Connectors](client_instcfg.html) for instructions.
 - You have initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Initializing and Managing PXF](cfginitstart_pxf.html) for PXF initialization and startup information.
 
 

--- a/gpdb-doc/markdown/pxf/install_java.html.md.erb
+++ b/gpdb-doc/markdown/pxf/install_java.html.md.erb
@@ -35,8 +35,8 @@ Perform the following procedure to install Java on the master and on each segmen
     1. Install the Java package. For example, to install Java version 1.8:
 
         ``` shell
-        gpadmin@gpmaster$ sudo yum -y install java-1.8.0-openjdk-devel*
-        gpadmin@gpmaster$ gpssh -e -v -f seghostfile sudo yum -y install java-1.8.0-openjdk-devel*
+        gpadmin@gpmaster$ sudo yum -y install java-1.8.0-openjdk-1.8.0*
+        gpadmin@gpmaster$ gpssh -e -v -f seghostfile sudo yum -y install java-1.8.0-openjdk-1.8.0*
         ```
 
     2. Identify the Java base install directory. Update the `gpadmin` user's `.bash_profile` file on each segment host to include this `$JAVA_HOME` setting if it is not already present. For example:

--- a/gpdb-doc/markdown/pxf/install_java.html.md.erb
+++ b/gpdb-doc/markdown/pxf/install_java.html.md.erb
@@ -35,8 +35,8 @@ Perform the following procedure to install Java on the master and on each segmen
     1. Install the Java package. For example, to install Java version 1.8:
 
         ``` shell
-        gpadmin@gpmaster$ sudo yum -y install java-1.8.0-openjdk-1.8.0*
-        gpadmin@gpmaster$ gpssh -e -v -f seghostfile sudo yum -y install java-1.8.0-openjdk-1.8.0*
+        gpadmin@gpmaster$ sudo yum -y install java-1.8.0-openjdk-devel*
+        gpadmin@gpmaster$ gpssh -e -v -f seghostfile sudo yum -y install java-1.8.0-openjdk-devel*
         ```
 
     2. Identify the Java base install directory. Update the `gpadmin` user's `.bash_profile` file on each segment host to include this `$JAVA_HOME` setting if it is not already present. For example:

--- a/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/instcfg_pxf.html.md.erb
@@ -2,7 +2,7 @@
 title: Configuring PXF
 ---
 
-The Greenplum Platform Extension Framework (PXF) provides connectors to Hadoop, Hive, HBase and external SQL data stores. You must configure PXF to support the connectors that you plan to use.
+The Greenplum Platform Extension Framework (PXF) provides connectors to Hadoop, Hive, HBase, and external SQL data stores. You must configure PXF to support the connectors that you plan to use.
 
 To configure PXF, you must:
 

--- a/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
@@ -21,7 +21,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The Greenplum Platform Extension Framework (PXF) provides parallel, high throughput data access and federated queries across heterogeneous data sources via built-in connectors that map a Greenplum Database external table definition to an external data source. PXF has its roots from Apache HAWQ project.
+The Greenplum Platform Extension Framework (PXF) provides parallel, high throughput data access and federated queries across heterogeneous data sources via built-in connectors that map a Greenplum Database external table definition to an external data source. PXF has its roots in the Apache HAWQ project.
 
 -   [PXF Architecture](intro_pxf.html)
 

--- a/gpdb-doc/markdown/pxf/pxf_kerbhdfs.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxf_kerbhdfs.html.md.erb
@@ -103,12 +103,6 @@ Perform the following steps to configure PXF for a secure HDFS. You will perform
     root@seghost$ yum install krb5-libs krb5-workstation
     ```
 
-3. Copy the configuration files from your Hadoop cluster to the PXF Hadoop configuration directory on the Greenplum Database segment host. The configuration file directory is specific to your Hadoop distribution. For example:
-
-    ``` shell
-    gpadmin@seghost$ scp hadoop_host:/etc/hadoop/conf/* /etc/hadoop/conf/
-    ```
-
 4. Open the PXF `pxf-env.sh` user configuration file in the editor of your choice. For example, to open the file with `vi` when `PXF_CONF=/etc/pxf/usercfg`:
 
     ``` shell

--- a/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
@@ -67,7 +67,7 @@ When PXF user personation is enabled (the default), you must configure the Hadoo
     ```
 4. After changing `core-site.xml`, you must restart Hadoop for your changes to take effect.
 
-5. Copy the updated `core-site.xml` file to the Hadoop configuration directory `/etc/hadoop/conf` on each Greenplum Database segment host.
+5. Copy the updated `core-site.xml` file to the PXF Hadoop configuration directory `$PXF_CONF/servers/default` on the master and each Greenplum Database segment host.
 
 ## <a id="hive"></a>Hive User Impersonation
 

--- a/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
@@ -67,7 +67,7 @@ When PXF user personation is enabled (the default), you must configure the Hadoo
     ```
 4. After changing `core-site.xml`, you must restart Hadoop for your changes to take effect.
 
-5. Copy the updated `core-site.xml` file to the PXF Hadoop configuration directory `$PXF_CONF/servers/default` on the master and each Greenplum Database segment host.
+5. Copy the updated `core-site.xml` file to the PXF Hadoop configuration directory `$PXF_CONF/servers/default` on the master and on each Greenplum Database segment host.
 
 ## <a id="hive"></a>Hive User Impersonation
 

--- a/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
@@ -17,7 +17,7 @@ The PXF agent determines certain runtime dependencies from configuration files f
 
 The `$GPHOME/pxf/conf/pxf-private.classpath` configuration file identifies the runtime dependencies for the PXF agent itself. This file also identifies the runtime dependencies for the PXF built-in HDFS, Hive, and HBase connectors.
 
-The Greenplum Database administrator registers a third-party connector and its runtime dependencies by copying the files to the `$PXF_CONF/lib` directory, and restarting the PXF agent on each segment host.
+The Greenplum Database administrator registers a third-party connector and its runtime dependencies by copying the files to the `$PXF_CONF/lib` directory, and then restarting the PXF agent on each segment host.
 
 
 ## <a id="deploy_to_cluster"></a>Deploying to the Greenplum Database Cluster

--- a/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
@@ -17,7 +17,7 @@ The PXF agent determines certain runtime dependencies from configuration files f
 
 The `$GPHOME/pxf/conf/pxf-private.classpath` configuration file identifies the runtime dependencies for the PXF agent itself. This file also identifies the runtime dependencies for the PXF built-in HDFS, Hive, and HBase connectors.
 
-The Greenplum Database administrator registers a third-party connector and its runtime dependencies by copying the files to the `$PXF_CONF/lib` directory.
+The Greenplum Database administrator registers a third-party connector and its runtime dependencies by copying the files to the `$PXF_CONF/lib` directory, and restarting the PXF agent on each segment host.
 
 
 ## <a id="deploy_to_cluster"></a>Deploying to the Greenplum Database Cluster

--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -153,7 +153,7 @@ Perform the following procedure to increase the heap size for the PXF agent runn
 5. Restart PXF on each Greenplum Database segment host. For example:
 
     ``` shell
-    $ gpadmin@gpmaster$ gpssh -e -v -f seghostfile "/usr/local/greenplum-db/pxf/bin/pxf restart"
+    gpadmin@gpmaster$ gpssh -e -v -f seghostfile "/usr/local/greenplum-db/pxf/bin/pxf restart"
     ```
 
 ### <a id="pxf-threadcfg"></a>Another Option for Resource-Constrained PXF Segment Hosts

--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -8,7 +8,7 @@ The PXF upgrade procedure describes how to upgrade PXF in your Greenplum Databas
 
 Most PXF installations do not require modifications to PXF configuration files and should experience a seamless upgrade.
 
-**Note**: Starting in Greenplum Database version 5.12.0, PXF no longer requires a Hadoop client installation. PXF now bundles all of the JAR files on which it depends, and loads these JARs at runtime. PXF still requires that the Hadoop configuration files reside in `/etc/<hadoop-service>/conf`.
+**Note**: Starting in Greenplum Database version 5.12.0, PXF no longer requires a Hadoop client installation. PXF now bundles all of the JAR files on which it depends, and loads these JARs at runtime.
 
 The PXF upgrade procedure has two parts. You perform one procedure before, and one procedure after, you upgrade to a new version of Greenplum Database:
 
@@ -86,7 +86,8 @@ After you upgrade to the new version of Greenplum Database, perform the followin
     3. If you updated the `pxf-log4j.properties` configuration file in your *PXF.from* installation, re-apply those changes to `$PXF_CONF/conf/pxf-log4j.properties` and copy the updated file to all segment hosts. Refer to Step 4a above for a similar `gpscp` command.
     4. If you updated the `pxf-public.classpath` configuration file in your *PXF.from* installation, copy every JAR referenced in the file to `$PXF_CONF/lib` on each segment host. Refer to Step 4a above for a similar `gpscp` command.
     5. If you added additional JAR files to your *PXF.from* installation, copy them to `$PXF_CONF/lib` on all segment hosts.
-    5. Starting in Greenplum Database version 5.14, the default Kerberos keytab file location for PXF is `$PXF_CONF/keytabs`. If you previously configured PXF for secure HDFS and the PXF keytab file is located in a *PXF.from* installation directory (for example, `$GPHOME/pxf/conf`), consider relocating the keytab file to `$PXF_CONF/keytabs`. Alternatively, you can update the `PXF_KEYTAB` property setting in the `$PXF_CONF/conf/pxf-env.sh` file to reference a different keytab file directory. Be sure to propagate any updated files to each segment host.
+    5. Starting in Greenplum Database version 5.14, PXF requires that the Hadoop configuration files reside in the `$PXF_CONF/servers/default` directory. If you configured PXF Hadoop connectors in your *PXF.from* installation, copy the Hadoop configuration files in `/etc/<hadoop_service>/conf` to `$PXF_CONF/servers/default` on the Greenplum Database master and all segment hosts.
+    5. Starting in Greenplum Database version 5.14, the default Kerberos keytab file location for PXF is `$PXF_CONF/keytabs`. If you previously configured PXF for secure HDFS and the PXF keytab file is located in a *PXF.from* installation directory (for example, `$GPHOME/pxf/conf`), consider relocating the keytab file to `$PXF_CONF/keytabs`. Alternatively, you can update the `PXF_KEYTAB` property setting in the `$PXF_CONF/conf/pxf-env.sh` file to reference a different keytab file system path. Be sure to propagate any updated files to each segment host.
  
 6. Start PXF on each segment host as described in [Starting PXF](cfginitstart_pxf.html#start_pxf).
 

--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -8,7 +8,7 @@ The PXF upgrade procedure describes how to upgrade PXF in your Greenplum Databas
 
 Most PXF installations do not require modifications to PXF configuration files and should experience a seamless upgrade.
 
-**Note**: Starting in Greenplum Database version 5.12.0, PXF no longer requires a Hadoop client installation. PXF now bundles all of the JAR files on which it depends, and loads these JARs at runtime.
+**Note**: Starting in Greenplum Database version 5.12, PXF no longer requires a Hadoop client installation. PXF now bundles all of the JAR files on which it depends, and loads these JARs at runtime.
 
 The PXF upgrade procedure has two parts. You perform one procedure before, and one procedure after, you upgrade to a new version of Greenplum Database:
 
@@ -82,12 +82,12 @@ After you upgrade to the new version of Greenplum Database, perform the followin
         ```
     2. If you updated the `pxf-profiles.xml` configuration file in your *PXF.from* installation, re-apply those changes to `$PXF_CONF/conf/pxf-profiles.xml` and copy the updated file to all segment hosts. Refer to Step 4a above for a similar `gpscp` command.
 
-        **Note:** Starting in Greenplum Database version 5.12.0, the package name for PXF classes was changed to use the prefix `org.greenplum.*`. If you are upgrading from an older *PXF.from* version and you customized the `pxf-profiles.xml` file, you must change any `org.apache.hawq.pxf.*` references to `org.greenplum.pxf.*` when you re-apply your changes.
+        **Note:** Starting in Greenplum Database version 5.12, the package name for PXF classes was changed to use the prefix `org.greenplum.*`. If you are upgrading from an older *PXF.from* version and you customized the `pxf-profiles.xml` file, you must change any `org.apache.hawq.pxf.*` references to `org.greenplum.pxf.*` when you re-apply your changes.
     3. If you updated the `pxf-log4j.properties` configuration file in your *PXF.from* installation, re-apply those changes to `$PXF_CONF/conf/pxf-log4j.properties` and copy the updated file to all segment hosts. Refer to Step 4a above for a similar `gpscp` command.
     4. If you updated the `pxf-public.classpath` configuration file in your *PXF.from* installation, copy every JAR referenced in the file to `$PXF_CONF/lib` on each segment host. Refer to Step 4a above for a similar `gpscp` command.
     5. If you added additional JAR files to your *PXF.from* installation, copy them to `$PXF_CONF/lib` on all segment hosts.
-    5. Starting in Greenplum Database version 5.14, PXF requires that the Hadoop configuration files reside in the `$PXF_CONF/servers/default` directory. If you configured PXF Hadoop connectors in your *PXF.from* installation, copy the Hadoop configuration files in `/etc/<hadoop_service>/conf` to `$PXF_CONF/servers/default` on the Greenplum Database master and all segment hosts.
-    5. Starting in Greenplum Database version 5.14, the default Kerberos keytab file location for PXF is `$PXF_CONF/keytabs`. If you previously configured PXF for secure HDFS and the PXF keytab file is located in a *PXF.from* installation directory (for example, `$GPHOME/pxf/conf`), consider relocating the keytab file to `$PXF_CONF/keytabs`. Alternatively, you can update the `PXF_KEYTAB` property setting in the `$PXF_CONF/conf/pxf-env.sh` file to reference a different keytab file system path. Be sure to propagate any updated files to each segment host.
+    5. Starting in Greenplum Database version 5.14, PXF requires that the Hadoop configuration files reside in the `$PXF_CONF/servers/default` directory. If you configured PXF Hadoop connectors in your *PXF.from* installation, copy the Hadoop configuration files in `/etc/<hadoop_service>/conf` to `$PXF_CONF/servers/default` on the Greenplum Database master and on all segment hosts.
+    5. Starting in Greenplum Database version 5.14, the default Kerberos keytab file location for PXF is `$PXF_CONF/keytabs`. If you previously configured PXF for secure HDFS and the PXF keytab file is located in a *PXF.from* installation directory (for example, `$GPHOME/pxf/conf`), consider relocating the keytab file to `$PXF_CONF/keytabs`. Alternatively, update the `PXF_KEYTAB` property setting in the `$PXF_CONF/conf/pxf-env.sh` file to reference your keytab file. Be sure to propagate any updated files to each segment host.
  
 6. Start PXF on each segment host as described in [Starting PXF](cfginitstart_pxf.html#start_pxf).
 

--- a/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/using_pxf.html.md.erb
@@ -173,7 +173,7 @@ A PXF profile definition includes the name of the profile, a description, and th
 
 ## <a id="profile-dependencies"></a>PXF JAR Dependencies
 
-You use PXF to access data stored on external systems. Depending upon the external data store, this access may require that you install and/or configure additional components or services for the external data store. For example, to use PXF to access a file stored in HDFS, you must install a Hadoop client on each Greenplum Database segment host.
+You use PXF to access data stored on external systems. Depending upon the external data store, this access may require that you install and/or configure additional components or services for the external data store.
 
 PXF depends on JAR files and other configuration information provided by these additional components. The `$GPHOME/pxf/conf/pxf-private.classpath` file identifies PXF internal JAR dependencies. In most cases, PXF manages the `pxf-private.classpath` file, adding entries as necessary based on the connectors that you use.
 


### PR DESCRIPTION
in this PR:
- remove unzip requirement, install openjdk-devel pkg
- hadoop config moved from /etc/xxx/conf to $PXF_CONF/servers/default - new steps in hadoop config and upgrade procedures
- new $PXF_CONF/templates directory
- corrected a few topic titles
- removed a step in pxf kerberos docs to copy hadoop config - the hadoop config should already be on the segment host
- misc edits

doc review site links:
- http://docs-lisa-pxfusrcfg2.cfapps.io/600/pxf/cfginitstart_pxf.html
- http://docs-lisa-pxfusrcfg2.cfapps.io/600/pxf/client_instcfg.html
- http://docs-lisa-pxfusrcfg2.cfapps.io/600/pxf/upgrade_pxf.html