### PR TITLE
docs - foreign data wrapper sql and catalog ref page updates

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FOREIGN_DATA_WRAPPER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FOREIGN_DATA_WRAPPER.xml
@@ -11,13 +11,15 @@
     [ HANDLER <varname>handler_function</varname> | NO HANDLER ]
     [ VALIDATOR <varname>validator_function</varname> | NO VALIDATOR ]
     [ OPTIONS ( [ ADD | SET | DROP ] <varname>option</varname> ['<varname>value</varname>'] [, ... ] ) ]
-ALTER FOREIGN DATA WRAPPER <varname>name</varname> OWNER TO <varname>new_owner</varname></codeblock>
+
+ALTER FOREIGN DATA WRAPPER <varname>name</varname> OWNER TO <varname>new_owner</varname>
+ALTER FOREIGN DATA WRAPPER <varname>name</varname> RENAME TO <varname>new_name</varname></codeblock>
         </section>
         <section id="section3">
             <title>Description</title>
             <p><codeph>ALTER FOREIGN DATA WRAPPER</codeph> changes the definition of a foreign-data wrapper.
                 The first form of the command changes the support functions or generic options of 
-                the foreign-data wrapper. Greenplum Database requires at least one clause. The second form of the command changes the owner of the foreign-data wrapper.</p>
+                the foreign-data wrapper. Greenplum Database requires at least one clause. The second and third forms of the command change the owner or name of the foreign-data wrapper.</p>
             <p>Only superusers can alter foreign-data wrappers. Additionally, only superusers can own foreign-data wrappers</p>
         </section>
         <section id="section4">
@@ -44,7 +46,7 @@ ALTER FOREIGN DATA WRAPPER <varname>name</varname> OWNER TO <varname>new_owner</
                 <plentry>
                     <pt>VALIDATOR <varname>validator_function</varname></pt>
                     <pd>
-                        <p>Specifies a new validator function for the foreign-data wrapper.</p><p>Options to the foreign-data wrapper, servers, and user mappings may become invalid when you change the validator function. You must make sure that these options are correct before using the foreign-data wrapper.</p>
+                        <p>Specifies a new validator function for the foreign-data wrapper.</p><p>Options to the foreign-data wrapper, servers, and user mappings may become invalid when you change the validator function. You must make sure that these options are correct before using the modified foreign-data wrapper. Note that Greenplum Database checks any options specified in this <codeph>ALTER FOREIGN DATA WRAPPER</codeph> command using the new validator.</p>
                     </pd>
                 </plentry>
                 <plentry>
@@ -65,16 +67,22 @@ ALTER FOREIGN DATA WRAPPER <varname>name</varname> OWNER TO <varname>new_owner</
                         <p>Specifies the new owner of the foreign-data wrapper. Only superusers can own foreign-data wrappers.</p>
                     </pd>
                 </plentry>
+                <plentry>
+                    <pt>RENAME TO <varname>new_name</varname></pt>
+                    <pd>
+                        <p>Specifies the new name of the foreign-data wrapper.</p>
+                    </pd>
+                </plentry>
             </parml>
         </section>
         <section id="section6">
             <title>Examples</title>
-            <p>Change the definition of a foreign-data wrapper named <codeph>dbi</codeph> by adding a new option named <codeph>foo</codeph>, and removing the option named <codeph>bar</codeph>:</p><codeblock>ALTER FOREIGN DATA WRAPPER dbi (ADD foo '1', DROP 'bar');</codeblock>
+            <p>Change the definition of a foreign-data wrapper named <codeph>dbi</codeph> by adding a new option named <codeph>foo</codeph>, and removing the option named <codeph>bar</codeph>:</p><codeblock>ALTER FOREIGN DATA WRAPPER dbi OPTIONS (ADD foo '1', DROP 'bar');</codeblock>
             <p>Change the validator function for a foreign-data wrapper named <codeph>dbi</codeph> to <codeph>bob.myvalidator</codeph>:</p><codeblock>ALTER FOREIGN DATA WRAPPER dbi VALIDATOR bob.myvalidator;</codeblock>
         </section>
         <section id="section7">
             <title>Compatibility</title>
