### PR TITLE
Hook script to run regress tests with random numsegments.

### DIFF
--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -553,7 +553,12 @@ sub format_query_output
     # EXPLAIN (COSTS OFF) output is *not* processed. The output with COSTS OFF
     # shouldn't contain anything that varies across runs, and shouldn't need
     # sanitizing.
-    if (exists($directive->{explain}) && $directive->{explain} ne 'costs_off'
+	#
+	# However when -ignore_plans is specified we also need to process
+	# EXPLAIN (COSTS OFF) to ignore the segments information.
+    if (exists($directive->{explain})
+		&& ($glob_ignore_plans
+			|| $directive->{explain} ne 'costs_off')
         && (!exists($directive->{explain_processing})
             || ($directive->{explain_processing} =~ m/on/)))
     {

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -8,6 +8,10 @@
 # of the test. Ignore the NOTICE if it exists already.
 m/^NOTICE:  extension "gp_inject_fault" already exists, skipping/
 
+# Some tests use the gp_debug_numsegments extension, and create it at the beginning
+# of the test. Ignore the NOTICE if it exists already.
+m/NOTICE:  extension "gp_debug_numsegments" already exists, skipping/
+
 # match ignore the gpmon WARNING message
 m/^WARNING:  gpmon:.*Connection refused.*/
 

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -117,6 +117,7 @@ static _stringlist *extra_install = NULL;
 static char *initfile = NULL;
 static char *aodir = NULL;
 static char *resgroupdir = NULL;
+static bool ignore_plans = false;
 
 /* internal variables */
 static const char *progname;
@@ -1587,6 +1588,7 @@ results_differ(const char *testname, const char *resultsfile, const char *defaul
 	int			i;
 	int			l;
 	const char *platform_expectfile;
+	const char *ignore_plans_opts;
 
 	/*
 	 * We can pass either the resultsfile or the expectfile, they should have
@@ -1599,6 +1601,11 @@ results_differ(const char *testname, const char *resultsfile, const char *defaul
 	else
 		strlcpy(expectfile, default_expectfile, sizeof(expectfile));
 
+	if (ignore_plans)
+		ignore_plans_opts = " -gpd_ignore_plans";
+	else
+		ignore_plans_opts = "";
+
 	/* Name to use for temporary diff file */
 	snprintf(diff, sizeof(diff), "%s.diff", resultsfile);
     
@@ -1606,18 +1613,18 @@ results_differ(const char *testname, const char *resultsfile, const char *defaul
 	if (initfile)
 	{
 	  snprintf(diff_opts, sizeof(diff_opts),
-			   "%s --gpd_init %s", basic_diff_opts, initfile);
+			   "%s%s --gpd_init %s", basic_diff_opts, ignore_plans_opts, initfile);
 
 	  snprintf(m_pretty_diff_opts, sizeof(m_pretty_diff_opts),
-			   "%s --gpd_init %s", pretty_diff_opts, initfile);
+			   "%s%s --gpd_init %s", pretty_diff_opts, ignore_plans_opts, initfile);
 	}
 	else
 	{
 		snprintf(diff_opts, sizeof(diff_opts),
-			   "%s", basic_diff_opts);
+			   "%s%s", basic_diff_opts, ignore_plans_opts);
 
 		snprintf(m_pretty_diff_opts, sizeof(m_pretty_diff_opts),
-                 "%s", pretty_diff_opts);
+				 "%s%s", pretty_diff_opts, ignore_plans_opts);
 	}
 
 	/* OK, run the diff */
@@ -2438,6 +2445,7 @@ help(void)
 	printf(_("  --ao-dir=DIR              directory name prefix containing generic\n"));
 	printf(_("                            UAO row and column tests\n"));
 	printf(_("  --resgroup-dir=DIR        directory name prefix containing resgroup tests\n"));
+	printf(_("  --ignore-plans            ignore any explain plan diffs\n"));
 	printf(_("\n"));
 	printf(_("Options for \"temp-install\" mode:\n"));
 	printf(_("  --extra-install=DIR       additional directory to install (e.g., contrib)\n"));
