### PR TITLE
Fix use-after-free bug in memtuple de-toasting

### DIFF
--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -724,7 +724,9 @@ ExecFetchSlotHeapTuple(TupleTableSlot *slot)
  *		that in addition to the regular tuple (not instead of, because
  *		callers may hold pointers to Datums within the regular tuple).
  *
- * As above, the result must be treated as read-only.
+ * This is Greenplum replacement for ExecFetchSlotMinimalTuple in PostgreSQL.
+ * The above comment from upstream applies.  In addtion, the result must be
+ * treated as read-only.
  *
  * Note: if the slot already contains a memtuple and it needs to be de-toasted
  * (inline_toast = true and de-toasted length is greater than current length)
@@ -770,9 +772,9 @@ ExecFetchSlotMemTuple(TupleTableSlot *slot, bool inline_toast)
 	}
 
 	/*
-	 * A side effect of this is the tuple is to mark the slot as virtual - the
-	 * values array in the slot contains pointers to corresponding locations
-	 * of toasted attributes in the memtuple.
+	 * A side effect of this is to mark the slot as virtual - the tts_values
+	 * array in the slot contains pointers to corresponding locations of
+	 * toasted attributes in the memtuple.
 	 */
 	slot_getallattrs(slot);
 

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -222,6 +222,11 @@ static inline void TupSetVirtualTuple(TupleTableSlot *slot)
 	slot->PRIVATE_tts_flags |= TTS_VIRTUAL;
 }
 
+static inline void TupClearVirtualTuple(TupleTableSlot *slot)
+{
+	slot->PRIVATE_tts_flags &= (~TTS_VIRTUAL);
+}
+
 static inline void TupSetVirtualTupleNValid(TupleTableSlot *slot, int nvalid)
 {
         free_heaptuple_memtuple(slot);


### PR DESCRIPTION
De-toasting of memtuples incorrectly marked the slot containing the de-toasted
memtuple as virtual.  When a TupleTableSlot is marked virtual, its values array
should point to addresses within the memtuple.  The bug was that the values
array was populated *before* de-toasting and the memory used by the toasted
memtuple was freed.  Subsequent usages of this slot suffered from dereferencing
invalid memory through the pointers in values array.

This is fixed by clearing the virtual flag from the slot after de-toasting.
Subsequent users of the slot would have to populate the values array with
valid addresses from the new de-toasted memtuple (see slot_getattr()).

The bug is hard to discover because motion node in executor is the only place
where a memtuple is de-toasted, before sending it over interconnect.  Only a
few plan nodes make use of a tuple that's already returned to the parent nodes
e.g. Unique (DISTINCT ON()) and SetOp (INTERSECT / EXCEPT).  Example plan that
manifests the bug:
```
 Gather Motion 3:1
   Merge Key: a, b
   ->  Unique
         Group By: a, b
         ->  Sort
               Sort Key (Distinct): a, b
               ->  Seq Scan
```
The Unique node uses the previous tuple de-toasted by the Gather Motion sender
to compare with the new tuple obtained from the Sort node for eliminating
duplicates.

## Here are some reminders before you submit the pull request
- [] Add tests for the change
Test is not added in this PR because we couldn't find a query that results in a plan like above.  The above plan is generated only on 5X_STABLE.  A test for this patch needs a plan where Unique or SetOp node is a direct child of a Motion node.

- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`