### PR TITLE
Support ALTER TABLE ONLY for expand table

### DIFF
--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -631,6 +631,7 @@ select gp_segment_id, * from mix_base_tbl order by 2, 1;
 -- reshuffle the parent table, both parent and child table will be rebalanced to all
 -- segments
 Alter table mix_base_tbl expand table;
+NOTICE:  Do not need to reshuffle test_reshuffle.mix_child_a
 select gp_segment_id, * from mix_base_tbl order by 2, 1;
  gp_segment_id | a  | b  
 ---------------+----+----
@@ -708,6 +709,22 @@ Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
              0 |    49
 (2 rows)
 
+begin;
+alter table only part_t1 expand table;
+select relname, numsegments from gp_distribution_policy d, pg_class c where c.oid = d.localoid and c.relname like 'part_t1%' and d.numsegments = 3;
+ relname | numsegments 
+---------+-------------
+ part_t1 |           3
+(1 row)
+
+select gp_segment_id, count(*) from part_t1 group by gp_segment_id;; 
+ gp_segment_id | count 
+---------------+-------
+             1 |    51
+             0 |    49
+(2 rows)
+
+abort;
 begin;
 Alter table part_t1 expand table;
 Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
@@ -810,6 +827,22 @@ Select count(*) > 0 from part_t1 where gp_segment_id=2;
  f
 (1 row)
 
+begin;
+alter table only part_t1 expand table;
+select relname, numsegments from gp_distribution_policy d, pg_class c where c.oid = d.localoid and c.relname like 'part_t1%' and d.numsegments = 3;
+ relname | numsegments 
+---------+-------------
+ part_t1 |           3
+(1 row)
+
+select gp_segment_id, count(*)>0 from part_t1 group by gp_segment_id;
+ gp_segment_id | ?column? 
+---------------+----------
+             1 | t
+             0 | t
+(2 rows)
+
+abort;
 begin;
 Alter table part_t1 expand table;
 Select count(*) from part_t1;
@@ -989,6 +1022,30 @@ select count(*) > 0 from inherit_t1_p1 where gp_segment_id = 2;
  f
 (1 row)
 
+begin;
+alter table only inherit_t1_p1 expand table;
+select relname, numsegments from gp_distribution_policy d, pg_class c where c.oid = d.localoid and c.relname like 'inherit_t1_p%' and d.numsegments = 3;
+    relname    | numsegments 
+---------------+-------------
+ inherit_t1_p1 |           3
+(1 row)
+
+select gp_segment_id, count(*) from inherit_t1_p1 group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    29
+             2 |     2
+             0 |    19
+(3 rows)
+
+select gp_segment_id, count(*) from inherit_t1_p2 group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    12
+             0 |     8
+(2 rows)
+
+abort;
 begin;
 alter table inherit_t1_p1 expand table;
 select count(*) > 0 from inherit_t1_p1 where gp_segment_id = 2;

--- a/src/test/regress/sql/reshuffle.sql
+++ b/src/test/regress/sql/reshuffle.sql
@@ -298,6 +298,12 @@ Update part_t1 set e = gp_segment_id;
 Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 
 begin;
+alter table only part_t1 expand table;
+select relname, numsegments from gp_distribution_policy d, pg_class c where c.oid = d.localoid and c.relname like 'part_t1%' and d.numsegments = 3;
+select gp_segment_id, count(*) from part_t1 group by gp_segment_id;; 
+abort;
+
+begin;
 Alter table part_t1 expand table;
 Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 abort;
@@ -336,6 +342,12 @@ Update part_t1 set e = gp_segment_id;
 
 Select count(*) from part_t1;
 Select count(*) > 0 from part_t1 where gp_segment_id=2;
+
+begin;
+alter table only part_t1 expand table;
+select relname, numsegments from gp_distribution_policy d, pg_class c where c.oid = d.localoid and c.relname like 'part_t1%' and d.numsegments = 3;
+select gp_segment_id, count(*)>0 from part_t1 group by gp_segment_id;
+abort;
 
 begin;
 Alter table part_t1 expand table;
@@ -406,6 +418,13 @@ insert into inherit_t1_p5 select i,i from generate_series(1,10) i;
 select count(*) > 0 from inherit_t1_p1 where gp_segment_id = 2;
 
 begin;
+alter table only inherit_t1_p1 expand table;
+select relname, numsegments from gp_distribution_policy d, pg_class c where c.oid = d.localoid and c.relname like 'inherit_t1_p%' and d.numsegments = 3;
+select gp_segment_id, count(*) from inherit_t1_p1 group by gp_segment_id;
+select gp_segment_id, count(*) from inherit_t1_p2 group by gp_segment_id;
+abort;
+
+begin;
 alter table inherit_t1_p1 expand table;
 select count(*) > 0 from inherit_t1_p1 where gp_segment_id = 2;
 abort;
@@ -417,3 +436,4 @@ alter table inherit_t1_p1 expand table;
 select count(*) > 0 from inherit_t1_p1 where gp_segment_id = 2;
 
 DROP TABLE inherit_t1_p1 CASCADE;
+


### PR DESCRIPTION
This PR fixes the https://github.com/greenplum-db/gpdb/issues/6309.

We generate an UPDATE parse tree to expand the data, If the relation is a root partition table, then the UPDATE will redistribute all the leaf tables although the `ONLY` flag is assigned because we set the default INH_DEFAULT options for RangeVar.

Now we treat the root partition table as a series of leaf tables when redistributed data and each leaf table only redistributed data for itself. If we expand a root partition table, all the leaf tables will be processed one by one.

If we ONLY expand a root partition table, then only the `numsegments` of its policy will be changed.

Co-authored-by: Zhenghua Lyu <zlv@pivotal.io> 