### PR TITLE
Remove /static/ from PostgreSQL doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ doing the actual work as a series of small, self-contained commits. This makes
 the reviewer's job much easier and increases the timeliness of feedback.
 
 When it comes to C and C++ parts of Greenplum, we try to follow
-[PostgreSQL Coding Conventions](https://www.postgresql.org/docs/devel/static/source.html).
+[PostgreSQL Coding Conventions](https://www.postgresql.org/docs/devel/source.html).
 In addition to that we require that:
    * All Python code passes [Pylint](https://www.pylint.org/)
    * All Go code is formatted according to [gofmt](https://golang.org/cmd/gofmt/)

--- a/gpdb-doc/dita/admin_guide/access_db/topics/g-database-application-interfaces.xml
+++ b/gpdb-doc/dita/admin_guide/access_db/topics/g-database-application-interfaces.xml
@@ -63,7 +63,7 @@
                   <entry colname="col1">libpq C Library</entry>
                   <entry colname="col2">libpq</entry>
                   <entry colname="col3">
-                     <xref href="https://www.postgresql.org/docs/8.3/static/libpq.html" scope="external" format="html"/>
+                     <xref href="https://www.postgresql.org/docs/8.3/libpq.html" scope="external" format="html"/>
                   </entry>
                </row>
             </tbody>

--- a/gpdb-doc/dita/admin_guide/admin_preface.xml
+++ b/gpdb-doc/dita/admin_guide/admin_preface.xml
@@ -32,7 +32,7 @@
       systems. Familiarity with structured query language (SQL) is helpful.</p>
     <p>Because Greenplum Database is based on PostgreSQL 8.3.23, this guide assumes some familiarity
       with PostgreSQL. References to <xref
-        href="https://www.postgresql.org/docs/8.3/static/index.html" scope="external" format="html"
+        href="https://www.postgresql.org/docs/8.3/index.html" scope="external" format="html"
           ><ph>PostgreSQL documentation</ph></xref> are provided throughout this guide for features
       that are similar to those in Greenplum Database.</p>
     <p>This guide provides information for system administrators responsible for administering a

--- a/gpdb-doc/dita/admin_guide/client_auth.xml
+++ b/gpdb-doc/dita/admin_guide/client_auth.xml
@@ -20,7 +20,7 @@
     <body>
       <p>Client access and authentication is controlled by the standard PostgreSQL host-based
         authentication file, <filepath>pg_hba.conf</filepath>. For detailed information about this
-        file, see <xref href="https://www.postgresql.org/docs/9.1/static/auth-pg-hba-conf.html"
+        file, see <xref href="https://www.postgresql.org/docs/9.1/auth-pg-hba-conf.html"
           scope="external" format="html">The pg_hba.conf File</xref> in the PostgreSQL
         documentation. </p>
       <p>In Greenplum Database, the <filepath>pg_hba.conf</filepath> file of the master instance
@@ -143,7 +143,7 @@
               <entry colname="col1">authentication-method</entry>
               <entry colname="col2">Specifies the authentication method to use when connecting.
                 Greenplum supports the <xref
-                  href="https://www.postgresql.org/docs/9.0/static/auth-methods.html"
+                  href="https://www.postgresql.org/docs/9.0/auth-methods.html"
                   scope="external" format="html">authentication methods</xref> supported by
                 PostgreSQL 9.0.</entry>
             </row>

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-index.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-index.xml
@@ -94,7 +94,7 @@ VACUUM ANALYZE old_table;
         are not supported. Each index type uses a different algorithm that is best suited to
         different types of queries. B-tree indexes fit the most common situations and are the
         default index type. See <xref
-          href="https://www.postgresql.org/docs/8.3/static/indexes-types.html" scope="external"
+          href="https://www.postgresql.org/docs/8.3/indexes-types.html" scope="external"
           format="html"><ph>Index Types</ph></xref> in the PostgreSQL documentation for a
         description of these types.</p>
       <note type="note">Greenplum Database allows unique indexes only if the columns of the index

--- a/gpdb-doc/dita/admin_guide/intro/arch_overview.xml
+++ b/gpdb-doc/dita/admin_guide/intro/arch_overview.xml
@@ -80,7 +80,7 @@
       <p>Greenplum Database end-users interact with Greenplum Database (through the master) as they
         would with a typical PostgreSQL database. They connect to the database using client programs
         such as <codeph>psql</codeph> or application programming interfaces (APIs) such as JDBC,
-        ODBC or <xref href="https://www.postgresql.org/docs/8.3/static/libpq.html" format="html"
+        ODBC or <xref href="https://www.postgresql.org/docs/8.3/libpq.html" format="html"
           scope="external">libpq</xref> (the PostgreSQL C API).</p>
       <p>The master is where the <i>global system catalog</i> resides. The global system catalog is
         the set of system tables that contain metadata about the Greenplum Database system itself.

--- a/gpdb-doc/dita/admin_guide/kerberos.xml
+++ b/gpdb-doc/dita/admin_guide/kerberos.xml
@@ -163,7 +163,7 @@ $ chmod 400 /home/gpadmin/gpdb-kerberos.keytab</codeblock>
               <codeph>include_realm</codeph> option to <codeph>0</codeph>
             excludes the realm name from the authenticated user name. For
             information about the <codeph>pg_hba.conf</codeph> file, see <xref
-              href="https://www.postgresql.org/docs/8.4/static/auth-pg-hba-conf.html"
+              href="https://www.postgresql.org/docs/8.4/auth-pg-hba-conf.html"
               scope="external" format="html">The pg_hba.conf file</xref> in the
             Postgres documentation.</p>
         </li>
@@ -277,7 +277,7 @@ mymap       /^(.*)_gp)@GPDB.KRB$   \1</codeblock>
           <codeph>pg_ident.conf</codeph> file, so the order of entries is
         significant.</p>
       <p>For more information about using username maps see <xref
-          href="https://www.postgresql.org/docs/8.4/static/auth-username-maps.html"
+          href="https://www.postgresql.org/docs/8.4/auth-username-maps.html"
           scope="external" format="html">Username maps</xref> in the PostgreSQL
         documentation.</p>
     </body>

--- a/gpdb-doc/dita/admin_guide/load/topics/g-installing-the-external-table-protocol.xml
+++ b/gpdb-doc/dita/admin_guide/load/topics/g-installing-the-external-table-protocol.xml
@@ -26,9 +26,9 @@
         <p>For more information on compiling and linking dynamically-loaded functions and examples
             of compiling C source code to create a shared library on other operating systems, see
             the Postgres documentation at <xref
-                href="https://www.postgresql.org/docs/8.4/static/xfunc-c.html#DFUNC" scope="external"
+                href="https://www.postgresql.org/docs/8.4/xfunc-c.html#DFUNC" scope="external"
                 format="html">
-                <ph>https://www.postgresql.org/docs/8.4/static/xfunc-c.html#DFUNC</ph>
+                <ph>https://www.postgresql.org/docs/8.4/xfunc-c.html#DFUNC</ph>
             </xref>. </p>
         <p>The manual pages for the C compiler <codeph>cc</codeph> and the link editor
                 <codeph>ld</codeph> for your operating system also contain information on compiling

--- a/gpdb-doc/dita/admin_guide/managing/maintain.xml
+++ b/gpdb-doc/dita/admin_guide/managing/maintain.xml
@@ -99,7 +99,7 @@ wraparound data loss in database "database_name"
           <p>For information about the configuration parameters, see the <i>Greenplum Database
               Reference Guide</i>. </p>
           <p>For information about transaction ID wraparound see the <xref
-              href="https://www.postgresql.org/docs/8.3/static/index.html" scope="external"
+              href="https://www.postgresql.org/docs/8.3/index.html" scope="external"
               format="html"><ph>PostgreSQL documentation</ph></xref>.</p>
         </section>
       </body>

--- a/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
@@ -133,7 +133,7 @@
                 information with the psql <codeph>\df+ <varname>function</varname></codeph>
                 command.</p>
             <p>Refer to the PostgreSQL <xref
-                    href="https://www.postgresql.org/docs/9.4/static/xfunc-volatility.html"
+                    href="https://www.postgresql.org/docs/9.4/xfunc-volatility.html"
                     scope="external" format="html">Function Volatility Categories</xref>
                 documentation for additional information about the Greenplum Database function
                 volatility classifications.</p>
@@ -187,7 +187,7 @@ SELECT foo();</codeblock>
         <title id="in141451">User-Defined Functions</title>
         <body>
             <p>Greenplum Database supports user-defined functions. See <xref format="html"
-                    href="https://www.postgresql.org/docs/9.4/static/extend.html" scope="external"
+                    href="https://www.postgresql.org/docs/9.4/extend.html" scope="external"
                     >Extending SQL</xref> in the PostgreSQL documentation for more information.</p>
             <p>Use the <codeph>CREATE FUNCTION</codeph> statement to register user-defined functions
                 that are used as described in <xref format="dita" href="#topic27" type="topic"/>. By
@@ -223,7 +223,7 @@ SELECT foo();</codeblock>
                 Database as in PostgreSQL with the exception of <codeph>STABLE</codeph> and
                     <codeph>VOLATILE</codeph> functions, which are subject to the restrictions noted
                 in <xref format="dita" href="#topic27" type="topic"/>. See the <xref format="html"
-                    href="https://www.postgresql.org/docs/9.4/static/functions.html"
+                    href="https://www.postgresql.org/docs/9.4/functions.html"
                     scope="external">Functions and Operators</xref> section of the PostgreSQL
                 documentation for more information about these built-in functions and operators.</p>
             <p>Greenplum Database includes JSON processing functions that manipulate values the
@@ -248,7 +248,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-logical.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-logical.html"
                                     scope="external">Logical Operators</xref>
                             </entry>
                             <entry colname="col2"/>
@@ -258,7 +258,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-comparison.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-comparison.html"
                                     scope="external">Comparison Operators</xref>
                             </entry>
                             <entry colname="col2"/>
@@ -268,7 +268,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-math.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-math.html"
                                     scope="external">
                                     <ph>Mathematical Functions and Operators</ph>
                                 </xref>
@@ -280,7 +280,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-string.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-string.html"
                                     scope="external">
                                     <ph>String Functions and Operators</ph>
                                 </xref>
@@ -294,7 +294,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-binarystring.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-binarystring.html"
                                     scope="external">
                                     <ph>Binary String Functions and Operators</ph>
                                 </xref>
@@ -306,7 +306,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-bitstring.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-bitstring.html"
                                     scope="external">
                                     <ph>Bit String Functions and Operators</ph>
                                 </xref>
@@ -318,7 +318,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-matching.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-matching.html"
                                     scope="external">
                                     <ph>Pattern Matching</ph>
                                 </xref>
@@ -330,7 +330,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-formatting.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-formatting.html"
                                     scope="external">
                                     <ph>Data Type Formatting Functions</ph>
                                 </xref>
@@ -342,7 +342,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-datetime.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-datetime.html"
                                     scope="external"> Date/Time Functions and Operators</xref>
                             </entry>
                             <entry colname="col2">timeofday</entry>
@@ -353,7 +353,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-enum.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-enum.html"
                                     scope="external"> Enum Support Functions </xref>
                             </entry>
                             <entry colname="col2"/>
@@ -363,7 +363,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-geometry.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-geometry.html"
                                     scope="external">
                                     <ph>Geometric Functions and Operators</ph>
                                 </xref>
@@ -375,7 +375,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-net.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-net.html"
                                     scope="external">
                                     <ph>Network Address Functions and Operators</ph>
                                 </xref>
@@ -387,7 +387,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-sequence.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-sequence.html"
                                     scope="external">
                                     <ph>Sequence Manipulation Functions</ph>
                                 </xref>
@@ -399,7 +399,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-conditional.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-conditional.html"
                                     scope="external">
                                     <ph>Conditional Expressions</ph>
                                 </xref>
@@ -411,7 +411,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-array.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-array.html"
                                     scope="external">
                                     <ph>Array Functions and Operators</ph>
                                 </xref>
@@ -425,7 +425,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-aggregate.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-aggregate.html"
                                     scope="external">
                                     <ph>Aggregate Functions</ph>
                                 </xref>
@@ -437,7 +437,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-subquery.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-subquery.html"
                                     scope="external">
                                     <ph>Subquery Expressions</ph>
                                 </xref>
@@ -449,7 +449,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-comparisons.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-comparisons.html"
                                     scope="external">
                                     <ph>Row and Array Comparisons</ph>
                                 </xref>
@@ -461,7 +461,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-srf.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-srf.html"
                                     scope="external">
                                     <ph>Set Returning Functions</ph>
                                 </xref>
@@ -473,7 +473,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-info.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-info.html"
                                     scope="external">
                                     <ph>System Information Functions</ph>
                                 </xref>
@@ -497,7 +497,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/functions-admin.html"
+                                    href="https://www.postgresql.org/docs/9.4/functions-admin.html"
                                     scope="external">
                                     <ph>System Administration Functions</ph>
                                 </xref>
@@ -513,7 +513,7 @@ SELECT foo();</codeblock>
                         <row>
                             <entry colname="col1">
                                 <xref format="html"
-                                    href="https://www.postgresql.org/docs/9.1/static/functions-xml.html"
+                                    href="https://www.postgresql.org/docs/9.1/functions-xml.html"
                                     scope="external">XML Functions</xref> and function-like
                                 expressions </entry>
                             <entry colname="col2"/>
@@ -912,7 +912,7 @@ SELECT sum(myvalue) FROM mymatrix;
                             <entry colname="col4">Transforms a one dimensional array into rows.
                                 Returns a set of <codeph>anyelement</codeph>, a polymorphic <xref
                                     format="html"
-                                    href="https://www.postgresql.org/docs/9.4/static/datatype-pseudo.html"
+                                    href="https://www.postgresql.org/docs/9.4/datatype-pseudo.html"
                                     scope="external"><ph>pseudo-type</ph></xref>  in
                                 PostgreSQL.</entry>
                         </row>

--- a/gpdb-doc/dita/admin_guide/query/topics/xml-data.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/xml-data.xml
@@ -452,7 +452,7 @@ SELECT xmlelement(name test, xmlattributes(func(a, b))) FROM test;</codeblock></
           <codeph>&amp;</codeph> will be converted to entities. Binary data (data type
           <codeph>bytea</codeph>) will be represented in base64 or hex encoding, depending on the
         setting of the configuration parameter <xref
-          href="https://www.postgresql.org/docs/9.1/static/runtime-config-client.html#GUC-XMLBINARY"
+          href="https://www.postgresql.org/docs/9.1/runtime-config-client.html#GUC-XMLBINARY"
           format="html" scope="external">xmlbinary</xref>. The particular behavior for individual
         data types is expected to evolve in order to align the SQL and Greenplum Database data types
         with the XML schema specification, at which point a more precise description will

--- a/gpdb-doc/dita/admin_guide/roles_privs.xml
+++ b/gpdb-doc/dita/admin_guide/roles_privs.xml
@@ -446,7 +446,7 @@
         want the ability to query other
         databases:<codeblock>$ psql -d testdb -f $GPHOME/share/postgresql/contrib/pgcrypto.sql</codeblock></p>
       <p>See <xref
-          href="https://www.postgresql.org/docs/8.3/static/pgcrypto.html"
+          href="https://www.postgresql.org/docs/8.3/pgcrypto.html"
           format="html" scope="external">pgcrypto</xref> in the PostgreSQL documentation for more
         information about individual functions.</p>
     </body>

--- a/gpdb-doc/dita/admin_guide/textsearch/dictionaries.xml
+++ b/gpdb-doc/dita/admin_guide/textsearch/dictionaries.xml
@@ -94,7 +94,7 @@
         partially normalize words to simplify the task of later dictionaries.
         For example, a filtering dictionary could be used to remove accents from
         accented letters, as is done by the <xref
-          href="https://www.postgresql.org/docs/9.4/static/unaccent.html"
+          href="https://www.postgresql.org/docs/9.4/unaccent.html"
           format="html" scope="external">unaccent</xref> module.</p>
     </section>
     <section id="stop-words">

--- a/gpdb-doc/dita/admin_guide/textsearch/gist-gin.xml
+++ b/gpdb-doc/dita/admin_guide/textsearch/gist-gin.xml
@@ -51,7 +51,7 @@
       <li>GIN indexes take about three times longer to build than GiST</li>
       <li>GIN indexes are moderately slower to update than GiST indexes, but about 10 times slower
         if fast-update support was disabled (see <xref
-          href="https://www.postgresql.org/docs/9.4/static/gin-implementation.html#GIN-FAST-UPDATE"
+          href="https://www.postgresql.org/docs/9.4/gin-implementation.html#GIN-FAST-UPDATE"
           format="html" scope="external">GIN Fast Update Technique</xref> in the PostgreSQL
         documentation for details)</li>
       <li>GIN indexes are two-to-three times larger than GiST indexes</li>

--- a/gpdb-doc/dita/best_practices/encryption.xml
+++ b/gpdb-doc/dita/best_practices/encryption.xml
@@ -276,7 +276,7 @@ ssb   2048R/4FD2EFBB 2015-01-13
           commands:<codeblock># gpg -a --export 4FD2EFBB &gt; public.key
 # gpg -a --export-secret-keys 2027CC30 &gt; secret.key</codeblock></li>
       </ol>
-      <p>See the <xref href="https://www.postgresql.org/docs/8.3/static/pgcrypto.html" format="html"
+      <p>See the <xref href="https://www.postgresql.org/docs/8.3/pgcrypto.html" format="html"
           scope="external">pgcrypto</xref> documentation for for more information about PGP
         encryption functions. </p>
     </section>
@@ -392,7 +392,7 @@ key_used | 9D4D255F4FD2EFBB
           <note>Different keys may have the same ID. This is rare, but is a normal event. The client
             application should try to decrypt with each one to see which fits — like handling
               <codeph>ANYKEY</codeph>. See <xref
-              href="https://www.postgresql.org/docs/8.3/static/pgcrypto.html" format="html"
+              href="https://www.postgresql.org/docs/8.3/pgcrypto.html" format="html"
               scope="external">pgp_key_id()</xref> in the pgcrypto documentation. </note>
         </li>
         <li>Decrypt the data using the private key.

--- a/gpdb-doc/dita/install_guide/env_var_ref.xml
+++ b/gpdb-doc/dita/install_guide/env_var_ref.xml
@@ -156,7 +156,7 @@ export MASTER_DATA_DIRECTORY</codeblock>
                                 <p>The name of the password file to use for lookups. If not set, it
                                         defaults to <codeph class="+ topic/ph pr-d/codeph "
                                                 >~/.pgpass</codeph>. See the topic about <xref
-                                                href="https://www.postgresql.org/docs/8.2/static/libpq-pgpass.html"
+                                                href="https://www.postgresql.org/docs/8.2/libpq-pgpass.html"
                                                 scope="external" format="html" class="- topic/xref "
                                                 >The Password File</xref> in the PostgreSQL
                                         documentation for more information.</p>

--- a/gpdb-doc/dita/install_guide/prep_os_install_gpdb.xml
+++ b/gpdb-doc/dita/install_guide/prep_os_install_gpdb.xml
@@ -605,7 +605,7 @@ sdw3-2</codeblock><p>Check
         <p>See <xref href="../utility_guide/dblink.html" format="dita" scope="peer" type="topic"
             >dblink Functions</xref> for basic information about using <codeph>dblink</codeph> to
           query other databases. See <xref
-            href="https://www.postgresql.org/docs/8.3/static/dblink.html" format="html"
+            href="https://www.postgresql.org/docs/8.3/dblink.html" format="html"
             scope="external">dblink</xref> in the PostgreSQL documentation for more information
           about individual functions.</p>
       </body>
@@ -627,7 +627,7 @@ sdw3-2</codeblock><p>Check
               <codeph>$GPHOME/share/postgresql/contrib/pgcrypto.sql</codeph> in each database where
             you want the ability to query other
             databases:<codeblock>$ psql -d testdb -f $GPHOME/share/postgresql/contrib/pgcrypto.sql</codeblock></p><p>See
-              <xref href="https://www.postgresql.org/docs/8.3/static/pgcrypto.html" format="html"
+              <xref href="https://www.postgresql.org/docs/8.3/pgcrypto.html" format="html"
               scope="external">pgcrypto</xref> in the PostgreSQL documentation for more information
             about individual functions.</p></note>
       </body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -1098,7 +1098,7 @@
     <body>
       <p>Sets the client-side encoding (character set). The default is to use the same as the
         database encoding. See <xref
-          href="https://www.postgresql.org/docs/8.3/static/multibyte.html#MULTIBYTE-CHARSET-SUPPORTED"
+          href="https://www.postgresql.org/docs/8.3/multibyte.html#MULTIBYTE-CHARSET-SUPPORTED"
           scope="external" format="html">Supported Character Sets</xref> in the PostgreSQL
         documentation.</p>
       <table id="client_encoding_table">
@@ -5734,7 +5734,7 @@
         when the <xref href="#DateStyle" format="dita"/> parameter was set to non-ISO output. </p>
       <p>The value <i>iso_8601</i> will produce output matching the time interval <i>format with
           designators</i> defined in section 4.4.3.2 of ISO 8601. See the <xref
-          href="https://www.postgresql.org/docs/8.4/static/datatype-datetime.html" scope="external"
+          href="https://www.postgresql.org/docs/8.4/datatype-datetime.html" scope="external"
           format="html"><ph>PostgreSQL 8.4 documentation</ph></xref> for more information. </p>
       <table id="IntervalStyle_table">
         <tgroup cols="3">
@@ -9025,7 +9025,7 @@
     <body>
       <p>Sets the time zone for displaying and interpreting time stamps. The default is to use
         whatever the system environment specifies as the time zone. See <xref
-          href="https://www.postgresql.org/docs/8.3/static/datetime-keywords.html" scope="external"
+          href="https://www.postgresql.org/docs/8.3/datetime-keywords.html" scope="external"
           format="html"><ph>Date/Time Keywords</ph></xref> in the PostgreSQL documentation.</p>
       <table id="TimeZone_table">
         <tgroup cols="3">
@@ -9532,7 +9532,7 @@
         decide whether to replace transaction IDs with <i>FrozenXID</i> while scanning a table.</p>
       <p>For information about <codeph>VACUUM</codeph> and transaction ID management, see "Managing
         Data" in the <cite>Greenplum Database Administrator Guide</cite> and the <xref
-          href="https://www.postgresql.org/docs/8.3/static/routine-vacuuming.html#VACUUM-FOR-WRAPAROUND"
+          href="https://www.postgresql.org/docs/8.3/routine-vacuuming.html#VACUUM-FOR-WRAPAROUND"
           scope="external" format="html">PostgreSQL documentation</xref>.</p>
       <table id="vacuum_freeze_min_age_table">
         <tgroup cols="3">

--- a/gpdb-doc/dita/ref_guide/data_types.xml
+++ b/gpdb-doc/dita/ref_guide/data_types.xml
@@ -65,7 +65,7 @@
               <entry colname="col2"/>
               <entry colname="col3"><i>n</i> bits</entry>
               <entry colname="col4"><xref
-                  href="https://www.postgresql.org/docs/8.3/static/sql-syntax.html#SQL-SYNTAX-BIT-STRINGS"
+                  href="https://www.postgresql.org/docs/8.3/sql-syntax.html#SQL-SYNTAX-BIT-STRINGS"
                   scope="external" format="html">bit string constant</xref></entry>
               <entry colname="col5">fixed-length bit string</entry>
             </row>
@@ -75,7 +75,7 @@
               <entry colname="col2">varbit</entry>
               <entry colname="col3">actual number of bits</entry>
               <entry colname="col4"><xref
-                  href="https://www.postgresql.org/docs/8.3/static/sql-syntax.html#SQL-SYNTAX-BIT-STRINGS"
+                  href="https://www.postgresql.org/docs/8.3/sql-syntax.html#SQL-SYNTAX-BIT-STRINGS"
                   scope="external" format="html">bit string constant</xref></entry>
               <entry colname="col5">variable-length bit string</entry>
             </row>
@@ -100,7 +100,7 @@
               <entry colname="col2"/>
               <entry colname="col3">1 byte + <i>binary string</i></entry>
               <entry colname="col4">sequence of <xref
-                  href="https://www.postgresql.org/docs/8.3/static/datatype-binary.html#DATATYPE-BINARY-SQLESC"
+                  href="https://www.postgresql.org/docs/8.3/datatype-binary.html#DATATYPE-BINARY-SQLESC"
                   scope="external" format="html"><ph>octets</ph></xref></entry>
               <entry colname="col5">variable-length binary string</entry>
             </row>

--- a/gpdb-doc/dita/ref_guide/datatype-datetime.xml
+++ b/gpdb-doc/dita/ref_guide/datatype-datetime.xml
@@ -9,11 +9,11 @@
    <p>Greenplum supports the full set of SQL date and time types, shown in <xref
       href="#topic_abq_gfk_qfb/datatype-datetime-table" format="dita"/>. The operations available on
      these data types are described in <xref
-      href="https://www.postgresql.org/docs/9.4/static/functions-datetime.html" format="html"
+      href="https://www.postgresql.org/docs/9.4/functions-datetime.html" format="html"
       scope="external">Date/Time Functions and Operators</xref> in the PostgreSQL documentation.
      Dates are counted according to the Gregorian calendar, even in years before that calendar was
      introduced (see <xref
-      href="https://www.postgresql.org/docs/9.4/static/datetime-units-history.html" format="html"
+      href="https://www.postgresql.org/docs/9.4/datetime-units-history.html" format="html"
       scope="external">History of Units</xref> in the PostgreSQL documentation for more
      information).</p>
 
@@ -160,7 +160,7 @@ MINUTE TO SECOND
      day-month-year interpretation, or <codeph>YMD</codeph> to select year-month-day interpretation.</p>
 
     <p>Greenplum is more flexible in handling date/time input than the SQL standard requires. See
-      <xref href="https://www.postgresql.org/docs/9.4/static/datetime-appendix.html" format="html"
+      <xref href="https://www.postgresql.org/docs/9.4/datetime-appendix.html" format="html"
       scope="external">Appendix B. Date/Time Support</xref> in the PostgreSQL documentation for the
      exact parsing rules of date/time input and for the recognized text fields including months,
      days of the week, and time zones.</p>
@@ -444,7 +444,7 @@ January 8 04:05:06 1999 PST
      from UTC to the current <varname>timezone</varname> zone, and displayed as local time in that
      zone. To see the time in another time zone, either change <varname>timezone</varname> or use
      the <codeph>AT TIME ZONE</codeph> construct (see <xref
-      href="https://www.postgresql.org/docs/9.4/static/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT"
+      href="https://www.postgresql.org/docs/9.4/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT"
       format="html" scope="external">AT TIME ZONE</xref> in the PostgreSQL documentation).</p>
 
      <p>Conversions between <codeph>timestamp without time zone</codeph> and
@@ -525,7 +525,7 @@ January 8 04:05:06 1999 PST
       <codeph>CURRENT_TIMESTAMP</codeph>, <codeph>LOCALTIME</codeph>,
       <codeph>LOCALTIMESTAMP</codeph>. The latter four accept an optional subsecond precision
      specification. (See <xref
-      href="https://www.postgresql.org/docs/9.4/static/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT"
+      href="https://www.postgresql.org/docs/9.4/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT"
       format="html" scope="external">Current Date/Time</xref> in the PostgreSQL documentation.) Note
      that these are SQL functions and are <i>not</i> recognized in data input strings.</p>
 
@@ -627,7 +627,7 @@ January 8 04:05:06 1999 PST
      client.</p>
 
     <p>The formatting function <codeph>to_char</codeph> (see <xref
-      href="https://www.postgresql.org/docs/9.4/static/functions-formatting.html" format="html"
+      href="https://www.postgresql.org/docs/9.4/functions-formatting.html" format="html"
       scope="external">Data Type Formatting Functions</xref>) is also available as a more flexible
      way to format date/time output.</p>
    </section>

--- a/gpdb-doc/dita/ref_guide/datatype-pseudo.xml
+++ b/gpdb-doc/dita/ref_guide/datatype-pseudo.xml
@@ -27,7 +27,7 @@
         an argument to a user-defined function. See <xref href="#topic_ig2_1pc_qfb" format="dita"/>
         for more about the <i>anytable</i> pseudo-type.</p>
       <p>For more information about pseudo-types, see the Postgres documentation about <xref
-          href="https://www.postgresql.org/docs/8.3/static/datatype-pseudo.html" format="html"
+          href="https://www.postgresql.org/docs/8.3/datatype-pseudo.html" format="html"
           scope="external">Pseudo-Types</xref>.</p>
     </body>
     <topic id="topic_dbn_bpc_qfb">
@@ -75,7 +75,7 @@
           argument matching and determining the actual result type, such a function behaves the same
           as if you had declared the appropriate number of <i>anynonarray</i> parameters.</p>
         <p>For more information about polymorphic types, see the Postgres documentation about <xref
-            href="https://www.postgresql.org/docs/8.3/static/xfunc-c.html#AEN41553" format="html"
+            href="https://www.postgresql.org/docs/8.3/xfunc-c.html#AEN41553" format="html"
             scope="external">Polymorphic Arguments and Return Types</xref>.</p>
       </body>
     </topic>

--- a/gpdb-doc/dita/ref_guide/env_var_ref.xml
+++ b/gpdb-doc/dita/ref_guide/env_var_ref.xml
@@ -145,7 +145,7 @@ export MASTER_DATA_DIRECTORY</codeblock>
             <body class="- topic/body ">
                 <p>The name of the password file to use for lookups. If not set, it defaults to
                         <codeph class="+ topic/ph pr-d/codeph ">~/.pgpass</codeph>. See the topic
-                    about <xref href="https://www.postgresql.org/docs/8.3/static/libpq-pgpass.html"
+                    about <xref href="https://www.postgresql.org/docs/8.3/libpq-pgpass.html"
                         scope="external" format="html" class="- topic/xref ">The Password File</xref> in the PostgreSQL documentation for more
                     information.</p>
             </body>

--- a/gpdb-doc/dita/ref_guide/extensions/gppc.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/gppc.xml
@@ -61,7 +61,7 @@
     <title id="py21716799">Using the GPPC API</title>
     <body>
       <p>The GPPC API shares some concepts with C language functions as defined
-        by PostgreSQL. Refer to <xref href="https://www.postgresql.org/docs/8.3/static/xfunc-c.html" format="html" scope="external">C-Language Functions</xref>
+        by PostgreSQL. Refer to <xref href="https://www.postgresql.org/docs/8.3/xfunc-c.html" format="html" scope="external">C-Language Functions</xref>
         in the PostgreSQL documentation for detailed information about developing
         C language functions.</p>
       <p>The GPPC API is a wrapper that makes a C/C++ function SQL-invokable
@@ -611,7 +611,7 @@ GppcReport(GPPC_ERROR, "Unknown user name: %s", GppcTextGetCString(uname));</cod
         <p>The Greenplum Database Server Programming Interface (SPI) provides
           writers of C/C++ functions the ability to run SQL commands within a
           GPPC function. For additional information on SPI functions, refer to
-           <xref href="https://www.postgresql.org/docs/8.3/static/spi.html"
+           <xref href="https://www.postgresql.org/docs/8.3/spi.html"
              scope="external"
              format="html">Server Programming Interface</xref>
             in the PostgreSQL documentation.</p>
@@ -1060,7 +1060,7 @@ ntuple = GppcAnyTableGetNextTuple(intbl);</codeblock></p>
         <p>To use the PGXS infrastructure to generate a shared library for
           functions that you create with the GPPC API, create a simple
           <codeph>Makefile</codeph> that sets PGXS-specific variables.</p>
-        <note>Refer to <xref href="https://www.postgresql.org/docs/8.3/static/xfunc-c.html#XFUNC-C-PGXS" format="html" scope="external">Extension Building Infrastructure</xref>
+        <note>Refer to <xref href="https://www.postgresql.org/docs/8.3/xfunc-c.html#XFUNC-C-PGXS" format="html" scope="external">Extension Building Infrastructure</xref>
           in the PostgreSQL documentation for information about the
           <codeph>Makefile</codeph> variables supported by PGXS.</note>
         <p>For example, the following <codeph>Makefile</codeph> generates

--- a/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
@@ -690,7 +690,7 @@ $$ LANGUAGE plcontainer;</codeblock></p>
           rolled back.</li>
         <li><codeph>plpy.subtransaction()</codeph> - Manages <codeph>plpy.execute</codeph> calls in
           an explicit subtransaction. See <xref
-            href="https://www.postgresql.org/docs/9.1/static/plpython-subtransaction.html"
+            href="https://www.postgresql.org/docs/9.1/plpython-subtransaction.html"
             format="html" scope="external">Explicit Subtransactions</xref> in the PostgreSQL
           documentation for additional information about
           <codeph>plpy.subtransaction()</codeph>.</li>
@@ -730,8 +730,8 @@ $$ LANGUAGE plcontainer;</codeblock></p>
         related containers would be shut down and the data from GD and SD lost.</p>
       <p>For information about PL/Python, see <xref href="pl_python.xml#topic1"/>. </p>
       <p>For information about the <codeph>plpy</codeph> methods, see <xref
-          href="https://www.postgresql.org/docs/8.4/static/plpython-database.html" format="html"
-          scope="external">https://www.postgresql.org/docs/8.4/static/plpython-database.htm</xref>.
+          href="https://www.postgresql.org/docs/8.4/plpython-database.html" format="html"
+          scope="external">https://www.postgresql.org/docs/8.4/plpython-database.htm</xref>.
       </p>
     </body>
   </topic>

--- a/gpdb-doc/dita/ref_guide/extensions/pl_perl.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_perl.xml
@@ -29,7 +29,7 @@
                 functions. PL/Perl provides both trusted and untrusted variants of the language. </p>
             <p> PL/Perl is embedded in your Greenplum Database distribution. Greenplum Database
                 PL/Perl requires Perl to be installed on the system of each database host. </p>
-            <p> Refer to the <xref href="https://www.postgresql.org/docs/9.1/static/plperl.html"
+            <p> Refer to the <xref href="https://www.postgresql.org/docs/9.1/plperl.html"
                     scope="external" format="html"> PostgreSQL PL/Perl documentation </xref> for
                 additional information. </p>
         </body>
@@ -77,7 +77,7 @@
                 user-defined functions. </p>
             <p> PL/Perl has limitations with respect to communication between interpreters and the
                 number of interpreters running in a single process. Refer to the PostgreSQL <xref
-                    href="https://www.postgresql.org/docs/9.1/static/plperl-trusted.html"
+                    href="https://www.postgresql.org/docs/9.1/plperl-trusted.html"
                     scope="external" format="html">Trusted and Untrusted PL/Perl</xref>
                 documentation for additional information. </p>
         </body>
@@ -202,7 +202,7 @@ SELECT perl_max( 1, null );
                 statements accept any string that is an acceptable input format for the function's
                 declared return type. </p>
             <p> Refer to the PostgreSQL <xref
-                    href="https://www.postgresql.org/docs/9.1/static/plperl-funcs.html"
+                    href="https://www.postgresql.org/docs/9.1/plperl-funcs.html"
                     scope="external" format="html">PL/Perl Functions and Arguments</xref>
                 documentation for additional information, including composite type and result set
                 manipulation. </p>
@@ -262,7 +262,7 @@ SELECT return_match( 'iff' );
 (1 row)
 </codeblock>
                 <p> Refer to the PostgreSQL PL/Perl <xref
-                        href="https://www.postgresql.org/docs/9.1/static/plperl-builtins.html"
+                        href="https://www.postgresql.org/docs/9.1/plperl-builtins.html"
                         scope="external" format="html">Built-in Functions</xref> documentation for a
                     detailed discussion of available functions. </p>
             </body>

--- a/gpdb-doc/dita/ref_guide/extensions/pl_python.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_python.xml
@@ -176,7 +176,7 @@ SELECT * FROM composite_type_as_list();
  {{"(first,1)","(second,1)"},{"(first,2)","(second,2)"},{"(first,3)","(second,3)"}}
 (1 row) </codeblock>
         <p>Refer to the PostgreSQL <xref
-            href="https://www.postgresql.org/docs/devel/static/plpython-data.html#plpython-arrays"
+            href="https://www.postgresql.org/docs/devel/plpython-data.html#plpython-arrays"
             scope="external" format="html">Arrays, Lists</xref> documentation for additional
           information on PL/Python handling of arrays and composite types.</p>
       </body>
@@ -191,7 +191,7 @@ SELECT * FROM composite_type_as_list();
           run the query from multiple Python functions.</p>
         <p>PL/Python also supports the <codeph>plpy.subtransaction()</codeph> function to help
           manage <codeph>plpy.execute</codeph> calls in an explicit subtransaction. See <xref
-            href="https://www.postgresql.org/docs/9.1/static/plpython-subtransaction.html"
+            href="https://www.postgresql.org/docs/9.1/plpython-subtransaction.html"
             format="html" scope="external">Explicit Subtransactions</xref> in the PostgreSQL
           documentation for additional information about <codeph>plpy.subtransaction()</codeph>.</p>
       </body>
@@ -237,8 +237,8 @@ SELECT * FROM composite_type_as_list();
           <p>When you prepare an execution plan using the PL/Python module the plan is automatically
             saved. See the Postgres Server Programming Interface (SPI) documentation for information
             about the execution plans <xref
-              href="https://www.postgresql.org/docs/8.3/static/spi.html" scope="external"
-              format="html">https://www.postgresql.org/docs/8.3/static/spi.html</xref>.</p>
+              href="https://www.postgresql.org/docs/8.3/spi.html" scope="external"
+              format="html">https://www.postgresql.org/docs/8.3/spi.html</xref>.</p>
           <p>To make effective use of saved plans across function calls you use one of the Python
             persistent storage dictionaries SD or GD. </p>
           <p>The global dictionary SD is available to store data between function calls. This
@@ -558,8 +558,8 @@ $$ language plpythonu;</codeblock>
         <p>For information about the Python language, see <xref href="https://www.python.org/"
             scope="external" format="html">https://www.python.org/</xref>.</p>
         <p>For information about PL/Python see the PostgreSQL documentation at <xref
-            href="https://www.postgresql.org/docs/8.3/static/plpython.html" scope="external"
-            format="html">https://www.postgresql.org/docs/8.3/static/plpython.html</xref>. </p>
+            href="https://www.postgresql.org/docs/8.3/plpython.html" scope="external"
+            format="html">https://www.postgresql.org/docs/8.3/plpython.html</xref>. </p>
         <p>For information about Python Package Index (PyPI), see <xref
             href="https://pypi.python.org/pypi" format="html" scope="external"
             >https://pypi.python.org/pypi</xref>.</p>

--- a/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
@@ -32,8 +32,8 @@
         Database SQL. </p>
       <p>The PL/pgSQL language is a subset of Oracle PL/SQL. Greenplum Database PL/pgSQL is based on
         Postgres PL/pgSQL. The Postgres PL/pgSQL documentation is at <xref
-          href="https://www.postgresql.org/docs/9.4/static/plpgsql.html" scope="external"
-          format="html">https://www.postgresql.org/docs/9.4/static/plpgsql.html</xref></p>
+          href="https://www.postgresql.org/docs/9.4/plpgsql.html" scope="external"
+          format="html">https://www.postgresql.org/docs/9.4/plpgsql.html</xref></p>
       <p>When using PL/pgSQL functions, function attributes affect how Greenplum Database creates
         query plans. You can specify the attribute <codeph>IMMUTABLE</codeph>,
           <codeph>STABLE</codeph>, or <codeph>VOLATILE</codeph> as part of the
@@ -89,9 +89,9 @@ END [ label ];</codeblock>
           clause effectively forms a subtransaction that can be rolled back without affecting the
           outer transaction. For more about the <codeph>EXCEPTION</codeph> clause, see the
           PostgreSQL documentation on trapping errors at <xref
-            href="https://www.postgresql.org/docs/9.4/static/plpgsql-control-structures.html#PLPGSQL-ERROR-TRAPPING"
+            href="https://www.postgresql.org/docs/9.4/plpgsql-control-structures.html#PLPGSQL-ERROR-TRAPPING"
             scope="external" format="html"
-            >https://www.postgresql.org/docs/9.4/static/plpgsql-control-structures.html#PLPGSQL-ERROR-TRAPPING</xref>. </note>
+            >https://www.postgresql.org/docs/9.4/plpgsql-control-structures.html#PLPGSQL-ERROR-TRAPPING</xref>. </note>
         <p>Keywords are case-insensitive. Identifiers
           are implicitly converted to lowercase unless double-quoted, just as they
           are in ordinary SQL commands.</p>
@@ -135,9 +135,9 @@ $$ LANGUAGE plpgsql;</codeblock>
           <p>You can execute SQL commands with PL/pgSQL statements such as <codeph>EXECUTE</codeph>,
               <codeph>PERFORM</codeph>, and <codeph>SELECT ... INTO</codeph>. For information about
             the PL/pgSQL statements, see <xref
-              href="https://www.postgresql.org/docs/9.4/static/plpgsql-statements.html"
+              href="https://www.postgresql.org/docs/9.4/plpgsql-statements.html"
               scope="external" format="html"
-              >https://www.postgresql.org/docs/9.4/static/plpgsql-statements.html</xref>. </p>
+              >https://www.postgresql.org/docs/9.4/plpgsql-statements.html</xref>. </p>
           <note type="note">The PL/pgSQL statement <codeph>SELECT INTO</codeph> is not supported in
             the <codeph>EXECUTE</codeph> statement. </note>
         </body>
@@ -153,7 +153,7 @@ $$ LANGUAGE plpgsql;</codeblock>
         <p>Greenplum Database will automatically re-plan a saved query plan if there is any schema change to any relation used in the query, or if any user-defined function used in the query is redefined. This makes the re-use of a prepared plan transparent in most cases.</p>
         <p>The SQL commands that you use in a PL/pgSQL function must refer to the same tables and columns on every execution. You cannot use a parameter as the name of a table or a column in an SQL command.</p>
         <p>PL/pgSQL caches a separate query plan for each combination of actual argument types in which you invoke a polymorphic function to ensure that data type differences do not cause unexpected failures.</p>
-        <p>Refer to the PostgreSQL <xref href="https://www.postgresql.org/docs/9.0/static/plpgsql-implementation.html#PLPGSQL-PLAN-CACHING" scope="external" format="html">Plan Caching</xref> documentation for a detailed discussion of plan caching considerations in the PL/pgSQL language.</p>
+        <p>Refer to the PostgreSQL <xref href="https://www.postgresql.org/docs/9.0/plpgsql-implementation.html#PLPGSQL-PLAN-CACHING" scope="external" format="html">Plan Caching</xref> documentation for a detailed discussion of plan caching considerations in the PL/pgSQL language.</p>
     </body>
   </topic>
   <topic id="topic6" xml:lang="en">
@@ -409,8 +409,8 @@ END $$ LANGUAGE plpgsql ;</codeblock></p>
     <title id="pt214450">References</title>
     <body>
       <p>The PostgreSQL documentation about PL/pgSQL is at <xref
-          href="https://www.postgresql.org/docs/9.4/static/plpgsql.html" scope="external"
-          format="html">https://www.postgresql.org/docs/9.4/static/plpgsql.html</xref></p>
+          href="https://www.postgresql.org/docs/9.4/plpgsql.html" scope="external"
+          format="html">https://www.postgresql.org/docs/9.4/plpgsql.html</xref></p>
       <p>Also, see the <codeph><xref href="../sql_commands/CREATE_FUNCTION.xml#topic1"/></codeph>
         command in the <cite>Greenplum Database Reference Guide</cite>.</p>
       <p>For a summary of built-in Greenplum Database functions, see <xref
@@ -418,8 +418,8 @@ END $$ LANGUAGE plpgsql ;</codeblock></p>
           Guide</cite>. For information about using Greenplum Database functions see "Querying Data"
         in the <cite>Greenplum Database Administrator Guide</cite></p>
       <p>For information about porting Oracle functions, see <xref
-          href="https://www.postgresql.org/docs/9.4/static/plpgsql-porting.html" scope="external"
-          format="html">https://www.postgresql.org/docs/9.4/static/plpgsql-porting.html</xref>. For
+          href="https://www.postgresql.org/docs/9.4/plpgsql-porting.html" scope="external"
+          format="html">https://www.postgresql.org/docs/9.4/plpgsql-porting.html</xref>. For
         information about installing and using the Oracle compatibility functions with Greenplum
         Database, see "Oracle Compatibility Functions" in the <cite>Greenplum Database Utility
           Guide</cite>.</p>

--- a/gpdb-doc/dita/ref_guide/function-summary.xml
+++ b/gpdb-doc/dita/ref_guide/function-summary.xml
@@ -112,7 +112,7 @@ SELECT foo();
         PostgreSQL. All functions and operators are supported in Greenplum Database as in PostgreSQL
         with the exception of <codeph>STABLE</codeph> and <codeph>VOLATILE</codeph> functions, which
         are subject to the restrictions noted in <xref href="#topic27" format="dita"/>. See the
-          <xref format="html" href="https://www.postgresql.org/docs/9.4/static/functions.html"
+          <xref format="html" href="https://www.postgresql.org/docs/9.4/functions.html"
           scope="external">Functions and Operators</xref> section of the PostgreSQL documentation
         for more information about these built-in functions and operators.</p>
       <table id="in204913">
@@ -134,7 +134,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-logical.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-logical.html"
                   scope="external">Logical Operators</xref>
               </entry>
               <entry colname="col2"/>
@@ -144,7 +144,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-comparison.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-comparison.html"
                   scope="external">Comparison Operators</xref>
               </entry>
               <entry colname="col2"/>
@@ -154,7 +154,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-math.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-math.html"
                   scope="external">
                   <ph>Mathematical Functions and Operators</ph>
                 </xref>
@@ -166,7 +166,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-string.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-string.html"
                   scope="external">
                   <ph>String Functions and Operators</ph>
                 </xref>
@@ -180,7 +180,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-binarystring.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-binarystring.html"
                   scope="external">
                   <ph>Binary String Functions and Operators</ph>
                 </xref>
@@ -192,7 +192,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-bitstring.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-bitstring.html"
                   scope="external">
                   <ph>Bit String Functions and Operators</ph>
                 </xref>
@@ -204,7 +204,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-matching.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-matching.html"
                   scope="external">
                   <ph>Pattern Matching</ph>
                 </xref>
@@ -216,7 +216,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-formatting.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-formatting.html"
                   scope="external">
                   <ph>Data Type Formatting Functions</ph>
                 </xref>
@@ -228,7 +228,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-datetime.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-datetime.html"
                   scope="external">
                   <ph>Date/Time Functions and Operators</ph>
                 </xref>
@@ -241,7 +241,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-enum.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-enum.html"
                   scope="external"> Enum Support Functions </xref>
               </entry>
               <entry colname="col2"/>
@@ -251,7 +251,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-geometry.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-geometry.html"
                   scope="external">
                   <ph>Geometric Functions and Operators</ph>
                 </xref>
@@ -263,7 +263,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-net.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-net.html"
                   scope="external">
                   <ph>Network Address Functions and Operators</ph>
                 </xref>
@@ -275,7 +275,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-sequence.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-sequence.html"
                   scope="external">
                   <ph>Sequence Manipulation Functions</ph>
                 </xref>
@@ -287,7 +287,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-conditional.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-conditional.html"
                   scope="external">
                   <ph>Conditional Expressions</ph>
                 </xref>
@@ -299,7 +299,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-array.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-array.html"
                   scope="external">
                   <ph>Array Functions and Operators</ph>
                 </xref>
@@ -313,7 +313,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-aggregate.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-aggregate.html"
                   scope="external">
                   <ph>Aggregate Functions</ph>
                 </xref>
@@ -325,7 +325,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-subquery.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-subquery.html"
                   scope="external">
                   <ph>Subquery Expressions</ph>
                 </xref>
@@ -337,7 +337,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-comparisons.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-comparisons.html"
                   scope="external">
                   <ph>Row and Array Comparisons</ph>
                 </xref>
@@ -349,7 +349,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-srf.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-srf.html"
                   scope="external">
                   <ph>Set Returning Functions</ph>
                 </xref>
@@ -361,7 +361,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-info.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-info.html"
                   scope="external">
                   <ph>System Information Functions</ph>
                 </xref>
@@ -385,7 +385,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/functions-admin.html"
+                  href="https://www.postgresql.org/docs/9.4/functions-admin.html"
                   scope="external">
                   <ph>System Administration Functions</ph>
                 </xref>
@@ -400,7 +400,7 @@ SELECT foo();
             <row>
               <entry colname="col1">
                 <xref format="html"
-                  href="https://www.postgresql.org/docs/9.1/static/functions-xml.html"
+                  href="https://www.postgresql.org/docs/9.1/functions-xml.html"
                   scope="external">XML Functions</xref> and function-like expressions </entry>
               <entry colname="col2"/>
               <entry colname="col3">
@@ -1151,7 +1151,7 @@ SELECT sum(myvalue) FROM mymatrix;
               </entry>
               <entry colname="col4">Transforms a one dimensional array into rows. Returns a set of
                   <codeph>anyelement</codeph>, a polymorphic <xref format="html"
-                  href="https://www.postgresql.org/docs/9.4/static/datatype-pseudo.html"
+                  href="https://www.postgresql.org/docs/9.4/datatype-pseudo.html"
                   scope="external"><ph>pseudotype in PostgreSQL</ph></xref>.</entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/preface.xml
+++ b/gpdb-doc/dita/ref_guide/preface.xml
@@ -33,7 +33,7 @@
    <p>This guide assumes knowledge of Linux/UNIX system administration, database management systems,
     database administration, and structured query language (SQL).</p>
    <p>Because Greenplum Database is based on PostgreSQL 8.3.23, this guide assumes some familiarity
-    with PostgreSQL. References to <xref href="https://www.postgresql.org/docs/8.3/static/index.html"
+    with PostgreSQL. References to <xref href="https://www.postgresql.org/docs/8.3/index.html"
      scope="external" format="html">PostgreSQL documentation</xref> are provided throughout this
     guide for features that are similar to those in Greenplum Database.</p>
    <p>This guide contains the following reference documentation:</p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_EXTENSION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_EXTENSION.xml
@@ -85,7 +85,7 @@ and <varname>aggregate_signature</varname> is:
           </pd>
         </plentry>
       </parml>
-      <p>See <xref href="https://www.postgresql.org/docs/9.6/static/extend-extensions.html"
+      <p>See <xref href="https://www.postgresql.org/docs/9.6/extend-extensions.html"
           format="html" scope="external">Packaging Related Objects into an Extension</xref> for more
         information about these operations. </p>
       <p>You must own the extension to use <codeph>ALTER EXTENSION</codeph>. The

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTENSION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTENSION.xml
@@ -130,7 +130,7 @@
                 control file and at least one least one SQL script file. The support files must be
                 installed in the same location on all Greenplum Database hosts. For information
                 about creating new extensions, see PostgreSQL information about <xref
-                    href="https://www.postgresql.org/docs/9.6/static/extend-extensions.html"
+                    href="https://www.postgresql.org/docs/9.6/extend-extensions.html"
                     format="html" scope="external">Packaging Related Objects into an
                     Extension</xref>.</p>
         </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
@@ -36,7 +36,7 @@
                 function. Use <codeph>CREATE OR REPLACE FUNCTION</codeph> to change a function
                 definition without breaking objects that refer to the function.</p><p>For more
                 information about creating functions, see the <xref
-                    href="https://www.postgresql.org/docs/8.3/static/xfunc.html" scope="external"
+                    href="https://www.postgresql.org/docs/8.3/xfunc.html" scope="external"
                     format="html">User Defined Functions</xref> section of the PostgreSQL
                 documentation.</p><sectiondiv id="section4"><b>Limited Use of VOLATILE and STABLE Functions</b><p>To prevent data from
                     becoming out-of-sync across the segments in Greenplum Database, any function
@@ -250,7 +250,7 @@ SELECT foo();</codeblock><p>In
                     <pt>COST <varname>execution_cost</varname></pt>
                     <pd>A positive number identifying the estimated execution cost for the function,
                         in <xref
-                            href="https://www.postgresql.org/docs/8.3/static/runtime-config-query.html#GUC-CPU-OPERATOR-COST"
+                            href="https://www.postgresql.org/docs/8.3/runtime-config-query.html#GUC-CPU-OPERATOR-COST"
                             scope="external" format="html">cpu_operator_cost</xref> units. If the
                         function returns a set, <varname>execution_cost</varname> identifies the
                         cost per returned row. If the cost is not specified, C-language and internal

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
@@ -191,7 +191,7 @@
                                                 disables or enables the GIN index fast update
                                                 technique. A value of ON enables fast update (the
                                                 default), and OFF disables it. See <xref
-                                                  href="https://www.postgresql.org/docs/8.4/static/gin-implementation.html#GIN-FAST-UPDATE"
+                                                  href="https://www.postgresql.org/docs/8.4/gin-implementation.html#GIN-FAST-UPDATE"
                                                   format="html" scope="external">GIN fast update
                                                   technique</xref> in the PostgreSQL documentation
                                                 for more information.<note>Turning
@@ -285,7 +285,7 @@
                                 specified, <codeph>CREATE INDEX</codeph> will interpret it as
                                         <codeph>USING gist</codeph>. </p>
                         <p>For more information on the GiST index type, refer to the <xref
-                                        href="https://www.postgresql.org/docs/8.3/static/indexes-types.html"
+                                        href="https://www.postgresql.org/docs/8.3/indexes-types.html"
                                         scope="external" format="html">PostgreSQL
                                         documentation</xref>.</p>
                         <p>The use of hash indexes has been disabled in Greenplum Database.</p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_LANGUAGE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_LANGUAGE.xml
@@ -37,7 +37,7 @@ CREATE [TRUSTED] [PROCEDURAL] LANGUAGE <varname>name</varname>
                 Greenplum Database distribution: PL/pgSQL, PL/Perl, and PL/Python. Language handlers
                 have also been added for PL/Java and PL/R, but those languages are not pre-installed
                 with Greenplum Database. See the topic on <xref
-                    href="https://www.postgresql.org/docs/8.3/static/xplang.html" scope="external"
+                    href="https://www.postgresql.org/docs/8.3/xplang.html" scope="external"
                     format="html">Procedural Languages</xref> in the PostgreSQL documentation for
                 more information on developing functions using these procedural languages.</p>
             <p>The PL/Perl, PL/Java, and PL/R libraries require the correct versions of Perl, Java,

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TYPE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TYPE.xml
@@ -38,7 +38,7 @@ when all that is wanted is to define a type. A stand-alone composite
 type is useful as the argument or return type of a function.</p></sectiondiv>
 <sectiondiv id="enum"><b>Enumerated Types</b>
 <p>The second form of <codeph>CREATE TYPE</codeph> creates an enumerated (<codeph>ENUM</codeph>) type, as described in 
-<xref href="https://www.postgresql.org/docs/8.3/static/datatype-enum.html" format="html" scope="external">Enumerated Types</xref> in the 
+<xref href="https://www.postgresql.org/docs/8.3/datatype-enum.html" format="html" scope="external">Enumerated Types</xref> in the 
 PostgreSQL documentation. Enum types take a list of one or more quoted labels, each of which must be less than 
 <codeph>NAMEDATALEN</codeph> bytes long (64 in a standard build).</p>
 </sectiondiv>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_EXTENSION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_EXTENSION.xml
@@ -43,7 +43,7 @@
           <pd>
             <p>Automatically drop objects that depend on the extension, and in turn all objects that
               depend on those objects. See the PostgreSQL information about <xref
-                href="https://www.postgresql.org/docs/9.6/static/ddl-depend.html" format="html"
+                href="https://www.postgresql.org/docs/9.6/ddl-depend.html" format="html"
                 scope="external">Dependency Tracking</xref>.</p>
           </pd>
         </plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/SET.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SET.xml
@@ -94,7 +94,7 @@ SET [SESSION | LOCAL] TIME ZONE {<varname>timezone</varname> | LOCAL | DEFAULT}<
           <pt>DEFAULT</pt>
           <pd>Set the time zone to your local time zone (the one that the server's operating system
             defaults to). See the <xref
-              href="https://www.postgresql.org/docs/8.3/static/datatype-datetime.html#DATATYPE-TIMEZONES"
+              href="https://www.postgresql.org/docs/8.3/datatype-datetime.html#DATATYPE-TIMEZONES"
               scope="external" format="html">Time zone section of the PostgreSQL
               documentation</xref> for more information about time zones in Greenplum Database.</pd>
         </plentry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
@@ -63,16 +63,16 @@
       Database, see the following sections of the PostgreSQL documentation:</p>
     <ul id="ul_c5v_3bd_xp">
       <li>
-        <xref href="https://www.postgresql.org/docs/8.3/static/views-overview.html" scope="external"
+        <xref href="https://www.postgresql.org/docs/8.3/views-overview.html" scope="external"
           format="html">System Views</xref>
       </li>
       <li>
         <xref
-          href="https://www.postgresql.org/docs/8.3/static/monitoring-stats.html#MONITORING-STATS-VIEWS-TABLE"
+          href="https://www.postgresql.org/docs/8.3/monitoring-stats.html#MONITORING-STATS-VIEWS-TABLE"
           scope="external" format="html">Statistics Collector Views</xref>
       </li>
       <li>
-        <xref href="https://www.postgresql.org/docs/8.3/static/information-schema.html"
+        <xref href="https://www.postgresql.org/docs/8.3/information-schema.html"
           scope="external" format="html">The Information Schema</xref>
       </li>
     </ul>

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -26,7 +26,7 @@
       <p>Client access and authentication is controlled by a configuration file named
           <codeph>pg_hba.conf</codeph> (the standard PostgreSQL host-based authentication file). For
         detailed information about this file, see <xref
-          href="https://www.postgresql.org/docs/9.1/static/auth-pg-hba-conf.html" format="html"
+          href="https://www.postgresql.org/docs/9.1/auth-pg-hba-conf.html" format="html"
           scope="external">The pg_hba.conf File</xref> in the PostgreSQL documentation. </p>
       <p>In Greenplum Database, the <codeph>pg_hba.conf</codeph> file of the master instance
         controls client access and authentication to your Greenplum system. The segments also have

--- a/gpdb-doc/dita/security-guide/topics/Encryption.xml
+++ b/gpdb-doc/dita/security-guide/topics/Encryption.xml
@@ -298,7 +298,7 @@ ssb   2048R/4FD2EFBB 2015-01-13</codeblock><p>2027CC30
             commands:<codeblock># gpg -a --export 4FD2EFBB &gt; public.key
 # gpg -a --export-secret-keys 2027CC30 &gt; secret.key</codeblock></li>
         </ol>
-        <p>See the <xref href="https://www.postgresql.org/docs/8.3/static/pgcrypto.html"
+        <p>See the <xref href="https://www.postgresql.org/docs/8.3/pgcrypto.html"
             format="html" scope="external">pgcrypto</xref> documentation for more information about
           PGP encryption functions. </p>
       </section>
@@ -467,7 +467,7 @@ key_used | 9D4D255F4FD2EFBB
             <note>Different keys may have the same ID. This is rare, but is a normal event. The
               client application should try to decrypt with each one to see which fits — like
               handling <codeph>ANYKEY</codeph>. See <xref
-                href="https://www.postgresql.org/docs/8.3/static/pgcrypto.html" format="html"
+                href="https://www.postgresql.org/docs/8.3/pgcrypto.html" format="html"
                 scope="external">pgp_key_id()</xref> in the pgcrypto documentation. </note>
           </li>
           <li>Decrypt the data using the private key.

--- a/gpdb-doc/dita/security-guide/topics/preface.xml
+++ b/gpdb-doc/dita/security-guide/topics/preface.xml
@@ -9,7 +9,7 @@
       structured query language (SQL) is helpful.</p>
     <p>Because Greenplum Database is based on PostgreSQL8.3.23, this guide assumes some familiarity
       with PostgreSQL. References to <xref
-        href="https://www.postgresql.org/docs/8.3/static/index.html" scope="external" format="html"
+        href="https://www.postgresql.org/docs/8.3/index.html" scope="external" format="html"
           ><ph>PostgreSQL documentation</ph></xref> are provided throughout this guide for features
       that are similar to those in Greenplum Database.</p>
     <p>This information is intended for system administrators responsible for administering a

--- a/gpdb-doc/dita/utility_guide/client_utilities/createlang.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/createlang.xml
@@ -30,7 +30,7 @@
       <p>The <codeph>PL/pgSQL</codeph> language is registered in all databases by default.</p>
       <p>Greenplum Database also has language handlers for <codeph>PL/Java</codeph> and
           <codeph>PL/R</codeph>, but those languages are not pre-installed with Greenplum Database.
-        See the <xref href="https://www.postgresql.org/docs/8.3/static/xplang.html" scope="external"
+        See the <xref href="https://www.postgresql.org/docs/8.3/xplang.html" scope="external"
           format="html">Procedural Languages</xref> section in the PostgreSQL documentation for more
         information.</p>
     </section>

--- a/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
@@ -848,7 +848,7 @@ lo_import 152801</codeblock>
         quotes loses its special meaning and is matched literally.</p>
       <p>Advanced users can use regular-expression notations. All regular expression special
         characters work as specified in the <xref
-          href="https://www.postgresql.org/docs/8.3/static/functions-matching.html#FUNCTIONS-POSIX-REGEXP"
+          href="https://www.postgresql.org/docs/8.3/functions-matching.html#FUNCTIONS-POSIX-REGEXP"
           scope="external" format="html">PostgreSQL documentation on regular expressions</xref>,
         except for <codeph>.</codeph> which is taken as a separator as mentioned above,
           <codeph>*</codeph> which is translated to the regular-expression notation

--- a/gpdb-doc/dita/utility_guide/dblink.xml
+++ b/gpdb-doc/dita/utility_guide/dblink.xml
@@ -19,7 +19,7 @@
       other databases. <codeph>dblink</codeph> is not intended for use as a replacement for external
       tables or for administrative tools such as <codeph>gpcopy</codeph> or
         <codeph>gptransfer</codeph>.</p>
-    <p>Refer to <xref href="https://www.postgresql.org/docs/8.4/static/dblink.html" format="html"
+    <p>Refer to <xref href="https://www.postgresql.org/docs/8.4/dblink.html" format="html"
         scope="external">dblink</xref> in the PostgreSQL documentation for more information about
       individual <codeph>dblink</codeph> functions. </p>
   </body>

--- a/gpdb-doc/dita/utility_guide/orafce_ref.xml
+++ b/gpdb-doc/dita/utility_guide/orafce_ref.xml
@@ -490,7 +490,7 @@ FROM suppliers;</codeblock></li>
         <p>This command is compatible with Oracle syntax and is provided for convenience. </p>
         <title class="- topic/title ">See Also</title>
         <p>PostgreSQL <codeph><xref
-              href="https://www.postgresql.org/docs/8.3/static/functions-binarystring.html"
+              href="https://www.postgresql.org/docs/8.3/functions-binarystring.html"
               scope="external" format="html" class="- topic/xref ">decode</xref></codeph> (not
           compatible with Oracle)</p>
       </section>
@@ -1125,7 +1125,7 @@ from clients;</codeblock>
           beginning with the second character.</p>
         <title class="- topic/title ">Compatibility</title>
         <p>PostgreSQL <codeph><xref
-              href="https://www.postgresql.org/docs/8.3/static/functions-string.html"
+              href="https://www.postgresql.org/docs/8.3/functions-string.html"
               scope="external" format="html" class="- topic/xref ">substr</xref></codeph> (not
           compatible with Oracle)</p>
       </section>
@@ -1295,7 +1295,7 @@ FROM ClientDB;</codeblock>
         <p>This command is compatible with Oracle syntax and is provided for convenience. </p>
         <title class="- topic/title ">See Also</title>
         <p>PostgreSQL <codeph><xref
-              href="https://www.postgresql.org/docs/8.3/static/functions-math.html" scope="external"
+              href="https://www.postgresql.org/docs/8.3/functions-math.html" scope="external"
               format="html" class="- topic/xref ">round</xref></codeph> (not compatible with
           Oracle)</p>
       </section>
@@ -1487,7 +1487,7 @@ FROM ClientDB;</codeblock>
         <p>This command is compatible with Oracle syntax and is provided for convenience. </p>
         <title class="- topic/title ">See Also</title>
         <p>PostgreSQL <codeph><xref
-              href="https://www.postgresql.org/docs/8.3/static/functions-math.html" scope="external"
+              href="https://www.postgresql.org/docs/8.3/functions-math.html" scope="external"
               format="html" class="- topic/xref ">trunc</xref></codeph> (not compatible with
           Oracle)</p>
       </section>

--- a/gpdb-doc/dita/utility_guide/preface.xml
+++ b/gpdb-doc/dita/utility_guide/preface.xml
@@ -37,7 +37,7 @@
     database administration, and structured query language (SQL).</p>
    <p>Because Greenplum Database is based on PostgreSQL 8.3.23, this guide assumes some familiarity
     with PostgreSQL. Links and cross-references to <xref
-     href="https://www.postgresql.org/docs/8.3/static/index.html" scope="external" format="html"
+     href="https://www.postgresql.org/docs/8.3/index.html" scope="external" format="html"
       ><ph>PostgreSQL documentation</ph></xref> are provided throughout this guide for features that
     are similar to those in Greenplum Database.</p>
   </body>

--- a/src/interfaces/gppc/README.md
+++ b/src/interfaces/gppc/README.md
@@ -202,7 +202,7 @@ The more examples of using GPCC table function are listed in
 https://github.com/greenplum-db/gpdb/tree/master/src/interfaces/gppc/test/tabfunc_gppc_demo
 
 ### Reference
-https://www.postgresql.org/docs/devel/static/xfunc-c.html  
+https://www.postgresql.org/docs/devel/xfunc-c.html
 https://github.com/greenplum-db/gpdb/blob/master/src/include/gppc.h  
 https://github.com/greenplum-db/gpdb/tree/master/src/interfaces/gppc/test/gppc_demo  
 https://github.com/greenplum-db/gpdb/tree/master/src/interfaces/gppc/test/tabfunc_gppc_demo

--- a/src/test/isolation2/expected/resgroup/resgroup_name_convention.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_name_convention.out
@@ -2,7 +2,7 @@
 -- Test the resource group name convention.
 --
 -- Resource group names follow the general object name convention:
--- https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+-- https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 --
 -- Besides that there are 3 reserved names:
 -- * default_group, admin_group: names of the 2 default resource groups;

--- a/src/test/isolation2/sql/resgroup/resgroup_name_convention.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_name_convention.sql
@@ -2,7 +2,7 @@
 -- Test the resource group name convention.
 --
 -- Resource group names follow the general object name convention:
--- https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+-- https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 --
 -- Besides that there are 3 reserved names:
 -- * default_group, admin_group: names of the 2 default resource groups;


### PR DESCRIPTION
Commit 17f9b7f070dbe17b2844a8b4dd428 in the pgweb repository removed the /static/ portion on all doc URLs, leaving a redirect in place. To avoid incurring a needless redirect, remove the /static/ part in the links to the PostgreSQL documentation.

The /static/ URLs stem from a time when there were interactive docs that had comment functionality. These docs were removed a very long time ago, but the static differentiator was left in place until now.

This leaves upstream files untouched, as well as Tinc testfiles which seem quite uninteresting to update.