### PR TITLE
Use DEBUG2 for ANALYZE debug logging rather than LOG

### DIFF
--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1066,7 +1066,7 @@ needs_sample(VacAttrStats **vacattrstats, int attr_cnt)
  *  split partitions.
  */
 bool
-leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols)
+leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 {
 	PartitionNode *pn = get_parts(attrelid,
 								  0 /* level */ ,
@@ -1113,9 +1113,13 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols)
 			if (!HeapTupleIsValid(heaptupleStats) || relpages == 0)
 			{
 				if (relid_exclude == InvalidOid)
-					elog(LOG, "column %s of partition %s is not analyzed, so ANALYZE will collect sample for stats calculation", attname, get_rel_name(partRelid));
+					ereport(elevel,
+							(errmsg("column %s of partition %s is not analyzed, so ANALYZE will collect sample for stats calculation",
+									attname, get_rel_name(partRelid))));
 				else
-					elog(LOG, "Auto merging of leaf partition stats to calculate root partition stats is not possible because column %s of partition %s is not analyzed", attname, get_rel_name(partRelid));
+					ereport(elevel,
+							(errmsg("auto merging of leaf partition stats to calculate root partition stats is not possible because column %s of partition %s is not analyzed",
+									attname, get_rel_name(partRelid))));
 				return false;
 			}
 			heap_freetuple(heaptupleStats);

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1119,7 +1119,9 @@ get_rel_oids(Oid relid, VacuumStmt *vacstmt, int stmttype)
 				}
 				if (optimizer_analyze_root_partition || (vacstmt->options & VACOPT_ROOTONLY))
 				{
-					if (leaf_parts_analyzed(root_rel_oid, relationOid, va_root_attnums))
+					int		elevel = ((vacstmt->options & VACOPT_VERBOSE) ? LOG : DEBUG2);
+
+					if (leaf_parts_analyzed(root_rel_oid, relationOid, va_root_attnums, elevel))
 						oid_list = lappend_oid(oid_list, root_rel_oid);
 				}
 			}

--- a/src/include/commands/analyzeutils.h
+++ b/src/include/commands/analyzeutils.h
@@ -54,6 +54,6 @@ extern int aggregate_leaf_partition_histograms(Oid relationOid,
 											   int rem_mcv,
 											   void **result);
 extern bool needs_sample(VacAttrStats **vacattrstats, int attr_cnt);
-extern bool leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols);
+extern bool leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel);
 
 #endif  /* ANALYZEUTILS_H */

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -84,6 +84,7 @@ typedef struct VacAttrStats
 	Form_pg_type attrtype;		/* copy of pg_type row for attrtypid */
 	char		relstorage;		/* pg_class.relstorage for table */
 	MemoryContext anl_context;	/* where to save long-lived data */
