### PR TITLE
Fix calculation of AO table's reltuples in new ANALYZE.

### DIFF
--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -889,3 +889,32 @@ select attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_
 (3 rows)
 
 drop table rep_table;
+--
+-- Test relpages collection for AO tables.
+--
+-- use a lower target, so that the whole table doesn't fit in the sample.
+set default_statistics_target=10;
+create table ao_analyze_test (i int4) with (appendonly=true);
+insert into ao_analyze_test select g from generate_series(1, 100000) g;
+create index ao_analyze_test_idx on ao_analyze_test (i);
+analyze ao_analyze_test;
+select relname, reltuples from pg_class where relname like 'ao_analyze_test%' order by relname;
+       relname       | reltuples 
+---------------------+-----------
+ ao_analyze_test     |    100000
+ ao_analyze_test_idx |    100000
+(2 rows)
+
+-- and same for AOCS
+create table aocs_analyze_test (i int4) with (appendonly=true, orientation=column);
+insert into aocs_analyze_test select g from generate_series(1, 100000) g;
+create index aocs_analyze_test_idx on aocs_analyze_test (i);
+analyze aocs_analyze_test;
+select relname, reltuples from pg_class where relname like 'aocs_analyze_test%' order by relname;
+        relname        | reltuples 
+-----------------------+-----------
+ aocs_analyze_test     |    100000
+ aocs_analyze_test_idx |    100000
+(2 rows)
+
+reset default_statistics_target;

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -426,3 +426,26 @@ select relname, reltuples, relpages from pg_class where relname ='rep_table' ord
 select attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='rep_table' ORDER BY attname;
 
 drop table rep_table;
+
+
+--
+-- Test relpages collection for AO tables.
+--
+
+-- use a lower target, so that the whole table doesn't fit in the sample.
+set default_statistics_target=10;
+
+create table ao_analyze_test (i int4) with (appendonly=true);
+insert into ao_analyze_test select g from generate_series(1, 100000) g;
+create index ao_analyze_test_idx on ao_analyze_test (i);
+analyze ao_analyze_test;
+select relname, reltuples from pg_class where relname like 'ao_analyze_test%' order by relname;
+
+-- and same for AOCS
+create table aocs_analyze_test (i int4) with (appendonly=true, orientation=column);
+insert into aocs_analyze_test select g from generate_series(1, 100000) g;
+create index aocs_analyze_test_idx on aocs_analyze_test (i);
+analyze aocs_analyze_test;
+select relname, reltuples from pg_class where relname like 'aocs_analyze_test%' order by relname;
+
+reset default_statistics_target;


### PR DESCRIPTION
The total number of rows in table, stored in pg_class.reltuples, was
calculated incorrectly. It was set to the number of rows in the sample,
not the (estimated?) total number of rows in the table. We didn't notice,
because most of the existing tests use small tables, so that the whole
table fit in the sample. Put back code like we used to have, for
collecting the totals.

This papers over the assertion failure we're seeing in the 'aocs' test in
the concourse pipeline, with ORCA, by changing the plan to one that doesn't
crash. It needs a proper fix, of course, but we're tracking that separately
as https://github.com/greenplum-db/gpdb/issues/6274.