### PR TITLE
Add handling of FIFO files for pg_rewind

### DIFF
--- a/src/bin/pg_rewind/copy_fetch.c
+++ b/src/bin/pg_rewind/copy_fetch.c
@@ -101,6 +101,11 @@ recurse_dir(const char *datadir, const char *parentpath,
 
 		if (S_ISREG(fst.st_mode))
 			callback(path, FILE_TYPE_REGULAR, fst.st_size, NULL);
+		else if (S_ISFIFO(fst.st_mode))
+		{
+			/* Greenplum uses FIFO for pgsql_tmp files. */
+			callback(path, FILE_TYPE_FIFO, fst.st_size, NULL);
+		}
 		else if (S_ISDIR(fst.st_mode))
 		{
 			callback(path, FILE_TYPE_DIRECTORY, 0, NULL);

--- a/src/bin/pg_rewind/file_ops.c
+++ b/src/bin/pg_rewind/file_ops.c
@@ -134,6 +134,7 @@ remove_target(file_entry_t *entry)
 			break;
 
 		case FILE_TYPE_REGULAR:
+		case FILE_TYPE_FIFO:
 			remove_target_file(entry->path, false);
 			break;
 
@@ -161,6 +162,11 @@ create_target(file_entry_t *entry)
 		case FILE_TYPE_REGULAR:
 			/* can't happen. Regular files are created with open_target_file. */
 			pg_fatal("invalid action (CREATE) for regular file\n");
+			break;
+
+		case FILE_TYPE_FIFO:
+			/* Only pgsql_tmp files are FIFO and they are ignored from source target. */
+			pg_fatal("invalid action (CREATE) for fifo file\n");
 			break;
 	}
 }

--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -228,6 +228,9 @@ process_source_file(const char *path, file_type_t type, size_t newsize,
 					action = FILE_ACTION_NONE;
 			}
 			break;
+
+		case FILE_TYPE_FIFO:
+			break;
 	}
 
 	/* Create a new entry for this file */

--- a/src/bin/pg_rewind/filemap.h
+++ b/src/bin/pg_rewind/filemap.h
@@ -35,6 +35,7 @@ typedef enum
 typedef enum
 {
 	FILE_TYPE_REGULAR,
+	FILE_TYPE_FIFO,
 	FILE_TYPE_DIRECTORY,
 	FILE_TYPE_SYMLINK
 } file_type_t;


### PR DESCRIPTION
In Greenplum, pgsql_tmp files are actually FIFO files. Without logic
in pg_rewind to handle these files, leftover FIFO tmp files on the
target server would cause pg_rewind to fail. We don't care about the
source server pgsql_tmp files because those are string matched to not
copy over.

This is the reason why PR pipeline for https://github.com/greenplum-db/gpdb/pull/6138 is failing.