### PR TITLE
Change qp_dml_joins test to expect error emitted by QE reader

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -533,15 +533,6 @@ ReadBuffer_common(SMgrRelation smgr, char relpersistence, ForkNumber forkNum,
 	else
 	{
 		/*
-		 * QE reader should not bring in a shared buffer from disk if its
-		 * writer has already aborted the transaction.  Check for interrupts
-		 * allows the reader to determine if the writer has sent a cancel
-		 * signal.
-		 */
-		if (!Gp_is_writer)
-			CHECK_FOR_INTERRUPTS();
-
-		/*
 		 * Read in the page, unless the caller intends to overwrite it and
 		 * just wants us to allocate a buffer.
 		 */

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -3,6 +3,10 @@
 -- s/ERROR:  moving tuple from partition .* to partition .* not supported/ERROR:  cross-partition or multi-update to a row/
 -- m/ERROR:  multiple updates to a row by the same query is not allowed/
 -- s/ERROR:  multiple updates to a row by the same query is not allowed/ERROR:  cross-partition or multi-update to a row/
+-- m/ERROR:  relation not found .*/
+-- s/ERROR:  relation not found .*/ERROR:  cross-partition or multi-update to a row/
+-- m/DETAIL:  This can be validly caused by a concurrent delete operation on this object/
+-- s/.//gs
 -- end_matchsubs
 -- First create a bunch of test tables
 -- start_matchsubs

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -3125,14 +3125,6 @@ SELECT SUM(b) FROM dml_heap_pt_r;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
 ERROR:  cross-partition or multi-update to a row  (seg1 10.152.10.75:25433 pid=28939)
 SELECT SUM(a) FROM dml_heap_pt_r;
@@ -3286,14 +3278,6 @@ SELECT * FROM dml_heap_pt_r WHERE a = 1;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
 ERROR:  cross-partition or multi-update to a row  (seg2 10.152.10.75:25434 pid=14697)
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -3,6 +3,10 @@
 -- s/ERROR:  moving tuple from partition .* to partition .* not supported/ERROR:  cross-partition or multi-update to a row/
 -- m/ERROR:  multiple updates to a row by the same query is not allowed/
 -- s/ERROR:  multiple updates to a row by the same query is not allowed/ERROR:  cross-partition or multi-update to a row/
+-- m/ERROR:  relation not found .*/
+-- s/ERROR:  relation not found .*/ERROR:  cross-partition or multi-update to a row/
+-- m/DETAIL:  This can be validly caused by a concurrent delete operation on this object/
+-- s/.//gs
 -- end_matchsubs
 -- First create a bunch of test tables
 -- start_matchsubs

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -3129,14 +3129,6 @@ SELECT SUM(b) FROM dml_heap_pt_r;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
 SELECT SUM(a) FROM dml_heap_pt_r;
  sum 
@@ -3297,14 +3289,6 @@ SELECT * FROM dml_heap_pt_r WHERE a = 1;
 (1 row)
 
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
 ERROR:  cross-partition or multi-update to a row
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -6,6 +6,12 @@
 -- m/ERROR:  multiple updates to a row by the same query is not allowed/
 -- s/ERROR:  multiple updates to a row by the same query is not allowed/ERROR:  cross-partition or multi-update to a row/
 
+-- m/ERROR:  relation not found .*/
+-- s/ERROR:  relation not found .*/ERROR:  cross-partition or multi-update to a row/
+
+-- m/DETAIL:  This can be validly caused by a concurrent delete operation on this object/
+-- s/.//gs
+
 -- end_matchsubs
 
 -- First create a bunch of test tables

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -1352,16 +1352,6 @@ begin;
 SELECT SUM(a) FROM dml_heap_pt_r;
 SELECT SUM(b) FROM dml_heap_pt_r;
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
-
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
-
 UPDATE dml_heap_pt_r SET a = DEFAULT, b = DEFAULT;
 SELECT SUM(a) FROM dml_heap_pt_r;
 SELECT SUM(b) FROM dml_heap_pt_r;
@@ -1427,16 +1417,6 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;
 SELECT dml_heap_pt_s.a + 10 FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a ORDER BY 1 LIMIT 1;
 SELECT * FROM dml_heap_pt_r WHERE a = 1;
 ALTER TABLE dml_heap_pt_r ADD DEFAULT partition def;
-
--- Temporary workaround to make the error reported by the following
--- update statement deterministic.  Without the savepoint, a QE reader
--- may continue performing its part of the plan even after its writer
--- has finished aborting the transaction.  This would lead to
--- occasional "relation not found for OID ..." errors because the
--- default partition would have been dropped as part of writer's abort
--- processing.
-SAVEPOINT sp1;
-
 UPDATE dml_heap_pt_r SET a = dml_heap_pt_s.a + 10 ,b = NULL FROM dml_heap_pt_s WHERE dml_heap_pt_r.a + 2= dml_heap_pt_s.b;
 SELECT * FROM dml_heap_pt_r WHERE a = 11 ORDER BY 1,2;
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE b is NULL;


### PR DESCRIPTION
We have also removed a redundant CHECK_FOR_INTERRUPTS() call added previously in PR #6089.

See individual commit messages for details.