### PR TITLE
Allow numsegments to be specified by DISTRIBUTED BY.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1828,16 +1828,6 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 	if (!CdbPathLocus_IsBottleneck(subpath->locus) &&
 		!cdbpathlocus_is_hashed_on_exprs(subpath->locus, uniq_exprs, false))
 	{
-		/*
-		 * We want to use numsegments from rel->cdbpolicy, however it might
-		 * be NULL.  Subpath is the cheapest path of rel, so it has the same
-		 * numsegments with rel.
-		 */
-		if (rel->cdbpolicy)
-		{
-			AssertEquivalent(rel->cdbpolicy->numsegments,
-							 subpath->locus.numsegments);
-		}
 		int			numsegments = CdbPathLocus_NumSegments(subpath->locus);
 
         locus = cdbpathlocus_from_exprs(root, uniq_exprs, numsegments);

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -61,6 +61,8 @@ analyze r2;
 -- a temp table is created during reorganization, its numsegments should be
 -- the same with original table, otherwise some data will be lost after the
 -- reorganization.
+--
+-- in most cases the temp table is created with CTAS.
 begin;
 	insert into t1 select i, i from generate_series(1,10) i;
 	select gp_segment_id, * from t1;
@@ -77,6 +79,12 @@ begin;
              0 |  9 |  9 |    |   
              0 | 10 | 10 |    |   
 (10 rows)
+
+	select gp_debug_set_create_table_default_numsegments('full');
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ FULL
+(1 row)
 
 	alter table t1 set with (reorganize=true) distributed by (c1);
 	select gp_segment_id, * from t1;
@@ -95,8 +103,158 @@ begin;
 (10 rows)
 
 abort;
+-- but there are also cases the temp table is created with CREATE + INSERT.
+-- case 1: with dropped columns
+begin;
+	insert into t1 select i, i from generate_series(1,10) i;
+	select gp_segment_id, * from t1;
+ gp_segment_id | c1 | c2 | c3 | c4 
+---------------+----+----+----+----
+             0 |  1 |  1 |    |   
+             0 |  2 |  2 |    |   
+             0 |  3 |  3 |    |   
+             0 |  4 |  4 |    |   
+             0 |  5 |  5 |    |   
+             0 |  6 |  6 |    |   
+             0 |  7 |  7 |    |   
+             0 |  8 |  8 |    |   
+             0 |  9 |  9 |    |   
+             0 | 10 | 10 |    |   
+(10 rows)
+
+	alter table t1 drop column c4;
+	select gp_debug_set_create_table_default_numsegments('full');
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ FULL
+(1 row)
+
+	alter table t1 set with (reorganize=true) distributed by (c1);
+	select gp_segment_id, * from t1;
+ gp_segment_id | c1 | c2 | c3 
+---------------+----+----+----
+             0 |  1 |  1 |   
+             0 |  2 |  2 |   
+             0 |  3 |  3 |   
+             0 |  4 |  4 |   
+             0 |  5 |  5 |   
+             0 |  6 |  6 |   
+             0 |  7 |  7 |   
+             0 |  8 |  8 |   
+             0 |  9 |  9 |   
+             0 | 10 | 10 |   
+(10 rows)
+
+abort;
+-- case 2: AOCO
+begin;
+	select gp_debug_set_create_table_default_numsegments('minimal');
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ MINIMAL
+(1 row)
+
+	create table t (c1 int, c2 int)
+	  with (appendonly=true, orientation=column)
+	  distributed by (c1, c2);
+	insert into t select i, i from generate_series(1,10) i;
+	select gp_segment_id, * from t;
+ gp_segment_id | c1 | c2 
+---------------+----+----
+             0 |  1 |  1
+             0 |  2 |  2
+             0 |  3 |  3
+             0 |  4 |  4
+             0 |  5 |  5
+             0 |  6 |  6
+             0 |  7 |  7
+             0 |  8 |  8
+             0 |  9 |  9
+             0 | 10 | 10
+(10 rows)
+
+	select gp_debug_set_create_table_default_numsegments('full');
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ FULL
+(1 row)
+
+	alter table t set with (reorganize=true) distributed by (c1);
+	select gp_segment_id, * from t;
+ gp_segment_id | c1 | c2 
+---------------+----+----
+             0 |  1 |  1
+             0 |  2 |  2
+             0 |  3 |  3
+             0 |  4 |  4
+             0 |  5 |  5
+             0 |  6 |  6
+             0 |  7 |  7
+             0 |  8 |  8
+             0 |  9 |  9
+             0 | 10 | 10
+(10 rows)
+
+abort;
+-- case 3: AO + index
+begin;
+	select gp_debug_set_create_table_default_numsegments('minimal');
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ MINIMAL
+(1 row)
+
+	create table t (c1 int, c2 int)
+	  with (appendonly=true, orientation=row)
+	  distributed by (c1, c2);
+	create index ti on t (c2);
+	insert into t select i, i from generate_series(1,10) i;
+	select gp_segment_id, * from t;
+ gp_segment_id | c1 | c2 
+---------------+----+----
+             0 |  1 |  1
+             0 |  2 |  2
+             0 |  3 |  3
+             0 |  4 |  4
+             0 |  5 |  5
+             0 |  6 |  6
+             0 |  7 |  7
+             0 |  8 |  8
+             0 |  9 |  9
+             0 | 10 | 10
+(10 rows)
+
+	select gp_debug_set_create_table_default_numsegments('full');
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ FULL
+(1 row)
+
+	alter table t set with (reorganize=true) distributed by (c1);
+	select gp_segment_id, * from t;
+ gp_segment_id | c1 | c2 
+---------------+----+----
+             0 |  1 |  1
+             0 |  2 |  2
+             0 |  3 |  3
+             0 |  4 |  4
+             0 |  5 |  5
+             0 |  6 |  6
+             0 |  7 |  7
+             0 |  8 |  8
+             0 |  9 |  9
+             0 | 10 | 10
+(10 rows)
+
+abort;
 -- restore the analyze information
 analyze t1;
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
 -- append SingleQE of different sizes
 select max(c1) as v, 1 as r from t2 union all select 1 as v, 2 as r;
  v | r 

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -175,6 +175,39 @@ begin;
 (26 rows)
 
 abort;
+-- partitioned table should have the same numsegments for parent and children
+-- even in RANDOM mode.
+select gp_debug_set_create_table_default_numsegments('random');
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ RANDOM
+(1 row)
+
+begin;
+	create table t (c1 int, c2 int) distributed by (c1)
+	partition by range(c2) (start(0) end(20) every(1));
+	-- verify that parent and children have the same numsegments
+	select count(a.localoid)
+	  from gp_distribution_policy a
+	  join pg_class c
+	    on a.localoid = c.oid
+	   and c.relname like 't_1_prt_%'
+	  join gp_distribution_policy b
+	    on a.numsegments = b.numsegments
+	   and b.localoid = 't'::regclass
+	;
+ count 
+-------
+    20
+(1 row)
+
+abort;
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
 --
 -- create table: LIKE, INHERITS and DISTRIBUTED BY
 --


### PR DESCRIPTION
CREATE TABLE always set numsegments to DEFAULT, however when there is a
DISTRIBUTED BY clause it might already contain a valid numsegments.

This will not happen in a user typed CREATE TABLE sql because there is
no syntax to specify numsegments, so far the only chance for this to
happen is the internal command constructed by reorganization, it might
be a CTAS or (CREATE + INSERT), both will pass original numsegments via
DISTRIBUTED BY.

One bug is that we only accept numsegments passed by CTAS but not the
other.  The (CREATE + INSERT) command is only constructed in 3 cases:

1. original table contains dropped column(s);
2. original table is AOCO;
3. original table is AO with index(es);

Fixed and added tests.

( This PR contains two commits, the first is exactly the same as https://github.com/greenplum-db/gpdb/pull/6352, please only review the second )