### PR TITLE
Fix dynahash HASH_ENTER usage

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -2850,12 +2850,9 @@ rel_partitioning_is_uniform(Oid rootOid)
 				if (fFirstNode)
 				{
 					/* add current constraint to hash table */
-					void	   *con_entry = hash_search(conHash, &curr_con, HASH_ENTER, &found);
+					void	   *con_entry;
 
-					if (con_entry == NULL)
-					{
-						ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("out of memory")));
-					}
+					con_entry = hash_search(conHash, &curr_con, HASH_ENTER, &found);
 					((ConNodeEntry *) con_entry)->entry = curr_con;
 				}
 

--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -368,10 +368,6 @@ addMCVToHashTable(HTAB *datumHash, MCVFreqPair *mcvFreqPair)
 		MCVFreqPair *key = MCVFreqPairCopy(mcvFreqPair);
 
 		mcvfreq = hash_search(datumHash, &key, HASH_ENTER, &found);
-		if (mcvfreq == NULL)
-		{
-			ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("out of memory")));
-		}
 		mcvfreq->entry = key;
 	}
 	else

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2783,7 +2783,7 @@ groupHashNew(Oid groupId)
 	Assert(i < pResGroupControl->nGroups);
 
 	entry = (ResGroupHashEntry *)
-		hash_search(pResGroupControl->htbl, (void *) &groupId, HASH_ENTER_NULL, &found);
+		hash_search(pResGroupControl->htbl, (void *) &groupId, HASH_ENTER, &found);
 	/* caller should test that the group does not exist already */
 	Assert(!found);
 	entry->index = i;


### PR DESCRIPTION
In `rel_partitioning_is_uniform()` we inserted with `HASH_ENTER`, and checked the returnvalue for NULL in order to error out on "out of memory". `HASH_ENTER` however doesn't return if it couldn't insert and will error out itself so remove the test as it cannot happen.

`groupHashNew()` was using `HASH_ENTER_NULL` which does return NULL in out of memory situations, but it failed to correctly handle the returnvalue and dereferenced without check risking a null pointer deref under memory pressure. Fix by using `HASH_ENTER` instead as the code clearly expect that behavior.