### PR TITLE
Recommit remove master syncrepwait hack

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -338,6 +338,19 @@ def check_and_start_standby():
                            standby.port,
                            standby.dbid,
                            array.getNumSegmentContents())
+    # set synchronous_standby_names to '*'
+    cmd = gp.GpAddConfigScript('master',
+                               array.master.datadir,
+                               'synchronous_standby_names',
+                               value="'*'",
+                               removeonly=False,
+                               ctxt=gp.REMOTE,
+                               remoteHost=array.master.hostname,
+                               autoconf=True)
+    cmd.run(validateAfter=True)
+    # make it effective
+    pg.ReloadDbConf.local('pg_ctl reload', array.master)
+
     logger.info("Successfully started standby master")
 
 #-------------------------------------------------------------------------

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -277,6 +277,20 @@ def delete_standby(options):
     # Disable Ctrl-C
     signal.signal(signal.SIGINT,signal.SIG_IGN)
     
+    # If the standby is down, and the synchronous_standby_names is *, the cluster will not start
+    # set synchronous_standby_names to ''
+    cmd = gp.GpAddConfigScript('master',
+                               array.master.datadir,
+                               'synchronous_standby_names',
+                               value="''",
+                               removeonly=False,
+                               ctxt=gp.REMOTE,
+                               remoteHost=array.master.hostname,
+                               autoconf=True)
+    cmd.run(validateAfter=True)
+    # make it effective
+    pg.ReloadDbConf.local('pg_ctl reload', array.master)
+
     try:
         remove_standby_from_catalog(options, array)
     except Exception, ex:

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -976,7 +976,7 @@ class GpCatVersionDirectory(Command):
 
 #-----------------------------------------------
 class GpAddConfigScript(Command):
-    def __init__(self, name, directorystring, entry, value=None, removeonly=False, ctxt=LOCAL, remoteHost=None):
+    def __init__(self, name, directorystring, entry, value=None, removeonly=False, ctxt=LOCAL, remoteHost=None, autoconf=False):
         cmdStr="echo '%s' | $GPHOME/sbin/gpaddconfig.py --entry %s" % (directorystring, entry)
         if value:
             # value will be encoded and unencoded in the script to protect against shell interpretation
@@ -984,6 +984,8 @@ class GpAddConfigScript(Command):
             cmdStr = cmdStr + " --value '" + value + "'"
         if removeonly:
             cmdStr = cmdStr + " --removeonly "
+        if autoconf:
+            cmdStr = cmdStr + " --autoconf "
 
         Command.__init__(self,name,cmdStr,ctxt,remoteHost)
 

--- a/gpMgmt/sbin/gpaddconfig.py
+++ b/gpMgmt/sbin/gpaddconfig.py
@@ -33,6 +33,7 @@ def parseargs():
     parser.add_option('--entry', type='string')
     parser.add_option('--value', type='string')
     parser.add_option('--removeonly', action='store_true')
+    parser.add_option('--autoconf', action='store_true')
     parser.set_defaults(removeonly=False)
 
     # Parse the command line arguments
@@ -61,7 +62,10 @@ while line:
 
     directory = line.rstrip()
 
-    filename = directory + "/postgresql.conf"
+    if options.autoconf:
+        filename = directory + "/postgresql.auto.conf"
+    else:
+        filename = directory + "/postgresql.conf"
     if not os.path.exists(filename):
         raise Exception("path does not exist" + filename)
 

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -101,8 +101,6 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 	char	   *new_status = NULL;
 	const char *old_status;
 	int			mode = SyncRepWaitMode;
