### PR TITLE
gpcloud: Use correct printf formatter for size_t

### DIFF
--- a/gpcontrib/gpcloud/src/s3key_writer.cpp
+++ b/gpcontrib/gpcloud/src/s3key_writer.cpp
@@ -89,7 +89,7 @@ void* S3KeyWriter::UploadThreadFunc(void* data) {
     S3KeyWriter* writer = params->keyWriter;
 
     try {
-        S3DEBUG("Upload thread start: %" PRIX64 ", part number: %" PRIu64 ", data size: %" PRIu64,
+        S3DEBUG("Upload thread start: %" PRIX64 ", part number: %" PRIu64 ", data size: %zu",
                 (uint64_t) pthread_self(), params->currentNumber, params->data.size());
         string etag = writer->s3Interface->uploadPartOfData(
             params->data, writer->params.getS3Url(), params->currentNumber, writer->uploadId);


### PR DESCRIPTION
The S3VectorUInt8 `.size()` function returns `size_t`, which is platform dependent. Use `%zu` as the printf formatter since it's intended to ensure the right format for each platform. This resolves the clang compiler warning on this file:
```
src/s3key_writer.cpp:93:67: warning: format specifies type 'unsigned long long' but the
	  argument has type 'std::__1::vector<unsigned char, PGAllocator<unsigned char> >::size_type'
      (aka 'unsigned long') [-Wformat]
                (uint64_t) pthread_self(), params->currentNumber, params->data.size());
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
```