-            <p><codeph>ALTER FOREIGN DATA WRAPPER</codeph> conforms to ISO/IEC 9075-9 (SQL/MED), with the exception that the <codeph>HANDLER</codeph>, <codeph>VALIDATOR</codeph>, and <codeph>OWNER TO</codeph> clauses are Greenplum Database extensions.</p>
+            <p><codeph>ALTER FOREIGN DATA WRAPPER</codeph> conforms to ISO/IEC 9075-9 (SQL/MED), with the exception that the <codeph>HANDLER</codeph>, <codeph>VALIDATOR</codeph>, <codeph>OWNER TO</codeph>, and <codeph>RENAME TO</codeph> clauses are Greenplum Database extensions.</p>
         </section>
         <section id="section8">
             <title>See Also</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_FOREIGN_TABLE.xml
@@ -7,22 +7,27 @@
         <p id="sql_command_desc">Changes the definition of a foreign table.</p>
         <section id="section2">
             <title>Synopsis</title>
-            <codeblock id="sql_command_synopsis">ALTER FOREIGN TABLE <varname>name</varname>
+            <codeblock id="sql_command_synopsis">ALTER FOREIGN TABLE [ IF EXISTS ] <varname>name</varname>
     <varname>action</varname> [, ... ]
-ALTER FOREIGN TABLE <varname>name</varname>
-    RENAME [ COLUMN ] <varname>column</varname> TO <varname>new_column</varname>
-ALTER FOREIGN TABLE <varname>name</varname>
+ALTER FOREIGN TABLE [ IF EXISTS ] <varname>name</varname>
+    RENAME [ COLUMN ] <varname>column_name</varname> TO <varname>new_column_name</varname>
+ALTER FOREIGN TABLE [ IF EXISTS ] <varname>name</varname>
     RENAME TO <varname>new_name</varname>
-ALTER FOREIGN TABLE <varname>name</varname>
+ALTER FOREIGN TABLE [ IF EXISTS ] <varname>name</varname>
     SET SCHEMA <varname>new_schema</varname>
 </codeblock>
 
 <p>where <varname>action</varname> is one of:</p><codeblock>
-
-    ADD [ COLUMN ] <varname>column_type</varname> [ NULL | NOT NULL ]
-    DROP [ COLUMN ] [ IF EXISTS ] <varname>column</varname> [ RESTRICT | CASCADE ]
-    ALTER [ COLUMN ] <varname>column</varname> [ SET DATA ] TYPE <varname>type</varname>
-    ALTER [ COLUMN ] <varname>column</varname> { SET | DROP } NOT NULL
+    ADD [ COLUMN ] <varname>column_name</varname> <varname>column_type</varname> [ COLLATE <varname>collation</varname> ] [ <varname>column_constraint</varname> [ ... ] ]
+    DROP [ COLUMN ] [ IF EXISTS ] <varname>column_name</varname> [ RESTRICT | CASCADE ]
+    ALTER [ COLUMN ] <varname>column_name</varname> [ SET DATA ] TYPE <varname>data_type</varname>
+    ALTER [ COLUMN ] <varname>column_name</varname> SET DEFAULT <varname>expression</varname>
+    ALTER [ COLUMN ] <varname>column_name</varname> DROP DEFAULT
+    ALTER [ COLUMN ] <varname>column_name</varname> { SET | DROP } NOT NULL
+    ALTER [ COLUMN ] <varname>column_name</varname> SET STATISTICS <varname>integer</varname>
+    ALTER [ COLUMN ] <varname>column_name</varname> SET ( <varname>attribute_option</varname> = <varname>value</varname> [, ... ] )
+    ALTER [ COLUMN ] <varname>column_name</varname> RESET ( <varname>attribute_option</varname> [, ... ] )
+    ALTER [ COLUMN ] <varname>column_name</varname> OPTIONS ( [ ADD | SET | DROP ] <varname>option</varname> ['<varname>value</varname>'] [, ... ])
     OWNER TO <varname>new_owner</varname>
     OPTIONS ( [ ADD | SET | DROP ] <varname>option</varname> ['<varname>value</varname>'] [, ... ] )</codeblock>
         </section>
@@ -33,7 +38,8 @@ ALTER FOREIGN TABLE <varname>name</varname>
                 <plentry>
                     <pt>ADD COLUMN</pt>
                     <pd>
