### PR TITLE
Remove unused matchignore rules from atmsort

### DIFF
--- a/src/test/regress/expected/metadata_track.out
+++ b/src/test/regress/expected/metadata_track.out
@@ -1189,7 +1189,6 @@ NOTICE:  CREATE TABLE will create partition "mdt_supplier_hybrid_part_1_prt_p1_2
 NOTICE:  CREATE TABLE will create partition "mdt_supplier_hybrid_part_1_prt_p1_2_prt_4" for table "mdt_supplier_hybrid_part_1_prt_p1"
 NOTICE:  CREATE TABLE will create partition "mdt_supplier_hybrid_part_1_prt_p1_2_prt_5" for table "mdt_supplier_hybrid_part_1_prt_p1"
 Vacuum analyse myschema.mdt_supplier_hybrid_part;
-NOTICE:  ANALYZE detected all empty sample pages for table mdt_supplier_hybrid_part, please run VACUUM FULL for accurate estimation.
 ALTER TABLE myschema.mdt_supplier_hybrid_part SET SCHEMA myschema_new;
 Vacuum myschema_new.mdt_supplier_hybrid_part;
 ALTER TABLE myschema.mdt_supplier_hybrid_part_1_prt_p1 SET SCHEMA myschema_new;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -63,21 +63,6 @@ m/^NOTICE:.*building index for child partition ".*"/
 # E.g exchanged partition "p1" of relation "parttest_t" with relation "pg_temp_4062621"
 m/^NOTICE:.*exchanged partition ".*" with relation ".*"/
 
-# The following NOTICE is generated when a user creates a table with no
-# columns. E.g CREATE TABLE foo(). It is to inform the user that database
-# cannot find any columns on which to distribute the data. Merging tests from
-# postgres might cause the tests to output these messages and we would need to
-# manually modify the corresponding expected output. Hence we want to ignore
-# these.
-m/^NOTICE:.*Table has no attributes to distribute on./
-
-# The following NOTICE is generated when user runs ANALYZE. The NOTICE message
-# generated seems to be non deterministic in that separate test runs produce
-# the NOTICE for different tables and different number of tables. For E.g in one
-# test run it produced the following NOTICE for pg_auth and in other it
-# produced a NOTICE for pg_auth and pg_auth_constraints.
-m/^NOTICE:.*ANALYZE detected all empty sample pages for table .*, please run VACUUM FULL for accurate estimation/
-
 m/^WARNING:  could not close temporary file .*: No such file or directory/
 
 # Messages when resource group is enabled:


### PR DESCRIPTION
These rules cover messages that are no longer in the code, so they will never match. Remove.