### PR TITLE
Remove gp_num_contents_in_cluster GUC.

### DIFF
--- a/contrib/pg_upgrade/server.c
+++ b/contrib/pg_upgrade/server.c
@@ -245,7 +245,7 @@ start_postmaster(ClusterInfo *cluster, bool throw_error)
 	 * win on ext4.
 	 */
 	snprintf(cmd, sizeof(cmd),
-		  "\"%s/pg_ctl\" -w -l \"%s\" -D \"%s\" -o \"-p %d --gp_dbid=1 --gp_num_contents_in_cluster=0 --gp_contentid=%d -c gp_role=utility -c synchronous_standby_names='' --xid_warn_limit=10000000 %s%s %s%s \" start",
+		  "\"%s/pg_ctl\" -w -l \"%s\" -D \"%s\" -o \"-p %d --gp_dbid=1 --gp_contentid=%d -c gp_role=utility -c synchronous_standby_names='' --xid_warn_limit=10000000 %s%s %s%s \" start",
 		  cluster->bindir, SERVER_LOG_FILE, cluster->pgconfig, cluster->port,
 			 (user_opts.segment_mode == DISPATCHER ? -1 : 0),
 			 (cluster->controldata.cat_ver >=

--- a/contrib/pg_upgrade/test_gpdb.sh
+++ b/contrib/pg_upgrade/test_gpdb.sh
@@ -130,7 +130,7 @@ check_vacuum_worked()
 
 	# Start the instance using the same pg_ctl invocation used by pg_upgrade.
 	"${NEW_BINDIR}/pg_ctl" -w -l /dev/null -D "${datadir}" \
-		-o "-p 18432 --gp_dbid=1 --gp_num_contents_in_cluster=0 --gp_contentid=${contentid} --xid_warn_limit=10000000 -b" \
+		-o "-p 18432 --gp_dbid=1 --gp_contentid=${contentid} --xid_warn_limit=10000000 -b" \
 		start
 
 	# Query for the xmin ages.

--- a/gpAux/gpdemo/gpsegwalrep.py
+++ b/gpAux/gpdemo/gpsegwalrep.py
@@ -150,8 +150,8 @@ class StartInstances():
         if contentid != GpSegmentConfiguration.MASTER_CONTENT_ID:
             dbid = 0
 
-        opts = ("-p %d --gp_dbid=%d --silent-mode=true -i --gp_contentid=%d --gp_num_contents_in_cluster=%d" %
-                (segment_port, dbid, contentid, self.clusterconfig.get_num_contents()))
+        opts = ("-p %d --gp_dbid=%d --silent-mode=true -i --gp_contentid=%d" %
+                (segment_port, dbid, contentid))
 
         # Arguments for the master.
         #

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1284,8 +1284,8 @@ CREATE_QD_DB () {
 		BUILD_PERFMON $GP_DIR
 		ERROR_CHK $? "create perfmon directories and configuration file" 1
 		LOG_MSG "[INFO]:-Starting the Master in admin mode" 1
-		export PGPORT=$GP_PORT;$PG_CTL -w -l $GP_DIR/pg_log/startup.log -D $GP_DIR -o "-i -p $GP_PORT -c gp_role=utility --gp_dbid=1 --gp_contentid=-1 \
-		--gp_num_contents_in_cluster=0 -m" start >> /dev/null 2>&1
+		export PGPORT=$GP_PORT;$PG_CTL -w -l $GP_DIR/pg_log/startup.log -D $GP_DIR -o "-i -p $GP_PORT -c gp_role=utility \
+		--gp_dbid=1 --gp_contentid=-1 -m" start >> /dev/null 2>&1
 		RET_TEXT="`$PG_CTL status -D $GP_DIR`"
 		RUNNING=`$ECHO $RET_TEXT|$EGREP -c "not running|neither"`
 		if [ $RUNNING -ne 0 ]; then

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -129,23 +129,23 @@ class PgCtlBackendOptions(CmdArgs):
     --------
 
     >>> str(PgCtlBackendOptions(5432, 1, 2))
-    '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true'
+    '-p 5432 --gp_dbid=1 --silent-mode=true'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_master(True))
-    '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true -i --gp_contentid=-1'
+    '-p 5432 --gp_dbid=1 --silent-mode=true -i --gp_contentid=-1'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_master(False))
-    '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true -i --gp_contentid=-1 -E'
+    '-p 5432 --gp_dbid=1 --silent-mode=true -i --gp_contentid=-1 -E'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_segment(1))
-    '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true -i --gp_contentid=1'
+    '-p 5432 --gp_dbid=1 --silent-mode=true -i --gp_contentid=1'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_special('upgrade'))
-    '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true -U'
+    '-p 5432 --gp_dbid=1 --silent-mode=true -U'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_special('maintenance'))
-    '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true -m'
+    '-p 5432 --gp_dbid=1 --silent-mode=true -m'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_utility(True))
-    '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true -c gp_role=utility'
+    '-p 5432 --gp_dbid=1 --silent-mode=true -c gp_role=utility'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_utility(False))
-    '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true'
+    '-p 5432 --gp_dbid=1 --silent-mode=true'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_restricted(True,1))
-    '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true -c superuser_reserved_connections=1'
+    '-p 5432 --gp_dbid=1 --silent-mode=true -c superuser_reserved_connections=1'
     >>>
 
     """
@@ -159,7 +159,6 @@ class PgCtlBackendOptions(CmdArgs):
         CmdArgs.__init__(self, [
             "-p", str(port),
             "--gp_dbid="+ str(dbid),
-            "--gp_num_contents_in_cluster="+ str(numcids),
         ])
 
     #
@@ -221,7 +220,7 @@ class PgCtlStartArgs(CmdArgs):
     >>> str(a).split(' ') #doctest: +NORMALIZE_WHITESPACE
     ['env', GPERA=123', '$GPHOME/bin/pg_ctl', '-D', '/data1/master/gpseg-1', '-l',
      '/data1/master/gpseg-1/pg_log/startup.log', '-w', '-t', '600',
-     '-o', '"', '-p', '5432', '--gp_dbid=1', '--gp_num_contents_in_cluster=2', '--silent-mode=true', '"', 'start']
+     '-o', '"', '-p', '5432', '--gp_dbid=1', '--silent-mode=true', '"', 'start']
     """
 
     def __init__(self, datadir, backend, era, wrapper, args, wait, timeout=None):

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -255,7 +255,7 @@ STOP_QE() {
 START_QE() {
 	LOG_MSG "[INFO][$INST_COUNT]:-Starting Functioning instance on segment ${GP_HOSTADDRESS}"
 	PG_CTL_WAIT=$1
-	$TRUSTED_SHELL ${GP_HOSTADDRESS} "$EXPORT_LIB_PATH;export PGPORT=${GP_PORT}; $PG_CTL $PG_CTL_WAIT -l $GP_DIR/pg_log/startup.log -D $GP_DIR -o \"-i -p ${GP_PORT} --gp_dbid=${GP_DBID} --gp_contentid=${GP_CONTENT} --gp_num_contents_in_cluster=${TOTAL_SEG}\" start" >> $LOG_FILE 2>&1
+	$TRUSTED_SHELL ${GP_HOSTADDRESS} "$EXPORT_LIB_PATH;export PGPORT=${GP_PORT}; $PG_CTL $PG_CTL_WAIT -l $GP_DIR/pg_log/startup.log -D $GP_DIR -o \"-i -p ${GP_PORT} --gp_dbid=${GP_DBID} --gp_contentid=${GP_CONTENT}\" start" >> $LOG_FILE 2>&1
 	RETVAL=$?
 	if [ $RETVAL -ne 0 ]; then
 		BACKOUT_COMMAND "$TRUSTED_SHELL $GP_HOSTADDRESS \"${EXPORT_LIB_PATH};export PGPORT=${GP_PORT}; $PG_CTL -w -D $GP_DIR -o \"-i -p ${GP_PORT}\" -m immediate  stop\""

--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -1280,9 +1280,6 @@
             <li id="kh177743">
               <codeph>gp_dbid</codeph>
             </li>
-            <li id="kh178565">
-              <codeph>gp_num_contents_in_cluster</codeph>
-            </li>
             <li id="kh164511">
               <codeph>gp_role</codeph>
             </li>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -354,9 +354,6 @@
             <li>
               <xref href="#gp_motion_cost_per_row"/>
             </li>
-            <li>
-              <xref href="#gp_num_contents_in_cluster"/>
-            </li>
             <li><xref href="#gp_recursive_cte_prototype"/></li>
             <li>
               <xref href="#gp_reject_percent_threshold"/>
@@ -4496,33 +4493,6 @@
               <entry colname="col1">floating point</entry>
               <entry colname="col2">0</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="gp_num_contents_in_cluster">
-    <title>gp_num_contents_in_cluster</title>
-    <body>
-      <p>The number of primary segments in the Greenplum Database system.</p>
-      <table id="gp_num_contents_in_cluster_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">-</entry>
-              <entry colname="col2">-</entry>
-              <entry colname="col3">read only</entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1550,10 +1550,6 @@
               <p>
                 <xref href="guc-list.xml#gp_dbid" type="section">gp_dbid</xref>
               </p>
-              <p>
-                <xref href="guc-list.xml#gp_num_contents_in_cluster" type="section"
-                  >gp_num_contents_in_cluster</xref>
-              </p>
             </stentry>
             <stentry>
               <p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -142,7 +142,6 @@
             <topicref href="guc-list.xml#gp_max_slices"/>
             <topicref href="guc-list.xml#memory_spill_ratio"/>
             <topicref href="guc-list.xml#gp_motion_cost_per_row"/>
-            <topicref href="guc-list.xml#gp_num_contents_in_cluster"/>
             <topicref href="guc-list.xml#gp_recursive_cte_prototype"/>
             <topicref href="guc-list.xml#gp_reject_percent_threshold"/>
             <topicref href="guc-list.xml#gp_reraise_signal"/>

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -68,8 +68,6 @@
 #define S_PER_D (60 * 60 * 24)
 #define MS_PER_D (1000 * 60 * 60 * 24)
 
-/* FIXME: remove this once gp_num_contents_in_cluster is retired */
-static int dummy_segments = -1;
 /*
  * Assign/Show hook functions defined in this module
  */
@@ -3284,22 +3282,6 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
 		},
 		&GpIdentity.segindex,
-		UNINITIALIZED_GP_IDENTITY_VALUE, INT_MIN, INT_MAX,
-		NULL, NULL, NULL
-	},
-
-	/*
-	 * FIXME: gp_num_contents_in_cluster take no effect already, can remove it.
-	 * add GUC_NO_SHOW_ALL to avoid gp_num_contents_in_cluster being used by
-	 * others like pg_settings
-	 */
-	{
-		{"gp_num_contents_in_cluster", PGC_POSTMASTER, PRESET_OPTIONS,
-			gettext_noop("Sets the number of segments in the cluster."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
-		},
-		&dummy_segments,
 		UNINITIALIZED_GP_IDENTITY_VALUE, INT_MIN, INT_MAX,
 		NULL, NULL, NULL
 	},

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -5,7 +5,7 @@ create language plpythonu;
 CREATE
 -- end_ignore
 
-create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int) returns text as $$ import subprocess cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
+create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int) returns text as $$ import subprocess cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d' % (port, dbid, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
 CREATE
 
 -- make sure we are in-sync for the primary we will be testing with

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -9,7 +9,7 @@ create language plpythonu;
 CREATE
 -- end_ignore
 
