### PR TITLE
Fix two log-rotation bugs.

### DIFF
--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -172,7 +172,7 @@ static FILE *logfile_open(const char *filename, const char *mode,
 #ifdef WIN32
 static unsigned int __stdcall pipeThread(void *arg);
 #endif
-static void logfile_rotate(bool time_based_rotation, bool size_based_rotation, const char *suffix,
+static bool logfile_rotate(bool time_based_rotation, bool size_based_rotation, const char *suffix,
 						   const char *log_directory, const char *log_filename,
                            FILE **fh, char **last_log_file_name);
 static char *logfile_getname(pg_time_t timestamp, const char *suffix, const char *log_directory, const char *log_file_pattern);
@@ -417,6 +417,8 @@ SysLoggerMain(int argc, char *argv[])
 		int			rc;
 #endif
 
+		bool		all_rotations_occurred = false;
+
 		/* Clear any already-pending wakeups */
 		ResetLatch(&sysLoggerLatch);
 
@@ -513,6 +515,9 @@ SysLoggerMain(int argc, char *argv[])
 			}
         }
 
+		all_rotations_occurred = rotation_requested ||
+								 (alert_log_level_opened && alert_rotation_requested);
+
         if (rotation_requested)
 		{
 			/*
@@ -523,20 +528,29 @@ SysLoggerMain(int argc, char *argv[])
 				size_rotation_for = LOG_DESTINATION_STDERR | LOG_DESTINATION_CSVLOG;
 
 			rotation_requested = false;
-            logfile_rotate(time_based_rotation, (size_rotation_for & LOG_DESTINATION_STDERR) != 0,
-						   NULL, Log_directory, Log_filename,
-						   &syslogFile, &last_file_name);
-            logfile_rotate(time_based_rotation, (size_rotation_for & LOG_DESTINATION_CSVLOG) != 0,
-						   ".csv", Log_directory, Log_filename,
-						   &csvlogFile, &last_csv_file_name);
+
+			all_rotations_occurred &=
+				logfile_rotate(time_based_rotation, (size_rotation_for & LOG_DESTINATION_STDERR) != 0,
+							   NULL, Log_directory, Log_filename,
+							   &syslogFile, &last_file_name);
+			all_rotations_occurred &=
+				logfile_rotate(time_based_rotation, (size_rotation_for & LOG_DESTINATION_CSVLOG) != 0,
+							   ".csv", Log_directory, Log_filename,
+							   &csvlogFile, &last_csv_file_name);
 		}
 
         if (alert_log_level_opened && alert_rotation_requested)
 		{
 			alert_rotation_requested = false;
-            logfile_rotate(time_based_rotation, size_rotation_for_alert,
-						   NULL, gp_perf_mon_directory, alert_file_pattern,
-                           &alertLogFile, &alert_last_file_name);
+			all_rotations_occurred &=
+				logfile_rotate(time_based_rotation, size_rotation_for_alert,
+							   NULL, gp_perf_mon_directory, alert_file_pattern,
+							   &alertLogFile, &alert_last_file_name);
+		}
+
+		if (all_rotations_occurred)
+		{
+			set_next_rotation_time();
 		}
 
 		/*
@@ -545,6 +559,9 @@ SysLoggerMain(int argc, char *argv[])
 		 * above is still close enough.  Note we can't make this calculation
 		 * until after calling logfile_rotate(), since it will advance
 		 * next_rotation_time.
+		 *
+		 * GPDB: logfile_rotate() doesn't advance next_rotation_time; we do that
+		 * explicitly above, once all rotations have been successful.
 		 *
 		 * Also note that we need to beware of overflow in calculation of the
 		 * timeout: with large settings of Log_RotationAge, next_rotation_time
@@ -2157,7 +2174,6 @@ logfile_open(const char *filename, const char *mode, bool allow_errors)
 /*
  * perform logfile rotation.
  *
- *
  * In GPDB, this has been modified significantly from the upstream version:
  *
  * - In PostgreSQL, one call to logfile_rotate performs rotation for both the
@@ -2165,11 +2181,12 @@ logfile_open(const char *filename, const char *mode, bool allow_errors)
  *   and also for the GPDB specific 'alert' log
  * - In PostgreSQL, this resets 'rotation_requested' flag. In GPDB, the caller
  *   has to do it.
- *
- *
- *
+ * - In PostgreSQL, this calls set_next_rotation_time(). In GPDB, the caller
+ *   has to do it once all calls to this function return true (i.e. after all
+ *   rotations have been successfully completed for the current timestamp), to
+ *   avoid having the filename timestamp advance multiple times per rotation.
  */
-static void
+static bool
 logfile_rotate(bool time_based_rotation, bool size_based_rotation,
 			   const char *suffix,
                const char *log_directory, 
@@ -2227,7 +2244,7 @@ logfile_rotate(bool time_based_rotation, bool size_based_rotation,
 
 			if (filename)
 				pfree(filename);
-			return;
+			return false;
 		}
 
 		if (*fh_p)
@@ -2244,7 +2261,7 @@ logfile_rotate(bool time_based_rotation, bool size_based_rotation,
 	if (filename)
 		pfree(filename);
 
-    set_next_rotation_time();
+	return true;
 }
 
 

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -477,8 +477,7 @@ SysLoggerMain(int argc, char *argv[])
 		if (Log_RotationAge > 0 && !rotation_disabled)
         {
             /* Do a logfile rotation if it's time */
-            pg_time_t	now = (pg_time_t) time(NULL);
-
+            now = (pg_time_t) time(NULL);
             if (now >= next_rotation_time)
             {
                 rotation_requested = time_based_rotation = true;


### PR DESCRIPTION
One bug that we've had at least since 5X, and another bug that was introduced into master with 9.2:

During time-based rotation of the log files, we'd create at least one extra log file that looked like it was from the future (e.g. at midnight on November 2nd you might see two log files created, `gpdb-2018-11-02_000000.csv` and `gpdb-2018-11-03_000000.csv`.) This was due to multiple calls to `set_next_rotation_time()`, which our first patch fixes. We're planning to backport this to 5X.

While manually testing that patch, we found that rotations still weren't happening when we expected them to -- they'd be delayed by a seemingly random but constant time. It turns out the wait delay was broken as part of the 9.2 merge, so we only rotated when receiving the periodic FTS logging information, not as part of an actual rotation wakeup. The second patch fixes that.