### PR TITLE
Remove dead code in ATExecSetDistributedBy

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14551,11 +14551,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 	Oid					relationOid = InvalidOid;
 	AutoStatsCmdType 	cmdType = AUTOSTATS_CMDTYPE_SENTINEL;
 
-	/* Permissions checks */
-	if (!pg_class_ownercheck(RelationGetRelid(rel), GetUserId()))
-		aclcheck_error(ACLCHECK_NOT_OWNER, ACL_KIND_CLASS,
-					   RelationGetRelationName(rel));
-
 	/* Can't ALTER TABLE SET system catalogs */
 	if (IsSystemRelation(rel))
 		ereport(ERROR,

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14610,7 +14610,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("with options at most one, reorg|reshuffle")));
+						 errmsg("not supported for more than one option in WITH clause")));
 			}
 
 			DefElem	*def = linitial(lwith);
@@ -14685,7 +14685,8 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("with options only support reorg|reshuffle")));
+						 errmsg("option \"%s\" not supported",
+								def->defname)));
 			}
 
 			lwith = nlist;
@@ -14696,7 +14697,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		if (ldistro)
 			change_policy = true;
 
-		/* abstract a macro or a function */
 		if (ldistro && ldistro->ptype == POLICYTYPE_PARTITIONED && ldistro->keys == NIL)
 		{
 			rand_pol = true;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14610,7 +14610,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("not supported for more than one option in WITH clause")));
+						 errmsg("cannot specify more than one option in WITH clause")));
 			}
 
 			DefElem	*def = linitial(lwith);
@@ -14620,10 +14620,10 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 				GpPolicy *newPolicy;
 				PartStatus targetRelPartStatus;
 
-				if (NULL != lsecond(lprime))
+				if (ldistro)
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("Can not set Distribute By")));
+							 errmsg("cannot use RESHUFFLE=true with SET DISTRIBUTED BY")));
 
 				/*
 				 * We generate a UpdateStmt when the relation is non-partition

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14081,54 +14081,28 @@ build_ctas_with_dist(Relation rel, DistributedBy *dist_clause,
 }
 
 static Datum
-new_rel_opts(Relation rel, List *lwith)
+new_rel_opts(Relation rel)
 {
 	Datum newOptions = PointerGetDatum(NULL);
-	bool make_heap = false;
-	if (lwith && list_length(lwith))
-	{
-		ListCell *lc;
 
-		/*
-		 * See if user has specified appendonly = false. If so, we
-		 * have no use for the existing reloptions
-		 */
-		foreach(lc, lwith)
-		{
-			DefElem *e = lfirst(lc);
-			if (pg_strcasecmp(e->defname, "appendonly") == 0 &&
-				pg_strcasecmp(defGetString(e), "false") == 0)
-			{
-				make_heap = true;
-				break;
-			}
-		}
-	}
+	/* Get the old reloptions */
+	bool isnull;
+	Oid relid = RelationGetRelid(rel);
+	HeapTuple optsTuple;
 
-	if (!make_heap)
-	{
-		/* Get the old reloptions */
-		bool isnull;
-		Oid relid = RelationGetRelid(rel);
-		HeapTuple optsTuple;
+	optsTuple = SearchSysCache1(RELOID,
+								ObjectIdGetDatum(relid));
+	if (!HeapTupleIsValid(optsTuple))
+		elog(ERROR, "cache lookup failed for relation %u", relid);
 
-		optsTuple = SearchSysCache1(RELOID,
-									ObjectIdGetDatum(relid));
-		if (!HeapTupleIsValid(optsTuple))
-				elog(ERROR, "cache lookup failed for relation %u", relid);
+	newOptions = SysCacheGetAttr(RELOID, optsTuple,
+								 Anum_pg_class_reloptions, &isnull);
 
-		newOptions = SysCacheGetAttr(RELOID, optsTuple,
-									 Anum_pg_class_reloptions, &isnull);
+	/* take a copy since we're using it after ReleaseSysCache() */
+	if (!isnull)
+		newOptions = datumCopy(newOptions, false, -1);
 
-		/* take a copy since we're using it after ReleaseSysCache() */
-		if (!isnull)
-			newOptions = datumCopy(newOptions, false, -1);
-
-		ReleaseSysCache(optsTuple);
-	}
-
-	/* Generate new proposed reloptions (text array) */
-	newOptions = transformRelOptions(newOptions, lwith, NULL, NULL, false, false);
+	ReleaseSysCache(optsTuple);
 
 	return newOptions;
 }
