### PR TITLE
Update tests to cleanup the distribution policy

### DIFF
--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10602,3 +10602,6 @@ create rule "_RETURN" as on select to rewrite_rules_1_prt_2 do instead
 select 1 as id, current_date as stamp, 1 as amount;
 select * from rewrite_rules;
 ERROR:  plan contains range table with relstorage='v' (allpaths.c:346)
+set allow_system_table_mods='dml';
+delete from gp_distribution_policy where localoid='rewrite_rules_1_prt_2'::regclass;
+reset allow_system_table_mods;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10669,3 +10669,6 @@ create rule "_RETURN" as on select to rewrite_rules_1_prt_2 do instead
 select 1 as id, current_date as stamp, 1 as amount;
 select * from rewrite_rules;
 ERROR:  undefined table type for storage format: v (execScan.c:414)
+set allow_system_table_mods='dml';
+delete from gp_distribution_policy where localoid='rewrite_rules_1_prt_2'::regclass;
+reset allow_system_table_mods;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1634,6 +1634,9 @@ partition by range (stamp) (
 create rule "_RETURN" as on select to rewrite_rules_1_prt_2 do instead 
 select 1 as id, current_date as stamp, 1 as amount;
 select * from rewrite_rules;
+set allow_system_table_mods='dml';
+delete from gp_distribution_policy where localoid='rewrite_rules_1_prt_2'::regclass;
+reset allow_system_table_mods;
 
 -- start_ignore
 DROP SCHEMA orca CASCADE;


### PR DESCRIPTION
Once we rewrite rules on the partition table and drop the table,
the entry for the partition is still left in the gp_distribution_policy
which causes gpcheckcat test to file, so update the test to remove the
inconsistent entry manually.

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`