-create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int) returns text as $$ import subprocess cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
+create or replace function pg_ctl(datadir text, command text, port int, contentid int, dbid int) returns text as $$ import subprocess cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir if command in ('stop', 'restart'): cmd = cmd + '-w -m immediate %s' % command elif command == 'start': opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d' % (port, dbid, contentid) cmd = cmd + '-o "%s" start' % opts else: return 'Invalid command input' return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
 CREATE
 
 -- make sure we are in-sync for the primary we will be testing with

--- a/src/test/isolation2/sql/segwalrep/commit_blocking.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking.sql
@@ -11,7 +11,7 @@ returns text as $$
     if command in ('stop', 'restart'):
         cmd = cmd + '-w -m immediate %s' % command
     elif command == 'start':
-        opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid)
+        opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d' % (port, dbid, contentid)
         cmd = cmd + '-o "%s" start' % opts
     else:
         return 'Invalid command input'

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -28,7 +28,7 @@ returns text as $$
     if command in ('stop', 'restart'):
         cmd = cmd + '-w -m immediate %s' % command
     elif command == 'start':
-        opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, dbid, contentid)
+        opts = '-p %d -\-gp_dbid=%d -i -\-gp_contentid=%d' % (port, dbid, contentid)
         cmd = cmd + '-o "%s" start' % opts
     else:
         return 'Invalid command input'

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/__init__.py
@@ -166,7 +166,7 @@ class WalReplKillProcessTestCase(TINCTestCase):
        activate_stdby = GpactivateStandby()
        stdby_mdd = activate_stdby.get_standby_dd()
        stdby_port = activate_stdby.get_standby_port()