-                        <p>This form adds a new column to the foreign table, using the same syntax as <codeph><xref href="CREATE_FOREIGN_TABLE.xml#topic1">CREATE FOREIGN TABLE</xref></codeph>.</p>
+                        <p>This form adds a new column to the foreign table, using the same syntax as <codeph><xref href="CREATE_FOREIGN_TABLE.xml#topic1">CREATE FOREIGN TABLE</xref></codeph>.
+                          Unlike the case when you add a column to a regular table, nothing happens to the underlying storage: this action simply declares that some new column is now accessible through the foreign table.</p>
                     </pd>
                 </plentry>
                 <plentry>
@@ -43,15 +49,46 @@ ALTER FOREIGN TABLE <varname>name</varname>
                     </pd>
                 </plentry>
                 <plentry>
+                    <pt>IF EXISTS</pt>
+                    <pd>
+                        <p>If you specify <codeph>IF EXISTS</codeph> and the foriegn table does not exist, no error is thrown. Greenplum Database issues a notice instead.</p>
+                    </pd>
+                </plentry>
+                <plentry>
                     <pt>SET DATA TYPE</pt>
                     <pd>
                         <p>This form changes the type of a column of a foreign table.</p>
                     </pd>
                 </plentry>
                 <plentry>
+                    <pt>SET/DROP DEFAULT</pt>
+                    <pd>
+                        <p>These forms set or remove the default value for a column. Default
+                          values apply only in subsequent <codeph>INSERT</codeph> or
+                          <codeph>UPDATE</codeph> commands; they do not cause rows already in
+                          the table to change.</p>
+                    </pd>
+                </plentry>
+                <plentry>
                     <pt>SET/DROP NOT NULL</pt>
                     <pd>
                         <p>Mark a column as allowing, or not allowing, null values.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>SET STATISTICS</pt>
+                    <pd>
+                        <p>This form sets the per-column statistics-gathering target for
+                          subsequent <codeph>ANALYZE</codeph> operations.  See the similar
+                          form of <codeph><xref href="ALTER_TABLE.xml#topic1">ALTER TABLE</xref></codeph> for more details.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>SET ( <varname>attribute_option</varname> = <varname>value</varname> [, ...] ] )</pt>
+                    <pt>RESET ( <varname>attribute_option</varname> [, ... ] )</pt>
+                    <pd>
+                        <p>This form sets or resets per-attribute options. See the similar 
+                          form of <codeph><xref href="ALTER_TABLE.xml#topic1">ALTER TABLE</xref></codeph> for more details.</p>
                     </pd>
                 </plentry>
                 <plentry>
@@ -63,7 +100,7 @@ ALTER FOREIGN TABLE <varname>name</varname>
                 <plentry>
                     <pt>RENAME</pt>
                     <pd>
-                        <p>The <codeph>RENAME</codeph> forms changes the name of a foreign table or the name of an individual column in a foreign table.</p>
+                        <p>The <codeph>RENAME</codeph> forms change the name of a foreign table or the name of an individual column in a foreign table.</p>
                     </pd>
                 </plentry>
                 <plentry>
@@ -80,7 +117,7 @@ ALTER FOREIGN TABLE <varname>name</varname>
                 </plentry>
             </parml>
             <p>You can combine all of the actions except <codeph>RENAME</codeph> and <codeph>SET SCHEMA</codeph> into a list of multiple alterations for Greenplum Database to apply in parallel. For example, it is possible to add several columns and/or alter the type of several columns in a single command.</p>
-            <p>You must own the table to use <codeph>ALTER FOREIGN TABLE</codeph>. To change the schema of a foreign table, you must also have <codeph>CREATE</codeph> privilege on the new schema. To alter the owner, you must also be a direct or indirect member of the new owning role, and that role must have <codeph>CREATE</codeph> privilege on the table's schema. (These restrictions enforce that altering the owner doesn't do anything you couldn't do by dropping and recreating the table. However, a superuser can alter ownership of any table anyway.)</p>
+            <p>You must own the table to use <codeph>ALTER FOREIGN TABLE</codeph>. To change the schema of a foreign table, you must also have <codeph>CREATE</codeph> privilege on the new schema. To alter the owner, you must also be a direct or indirect member of the new owning role, and that role must have <codeph>CREATE</codeph> privilege on the table's schema. (These restrictions enforce that altering the owner doesn't do anything you couldn't do by dropping and recreating the table. However, a superuser can alter ownership of any table anyway.) To add a column or to alter a column type, you must also have <codeph>USAGE</codeph> privilege on the data type.</p>
         </section>
         <section id="section4">
             <title>Parameters</title>