-	bool		syncStandbyPresent = false;
-	int			i = 0;
 
 	/*
 	 * SIGUSR1 is used to wake us up, cannot wait from inside SIGUSR1 handler

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -240,3 +240,15 @@ a
 9 
 10
 (12 rows)
+
+-- set synchronous_standby_names to default value ''
+alter system set synchronous_standby_names to '';
+ALTER
+
+-- reload to make synchronous_standby_names effective
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=-1), 'reload', NULL, NULL, NULL);
+pg_ctl          
+----------------
+server signaled
+
+(1 row)

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -5,7 +5,7 @@ create language plpythonu;
 CREATE
 -- end_ignore
 
-create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int) returns text as $$ import subprocess cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
+create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int) returns text as $$ import subprocess cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid) cmd = cmd + '-o "%s" start' % opts elif command == 'reload': cmd = cmd + command else: return 'Invalid command input' return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
 CREATE
 
 -- make sure we are in-sync for the primary we will be testing with
@@ -150,3 +150,93 @@ a
 9 
 10
 (14 rows)
+
+-- set synchronous_standby_names to '*'
+alter system set synchronous_standby_names to '*';
+ALTER
+
+-- reload to make synchronous_standby_names effective
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=-1), 'reload', NULL, NULL, NULL);
+pg_ctl          
+----------------
+server signaled
+
+(1 row)
+
+-- create table and show commits are not blocked
+2: create table standbywalrep_commit_blocking (a int) distributed by (a);
+CREATE
+2: insert into standbywalrep_commit_blocking values (1);
+INSERT 1
+
+-- stop standby and show commit will block
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=-1), 'stop', NULL, NULL, NULL);
+pg_ctl                                              
+----------------------------------------------------
+waiting for server to shut down done
+server stopped
+
+(1 row)
+
+-- this should block since standby is not up and sync replication is on
+3: begin;
+BEGIN
+3: insert into standbywalrep_commit_blocking values (2);
+INSERT 1
+3&: commit;  <waiting ...>
+
+-- set synchronous_standby_names to ''
+alter system set synchronous_standby_names to '';
+ALTER
+
+-- reload to make synchronous_standby_names effective
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=-1), 'reload', NULL, NULL, NULL);
+pg_ctl          
+----------------
+server signaled
+
+(1 row)
+
+-- should unblock and commit now that synchronous_standby_names set to ''
+3<:  <... completed>
+COMMIT
+
+-- bring the standby back up
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=-1), 'start', (select port from gp_segment_configuration where content = -1 and preferred_role = 'm'), 0, (select dbid from gp_segment_configuration c where c.role='m' and c.content=-1));
+pg_ctl          
+----------------
+server starting
+
+(1 row)
+
+-- set synchronous_standby_names to '*'
+alter system set synchronous_standby_names to '*';
+ALTER
+
+-- reload to make synchronous_standby_names effective
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=-1), 'reload', NULL, NULL, NULL);
+pg_ctl          
+----------------
+server signaled
+
+(1 row)
+
+-- everything should be back to normal
+4: insert into standbywalrep_commit_blocking select i from generate_series(1,10)i;
+INSERT 10
+4: select * from standbywalrep_commit_blocking order by a;
+a 
+--
+1 
+1 
+2 
+2 
+3 
+4 
+5 
+6 
+7 
+8 
+9 
+10
+(12 rows)

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -116,3 +116,9 @@ alter system set synchronous_standby_names to '*';
 -- everything should be back to normal
 4: insert into standbywalrep_commit_blocking select i from generate_series(1,10)i;
 4: select * from standbywalrep_commit_blocking order by a;
+
+-- set synchronous_standby_names to default value ''
+alter system set synchronous_standby_names to '';
+
+-- reload to make synchronous_standby_names effective
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=-1), 'reload', NULL, NULL, NULL);

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -13,6 +13,8 @@ returns text as $$
     elif command == 'start':
         opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid)
         cmd = cmd + '-o "%s" start' % opts
+    elif command == 'reload':
+        cmd = cmd + command
     else:
         return 'Invalid command input'
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
@@ -74,3 +76,43 @@ select gp_inject_fault('fts_probe', 'reset', 1);
 -- everything should be back to normal
 4: insert into segwalrep_commit_blocking select i from generate_series(1,10)i;
 4: select * from segwalrep_commit_blocking order by a;
+
+-- set synchronous_standby_names to '*'
+alter system set synchronous_standby_names to '*';
+
+-- reload to make synchronous_standby_names effective
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=-1), 'reload', NULL, NULL, NULL);
+
+-- create table and show commits are not blocked
+2: create table standbywalrep_commit_blocking (a int) distributed by (a);
+2: insert into standbywalrep_commit_blocking values (1);
+
+-- stop standby and show commit will block
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=-1), 'stop', NULL, NULL, NULL);
+
+-- this should block since standby is not up and sync replication is on
+3: begin;
+3: insert into standbywalrep_commit_blocking values (2);
+3&: commit;
+
+-- set synchronous_standby_names to ''
+alter system set synchronous_standby_names to '';
+
+-- reload to make synchronous_standby_names effective
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=-1), 'reload', NULL, NULL, NULL);
+
+-- should unblock and commit now that synchronous_standby_names set to ''
+3<:
+
+-- bring the standby back up
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=-1), 'start', (select port from gp_segment_configuration where content = -1 and preferred_role = 'm'), 0, (select dbid from gp_segment_configuration c where c.role='m' and c.content=-1));
+
+-- set synchronous_standby_names to '*'
+alter system set synchronous_standby_names to '*';
+
+-- reload to make synchronous_standby_names effective
+-1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=-1), 'reload', NULL, NULL, NULL);
+
+-- everything should be back to normal
+4: insert into standbywalrep_commit_blocking select i from generate_series(1,10)i;
+4: select * from standbywalrep_commit_blocking order by a;


### PR DESCRIPTION
Recommit the four commits, which was reverted by me when prod pipeline is yellow. And add a new commit to fix the yellow pipeline.

Prod pipeline is yellow because it was blocked when it tries to `gpstart -a`.

The reason is that after test `isolation2/commit_blocking`, `synchronous_standby_names` set to `* `during the test. 

So after `gpstop -a `successfully performed,  `gpstart -a` will block. ( icw_gporca_centos6 job has this  gpdb cluster restart step, while icw_planner_centos6 job do not has this step, so only icw_gporca_centos6 was blocked )

To fix the blocking during `gpstart -a`. `synchronous_standby_names` should set back to empty(empty is the default value).

The first, second, third, fourth commit is the one I reverted last Friday, the last commit is the new added, to fix the yellow pipeline.