### PR TITLE
Fix build failure due to lack of PG_MODULE_MAGIC definition

### DIFF
--- a/gpcontrib/zstd/zstd_compression.c
+++ b/gpcontrib/zstd/zstd_compression.c
@@ -18,7 +18,7 @@
 #include <zstd.h>
 #include <zstd_errors.h>
 
-#ifndef PG_MODULE_MAGIC
+#ifndef UNIT_TESTING
 PG_MODULE_MAGIC;
 #endif
 


### PR DESCRIPTION
Commit https://github.com/greenplum-db/gpdb/commit/647cf58c41621846976e6079ec0434c7a8a8b411 introduced a wrapper around PG_MODULE_MAGIC, which is errorneous, as described in https://groups.google.com/a/greenplum.org/forum/?utm_source=digest&utm_medium=email#!topic/gpdb-dev/YVuYL1BK-QQ.

The correct wrapper around that definition is with 'UNIT_TESTING'.

Both wrappers are used to enable inclusion of `zstd_compression.c` in `test/zstd_compression_test.c`. This, in turn, is necessary to build unit tests.