@@ -92,13 +129,13 @@ ALTER FOREIGN TABLE <varname>name</varname>
                     </pd>
                 </plentry>
                 <plentry>
-                    <pt><varname>column</varname></pt>
+                    <pt><varname>column_name</varname></pt>
                     <pd>
                         <p>The name of a new or existing column.</p>
                     </pd>
                 </plentry>
                 <plentry>
-                    <pt><varname>new_column</varname></pt>
+                    <pt><varname>new_column_name</varname></pt>
                     <pd>
                         <p>The new name for an existing column.</p>
                     </pd>
@@ -110,7 +147,7 @@ ALTER FOREIGN TABLE <varname>name</varname>
                     </pd>
                 </plentry>
                 <plentry>
-                    <pt><varname>type</varname></pt>
+                    <pt><varname>data_type</varname></pt>
                     <pd>
                         <p>The data type of the new column, or new data type for an existing column.</p>
                     </pd>
@@ -160,7 +197,8 @@ ALTER FOREIGN TABLE <varname>name</varname>
         </section>
         <section id="section8">
             <title>See Also</title>
-            <p><codeph><xref href="CREATE_FOREIGN_TABLE.xml#topic1">CREATE FOREIGN TABLE</xref></codeph>,
+            <p><codeph><xref href="ALTER_TABLE.xml#topic1">ALTER TABLE</xref></codeph>,
+                <codeph><xref href="CREATE_FOREIGN_TABLE.xml#topic1">CREATE FOREIGN TABLE</xref></codeph>,
                         <codeph><xref href="DROP_FOREIGN_TABLE.xml#topic1">DROP
                     FOREIGN TABLE</xref></codeph></p>
         </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_SERVER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_SERVER.xml
@@ -9,13 +9,15 @@
             <title>Synopsis</title>
             <codeblock id="sql_command_synopsis">ALTER SERVER <varname>server_name</varname> [ VERSION '<varname>new_version</varname>' ]
     [ OPTIONS ( [ ADD | SET | DROP ] <varname>option</varname> ['<varname>value</varname>'] [, ... ] ) ]
-ALTER SERVER <varname>server_name</varname> OWNER TO <varname>new_owner</varname></codeblock>
+
+ALTER SERVER <varname>server_name</varname> OWNER TO <varname>new_owner</varname>
+ALTER SERVER <varname>server_name</varname> RENAME TO <varname>new_name</varname></codeblock>
         </section>
         <section id="section3">
             <title>Description</title>
             <p><codeph>ALTER SERVER</codeph> changes the definition of a foreign server.
                 The first form of the command changes the version string or the generic options of 
-                the server. Greenplum Database requires at least one clause. The second form of the command changes the owner of the server.</p>
+                the server. Greenplum Database requires at least one clause. The second and third forms of the command change the owner or the name of the server.</p>
             <p>To alter the server, you must be the owner of the server. To alter the owner you must:<ul>
               <li>Own the server.</li>
               <li>Be a direct or indirect member of the new owning role.</li>
@@ -46,7 +48,13 @@ ALTER SERVER <varname>server_name</varname> OWNER TO <varname>new_owner</varname
                 <plentry>
                     <pt>OWNER TO <varname>new_owner</varname></pt>
                     <pd>
-                        <p>Specifies the new owner of the server.</p>
+                        <p>Specifies the new owner of the foreign server.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>RENAME TO <varname>new_name</varname></pt>
+                    <pd>
+                        <p>Specifies the new name of the foreign server.</p>
                     </pd>
                 </plentry>
             </parml>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_DATA_WRAPPER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_DATA_WRAPPER.xml
@@ -38,7 +38,7 @@
                 <plentry>
                     <pt>VALIDATOR <varname>validator_function</varname></pt>
                     <pd>
