### PR TITLE
WIP: pg_dump: set correct numsegments for relations.

### DIFF
--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -317,6 +317,7 @@ typedef struct _tableInfo
 	 * (it's either a table to dump, or a direct parent of a dumpable table).
 	 */
 	int			numatts;		/* number of attributes */
+	int			numsegments;	/* number of segments */
 	char	  **attnames;		/* the attribute names */
 	char	  **atttypnames;	/* attribute type names */
 	int		   *atttypmod;		/* type-specific type modifiers */


### PR DESCRIPTION
pg_dump dump relations as CREATE commands, however the internal
numsegments property can not be specified in CREATE commands, their
values are decided on execution from the cluster size, however as a
utility mode master is used to restore the tables the invalid cluster
size is used as numsegments for all the tables.

To fix the issue we generate an UPDATE gp_distribution_policy command
after each CREATE command to correct the numsegments property, so no
matter there are partially distributed tables or not they can always be
correctly restored.

Also added a check in pg_upgrade, when online expansion is in progress refuse to upgrade.

This PR is only for review, tests are not included, some decisions are still being discussed, please do not merge it.