### PR TITLE
Limit number of workers used by gpstart (gpsegstart) on each host

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -29,11 +29,11 @@ GPHOME=os.environ.get('GPHOME')
 SEGMENT_TIMEOUT_DEFAULT=600
 SEGMENT_STOP_TIMEOUT_DEFAULT=120
 
-#Maximum allowed number of workers for segstart
-SEGMENT_START_MAX_WORKERS=64
-
 #"Command not found" return code in bash
 COMMAND_NOT_FOUND=127
+
+#Default size of thread pool for gpstart and gpsegstart
+DEFAULT_GPSTART_NUM_WORKERS=64
 
 def get_postmaster_pid_locally(datadir):
     cmdStr = "ps -ef | grep postgres | grep -v grep | awk '{print $2}' | grep `cat %s/postmaster.pid | head -1` || echo -1" % (datadir)
@@ -608,6 +608,15 @@ class GpSegStartArgs(CmdArgs):
             self.append(data)
         return self
 
+    def set_parallel(self, parallel):
+        """
+        @param parallel - maximum size of a thread pool to start segments
+        """
+        if parallel is not None:
+            self.append("-B")
+            self.append(str(parallel))
+        return self
+
 
 
 class GpSegStartCmd(Command):
@@ -616,7 +625,7 @@ class GpSegStartCmd(Command):
                  timeout=SEGMENT_TIMEOUT_DEFAULT, verbose=False,
                  ctxt=LOCAL, remoteHost=None, pickledTransitionData=None,
                  specialMode=None, wrapper=None, wrapper_args=None,
-                 logfileDirectory=False):
+                 parallel=None, logfileDirectory=False):
 
         # Referenced by calling code (in operations/startSegments.py), create a clone
         self.dblist = [x for x in segments]
@@ -628,6 +637,7 @@ class GpSegStartCmd(Command):
         c.set_transition(pickledTransitionData)
         c.set_wrapper(wrapper, wrapper_args)
         c.set_segments(segments)
+        c.set_parallel(parallel)
 
         cmdStr = str(c)
         logger.debug(cmdStr)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -29,6 +29,9 @@ GPHOME=os.environ.get('GPHOME')
 SEGMENT_TIMEOUT_DEFAULT=600
 SEGMENT_STOP_TIMEOUT_DEFAULT=120
 
+#Maximum allowed number of workers for segstart
+SEGMENT_START_MAX_WORKERS=64
+
 #"Command not found" return code in bash
 COMMAND_NOT_FOUND=127
 

--- a/gpMgmt/bin/gppylib/operations/startSegments.py
+++ b/gpMgmt/bin/gppylib/operations/startSegments.py
@@ -58,7 +58,7 @@ class StartSegmentsResult:
 
     def addFailure(self, segment, reason, reasonCode):
         self.__failedSegments.append(FailedSegmentResult(segment, reason, reasonCode))
-        
+
     def clearSuccessfulSegments(self):
         self.__successfulSegments = []
 
@@ -67,13 +67,13 @@ class StartSegmentsOperation:
        This operation, to be run from the master, will start the segments up
             and, if necessary, convert them to the proper mode
 
