### PR TITLE
Fix numsegments when appending multiple SingleQEs.

### DIFF
--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -97,9 +97,14 @@ begin;
 abort;
 -- restore the analyze information
 analyze t1;
---
--- regression tests
---
+-- append SingleQE of different sizes
+select max(c1) as v, 1 as r from t2 union all select 1 as v, 2 as r;
+ v | r 
+---+---
+   | 1
+ 1 | 2
+(2 rows)
+
 -- append node should use the max numsegments of all the subpaths
 begin;
 	-- insert enough data to ensure executors got reached on segments

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -55,9 +55,8 @@ abort;
 -- restore the analyze information
 analyze t1;
 
---
--- regression tests
---
+-- append SingleQE of different sizes
+select max(c1) as v, 1 as r from t2 union all select 1 as v, 2 as r;
 
 -- append node should use the max numsegments of all the subpaths
 begin;


### PR DESCRIPTION
When Append node contains SingleQE subpath we used to put Append on ALL
the segments, however if the SingleQE is partially distributed then
apparently we could not put the SingleQE on ALL the segments, this
conflict could results in runtime or incorrect results.

To fix this we should put Append on SingleQE's segments.

In the other hand when there are multiple SingleQE subpaths we should
put Append on the common segments of SingleQEs.