### PR TITLE
Create index on leaf partitions for unnamed index

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1517,8 +1517,9 @@ ProcessUtilitySlow(Node *parsetree,
 					 */
 					if (stmt->relationOid)
 						relid = stmt->relationOid;
-					relid =
-						RangeVarGetRelidExtended(stmt->relation, lockmode,
+					else
+						relid =
+							RangeVarGetRelidExtended(stmt->relation, lockmode,
 												 false, false,
 												 RangeVarCallbackOwnsRelation,
 												 NULL);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1524,6 +1524,23 @@ ProcessUtilitySlow(Node *parsetree,
 												 RangeVarCallbackOwnsRelation,
 												 NULL);
 
+					/*
+					 * For unnamed indexes, choose an index name that will be
+					 * used later when creating IndexStmts for the leaf
+					 * partitions in a partitioned table.
+					 */
+					if (stmt->idxname == NULL && rel_is_partitioned(relid))
+					{
+						Relation rel = heap_open(relid, NoLock);
+						stmt->idxname = ChooseIndexName(RelationGetRelationName(rel),
+														RelationGetNamespace(rel),
+														ChooseIndexColumnNames(stmt->indexParams),
+														stmt->excludeOpNames,
+														stmt->primary,
+														stmt->isconstraint);
+						heap_close(rel, NoLock);
+					}
+
 					/* Run parse analysis ... */
 					stmts = transformIndexStmt(relid, stmt, queryString);
 

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -256,20 +256,11 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
 (2 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |    node    
--------------------+---------------------+----------+------------
- partlockt_1_prt_8 | ShareLock           | relation | n segments
- partlockt_1_prt_4 | ShareLock           | relation | n segments
- partlockt_1_prt_5 | ShareLock           | relation | n segments
- partlockt_1_prt_3 | ShareLock           | relation | n segments
- partlockt_1_prt_1 | ShareLock           | relation | n segments
- partlockt_1_prt_2 | ShareLock           | relation | n segments
- partlockt_1_prt_9 | ShareLock           | relation | n segments
- partlockt_idx     | AccessExclusiveLock | relation | n segments
- partlockt_1_prt_7 | ShareLock           | relation | n segments
- partlockt         | ShareLock           | relation | n segments
- partlockt_1_prt_6 | ShareLock           | relation | n segments
-(11 rows)
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ partlockt     | ShareLock           | relation | n segments
+ partlockt_idx | AccessExclusiveLock | relation | n segments
+(2 rows)
 
 commit;
 -- Force use of the index in the select and delete below. We're not interested

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -256,20 +256,11 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
 (2 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |    node    
--------------------+---------------------+----------+------------
- partlockt_1_prt_8 | ShareLock           | relation | n segments
- partlockt_1_prt_4 | ShareLock           | relation | n segments
- partlockt_1_prt_5 | ShareLock           | relation | n segments
- partlockt_1_prt_3 | ShareLock           | relation | n segments
- partlockt_1_prt_1 | ShareLock           | relation | n segments
- partlockt_1_prt_2 | ShareLock           | relation | n segments
- partlockt_1_prt_9 | ShareLock           | relation | n segments
- partlockt_idx     | AccessExclusiveLock | relation | n segments
- partlockt_1_prt_7 | ShareLock           | relation | n segments
- partlockt         | ShareLock           | relation | n segments
- partlockt_1_prt_6 | ShareLock           | relation | n segments
-(11 rows)
+   coalesce    |        mode         | locktype |    node    
+---------------+---------------------+----------+------------
+ partlockt     | ShareLock           | relation | n segments
+ partlockt_idx | AccessExclusiveLock | relation | n segments
+(2 rows)
 
 commit;
 -- Force use of the index in the select and delete below. We're not interested

--- a/src/test/regress/input/partindex_test.source
+++ b/src/test/regress/input/partindex_test.source
@@ -563,6 +563,75 @@ exchange partition for (integer '2') with table exchange_external_table without 
 
 select * from exchange_sub_partition;
 
+--
+-- ************************************************************
+-- * Scenario 11
+-- *  - Test unnamed index creation on all partitions for a
+-- *      single level partitioned table.
+-- *  - no default parts, no dropped columns
+-- ************************************************************
+--
+create table unnamed_index_part_table
+(
+  part_key int,
+  index_key int
+)
+partition by range(part_key)
+(
+  partition part1 end (3),
+  partition part2 start (3)
+);
+
+-- physical unnamed index on all parts
+-- output shows indexes created on all parts
+create index on unnamed_index_part_table(index_key);
+
+SELECT n.nspname as "Schema", c.relname as "Name", c.relkind, c2.relname as "Table"
+FROM pg_catalog.pg_class c
+     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+     LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
+     LEFT JOIN pg_catalog.pg_class c2 ON i.indrelid = c2.oid
+WHERE c.relkind IN ('i','') AND c2.relname like 'unnamed_index_part_table%';
+
+--
+-- ************************************************************
+-- * Scenario 12
+-- * 	- unnamed indexes on multi-level partitions
+-- ************************************************************
+--
+create table unnamed_index_multi_part_table
+(
+  date date,
+  region text,
+  region1 text,
+  amount decimal(10,2)
+)
+partition by range(date)
+subpartition by list(region)
+(
+ partition part1 start(date '2008-01-01') end(date '2009-01-01')
+	(
+	subpartition usa	values ('usa'),
+	subpartition asia	values ('asia'),
+	default subpartition def
+	),
+ partition part2 start(date '2009-01-01') end(date '2010-01-01')
+	(
+	subpartition usa	values ('usa'),
+	subpartition asia	values ('asia')
+	)
+);
+
+-- create unnamed indexe (will be created on all parts/subparts)
+create index on unnamed_index_multi_part_table(date, amount);
+
+SELECT n.nspname as "Schema", c.relname as "Name", c.relkind, c2.relname as "Table"
+FROM pg_catalog.pg_class c
+     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+     LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
+     LEFT JOIN pg_catalog.pg_class c2 ON i.indrelid = c2.oid
+WHERE c.relkind IN ('i','') AND c2.relname like 'unnamed_index_multi_part_table%';
+
 -- cleanup
 drop function gp_build_logical_index(oid);
 drop function gp_get_physical_index_relid(oid, oid, int[], text, text, bool);

--- a/src/test/regress/output/partindex_test.source
+++ b/src/test/regress/output/partindex_test.source
@@ -1145,6 +1145,110 @@ select * from exchange_sub_partition;
  2 | 2
 (1 row)
 
+--
+-- ************************************************************
+-- * Scenario 11
+-- *  - Test unnamed index creation on all partitions for a
+-- *      single level partitioned table.
+-- *  - no default parts, no dropped columns
+-- ************************************************************
+--
+create table unnamed_index_part_table
+(
+  part_key int,
+  index_key int
+)
+partition by range(part_key)
+(
+  partition part1 end (3),
+  partition part2 start (3)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'part_key' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "unnamed_index_part_table_1_prt_part1" for table "unnamed_index_part_table"
+NOTICE:  CREATE TABLE will create partition "unnamed_index_part_table_1_prt_part2" for table "unnamed_index_part_table"
+-- physical unnamed index on all parts
+-- output shows indexes created on all parts
+create index on unnamed_index_part_table(index_key);
+NOTICE:  building index for child partition "unnamed_index_part_table_1_prt_part1"
+NOTICE:  building index for child partition "unnamed_index_part_table_1_prt_part2"
+SELECT n.nspname as "Schema", c.relname as "Name", c.relkind, c2.relname as "Table"
+FROM pg_catalog.pg_class c
+     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+     LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
+     LEFT JOIN pg_catalog.pg_class c2 ON i.indrelid = c2.oid
+WHERE c.relkind IN ('i','') AND c2.relname like 'unnamed_index_part_table%';
+ Schema |                        Name                        | relkind |                Table                 
+--------+----------------------------------------------------+---------+--------------------------------------
+ public | unnamed_index_part_table_index_key_idx             | i       | unnamed_index_part_table
+ public | unnamed_index_part_table_index_key_idx_1_prt_part1 | i       | unnamed_index_part_table_1_prt_part1
+ public | unnamed_index_part_table_index_key_idx_1_prt_part2 | i       | unnamed_index_part_table_1_prt_part2
+(3 rows)
+
+--
+-- ************************************************************
+-- * Scenario 12
+-- * 	- unnamed indexes on multi-level partitions
+-- ************************************************************
+--
+create table unnamed_index_multi_part_table
+(
+  date date,
+  region text,
+  region1 text,
+  amount decimal(10,2)
+)
+partition by range(date)
+subpartition by list(region)
+(
+ partition part1 start(date '2008-01-01') end(date '2009-01-01')
+	(
+	subpartition usa	values ('usa'),
+	subpartition asia	values ('asia'),
+	default subpartition def
+	),
+ partition part2 start(date '2009-01-01') end(date '2010-01-01')
+	(
+	subpartition usa	values ('usa'),
+	subpartition asia	values ('asia')
+	)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'date' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "unnamed_index_multi_part_table_1_prt_part1" for table "unnamed_index_multi_part_table"
+NOTICE:  CREATE TABLE will create partition "unnamed_index_multi_part_table_1_prt_part1_2_prt_usa" for table "unnamed_index_multi_part_table_1_prt_part1"
+NOTICE:  CREATE TABLE will create partition "unnamed_index_multi_part_table_1_prt_part1_2_prt_asia" for table "unnamed_index_multi_part_table_1_prt_part1"
+NOTICE:  CREATE TABLE will create partition "unnamed_index_multi_part_table_1_prt_part1_2_prt_def" for table "unnamed_index_multi_part_table_1_prt_part1"
+NOTICE:  CREATE TABLE will create partition "unnamed_index_multi_part_table_1_prt_part2" for table "unnamed_index_multi_part_table"
+NOTICE:  CREATE TABLE will create partition "unnamed_index_multi_part_table_1_prt_part2_2_prt_usa" for table "unnamed_index_multi_part_table_1_prt_part2"
+NOTICE:  CREATE TABLE will create partition "unnamed_index_multi_part_table_1_prt_part2_2_prt_asia" for table "unnamed_index_multi_part_table_1_prt_part2"
+-- create unnamed indexe (will be created on all parts/subparts)
+create index on unnamed_index_multi_part_table(date, amount);
+NOTICE:  building index for child partition "unnamed_index_multi_part_table_1_prt_part1"
+NOTICE:  building index for child partition "unnamed_index_multi_part_table_1_prt_part1_2_prt_usa"
+NOTICE:  building index for child partition "unnamed_index_multi_part_table_1_prt_part1_2_prt_asia"
+NOTICE:  building index for child partition "unnamed_index_multi_part_table_1_prt_part1_2_prt_def"
+NOTICE:  building index for child partition "unnamed_index_multi_part_table_1_prt_part2"
+NOTICE:  building index for child partition "unnamed_index_multi_part_table_1_prt_part2_2_prt_usa"
+NOTICE:  building index for child partition "unnamed_index_multi_part_table_1_prt_part2_2_prt_asia"
+SELECT n.nspname as "Schema", c.relname as "Name", c.relkind, c2.relname as "Table"
+FROM pg_catalog.pg_class c
+     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+     LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
+     LEFT JOIN pg_catalog.pg_class c2 ON i.indrelid = c2.oid
+WHERE c.relkind IN ('i','') AND c2.relname like 'unnamed_index_multi_part_table%';
+ Schema |                              Name                               | relkind |                         Table                         
+--------+-----------------------------------------------------------------+---------+-------------------------------------------------------
+ public | unnamed_index_multi_part_table_date_amount_idx                  | i       | unnamed_index_multi_part_table
+ public | unnamed_index_multi_part_table_date_amount_idx_1_prt_part1      | i       | unnamed_index_multi_part_table_1_prt_part1
+ public | unnamed_index_multi_part_table_date_amount_idx_1_prt__2_prt_usa | i       | unnamed_index_multi_part_table_1_prt_part1_2_prt_usa
+ public | unnamed_index_multi_part_table_date_amount_idx_1_prt_2_prt_asia | i       | unnamed_index_multi_part_table_1_prt_part1_2_prt_asia
+ public | unnamed_index_multi_part_table_date_amount_idx_1_prt__2_prt_def | i       | unnamed_index_multi_part_table_1_prt_part1_2_prt_def
+ public | unnamed_index_multi_part_table_date_amount_idx_1_prt_part2      | i       | unnamed_index_multi_part_table_1_prt_part2
+ public | unnamed_index_multi_part_table_date_amount_idx_1_prt_2_prt_usa1 | i       | unnamed_index_multi_part_table_1_prt_part2_2_prt_usa
+ public | unnamed_index_multi_part_table_date_amount_idx_1_pr_2_prt_asia1 | i       | unnamed_index_multi_part_table_1_prt_part2_2_prt_asia
+(8 rows)
+
 -- cleanup
 drop function gp_build_logical_index(oid);
 drop function gp_get_physical_index_relid(oid, oid, int[], text, text, bool);


### PR DESCRIPTION
This PR adds support for creating corresponding indexes on the leaf partitions when creating an unnamed index on a partition table similar to how they are created for named indexes.

Before this PR, while creating an unnamed index, the index would only get created for the root table.   For example:

```
CREATE TABLE part_table (a INT, b INT)
DISTRIBUTED BY (a) 
PARTITION BY RANGE(b) (PARTITION alpha  END (3), PARTITION beta START (3));

CREATE INDEX ON part_table USING btree (a);
\di
 Schema |        Name        | Type  |   Owner   | Storage |   Table
--------+--------------------+-------+-----------+---------+------------
 public | part_table_a_idx   | index | kkrempely | heap    | part_table
```

With the current patch, we would go ahead and create indexes for the leaf partitions as well.

```
CREATE TABLE part_table (a INT, b INT)
DISTRIBUTED BY (a) 
PARTITION BY RANGE(b) (PARTITION alpha  END (3), PARTITION beta START (3));

CREATE INDEX ON part_table USING btree (a);

\di
                                     List of relations
 Schema |             Name             | Type  |  Owner  | Storage |         Table
--------+------------------------------+-------+---------+---------+------------------------
 public | part_table_a_idx             | index | pivotal | heap    | part_table
 public | part_table_a_idx_1_prt_alpha | index | pivotal | heap    | part_table_1_prt_alpha
 public | part_table_a_idx_1_prt_beta  | index | pivotal | heap    | part_table_1_prt_beta
```

We have also fixed an unnecessary lookup for relationOid by QE if the relation
OID has already been looked up.

We also added tests for unnamed indexes on partitioned tables.