@@ -2490,6 +2498,7 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
         {"ao-dir", required_argument, NULL, 26},
         {"resgroup-dir", required_argument, NULL, 27},
         {"exclude-tests", required_argument, NULL, 28},
+		{"ignore-plans", no_argument, NULL, 29},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -2616,6 +2625,9 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
             case 28:
                 split_to_stringlist(strdup(optarg), ", ", &exclude_tests);
                 break;
+			case 29:
+				ignore_plans = true;
+				break;
 			default:
 				/* getopt_long already emitted a complaint */
 				fprintf(stderr, _("\nTry \"%s -h\" for more information.\n"),

--- a/src/test/regress/pg_regress.h
+++ b/src/test/regress/pg_regress.h
@@ -41,6 +41,7 @@ extern _stringlist *dblist;
 extern bool debug;
 extern char *inputdir;
 extern char *outputdir;
+extern char *prehook;
 extern char *launcher;
 extern bool optimizer_enabled;
 extern bool resgroup_enabled;

--- a/src/test/regress/pg_regress_main.c
+++ b/src/test/regress/pg_regress_main.c
@@ -35,7 +35,7 @@ psql_start_test(const char *testname,
 	char		infile[MAXPGPATH];
 	char		outfile[MAXPGPATH];
 	char		expectfile[MAXPGPATH] = "";
-	char		psql_cmd[MAXPGPATH * 3];
+	char		psql_cmd[MAXPGPATH * 4];
 	size_t		offset = 0;
 	char		use_utility_mode = 0;
 	char	   *lastslash;
@@ -97,14 +97,36 @@ psql_start_test(const char *testname,
 		offset += snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
 						   "%s ", launcher);
 
+	/*
+	 * We need to pass multiple input files (prehook and infile) to psql,
+	 * to do this a simple way is to execute it like this:
+	 *
+	 *     cat prehook infile | psql
+	 *
+	 * However the problem is that cat's pid is returned, although it does not
+	 * really matter we prefer to return psql's pid.  We could change the
+	 * command like this:
+	 *
+	 *     psql <(prehook infile)
+	 *
+	 * However some shells like dash do not support it.  So we have to
+	 * execute the command as below:
+	 *
+	 *     psql <<EOF
+	 *     $(cat prehook infile)
+	 *     EOF
+	 */
 	snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
-			 "%s \"%s%spsql\" -X -a -q -d \"%s\" < \"%s\" > \"%s\" 2>&1",
+			 "%s \"%s%spsql\" -X -a -q -d \"%s\" > \"%s\" 2>&1 <<EOF\n"
+			 "$(cat \"%s\" \"%s\")\n"
+			 "EOF",
 			 use_utility_mode ? "env PGOPTIONS='-c gp_session_role=utility'" : "",
 			 psqldir ? psqldir : "",
 			 psqldir ? "/" : "",
 			 dblist->str,
-			 infile,
-			 outfile);
+			 outfile,
+			 prehook[0] ? prehook : "/dev/null",
+			 infile);
 
 	pid = spawn_process(psql_cmd);
 

--- a/src/test/regress/sql/hooks/randomize_create_table_default_numsegments.sql
+++ b/src/test/regress/sql/hooks/randomize_create_table_default_numsegments.sql
@@ -1,0 +1,12 @@
+-- start_ignore
+
+-- HOOK NAME: randomize_create_table_default_numsegments
+-- HOOK TYPE: prehook
+-- HOOK DESCRIPTION:
+--   when used as prehook all the tables wiil be created with random
+--   numsegments.
+
+create extension if not exists gp_debug_numsegments;
+select gp_debug_reset_create_table_default_numsegments('random');
+
+-- end_ignore


### PR DESCRIPTION
This PR introduces two new pg_regress arguments:
- `--ignore-plans`: let `atmsort.pm` ignore all the plan diffs;
- `--prehook <hookname>`: set a hook for the tests;

A hook script is also provided to force tables create with random numsegments during regress tests.

Please refer to the commit messages for details.

These changes do not change the default behavior of ICG / ICW.

Tests are not included as I do not know how to test pg_regress; in the other hand this PR is a preparation for a new pipeline job which will run the ICG tests with random numsegments, the new arguments and hook provided in this PR will all be used by that pipeline job.