### PR TITLE
gpcrondump: Do not drop post data objects by default

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
@@ -111,6 +111,7 @@ Feature: Validate command line arguments
 
     @nbupartI
     @ddpartI
+    @skip_for_gpdb_43
     Scenario: 5a Full Backup and Restore with constraints
         Given the backup test is initialized with database "bkdb5a"
         And there is a "heap" table "public.heap_table" in "bkdb5a" with data

--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_backups.feature
@@ -111,7 +111,7 @@ Feature: Validate command line arguments
 
     @nbupartI
     @ddpartI
-    Scenario: 5a Full Backup and Restore
+    Scenario: 5a Full Backup and Restore with constraints
         Given the backup test is initialized with database "bkdb5a"
         And there is a "heap" table "public.heap_table" in "bkdb5a" with data
         And there is a "ao" partition table "public.ao_part_table" in "bkdb5a" with data

--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
@@ -66,6 +66,7 @@ Feature: Validate command line arguments
 
     @nbupartI
     @ddpartI
+    @skip_for_gpdb_43
     Scenario: 5a Full Backup and Restore with constraints
         Given the old timestamps are read from json
         When the user runs gpdbrestore -e with the stored timestamp

--- a/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup_and_restore_restores.feature
@@ -66,14 +66,14 @@ Feature: Validate command line arguments
 
     @nbupartI
     @ddpartI
-    Scenario: 5a Full Backup and Restore
+    Scenario: 5a Full Backup and Restore with constraints
         Given the old timestamps are read from json
         When the user runs gpdbrestore -e with the stored timestamp
         Then gpdbrestore should return a return code of 0
         And verify that there is a "heap" table "public.heap_table" in "bkdb5a" with data
         And verify that there is a "ao" table "public.ao_part_table" in "bkdb5a" with data
-        And verify that the "report" file in " " dir does not contain "ERROR"
-        And verify that the "status" file in " " dir does not contain "ERROR"
+        And verify that the "restore_report" file in " " dir does not contain "ERROR"
+        And verify that the "restore_status" file in " " dir does not contain "ERROR"
         And verify that there is a constraint "check_constraint_no_domain" in "bkdb5a"
         And verify that there is a constraint "check_constraint_with_domain" in "bkdb5a"
         And verify that there is a constraint "unique_constraint" in "bkdb5a"

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/add_rules_indexes_constraints_triggers.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/add_rules_indexes_constraints_triggers.sql
@@ -1,15 +1,21 @@
 -- create various rules, constraints, indexes, domains
 
-drop table if exists mytable;
-drop table if exists mytable2;
-drop table if exists mytable3;
-drop table if exists mytable4;
-drop table if exists us_snail_addy;
-drop domain if exists us_postal_code;
-create table mytable (i int, s varchar);
-create table mytable2 (i int);
-create table mytable3 (i int PRIMARY KEY);
-create table mytable4 (i int UNIQUE);
+DROP TABLE IF EXISTS mytable;
+DROP TABLE IF EXISTS mytable2;
+DROP TABLE IF EXISTS mytable3;
+DROP TABLE IF EXISTS mytable4;
+DROP TABLE IF EXISTS us_snail_addy;
+DROP DOMAIN IF EXISTS us_postal_code;
+CREATE TABLE mytable (i int, s varchar);
+CREATE TABLE mytable2 (i int);
+CREATE TABLE mytable3 (i int PRIMARY KEY);
+CREATE TABLE mytable4 (i int UNIQUE);
+CREATE TABLE mytable5 (id int, date date PRIMARY KEY, amt decimal(10,2))
+DISTRIBUTED BY (date)
+PARTITION BY RANGE (date)
+( START (date '2018-01-01') INCLUSIVE
+   END (date '2018-01-31') EXCLUSIVE
+   EVERY (INTERVAL '1 week') );
 
 
 CREATE DOMAIN us_postal_code AS TEXT
@@ -28,7 +34,7 @@ CREATE OR REPLACE RULE myrule AS
   ON UPDATE TO mytable             -- another similar rule for DELETE
   DO INSTEAD NOTHING;
 
-create or replace function do_nothing () returns trigger as
+CREATE OR REPLACE FUNCTION do_nothing () RETURNS TRIGGER AS
 $$
 begin
 return new;
@@ -47,5 +53,5 @@ CREATE UNIQUE INDEX my_unique_index ON mytable (i);
 ALTER TABLE mytable ADD CONSTRAINT check_constraint_no_domain CHECK (char_length(s) < 30);
 ALTER TABLE us_snail_addy ADD CONSTRAINT check_constraint_with_domain CHECK (char_length(s) < 30);
 ALTER TABLE us_snail_addy ADD PRIMARY KEY (address_id);
-ALTER TABLE mytable2 add CONSTRAINT unique_constraint UNIQUE (i);
+ALTER TABLE mytable2 ADD CONSTRAINT unique_constraint UNIQUE (i);
 ALTER TABLE mytable3 ADD CONSTRAINT foreign_key FOREIGN KEY (i) REFERENCES mytable4 (i) MATCH FULL;

--- a/src/bin/pg_dump/pg_backup_files.c
+++ b/src/bin/pg_dump/pg_backup_files.c
@@ -461,7 +461,7 @@ _CloseArchive(ArchiveHandle *AH)
 		AH->CustomOutPtr = _WriteBuf;
 
 		ropt = NewRestoreOptions();
-		ropt->dropSchema = 1;
+		ropt->dropSchema = 0;
 		ropt->compression = 0;
 		ropt->superuser = NULL;
 		ropt->suppressDumpWarnings = true;


### PR DESCRIPTION
Previously, gpcrondump was dropping postdata objects before recreating
them on restore. The drop statements were generating errors for partition
tables due to invalid syntax. pg_dump does not generate these statements
so we feel it is safe to remove them in order to fix the errors.