-       Note that this can be used to start only a subset of the segments 
+       Note that this can be used to start only a subset of the segments
 
     """
 
     def __init__(self, workerPool, quiet, gpVersion,
                  gpHome, masterDataDirectory, master_checksum_value=None, timeout=SEGMENT_TIMEOUT_DEFAULT,
-                 specialMode=None, wrapper=None, wrapper_args=None,
+                 specialMode=None, wrapper=None, wrapper_args=None, parallel=gp.DEFAULT_GPSTART_NUM_WORKERS,
                  logfileDirectory=False):
         checkNotNone("workerPool", workerPool)
         self.__workerPool = workerPool
@@ -86,6 +86,7 @@ class StartSegmentsOperation:
         self.__specialMode = specialMode
         self.__wrapper = wrapper
         self.__wrapper_args = wrapper_args
+        self.__parallel = parallel
         self.master_checksum_value = master_checksum_value
         self.logfileDirectory = logfileDirectory
 
@@ -199,6 +200,7 @@ class StartSegmentsOperation:
                                    specialMode=self.__specialMode,
                                    wrapper=self.__wrapper,
                                    wrapper_args=self.__wrapper_args,
+                                   parallel=self.__parallel,
                                    logfileDirectory=self.logfileDirectory)
             self.__workerPool.addCommand(cmd)
             dispatchCount+=1

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstart.py
@@ -15,7 +15,7 @@ class GpSegStartTestCase(unittest.TestCase):
     @patch('gpsegstart.base.WorkerPool')
     def test_check_postmasters_01(self, mk1, mk2, mk3):
         db = '1|1|p|p|s|u|mdw|mdw-1|2000|/data/gpseg-1s'
-        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None)
+        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None, None)
         result = gpseg.checkPostmasters(False)
         self.assertTrue(result)
 
@@ -25,7 +25,7 @@ class GpSegStartTestCase(unittest.TestCase):
     @patch('gpsegstart.base.WorkerPool')
     def test_check_postmasters_02(self, mk1, mk2, mk3, mk4):
         db = '1|1|p|p|s|u|mdw|mdw-1|2000|/data/gpseg-1s'
-        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None)
+        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None, None)
         result = gpseg.checkPostmasters(False)
         self.assertFalse(result)
 
@@ -35,7 +35,7 @@ class GpSegStartTestCase(unittest.TestCase):
     @patch('gpsegstart.base.WorkerPool')
     def test_check_postmasters_03(self, mk1, mk2, mk3, mk4):
         db = '1|1|p|p|s|u|mdw|mdw-1|2000|/data/gpseg-1s'
-        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None)
+        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None, None)
         result = gpseg.checkPostmasters(False)
         self.assertFalse(result)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -73,6 +73,7 @@ class GpStart(GpTestCase):
         self.mock_gp.get_masterdatadir.return_value = 'masterdatadir'
         self.mock_gp.GpCatVersion.local.return_value = 1
         self.mock_gp.GpCatVersionDirectory.local.return_value = 1
+        self.mock_gp.DEFAULT_GPSTART_NUM_WORKERS = gp.DEFAULT_GPSTART_NUM_WORKERS
         sys.argv = ["gpstart"]  # reset to relatively empty args list
 
     def tearDown(self):

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -37,7 +37,6 @@ try:
 except ImportError, e:
     sys.exit('Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
-DEFAULT_NUM_WORKERS = 64
 logger = get_default_logger()
 
 
@@ -48,7 +47,7 @@ class GpStart:
                  wrapper,
                  wrapper_args,
                  skip_standby_check,
-                 parallel=DEFAULT_NUM_WORKERS,
+                 parallel=gp.DEFAULT_GPSTART_NUM_WORKERS,
                  quiet=False,
                  masteronly=False,
                  interactive=False,
@@ -426,7 +425,7 @@ class GpStart:
         # this will eventually start gpsegstart.py
         segmentStartOp = StartSegmentsOperation(self.pool, self.quiet, self.gpversion,
                                                 self.gphome, self.master_datadir, self.master_checksum_value,
-                                                self.timeout, self.specialMode, self.wrapper, self.wrapper_args,
+                                                self.timeout, self.specialMode, self.wrapper, self.wrapper_args, self.parallel,
                                                 logfileDirectory=self.logfileDirectory)
         segmentStartResult = segmentStartOp.startSegments(self.gparray, segmentsToStart, startMode, self.era)
 
@@ -789,8 +788,8 @@ class GpStart:
                          help='start master instance only in maintenance mode')
         addTo.add_option('-y', '--no_standby', dest="start_standby", action='store_false', default=True,
                          help='do not start master standby server')
-        addTo.add_option('-B', '--parallel', type="int", default=DEFAULT_NUM_WORKERS, metavar="<parallel_processes>",
-                         help='number of segment hosts to run in parallel. Default is %d' % DEFAULT_NUM_WORKERS)
+        addTo.add_option('-B', '--parallel', type="int", default=gp.DEFAULT_GPSTART_NUM_WORKERS, metavar="<parallel_processes>",
+                         help='number of segment hosts to run in parallel. Default is %d' % gp.DEFAULT_GPSTART_NUM_WORKERS)
         addTo.add_option('-R', '--restricted', action='store_true',
                          help='start in restricted mode. Only users with superuser privilege are allowed to connect.')
         addTo.add_option('-t', '--timeout', dest='timeout', default=SEGMENT_TIMEOUT_DEFAULT, type='int',

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -160,7 +160,7 @@ class GpSegStart:
 
         # initialize state
         #
-        self.pool                  = base.WorkerPool(numWorkers=len(dblist))
+        self.pool                  = base.WorkerPool(numWorkers=min(len(dblist), gp.SEGMENT_START_MAX_WORKERS))
         self.logger                = logger
         self.overall_status        = None
 


### PR DESCRIPTION
This is another solution for https://github.com/greenplum-db/gpdb/issues/6176, the first one being https://github.com/greenplum-db/gpdb/pull/6177.

The idea was proposed by @jchampio in https://github.com/greenplum-db/gpdb/issues/6176#issuecomment-442159094. The size of [`WorkerPool`](https://github.com/greenplum-db/gpdb/blob/afadea49ec26e823621101c6652272ad04ec230b/gpMgmt/sbin/gpsegstart.py#L163) is capped by a value provided to `gpsegstart` as [`-B`](https://github.com/greenplum-db/gpdb/blob/afadea49ec26e823621101c6652272ad04ec230b/gpMgmt/bin/gpstart#L792) (a.k.a. `-parallel`) option. If the value is not provided, the default one is used (`64`).

The current implementation fulfills three requirements:
* Prevents an error discussed in https://github.com/greenplum-db/gpdb/issues/6176
* Provides control over thread pool size (in contrast, the [first commit](https://github.com/greenplum-db/gpdb/commit/48f308bc623ad49ea0f543229baf7f1548448dcc) in this PR limits the thread pool size by a hardcoded value; that could be another viable implementation)
* Does not complicate `gpstart`