### PR TITLE
Optimize motion receive

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -91,10 +91,12 @@ reconstructTuple(MotionNodeEntry *pMNEntry, ChunkSorterEntry *pCSEntry, TupleRem
 	SerTupInfo *pSerInfo = &pMNEntry->ser_tup_info;
 
 	/*
-	 * Convert the list of chunks into a tuple, then stow it away. This frees
-	 * our TCList as a side-effect
+	 * Convert the list of chunks into a tuple, then stow it away.
 	 */
 	tup = CvtChunksToTup(&pCSEntry->chunk_list, pSerInfo, remapper);
+
+	/* We're done with the chunks now. */
+	clearTCList(NULL, &pCSEntry->chunk_list);
 
 	if (!tup)
 		return;

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -303,7 +303,7 @@ InitMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID)
  * This function is called from:  ExecInitMotion()
  */
 void
-UpdateMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool preserveOrder, TupleDesc tupDesc, uint64 operatorMemKB)
+UpdateMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool preserveOrder, TupleDesc tupDesc)
 {
 	MemoryContext oldCtxt;
 	MotionNodeEntry *pEntry;
@@ -342,14 +342,10 @@ UpdateMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool preserve
 	pEntry->tuple_desc = CreateTupleDescCopy(tupDesc);
 	InitSerTupInfo(pEntry->tuple_desc, &pEntry->ser_tup_info);
 
-	pEntry->memKB = operatorMemKB;
-
 	if (!preserveOrder)
 	{
-		Assert(pEntry->memKB > 0);
-
 		/* Create a tuple-store for the motion node's incoming tuples. */
-		pEntry->ready_tuples = htfifo_create(pEntry->memKB);
+		pEntry->ready_tuples = htfifo_create();
 	}
 	else
 		pEntry->ready_tuples = NULL;
@@ -1042,8 +1038,7 @@ getChunkSorterEntry(MotionLayerState *mlStates,
 	 */
 	if (motNodeEntry->preserve_order)
 	{
-		Assert(motNodeEntry->memKB > 0);
-		chunkSorterEntry->ready_tuples = htfifo_create(motNodeEntry->memKB);
+		chunkSorterEntry->ready_tuples = htfifo_create();
 
 #ifdef AMS_VERBOSE_LOGGING
 		elog(DEBUG5, "Motion node %d is order-preserving.  Creating tuple-store for entry [src=%d,mn=%d].",

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -202,8 +202,9 @@ RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates)
 		 * We store the data inplace, and handle any necessary copying later
 		 * on
 		 */
-		tcItem = (TupleChunkListItem) palloc0(sizeof(TupleChunkListItemData));
+		tcItem = (TupleChunkListItem) palloc(sizeof(TupleChunkListItemData));
 
+		tcItem->p_next = NULL;
 		tcItem->chunk_length = tcSize;
 		tcItem->inplace = (char *) (conn->msgPos + bytesProcessed);
 

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -750,7 +750,7 @@ execMotionSortedReceiver(MotionState * node)
     node->numTuplesToParent++;
 
     /* Store tuple in our result slot. */
-    slot = outerPlanState(node)->ps_ResultTupleSlot;
+    slot = node->ps.ps_ResultTupleSlot;
     slot = ExecStoreGenericTuple(tuple, slot, true /* shouldFree */);
 
 #ifdef CDB_MOTION_DEBUG

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -1082,8 +1082,7 @@ ExecInitMotion(Motion * node, EState *estate, int eflags)
 	UpdateMotionLayerNode(motionstate->ps.state->motionlayer_context, 
 			node->motionID, 
 			node->sendSorted, 
-			tupDesc, 
-			PlanStateOperatorMemKB((PlanState *) motionstate));
+			tupDesc);
 
 	
 #ifdef CDB_MOTION_DEBUG
@@ -1312,7 +1311,6 @@ CdbMergeComparator_CreateContext(TupleDesc      tupDesc,
     ctx->numSortCols = numSortCols;
     ctx->sortColIdx = sortColIdx;
     ctx->tupDesc = tupDesc;
-
     ctx->mt_bind = create_memtuple_binding(tupDesc);
 
     /* Allocate the sort function arrays. */

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -475,8 +475,6 @@ typedef struct MotionNodeEntry
 		* value. */
 	uint64          sel_rd_wait;            /* Total time (usec) spent in select wait trying to read */
 	uint64          sel_wr_wait;            /* Total time spent (usec) in select wait trying to write */
-
-	uint64			memKB;	/* How much memory should this motion node use? */
 }       MotionNodeEntry;
 
 

--- a/src/include/cdb/cdbmotion.h
+++ b/src/include/cdb/cdbmotion.h
@@ -65,7 +65,7 @@ extern void InitMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID);
 
 /* Initialization of each motion node in execution plan. */
 extern void UpdateMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool preserveOrder,
-								  TupleDesc tupDesc, uint64 operatorMemKB);
+								  TupleDesc tupDesc);
 
 /* Cleanup of each motion node in execution plan (normal termination). */
 extern void EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool flushCommLayer);

