### PR TITLE
Create partition table with same numsegments for parent and children.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1828,16 +1828,6 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 	if (!CdbPathLocus_IsBottleneck(subpath->locus) &&
 		!cdbpathlocus_is_hashed_on_exprs(subpath->locus, uniq_exprs, false))
 	{
-		/*
-		 * We want to use numsegments from rel->cdbpolicy, however it might
-		 * be NULL.  Subpath is the cheapest path of rel, so it has the same
-		 * numsegments with rel.
-		 */
-		if (rel->cdbpolicy)
-		{
-			AssertEquivalent(rel->cdbpolicy->numsegments,
-							 subpath->locus.numsegments);
-		}
 		int			numsegments = CdbPathLocus_NumSegments(subpath->locus);
 
         locus = cdbpathlocus_from_exprs(root, uniq_exprs, numsegments);

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -175,6 +175,39 @@ begin;
 (26 rows)
 
 abort;
+-- partitioned table should have the same numsegments for parent and children
+-- even in RANDOM mode.
+select gp_debug_set_create_table_default_numsegments('random');
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ RANDOM
+(1 row)
+
+begin;
+	create table t (c1 int, c2 int) distributed by (c1)
+	partition by range(c2) (start(0) end(20) every(1));
+	-- verify that parent and children have the same numsegments
+	select count(a.localoid)
+	  from gp_distribution_policy a
+	  join pg_class c
+	    on a.localoid = c.oid
+	   and c.relname like 't_1_prt_%'
+	  join gp_distribution_policy b
+	    on a.numsegments = b.numsegments
+	   and b.localoid = 't'::regclass
+	;
+ count 
+-------
+    20
+(1 row)
+
+abort;
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
 --
 -- create table: LIKE, INHERITS and DISTRIBUTED BY
 --


### PR DESCRIPTION
When creating a partition table we want children have the same
numsegments with parent.  As they all set their numsegments to DEFAULT,
does this meet our expectation?  No, because DEFAULT does not always
equal to DEFAULT itself.  When DEFAULT is set to RANDOM a different
value is returned each time.

So we have to align numsegments explicitly.

Also removed an incorrect assert and comment.