### PR TITLE
[WIP] Fix motion path.rows for cost calculation.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -50,11 +50,7 @@ cdbpath_cost_motion(PlannerInfo *root, CdbMotionPath *motionpath)
 	double		recvrows;
 	double		sendrows;
 
-	if (! IsA(subpath, BitmapHeapPath) &&
-		! IsA(subpath, BitmapAppendOnlyPath) && 
-		! IsA(subpath, IndexPath) && 
-		! IsA(subpath, UniquePath) &&
-		CdbPathLocus_IsReplicated(motionpath->path.locus))
+	if (CdbPathLocus_IsReplicated(motionpath->path.locus))
 		/* FIXME: should use other.numsegments instead of cdbpath_segments */
 		motionpath->path.rows = subpath->rows * root->config->cdbpath_segments;
 	else


### PR DESCRIPTION
For locus CdbLocusType_Replicated, compared with other motions, apparently the cost should multiply by the number of segment.

Here is an example of plan with wrong cost. (Check the "rows" in "Broadcast Motion" line).
```
regression=# explain select a.idv, b.idv from tidv a, tidv b where a.idv = b.idv;
                                                QUERY PLAN
-----------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)  (cost=0.33..134274.57 rows=2787840 width=64)
   ->  Nested Loop  (cost=0.33..134274.57 rows=929280 width=64)
         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.17..21848.17 rows=17600 width=32)
               ->  Index Only Scan using tidv_idv_idx on tidv a  (cost=0.17..20792.17 rows=17600 width=32)
         ->  Index Only Scan using tidv_idv_idx on tidv b  (cost=0.17..1.60 rows=18 width=32)
               Index Cond: (idv = a.idv)

regression=# explain select * from tidv;
                                    QUERY PLAN
-----------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..628.00 rows=52800 width=32)
   ->  Seq Scan on tidv  (cost=0.00..628.00 rows=17600 width=32)
```