-                        <p>The name of a previously registered function that Greenplum Database calls to check the options provided to the foreign-data wrapper. This function also checks the options for foreign servers and user mappings that use the foreign-data wrapper. If no validator function or <codeph>NO VALIDATOR</codeph> is specified, Greenplum Database does not check options at creation time. (Depending upon the implementation, foreign-data wrappers may ignore or reject invalid options at runtime.)</p><p><varname>validator_function</varname> must take two arguments: one of type <codeph>text[]</codeph>, which contains the array of options as stored in the system catalogs, and one of type <codeph>oid</codeph>, which identifies the OID of the system catalog containing the options.</p><p>The return type is ignored; <varname>validator_function</varname> should report invalid options using the <codeph>ereport(ERROR)</codeph> function.</p>
+                        <p>The name of a previously registered function that Greenplum Database calls to check the options provided to the foreign-data wrapper. This function also checks the options for foreign servers, user mappings, and foreign tables that use the foreign-data wrapper. If no validator function or <codeph>NO VALIDATOR</codeph> is specified, Greenplum Database does not check options at creation time. (Depending upon the implementation, foreign-data wrappers may ignore or reject invalid options at runtime.)</p><p><varname>validator_function</varname> must take two arguments: one of type <codeph>text[]</codeph>, which contains the array of options as stored in the system catalogs, and one of type <codeph>oid</codeph>, which identifies the OID of the system catalog containing the options.</p><p>The return type is ignored; <varname>validator_function</varname> should report invalid options using the <codeph>ereport(ERROR)</codeph> function.</p>
                     </pd>
                 </plentry>
                 <plentry>
@@ -51,15 +51,13 @@
         </section>
         <section id="section5">
             <title>Notes</title>
-            <p>At the moment, the foreign-data wrapper functionality is rudimentary. There is no support for updating a foreign table, and optimization of queries is primitive (and mostly left to the wrapper, too).</p>
-            <p>Greenplum Database provides one built-in foreign-data wrapper validator function named <codeph>postgresql_fdw_validator()</codeph>. This function accepts options corresponding to <codeph>libpq</codeph> connection parameters.</p>
+            <p>The foreign-data wrapper functionality is still under development. Optimization of queries is primitive (and mostly left to the wrapper).</p>
         </section>
         <section id="section6">
             <title>Examples</title>
             <p>Create a useless foreign-data wrapper named <codeph>dummy</codeph>:</p><codeblock>CREATE FOREIGN DATA WRAPPER dummy;</codeblock>
             <p>Create a foreign-data wrapper named <codeph>file</codeph> with a handler function named <codeph>file_fdw_handler</codeph>:</p><codeblock>CREATE FOREIGN DATA WRAPPER file HANDLER file_fdw_handler;</codeblock>
-            <p>Create a foreign-data wrapper named <codeph>mywrapper</codeph> that includes an option:</p><codeblock>CREATE FOREIGN DATA WRAPPER mywrapper
-    OPTIONS (debug 'true');</codeblock>
+            <p>Create a foreign-data wrapper named <codeph>mywrapper</codeph> that includes an option:</p><codeblock>CREATE FOREIGN DATA WRAPPER mywrapper OPTIONS (debug 'true');</codeblock>
         </section>
         <section id="section7">
             <title>Compatibility</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
@@ -8,11 +8,14 @@
         <section id="section2">
             <title>Synopsis</title>
             <codeblock id="sql_command_synopsis">CREATE FOREIGN TABLE [ IF NOT EXISTS ] <varname>table_name</varname> ( [
-    { <varname>column_name</varname> <varname>data_type</varname> [ NULL | NOT NULL ] }
+    <varname>column_name</varname> <varname>data_type</varname> [ OPTIONS ( <varname>option</varname> '<varname>value</varname>' [, ... ] ) ] [ COLLATE <varname>collation</varname> ] [ <varname>column_constraint</varname> [ ... ] ]
       [, ... ]
 ] )
     SERVER <varname>server_name</varname>
-    [ OPTIONS ( <varname>option</varname> '<varname>value</varname>' [, ... ] ) ]</codeblock>
+  [ OPTIONS ( [ mpp_execute {'any' | 'master' | 'all segments'} ], <varname>option</varname> '<varname>value</varname>' [, ... ] ) ]</codeblock>
+        <p>where <varname>column_constraint</varname> is:</p><codeblock>
+[ CONSTRAINT <varname>constraint_name</varname> ]
+{ NOT NULL | NULL | DEFAULT <varname>default_expr</varname> }</codeblock>
         </section>
         <section id="section3">
             <title>Description</title>
