### PR TITLE
Code review of ALTER TABLE EXPAND TABLE.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14589,8 +14589,8 @@ ReshuffleRelationData(Relation rel)
  * of tuples to be moved to be smaller than SCALE_THRESHOLD, we use the
  * reshuffle method, and CTAS method otherwise.
  *
- * All this assumes that the table is distributed by a has. On a randomly
- * distributed table, we don't need to move any tuples, as all the tuples
+ * A mandatory data movement is applied to a randomly distributed table to
+ * avoid data skew. Another choice is don't move any tuples, as all the tuples
  * can legitimately still reside on the old segments even after expanding.
  * To rebalance a randomly distributed table after expanding, you can use
  * WITH (REORGANIZE=TRUE), but that's a completely different codepath.

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3617,10 +3617,6 @@ _copyExpandStmtSpec(const ExpandStmtSpec *from)
 	ExpandStmtSpec *newnode = makeNode(ExpandStmtSpec);
 
 	COPY_SCALAR_FIELD(method);
-	COPY_BITMAPSET_FIELD(ps_none);
-	COPY_BITMAPSET_FIELD(ps_root);
-	COPY_BITMAPSET_FIELD(ps_interior);
-	COPY_BITMAPSET_FIELD(ps_leaf);
 	COPY_SCALAR_FIELD(backendId);
 
 	return newnode;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3092,10 +3092,6 @@ _outExpandStmtSpec(StringInfo str, const ExpandStmtSpec *node)
 {
 	WRITE_NODE_TYPE("EXPANDSTMTSPEC");
 	WRITE_ENUM_FIELD(method, ExpandMethod);
-	WRITE_BITMAPSET_FIELD(ps_none);
-	WRITE_BITMAPSET_FIELD(ps_root);
-	WRITE_BITMAPSET_FIELD(ps_interior);
-	WRITE_BITMAPSET_FIELD(ps_leaf);
 	WRITE_OID_FIELD(backendId);
 }
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1228,10 +1228,6 @@ _readExpandStmtSpec(void)
 	READ_LOCALS(ExpandStmtSpec);
 
 	READ_ENUM_FIELD(method, ExpandMethod);
-	READ_BITMAPSET_FIELD(ps_none);
-	READ_BITMAPSET_FIELD(ps_root);
-	READ_BITMAPSET_FIELD(ps_interior);
-	READ_BITMAPSET_FIELD(ps_leaf);
 	READ_OID_FIELD(backendId);
 
 	READ_DONE();

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2124,15 +2124,7 @@ typedef struct ExpandStmtSpec
 	NodeTag				type;
 	/* method to move data internal */
 	ExpandMethod		method;
-	/*
-	 * QEs has empty pg_partition and pg_partitions
-	 * so we need to pass necessary partition related
-	 * info to QEs.
-	 */
-	Bitmapset			*ps_none;
-	Bitmapset			*ps_root;
-	Bitmapset			*ps_interior;
-	Bitmapset			*ps_leaf;
+
 	/* for ctas method */
 	Oid					backendId;
 } ExpandStmtSpec;

--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -1017,3 +1017,9 @@ DETAIL:  drop cascades to table inherit_t1_p2
 drop cascades to table inherit_t1_p4
 drop cascades to table inherit_t1_p3
 drop cascades to table inherit_t1_p5
+--
+-- Test EXPAND, on a table that doesn't need expanding. Should be a no-op.
+--
+CREATE TABLE expand_noop(i int) distributed by (i);
+ALTER TABLE expand_noop EXPAND TABLE;
+ALTER TABLE expand_noop EXPAND TABLE;

--- a/src/test/regress/sql/reshuffle.sql
+++ b/src/test/regress/sql/reshuffle.sql
@@ -417,3 +417,10 @@ alter table inherit_t1_p1 expand table;
 select count(*) > 0 from inherit_t1_p1 where gp_segment_id = 2;
 
 DROP TABLE inherit_t1_p1 CASCADE;
+
+--
+-- Test EXPAND, on a table that doesn't need expanding. Should be a no-op.
+--
+CREATE TABLE expand_noop(i int) distributed by (i);
+ALTER TABLE expand_noop EXPAND TABLE;
+ALTER TABLE expand_noop EXPAND TABLE;


### PR DESCRIPTION
Clean up unused code, inadequate comments, etc. from commit cfe3f386fb.

Change behavior if you run ALTER TABLE EXPAND TABLE on a table that has
already been expanded, to be a no-op, instead of throwing an error. Add
test case for it.