### PR TITLE
Remove unused arguments to query

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2589,11 +2589,9 @@ def missingEntryQuery(max_content, catname, pkey, castedPkey):
           WHERE master.segid is null
              OR segids is null
              OR NOT segids @> (select array_agg(content::int4) from gp_segment_configuration WHERE content >= 0)
-          """.format(oidcasted_pk=','.join(castedPkey),
-                     primary_key=','.join(pkey),
+          """.format(primary_key=','.join(pkey),
                      catalog=catname,
-                     catalog_exclude=catalog_exclude,
-                     max_content=max_content)
+                     catalog_exclude=catalog_exclude)
 
     return qry
 


### PR DESCRIPTION
Commit 226e8867d88d3dca0c1381cd0d90255c91221058 removed oidcasted_pk and max_content from the SQL query, but didn't remove the arguments. While they don't cause an issue as they will be unused, remove to avoid confusing readers.