-       cmd="pg_ctl -l postmaster.log -D %s -o '-p %s --gp_dbid=%s --gp_num_contents_in_cluster=2 -i --gp_contentid=-1 -E' start &"%(stdby_mdd, stdby_port, stdby_dbid)
+       cmd="pg_ctl -l postmaster.log -D %s -o '-p %s --gp_dbid=%s -i --gp_contentid=-1 -E' start &"%(stdby_mdd, stdby_port, stdby_dbid)
        self.run_remote(stdby_host,cmd,stdby_port,stdby_mdd)
        
 

--- a/src/test/walrep/expected/missing_xlog.out
+++ b/src/test/walrep/expected/missing_xlog.out
@@ -9,7 +9,7 @@ returns text as $$
     if command in ('stop', 'restart'):
         cmd = cmd + '-w -m immediate %s' % command
     elif command == 'start':
-        opts = '-p %d -\-gp_dbid=0 -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid)
+        opts = '-p %d -\-gp_dbid=0 -i -\-gp_contentid=%d' % (port, contentid)
         cmd = cmd + '-o "%s" start' % opts
     elif command == 'reload':
         cmd = cmd + 'reload'

--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -10,7 +10,7 @@ returns text as $$
     if command in ('stop', 'restart'):
         cmd = cmd + '-w -m immediate %s' % command
     elif command == 'start':
-        opts = '-p %d -\-gp_dbid=0 -i -\-gp_contentid=%d -\-gp_num_contents_in_cluster=3' % (port, contentid)
+        opts = '-p %d -\-gp_dbid=0 -i -\-gp_contentid=%d' % (port, contentid)
         cmd = cmd + '-o "%s" start' % opts
     elif command == 'reload':
         cmd = cmd + 'reload'


### PR DESCRIPTION
Given the online gpexpand work, the gp_num_contents_in_cluster GUC is
unused. So, delete the same from code to avoid confusions and eliminate this
long argument required to start a postgres instance in gpdb.