### PR TITLE
Fix SIGSEGV causes by unexpected cleanup of gangs

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -322,5 +322,36 @@ select gp_inject_fault('after_one_slice_dispatched', 'reset', 1);
 select * from gp_dist_random('gp_id')
 	where gpname > (select * from repeat('sssss', 10000000));
 
+--
+-- Test portal cleanup
+-- prepare a query contains init plan, main plan create a unnamed portal
+-- and will need multiple slices , init plan also need to allocated multiple
+-- slices in a named portal (eg: a cursor). The executing order is:
+-- 1. gangs of main plan is pre-assigned 2. init plan is executed 3. main plan
+-- is executed. This test it meant to test that cleanup of the named portal in
+-- the end of step2 will not affect the pre-allocated gangs of the main plan.
+--
+create table foo (c1 int, c2 int);
+create table bar (c1 int, c2 int);
+create or replace function foo_func()
+returns int
+as
+$BODY$
+declare
+t_record record;
+BEGIN
+	drop table if exists tmp1;
+	create temp table tmp1 as select foo.c1, bar.c2 from foo, bar;
+	for t_record in (select count(*) from foo, bar)
+	loop
+		NULL;
+	end loop;
+	return 1;
+END;
+$BODY$
+language plpgsql volatile;
+set gp_cached_segworkers_threshold to 1;
+select count(*) from foo, bar where exists (select foo_func());
+reset gp_cached_segworkers_threshold;
 \c regression
 DROP DATABASE dispatch_test_db;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -573,5 +573,52 @@ select * from gp_dist_random('gp_id')
 --------+-------------+------+---------
 (0 rows)
 
+--
+-- Test portal cleanup
+-- prepare a query contains init plan, main plan create a unnamed portal
+-- and will need multiple slices , init plan also need to allocated multiple
+-- slices in a named portal (eg: a cursor). The executing order is:
+-- 1. gangs of main plan is pre-assigned 2. init plan is executed 3. main plan
+-- is executed. This test it meant to test that cleanup of the named portal in
+-- the end of step2 will not affect the pre-allocated gangs of the main plan.
+--
+create table foo (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create or replace function foo_func()
+returns int
+as
+$BODY$
+declare
+t_record record;
+BEGIN
+	drop table if exists tmp1;
+	create temp table tmp1 as select foo.c1, bar.c2 from foo, bar;
+	for t_record in (select count(*) from foo, bar)
+	loop
+		NULL;
+	end loop;
+	return 1;
+END;
+$BODY$
+language plpgsql volatile;
+set gp_cached_segworkers_threshold to 1;
+select count(*) from foo, bar where exists (select foo_func());
+NOTICE:  table "tmp1" does not exist, skipping
+CONTEXT:  SQL statement "drop table if exists tmp1"
+PL/pgSQL function "foo_func" line 4 at SQL statement
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CONTEXT:  SQL statement "create temp table tmp1 as select foo.c1, bar.c2 from foo, bar"
+PL/pgSQL function "foo_func" line 5 at SQL statement
+ count 
+-------
+     0
+(1 row)
+
+reset gp_cached_segworkers_threshold;
 \c regression
 DROP DATABASE dispatch_test_db;


### PR DESCRIPTION
There is a rule that when cleaning up gangs for a portal, it should not
clean up gangs belong to other portals, most code path follow the rule
except the cleanupPortalGangList(), this commit fixed this bug.

master has been refactored and has total different code path, so this is for 5x_stable only