### PR TITLE
Use dwarf 2 symbols when building on rhel6

### DIFF
--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -148,7 +148,7 @@ export NO_M64=1
 # 32-bit/64-bit compiler/linker flag settings
 hpux_ia64_BLD_CFLAGS=-mlp64 -D_XOPEN_SOURCE_EXTENDED
 osx106_x86_BLD_CFLAGS=-m32 -march=i686
-rhel6_x86_64_BLD_CFLAGS=-m64
+rhel6_x86_64_BLD_CFLAGS=-m64 -gdwarf-2 -gstrict-dwarf
 rhel7_x86_64_BLD_CFLAGS=-m64
 rhel5_x86_64_BLD_CFLAGS=-m64
 rhel5_x86_32_BLD_CFLAGS=-m32


### PR DESCRIPTION
GDB on `centos6`/`rhel6` doesn't recognize dwarf 4 symbols, as it was originally implemented in GDB 7.4.`Centos 6` ships with GDB 7.2, so it can't read the newer dwarf formats.

From the GCC manual:

-gstrict-dwarf

	Disallow using extensions of later DWARF standard version than
	selected with -gdwarf-version. On most targets using
	non-conflicting DWARF extensions from later standard versions is
	allowed.

-gdwarf-[version]

	Produce debugging information in DWARF format (if that is supported).
	The value of version may be either 2, 3, 4 or 5; the default version for
	most targets is 4. DWARF Version 5 is only experimental.

Co-authored-by: Taylor Vesely <tvesely@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>