@@ -21,6 +24,7 @@
                  its owner.</p>
             <p>If you schema-qualify the table name (for example, <codeph>CREATE FOREIGN TABLE myschema.mytable ...</codeph>), Greenplum Database creates the table in the specified schema. Otherwise, the foreign table is created in the current schema. The name of the foreign table must be distinct from the name of any other foreign table, table, sequence, index, or view in the same schema.</p>
             <p>Because <codeph>CREATE FOREIGN TABLE</codeph> automatically creates a data type that represents the composite type corresponding to one row of the foreign table, foreign tables cannot have the same name as any existing data type in the same schema.</p>
+            <p>To create a foreign table, you must have <codeph>USAGE</codeph> privilege on the foreign server, as well as <codeph>USAGE</codeph> privilege on all column types used in the table.</p>
         </section>
         <section id="section4">
             <title>Parameters</title>
@@ -56,22 +60,47 @@
                     </pd>
                 </plentry>
                 <plentry>
-                    <pt> NULL</pt>
+                    <pt>NULL</pt>
                     <pd>
-                        <p>The column is allowed to contain null values. This is the default</p>
+                        <p>The column is allowed to contain null values. This is the default.</p>
                         <p>This clause is provided only for compatibility with non-standard SQL databases. Its use is discouraged in new applications.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>DEFAULT <varname>default_expr</varname></pt>
+                    <pd>
+                        <p>The <codeph>DEFAULT</codeph> clause assigns a default value for the
+                          column whose definition it appears within. The value is any
+                          variable-free expression; Greenplum Database does not allow subqueries
+                          and cross-references to other columns in the current table. The data
+                          type of the default expression must match the data type of the column.</p>
+                        <p>Greenplum Database uses the default expression in any insert operation
+                          that does not specify a value for the column. If there is no default
+                          for a column, then the default is null.</p>
                     </pd>
                 </plentry>
                 <plentry>
                     <pt><varname>server_name</varname></pt>
                     <pd>
-                        <p>The name of an existing server for the foreign table.</p>
+                        <p>The name of an existing server to use for the foreign table.
+                          For details on defining a server, see <codeph><xref href="CREATE_SERVER.xml#topic1">CREATE
+                    SERVER</xref></codeph>.</p>
                     </pd>
                 </plentry>
                 <plentry>
                     <pt>OPTIONS ( <varname>option</varname> '<varname>value</varname>' [, ... ] )</pt>
                     <pd>
-                        <p>The options for the new foreign table. Option names must be unique. The option names and values are foreign-data wrapper-specific and are validated using the foreign-data wrapper's <varname>validator_function</varname>.</p>
+                        <p>The options for the new foreign table or one of its columns. While option names must be unique, a table option and a column option may have the same name. The option names and values are foreign-data wrapper-specific. Greenplum Database validates the options and values using the foreign-data wrapper's <varname>validator_function</varname>.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>mpp_execute { 'master | 'any' | 'all segments' }</pt>
+                    <pd>
+                      <p>Identifies the host from which the foreign data-wrapper requests data: the
+                        master, any segment, or all segments. The default option value is 
+                       '<codeph>master</codeph>'.</p>
+                      <p>Use of the <codeph>mpp_execute</codeph> option, and the specific modes
+                       supported, is foreign data-wrapper-specific.</p>
                     </pd>
                 </plentry>
             </parml>
@@ -86,12 +115,14 @@
     kind        varchar(10),
     len         interval hour to minute
 )
-SERVER film_server;;</codeblock>
+SERVER film_server;</codeblock>
         </section>
         <section id="section7">
             <title>Compatibility</title>
-            <p><codeph>CREATE FOREIGN DATA WRAPPER</codeph> largely conforms to the SQL standard; however, much as with <codeph><xref href="CREATE_TABLE.xml#topic1">CREATE
-                    TABLE</xref></codeph>, <codeph>NULL</codeph> constraints and zero-column foreign tables are permitted.</p>
+            <p><codeph>CREATE FOREIGN TABLE</codeph> largely conforms to the SQL standard; however, much as with <codeph><xref href="CREATE_TABLE.xml#topic1">CREATE
+                    TABLE</xref></codeph>, Greenplum Database permits <codeph>NULL</codeph> constraints and zero-column foreign tables.
+               The ability to specify a default value is a Greenplum Database extension,
+               as is the <codeph>mpp_execute</codeph> option.</p>
         </section>
         <section id="section8">
             <title>See Also</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
