### PR TITLE
 Enable alter table column with index

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -361,7 +361,7 @@ heap_create(const char *relname,
 	if (OidIsValid(relfilenode))
 		create_storage = false;
 	else
-		relfilenode = relid;
+		relfilenode = InvalidOid;
 
 	/*
 	 * Never allow a pg_class entry to explicitly specify the database's

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -11639,15 +11639,13 @@ ATPostAlterTypeCleanup(List **wqueue, AlteredTableInfo *tab, LOCKMODE lockmode)
 	forboth(oid_item, tab->changedIndexOids,
 			def_item, tab->changedIndexDefs)
 	{
-		/*
-		 * Temporary workaround for MPP-1318. INDEX CREATE is dispatched
-		 * immediately, which unfortunately breaks the ALTER work queue.
-		 */
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot alter indexed column"),
-						errhint("DROP the index first, and recreate it after the ALTER")));
-		/*ATPostAlterTypeParse((char *) lfirst(l), wqueue, lockmode);*/
+		Oid			oldId = lfirst_oid(oid_item);
+		Oid			relid;
+
+		relid = IndexGetRelation(oldId, false);
+		ATPostAlterTypeParse(oldId, relid, InvalidOid,
+							 (char *) lfirst(def_item),
+							 wqueue, lockmode, tab->rewrite);
 	}
 
 	/*

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -938,7 +938,7 @@ pg_get_triggerdef_worker(Oid trigid, bool pretty)
  *
  * Note that the SQL-function versions of this omit any info about the
  * index tablespace; this is intentional because pg_dump wants it that way.
- * However pg_get_indexdef_string() includes index tablespace if not default.
+ * However pg_get_indexdef_string() includes the index tablespace.
  * ----------
  */
 Datum
@@ -970,7 +970,11 @@ pg_get_indexdef_ext(PG_FUNCTION_ARGS)
 														   prettyFlags)));
 }
 
-/* Internal version that returns a palloc'd C string; no pretty-printing */
+/*
+ * Internal version for use by ALTER TABLE.
+ * Includes a tablespace clause in the result.
+ * Returns a palloc'd C string; no pretty-printing.
+ */
 char *
 pg_get_indexdef_string(Oid indexrelid)
 {
@@ -1223,20 +1227,19 @@ pg_get_indexdef_worker(Oid indexrelid, int colno,
 		}
 
 		/*
-		 * If it's in a nondefault tablespace, say so, but only if requested
+		 * Print tablespace, but only if requested
 		 */
 		if (showTblSpc)
 		{
 			Oid			tblspc;
 
 			tblspc = get_rel_tablespace(indexrelid);
-			if (OidIsValid(tblspc))
-			{
-				if (isConstraint)
-					appendStringInfoString(&buf, " USING INDEX");
-				appendStringInfo(&buf, " TABLESPACE %s",
-							  quote_identifier(get_tablespace_name(tblspc)));
-			}
+			if (!OidIsValid(tblspc))
+				tblspc = MyDatabaseTableSpace;
+			if (isConstraint)
+				appendStringInfoString(&buf, " USING INDEX");
+			appendStringInfo(&buf, " TABLESPACE %s",
+							 quote_identifier(get_tablespace_name(tblspc)));
 		}
 
 		/*

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3016,6 +3016,8 @@ RelationBuildLocalRelation(const char *relname,
 	 */
 	if (relid < FirstNormalObjectId) /* bootstrap only */
 		rel->rd_rel->relfilenode = relid;
+	else if (OidIsValid(relfilenode))
+		rel->rd_rel->relfilenode = relfilenode;
 	else
 	{
 		rel->rd_rel->relfilenode = GetNewRelFileNode(reltablespace, NULL, relpersistence);

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -21,20 +21,16 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'dummy
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create index tbl1318_daa on qp_misc_jiras.tbl1318(dummy,aa);
 alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa);
-ERROR:  cannot alter indexed column
-HINT:  DROP the index first, and recreate it after the ALTER
 drop index qp_misc_jiras.tbl1318_daa;
-alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa);
+alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa::text);
 drop table qp_misc_jiras.tbl1318;
 create table qp_misc_jiras.tbl1318(dummy integer, aa text not null);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'dummy' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create index tbl1318_daa on qp_misc_jiras.tbl1318 using bitmap(dummy,aa);
 alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa);