--- a/src/include/cdb/htupfifo.h
+++ b/src/include/cdb/htupfifo.h
@@ -46,29 +46,9 @@ typedef struct htup_fifo_state
 	htf_entry	freelist;
 	int			freelist_count;
 
-	/* A count of HeapTuples in the FIFO. */
-	int			tup_count;
-
-	/*
-	 * An estimate of the current in-memory size of the FIFO's contents, in
-	 * bytes.
-	 */
-	int			curr_mem_size;
-
-	/*
-	 * The maximum size that the FIFO is allowed to grow to, in bytes, before
-	 * it will cause an error to be reported.
-	 */
-	uint32		max_mem_size;
-
 }	htup_fifo_state, *htup_fifo;
 
-
-#define MIN_HTUPFIFO_KB 8
-
-
-extern htup_fifo htfifo_create(int max_mem_kb);
-extern void htfifo_init(htup_fifo htf, int max_mem_kb);
+extern htup_fifo htfifo_create(void);
 extern void htfifo_destroy(htup_fifo htf);
 
 extern void htfifo_addtuple(htup_fifo htf, GenericTuple htup);

--- a/src/include/cdb/htupfifo.h
+++ b/src/include/cdb/htupfifo.h
@@ -44,7 +44,6 @@ typedef struct htup_fifo_state
 	htf_entry	p_last;
 
 	htf_entry	freelist;
-	int			freelist_count;
 
 }	htup_fifo_state, *htup_fifo;
 


### PR DESCRIPTION
This is some low-hanging fruit that came up, when I did some performance testing of Sorted Motion Receives. Some of these optimizations are not specific to Sorted Receives, though, and should help in many other scenarios, too. Some of these only have an effect in the `gp_enable_motion_mk_sort=off` codepath.

Why now? I was originally wondering why we have a GPDB-specific binary heap implementation, CdbHeap, when there's an almost identical one in upstream, in src/backend/lib/binaryheap.c. I'm not changing that as part of this patch, but that's what got me looking into this code.

Performance testing I did
====

Test setup:
```
create table sortedmotiontest (i int4) distributed by (i);
insert into sortedmotiontest select g from generate_series(1, 10000000) g;
create index on sortedmotiontest (i);
```

To test performance of Sorted Motion Receive, I used this query:
```
postgres=# explain select count(*) from (select i from sortedmotiontest order by i offset 1) x;
                                                            QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=1463652.05..1463652.06 rows=1 width=8)
   ->  Limit  (cost=0.32..1338652.06 rows=9999999 width=4)
         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.18..1338652.06 rows=10000000 width=4)
               Merge Key: sortedmotiontest.i
               ->  Index Only Scan using sortedmotiontest_i_idx on sortedmotiontest  (cost=0.18..1138652.06 rows=3333334 width=4)
 Planning time: 0.276 ms
 Optimizer: legacy query optimizer
(7 rows)
```

I repeated this query a few times, to not be fooled by random variance. I didn't bother to calculate an average, but the number shown here is a fairly representative one, on my laptop, with a three-segment cluster:

Before these patches:
```
postgres=# set gp_enable_motion_mk_sort=off;
SET
Time: 9.613 ms
postgres=# select count(*) from (select i from sortedmotiontest order by i offset 1) x;
  count  
---------
 9999999
(1 row)

Time: 3111.369 ms
```

