### PR TITLE
Correct numsegments in reshuffle node

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1538,10 +1538,10 @@ make_reshuffle(PlannerInfo *root,
 			   RangeTblEntry *rte,
 			   Index resultRelationsIdx)
 {
+	int 		 i;
 	Reshuffle 	*reshufflePlan = makeNode(Reshuffle);
 	Relation 	rel = relation_open(rte->relid, NoLock);
 	GpPolicy 	*policy = rel->rd_cdbpolicy;
-	int 		i;
 
 	reshufflePlan->plan.targetlist = list_copy(subplan->targetlist);
 	reshufflePlan->plan.lefttree = subplan;
@@ -1563,8 +1563,7 @@ make_reshuffle(PlannerInfo *root,
 
 	reshufflePlan->ptype = policy->ptype;
 
-	/* FIXME: pass old or new cluster size to numsegments? */
-	mark_plan_strewn((Plan *) reshufflePlan, GP_POLICY_ALL_NUMSEGMENTS);
+	mark_plan_strewn((Plan *) reshufflePlan, subplan->flow->numsegments);
 
 	heap_close(rel, NoLock);
 

--- a/src/test/regress/expected/gangsize.out
+++ b/src/test/regress/expected/gangsize.out
@@ -221,3 +221,22 @@ INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 end;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- add test for table expand
+begin;
+alter table random_2_0 expand table;
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
+abort;
+INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents: 0 1 2
+begin;
+alter table replicate_2_1 expand table;
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
+abort;
+INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents: 0 1 2
+begin;
+alter table hash_2_3_4 expand table;
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
+abort;
+INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents: 0 1 2

--- a/src/test/regress/expected/gangsize_optimizer.out
+++ b/src/test/regress/expected/gangsize_optimizer.out
@@ -219,3 +219,22 @@ INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 end;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- add test for table expand
+begin;
+alter table random_2_0 expand table;
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
+abort;
+INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents: 0 1 2
+begin;
+alter table replicate_2_1 expand table;
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
+abort;
+INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents: 0 1 2
+begin;
+alter table hash_2_3_4 expand table;
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
+abort;
+INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents: 0 1 2

--- a/src/test/regress/sql/gangsize.sql
+++ b/src/test/regress/sql/gangsize.sql
@@ -139,3 +139,16 @@ delete from hash_2_3_4 where a in (1, 2, 3);
 begin;
 delete from hash_2_3_4 where a = 4 or a = 5;
 end;
+
+-- add test for table expand
+begin;
+alter table random_2_0 expand table;
+abort;
+
+begin;
+alter table replicate_2_1 expand table;
+abort;
+
+begin;
+alter table hash_2_3_4 expand table;
+abort;


### PR DESCRIPTION
Previously the reshuffle node's numsegments is always
set to the cluster size. Now we have flexible gang & dispath
API, we should correct the numsegments field of reshuffle
node to set it as the its lefttree's flow->numsegments.

Co-authored-by: Shujie Zhang <shzhang@pivotal.io>
Co-authored-by: Zhenghua Lyu <zlv@pivotal.io>