### PR TITLE
Add a --socketdir option to pg_upgrade

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -424,7 +424,8 @@ typedef struct
 	bool		check;			/* TRUE -> ask user for permission to make
 								 * changes */
 	transferMode transfer_mode; /* copy files or link them? */
-	int			jobs;
+	int			jobs;			/* number of processes/threads to use */
+	char	   *socketdir;		/* directory to use for Unix sockets */
 
 	bool		progress;
 	segmentMode	segment_mode;


### PR DESCRIPTION
This is a backport of the below commit from upstream PostgreSQL, which was originally written for Greenplum and submitted as an upstream-first feature. The commit didn't cherrypick as upstream
has moved pg_upgrade to src/bin and Greenplum has yet to merge that.
```
  commit 2d34ad84303181111c6f0747186857ff50106267
  Author: Tom Lane <tgl@sss.pgh.pa.us>
  Date:   Sat Dec 1 15:45:11 2018 -0500

    Add a --socketdir option to pg_upgrade.

    This allows control of the directory in which the postmaster sockets
    are created for the temporary postmasters started by pg_upgrade.
    The default location remains the current working directory, which is
    typically fine, but if it is deeply nested then its pathname might
    be too long to be a socket name.

    In passing, clean up some messiness in pg_upgrade's option handling,
    particularly the confusing and undocumented way that configuration-only
    datadirs were handled.  And fix check_required_directory's substantially
    under-baked cleanup of directory pathnames.

    Daniel Gustafsson, reviewed by Hironobu Suzuki, some code cleanup by me

    Discussion: https://postgr.es/m/E72DD5C3-2268-48A5-A907-ED4B34BEC223@yesql.se
```