### PR TITLE
Remove unused imports and variable from Python code

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupimpl
+++ b/gpMgmt/bin/gpcheckresgroupimpl
@@ -5,7 +5,6 @@
 
 import os
 import sys
-import psutil
 from gppylib.commands import gp
 from gppylib import gpversion
 

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -19,7 +19,6 @@ try:
     from gppylib.commands.unix import *
     from gppylib.fault_injection import inject_fault
     from gppylib.commands.gp import *
-    from gppylib.commands.pg import PgControlData
     from gppylib.gparray import GpArray, MODE_CHANGELOGGING, STATUS_DOWN
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.gplog import *

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -6,8 +6,6 @@
 import os
 import sys
 import signal
-import shutil
-import socket
 
 # import GPDB modules
 try:
@@ -16,7 +14,6 @@ try:
     from gppylib.commands import unix, gp, base, pg
     from gppylib import gparray
     from gppylib.db import dbconn
-    from gppylib.db import catalog
     from gppylib.userinput import *
     from gppylib.gp_dbid import GpDbidFile
     from gppylib.operations.initstandby import cleanup_pg_hba_backup_on_segment, update_pg_hba_conf_on_segments, restore_pg_hba_on_segment

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1319,7 +1319,6 @@ class gpload:
         Level is either DEBUG, LOG, INFO, ERROR. a is the message
         """
         try:
-            t = time.localtime()
             str = '|'.join(
                        [datetime.datetime.today().strftime('%Y-%m-%d %H:%M:%S'),
                         self.elevel2str(level), a]) + '\n'

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
@@ -35,7 +35,6 @@ class GpExpand(GpTestCase):
             patch('gpexpand.GpArray.initFromCatalog', return_value=self.gparray),
             patch('__builtin__.open', mock_open(), create=True),
             patch('__builtin__.raw_input'),
-            patch('gpexpand.PgControlData', return_value=Mock()),
             patch('gpexpand.copy.deepcopy', return_value=Mock()),
             patch('gpexpand.dbconn.execSQL', return_value=FakeCursor()),
             patch('gpexpand.GpExpandStatus', return_value=Mock()),


### PR DESCRIPTION
Nothing exciting here, just removing a few unused imports and an unused variable.