### PR TITLE
Simulate orca CTAS behavior when falling back to planner.

### DIFF
--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -2,6 +2,9 @@
 -- TODO: partition tables
 -- TODO: ao tables
 -- TODO: tables and temp tables
+-- start_matchignore
+-- m/^NOTICE:  Using default RANDOM distribution since no distribution was specified.$/
+-- end_matchignore
 \set explain 'explain analyze'
 create extension if not exists gp_debug_numsegments;
 drop schema if exists test_partial_table;
@@ -110,17 +113,40 @@ select localoid::regclass, attrnums, policytype, numsegments
 (1 row)
 
 drop table t;
--- CTAS set numsegments with DEFAULT,
--- let it be a fixed value to get stable output
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
+--
+-- create table: CTAS
+--
+-- CTAS has different behavior in planner mode and orca mode:
+--
+-- - in planner mode the dist policy inherits from the source table,
+--   numsegments is set with DEFAULT;
+-- - in orca mode the dist policy is always NULL and numsegments is always FULL;
+--
+-- adjust the GUCs to simulate orca behaviors to get stable output.
 select gp_debug_set_create_table_default_numsegments('full');
  gp_debug_set_create_table_default_numsegments 
 -----------------------------------------------
  FULL
 (1 row)
 
-create table t as table t1;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1, c2' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set gp_create_table_random_default_distribution to on;
+create table t as values (1, 2), (3, 4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           3
+(1 row)
+
+drop table t;
+create table t as values (1, 2), (3, 4) distributed by (column1, column2);
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
@@ -129,14 +155,45 @@ select localoid::regclass, attrnums, policytype, numsegments
 (1 row)
 
 drop table t;
-create table t as select * from t1;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1, c2' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t as select i as c1, 0 as c2 from generate_series(1, 10) i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           3
+(1 row)
+
+drop table t;
+create table t as select i as c1, 0 as c2 from generate_series(1, 10) i
+	distributed by (c1, c2);
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
 ----------+----------+------------+-------------
  t        | {1,2}    | p          |           3
+(1 row)
+
+drop table t;
+create table t as table t1;
+NOTICE:  Using default RANDOM distribution since no distribution was specified.
+HINT:  Consider including the 'DISTRIBUTED BY' clause to determine the distribution of rows.
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           3
+(1 row)
+
+drop table t;
+create table t as select * from t1;
+NOTICE:  Using default RANDOM distribution since no distribution was specified.
+HINT:  Consider including the 'DISTRIBUTED BY' clause to determine the distribution of rows.
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           3
 (1 row)
 
 drop table t;
@@ -168,13 +225,13 @@ select localoid::regclass, attrnums, policytype, numsegments
 
 drop table t;
 select * into table t from t1;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1, c2' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Using default RANDOM distribution since no distribution was specified.
+HINT:  Consider including the 'DISTRIBUTED BY' clause to determine the distribution of rows.
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
 ----------+----------+------------+-------------
- t        | {1,2}    | p          |           3
+ t        |          | p          |           3
 (1 row)
 
 drop table t;
@@ -184,6 +241,7 @@ select gp_debug_reset_create_table_default_numsegments();
  
 (1 row)
 
+reset gp_create_table_random_default_distribution;
 --
 -- alter table
 --

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -3,6 +3,10 @@
 -- TODO: ao tables
 -- TODO: tables and temp tables
 
+-- start_matchignore
+-- m/^NOTICE:  Using default RANDOM distribution since no distribution was specified.$/
+-- end_matchignore
+
 \set explain 'explain analyze'
 
 create extension if not exists gp_debug_numsegments;
@@ -64,9 +68,42 @@ select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
 drop table t;
 
--- CTAS set numsegments with DEFAULT,
--- let it be a fixed value to get stable output
+select gp_debug_reset_create_table_default_numsegments();
+
+--
+-- create table: CTAS
+--
+
+-- CTAS has different behavior in planner mode and orca mode:
+--
+-- - in planner mode the dist policy inherits from the source table,
+--   numsegments is set with DEFAULT;
+-- - in orca mode the dist policy is always NULL and numsegments is always FULL;
+--
+-- adjust the GUCs to simulate orca behaviors to get stable output.
 select gp_debug_set_create_table_default_numsegments('full');
+set gp_create_table_random_default_distribution to on;
+
+create table t as values (1, 2), (3, 4);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+create table t as values (1, 2), (3, 4) distributed by (column1, column2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+create table t as select i as c1, 0 as c2 from generate_series(1, 10) i;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+create table t as select i as c1, 0 as c2 from generate_series(1, 10) i
+	distributed by (c1, c2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
 
 create table t as table t1;
 select localoid::regclass, attrnums, policytype, numsegments
@@ -99,6 +136,7 @@ select localoid::regclass, attrnums, policytype, numsegments
 drop table t;
 
 select gp_debug_reset_create_table_default_numsegments();
+reset gp_create_table_random_default_distribution;
 
 --
 -- alter table


### PR DESCRIPTION
Orca always create tables randomly distributed tables in CTAS unless a
DISTRIBUTED BY clause is specified.  However as orca does not support
partially distributed tables it will fallback to planner if any of the
source tables is partially distributed tables.  Planner's decision on
the distribution policy in CTAS is based on the source tables and the
GUC gp_create_table_random_default_distribution, in such a case it might
create non-randomly distributed tables.

To provide consistent behavior for orca now we simulate orca CTAS
behavior when falling back to planner.