### PR TITLE
5X: resgroup: fix startup error when all cpu cores are allocated

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -665,11 +665,21 @@ InitResGroups(void)
 		/*
 		 * set default cpuset
 		 */
-		BitsetToCpuset(bmsUnused, cpuset, MaxCpuSetLength);
-		if (CpusetIsEmpty(cpuset))
+
+		if (bms_is_empty(bmsUnused))
 		{
+			/* no unused core, assign default core to default group */
 			snprintf(cpuset, MaxCpuSetLength, "%d", defaultCore);
 		}
+		else
+		{
+			/* assign all unused cores to default group */
+			BitsetToCpuset(bmsUnused, cpuset, MaxCpuSetLength);
+		}
+
+		Assert(cpuset[0]);
+		Assert(!CpusetIsEmpty(cpuset));
+
 		ResGroupOps_SetCpuSet(DEFAULT_CPUSET_GROUP_ID, cpuset);
 	}
 	
@@ -4022,8 +4032,9 @@ void SetCpusetEmpty(char *cpuset, int cpusetSize)
 }
 
 /*
- * Transform bitset to cpuset
- * if the bit is set to 1, the corresponding core number must exist in cpuset
+ * Transform non-empty bitset to cpuset.
+ *
+ * This function does not check the cpu cores are available or not.
  */
 void
 BitsetToCpuset(const Bitmapset *bms,
@@ -4035,6 +4046,11 @@ BitsetToCpuset(const Bitmapset *bms,
 	int	intervalStart = -1;
 	int num;
 	char buffer[32] = {0};
+
+	Assert(!bms_is_empty(bms));
+
+	cpuset[0] = '\0';
+
 	bms_foreach(num, bms)
 	{
 		if (lastContinuousBit == -1)
@@ -4055,6 +4071,7 @@ BitsetToCpuset(const Bitmapset *bms,
 				}
 				if (len + strlen(buffer) >= cpusetSize)
 				{
+					Assert(cpuset[0]);
 					return ;
 				}
 				strcpy(cpuset + len, buffer);
@@ -4079,6 +4096,7 @@ BitsetToCpuset(const Bitmapset *bms,
 		}
 		if (len + strlen(buffer) >= cpusetSize)
 		{
+			Assert(cpuset[0]);
 			return ;
 		}
 		strcpy(cpuset + len, buffer);
@@ -4086,7 +4104,8 @@ BitsetToCpuset(const Bitmapset *bms,
 	}
 	else
 	{
-		cpuset[0] = '\0';
+		/* bms is non-empty, so it should never reach here */
+		pg_unreachable();
 	}
 }
 

--- a/src/backend/utils/resgroup/test/resgroup_test.c
+++ b/src/backend/utils/resgroup/test/resgroup_test.c
@@ -196,7 +196,7 @@ test_BitsetToCpuset(void **state)
 		bms = bms_union(bms, bms_make_singleton(i));
 	}
 	BitsetToCpuset(bms, cpusetList, 1024);
-	assert_int_equal(strcmp(cpusetList, "0-7"), 0);
+	assert_string_equal(cpusetList, "0-7");
 	//
 	bms = NULL;
 	for (i = 0; i < 10; i += 2)
@@ -204,7 +204,7 @@ test_BitsetToCpuset(void **state)
 		bms = bms_union(bms, bms_make_singleton(i));
 	}
 	BitsetToCpuset(bms, cpusetList, 1024);
-	assert_int_equal(strcmp(cpusetList, "0,2,4,6,8"), 0);
+	assert_string_equal(cpusetList, "0,2,4,6,8");
 	//
 	bms = NULL;
 	for (i = 8; i < 24; ++i)
@@ -212,7 +212,7 @@ test_BitsetToCpuset(void **state)
 		bms = bms_union(bms, bms_make_singleton(i));
 	}
 	BitsetToCpuset(bms, cpusetList, 1024);
-	assert_int_equal(strcmp(cpusetList, "8-23"), 0);
+	assert_string_equal(cpusetList, "8-23");
 	//
 	bms = NULL;
 	for (i = 0; i < 1024; ++i)
@@ -220,7 +220,7 @@ test_BitsetToCpuset(void **state)
 		bms = bms_union(bms, bms_make_singleton(i));
 	}
 	BitsetToCpuset(bms, cpusetList, 1024);
