### PR TITLE
Remove return after ereport(ERROR..)

### DIFF
--- a/gpcontrib/gp_sparse_vector/SparseData.c
+++ b/gpcontrib/gp_sparse_vector/SparseData.c
@@ -248,9 +248,6 @@ double *sdata_to_float8arr(SparseData sdata) {
 		ereport(ERROR,(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 		 errmsg("Array size is incorrect, is: %d and should be %d\n",
 				aptr,sdata->total_value_count)));
-
-		pfree(array);
-		return NULL;
 	}
 
 	return array;


### PR DESCRIPTION
Calling ereport(ERROR..) will break out of any codepath never to
return, so returning NULL is dead code here. Resources are also
automatically clenaed on erroring out, so remove the pfree() call
(which is also dead code) rather than moving it before the ereport.