+	int16		elevel;			/* set to LOG for ANALYZE VERBOSE */
 
 	/*
 	 * These fields must be filled in by the typanalyze routine, unless it

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10566,7 +10566,6 @@ set log_statement='none';
 set log_min_duration_statement=-1;
 set client_min_messages='log';
 create table foo_ctas(a) as (select generate_series(1,10)) distributed by (a);
-LOG:  Computing Scalar Stats : column a
 reset client_min_messages;
 reset log_min_duration_statement;
 reset log_statement;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10657,7 +10657,6 @@ LOG:  2017-05-31 14:43:22:338568 PDT,THD000,NOTICE,"Feature not supported: CTAS.
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA
 LOG:  Planner produced plan :0
-LOG:  Computing Scalar Stats : column a
 reset client_min_messages;
 reset log_min_duration_statement;
 reset log_statement;

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1689,11 +1689,14 @@ SET client_min_messages = 'log';
 -- the leaf partitions does not have any stats for it, yet
 ALTER TABLE foo ADD COLUMN c int;
 INSERT INTO foo SELECT i, i%9, i%100 FROM generate_series(1,500)i;
-ANALYZE rootpartition foo;
-LOG:  column c of partition foo_1_prt_1 is not analyzed, so ANALYZE will collect sample for stats calculation
-LOG:  Merging leaf partition stats to calculate root partition stats : column a
-LOG:  Merging leaf partition stats to calculate root partition stats : column b
-LOG:  Computing Scalar Stats : column c
+-- start_matchsubs
+-- m/gp_acquire_sample_rows([^,]+, [^,]+, .+)/
+-- s/gp_acquire_sample_rows([^,]+, [^,]+, .+)/gp_acquire_sample_rows()/
+-- end_matchsubs
+ANALYZE VERBOSE rootpartition foo;
+INFO:  analyzing "public.foo" inheritance tree
+INFO:  column c of partition foo_1_prt_1 is not analyzed, so ANALYZE will collect sample for stats calculation
+INFO:  Executing SQL: select * from pg_catalog.gp_acquire_sample_rows(17861, 400, 't') as (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_bitmap pg_catalog.text, a integer, b integer, c integer)
 -- Testing auto merging root statistics for all columns
 -- where column attnums are differents due to dropped columns
 -- and split partitions.
@@ -1715,27 +1718,9 @@ NOTICE:  CREATE TABLE will create partition "foo_1_prt_new_part" for table "foo"
 NOTICE:  CREATE TABLE will create partition "foo_1_prt_def_part" for table "foo"
 set client_min_messages to 'log';
 ANALYZE foo_1_prt_2;
-LOG:  Auto merging of leaf partition stats to calculate root partition stats is not possible because column a of partition foo_1_prt_3 is not analyzed
-LOG:  Computing Scalar Stats : column a
-LOG:  Computing Scalar Stats : column c
-LOG:  Computing Scalar Stats : column d
 ANALYZE foo_1_prt_3;
-LOG:  Auto merging of leaf partition stats to calculate root partition stats is not possible because column a of partition foo_1_prt_new_part is not analyzed
-LOG:  Computing Scalar Stats : column a
-LOG:  Computing Scalar Stats : column c
-LOG:  Computing Scalar Stats : column d
 ANALYZE foo_1_prt_new_part;
-LOG:  Auto merging of leaf partition stats to calculate root partition stats is not possible because column a of partition foo_1_prt_def_part is not analyzed
-LOG:  Computing Scalar Stats : column a
-LOG:  Computing Scalar Stats : column c
-LOG:  Computing Scalar Stats : column d
 ANALYZE foo_1_prt_def_part;
-LOG:  Computing Scalar Stats : column a
-LOG:  Computing Scalar Stats : column c
-LOG:  Computing Scalar Stats : column d
-LOG:  Merging leaf partition stats to calculate root partition stats : column a
-LOG:  Merging leaf partition stats to calculate root partition stats : column c
-LOG:  Merging leaf partition stats to calculate root partition stats : column d
 reset client_min_messages;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
      tablename      | attname | null_frac | n_distinct | most_common_vals |           most_common_freqs           |                          histogram_bounds                           
@@ -1778,17 +1763,9 @@ NOTICE:  CREATE TABLE will create partition "foo_1_prt_new_part" for table "foo"
 NOTICE:  CREATE TABLE will create partition "foo_1_prt_def_part" for table "foo"
 set client_min_messages to 'log';
 ANALYZE foo_1_prt_2(a);
-LOG:  Auto merging of leaf partition stats to calculate root partition stats is not possible because column a of partition foo_1_prt_3 is not analyzed
-LOG:  Computing Scalar Stats : column a
 ANALYZE foo_1_prt_3(a);
-LOG:  Auto merging of leaf partition stats to calculate root partition stats is not possible because column a of partition foo_1_prt_new_part is not analyzed
-LOG:  Computing Scalar Stats : column a
 ANALYZE foo_1_prt_new_part(a);
-LOG:  Auto merging of leaf partition stats to calculate root partition stats is not possible because column a of partition foo_1_prt_def_part is not analyzed
-LOG:  Computing Scalar Stats : column a
 ANALYZE foo_1_prt_def_part(a);
-LOG:  Computing Scalar Stats : column a
-LOG:  Merging leaf partition stats to calculate root partition stats : column a
 reset client_min_messages;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
      tablename      | attname | null_frac | n_distinct | most_common_vals |           most_common_freqs           | histogram_bounds 
@@ -1821,17 +1798,9 @@ NOTICE:  CREATE TABLE will create partition "foo_1_prt_new_part" for table "foo"
 NOTICE:  CREATE TABLE will create partition "foo_1_prt_def_part" for table "foo"
 set client_min_messages to 'log';
 ANALYZE foo_1_prt_2(d);
-LOG:  Auto merging of leaf partition stats to calculate root partition stats is not possible because column d of partition foo_1_prt_3 is not analyzed
-LOG:  Computing Scalar Stats : column d
 ANALYZE foo_1_prt_3(d);
-LOG:  Auto merging of leaf partition stats to calculate root partition stats is not possible because column d of partition foo_1_prt_new_part is not analyzed
-LOG:  Computing Scalar Stats : column d
 ANALYZE foo_1_prt_new_part(d);
-LOG:  Auto merging of leaf partition stats to calculate root partition stats is not possible because column d of partition foo_1_prt_def_part is not analyzed
-LOG:  Computing Scalar Stats : column d
 ANALYZE foo_1_prt_def_part(d);
-LOG:  Computing Scalar Stats : column d
-LOG:  Merging leaf partition stats to calculate root partition stats : column d
 reset client_min_messages;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
      tablename      | attname | null_frac | n_distinct | most_common_vals | most_common_freqs | histogram_bounds 
@@ -1859,12 +1828,6 @@ set client_min_messages to 'log';
 -- ANALYZE ROOTPARTITION will sample the table and compute statistics since there
 -- is not stats to be merged in the leaf partitions
 ANALYZE ROOTPARTITION foo;
-LOG:  column a of partition foo_1_prt_1 is not analyzed, so ANALYZE will collect sample for stats calculation
-LOG:  column b of partition foo_1_prt_1 is not analyzed, so ANALYZE will collect sample for stats calculation
-LOG:  column c of partition foo_1_prt_1 is not analyzed, so ANALYZE will collect sample for stats calculation
-LOG:  Computing Scalar Stats : column a
-LOG:  Computing Scalar Stats : column b
-LOG:  Computing Scalar Stats : column c
 reset client_min_messages;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
  tablename | attname | null_frac | n_distinct | most_common_vals | most_common_freqs |                         histogram_bounds                         
@@ -1879,9 +1842,6 @@ ANALYZE foo_1_prt_2;
 set client_min_messages to 'log';
 -- ANALYZE ROOT PARTITION will piggyback on the stats collected from the leaf and merge them
 ANALYZE ROOTPARTITION foo;
-LOG:  Merging leaf partition stats to calculate root partition stats : column a
-LOG:  Merging leaf partition stats to calculate root partition stats : column b
-LOG:  Merging leaf partition stats to calculate root partition stats : column c
 reset client_min_messages;
 reset optimizer_analyze_root_partition;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -677,7 +677,11 @@ SET client_min_messages = 'log';
 -- the leaf partitions does not have any stats for it, yet
 ALTER TABLE foo ADD COLUMN c int;
 INSERT INTO foo SELECT i, i%9, i%100 FROM generate_series(1,500)i;
-ANALYZE rootpartition foo;
+-- start_matchsubs
+-- m/gp_acquire_sample_rows([^,]+, [^,]+, .+)/
+-- s/gp_acquire_sample_rows([^,]+, [^,]+, .+)/gp_acquire_sample_rows()/
+-- end_matchsubs
+ANALYZE VERBOSE rootpartition foo;
 -- Testing auto merging root statistics for all columns
 -- where column attnums are differents due to dropped columns
 -- and split partitions.


### PR DESCRIPTION
Running ANALYZE with the HLL computation produce a lot of LOG messages which are more geared towards troubleshooting than general purpose log files. Demote these to elevel DEBUG2 to avoid cluttering up logfiles on production systems.

Also fixes a C++ comment to conform with code style which was in the vicinity