### PR TITLE
resgroup: allow operators enlarge their memory quota.

### DIFF
--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -936,8 +936,10 @@ PolicyEagerFreeAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memAvailableByte
 	 * Make sure there is enough operator memory in resource group mode.
 	 */
 	autoIncOpMemForResGroup(&ctx.groupTree->groupMemKB,
-							ctx.groupTree->numNonMemIntenseOps +
-							ctx.groupTree->numMemIntenseOps);
+							Max(ctx.groupTree->numNonMemIntenseOps,
+								ctx.groupTree->maxNumConcNonMemIntenseOps) +
+							Max(ctx.groupTree->numMemIntenseOps,
+								ctx.groupTree->maxNumConcMemIntenseOps));
 
 	/*
 	 * Check if memory exceeds the limit in the root group

--- a/src/include/executor/execHHashagg.h
+++ b/src/include/executor/execHHashagg.h
@@ -127,6 +127,7 @@ typedef struct HashAggTableSizes
 	unsigned  workmem_initial;    /* Estimated work_mem bytes at #entries=0 */
 	unsigned  workmem_per_entry;  /* Additional work_mem bytes per entry */
 	bool      spill;      /* Do we expect to spill ? */
+	double    memquota;   /* Minimal required memquota */
 } HashAggTableSizes;
 
 /*

--- a/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
@@ -18,7 +18,7 @@ DROP RESOURCE GROUP rg2_opmem_test;
 -- we have to keep the columns provided by them in the target list, instead of
 -- composing a long SELECT c1,c2,... list we use SELECT * here, but we should
 -- not output the groupid as it changes each time.
-CREATE OR REPLACE VIEW many_ops AS SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config ;
+CREATE OR REPLACE VIEW many_ops AS SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 ;
 CREATE
 
 CREATE RESOURCE GROUP rg1_opmem_test WITH (cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0, concurrency=20, memory_spill_ratio=0);
@@ -34,6 +34,9 @@ GRANT
 -- each operator, no matter it is memory intensive or not.  As long as there is
 -- enough shared memory the query should be executed successfully.
 --
+-- some operators like HashAgg require more memory to run, the memory quota is
+-- also dynamically increased to meet their minimal requirements.
+--
 -- note: when there is no enough operator memory there should be a warning,
 -- however warnings are not displayed in isolation2 tests.
 
@@ -46,9 +49,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
 RESET role;
 RESET
 
@@ -57,9 +61,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
 RESET role;
 RESET
 
@@ -68,9 +73,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
 RESET role;
 RESET
 
@@ -127,9 +133,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
 RESET role;
 RESET
 
@@ -138,9 +145,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
 RESET role;
 RESET
 
@@ -149,9 +157,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
 RESET role;
 RESET
 
@@ -175,9 +184,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
 RESET role;
 RESET
 
@@ -186,9 +196,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
 RESET role;
 RESET
 
@@ -197,9 +208,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
 RESET role;
 RESET
 

--- a/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
@@ -18,26 +18,26 @@ DROP RESOURCE GROUP rg2_opmem_test;
 -- composing a long SELECT c1,c2,... list we use SELECT * here, but we should
 -- not output the groupid as it changes each time.
 CREATE OR REPLACE VIEW many_ops AS
-       SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+      SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
 ;
 
 CREATE RESOURCE GROUP rg1_opmem_test
@@ -51,6 +51,9 @@ GRANT ALL ON many_ops TO r1_opmem_test;
 -- memory reserved, however in resource group mode we assign at least 100KB to
 -- each operator, no matter it is memory intensive or not.  As long as there is
 -- enough shared memory the query should be executed successfully.
+--
+-- some operators like HashAgg require more memory to run, the memory quota is
+-- also dynamically increased to meet their minimal requirements.
 --
 -- note: when there is no enough operator memory there should be a warning,
 -- however warnings are not displayed in isolation2 tests.


### PR DESCRIPTION
Operators like HashAgg might need more memory quota than granted.  In
resource group mode this could be allowed as memory can be allocated
from global or per-group shared memory.

By supporting this we improved the support for low-end resgroups, as
long as there is enough shared memory low-end resgroups could still run
large queries although the performance might not be the best.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes: not sure if this is needed
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`