@@ -99,7 +99,7 @@
                     <pt>mpp_execute { 'master | 'any' | 'all segments' }</pt>
                     <pd>
                       <p>Option that identifies the host from which the foreign data-wrapper requests data: the
-                        master host, any segment host, or all segment hosts. The default option value
+                        master host, any (master or single segment) host, or all segment hosts. The default option value
                        is '<codeph>master</codeph>'.</p>
                       <p>Use of the foreign table <codeph>mpp_execute</codeph> option, and the
                        specific modes supported, is foreign data-wrapper-specific.</p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
@@ -12,10 +12,12 @@
       [, ... ]
 ] )
     SERVER <varname>server_name</varname>
-  [ OPTIONS ( [ mpp_execute {'any' | 'master' | 'all segments'} ], <varname>option</varname> '<varname>value</varname>' [, ... ] ) ]</codeblock>
+  [ OPTIONS ( [ mpp_execute { 'master' | 'any' | 'all segments' } [, ] ] <varname>option</varname> '<varname>value</varname>' [, ... ] ) ]</codeblock>
         <p>where <varname>column_constraint</varname> is:</p><codeblock>
 [ CONSTRAINT <varname>constraint_name</varname> ]
-{ NOT NULL | NULL | DEFAULT <varname>default_expr</varname> }</codeblock>
+{ NOT NULL |
+  NULL |
+  DEFAULT <varname>default_expr</varname> }</codeblock>
         </section>
         <section id="section3">
             <title>Description</title>
