### PR TITLE
pg_dump: Preserve OID for schema "public" during upgrade

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -570,7 +570,7 @@ create_new_objects(void)
 		parallel_exec_prog(log_file_name,
 						   NULL,
 		 "PGOPTIONS='-c gp_session_role=utility' "
-		 "\"%s/pg_restore\" %s --exit-on-error --verbose --dbname %s \"%s\"",
+		 "\"%s/pg_restore\" %s --exit-on-error --binary-upgrade --verbose --dbname %s \"%s\"",
 						   new_cluster.bindir,
 						   cluster_conn_opts(&new_cluster),
 						   escaped_connstr.data,

--- a/src/bin/pg_dump/pg_backup.h
+++ b/src/bin/pg_dump/pg_backup.h
@@ -151,6 +151,8 @@ typedef struct _restoreOptions
 	bool		single_txn;
 
 	bool	   *idWanted;		/* array showing which dump IDs to emit */
+
+	int			binary_upgrade;	/* GPDB: restoring for a binary upgrade */
 } RestoreOptions;
 
 typedef void (*SetupWorkerPtr) (Archive *AH, RestoreOptions *ropt);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1102,6 +1102,8 @@ main(int argc, char **argv)
 
 	ropt->suppressDumpWarnings = true;	/* We've already shown them */
 
+	ropt->binary_upgrade = binary_upgrade;
+
 	SetArchiveRestoreOptions(fout, ropt);
 
 	/*

--- a/src/bin/pg_dump/pg_restore.c
+++ b/src/bin/pg_dump/pg_restore.c
@@ -76,6 +76,8 @@ main(int argc, char **argv)
 	static int	use_setsessauth = 0;
 	static int	no_security_labels = 0;
 
+	static int	binary_upgrade = 0;
+
 	struct option cmdopts[] = {
 		{"clean", 0, NULL, 'c'},
 		{"create", 0, NULL, 'C'},
@@ -118,6 +120,9 @@ main(int argc, char **argv)
 		{"section", required_argument, NULL, 3},
 		{"use-set-session-authorization", no_argument, &use_setsessauth, 1},
 		{"no-security-labels", no_argument, &no_security_labels, 1},
+
+		/* GPDB */
+		{"binary-upgrade", no_argument, &binary_upgrade, 1},
 
 		{NULL, 0, NULL, 0}
 	};
@@ -342,6 +347,8 @@ main(int argc, char **argv)
 	opts->noTablespace = outputNoTablespaces;
 	opts->use_setsessauth = use_setsessauth;
 	opts->no_security_labels = no_security_labels;
+
+	opts->binary_upgrade = binary_upgrade;
 
 	if (if_exists && !opts->dropSchema)
 	{

--- a/src/test/regress/expected/gp_upgrade_cornercases.out
+++ b/src/test/regress/expected/gp_upgrade_cornercases.out
@@ -45,3 +45,14 @@ INSERT INTO no_cols_left VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
 ALTER TABLE no_cols_left DROP COLUMN a;
 ALTER TABLE no_cols_left DROP COLUMN b;
 ALTER TABLE no_cols_left DROP COLUMN c;
+-- Test a database with a recreated "public" schema.
+-- If you are adding tests, you most likely want to add them BEFORE this, since
+-- we connect to a different database.
+DROP DATABASE IF EXISTS upgrade_recreated_public;
+NOTICE:  database "upgrade_recreated_public" does not exist, skipping
+CREATE DATABASE upgrade_recreated_public;
+\c upgrade_recreated_public
+DROP SCHEMA public;
+CREATE SCHEMA public;
+CREATE TABLE public.t();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.

--- a/src/test/regress/sql/gp_upgrade_cornercases.sql
+++ b/src/test/regress/sql/gp_upgrade_cornercases.sql
@@ -55,3 +55,15 @@ INSERT INTO no_cols_left VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
 ALTER TABLE no_cols_left DROP COLUMN a;
 ALTER TABLE no_cols_left DROP COLUMN b;
 ALTER TABLE no_cols_left DROP COLUMN c;
+
+-- Test a database with a recreated "public" schema.
+-- If you are adding tests, you most likely want to add them BEFORE this, since
+-- we connect to a different database.
+DROP DATABASE IF EXISTS upgrade_recreated_public;
+CREATE DATABASE upgrade_recreated_public;
+\c upgrade_recreated_public
+
+DROP SCHEMA public;
+CREATE SCHEMA public;
+
+CREATE TABLE public.t();


### PR DESCRIPTION
Given a database in which the "public" schema does not have its default
OID 2200 (e.g. it was dropped and recreated), pg_upgrade would ignore
the previous OID and use the built-in "public" schema at restoration.
This is because creation of the "public" schema is skipped in
dump / restore.

Add a binary_upgrade field to RestoreOptions, to teach pg_dump /
pg_restore not to skip the public schema during binary upgrade. This
adds a new "--binary-upgrade" option to pg_restore.

Co-authored-by: Jacob Champion <pchampion@pivotal.io>
Co-authored-by: Jesse Zhang <sbjesse@gmail.com>

Fixes #6166 

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`