### PR TITLE
Avoid including 1 kB of zeros in every QD -> QE query dispatch.

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -127,7 +127,7 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 				(errcode(ERRCODE_RESERVED_NAME),
 				 errmsg("resource group name \"none\" is reserved")));
 
-	MemSet(&caps, 0, sizeof(caps));
+	ClearResGroupCaps(&caps);
 	parseStmtOptions(stmt, &caps);
 
 	/*
@@ -545,7 +545,7 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 	 */
 	int			mask = 0;
 
-	MemSet(resgroupCaps, 0, sizeof(ResGroupCaps));
+	ClearResGroupCaps(resgroupCaps);
 
 	/* Init cpuset with proper value */
 	strcpy(resgroupCaps->cpuset, DefaultCpuset);

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -68,6 +68,11 @@ typedef struct ResGroupCaps
 	char			cpuset[MaxCpuSetLength];
 } ResGroupCaps;
 
+/* Set 'cpuset' to an empty string, and reset all other fields to zero */
+#define ClearResGroupCaps(caps) \
+	MemSet((caps), 0, offsetof(ResGroupCaps, cpuset) + 1)
+
+
 /*
  * GUC variables.
  */


### PR DESCRIPTION
The 'M' type QD->QE dispatch message includes a serialized version of the
current resource group information. That included a 'cpuset' field, which
has 1 kB of space reserved for it, and the serialization routine included
all the padding zeros in it. (Copying or memsetting that into a local
variable in SerializeResGroupInfo() wasn't completely free either).
Rewrite the serialized format to be less silly.