-	assert_int_equal(strcmp(cpusetList, "0-1023"), 0);
+	assert_string_equal(cpusetList, "0-1023");
 	//
 	bms = NULL;
 	for (i = 0; i < 16; ++i)
@@ -228,17 +228,13 @@ test_BitsetToCpuset(void **state)
 		bms = bms_union(bms, bms_make_singleton(i));
 	}
 	BitsetToCpuset(bms, cpusetList, 1024);
-	assert_int_equal(strcmp(cpusetList, "0-15"), 0);
-	//
-	bms = NULL;
-	BitsetToCpuset(bms, cpusetList, 1024);
-	assert_int_equal(strcmp(cpusetList, ""), 0);
+	assert_string_equal(cpusetList, "0-15");
 	//
 	bms = NULL;
 	bms = bms_union(bms, bms_make_singleton(0));
 	bms = bms_union(bms, bms_make_singleton(100));
 	BitsetToCpuset(bms, cpusetList, 4);
-	assert_int_equal(strcmp(cpusetList, "0,"), 0);
+	assert_string_equal(cpusetList, "0,");
 }
 
 void
@@ -248,40 +244,40 @@ test_CpusetOperation(void **state)
 
 	strcpy(cpuset, "0-100");
 	cpusetOperation(cpuset, "1-99", 1024, true);
-	assert_int_equal(strcmp(cpuset, "0,100"), 0);
+	assert_string_equal(cpuset, "0,100");
 
 	strcpy(cpuset, "0,1,2,3");
 	cpusetOperation(cpuset, "0,3", 1024, true);
-	assert_int_equal(strcmp(cpuset, "1-2"), 0);
+	assert_string_equal(cpuset, "1-2");
 
 	strcpy(cpuset, "1-10");
 	cpusetOperation(cpuset, "3-100", 1024, true);
-	assert_int_equal(strcmp(cpuset, "1-2"), 0);
+	assert_string_equal(cpuset, "1-2");
 
 	strcpy(cpuset, "1-10");
 	cpusetOperation(cpuset, "0-100", 1024, false);
-	assert_int_equal(strcmp(cpuset, "0-100"), 0);
+	assert_string_equal(cpuset, "0-100");
 
 	strcpy(cpuset, "1-10");
 	cpusetOperation(cpuset, "100-200", 1024, false);
-	assert_int_equal(strcmp(cpuset, "1-10,100-200"), 0);
+	assert_string_equal(cpuset, "1-10,100-200");
 
 	strcpy(cpuset, "1-10");
 	cpusetOperation(cpuset, "5-15", 1024, false);
-	assert_int_equal(strcmp(cpuset, "1-15"), 0);
+	assert_string_equal(cpuset, "1-15");
 
 	strcpy(cpuset, "1-10");
 	cpusetOperation(cpuset, "", 1024, false);
-	assert_int_equal(strcmp(cpuset, "1-10"), 0);
+	assert_string_equal(cpuset, "1-10");
 
 	strcpy(cpuset, "1-10");
 	cpusetOperation(cpuset, "", 1024, true);
-	assert_int_equal(strcmp(cpuset, "1-10"), 0);
+	assert_string_equal(cpuset, "1-10");
 
 	//ResGroupOps_Probe();
 	//strcpy(cpuset, "1-10");
 	//cpusetOperation(cpuset, "0-100", 1024, true);
-	//assert_int_equal(strcmp(cpuset, "0"), 0);
+	//assert_string_equal(cpuset, "0");
 }
 
 int