-ERROR:  cannot alter indexed column
-HINT:  DROP the index first, and recreate it after the ALTER
 drop index qp_misc_jiras.tbl1318_daa;
-alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa);
+alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa::text);
 drop table qp_misc_jiras.tbl1318;
 -- Test for the upstream bug with combocids:
 -- https://www.postgresql.org/message-id/48B87164.4050802%40soe.ucsc.edu

--- a/src/test/regress/input/tablespace.source
+++ b/src/test/regress/input/tablespace.source
@@ -38,6 +38,37 @@ CREATE INDEX foo_idx on testschema.foo(i) TABLESPACE testspace;
 SELECT relname, spcname FROM pg_catalog.pg_tablespace t, pg_catalog.pg_class c
     where c.reltablespace = t.oid AND c.relname = 'foo_idx';
 
+-- check that default_tablespace doesn't affect ALTER TABLE index rebuilds
+CREATE TABLE testschema.test_default_tab(id bigint) TABLESPACE testspace;
+INSERT INTO testschema.test_default_tab VALUES (1);
+CREATE INDEX test_index1 on testschema.test_default_tab (id);
+CREATE INDEX test_index2 on testschema.test_default_tab (id) TABLESPACE testspace;
+\d testschema.test_index1
+\d testschema.test_index2
+-- use a custom tablespace for default_tablespace
+SET default_tablespace TO testspace;
+-- tablespace should not change if no rewrite
+ALTER TABLE testschema.test_default_tab ALTER id TYPE bigint;
+\d testschema.test_index1
+\d testschema.test_index2
+SELECT * FROM testschema.test_default_tab;
+-- tablespace should not change even if there is an index rewrite
+ALTER TABLE testschema.test_default_tab ALTER id TYPE int;
+\d testschema.test_index1
+\d testschema.test_index2
+SELECT * FROM testschema.test_default_tab;
+-- now use the default tablespace for default_tablespace
+SET default_tablespace TO '';
+-- tablespace should not change if no rewrite
+ALTER TABLE testschema.test_default_tab ALTER id TYPE int;
+\d testschema.test_index1
+\d testschema.test_index2
+-- tablespace should not change even if there is an index rewrite
+ALTER TABLE testschema.test_default_tab ALTER id TYPE bigint;
+\d testschema.test_index1
+\d testschema.test_index2
+DROP TABLE testschema.test_default_tab;
+
 -- let's try moving a table from one place to another
 CREATE TABLE testschema.atable AS VALUES (1), (2);
 alter table testschema.atable set with (reorganize=true) distributed by (column1);

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -660,8 +660,6 @@ select indexname from pg_indexes where tablename = 'co' order by indexname;
 (4 rows)
 
 alter table co alter j type bigint;
-ERROR:  cannot alter indexed column
-HINT:  DROP the index first, and recreate it after the ALTER
 alter table co rename j to j_renamed;
 alter table co drop column j_renamed;
 select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'co' order by attname, tablename;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -746,8 +746,6 @@ select indexname from pg_indexes where tablename = 'ao' order by indexname;
 (4 rows)
 
 alter table ao alter j type bigint;
-ERROR:  cannot alter indexed column
-HINT:  DROP the index first, and recreate it after the ALTER
 alter table ao rename j to j_renamed;
 alter table ao drop column j_renamed;
 select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'ao' order by attname, tablename;

--- a/src/test/regress/output/tablespace.source
+++ b/src/test/regress/output/tablespace.source
@@ -54,6 +54,111 @@ SELECT relname, spcname FROM pg_catalog.pg_tablespace t, pg_catalog.pg_class c
  foo_idx | testspace
 (1 row)
 
