### PR TITLE
Remove references to sanmateo.greenplum.com in gpAux scripts

### DIFF
--- a/gpAux/releng/bin/build-gpdb.sh
+++ b/gpAux/releng/bin/build-gpdb.sh
@@ -387,7 +387,6 @@ compileSource() {
         echo ""
         echo `date` "Error during compilation"
         buildTestUpdate
-        mailMakeError
         echo "Exiting"
         exit 1
     else
@@ -455,16 +454,6 @@ compilePGTest() {
     popd > /dev/null 2>&1
     echo "${LIBREGRES} -> ${GPDB_INSTALL}/test/regress.so"
     echo "Finished compile of libregress at" `date`
-    echo ""
-}
-
-mailMakeError() {
-    mailTo="eng@build-prod.sanmateo.greenplum.com"
-    mailSubject="Build Failure: ${BRANCH} ${BUILD_TYPE} : `date +%Y%m%d%H%M`"
-    mailLine=50
-    `${TAIL_CMD} -n ${mailLine} ${WORKDIR}/build.out > errorBuild.txt`
-    mail -s "${mailSubject}" ${mailTo} < errorBuild.txt
-    echo `date` "Sending mail to ${mailTo}"
     echo ""
 }
 

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -87,25 +87,13 @@ opt_write_test:
 	    exit 1; \
 	fi
 
-/opt/releng/apache-ant: 
-	${MAKE} opt_write_test
-	echo "Sync Ivy project dependency management framework ..."
-	type curl; \
-	if [ $$? = 0 ]; then curl --silent http://releng.sanmateo.greenplum.com/tools/apache-ant.1.8.1.tar.gz -o /tmp/apache-ant.1.8.1.tar.gz; \
-	else wget -q http://releng.sanmateo.greenplum.com/tools/apache-ant.1.8.1.tar.gz -O /tmp/apache-ant.1.8.1.tar.gz; fi; \
-	( umask 002; [ ! -d /opt/releng ] && mkdir -p /opt/releng; \
-	   cd /opt/releng; \
-	   gunzip -qc /tmp/apache-ant.1.8.1.tar.gz | tar xf -; \
-	   rm -f /tmp/apache-ant.1.8.1.tar.gz; \
-	   chmod -R a+w /opt/releng/apache-ant )
-
 # ----------------------------------------------------------------------
 # Populate dependent internal and thirdparty dependencies.  This
 # will be retrieved and place in "ext" directory in root
 # directory.
 # ----------------------------------------------------------------------
 
-sync_tools: opt_write_test /opt/releng/apache-ant
+sync_tools: opt_write_test
 	@if [ -d /opt/releng/tools ]; then \
 	    LCK_FILES=$$( find /opt/releng/tools -name "*.lck" ); \
 	    if [ -n "$${LCK_FILES}" ]; then \


### PR DESCRIPTION
These are dead references. Just remove them as simple clean up.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>
Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>