### PR TITLE
resgroup: allow shared memory as operator memory.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -88,6 +88,7 @@
 #include "utils/typcache.h"
 #include "utils/workfile_mgr.h"
 #include "utils/faultinjector.h"
+#include "utils/resource_manager.h"
 
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_class.h"
@@ -309,8 +310,14 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		/**
 		 * There are some statements that do not go through the resource queue, so we cannot
 		 * put in a strong assert here. Someday, we should fix resource queues.
+		 *
+		 * In resource group mode we always assign some memory to operators
+		 * even if the amount is larger than the spill memory, the memory can
+		 * be actually allocated from the shared memory.  If there is not enough
+		 * shared memory OOM will be raised on executors.
 		 */
-		if (queryDesc->plannedstmt->query_mem > 0)
+		if (IsResGroupEnabled() ||
+			queryDesc->plannedstmt->query_mem > 0)
 		{
 			switch(*gp_resmanager_memory_policy)
 			{

--- a/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
@@ -1,0 +1,215 @@
+SET optimizer TO off;
+SET
+
+--
+-- setup
+--
+
+--start_ignore
+DROP VIEW IF EXISTS many_ops;
+DROP ROLE r1_opmem_test;
+DROP RESOURCE GROUP rg1_opmem_test;
+DROP RESOURCE GROUP rg2_opmem_test;
+--end_ignore
+
+-- this view contains many operators in the plan, which is used to trigger
+-- the issue.  gp_toolkit.gp_resgroup_config is a large JOIN view of many
+-- relations, to prevent the source relations being optimized out from the plan
+-- we have to keep the columns provided by them in the target list, instead of
+-- composing a long SELECT c1,c2,... list we use SELECT * here, but we should
+-- not output the groupid as it changes each time.
+CREATE OR REPLACE VIEW many_ops AS SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config ;
+CREATE
+
+CREATE RESOURCE GROUP rg1_opmem_test WITH (cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0, concurrency=20, memory_spill_ratio=0);
+CREATE
+
+CREATE ROLE r1_opmem_test RESOURCE GROUP rg1_opmem_test;
+CREATE
+GRANT ALL ON many_ops TO r1_opmem_test;
+GRANT
+
+-- rg1 has very low per-xact memory quota, there will be no enough operator
+-- memory reserved, however in resource group mode we assign at least 100KB to
+-- each operator, no matter it is memory intensive or not.  As long as there is
+-- enough shared memory the query should be executed successfully.
+--
+-- note: when there is no enough operator memory there should be a warning,
+-- however warnings are not displayed in isolation2 tests.
+
+--
+-- positive: there is enough global shared memory
+--
+
+SET gp_resgroup_memory_policy TO none;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+(0 rows)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+(0 rows)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+(0 rows)
+RESET role;
+RESET
+
+--
+-- negative: there is not enough shared memory
+--
+
+-- rg1 has no group level shared memory, and most memory are granted to rg2,
+-- there is only very little global shared memory due to integer rounding.
+CREATE RESOURCE GROUP rg2_opmem_test WITH (cpu_rate_limit=10, memory_limit=40);
+CREATE
+
+-- this query can execute but will raise OOM error.
+
+SET gp_resgroup_memory_policy TO none;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+ERROR:  Out of memory
+DETAIL:  Resource group memory limit reached
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+ERROR:  Out of memory
+DETAIL:  Resource group memory limit reached
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+ERROR:  Out of memory
+DETAIL:  Resource group memory limit reached
+RESET role;
+RESET
+
+--
+-- positive: there is enough group shared memory
+--
+
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 100;
+ALTER
+
+SET gp_resgroup_memory_policy TO none;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+(0 rows)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+(0 rows)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+(0 rows)
+RESET role;
+RESET
+
+--
+-- positive: increased group memory settings
+--
+
+DROP RESOURCE GROUP rg2_opmem_test;
+DROP
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_limit 40;
+ALTER
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 50;
+ALTER
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_spill_ratio 30;
+ALTER
+ALTER RESOURCE GROUP rg1_opmem_test SET concurrency 1;
+ALTER
+
+SET gp_resgroup_memory_policy TO none;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+(0 rows)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+(0 rows)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+(0 rows)
+RESET role;
+RESET
+
+--
+-- cleanup
+--
+
+DROP VIEW many_ops;
+DROP
+DROP ROLE r1_opmem_test;
+DROP
+DROP RESOURCE GROUP rg1_opmem_test;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -31,6 +31,7 @@ test: resgroup/resgroup_cancel_terminate_concurrency
 
 # regression tests
 test: resgroup/resgroup_recreate
+test: resgroup/resgroup_operator_memory
 
 # parallel tests
 #test: resgroup/restore_default_resgroup

--- a/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
@@ -1,0 +1,155 @@
+SET optimizer TO off;
+
+--
+-- setup
+--
+
+--start_ignore
+DROP VIEW IF EXISTS many_ops;
+DROP ROLE r1_opmem_test;
+DROP RESOURCE GROUP rg1_opmem_test;
+DROP RESOURCE GROUP rg2_opmem_test;
+--end_ignore
+
+-- this view contains many operators in the plan, which is used to trigger
+-- the issue.  gp_toolkit.gp_resgroup_config is a large JOIN view of many
+-- relations, to prevent the source relations being optimized out from the plan
+-- we have to keep the columns provided by them in the target list, instead of
+-- composing a long SELECT c1,c2,... list we use SELECT * here, but we should
+-- not output the groupid as it changes each time.
+CREATE OR REPLACE VIEW many_ops AS
+       SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+;
+
+CREATE RESOURCE GROUP rg1_opmem_test
+  WITH (cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0,
+        concurrency=20, memory_spill_ratio=0);
+
+CREATE ROLE r1_opmem_test RESOURCE GROUP rg1_opmem_test;
+GRANT ALL ON many_ops TO r1_opmem_test;
+
+-- rg1 has very low per-xact memory quota, there will be no enough operator
+-- memory reserved, however in resource group mode we assign at least 100KB to
+-- each operator, no matter it is memory intensive or not.  As long as there is
+-- enough shared memory the query should be executed successfully.
+--
+-- note: when there is no enough operator memory there should be a warning,
+-- however warnings are not displayed in isolation2 tests.
+
+--
+-- positive: there is enough global shared memory
+--
+
+SET gp_resgroup_memory_policy TO none;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO auto;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+--
+-- negative: there is not enough shared memory
+--
+
+-- rg1 has no group level shared memory, and most memory are granted to rg2,
+-- there is only very little global shared memory due to integer rounding.
+CREATE RESOURCE GROUP rg2_opmem_test
+  WITH (cpu_rate_limit=10, memory_limit=40);
+
+-- this query can execute but will raise OOM error.
+
+SET gp_resgroup_memory_policy TO none;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO auto;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+--
+-- positive: there is enough group shared memory
+--
+
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 100;
+
+SET gp_resgroup_memory_policy TO none;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO auto;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+--
+-- positive: increased group memory settings
+--
+
+DROP RESOURCE GROUP rg2_opmem_test;
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_limit 40;
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 50;
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_spill_ratio 30;
+ALTER RESOURCE GROUP rg1_opmem_test SET concurrency 1;
+
+SET gp_resgroup_memory_policy TO none;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO auto;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+--
+-- cleanup
+--
+
+DROP VIEW many_ops;
+DROP ROLE r1_opmem_test;
+DROP RESOURCE GROUP rg1_opmem_test;


### PR DESCRIPTION
GPDB assigns 100KB for each non memory intensive operator, and report an
error if there is not enough memory reserved for the operators.  In low
memory resource groups it is easy to trigger this error with large
queries.

Improved by always assign at least 100KB memory to operators, both
memory intensive or non-intensive, the memory can be allocated from
shared memory, and will raise OOM error if there is not enough shared
memory.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`