### PR TITLE
Fix memory leak for the partition selector method used by planner

### DIFF
--- a/src/backend/executor/nodePartitionSelector.c
+++ b/src/backend/executor/nodePartitionSelector.c
@@ -216,6 +216,7 @@ ExecPartitionSelector(PartitionSelectorState *node)
 		{
 			InsertPidIntoDynamicTableScanInfo(estate, ps->scanId, lfirst_oid(lc), ps->selectorId);
 		}
+		list_free(oids);
 	}
 	else
 	{


### PR DESCRIPTION
We should free the oid list once that is inserted into the DTS info