### PR TITLE
gpexpand improvement using newly added features

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -296,6 +296,7 @@ status_detail_table_sql = """CREATE TABLE %s.%s
                           distribution_policy_names text,
                           distribution_policy_coloids text,
                           distribution_policy_type text,
+                          root_partition_name text,
                           storage_options text,
                           rank int,
                           status text,
@@ -1737,7 +1738,6 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
             self._populate_regular_tables(dbname)
             self._populate_partitioned_tables(dbname)
             inject_fault('gpexpand MPP-14620 fault injection')
-            self._update_distribution_policy(dbname)
 
         nowStr = datetime.datetime.now()
         statusSQL = "INSERT INTO %s.%s VALUES ( 'SETUP DONE', '%s' ) " % (gpexpand_schema, status_table, nowStr)
@@ -1767,7 +1767,8 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
     p.attrnums as distribution_policy,
     now() as last_updated,
     %s,
-    p.policytype as distribution_policy_type
+    p.policytype as distribution_policy_type,
+    NULL as root_partition_name
 FROM
             pg_class c
     JOIN pg_namespace n ON (c.relnamespace=n.oid)
@@ -1806,13 +1807,14 @@ WHERE
                     dist_policy = 'NULL'
 
                 dist_policy_type = row[6];
+                root_partition_name = row[7]
                 full_name = '%s.%s' % (dbname, fqname)
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
-                fp.write("""%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
+                fp.write("""%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
                     dbname, fqname, schema_oid, table_oid,
                     dist_policy, policy_name, policy_oids,
-                    dist_policy_type, rank, undone_status, rel_bytes))
+                    dist_policy_type, root_partition_name, rank, undone_status, rel_bytes))
         except Exception, e:
             raise ExpansionError(e)
         finally:
@@ -1832,36 +1834,47 @@ WHERE
         table_conn.close()
 
     def _populate_partitioned_tables(self, dbname):
-        """population of status_detail for partitioned tables. """
-        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(p.partitionschemaname) || '.' || quote_ident(p.partitiontablename))"
+        """
+        population of status_detail for partitioned tables, leaf partition cannot
+        has different numsegments with root partition, we need to expand root
+        partition in one shot, so just populate root partition for now.
+
+        TODO:
+        We used to use a tricky but effective way to expand leaf partition in
+        in parallel, that way is still under discussion. Keep the old method
+        here in case we need bring it back someday.
+
+        Step1:
+           BEGIN;
+           Lock all root/interior/leaf partitions
+           Change all numsegments of root/interior/leaf partitions to size of cluster;
+           Change all leaf partition to random distributed;
+           COMMIT;
+        Step2:
+           Change all leaf partition's policy back to old policy with a mandatory
+           data movement.
+"""
+        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
         sql = """
 SELECT
-    p.partitionschemaname || '.' || p.partitiontablename as fq_name,
+    n.nspname || '.' || c.relname as fq_name,
     n.oid as schemaoid,
-    c2.oid as tableoid,
+    c.oid as tableoid,
     d.attrnums as distributed_policy,
     now() as last_updated,
     %s,
-    partitiontype,partitionlevel,partitionrank,partitionposition,
-    partitionrangestart
+    n.nspname || '.' || c.relname as root_partition_name
 FROM
-    pg_partitions p,
     pg_class c,
-    pg_class c2,
     pg_namespace n,
-    pg_namespace n2,
+    pg_partition p,
     gp_distribution_policy d
 WHERE
-    quote_ident(p.tablename) = quote_ident(c.relname)
-    AND    d.localoid = c2.oid
-    AND quote_ident(p.schemaname) = quote_ident(n.nspname)
-    AND c.relnamespace = n.oid
-    AND p.partitionlevel = (select max(parlevel) FROM pg_partition WHERE parrelid = c.oid)
-    AND quote_ident(p.partitionschemaname) = quote_ident(n2.nspname)
-    AND quote_ident(p.partitiontablename) = quote_ident(c2.relname)
-    AND c2.relnamespace = n2.oid
-    AND c2.relstorage != 'x'
-ORDER BY tablename, c2.oid desc;
+    c.relnamespace = n.oid
+    AND p.parrelid = c.oid
+    AND d.localoid = c.oid
+    AND parlevel = 0
+ORDER BY fq_name, tableoid desc;
                   """ % (src_bytes_str)
         self.logger.debug(sql)
         table_conn = self.connect_database(dbname)
@@ -1888,14 +1901,15 @@ ORDER BY tablename, c2.oid desc;
                 if dist_policy is None:
                     dist_policy = 'NULL'
 
-                dist_policy_type = row[6];
+                dist_policy_type = 'p';
+                root_partition_name = row[6]
                 full_name = '%s.%s' % (dbname, fqname)
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
-                fp.write("""%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
+                fp.write("""%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
                     dbname, fqname, schema_oid, table_oid,
                     dist_policy, policy_name, policy_oids,
-                    dist_policy_type, rank, undone_status, rel_bytes))
+                    dist_policy_type, root_partition_name, rank, undone_status, rel_bytes))
         except Exception:
             raise
         finally:
@@ -1911,56 +1925,6 @@ ORDER BY tablename, c2.oid desc;
         finally:
             os.unlink(sql_file)
 
-        table_conn.commit()
-        table_conn.close()
-
-    def _update_distribution_policy(self, dbname):
-        """ NULL out the distribution policy for both
-            regular and partitioned table before expansion
-            Notice: Don't do this for replicated table. 
-        """
-
-        table_conn = self.connect_database(dbname)
-        # null out the dist policies
-        sql = """
-UPDATE  gp_distribution_policy
-  SET attrnums = NULL
-FROM pg_class c
-    JOIN pg_namespace n ON (c.relnamespace=n.oid)
-    LEFT JOIN pg_partition pp ON (c.oid=pp.parrelid)
-    LEFT JOIN pg_partition_rule pr ON (c.oid=pr.parchildrelid)
-WHERE
-    localoid = c.oid
-    AND policytype = 'p'
-    AND pp.parrelid IS NULL
-    AND pr.parchildrelid IS NULL
-    AND n.nspname != 'gpexpand';
-        """
-
-        self.logger.debug(sql)
-        dbconn.execSQL(table_conn, sql)
-
-        sql = """
-UPDATE gp_distribution_policy
-    SET attrnums = NULL
-    FROM
-        ( SELECT pp.parrelid AS tableoid,
-                 n2.nspname AS partitionschemaname, cl2.relname AS partitiontablename,
-                 cl2.oid AS partitiontableoid, pr1.parname AS partitionname, cl3.relname AS parentpartitiontablename, pr2.parname AS parentpartitioname,
-                    pp.parlevel AS partitionlevel, pr1.parruleord AS partitionposition
-               FROM pg_namespace n, pg_namespace n2, pg_class cl, pg_class cl2, pg_partition pp, pg_partition_rule pr1
-          LEFT JOIN pg_partition_rule pr2 ON pr1.parparentrule = pr2.oid
-       LEFT JOIN pg_class cl3 ON pr2.parchildrelid = cl3.oid
-      WHERE pp.paristemplate = FALSE AND pp.parrelid = cl.oid AND pr1.paroid = pp.oid AND cl2.oid = pr1.parchildrelid AND cl.relnamespace = n.oid AND cl2.relnamespace = n2.oid
-    ) p1
-    WHERE
-    localoid = p1.partitiontableoid
-    AND policytype = 'p'
-    AND p1.partitionlevel = (SELECT max(parlevel) FROM pg_partition WHERE parrelid = p1.tableoid);
-
-"""
-        self.logger.debug(sql)
-        dbconn.execSQL(table_conn, sql)
         table_conn.commit()
         table_conn.close()
 
@@ -2011,15 +1975,11 @@ UPDATE gp_distribution_policy
         sql = "SELECT * FROM %s.%s WHERE status = 'NOT STARTED' ORDER BY rank" % (gpexpand_schema, status_detail_table)
         cursor = dbconn.execSQL(self.conn, sql)
 
-        # get the total number of primaries in the cluster after expansion
-        # we need it to update the numsegments column in gp_distribution_policy before redistribution
-        num_segments_after_expansion = len(self.gparray.segmentPairs)
-
         for row in cursor:
             self.logger.debug(row)
             name = "name"
             tbl = ExpandTable(options=self.options, row=row)
-            cmd = ExpandCommand(name=name, status_url=self.dburl, table=tbl, options=self.options, num_segments=num_segments_after_expansion)
+            cmd = ExpandCommand(name=name, status_url=self.dburl, table=tbl, options=self.options)
             self.queue.addCommand(cmd)
 
         table_expand_error = False
@@ -2213,22 +2173,25 @@ UPDATE gp_distribution_policy
 class ExpandTable():
     def __init__(self, options, row=None):
         self.options = options
+        self.is_root_partition = False
         if row is not None:
             (self.dbname, self.fq_name, self.schema_oid, self.table_oid,
              self.distrib_policy, self.distrib_policy_names, self.distrib_policy_coloids,
-             self.distrib_policy_type,
+             self.distrib_policy_type, self.root_partition_name,
              self.storage_options, self.rank, self.status,
              self.expansion_started, self.expansion_finished,
              self.source_bytes) = row
+        if self.fq_name.strip() == self.root_partition_name:
+            self.is_root_partition = True
 
     def add_table(self, conn):
         insertSQL = """INSERT INTO %s.%s
                             VALUES ('%s','%s',%s,%s,
-                                    '%s','%s', '%s', '%s','%s',%d,'%s','%s','%s',%d)
+                                    '%s','%s', '%s', '%s', '%s','%s',%d,'%s','%s','%s',%d)
                     """ % (gpexpand_schema, status_detail_table,
                            self.dbname, self.fq_name, self.schema_oid, self.table_oid,
                            self.distrib_policy, self.distrib_policy_names, self.distrib_policy_coloids,
-                           self.distrib_policy_type,
+                           self.distrib_policy_type, self.root_partition_name,
                            self.storage_options, self.rank, self.status,
                            self.expansion_started, self.expansion_finished,
                            self.source_bytes)
@@ -2270,32 +2233,21 @@ class ExpandTable():
         dbconn.execSQL(status_conn, sql)
         status_conn.commit()
 
-    def expand(self, table_conn, cancel_flag, num_segments):
-        policy_names = self.distrib_policy_names.strip()
+    def expand(self, table_conn, cancel_flag):
+        # for root partition, we want to expand whose partition in one shot
+        # TODO: expand leaf partitions seperately in parallel
+        if self.is_root_partition:
+            only_str = ""
+        else:
+            only_str = "ONLY"
+
         new_storage_options = ''
         if self.storage_options:
             new_storage_options = ',' + self.storage_options
 
         (schema_name, table_name) = self.fq_name.split('.')
 
-        logger.info("Distribution policy for table %s is '%s' " % (self.fq_name.decode('utf-8'), policy_names.decode('utf-8')))
-
-        # The UPDATE query below updates the numsegments value on the master only.
-        # The following ALTER TABLE query updates the segment values as part of the redistribution process.
-        sql = """UPDATE gp_distribution_policy SET numsegments=%d WHERE localoid=%d; """ % (
-                num_segments, self.table_oid)
-        if self.distrib_policy_type.strip() == 'r':
-            sql += 'ALTER TABLE ONLY "%s"."%s" SET WITH(REORGANIZE=TRUE%s) DISTRIBUTED REPLICATED' % (
-                schema_name, table_name, new_storage_options)
-        elif policy_names == "" or policy_names == "None" or policy_names is None:
-            sql += 'ALTER TABLE ONLY "%s"."%s" SET WITH(REORGANIZE=TRUE%s) DISTRIBUTED RANDOMLY' % (
-                schema_name, table_name, new_storage_options)
-        else:
-            dist_cols = policy_names.split(',')
-            dist_cols = ['"%s"' % x.strip() for x in dist_cols]
-            dist_cols = ','.join(dist_cols)
-            sql += 'ALTER TABLE ONLY "%s"."%s" SET WITH(REORGANIZE=TRUE%s) DISTRIBUTED BY (%s)' % (
-                schema_name, table_name, new_storage_options, dist_cols)
+        sql = 'ALTER TABLE %s "%s"."%s" EXPAND TABLE' % (only_str, schema_name, table_name)
 
         logger.info('Expanding %s.%s' % (self.dbname.decode('utf-8'), self.fq_name.decode('utf-8')))
         logger.debug("Expand SQL: %s" % sql.decode('utf-8'))
@@ -2410,11 +2362,10 @@ class ExecuteSQLStatementsCommand(SQLCommand):
 
 # -----------------------------------------------
 class ExpandCommand(SQLCommand):
-    def __init__(self, name, status_url, table, options, num_segments):
+    def __init__(self, name, status_url, table, options):
         self.status_url = status_url
         self.table = table
         self.options = options
-        self.num_segments = num_segments
         self.cmdStr = "Expand %s.%s" % (table.dbname, table.fq_name)
         self.table_url = copy.deepcopy(status_url)
         self.table_url.pgdb = table.dbname
@@ -2431,7 +2382,7 @@ class ExpandCommand(SQLCommand):
 
         try:
             status_conn = dbconn.connect(self.status_url, encoding='UTF8')
-            table_conn = dbconn.connect(self.table_url, encoding='UTF8', allowSystemTableMods=True) # need to modify gp_distribution_policy
+            table_conn = dbconn.connect(self.table_url, encoding='UTF8')
         except DatabaseError, ex:
             if self.options.verbose:
                 logger.exception(ex)
@@ -2466,7 +2417,7 @@ class ExpandCommand(SQLCommand):
                 if not self.options.simple_progress:
                     self.table.mark_started(status_conn, table_conn, start_time, self.cancel_flag)
 
-                table_exp_success = self.table.expand(table_conn, self.cancel_flag, self.num_segments)
+                table_exp_success = self.table.expand(table_conn, self.cancel_flag)
 
         except Exception, ex:
             if ex.__str__().find('canceling statement due to user request') == -1 and not self.cancel_flag:

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1761,7 +1761,7 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
 
         src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
         sql = """SELECT
-    n.nspname || '.' || c.relname as fq_name,
+    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
     n.oid as schemaoid,
     c.oid as tableoid,
     p.attrnums as distribution_policy,
@@ -1853,17 +1853,17 @@ WHERE
         Step2:
            Change all leaf partition's policy back to old policy with a mandatory
            data movement.
-"""
+        """
         src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
         sql = """
 SELECT
-    n.nspname || '.' || c.relname as fq_name,
+    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
     n.oid as schemaoid,
     c.oid as tableoid,
     d.attrnums as distributed_policy,
     now() as last_updated,
     %s,
-    n.nspname || '.' || c.relname as root_partition_name
+    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as root_partition_name
 FROM
     pg_class c,
     pg_namespace n,
@@ -2181,7 +2181,7 @@ class ExpandTable():
              self.storage_options, self.rank, self.status,
              self.expansion_started, self.expansion_finished,
              self.source_bytes) = row
-        if self.fq_name.strip() == self.root_partition_name:
+        if self.fq_name == self.root_partition_name:
             self.is_root_partition = True
 
     def add_table(self, conn):
@@ -2189,7 +2189,7 @@ class ExpandTable():
                             VALUES ('%s','%s',%s,%s,
                                     '%s','%s', '%s', '%s', '%s','%s',%d,'%s','%s','%s',%d)
                     """ % (gpexpand_schema, status_detail_table,
-                           self.dbname, self.fq_name, self.schema_oid, self.table_oid,
+                           self.dbname, self.fq_name.replace("\'", "\'\'"), self.schema_oid, self.table_oid,
                            self.distrib_policy, self.distrib_policy_names, self.distrib_policy_coloids,
                            self.distrib_policy_type, self.root_partition_name,
                            self.storage_options, self.rank, self.status,
@@ -2202,8 +2202,7 @@ class ExpandTable():
     def mark_started(self, status_conn, table_conn, start_time, cancel_flag):
         if cancel_flag:
             return
-        (schema_name, table_name) = self.fq_name.split('.')
-        sql = "SELECT pg_relation_size(quote_ident('%s') || '.' || quote_ident('%s'))" % (schema_name, table_name)
+        sql = "SELECT pg_relation_size(%s)" % (self.table_oid)
         cursor = dbconn.execSQL(table_conn, sql)
         row = cursor.fetchone()
         src_bytes = int(row[0])
@@ -2245,9 +2244,7 @@ class ExpandTable():
         if self.storage_options:
             new_storage_options = ',' + self.storage_options
 
-        (schema_name, table_name) = self.fq_name.split('.')
-
-        sql = 'ALTER TABLE %s "%s"."%s" EXPAND TABLE' % (only_str, schema_name, table_name)
+        sql = 'ALTER TABLE %s %s EXPAND TABLE' % (only_str, self.fq_name)
 
         logger.info('Expanding %s.%s' % (self.dbname.decode('utf-8'), self.fq_name.decode('utf-8')))
         logger.debug("Expand SQL: %s" % sql.decode('utf-8'))
@@ -2257,8 +2254,8 @@ class ExpandTable():
             dbconn.execSQL(table_conn, sql)
             table_conn.commit()
             if self.options.analyze:
-                sql = 'ANALYZE "%s"."%s"' % (schema_name, table_name)
-                logger.info('Analyzing %s.%s' % (schema_name.decode('utf-8'), table_name.decode('utf-8')))
+                sql = 'ANALYZE %s' % (self.fq_name)
+                logger.info('Analyzing %s' % (self.fq_name.decode('utf-8')))
                 dbconn.execSQL(table_conn, sql)
                 table_conn.commit()
 
@@ -2395,15 +2392,14 @@ class ExpandCommand(SQLCommand):
         # validate table hasn't been dropped
         start_time = None
         try:
-            (schema_name, table_name) = self.table.fq_name.split('.')
             sql = """select * from pg_class c, pg_namespace n
-            where c.relname = '%s' and n.oid = c.relnamespace and n.nspname='%s'""" % (table_name, schema_name)
+            where c.oid = %d and n.oid = c.relnamespace and n.oid=%d""" % (self.table.table_oid,
+                                                                           self.table.schema_oid)
 
             cursor = dbconn.execSQL(table_conn, sql)
 
             if cursor.rowcount == 0:
-                logger.info('%s.%s no longer exists in database %s' % (schema_name.decode('utf-8'),
-                                                                       table_name.decode('utf-8'),
+                logger.info('%s no longer exists in database %s' % (self.table.fq_name.decode('utf-8'),
                                                                        self.table.dbname.decode('utf-8')))
 
                 self.table.mark_does_not_exist(status_conn, datetime.datetime.now())


### PR DESCRIPTION
commit 8eed421738 & e0b06678aa allow us to do a gpexpand of GPDB cluster
without a restart, so we called this strategy as "online expand", those
two commits were mainly focus on how to avoid restarting cluster when
expanding cluster, this commit will do the left work to improve gpexpand
using a few features we merged to master recently.

First improvement is, it's no longer necessary to change policy of all
non-partition table to random at the beginning of gpexpand. Previously,
we couldn't tell the difference between expanded table and non-expaned
table, so if the distribution policy of these tables were the same,
planner took these tables's data as co-located and produced a incorrect
plan. To avoid this, gpexpand used to change policy of all table to
random so planner could produce a correct but a non-effective plan,
because random policy always means annoying broadcase motion.

Now each table has a 'numsegments' attribute introduced by 4eb65a53, GPDB
can recognize expanded and non-expand table and produced correct plans. so
the first imporvement is removing the randomization step of tables.

The second improvement is, use a brand new syntax "ALTER TABLE foo EXPAND TABLE"
to focus on the data rebalance of tables. Previously, tables were converted
to randomly before rebalance and numsegments of tables were always the same
with GPDB cluster size, so we can use a tricky "ALTER TABLE foo SET WITH
(REORGNIZE = true) DISTRIBUTED BY (original_key)" command to rebalance data
to new added segments, now policy and numsegments are not changed before
rebalancing data, so expanding such tables is not match the concept of "SET
DISTRIBUTED BY" now, we need a proper syntax to focus on table expanding.

New expand syntax named "ALTER TABLE foo EXPAND TABLE", we have two methods
to do the real data movement inside, one is CTAS, another is RESHUFFLE, which
one is better depends on how much data needs to be moved and whether the table
has index and whether the table is a append only table (analyzed by Hekki).

A drawback of this commit is we always expand a partition within a transaction,
the old behavior is expand the leaf partition in parallel which is faster for
a partition table. We don't allow root partition and its leaf partitions to
have different numsegments for now, this commit disabled the old behavior
temporarily. A topic on how to expanding partition table in parallel is
under discussion and we wish to bring the ability back properly in the feature.