### PR TITLE
Fix numeric round() and trunc() to not scribble on their input.

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -1155,7 +1155,8 @@ numeric_round(PG_FUNCTION_ARGS)
 	/*
 	 * Unpack the argument and round it at the proper digit position
 	 */
-	init_var_from_num(num, &arg);
+	init_var(&arg);
+	set_var_from_num(num, &arg);
 
 	round_var(&arg, scale);
 
@@ -1202,7 +1203,8 @@ numeric_trunc(PG_FUNCTION_ARGS)
 	/*
 	 * Unpack the argument and truncate it at the proper digit position
 	 */
-	init_var_from_num(num, &arg);
+	init_var(&arg);
+	set_var_from_num(num, &arg);
 
 	trunc_var(&arg, scale);
 
@@ -7977,6 +7979,14 @@ round_var(NumericVar *var, int rscale)
 	int			ndigits;
 	int			carry;
 
+	/*
+	 * sanity check that the 'digits' are dynamically allocated, and point
+	 * to somewhere in the 'buf'. (This only catches the case that the
+	 * 'digits' happens to be allocated at an address below 'buf', but it's
+	 * better than nothing.)
+	 */
+	Assert(var->digits >= var->buf);
+
 	var->dscale = rscale;
 
 	/* decimal digits wanted */
@@ -8080,6 +8090,14 @@ trunc_var(NumericVar *var, int rscale)
 {
 	int			di;
 	int			ndigits;
+
+	/*
+	 * sanity check that the 'digits' are dynamically allocated, and point
+	 * to somewhere in the 'buf'. (This only catches the case that the
+	 * 'digits' happens to be allocated at an address below 'buf', but it's
+	 * better than nothing.)
+	 */
+	Assert(var->digits >= var->buf);
 
 	var->dscale = rscale;
 

--- a/src/test/regress/expected/qp_functions.out
+++ b/src/test/regress/expected/qp_functions.out
@@ -593,6 +593,12 @@ SELECT round(4.0, 4);
  4.0000
 (1 row)
 
+SELECT round(0.998, 2);
+ round 
+-------
+  1.00
+(1 row)
+
 SELECT substr('1234', 3);
  substr 
 --------
@@ -1115,3 +1121,20 @@ drop aggregate agg_point_add1(point);
 drop table agg_point_tbl;
 drop aggregate agg_point_add2(point);
 drop table agg_numeric_tbl;
+--
+-- Test for an old bug, where numeric trunc() scribbled on its input.
+--
+do $$
+declare
+  n numeric;
+begin
+  n = repeat('9', 1) || '.12';
+
+  raise notice 'n: %', n;
+  raise notice 't: %', trunc(n,1);
+  raise notice 'n: %', n;
+end;
+$$;
+NOTICE:  n: 9.12
+NOTICE:  t: 9.1
+NOTICE:  n: 9.12

--- a/src/test/regress/sql/qp_functions.sql
+++ b/src/test/regress/sql/qp_functions.sql
@@ -158,6 +158,7 @@ SELECT round(4);
 SELECT round(4, 1+1);
 SELECT round(CAST (4 AS numeric), 4);
 SELECT round(4.0, 4);
+SELECT round(0.998, 2);
 SELECT substr('1234', 3);
 SELECT substr(varchar '1234', 3);
 SELECT substr(CAST (varchar '1234' AS text), 3);
@@ -493,3 +494,19 @@ drop aggregate agg_point_add1(point);
 drop table agg_point_tbl;
 drop aggregate agg_point_add2(point);
 drop table agg_numeric_tbl;
+
+
+--
+-- Test for an old bug, where numeric trunc() scribbled on its input.
+--
+do $$
+declare
+  n numeric;
+begin
+  n = repeat('9', 1) || '.12';
+
+  raise notice 'n: %', n;
+  raise notice 't: %', trunc(n,1);
+  raise notice 'n: %', n;
+end;
+$$;


### PR DESCRIPTION
numeric_round() and numeric_trunc() initialized the NumericVar to
represent the argument with init_var_from_num(), and then called
round_var() on it. That's not cool, init_var_from_num() creates a
read-only NumericVar, whose 'digits' points directly to the argument
datum, and round_var() scribbles on it. There is a comment in
init_var_from_num() warning explicitly to not do exactly that, but we
failed to heed the warning.

Fixes github issue https://github.com/greenplum-db/gpdb/issues/6383. I
also added a test case for this, although it's a bit hard to see this bug
to reappear in exactly the same form. It's not far-fetched that we might
re-introduce it in a slightly different form, though, so I also added some
extra Asserts in round_var() and trunc_var() for it.
