### PR TITLE
Add check Nullptr for CdbTryOpenRelation in parserOpenTable

### DIFF
--- a/src/test/isolation2/expected/select_dropped_table.out
+++ b/src/test/isolation2/expected/select_dropped_table.out
@@ -1,0 +1,34 @@
+-- The transaction that drop a table will
+-- hold Access Exclusive Lock on that table,
+-- then other transactions do select|update|delete
+-- on that table will wait on that lock.
+
+-- Greenplum has a upgrade-lock logic to avoid global
+-- deadlock, this logic is still in the code for ao-table
+-- and select-for-update cases even we have GDD now.
+-- The lock-upgrade logic is implemented by `CdbTryOpenRelation`,
+-- this function might return a NULL pointer if the relation is
+-- dropped (or some other reasons).
+
+-- Previous code of parserOpenTable invokes CdbTryOpenRelation,
+-- and use the result without checking if the value is a NULL
+-- pointer so that leads to SIGSEGV.
+
+-- This bug has been fixed by adding a check in parserOpenTable.
+-- This test is used to confirm the fix.
+
+1: create table tab_select_dropped_table (c int);
+CREATE
+1: begin;
+BEGIN
+1: drop table tab_select_dropped_table;
+DROP
+
+2&: select * from tab_select_dropped_table;  <waiting ...>
+
+1: end;
+END
+2<:  <... completed>
+ERROR:  relation "tab_select_dropped_table" does not exist
+LINE 1: select * from tab_select_dropped_table;
+                      ^

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,3 +1,4 @@
+test: select_dropped_table
 # test update hash col under utility mode
 test: update_hash_col_utilitymode
 

--- a/src/test/isolation2/sql/select_dropped_table.sql
+++ b/src/test/isolation2/sql/select_dropped_table.sql
@@ -1,0 +1,27 @@
+-- The transaction that drop a table will
+-- hold Access Exclusive Lock on that table,
+-- then other transactions do select|update|delete
+-- on that table will wait on that lock.
+
+-- Greenplum has a upgrade-lock logic to avoid global
+-- deadlock, this logic is still in the code for ao-table
+-- and select-for-update cases even we have GDD now.
+-- The lock-upgrade logic is implemented by `CdbTryOpenRelation`,
+-- this function might return a NULL pointer if the relation is
+-- dropped (or some other reasons).
+
+-- Previous code of parserOpenTable invokes CdbTryOpenRelation,
+-- and use the result without checking if the value is a NULL
+-- pointer so that leads to SIGSEGV.
+
+-- This bug has been fixed by adding a check in parserOpenTable.
+-- This test is used to confirm the fix.
+
+1: create table tab_select_dropped_table (c int);
+1: begin;
+1: drop table tab_select_dropped_table;
+
+2&: select * from tab_select_dropped_table;
+
+1: end;
+2<:


### PR DESCRIPTION
`CdbTryOpenRelation` might return a NULL pointer. Each time we
use the value returned by it we should always check if the
result is NULL. `parserOpenTable` forgot doing such check, this
commit adds the check for NULL.

This fix the github issue #6434 

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] ~Document changes~(does not need)
- [x] ~Communicate in the mailing list if needed~(does not need)
- [x] Pass `make installcheck`