### PR TITLE
Add hook point for `alter table set distributed by`

### DIFF
--- a/src/test/regress/input/query_info_hook_test.source
+++ b/src/test/regress/input/query_info_hook_test.source
@@ -18,3 +18,6 @@ SELECT * FROM generate_series(1, 3/0);
 -- Test query abort
 select pg_cancel_backend(pg_backend_pid());
 
+-- Test alter table set distributed by
+CREATE TABLE queryInfoHookTable1 (id int, name text) DISTRIBUTED BY(id);
+ALTER TABLE queryInfoHookTable1 SET DISTRIBUTED BY (name);

--- a/src/test/regress/output/query_info_hook_test.source
+++ b/src/test/regress/output/query_info_hook_test.source
@@ -40,3 +40,18 @@ WARNING:  Plan node executing
 WARNING:  Query Canceling
 WARNING:  Query Canceled
 ERROR:  canceling statement due to user request
+-- Test alter table set distributed by
+CREATE TABLE queryInfoHookTable1 (id int, name text) DISTRIBUTED BY(id);
+ALTER TABLE queryInfoHookTable1 SET DISTRIBUTED BY (name);
+WARNING:  Query submit
+WARNING:  Query start
+WARNING:  Plan node initializing
+WARNING:  Plan node executing
+WARNING:  Plan node finished
+WARNING:  Query Done
+WARNING:  Query submit
+WARNING:  Query start
+WARNING:  Plan node initializing
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Query Done


### PR DESCRIPTION
Add hook point for `alter stable set distributed by` so that we can get its query text and its progress in instrument in the hook function.