@@ -96,11 +98,11 @@
                 <plentry>
                     <pt>mpp_execute { 'master | 'any' | 'all segments' }</pt>
                     <pd>
-                      <p>Identifies the host from which the foreign data-wrapper requests data: the
-                        master, any segment, or all segments. The default option value is 
-                       '<codeph>master</codeph>'.</p>
-                      <p>Use of the <codeph>mpp_execute</codeph> option, and the specific modes
-                       supported, is foreign data-wrapper-specific.</p>
+                      <p>Option that identifies the host from which the foreign data-wrapper requests data: the
+                        master host, any segment host, or all segment hosts. The default option value
+                       is '<codeph>master</codeph>'.</p>
+                      <p>Use of the foreign table <codeph>mpp_execute</codeph> option, and the
+                       specific modes supported, is foreign data-wrapper-specific.</p>
                     </pd>
                 </plentry>
             </parml>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_SERVER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_SERVER.xml
@@ -13,7 +13,7 @@
         </section>
         <section id="section3">
             <title>Description</title>
-            <p><codeph>CREATE SERVER</codeph> defines a new foreign server. The who defines
+            <p><codeph>CREATE SERVER</codeph> defines a new foreign server. The user who defines
                the server becomes its owner.</p>
             <p>A foreign server typically encapsulates connection information that a foreign-data
               wrapper uses to access an external data source. Additional user-specific connection
@@ -33,13 +33,13 @@
                 <plentry>
                     <pt><varname>server_type</varname></pt>
                     <pd>
-                        <p>Optional server type.</p>
+                        <p>Optional server type, potentially useful to foreign-data wrappers.</p>
                     </pd>
                 </plentry>
                 <plentry>
                     <pt><varname>server_version</varname></pt>
                     <pd>
-                        <p>Optional server version.</p>
+                        <p>Optional server version, potentially useful to foreign-data wrappers.</p>
                     </pd>
                 </plentry>
                 <plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_FOREIGN_TABLE.xml
@@ -24,7 +24,7 @@
                     </pd>
                 </plentry>
                 <plentry>
-                    <pt><varname>_name</varname></pt>
+                    <pt><varname>name</varname></pt>
                     <pd>
                         <p>The name (optionally schema-qualified) of the foreign table to drop.</p>
                     </pd>
@@ -49,7 +49,7 @@
         </section>
         <section id="section7">
             <title>Compatibility</title>
-            <p><codeph>DROP SERVER</codeph> conforms to ISO/IEC 9075-9 (SQL/MED), except that the standard only allows one foreign table to be dropped per command. The <codeph>IF EXISTS</codeph> clause is a Greenplum Database extension.</p>
+            <p><codeph>DROP FOREIGN TABLE</codeph> conforms to ISO/IEC 9075-9 (SQL/MED), except that the standard only allows one foreign table to be dropped per command. The <codeph>IF EXISTS</codeph> clause is a Greenplum Database extension.</p>
         </section>
         <section id="section8">
             <title>See Also</title>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_data_wrapper_options.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_data_wrapper_options.xml
@@ -29,8 +29,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign-data wrapper
-              (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign-data wrapper
+              is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_data_wrappers.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_data_wrappers.xml
@@ -29,8 +29,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign-data wrapper
-              (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign-data wrapper
+              is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_server_options.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_server_options.xml
@@ -29,8 +29,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign server
-              (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign server
+             is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_servers.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_servers.xml
@@ -29,8 +29,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign server
-              (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign server
+              is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -46,8 +46,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign-data wrapper
-              used by the foreign server (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign-data wrapper
+              used by the foreign server is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_table_options.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_table_options.xml
@@ -29,8 +29,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign table
-              (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign table
+              is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/foreign_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/foreign_tables.xml
@@ -29,8 +29,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign table
-              (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign table
+              is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -54,8 +54,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign server
-              (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign server
+              is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_user_mappings.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_user_mappings.xml
@@ -39,7 +39,7 @@
           <row>
             <entry colname="col1"><codeph>srvname</codeph></entry>
             <entry colname="col2">text</entry>
-            <entry colname="col3"></entry>
+            <entry colname="col3">pg_foreign_server.srvname</entry>
             <entry colname="col4">Name of the foreign server.</entry>
           </row>
           <row>
@@ -58,12 +58,20 @@
             <entry colname="col1"><codeph>umoptions</codeph></entry>
             <entry colname="col2">text[]</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">User mapping-specific options, as "keyword=value" strings;
-               viewable only if the current user is the owner of the foreign server, else
-                null.</entry>
+            <entry colname="col4">User mapping-specific options, as "keyword=value" strings.</entry>
           </row>
         </tbody>
       </tgroup>
     </table>
+    <p>
+      To protect password information stored as a user mapping option, the
+      <codeph>umoptions</codeph> column reads as null unless one of the following
+      applies:</p> <ul>
+        <li>The current user is the user being mapped, and owns the server or holds
+          <codeph>USAGE</codeph> privilege on it.</li>
+        <li>The current user is the server owner and the mapping is for
+          <codeph>PUBLIC</codeph>.</li>
+        <li>The current user is a superuser.</li>
+      </ul>
   </body>
 </topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/user_mapping_options.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/user_mapping_options.xml
@@ -38,8 +38,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign server used by
-              this mapping (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign server used by
+              this mapping is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/user_mappings.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/user_mappings.xml
@@ -38,8 +38,8 @@
             </entry>
             <entry colname="col2">sql_identifier</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">Name of the database that contains the foreign server used by
-              this mapping (always the current database).</entry>
+            <entry colname="col4">Name of the database in which the foreign server used by
+              this mapping is defined (always the current database).</entry>
           </row>
           <row>
             <entry colname="col1">


### PR DESCRIPTION
in this PR:
- update FDW-related sql and catalog ref pages to postgresql 9.4 
- add greenplum-specific foreign table option named mpp_execute
- misc edits (typos, corrections, wording changes)

NOT in this PR:
- "using" type info, like how to develop a greenplum FDW - this will come in a separate PR

questions:
- doe CREATE/ALTER FOREIGN TABLE support the TRIGGER and REPLICA TRIGGER clauses?
- does ALTER FOREIGN TABLE support the "ALTER [ COLUMN ] column_name SET STATISTICS ..." clause?

doc review site links:
- http://docs-lisa-fdw.cfapps.io/600/ref_guide/sql_commands/ALTER_FOREIGN_DATA_WRAPPER.html
- http://docs-lisa-fdw.cfapps.io/600/ref_guide/sql_commands/ALTER_FOREIGN_TABLE.html
- http://docs-lisa-fdw.cfapps.io/600/ref_guide/sql_commands/CREATE_FOREIGN_DATA_WRAPPER.html
- http://docs-lisa-fdw.cfapps.io/600/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.html