### PR TITLE
Set statistics to zero when no sampled rows

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -3862,10 +3862,16 @@ compute_scalar_stats(VacAttrStatsP stats,
 	}
 	else
 	{
-		/* ORCA complains if a column has no statistics whatsoever,
-		 * so store something */
+		/*
+		 * ORCA complains if a column has no statistics whatsoever, so store
+		 * either the best we can figure out given what we have, or zero in
+		 * case we don't have enough.
+		 */
 		stats->stats_valid = true;
-		stats->stanullfrac = (double) null_cnt / (double) samplerows;
+		if (samplerows)
+			stats->stanullfrac = (double) null_cnt / (double) samplerows;
+		else
+			stats->stanullfrac = 0.0;
 		if (is_varwidth)
 			stats->stawidth = 0;	/* "unknown" */
 		else


### PR DESCRIPTION
In the unlikely event that we reach this codepath with a samplerows value of zero (which albeit unlikely could happen), avoid performing a division by zero and instead set the null fraction to zero as we clearly don't have any more information to go on. The HLL code calls calls the compute_stats function pointer with zero samplerows, and while that's using a different compute_stats function, it's an easy
mistake to make when not all functions can handle a division by zero. This is defensive programming prompted by a report that triggered an old bug like this without actually hitting this, but there is little reason to take the risk of a crash. Suspenders go well with belts.

To the careful observer: my branch is named `orca_div_zero` but this has nothing to do with Orca, it was a misnaming on my part that I'm too lazy to change.