### PR TITLE
Add a testcase to test the gang management

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -405,5 +405,36 @@ select gp_inject_fault('fts_probe', 'reset', 1);
 -- resume GDD scan 
 select gp_inject_fault('gdd_probe', 'reset', 1);
 
+--
+-- Test portal cleanup
+-- prepare a query contains init plan, main plan create a unnamed portal
+-- and will need multiple slices , init plan also need to allocated multiple
+-- slices in a named portal (eg: a cursor). The executing order is:
+-- 1. gangs of main plan is pre-assigned 2. init plan is executed 3. main plan
+-- is executed. This test it meant to test that cleanup of the named portal in
+-- the end of step2 will not affect the pre-allocated gangs of the main plan.
+--
+create table foo (c1 int, c2 int);
+create table bar (c1 int, c2 int);
+create or replace function foo_func()
+returns int
+as
+$BODY$
+declare
+t_record record;
+BEGIN
+	drop table if exists tmp1;
+	create temp table tmp1 as select foo.c1, bar.c2 from foo, bar;
+	for t_record in (select count(*) from foo, bar)
+	loop
+		NULL;
+	end loop;
+	return 1;
+END;
+$BODY$
+language plpgsql volatile;
+set gp_cached_segworkers_threshold to 1;
+select count(*) from foo, bar where exists (select foo_func());
+reset gp_cached_segworkers_threshold;
 \c regression
 DROP DATABASE dispatch_test_db;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -733,5 +733,48 @@ NOTICE:  Success:
  t
 (1 row)
 
+--
+-- Test portal cleanup
+-- prepare a query contains init plan, main plan create a unnamed portal
+-- and will need multiple slices , init plan also need to allocated multiple
+-- slices in a named portal (eg: a cursor). The executing order is:
+-- 1. gangs of main plan is pre-assigned 2. init plan is executed 3. main plan
+-- is executed. This test it meant to test that cleanup of the named portal in
+-- the end of step2 will not affect the pre-allocated gangs of the main plan.
+--
+create table foo (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create or replace function foo_func()
+returns int
+as
+$BODY$
+declare
+t_record record;
+BEGIN
+	drop table if exists tmp1;
+	create temp table tmp1 as select foo.c1, bar.c2 from foo, bar;
+	for t_record in (select count(*) from foo, bar)
+	loop
+		NULL;
+	end loop;
+	return 1;
+END;
+$BODY$
+language plpgsql volatile;
+set gp_cached_segworkers_threshold to 1;
+select count(*) from foo, bar where exists (select foo_func());
+NOTICE:  table "tmp1" does not exist, skipping
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ count 
+-------
+     0
+(1 row)
+
+reset gp_cached_segworkers_threshold;
 \c regression
 DROP DATABASE dispatch_test_db;


### PR DESCRIPTION
The gang management now has a smaller granularity and a better management
of memory context, meanwhile, gangs are not pre-assigned anymore for main
plan and init plans. An issue was reported for old implementation of gang
management, although it cannot been reproduced now, it's still necessary
to add a test case to avoid regression in the feature.

The test strategy is preparing a query contains both main and init plan,
main plan create a unnamed portal and will need multiple slices , init
plan also need to allocated multiple slices in a named portal (eg: a
cursor), the expect result is gang management works fine in such mixed
combination.