### PR TITLE
docs: update gprecoverseg_help

### DIFF
--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -48,7 +48,7 @@ using gprecoverseg.
 Segment recovery using gprecoverseg requires that you have an active 
 mirror to recover from. For systems that do not have mirroring enabled, 
 or in the event of a double fault (a primary and mirror pair both down 
-at the same time) — do a system restart to bring the segments back 
+at the same time) - do a system restart to bring the segments back 
 online (gpstop -r).
 
 By default, a failed segment is recovered in place, meaning that 
@@ -122,7 +122,7 @@ Do not prompt the user for confirmation.
 -B parallel_processes
 
 The number of segments to recover in parallel. If not specified, 
-the utility will start up to four parallel processes depending 
+the utility will start up to 16 parallel processes depending 
 on how many segment instances it needs to recover.
 
 


### PR DESCRIPTION
Update documentation to match the default setting when adding the option
in gpMgmt/bin/gppylib/programs/clsRecoverSegment.py:

```
    addTo.add_option("-B", None, type="int", default=16,
```

[ci skip]

Co-authored-by: David Krieger <dkrieger@pivotal.io>
Co-authored-by: Kalen Kempely <kkrempely@pivotal.io>
Co-authored-by: Jim Doty <jdoty@pivotal.io>

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`