After:
```
postgres=# set gp_enable_motion_mk_sort=off;
SET
Time: 0.788 ms
postgres=# select count(*) from (select i from sortedmotiontest order by i offset 1) x;
  count  
---------
 9999999
(1 row)

Time: 2437.183 ms
```


Profiling
-----

I took a profile of that with Linux perf (`perf report --call-graph-callee`). I expanded the pfree and AllocSetAllocImpl to show where those calls are coming from.
```
Samples: 92K of event 'cycles', Event count (approx.): 46659727978
  Children      Self  Command     Shared Object        Symbol                                                                                                                                ◆
+   70.48%     7.00%  postmaster  postgres             [.] ExecProcNode                                                                                                                      ▒
+   64.29%     0.79%  postmaster  postgres             [.] ExecAgg                                                                                                                           ▒
+   59.24%     3.31%  postmaster  postgres             [.] ExecMotion                                                                                                                        ▒
+   58.40%     1.16%  postmaster  postgres             [.] ExecLimit                                                                                                                         ▒
+   37.38%     5.59%  postmaster  postgres             [.] RecvTupleFrom                                                                                                                     ▒
+   28.04%     0.00%  postmaster  postgres             [.] standard_ExecutorRun                                                                                                              ▒
+   18.67%     3.78%  postmaster  postgres             [.] SiftDown                                                                                                                          ▒
+   18.42%     0.00%  postmaster  postgres             [.] PostgresMain                                                                                                                      ▒
+   18.42%     0.00%  postmaster  postgres             [.] exec_simple_query                                                                                                                 ▒
+   18.41%     0.00%  postmaster  postgres             [.] PortalRun                                                                                                                         ▒
+   18.41%     0.00%  postmaster  postgres             [.] PortalRunSelect                                                                                                                   ▒
+   16.74%     0.00%  postmaster  postgres             [.] ExecutePlan                                                                                                                       ▒
+   15.94%     4.74%  postmaster  postgres             [.] CdbMergeComparator                                                                                                                ▒
+   14.71%     2.45%  postmaster  postgres             [.] CvtChunksToTup                                                                                                                    ▒
-   10.57%     9.98%  postmaster  postgres             [.] AllocSetAllocImpl                                                                                                                 ▒
   - 7.18% palloc                                                                                                                                                                            ▒
      + 2.78% htfifo_addtuple                                                                                                                                                                ▒
      + 2.23% CvtChunksToTup                                                                                                                                                                 ▒
      + 2.17% initStringInfoOfSize                                                                                                                                                           ▒
   + 2.21% AllocSetAlloc                                                                                                                                                                     ▒
     0.63% AllocSetAllocImpl                                                                                                                                                                 ▒
-    9.37%     1.91%  postmaster  postgres             [.] pfree                                                                                                                             ▒
   - 9.24% pfree                                                                                                                                                                             ▒
      + 3.06% ExecStoreMinimalTuple                                                                                                                                                          ▒
      + 2.33% clearTCList                                                                                                                                                                    ▒
      + 1.95% CvtChunksToTup                                                                                                                                                                 ▒
      + 1.78% htfifo_gettuple                                                                                                                                                                ▒
+    8.63%     3.04%  postmaster  postgres             [.] advance_aggregates                                                                                                                ▒
+    8.29%     7.82%  postmaster  postgres             [.] memtuple_getattr_by_alignment                                                                                                     ▒
+    7.97%     0.73%  postmaster  postgres             [.] palloc                                                                                                                            ▒
+    7.89%     0.44%  postmaster  postgres             [.] memtuple_getattr                                                                                                                  ▒
+    7.80%     7.36%  postmaster  postgres             [.] AllocSetFreeImpl                                                                                                                  ▒
+    7.29%     2.66%  postmaster  postgres             [.] htfifo_gettuple                    
```

These patches address the overheads shown in the profile like this:

* The "Remove limit on htupfifo freelist size" commit removes the palloc/pfree overhead from htfifo_addtuple/getuple.

* The "Optimize CvtChunksToTup" commit eliminates the palloc/pfree overhead from initStringInfoOfSize.

* The "Avoid overhead of extracting first key column in Sorted Motion Receiver" commit reduces the number of memtuple_getattr calls.