@@ -14572,9 +14546,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 	bool        force_reorg = false;
 	Datum		newOptions = PointerGetDatum(NULL);
 	bool		change_policy = false;
-	bool		is_ao = false;
-	bool        is_aocs = false;
-	char        relstorage = RELSTORAGE_HEAP;
 	int         nattr; /* number of attributes */
 	int			numsegments;
 	bool				useExistingColumnAttributes = true;
@@ -14635,174 +14606,102 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		if (lwith)
 		{
 			bool		 seen_reorg = false;
-			ListCell	*lc;
 			char		*reorg_str = "reorganize";
 			char		*reshuffle_str = "reshuffle";
 			List		*nlist = NIL;
 
-			/* remove the "REORGANIZE=true/false" from the WITH clause */
-			foreach(lc, lwith)
-			{
-				DefElem	*def = lfirst(lc);
-
-				if (pg_strcasecmp(reshuffle_str, def->defname) == 0)
-				{
-					MemoryContext oldcontext;
-					GpPolicy *newPolicy;
-					PartStatus targetRelPartStatus;
-
-					if (NULL != lsecond(lprime))
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-										errmsg("Can not set Distribute By")));
-
-					/*
-					 * We generate a UpdateStmt when the relation is non-partition
-					 * table or root-partition table.
-					 */
-					targetRelPartStatus = rel_part_status(RelationGetRelid(rel));
-
-					if(PART_STATUS_LEAF == targetRelPartStatus ||
-					   PART_STATUS_NONE == targetRelPartStatus)
-					{
-						ReshuffleRelationData(rel);
-					}
-
-					/* Generate a new policy and adjust the numsegments */
-					policy = rel->rd_cdbpolicy;
-					oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
-					newPolicy = GpPolicyCopy(policy);
-					MemoryContextSwitchTo(oldcontext);
-
-					newPolicy->numsegments = getgpsegmentCount();
-
-					/* Update the numsegments in gp_distribution_policy */
-					GpPolicyReplace(RelationGetRelid(rel), newPolicy);
-					oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
-					rel->rd_cdbpolicy = GpPolicyCopy(newPolicy);
-					MemoryContextSwitchTo(oldcontext);
-					heap_close(rel, NoLock);
-
-					/*
-					 * Save the policy in the CMD, it would be dispatched in
-					 * next step.
-					 */
-					lsecond(lprime) = makeNode(SetDistributionCmd);
-					/*
-					 * Notice: reshuffle can not specify (Distribute By), so
-					 * we don't need to pass a policy info to segments like
-					 * lprime = lappend(lprime, newPolicy);
-					 */
-					goto l_distro_fini;
-				}
-				else if (pg_strcasecmp(reorg_str, def->defname) != 0)
-				{
-					/* MPP-7770: disable changing storage options for now */
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("option \"%s\" not supported",
-									def->defname)));
-
-					if (pg_strcasecmp(def->defname, "appendonly") == 0)
-					{
-						if (IsA(def->arg, String) && pg_strcasecmp(strVal(def->arg), "true") == 0)
-						{
-							is_ao = true;
-							relstorage = RELSTORAGE_AOROWS;
-						}
-						else
-							is_ao = false;
-					}
-					else if (pg_strcasecmp(def->defname, "orientation") == 0)
-					{
-						if (IsA(def->arg, String) && pg_strcasecmp(strVal(def->arg), "column") == 0)
-						{
-							is_aocs = true;
-							relstorage = RELSTORAGE_AOCOLS;
-						}
-						else
-						{
-							if (!IsA(def->arg, String) || pg_strcasecmp(strVal(def->arg), "row") != 0)
-								ereport(ERROR,
-										(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-										 errmsg("invalid orientation option"),
-										 errhint("Valid orientation options are \"column\" or \"row\".")));
-						}
-					}
-					else
-					{
-						useExistingColumnAttributes=false;
-					}
-
-					nlist = lappend(nlist, def);
-				}
-				else
-				{
-					/* have we been here before ? */
-					if (seen_reorg)
-						ereport(ERROR,
-								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-								 errmsg("\"%s\" specified more than once",
-								 		reorg_str)));
-
-					seen_reorg = true;
-					if (!def->arg)
-						force_reorg = true;
-					else
-					{
-						if (IsA(def->arg, String) && pg_strcasecmp("TRUE", strVal(def->arg)) == 0)
-							force_reorg = true;
-						else if (IsA(def->arg, String) && pg_strcasecmp("FALSE", strVal(def->arg)) == 0)
-							force_reorg = false;
-						else
-							ereport(ERROR,
-									(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-									 errmsg("Invalid REORGANIZE option"),
-									 errhint("Valid REORGANIZE options are \"true\" or \"false\".")));
-					}
-				}
-			}
-
-			if (is_aocs && !is_ao)
+			if (list_length(lwith) > 1)
 			{
 				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("specified orientation requires appendonly")));
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("with options at most one, reorg|reshuffle")));
+			}
+
+			DefElem	*def = linitial(lwith);
+			if (pg_strcasecmp(reshuffle_str, def->defname) == 0)
+			{
+				MemoryContext oldcontext;
+				GpPolicy *newPolicy;
+				PartStatus targetRelPartStatus;
+
+				if (NULL != lsecond(lprime))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("Can not set Distribute By")));
+
+				/*
+				 * We generate a UpdateStmt when the relation is non-partition
+				 * table or root-partition table.
+				 */
+				targetRelPartStatus = rel_part_status(RelationGetRelid(rel));
+
+				if(PART_STATUS_LEAF == targetRelPartStatus ||
+				   PART_STATUS_NONE == targetRelPartStatus)
+				{
+					ReshuffleRelationData(rel);
+				}
+
+				/* Generate a new policy and adjust the numsegments */
+				policy = rel->rd_cdbpolicy;
+				oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
+				newPolicy = GpPolicyCopy(policy);
+				MemoryContextSwitchTo(oldcontext);
+
+				newPolicy->numsegments = getgpsegmentCount();
+
+				/* Update the numsegments in gp_distribution_policy */
+				GpPolicyReplace(RelationGetRelid(rel), newPolicy);
+				oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
+				rel->rd_cdbpolicy = GpPolicyCopy(newPolicy);
+				MemoryContextSwitchTo(oldcontext);
+				heap_close(rel, NoLock);
+
+				/*
+				 * Save the policy in the CMD, it would be dispatched in
+				 * next step.
+				 */
+				lsecond(lprime) = makeNode(SetDistributionCmd);
+				/*
+				 * Notice: reshuffle can not specify (Distribute By), so
+				 * we don't need to pass a policy info to segments like
+				 * lprime = lappend(lprime, newPolicy);
+				 */
+				goto l_distro_fini;
+
+			}
+			else if (pg_strcasecmp(reorg_str, def->defname) == 0)
+			{
+				seen_reorg = true;
+				if (!def->arg)
+					force_reorg = true;
+				else if (IsA(def->arg, String) && pg_strcasecmp("TRUE", strVal(def->arg)) == 0)
+					force_reorg = true;
+				else if (IsA(def->arg, String) && pg_strcasecmp("FALSE", strVal(def->arg)) == 0)
+					force_reorg = false;
+				else
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("Invalid REORGANIZE option"),
+							 errhint("Valid REORGANIZE options are \"true\" or \"false\".")));
+				}
+			}
+			else
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("with options only support reorg|reshuffle")));
 			}
 
 			lwith = nlist;
