### PR TITLE
The showtype argument of get_const_expr() is no longer bool.

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -8218,7 +8218,7 @@ get_coercion_expr(Node *arg, deparse_context *context,
 		((Const *) arg)->consttypmod == -1)
 	{
 		/* Show the constant without normal ::typename decoration */
-		get_const_expr((Const *) arg, context, false);
+		get_const_expr((Const *) arg, context, -1);
 	}
 	else
 	{


### PR DESCRIPTION
PG patch 59358907 changed that but somehow this code line change is lost during
merge.