### PR TITLE
Fix wrong line number in include_dir errors

### DIFF
--- a/src/backend/utils/misc/guc-file.l
+++ b/src/backend/utils/misc/guc-file.l
@@ -627,7 +627,6 @@ ParseConfigFp(FILE *fp, const char *config_file, int depth, int elevel,
 								 head_p, tail_p))
 				OK = false;
 			yy_switch_to_buffer(lex_buffer);
-			ConfigFileLineno = save_ConfigFileLineno;
 			pfree(opt_name);
 			pfree(opt_value);
 		}


### PR DESCRIPTION
This commit removes a mistaken assignment to ConfigFileLineno on error
(introduced in upstream commit 2a0c81a12c7 which added support for
"include_dir" in GUC files). The bug would manifest itself when
`include_dir` is misconfigured, and the line number reported will be
nonsense.

Commit 2a0c81a12c7 [1] was written before commit 4b496a3583 [2] went in,
so the extra assignment looks like a leftover after a rebase.

1. Smith, Lane, Misch, et al. (2011, Nov 16 - 2012, Sep 25). "Configuration include directory". https://www.postgresql.org/message-id/flat/4EC341E1.1060908%402ndQuadrant.com

2. Misch, Lane, Haas. (2011, Dec 16 - 2012, Jan 18). "fatal flex error in guc-file.l kills the postmaster". https://www.postgresql.org/message-id/flat/20111216172258.GA4045%40tornado.leadboat.com

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`