-
-			/*
-			 * If there are other storage options, but REORGANIZE is not
-			 * specified, then the storage must be re-org'd.  But if REORGANIZE
-			 * was specified use that setting.
-			 *
-			 * If the user specified we not force a reorg but there are other
-			 * WITH clause items, then we cannot honour what the user has
-			 * requested.
-			 */
-			if (!seen_reorg && list_length(lwith))
-				force_reorg = true;
-			else if (seen_reorg && force_reorg == false && list_length(lwith))
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("%s must be set to true when changing storage type",
-						 		reorg_str)));
-
-			newOptions = new_rel_opts(rel, lwith);
-
-			/* ensure that the options parse */
-			if (newOptions)
-				(void) heap_reloptions(rel->rd_rel->relkind, newOptions, true);
 		}
-		else
-		{
-			newOptions = new_rel_opts(rel, NIL);
-		}
+
+		newOptions = new_rel_opts(rel);
 
 		if (ldistro)
 			change_policy = true;
 
+		/* abstract a macro or a function */
 		if (ldistro && ldistro->ptype == POLICYTYPE_PARTITIONED && ldistro->keys == NIL)
 		{
 			rand_pol = true;
@@ -15164,27 +15063,12 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 	{
 		int			backend_id;
 		bool		reorg = false;
-		ListCell   *lc;
-		DefElem    *def;
 
 		Assert(list_length(lprime) >= 2);
 
 		lwith = linitial(lprime);
 		qe_data = lsecond(lprime);
 		policy = lthird(lprime);
-
-		/* Remove "reorganize" since we don't want it in reloptions of pg_class */	
-		foreach(lc, lwith)
-		{
-			def = lfirst(lc);
-			if (pg_strcasecmp(def->defname, "reorganize") == 0)
-			{
-				if (pg_strcasecmp(strVal(def->arg), "true") == 0)
-					reorg = true;
-				lwith = list_delete(lwith, def);
-				break;
-			}
-		}
 
 		if (policy)
 			GpPolicyReplace(RelationGetRelid(rel), policy);
@@ -15207,28 +15091,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		tmprv = make_temp_table_name(rel, backend_id);
 		oid_map = qe_data->indexOidMap;
 
-		if (list_length(lprime) == 4)
-		{
-			Value *v = lfourth(lprime);
-			if (intVal(v) == 1)
-			{
-				is_ao = true;
-				relstorage = RELSTORAGE_AOROWS;
-			}
-			else if (intVal(v) == 2)
-			{
-				is_ao = true;
-				is_aocs = true;
-				relstorage = RELSTORAGE_AOCOLS;
-			}
-			else
-			{
-				is_ao = false;
-				relstorage = RELSTORAGE_HEAP;
-			}
-		}
-
-		newOptions = new_rel_opts(rel, lwith);
+		newOptions = new_rel_opts(rel);
 	}
 
 	/*
@@ -15341,7 +15204,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		linitial(lprime) = lwith;
 		lsecond(lprime) = qe_data;
 		lprime = lappend(lprime, policy);
-		lprime = lappend(lprime, makeInteger(is_ao ? (is_aocs ? 2 : 1) : 0));
 	}
 
 	/* Step (h) Drop the table */

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3318,7 +3318,6 @@ _copySetDistributionCmd(const SetDistributionCmd *from)
 
 	COPY_SCALAR_FIELD(backendId);
 	COPY_NODE_FIELD(relids);
-	COPY_NODE_FIELD(indexOidMap);
 	COPY_NODE_FIELD(hiddenTypes);
 
 	return newnode;

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1048,7 +1048,6 @@ _equalSetDistributionCmd(const SetDistributionCmd *a, const SetDistributionCmd *
 {
 	COMPARE_SCALAR_FIELD(backendId);
 	COMPARE_NODE_FIELD(relids);
-	COMPARE_NODE_FIELD(indexOidMap);
 	COMPARE_NODE_FIELD(hiddenTypes);
 
 	return true;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2779,13 +2779,12 @@ _outAlterTableCmd(StringInfo str, const AlterTableCmd *node)
 }
 
 static void
-_outSetDistributionCmd(StringInfo str, const SetDistributionCmd*node)
+_outSetDistributionCmd(StringInfo str, const SetDistributionCmd *node)
 {
 	WRITE_NODE_TYPE("SETDISTRIBUTIONCMD");
 
 	WRITE_INT_FIELD(backendId);
 	WRITE_NODE_FIELD(relids);
-	WRITE_NODE_FIELD(indexOidMap);
 	WRITE_NODE_FIELD(hiddenTypes);
 }
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -591,7 +591,6 @@ _readSetDistributionCmd(void)
 
 	READ_INT_FIELD(backendId);
 	READ_NODE_FIELD(relids);
-	READ_NODE_FIELD(indexOidMap);
 	READ_NODE_FIELD(hiddenTypes);
 
 	READ_DONE();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1033,7 +1033,6 @@ _readSetDistributionCmd(void)
 
 	READ_INT_FIELD(backendId);
 	READ_NODE_FIELD(relids);
-	READ_NODE_FIELD(indexOidMap);
 	READ_NODE_FIELD(hiddenTypes);
 
 	READ_DONE();

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1547,7 +1547,6 @@ typedef struct SetDistributionCmd
 	NodeTag		type;
 	int	        backendId;     /* backend ID on QD */
 	List	   *relids;            /* oid of relations(partitions) which have related temporary table */
-	List	   *indexOidMap;       /* the map between relation oid and index oid */
 	List	   *hiddenTypes;       /* the types need to build for dropped column */
 } SetDistributionCmd;
 

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -211,7 +211,7 @@ ERROR:  permission denied: "pg_class" is a system catalog
 create table atsdb (i int, j text) distributed by (j);
 insert into atsdb select i, i::text from generate_series(1, 10) i;
 alter table atsdb set with(appendonly = true);
-ERROR:  with options only support reorg|reshuffle
+ERROR:  option "appendonly" not supported
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
  relname | ?column? | reloptions 
@@ -356,7 +356,7 @@ select * from distcheck where rel = 'atsdb';
 
 alter table atsdb drop column n;
 alter table atsdb set with(appendonly = true, compresslevel = 3);
-ERROR:  with options at most one, reorg|reshuffle
+ERROR:  not supported for more than one option in WITH clause
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
  relname | ?column? | reloptions 
@@ -594,13 +594,13 @@ select * from atsdb;
 
 -- validate parameters
 alter table atsdb set with (appendonly = ff);
-ERROR:  with options only support reorg|reshuffle
+ERROR:  option "appendonly" not supported
 alter table atsdb set with (reorganize = true);
 alter table atsdb set with (fgdfgef = asds);
-ERROR:  with options only support reorg|reshuffle
+ERROR:  option "fgdfgef" not supported
 alter table atsdb set with(reorganize = true, reorganize = false) distributed
 randomly;
-ERROR:  with options at most one, reorg|reshuffle
+ERROR:  not supported for more than one option in WITH clause
 drop table atsdb;
 -- check distribution after dropping distribution key column.
 create table atsdb (i int, j int, t text, n numeric) distributed by (i, j);
@@ -697,7 +697,7 @@ select * from atsdb order by 1, 2, 3;
 (9 rows)
 
 alter table atsdb set with(appendonly = true);
-ERROR:  with options only support reorg|reshuffle
+ERROR:  option "appendonly" not supported
 select relname, a.blocksize, compresslevel, compresstype, checksum from pg_class c, pg_appendonly a where
 relname  like 'atsdb%' and c.oid = a.relid order by 1;
  relname | blocksize | compresslevel | compresstype | checksum 
@@ -823,7 +823,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into mpp5746 select array[i], i from generate_series(1, 100) i;
 alter table mpp5746 set with (reorganize=true, appendonly = true);
-ERROR:  with options at most one, reorg|reshuffle
+ERROR:  not supported for more than one option in WITH clause
 select * from mpp5746 order by 1;
    c   |  t  
 -------+-----
@@ -1036,7 +1036,7 @@ select * from mpp5746 order by 1;
 (100 rows)
 
 alter table mpp5746 set with (reorganize=true, appendonly = false);
-ERROR:  with options at most one, reorg|reshuffle
+ERROR:  not supported for more than one option in WITH clause
 select * from mpp5746 order by 1;
    c   
 -------
@@ -1175,7 +1175,7 @@ select * from mpp5738;
 
 alter table mpp5738 alter partition for(rank(1)) set with (appendonly=true);
 NOTICE:  altering table "mpp5738_1_prt_1" (partition for rank 1 of relation "mpp5738")
-ERROR:  with options only support reorg|reshuffle
+ERROR:  option "appendonly" not supported
 select * from mpp5738;
  a  | b  | c  | d  
 ----+----+----+----
@@ -1307,7 +1307,7 @@ drop table abc;
 -- disallow, so fails
 create table atsdb (i int, j text) distributed by (j);
 alter table atsdb set with(appendonly = true);
-ERROR:  with options only support reorg|reshuffle
+ERROR:  option "appendonly" not supported
 drop table atsdb;
 -- MPP-18660: duplicate entry in gp_distribution_policy
 set enable_indexscan=on;

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -211,7 +211,7 @@ ERROR:  permission denied: "pg_class" is a system catalog
 create table atsdb (i int, j text) distributed by (j);
 insert into atsdb select i, i::text from generate_series(1, 10) i;
 alter table atsdb set with(appendonly = true);
-ERROR:  option "appendonly" not supported
+ERROR:  with options only support reorg|reshuffle
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
  relname | ?column? | reloptions 
@@ -356,7 +356,7 @@ select * from distcheck where rel = 'atsdb';
 
 alter table atsdb drop column n;
 alter table atsdb set with(appendonly = true, compresslevel = 3);
-ERROR:  option "appendonly" not supported
+ERROR:  with options at most one, reorg|reshuffle
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
  relname | ?column? | reloptions 
@@ -594,13 +594,13 @@ select * from atsdb;
 
 -- validate parameters
 alter table atsdb set with (appendonly = ff);
-ERROR:  option "appendonly" not supported
+ERROR:  with options only support reorg|reshuffle
 alter table atsdb set with (reorganize = true);
 alter table atsdb set with (fgdfgef = asds);
-ERROR:  option "fgdfgef" not supported
+ERROR:  with options only support reorg|reshuffle
 alter table atsdb set with(reorganize = true, reorganize = false) distributed
 randomly;
-ERROR:  "reorganize" specified more than once
+ERROR:  with options at most one, reorg|reshuffle
 drop table atsdb;
 -- check distribution after dropping distribution key column.
 create table atsdb (i int, j int, t text, n numeric) distributed by (i, j);
@@ -697,7 +697,7 @@ select * from atsdb order by 1, 2, 3;
 (9 rows)
 
 alter table atsdb set with(appendonly = true);
-ERROR:  option "appendonly" not supported
+ERROR:  with options only support reorg|reshuffle
 select relname, a.blocksize, compresslevel, compresstype, checksum from pg_class c, pg_appendonly a where
 relname  like 'atsdb%' and c.oid = a.relid order by 1;
  relname | blocksize | compresslevel | compresstype | checksum 
@@ -823,7 +823,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into mpp5746 select array[i], i from generate_series(1, 100) i;
 alter table mpp5746 set with (reorganize=true, appendonly = true);
-ERROR:  option "appendonly" not supported
+ERROR:  with options at most one, reorg|reshuffle
 select * from mpp5746 order by 1;
    c   |  t  
 -------+-----
@@ -1036,7 +1036,7 @@ select * from mpp5746 order by 1;
 (100 rows)
 
 alter table mpp5746 set with (reorganize=true, appendonly = false);
-ERROR:  option "appendonly" not supported
+ERROR:  with options at most one, reorg|reshuffle
 select * from mpp5746 order by 1;
    c   
 -------
@@ -1175,7 +1175,7 @@ select * from mpp5738;
 
 alter table mpp5738 alter partition for(rank(1)) set with (appendonly=true);
 NOTICE:  altering table "mpp5738_1_prt_1" (partition for rank 1 of relation "mpp5738")
-ERROR:  option "appendonly" not supported
+ERROR:  with options only support reorg|reshuffle
 select * from mpp5738;
  a  | b  | c  | d  
 ----+----+----+----
@@ -1307,7 +1307,7 @@ drop table abc;
 -- disallow, so fails
 create table atsdb (i int, j text) distributed by (j);
 alter table atsdb set with(appendonly = true);
-ERROR:  option "appendonly" not supported
+ERROR:  with options only support reorg|reshuffle
 drop table atsdb;
 -- MPP-18660: duplicate entry in gp_distribution_policy
 set enable_indexscan=on;

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -356,7 +356,7 @@ select * from distcheck where rel = 'atsdb';
 
 alter table atsdb drop column n;
 alter table atsdb set with(appendonly = true, compresslevel = 3);
-ERROR:  not supported for more than one option in WITH clause
+ERROR:  cannot specify more than one option in WITH clause
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
  relname | ?column? | reloptions 
@@ -600,7 +600,7 @@ alter table atsdb set with (fgdfgef = asds);
 ERROR:  option "fgdfgef" not supported
 alter table atsdb set with(reorganize = true, reorganize = false) distributed
 randomly;
-ERROR:  not supported for more than one option in WITH clause
+ERROR:  cannot specify more than one option in WITH clause
 drop table atsdb;
 -- check distribution after dropping distribution key column.
 create table atsdb (i int, j int, t text, n numeric) distributed by (i, j);
@@ -823,7 +823,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into mpp5746 select array[i], i from generate_series(1, 100) i;
 alter table mpp5746 set with (reorganize=true, appendonly = true);
-ERROR:  not supported for more than one option in WITH clause
+ERROR:  cannot specify more than one option in WITH clause
 select * from mpp5746 order by 1;
    c   |  t  
 -------+-----
@@ -1036,7 +1036,7 @@ select * from mpp5746 order by 1;
 (100 rows)
 
 alter table mpp5746 set with (reorganize=true, appendonly = false);
-ERROR:  not supported for more than one option in WITH clause
+ERROR:  cannot specify more than one option in WITH clause
 select * from mpp5746 order by 1;
    c   
 -------


### PR DESCRIPTION
This commit is the first step to refactor ATExecSetDistributedBy. Its
main purpose is to remove some dead code in this function and during
the process we find some helper functions can also be simplified so
the simplification is also in this commit.

According to MPP-7770, we should disable changing storage options for now.
It is ugly to just throw an error when encounter `appendonly` option but
without removing the code. In this commit remove all related logic.

Because of with clause can only contain reshuffle|reorganize, we only need
new_rel_opts if the table itself is ao|aoco. No need to deduce it from with
clause.

We also remove the unnecessary checks at the start of this function. Because
These checks have been areadly done in the function `ATPrepCmd`. 

Co-authored-by: Shuejie Zhang <shzhang@pivotal.io >