### PR TITLE
Fix intermittent failure for select_into case

### DIFF
--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -90,7 +90,7 @@ ignore: random
 # ----------
 # Another group of parallel tests
 # ----------
-test: select_into select_distinct select_distinct_on select_implicit select_having subselect union case join aggregates random portals arrays btree_index hash_index update delete lock
+test: select_into select_distinct select_distinct_on select_implicit select_having subselect union case join aggregates random portals arrays btree_index hash_index update delete
 
 # In PostgreSQL, namespace test is run as part of the fourth group, but there
 # are some GPDB additions in it that will show diff if concurrent tests use


### PR DESCRIPTION
Recently, ICW case 'select_into' failed intermittently, the error looks like

"CREATE TABLE selinto_schema.tmp3 (a,b,c)
 	   AS SELECT oid,relname,relacl FROM pg_class
 	   WHERE relname like '%c%';	-- OK
ERROR:  role "30973" does not exist"

The RCA is, case 'lock' should not run concurrently with 'select_into',
a minirepo is:

1. in 'lock' case
CREATE TABLE lock_tbl1 (a BIGINT);
CREATE ROLE regress_rol_lock1;
GRANT UPDATE ON TABLE lock_tbl1 TO regress_rol_lock1;
select oid, relname, relacl from pg_class where relname like '%c%';
  oid   |  relname  |                        relacl
--------+-----------+-------------------------------------------------------
 180367 | lock_tbl1 | {gpadmin=arwdDxt/gpadmin,regress_rol_lock1=w/gpadmin}

2. in 'select_into' test case
CREATE TABLE selinto_schema.tmp3 (a,b,c)
       AS SELECT oid,relname,relacl FROM pg_class
       WHERE relname like '%c%';

3. in 'lock' test case
DROP TABLE lock_tbl1;
DROP ROLE regress_rol_lock1;

4. in 'select_into' test case
select * from tmp3;
   a    |     b     |                     c
--------+-----------+--------------------------------------------
 180367 | lock_tbl1 | {gpadmin=arwdDxt/gpadmin,180370=w/gpadmin}

create table tmp4 as select * from tmp3;
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
ERROR:  role "180370" does not exist

In Step4, role 'regress_rol_lock1' has been dropped, so when it tries to parse
acl, it finds role "180370" does not exist, the error seems to be reasonable.

In upstream, test 'lock' doesn't run concurrently with 'select_into', I also notice
that we have two 'lock' test within parallel_schedule, so remove the first one
to match upstream and avoid the intermittent failure of 'select_into'