### PR TITLE
Always create fully distributed tables.

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -416,8 +416,19 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString, bool createPartit
 	 *  explicitly). Not for foreign tables, though.
 	 */
 	if (stmt->relKind == RELKIND_RELATION)
+	{
+		/* Parent is always created on DEFAULT numsegments */
+		AssertImply(stmt->distributedBy,
+					stmt->distributedBy->numsegments == -1 ||
+					stmt->distributedBy->numsegments == GP_POLICY_DEFAULT_NUMSEGMENTS);
+
 		stmt->distributedBy = transformDistributedBy(&cxt, stmt->distributedBy,
 							   likeDistributedBy, bQuiet);
+
+		/* Partitions are always created on DEFAULT numsegments, too */
+		AssertImply(stmt->is_part_child,
+					stmt->distributedBy->numsegments == GP_POLICY_DEFAULT_NUMSEGMENTS);
+	}
 
 	if (stmt->partitionBy != NULL &&
 		stmt->distributedBy &&
@@ -1724,8 +1735,6 @@ transformDistributedBy(CreateStmtContext *cxt,
 {
 	ListCell	*keys = NULL;
 	List		*distrkeys = NIL;
-	/* By default tables should be distributed on ALL segments */
-	int			numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 	ListCell   *lc;
 
 	/*
@@ -1894,6 +1903,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 				distributedBy = make_distributedby_for_rel(parentrel);
 				heap_close(parentrel, AccessShareLock);
 
+				distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 				return distributedBy;
 			}
 			heap_close(parentrel, AccessShareLock);
@@ -1906,25 +1916,19 @@ transformDistributedBy(CreateStmtContext *cxt,
 			elog(NOTICE, "Table doesn't have 'DISTRIBUTED BY' clause, "
 				 "defaulting to distribution columns from LIKE table");
 
-		/*
-		 * Distribution policy is inherited from the LIKE table, do the same
-		 * to numsegments.
-		 */
-		numsegments = likeDistributedBy->numsegments;
-
 		if (likeDistributedBy->ptype == POLICYTYPE_PARTITIONED &&
 			likeDistributedBy->keys == NIL)
 		{
 			distributedBy = makeNode(DistributedBy);
 			distributedBy->ptype = POLICYTYPE_PARTITIONED;
-			distributedBy->numsegments = numsegments;
+			distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 			return distributedBy;
 		}
 		else if (likeDistributedBy->ptype == POLICYTYPE_REPLICATED)
 		{
 			distributedBy = makeNode(DistributedBy);
 			distributedBy->ptype = POLICYTYPE_REPLICATED;
-			distributedBy->numsegments = numsegments;
+			distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 			return distributedBy;
 		}
 
@@ -1943,14 +1947,9 @@ transformDistributedBy(CreateStmtContext *cxt,
 				 errhint("Consider including the 'DISTRIBUTED BY' clause to determine the distribution of rows.")));
 		}
 
-		/*
-		 * Create with default distribution policy and numsegments.
-		 */
-		numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
-
 		distributedBy = makeNode(DistributedBy);
 		distributedBy->ptype = POLICYTYPE_PARTITIONED;
-		distributedBy->numsegments = numsegments;
+		distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 		return distributedBy;
 	}
 	else if (distrkeys == NIL)
@@ -2053,14 +2052,9 @@ transformDistributedBy(CreateStmtContext *cxt,
 			if (!bQuiet)
 				elog(NOTICE, "Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.");
 
-			/*
-			 * Create with default distribution policy and numsegments.
-			 */
-			numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
-
 			distributedBy = makeNode(DistributedBy);
 			distributedBy->ptype = POLICYTYPE_PARTITIONED;
-			distributedBy->numsegments = numsegments;
+			distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 			return distributedBy;
 		}
 	}
@@ -2249,13 +2243,11 @@ transformDistributedBy(CreateStmtContext *cxt,
 		}
 	}
 
-	Assert(numsegments > 0);
-
 	/* Form the resulting Distributed By clause */
 	distributedBy = makeNode(DistributedBy);
 	distributedBy->ptype = POLICYTYPE_PARTITIONED;
 	distributedBy->keys = distrkeys;
-	distributedBy->numsegments = numsegments;
+	distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
 
 	return distributedBy;
 }

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -171,18 +171,143 @@ begin;
 
 abort;
 --
--- create table
+-- create table: LIKE, INHERITS and DISTRIBUTED BY
 --
-create table t (like t1);
+-- tables are always created with DEFAULT as numsegments,
+-- no matter there is LIKE, INHERITS or DISTRIBUTED BY.
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+-- none of the clauses
+create table t ();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           2
+(1 row)
+
+drop table t;
+-- DISTRIBUTED BY only
+create table t () distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           2
+(1 row)
+
+drop table t;
+-- INHERITS only
+create table t () inherits (t2);
+NOTICE:  Table has parent, setting distribution columns to match parent table
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           2
+(1 row)
+
+drop table t;
+-- LIKE only
+create table t (like d1);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
  localoid | attrnums | policytype | numsegments 
 ----------+----------+------------+-------------
- t        | {1,2}    | p          |           1
+ t        |          | r          |           2
 (1 row)
 
 drop table t;
