### PR TITLE
Downgrade FIXMEs on simple union all pullup optimization to plain comments.

### DIFF
--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -1436,8 +1436,8 @@ ORDER BY thousand, tenthous;
 (9 rows)
 
 -- Check min/max aggregate optimization
--- GPDB_92_MERGE_FIXME: simple union all pull up is disabled
--- in pull_up_subqueries(), need some work on that.
+-- GPDB: simple union all pull up is disabled in pull_up_subqueries(), so the
+-- min/max optimization doesn't kick in.
 explain (costs off)
 SELECT min(x) FROM
   (SELECT unique1 AS x FROM tenk1 a

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1436,8 +1436,8 @@ ORDER BY thousand, tenthous;
 (9 rows)
 
 -- Check min/max aggregate optimization
--- GPDB_92_MERGE_FIXME: simple union all pull up is disabled
--- in pull_up_subqueries(), need some work on that.
+-- GPDB: simple union all pull up is disabled in pull_up_subqueries(), so the
+-- min/max optimization doesn't kick in.
 explain (costs off)
 SELECT min(x) FROM
   (SELECT unique1 AS x FROM tenk1 a

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -522,8 +522,8 @@ INSERT INTO t2c VALUES ('vw'), ('cd'), ('mn'), ('ef');
 CREATE INDEX t1c_ab_idx on t1c ((a || b));
 set enable_seqscan = on;
 set enable_indexonlyscan = off;
---- GPDB_94_MERGE_FIXME: GPDB would choose seqscan rather than indexscan for t1.
---- This is a side-effect of disabling pull-up for simple union all in GPDB.
+-- NOTE: GPDB planner chooses a seqscan rather than indexscan for t1.
+-- This is a side-effect of disabling pull-up for simple union all in GPDB.
 explain (costs off)
   SELECT * FROM
   (SELECT a || b AS ab FROM t1

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -532,8 +532,8 @@ INSERT INTO t2c VALUES ('vw'), ('cd'), ('mn'), ('ef');
 CREATE INDEX t1c_ab_idx on t1c ((a || b));
 set enable_seqscan = on;
 set enable_indexonlyscan = off;
---- GPDB_94_MERGE_FIXME: GPDB would choose seqscan rather than indexscan for t1.
---- This is a side-effect of disabling pull-up for simple union all in GPDB.
+-- NOTE: GPDB planner chooses a seqscan rather than indexscan for t1.
+-- This is a side-effect of disabling pull-up for simple union all in GPDB.
 explain (costs off)
   SELECT * FROM
   (SELECT a || b AS ab FROM t1

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -440,8 +440,8 @@ SELECT thousand, random()::integer FROM tenk1
 ORDER BY thousand, tenthous;
 
 -- Check min/max aggregate optimization
--- GPDB_92_MERGE_FIXME: simple union all pull up is disabled
--- in pull_up_subqueries(), need some work on that.
+-- GPDB: simple union all pull up is disabled in pull_up_subqueries(), so the
+-- min/max optimization doesn't kick in.
 explain (costs off)
 SELECT min(x) FROM
   (SELECT unique1 AS x FROM tenk1 a

--- a/src/test/regress/sql/union.sql
+++ b/src/test/regress/sql/union.sql
@@ -213,8 +213,8 @@ CREATE INDEX t1c_ab_idx on t1c ((a || b));
 set enable_seqscan = on;
 set enable_indexonlyscan = off;
 
---- GPDB_94_MERGE_FIXME: GPDB would choose seqscan rather than indexscan for t1.
---- This is a side-effect of disabling pull-up for simple union all in GPDB.
+-- NOTE: GPDB planner chooses a seqscan rather than indexscan for t1.
+-- This is a side-effect of disabling pull-up for simple union all in GPDB.
 explain (costs off)
   SELECT * FROM
   (SELECT a || b AS ab FROM t1


### PR DESCRIPTION
As the comments in code explain, the simple union all pullup optimization
is problematic in GPDB. I don't think we have plans to "fix" it any time
soon.