+-- check that default_tablespace doesn't affect ALTER TABLE index rebuilds
+CREATE TABLE testschema.test_default_tab(id bigint) TABLESPACE testspace;
+INSERT INTO testschema.test_default_tab VALUES (1);
+CREATE INDEX test_index1 on testschema.test_default_tab (id);
+CREATE INDEX test_index2 on testschema.test_default_tab (id) TABLESPACE testspace;
+\d testschema.test_index1
+Index "testschema.test_index1"
+ Column |  Type  | Definition 
+--------+--------+------------
+ id     | bigint | id
+btree, for table "testschema.test_default_tab"
+
+\d testschema.test_index2
+Index "testschema.test_index2"
+ Column |  Type  | Definition 
+--------+--------+------------
+ id     | bigint | id
+btree, for table "testschema.test_default_tab"
+Tablespace: "testspace"
+
+-- use a custom tablespace for default_tablespace
+SET default_tablespace TO testspace;
+-- tablespace should not change if no rewrite
+ALTER TABLE testschema.test_default_tab ALTER id TYPE bigint;
+\d testschema.test_index1
+Index "testschema.test_index1"
+ Column |  Type  | Definition 
+--------+--------+------------
+ id     | bigint | id
+btree, for table "testschema.test_default_tab"
+
+\d testschema.test_index2
+Index "testschema.test_index2"
+ Column |  Type  | Definition 
+--------+--------+------------
+ id     | bigint | id
+btree, for table "testschema.test_default_tab"
+Tablespace: "testspace"
+
+SELECT * FROM testschema.test_default_tab;
+ id 
+----
+  1
+(1 row)
+
+-- tablespace should not change even if there is an index rewrite
+ALTER TABLE testschema.test_default_tab ALTER id TYPE int;
+\d testschema.test_index1
+Index "testschema.test_index1"
+ Column |  Type   | Definition 
+--------+---------+------------
+ id     | integer | id
+btree, for table "testschema.test_default_tab"
+
+\d testschema.test_index2
+Index "testschema.test_index2"
+ Column |  Type   | Definition 
+--------+---------+------------
+ id     | integer | id
+btree, for table "testschema.test_default_tab"
+Tablespace: "testspace"
+
+SELECT * FROM testschema.test_default_tab;
+ id 
+----
+  1
+(1 row)
+
+-- now use the default tablespace for default_tablespace
+SET default_tablespace TO '';
+-- tablespace should not change if no rewrite
+ALTER TABLE testschema.test_default_tab ALTER id TYPE int;
+\d testschema.test_index1
+Index "testschema.test_index1"
+ Column |  Type   | Definition 
+--------+---------+------------
+ id     | integer | id
+btree, for table "testschema.test_default_tab"
+
+\d testschema.test_index2
+Index "testschema.test_index2"
+ Column |  Type   | Definition 
+--------+---------+------------
+ id     | integer | id
+btree, for table "testschema.test_default_tab"
+Tablespace: "testspace"
+
+-- tablespace should not change even if there is an index rewrite
+ALTER TABLE testschema.test_default_tab ALTER id TYPE bigint;
+\d testschema.test_index1
+Index "testschema.test_index1"
+ Column |  Type  | Definition 
+--------+--------+------------
+ id     | bigint | id
+btree, for table "testschema.test_default_tab"
+
+\d testschema.test_index2
+Index "testschema.test_index2"
+ Column |  Type  | Definition 
+--------+--------+------------
+ id     | bigint | id
+btree, for table "testschema.test_default_tab"
+Tablespace: "testspace"
+
+DROP TABLE testschema.test_default_tab;
 -- let's try moving a table from one place to another
 CREATE TABLE testschema.atable AS VALUES (1), (2);
 alter table testschema.atable set with (reorganize=true) distributed by (column1);

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -17,14 +17,14 @@ create table qp_misc_jiras.tbl1318(dummy integer, aa text not null);
 create index tbl1318_daa on qp_misc_jiras.tbl1318(dummy,aa);
 alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa);
 drop index qp_misc_jiras.tbl1318_daa;
-alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa);
+alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa::text);
 drop table qp_misc_jiras.tbl1318;
 
 create table qp_misc_jiras.tbl1318(dummy integer, aa text not null);
 create index tbl1318_daa on qp_misc_jiras.tbl1318 using bitmap(dummy,aa);
 alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa);
 drop index qp_misc_jiras.tbl1318_daa;
-alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa);
+alter table qp_misc_jiras.tbl1318 alter column aa type integer using  bit_length(aa::text);
 drop table qp_misc_jiras.tbl1318;
 
 -- Test for the upstream bug with combocids:


### PR DESCRIPTION
Originally, we disabled alter table column with index. Because INDEX CREATE is dispatched immediately, which unfortunately breaks the ALTER work queue. So we have a workaround and disable alter table column with index. 
In postgres91, is_alter_table param was introduced to 'DefineIndex'. So we have a chance to re-enable this feature.