### PR TITLE
Remove superfluous pass statements

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -993,7 +993,6 @@ class gpexpand:
             self.tempDir = createTempDirectoryName(self.options.master_data_directory, "gpexpand")
         self.queue = None
         self.segTemplate = None
-        pass
 
     @staticmethod
     def prepare_gpdb_state(logger, dburl, options):
@@ -2352,7 +2351,6 @@ class ExecuteSQLStatementsCommand(SQLCommand):
         self.error = None
 
         SQLCommand.__init__(self, name)
-        pass
 
     def run(self, validateAfter=False):
         statement = None
@@ -2421,7 +2419,6 @@ class ExpandCommand(SQLCommand):
         self.table_expand_error = False
 
         SQLCommand.__init__(self, name)
-        pass
 
     def run(self, validateAfter=False):
         # connect.

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -304,7 +304,6 @@ class CommandResult():
         self.stderr = stderr
         self.completed = completed
         self.halt = halt
-        pass
 
     def printResult(self):
         res = "cmd had rc=%d completed=%s halted=%s\n  stdout='%s'\n  " \

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1273,7 +1273,6 @@ def chk_gpdb_id(username):
     if not os.access(path,os.X_OK):
         raise GpError("File permission mismatch.  The current user %s does not have sufficient"
                       " privileges to run the Greenplum binaries and management utilities." % username )
-    pass
 
 
 def chk_local_db_running(datadir, port):

--- a/gpMgmt/bin/gppylib/operations/startSegments.py
+++ b/gpMgmt/bin/gppylib/operations/startSegments.py
@@ -42,7 +42,6 @@ class StartSegmentsResult:
     def __init__(self):
         self.__successfulSegments = []
         self.__failedSegments = []
-        pass
 
     def getSuccessfulSegments(self):
         return self.__successfulSegments[:]


### PR DESCRIPTION
The pass statement is a no-op intended to be used in empty classes or other types of stubs. When following other statements in a block it has no purpose. Remove all such occurrences.