+-- DISTRIBUTED BY + INHERITS
+create table t () inherits (t2) distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           2
+(1 row)
+
+drop table t;
+-- DISTRIBUTED BY + LIKE
+create table t (like d1) distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           2
+(1 row)
+
+drop table t;
+-- INHERITS + LIKE
+create table t (like d1) inherits (t2);
+NOTICE:  Table has parent, setting distribution columns to match parent table
+NOTICE:  merging column "c1" with inherited definition
+NOTICE:  merging column "c2" with inherited definition
+NOTICE:  merging column "c3" with inherited definition
+NOTICE:  merging column "c4" with inherited definition
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1,2}    | p          |           2
+(1 row)
+
+drop table t;
+-- DISTRIBUTED BY + INHERITS + LIKE
+create table t (like d1) inherits (t2) distributed randomly;
+NOTICE:  merging column "c1" with inherited definition
+NOTICE:  merging column "c2" with inherited definition
+NOTICE:  merging column "c3" with inherited definition
+NOTICE:  merging column "c4" with inherited definition
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           2
+(1 row)
+
+drop table t;
+-- INHERITS from multiple parents
+create table t () inherits (r1, t2);
+NOTICE:  Table has parent, setting distribution columns to match parent table
+NOTICE:  merging multiple inherited definitions of column "c1"
+NOTICE:  merging multiple inherited definitions of column "c2"
+NOTICE:  merging multiple inherited definitions of column "c3"
+NOTICE:  merging multiple inherited definitions of column "c4"
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        |          | p          |           2
+(1 row)
+
+drop table t;
+-- DISTRIBUTED BY + INHERITS from multiple parents
+create table t () inherits (r1, t2) distributed by (c1);
+NOTICE:  merging multiple inherited definitions of column "c1"
+NOTICE:  merging multiple inherited definitions of column "c2"
+NOTICE:  merging multiple inherited definitions of column "c3"
+NOTICE:  merging multiple inherited definitions of column "c4"
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+ localoid | attrnums | policytype | numsegments 
+----------+----------+------------+-------------
+ t        | {1}      | p          |           2
+(1 row)
+
+drop table t;
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
 -- CTAS set numsegments with DEFAULT,
 -- let it be a fixed value to get stable output
 select gp_debug_set_create_table_default_numsegments('full');
@@ -260,6 +385,13 @@ select gp_debug_reset_create_table_default_numsegments();
 --
 -- alter table
 --
+-- numsegments should not be changed
+select gp_debug_set_create_table_default_numsegments(1);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 1
+(1 row)
+
 create table t (like t1);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 select localoid::regclass, attrnums, policytype, numsegments
@@ -310,6 +442,12 @@ select localoid::regclass, attrnums, policytype, numsegments
 (1 row)
 
 drop table t;
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
 -- below join cases cover all the combinations of
 --
 --     select * from {t,d,r}{1,2} a

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -73,13 +73,74 @@ begin;
 abort;
 
 --
--- create table
+-- create table: LIKE, INHERITS and DISTRIBUTED BY
 --
+-- tables are always created with DEFAULT as numsegments,
+-- no matter there is LIKE, INHERITS or DISTRIBUTED BY.
 
-create table t (like t1);
+select gp_debug_set_create_table_default_numsegments(2);
+
+-- none of the clauses
+create table t ();
 select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
 drop table t;
+
+-- DISTRIBUTED BY only
+create table t () distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+-- INHERITS only
+create table t () inherits (t2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+-- LIKE only
+create table t (like d1);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+-- DISTRIBUTED BY + INHERITS
+create table t () inherits (t2) distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+-- DISTRIBUTED BY + LIKE
+create table t (like d1) distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+-- INHERITS + LIKE
+create table t (like d1) inherits (t2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+-- DISTRIBUTED BY + INHERITS + LIKE
+create table t (like d1) inherits (t2) distributed randomly;
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+-- INHERITS from multiple parents
+create table t () inherits (r1, t2);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+-- DISTRIBUTED BY + INHERITS from multiple parents
+create table t () inherits (r1, t2) distributed by (c1);
+select localoid::regclass, attrnums, policytype, numsegments
+	from gp_distribution_policy where localoid in ('t'::regclass);
+drop table t;
+
+select gp_debug_reset_create_table_default_numsegments();
 
 -- CTAS set numsegments with DEFAULT,
 -- let it be a fixed value to get stable output
@@ -120,6 +181,9 @@ select gp_debug_reset_create_table_default_numsegments();
 --
 -- alter table
 --
+-- numsegments should not be changed
+
+select gp_debug_set_create_table_default_numsegments(1);
 
 create table t (like t1);
 select localoid::regclass, attrnums, policytype, numsegments
@@ -146,6 +210,8 @@ select localoid::regclass, attrnums, policytype, numsegments
 	from gp_distribution_policy where localoid in ('t'::regclass);
 
 drop table t;
+
+select gp_debug_reset_create_table_default_numsegments();
 
 -- below join cases cover all the combinations of
 --


### PR DESCRIPTION
In CREATE TABLE we used to decide numsegments from LIKE, INHERITS and
DISTRIBUTED BY clauses.  However we do not want partially distributed
tables to be created by end users, so change the logic to always create
tables with DEFAULT as numsegments.  We still allow developers to hack
the DEFAULT numsegments with the gp_debug_numsegments extension.