* The "Use SortSupport in Motion node" reduces the time spent in CdbMergeComparator.


With these patches applied, the profile looks like this:
```
Samples: 71K of event 'cycles', Event count (approx.): 33545443345
  Children      Self  Command     Shared Object        Symbol                                                                                                                                ◆
+   66.91%     9.41%  postmaster  postgres             [.] ExecProcNode                                                                                                                      ▒
+   59.65%     1.16%  postmaster  postgres             [.] ExecAgg                                                                                                                           ▒
+   52.02%     7.23%  postmaster  postgres             [.] ExecMotion                                                                                                                        ▒
+   51.71%     1.70%  postmaster  postgres             [.] ExecLimit                                                                                                                         ▒
+   28.94%     7.43%  postmaster  postgres             [.] RecvTupleFrom                                                                                                                     ▒
+   18.19%     0.00%  postmaster  postgres             [.] standard_ExecutorRun                                                                                                              ▒
+   12.04%     3.96%  postmaster  postgres             [.] advance_aggregates                                                                                                                ▒
+   10.56%     6.38%  postmaster  postgres             [.] SiftDown                                                                                                                          ▒
+   10.38%     0.00%  postmaster  postgres             [.] ExecutePlan                                                                                                                       ▒
-    7.91%     7.27%  postmaster  postgres             [.] AllocSetAllocImpl                                                                                                                 ▒
   - 6.72% palloc                                                                                                                                                                            ▒
      + 3.38% CvtChunksToTup                                                                                                                                                                 ▒
      + 3.33% RecvTupleChunk                                                                                                                                                                 ▒
     0.67% AllocSetAllocImpl                                                                                                                                                                 ▒
-    7.74%     2.54%  postmaster  postgres             [.] pfree                                                                                                                             ▒
   - 7.54% pfree                                                                                                                                                                             ▒
      + 4.53% ExecStoreMinimalTuple                                                                                                                                                          ▒
      + 2.81% clearTCList                                                                                                                                                                    ▒
+    7.45%     0.65%  postmaster  postgres             [.] palloc                                                                                                                            ▒
+    6.51%     1.93%  postmaster  postgres             [.] CvtChunksToTup                                                                                                                    ▒
+    6.23%     1.57%  postmaster  postgres             [.] ExecStoreMinimalTuple                                                                                                             ▒
+    6.12%     0.15%  postmaster  postgres             [.] CdbHeap_DeleteMinAndInsert                                                                                                        ▒
+    5.99%     0.07%  postmaster  [kernel.kallsyms]    [k] entry_SYSCALL_64_after_swapgs                                                                                                     ▒
+    5.92%     0.04%  postmaster  [kernel.kallsyms]    [k] do_syscall_64                                                                                                                     ▒
+    5.63%     5.16%  postmaster  postgres             [.] AllocSetFreeImpl                                                                                                                  ▒
+    5.17%     4.76%  postmaster  postgres             [.] BackoffBackendTick                                                                                                                ▒
+    4.66%     0.97%  postmaster  postgres             [.] RecvTupleChunk                                                                                                                    ▒
+    4.59%     0.08%  postmaster  [kernel.kallsyms]    [k] udp_sendmsg                                                                                                                       ▒
+    4.54%     0.02%  postmaster  [kernel.kallsyms]    [k] ktime_get_ts64                                                                                                                    ▒
+    4.53%     0.02%  postmaster  [kernel.kallsyms]    [k] read_tsc                                                                                                                          ▒
+    4.40%     2.31%  postmaster  postgres             [.] ExecProject                                                                                                                       ▒
+    4.32%     1.24%  postmaster  postgres             [.] advance_transition_function                                                                                                       ▒
+    4.28%     0.09%  postmaster  [kernel.kallsyms]    [k] udpv6_recvmsg                                                                                                                     ▒
+    4.28%     0.05%  postmaster  postgres             [.] RecvTupleChunkFromUDPIFC                                                                                                          ▒
+    4.25%     0.01%  postmaster  [kernel.kallsyms]    [k] __intel_pmu_enable_all.constprop.17                                                                                               ▒
+    4.23%     3.09%  postmaster  postgres             [.] CdbMergeComparator                                                                                                                ▒
```

