### PR TITLE
Fix crash with ORCA for partition tables with rewritten rules

### DIFF
--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -4084,7 +4084,7 @@ child_distribution_mismatch(Relation rel)
 	GpPolicy *rootPolicy = rel->rd_cdbpolicy;
 	Assert(NULL != rootPolicy && "Partitioned tables cannot be master-only");
 
-	if (POLICYTYPE_PARTITIONED == rootPolicy->ptype && 0 == rootPolicy->nattrs)
+	if (GpPolicyIsRandomly(rootPolicy))
 	{
 		/* root partition policy already marked as Random, no mismatch possible as
 		 * all children must be random as well */
@@ -4101,7 +4101,8 @@ child_distribution_mismatch(Relation rel)
 		Assert(NULL != relChild);
 
 		GpPolicy *childPolicy = relChild->rd_cdbpolicy;
-		if (POLICYTYPE_PARTITIONED == childPolicy->ptype && 0 == childPolicy->nattrs)
+
+		if (GpPolicyIsRandomly(childPolicy))
 		{
 			/* child partition is Random, and parent is not */
 			RelationClose(relChild);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10588,3 +10588,17 @@ WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onet
         1 |        0 |        2
 (10 rows)
 
+-- queries on partition table with rewritten rule should not crash
+-- github issue #5913
+create table rewrite_rules (id int, stamp date, amount int)
+with (appendonly=false) distributed by (id)
+partition by range (stamp) (
+  start ('2018-01-01') end ('2019-01-01') every(interval '1 year'),
+  default partition extra
+);
+NOTICE:  CREATE TABLE will create partition "rewrite_rules_1_prt_extra" for table "rewrite_rules"
+NOTICE:  CREATE TABLE will create partition "rewrite_rules_1_prt_2" for table "rewrite_rules"
+create rule "_RETURN" as on select to rewrite_rules_1_prt_2 do instead 
+select 1 as id, current_date as stamp, 1 as amount;
+select * from rewrite_rules;
+ERROR:  plan contains range table with relstorage='v' (allpaths.c:346)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10655,3 +10655,17 @@ WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onet
         1 |        0 |        2
 (10 rows)
 
+-- queries on partition table with rewritten rule should not crash
+-- github issue #5913
+create table rewrite_rules (id int, stamp date, amount int)
+with (appendonly=false) distributed by (id)
+partition by range (stamp) (
+  start ('2018-01-01') end ('2019-01-01') every(interval '1 year'),
+  default partition extra
+);
+NOTICE:  CREATE TABLE will create partition "rewrite_rules_1_prt_extra" for table "rewrite_rules"
+NOTICE:  CREATE TABLE will create partition "rewrite_rules_1_prt_2" for table "rewrite_rules"
+create rule "_RETURN" as on select to rewrite_rules_1_prt_2 do instead 
+select 1 as id, current_date as stamp, 1 as amount;
+select * from rewrite_rules;
+ERROR:  undefined table type for storage format: v (execScan.c:414)


### PR DESCRIPTION
Earlier, the check for identifying if a table is randomly distributed relied
on the policy to be not null, however if we have rewritten rules on child
partition table, the table storage is marked as RELSTORAGE_VIRTUAL which can
lead to null policy.

Should the table be marked with virtual storage, that's a different issue though.

Master already handles this:
https://github.com/greenplum-db/gpdb/blob/master/src/backend/utils/cache/lsyscache.c#L4218
https://github.com/greenplum-db/gpdb/blob/master/src/backend/utils/cache/lsyscache.c#L4238

Also, in master, the relstorage is not marked as virtual.

Earlier the query used to crash for orca, now it will error out.
Github Issue: https://github.com/greenplum-db/gpdb/issues/5913