### PR TITLE
Do not generate ReshuffleExpr for replicated table

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14453,7 +14453,7 @@ ReshuffleRelationData(Relation rel)
 	char				*namespace_name;
 	RangeVar			*relation;
 	UpdateStmt			*stmt = makeNode(UpdateStmt);
-	ReshuffleExpr		*reshuffleExpr = makeNode(ReshuffleExpr);
+	ReshuffleExpr		*reshuffleExpr = NULL;
 	GpPolicy 			*policy = rel->rd_cdbpolicy;
 	int					i;
 	Query 				*q;
@@ -14485,9 +14485,13 @@ ReshuffleRelationData(Relation rel)
 	stmt->relation = relation;
 
 	/* make an reshuffle expression to filter some tuples */
-	reshuffleExpr->newSegs = getgpsegmentCount();
-	reshuffleExpr->oldSegs = policy->numsegments;
-	reshuffleExpr->ptype = policy->ptype;
+	if (!GpPolicyIsReplicated(policy))
+	{
+		reshuffleExpr = makeNode(ReshuffleExpr);
+		reshuffleExpr->newSegs = getgpsegmentCount();
+		reshuffleExpr->oldSegs = policy->numsegments;
+		reshuffleExpr->ptype = policy->ptype;
+	}
 	stmt->whereClause = (Node*)reshuffleExpr;
 
 	/* make an target list for the UpdateStmt */

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -5212,6 +5212,7 @@ ExecEvalReshuffleExpr(ReshuffleExprState *astate,
 	bool		result;
 
 	Assert(!IS_QUERY_DISPATCHER());
+	Assert(sr->ptype != POLICYTYPE_REPLICATED);
 
 	if(sr->ptype == POLICYTYPE_PARTITIONED)
 	{
@@ -5251,26 +5252,6 @@ ExecEvalReshuffleExpr(ReshuffleExprState *astate,
 
 			result = (cdbhashrandomseg(newSegs) >= sr->oldSegs);
 		}
-	}
-	else if(sr->ptype == POLICYTYPE_REPLICATED)
-	{
-		/*
-		 * For replicated tables:
-		 * if we have 3 old segments: 0 1 2
-		 * and we add 4 new segments: 3 4 5 6
-		 * The seg#0 is responsible for reshuffling data into seg#3 and seg#6
-		 * The seg#1 is responsible for reshuffling data into seg#4
-		 * The seg#2 is responsible for reshuffling data into seg#5
-		 *
-		 * 1. New segments need not reshuffle data
-		 * 2. if we have 3 old segments and only add 1 new segments,
-		 * 	  then the seg#1 and seg#2 need not reshuffle data
-		 */
-		if (GpIdentity.segindex >= sr->oldSegs ||
-			GpIdentity.segindex + sr->oldSegs >= sr->newSegs)
-			result = false;
-		else
-			result = true;
 	}
 	else
 		result = false;

--- a/src/backend/executor/nodeReshuffle.c
+++ b/src/backend/executor/nodeReshuffle.c
@@ -97,7 +97,8 @@
  * 		For replicated table, the table data is same in the all old
  * 		segments, so there do not need to delete any tuples, it only
  * 		need copy the tuple which is in the old segments to the new
- * 		segments, so the ReshuffleExpr do not filte any tuples, In
+ * 		segments, the ReshuffleExpr do not filte any tuples, and
+ * 		we make it NULL pointer in the Parse Tree as an optimization,
  * 		the Reshuffle node, we neglect the tuple which is generated
  * 		for deleting, only return the inserting tuple to motion. Let
  * 		me illustrate this with an example:


### PR DESCRIPTION
When we expand a partial replicated table via `alter
table t expand table`, internally we use the split-update
framework to implement the expansion. That framework is
designed for hash-distribtued tables at first. For replicated
table, we do not need it at all because we need to transfer
all data in a replicated table.

No need to add cases because the reshuffle test cases are enough.

------

You can be familiar with the logic by reading the comments here: https://github.com/greenplum-db/gpdb/blob/master/src/backend/executor/nodeReshuffle.c#L8 

I find that in the plan generated by `alter table repli_table expand table`, the scan slice's numsegments is full cluster size. I think it could be the replicated's old numsegments because there is no data in the new segments yet.

~~Consider adding this improvement in this PR too.~~

**I decide to open a new PR to modify the slice info, not including in this PR because expand other kind of table also has such a problem.** A new PR is opened: https://github.com/greenplum-db/gpdb/pull/6323

**So this PR is ready. Wait for more comments to merge it.**