--- a/src/test/isolation2/expected/resgroup/resgroup_cpuset_empty_default.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cpuset_empty_default.out
@@ -1,0 +1,38 @@
+-- A regression test for cpuset.
+--
+-- When all the cpu cores are allocated the default cpuset group should
+-- fallback to core 0.  However this fallback logic was only added on
+-- CREATE / ALTER RESOURCE GROUP, but missing in startup logic, an empty cpu
+-- core list "" is set to cgroup and cause a runtime error:
+--
+--     can't write data to file '/sys/fs/cgroup/cpuset/gpdb/1/cpuset.cpus':
+--       No space left on device (resgroup-ops-linux.c:916)
+--
+-- To trigger the issue we create a resource group, allocate all the cpu cores
+-- to it, and restart the cluster.
+
+-- start_ignore
+DROP RESOURCE GROUP rg1_cpuset_test;
+-- end_ignore
+
+-- Create a resource group with all the cpu cores.
+-- The isolation2 test framework does not support \set so we have to plan with
+-- some tricks.
+! psql -d isolation2resgrouptest -Ac "CREATE RESOURCE GROUP rg1_cpuset_test WITH (memory_limit=10, cpuset='0-$(($(nproc)-1))')";
+CREATE RESOURCE GROUP
+
+
+-- Alter a resource group from / to all the cpu cores should also work.
+ALTER RESOURCE GROUP rg1_cpuset_test SET cpuset '0';
+ALTER
+! psql -d isolation2resgrouptest -Ac "ALTER RESOURCE GROUP rg1_cpuset_test SET cpuset '0-$(($(nproc)-1))'";
+ALTER RESOURCE GROUP
+
+
+-- start_ignore
+! gpstop -rai;
+-- end_ignore
+
+-- Cleanup in a new connection as the default one is disconnected by gpstop
+10: DROP RESOURCE GROUP rg1_cpuset_test;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -16,6 +16,7 @@ test: resgroup/resgroup_alter_memory
 test: resgroup/resgroup_cpu_rate_limit
 test: resgroup/resgroup_alter_memory_spill_ratio
 test: resgroup/resgroup_cpuset
+test: resgroup/resgroup_cpuset_empty_default
 test: resgroup/resgroup_set_memory_spill_ratio
 test: resgroup/resgroup_unlimit_memory_spill_ratio
 test: resgroup/resgroup_cancel_terminate_concurrency

--- a/src/test/isolation2/sql/resgroup/resgroup_cpuset_empty_default.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_cpuset_empty_default.sql
@@ -1,0 +1,32 @@
+-- A regression test for cpuset.
+--
+-- When all the cpu cores are allocated the default cpuset group should
+-- fallback to core 0.  However this fallback logic was only added on
+-- CREATE / ALTER RESOURCE GROUP, but missing in startup logic, an empty cpu
+-- core list "" is set to cgroup and cause a runtime error:
+--
+--     can't write data to file '/sys/fs/cgroup/cpuset/gpdb/1/cpuset.cpus':
+--       No space left on device (resgroup-ops-linux.c:916)
+--
+-- To trigger the issue we create a resource group, allocate all the cpu cores
+-- to it, and restart the cluster.
+
+-- start_ignore
+DROP RESOURCE GROUP rg1_cpuset_test;
+-- end_ignore
+
+-- Create a resource group with all the cpu cores.
+-- The isolation2 test framework does not support \set so we have to plan with
+-- some tricks.
+! psql -d isolation2resgrouptest -Ac "CREATE RESOURCE GROUP rg1_cpuset_test WITH (memory_limit=10, cpuset='0-$(($(nproc)-1))')";
+
+-- Alter a resource group from / to all the cpu cores should also work.
+ALTER RESOURCE GROUP rg1_cpuset_test SET cpuset '0';
+! psql -d isolation2resgrouptest -Ac "ALTER RESOURCE GROUP rg1_cpuset_test SET cpuset '0-$(($(nproc)-1))'";
+
+-- start_ignore
+! gpstop -rai;
+-- end_ignore
+
+-- Cleanup in a new connection as the default one is disconnected by gpstop
+10: DROP RESOURCE GROUP rg1_cpuset_test;


### PR DESCRIPTION
When all the cpu cores are allocated the default cpuset group should
fallback to core 0.  However this fallback logic was only added on
CREATE / ALTER RESOURCE GROUP, but missing in startup logic, an empty cpu
core list "" is set to cgroup and cause a runtime error:

    can't write data to file '/sys/fs/cgroup/cpuset/gpdb/1/cpuset.cpus':
      No space left on device (resgroup-ops-linux.c:916)

Fixed by converting "" to "-1" in startup logic.

(cherry picked from commit a50fc538b25dc83b6afd91ad256ed762e98ebbe2)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes: not needed
- [x] Communicate in the mailing list if needed: reviewed on master already
- [x] Pass `make installcheck`