### PR TITLE
Avoid using GP_ROLE_UNDEFINED in code

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -140,16 +140,12 @@ cdbparallelize(PlannerInfo *root,
 	PlanProfile *context = &profile;
 
 	/* Make sure we're called correctly (and need to be called).  */
-	switch (Gp_role)
-	{
-		case GP_ROLE_DISPATCH:
-			break;
-		case GP_ROLE_UTILITY:
-			return plan;
-		case GP_ROLE_EXECUTE:
-		case GP_ROLE_UNDEFINED:
-			Insist(0);
-	}
+	if (Gp_role == GP_ROLE_UTILITY)
+		return plan;
+	if (Gp_role != GP_ROLE_DISPATCH)
+		elog(ERROR, "Plan parallelization invoked for incorrect role: %s",
+			 role_to_string(Gp_role));
+
 	Assert(is_plan_node((Node *) plan));
 	Assert(query !=NULL && IsA(query, Query));
 

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -10,8 +10,6 @@
  * IDENTIFICATION
  *	    src/backend/cdb/cdbllize.c
  *
- * NOTES
- *
  *-------------------------------------------------------------------------
  */
 
@@ -129,12 +127,7 @@ static Plan *materialize_subplan(PlannerInfo *root, Plan *subplan);
  * ------------------------------------------------------------------------- *
  */
 Plan *
-cdbparallelize(PlannerInfo *root,
-			   Plan *plan,
-			   Query *query,
-			   int cursorOptions __attribute__((unused)),
-			   ParamListInfo boundParams __attribute__((unused))
-)
+cdbparallelize(PlannerInfo *root, Plan *plan, Query *query)
 {
 	PlanProfile profile;
 	PlanProfile *context = &profile;
@@ -147,7 +140,7 @@ cdbparallelize(PlannerInfo *root,
 			 role_to_string(Gp_role));
 
 	Assert(is_plan_node((Node *) plan));
-	Assert(query !=NULL && IsA(query, Query));
+	Assert(query != NULL && IsA(query, Query));
 
 	/* Print plan if debugging. */
 	if (Debug_print_prelim_plan)
@@ -186,9 +179,8 @@ cdbparallelize(PlannerInfo *root,
 			break;
 
 		default:
-			Insist(0);
+			elog(ERROR, "Incorrect commandtype for plan parallelization");
 	}
-
 
 	/*
 	 * We need to keep track of whether any part of the plan needs to be

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -401,9 +401,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		top_plan = cdbparallelize(root, top_plan, parse,
-								  cursorOptions,
-								  boundParams);
+		top_plan = cdbparallelize(root, top_plan, parse);
 
 		/*
 		 * cdbparallelize() mutates all the nodes, so the producer nodes we

--- a/src/include/cdb/cdbllize.h
+++ b/src/include/cdb/cdbllize.h
@@ -1,7 +1,7 @@
 /*-------------------------------------------------------------------------
  *
  * cdbllize.h
- *	  definitions for cdbplan.c utilities
+ *	  definitions for parallelizing a PostgreSQL sequential plan tree.
  *
  * Portions Copyright (c) 2005-2008, Greenplum inc
  * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
@@ -9,9 +9,6 @@
  *
  * IDENTIFICATION
  *	    src/include/cdb/cdbllize.h
- *
- *
- * NOTES
  *
  *-------------------------------------------------------------------------
  */
@@ -24,9 +21,7 @@
 #include "nodes/plannodes.h"
 #include "nodes/params.h"
 
-extern Plan *cdbparallelize(struct PlannerInfo *root, Plan *plan, Query *query,
-							int cursorOptions, 
-							ParamListInfo boundParams);
+extern Plan *cdbparallelize(struct PlannerInfo *root, Plan *plan, Query *query);
 
 extern bool is_plan_node(Node *node);
 


### PR DESCRIPTION
The segment role GP_ROLE_UNDEFINED should never be set, and cdbvars is guarding against that ever happening. Thus, testing for it in the code makes it look like it could indeed happen which is misleading to the reader. Remove the test and refactor the switch() to instead use a default clause (effectively generating the same code as today).
