### PR TITLE
docs - operator-related sys catalog ref pages to 9.4

### DIFF
--- a/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-tables.xml
@@ -123,6 +123,9 @@
       <li id="eu150406">
         <xref href="./pg_operator.xml#topic1" type="topic" format="dita"/>
       </li>
+      <li id="eu149938f">
+        <xref href="./pg_opfamily.xml#topic1" type="topic" format="dita"/>
+      </li>
       <li id="eu150051">
         <xref href="./pg_partition.xml#topic1" type="topic" format="dita"/>
       </li>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_am.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_am.xml
@@ -1,12 +1,223 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1" xml:lang="en"><title id="fv141670">pg_am</title><body><p>The <codeph>pg_am</codeph> table stores information about index access
+<topic id="topic1" xml:lang="en">
+  <title id="fv141670">pg_am</title>
+  <body>
+    <p>The <codeph>pg_am</codeph> table stores information about index access
 methods. There is one row for each index access method supported by the
-system.</p><table id="fv141982"><title>pg_catalog.pg_am</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>amname</codeph></entry><entry colname="col2">name</entry><entry colname="col3"/><entry colname="col4">Name of the access method</entry></row><row><entry colname="col1"><codeph>amstrategies</codeph></entry><entry colname="col2">int2</entry><entry colname="col3"/><entry colname="col4">Number of operator strategies for this access
-method</entry></row><row><entry colname="col1"><codeph>amsupport</codeph></entry><entry colname="col2">int2</entry><entry colname="col3"/><entry colname="col4">Number of support routines for this access method</entry></row><row><entry colname="col1"><codeph>amorderstrategy</codeph></entry><entry colname="col2">int2</entry><entry colname="col3"/><entry colname="col4">Zero if the index offers no sort order, otherwise
-the strategy number of the strategy operator that describes the sort
-order</entry></row><row><entry colname="col1"><codeph>amcanunique</codeph></entry><entry colname="col2">boolean</entry><entry colname="col3"/><entry colname="col4">Does the access method support unique indexes?</entry></row><row><entry colname="col1"><codeph>amcanmulticol</codeph></entry><entry colname="col2">boolean</entry><entry colname="col3"/><entry colname="col4">Does the access method support multicolumn indexes?</entry></row><row><entry colname="col1"><codeph>amoptionalkey</codeph></entry><entry colname="col2">boolean</entry><entry colname="col3"/><entry colname="col4">Does the access method support a scan without
-any constraint for the first index column?</entry></row><row><entry colname="col1"><codeph>amindexnulls</codeph></entry><entry colname="col2">boolean</entry><entry colname="col3"/><entry colname="col4">Does the access method support null index entries?</entry></row><row><entry colname="col1"><codeph>amstorage</codeph></entry><entry colname="col2">boolean</entry><entry colname="col3"/><entry colname="col4">Can index storage data type differ from column
-data type?</entry></row><row><entry colname="col1"><codeph>amclusterable</codeph></entry><entry colname="col2">boolean</entry><entry colname="col3"/><entry colname="col4">Can an index of this type be clustered on?</entry></row><row><entry colname="col1"><codeph>aminsert</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">"Insert this tuple" function</entry></row><row><entry colname="col1"><codeph>ambeginscan</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">"Start new scan" function</entry></row><row><entry colname="col1"><codeph>amgettuple</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">"Next valid tuple" function</entry></row><row><entry colname="col1"><codeph>amgetmulti</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">"Fetch multiple tuples" function</entry></row><row><entry colname="col1"><codeph>amrescan</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">"Restart this scan" function</entry></row><row><entry colname="col1"><codeph>amendscan</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">"End this scan" function</entry></row><row><entry colname="col1"><codeph>ammarkpos</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">"Mark current scan position" function</entry></row><row><entry colname="col1"><codeph>amrestrpos</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">"Restore marked scan position" function</entry></row><row><entry colname="col1"><codeph>ambuild</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">"Build new index" function</entry></row><row><entry colname="col1"><codeph>ambulkdelete</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">Bulk-delete function</entry></row><row><entry colname="col1"><codeph>amvacuumcleanup</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">Post-<codeph>VACUUM</codeph> cleanup function</entry></row><row><entry colname="col1"><codeph>amcostestimate</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">Function to estimate cost of an index scan</entry></row><row><entry colname="col1"><codeph>amoptions</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">Function to parse and validate reloptions for
-an index</entry></row></tbody></tgroup></table></body></topic>
+system.</p>
+    <table id="fv141982">
+      <title>pg_catalog.pg_am</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>oid</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Row identifier (hidden attribute; must be explicitly selected)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amname</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of the access method</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amstrategies</codeph></entry>
+            <entry colname="col2">int2</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Number of operator strategies for this access
+method,
+              or zero if the access method does not have a fixed set of operator strategies</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amsupport</codeph></entry>
+            <entry colname="col2">int2</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Number of support routines for this access method</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amcanorder</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Does the access method support ordered scans sorted by the indexed
+              column's value?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amcanorderbyop</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Does the access method support ordered scans sorted by the result
+              of an operator on the indexed column?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amcanbackward</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Does the access method support backward scanning?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amcanunique</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Does the access method support unique indexes?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amcanmulticol</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Does the access method support multicolumn indexes?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amoptionalkey</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Does the access method support a scan without
+              any constraint for the first index column?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amsearcharray</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Does the access method support <codeph>ScalarArrayOpExpr</codeph>
+              searches?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amsearchnulls</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Does the access method support <codeph>IS NULL/NOT NULL</codeph>
+              searches?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amstorage</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Can index storage data type differ from column
+data type?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amclusterable</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Can an index of this type be clustered on?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>ampredlocks</codeph></entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Does an index of this type manage fine-grained predicae locks?</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amkeytype</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_type.oid</entry>
+            <entry colname="col4">Type of data stored in index, or zero if not a fixed type</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aminsert</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"Insert this tuple" function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>ambeginscan</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"Prepare for index scan" function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amgettuple</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"Next valid tuple" function, or zero if none</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amgetbitmap</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"Fetch all tuples" function, or zero if none</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amrescan</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"(Re)start index scan" function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amendscan</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"Clean up after index scan" function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>ammarkpos</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"Mark current scan position" function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amrestrpos</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"Restore marked scan position" function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>ambuild</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"Build new index" function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>ambuildempty</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">"Build empty index" function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>ambulkdelete</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Bulk-delete function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amvacuumcleanup</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Post-<codeph>VACUUM</codeph> cleanup function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amcanreturn</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Function to check whether index supports index-only scans, or
+              zero if none</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amcostestimate</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Function to estimate cost of an index scan</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amoptions</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Function to parse and validate <codeph>reloptions</codeph> for
+              an index</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_amop.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_amop.xml
@@ -7,6 +7,12 @@
     <p>The <codeph>pg_amop</codeph> table stores information about operators associated with index
       access method operator classes. There is one row for each operator that is a member of an
       operator class.</p>
+    <p>An entry's <codeph>amopmethod</codeph> must match the <codeph>opfmethod</codeph>
+        of its containing operator family (including <codeph>amopmethod</codeph> here is
+        an intentional denormalization of the catalog structure for performance reasons).
+        Also, <codeph>amoplefttype</codeph> and <codeph>amoprighttype</codeph> must match
+        the <codeph>oprleft</codeph> and <codeph>oprright</codeph> fields of the referenced
+        <codeph>pg_operator</codeph> entry.</p>
     <table id="fw143542">
       <title>pg_catalog.pg_amop</title>
       <tgroup cols="4">
@@ -24,17 +30,28 @@
         </thead>
         <tbody>
           <row>
-            <entry colname="col1"><codeph>amopclaid</codeph></entry>
+            <entry colname="col1"><codeph>oid</codeph></entry>
             <entry colname="col2">oid</entry>
-            <entry colname="col3">pg_opclass.oid</entry>
-            <entry colname="col4">The index operator class this entry is for</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Row identifier (hidden attribute; must be explicitly selected)</entry>
           </row>
           <row>
-            <entry colname="col1"><codeph>amopsubtype</codeph></entry>
+            <entry colname="col1"><codeph>amopfamily</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_opfamily.oid</entry>
+            <entry colname="col4">The operator family that this entry is for</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amoplefttype</codeph></entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
-            <entry colname="col4">Subtype to distinguish multiple entries for one strategy; zero for
-              default</entry>
+            <entry colname="col4">Left-hand input data type of operator</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amoprighttype</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_type.oid</entry>
+            <entry colname="col4">Right-hand input data type of operator</entry>
           </row>
           <row>
             <entry colname="col1"><codeph>amopstrategy</codeph></entry>
@@ -43,16 +60,30 @@
             <entry colname="col4">Operator strategy number</entry>
           </row>
           <row>
-            <entry colname="col1"><codeph>amopreqcheck</codeph></entry>
-            <entry colname="col2">boolean</entry>
+            <entry colname="col1"><codeph>amoppurpose</codeph></entry>
+            <entry colname="col2">char</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Index hit must be rechecked</entry>
+            <entry colname="col4">Operator purpose, either <codeph>s</codeph> for search or
+             <codeph>o</codeph> for ordering</entry>
           </row>
           <row>
             <entry colname="col1"><codeph>amopopr</codeph></entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_operator.oid</entry>
             <entry colname="col4">OID of the operator</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amopmethod</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_am.oid</entry>
+            <entry colname="col4">Index access method for the operator family</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amopsortfamily</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_opfamily.oid</entry>
+            <entry colname="col4">If an ordering operator, the B-tree operator family that this entry
+              sorts according to; zero if a search operator</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_amproc.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_amproc.xml
@@ -1,6 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1" xml:lang="en"><title id="fx143896">pg_amproc</title><body><p>The <codeph>pg_amproc</codeph> table stores information about support procedures associated with
+<topic id="topic1" xml:lang="en">
+  <title id="fx143896">pg_amproc</title>
+  <body>
+    <p>The <codeph>pg_amproc</codeph> table stores information about support procedures associated with
       index access method operator classes. There is one row for each support procedure belonging to
-      an operator class.</p><table id="fx143898"><title>pg_catalog.pg_amproc</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>amopclaid</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_opclass.oid</entry><entry colname="col4">The index operator class this entry is for</entry></row><row><entry colname="col1"><codeph>amprocsubtype</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_type.oid</entry><entry colname="col4">Subtype, if cross-type routine, else zero</entry></row><row><entry colname="col1"><codeph>amprocnum</codeph></entry><entry colname="col2">int2</entry><entry colname="col3"/><entry colname="col4">Support procedure number</entry></row><row><entry colname="col1"><codeph>amproc</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">OID of the procedure</entry></row></tbody></tgroup></table></body></topic>
+      an operator class.</p>
+    <table id="fx143898">
+      <title>pg_catalog.pg_amproc</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>oid</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Row identifier (hidden attribute; must be explicitly selected)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amprocfamily</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_opfamily.oid</entry>
+            <entry colname="col4">The operator family this entry is for</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amproclefttype</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_type.oid</entry>
+            <entry colname="col4">Left-hand input data type of associated operator</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amprocrighttype</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_type.oid</entry>
+            <entry colname="col4">Right-hand input data type of associated operator</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amprocnum</codeph></entry>
+            <entry colname="col2">int2</entry>
+            <entry colname="col3"/><entry colname="col4">Support procedure number</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>amproc</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry><entry colname="col4">OID of the procedure</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>
+

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_authid.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_authid.xml
@@ -33,6 +33,14 @@
         <tbody>
           <row>
             <entry colname="col1">
+              <codeph>oid</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Row identifier (hidden attribute; must be explicitly selected)</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>rolname</codeph>
             </entry>
             <entry colname="col2">name</entry>
@@ -92,6 +100,16 @@
           </row>
           <row>
             <entry colname="col1">
+              <codeph>rolreplication</codeph>
+            </entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Role is a replication role. That is, this role can initiate streaming
+              replication and set/unset the system backup mode using <codeph>pg_start_backup</codeph>
+              and <codeph>pg_stop_backup</codeph>.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>rolconnlimit</codeph>
             </entry>
             <entry colname="col2">int4</entry>
@@ -105,7 +123,13 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Password (possibly encrypted); NULL if none</entry>
+            <entry colname="col4">Password (possibly encrypted); NULL if none. If the password is
+              encrypted, this column will begin with the string <codeph>md5</codeph> followed by a
+              32-character hexadecimal MD5 hash. The MD5 hash will be the user's password concatenated
+              to their user name. For example, if user <codeph>joe</codeph> has password
+              <codeph>xyzzy</codeph>, Greenplum Database will store the md5 hash of
+              <codeph>xyzzyjoe</codeph>. Greenplum assumes that a password that does not follow that
+              format is unencrypted.</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_namespace.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_namespace.xml
@@ -1,7 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1" xml:lang="en"><title id="gx143896">pg_namespace</title><body><p>The <codeph>pg_namespace</codeph> system catalog table stores namespaces.
+<topic id="topic1" xml:lang="en">
+  <title id="gx143896">pg_namespace</title>
+  <body>
+    <p>The <codeph>pg_namespace</codeph> system catalog table stores namespaces.
 A namespace is the structure underlying SQL schemas: each namespace can
-have a separate collection of relations, types, etc. without name conflicts.</p><table id="gx143898"><title>pg_catalog.pg_namespace</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>nspname</codeph></entry><entry colname="col2">name</entry><entry colname="col3"/><entry colname="col4">Name of the namespace</entry></row><row><entry colname="col1"><codeph>nspowner</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_authid.oid</entry><entry colname="col4">Owner of the namespace</entry></row><row><entry colname="col1"><codeph>nspacl </codeph></entry><entry colname="col2">aclitem[]</entry><entry colname="col3"/><entry colname="col4">Access privileges as given by <codeph>GRANT</codeph>
-and <codeph>REVOKE</codeph>.</entry></row></tbody></tgroup></table></body></topic>
+have a separate collection of relations, types, etc. without name conflicts.</p>
+    <table id="gx143898">
+      <title>pg_catalog.pg_namespace</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry>
+          </row></thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>oid</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Row identifier (hidden attribute; must be explicitly selected)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>nspname</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Name of the namespace</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>nspowner</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_authid.oid</entry>
+            <entry colname="col4">Owner of the namespace</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>nspacl </codeph></entry>
+            <entry colname="col2">aclitem[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Access privileges as given by <codeph>GRANT</codeph>
+and <codeph>REVOKE</codeph></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_opclass.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_opclass.xml
@@ -6,14 +6,14 @@
   <body>
     <p>The <codeph>pg_opclass</codeph> system catalog table defines index access method operator
       classes. Each operator class defines semantics for index columns of a particular data type and
-      a particular index access method. Note that there can be multiple operator classes for a given
-      data type/access method combination, thus supporting multiple behaviors. The majority of the
-      information defining an operator class is actually not in its <codeph>pg_opclass</codeph> row,
-      but in the associated rows in <xref href="pg_amop.xml#topic1">pg_amop</xref> and <xref
-        href="pg_amproc.xml#topic1">pg_amproc</xref>. Those rows are considered to be part of the
-      operator class definition — this is not unlike the way that a relation is defined by a single
-        <xref href="pg_class.xml#topic1">pg_class</xref> row plus associated rows in <xref
-        href="pg_attribute.xml#topic1">pg_attribute</xref> and other tables.</p>
+      a particular index access method. An operator class essentially specifies that a particular
+      operator family is applicable to a particular indexable column data type. The set of operators
+      from the family that are actually usable with the indexed column are those that accept the
+      column's data type as their left-hand input.</p>
+    <p>An operator class's <codeph>opcmethod</codeph> must match the <codeph>opfmethod</codeph> of
+      its containing operator family. Also, there must be no more than one <codeph>pg_opclass</codeph>
+      row having <codeph>opcdefault</codeph> true for any given combination of
+      <codeph>opcmethod</codeph> and <codeph>opcintype</codeph>.</p>
     <table id="gw141982">
       <title>pg_catalog.pg_opclass</title>
       <tgroup cols="4">
@@ -32,11 +32,19 @@
         <tbody>
           <row>
             <entry colname="col1">
-              <codeph>opcamid</codeph>
+              <codeph>oid</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Row identifier (hidden attribute; must be explicitly selected)</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>opcmethod</codeph>
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_am.oid</entry>
-            <entry colname="col4">Index access method operator class is for.</entry>
+            <entry colname="col4">Index access method operator class is for</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -64,11 +72,19 @@
           </row>
           <row>
             <entry colname="col1">
+              <codeph>opcfamily</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_opfamily.oid</entry>
+            <entry colname="col4">Operator family containing the operator class</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>opcintype</codeph>
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
-            <entry colname="col4">Data type that the operator class indexes.</entry>
+            <entry colname="col4">Data type that the operator class indexes</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -77,7 +93,7 @@
             <entry colname="col2">boolean</entry>
             <entry colname="col3"/>
             <entry colname="col4">True if this operator class is the default for the data type
-              opcintype.</entry>
+              <codeph>opcintype</codeph></entry>
           </row>
           <row>
             <entry colname="col1">
@@ -86,7 +102,7 @@
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
             <entry colname="col4">Type of data stored in index, or zero if same as
-              opcintype.</entry>
+              <codeph>opcintype</codeph></entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_operator.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_operator.xml
@@ -25,11 +25,19 @@
         <tbody>
           <row>
             <entry colname="col1">
+              <codeph>oid</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Row identifier (hidden attribute, must be explicityly selected)</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>oprname</codeph>
             </entry>
             <entry colname="col2">name</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Name of the operator.</entry>
+            <entry colname="col4">Name of the operator</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -37,7 +45,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_namespace.oid</entry>
-            <entry colname="col4">The OID of the namespace that contains this operator.</entry>
+            <entry colname="col4">The OID of the namespace that contains this operator</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -45,7 +53,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_authid.oid</entry>
-            <entry colname="col4">Owner of the operator. </entry>
+            <entry colname="col4">Owner of the operator</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -58,11 +66,19 @@
           </row>
           <row>
             <entry colname="col1">
+              <codeph>oprcanmerge</codeph>
+            </entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">This operator supports merge joins</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>oprcanhash</codeph>
             </entry>
             <entry colname="col2">boolean</entry>
             <entry colname="col3"/>
-            <entry colname="col4">This operator supports hash joins.</entry>
+            <entry colname="col4">This operator supports hash joins</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -70,7 +86,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
-            <entry colname="col4">Type of the left operand.</entry>
+            <entry colname="col4">Type of the left operand</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -78,7 +94,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
-            <entry colname="col4">Type of the right operand.</entry>
+            <entry colname="col4">Type of the right operand</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -86,7 +102,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
-            <entry colname="col4">Type of the result.</entry>
+            <entry colname="col4">Type of the result</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -94,51 +110,15 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_operator.oid</entry>
-            <entry colname="col4">Commutator of this operator, if any.</entry>
+            <entry colname="col4">Commutator of this operator, if any</entry>
           </row>
           <row>
             <entry colname="col1">
               <codeph>oprnegate</codeph>
             </entry>
-            <entry colname="col2"/>
-            <entry colname="col3">pg_operator.oid</entry>
-            <entry colname="col4">Negator of this operator, if any.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
-              <codeph>oprlsortop</codeph>
-            </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_operator.oid</entry>
-            <entry colname="col4">If this operator supports merge joins, the operator that sorts the
-              type of the left-hand operand (<codeph>L&lt;L</codeph>).</entry>
-          </row>
-          <row>
-            <entry colname="col1">
-              <codeph>oprrsortop</codeph>
-            </entry>
-            <entry colname="col2">oid</entry>
-            <entry colname="col3">pg_operator.oid</entry>
-            <entry colname="col4">If this operator supports merge joins, the operator that sorts the
-              type of the right-hand operand (<codeph>R&lt;R</codeph>).</entry>
-          </row>
-          <row>
-            <entry colname="col1">
-              <codeph>oprltcmpop</codeph>
-            </entry>
-            <entry colname="col2">oid</entry>
-            <entry colname="col3">pg_operator.oid</entry>
-            <entry colname="col4">If this operator supports merge joins, the less-than operator that
-              compares the left and right operand types (<codeph>L&lt;R</codeph>).</entry>
-          </row>
-          <row>
-            <entry colname="col1">
-              <codeph>oprgtcmpop</codeph>
-            </entry>
-            <entry colname="col2">oid</entry>
-            <entry colname="col3">pg_operator.oid</entry>
-            <entry colname="col4">If this operator supports merge joins, the greater-than operator
-              that compares the left and right operand types (<codeph>L&gt;R</codeph>).</entry>
+            <entry colname="col4">Negator of this operator, if any</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -146,7 +126,7 @@
             </entry>
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
-            <entry colname="col4">Function that implements this operator.</entry>
+            <entry colname="col4">Function that implements this operator</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -155,7 +135,7 @@
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
             <entry colname="col4">Restriction selectivity estimation function for this
-              operator.</entry>
+              operator</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -163,7 +143,7 @@
             </entry>
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
-            <entry colname="col4">Join selectivity estimation function for this operator.</entry>
+            <entry colname="col4">Join selectivity estimation function for this operator</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_opfamily.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_opfamily.xml
@@ -10,6 +10,11 @@
       compatible in a way that is specified by the access method. The operator family concept allows
       cross-data-type operators to be used with indexes and to be reasoned about using knowledge of
       access method semantics.</p>
+    <p>The majority of the information defining an operator family is not in its
+      <codeph>pg_opfamily</codeph> row, but in the associated rows in
+      <codeph><xref href="./pg_amop.xml#topic1" type="topic" format="dita"/></codeph>,
+      <codeph><xref href="./pg_amproc.xml#topic1" type="topic" format="dita"/></codeph>, and
+      <codeph><xref href="./pg_opclass.xml#topic1" type="topic" format="dita"/></codeph>.</p>
     <table id="table_dfn_chh_sfb">
       <title>pg_opfamily</title>
       <tgroup cols="4">
@@ -26,6 +31,12 @@
           </row>
         </thead>
         <tbody>
+          <row>
+            <entry><codeph>oid</codeph></entry>
+            <entry>oid</entry>
+            <entry></entry>
+            <entry>Row identifier (hidden attribute; must be explicitly selected)</entry>
+          </row>
           <row>
             <entry><codeph>opfmethod</codeph></entry>
             <entry>oid</entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_proc.xml
@@ -32,11 +32,19 @@
         <tbody>
           <row>
             <entry colname="col1">
+              <codeph>oid</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Row identifier (hidden attribute; ust be explicitly selected)</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>proname</codeph>
             </entry>
             <entry colname="col2">name</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Name of the function.</entry>
+            <entry colname="col4">Name of the function</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -44,7 +52,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_namespace.oid</entry>
-            <entry colname="col4">The OID of the namespace that contains this function.</entry>
+            <entry colname="col4">The OID of the namespace that contains this function</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -52,7 +60,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_authid.oid</entry>
-            <entry colname="col4">Owner of the function.</entry>
+            <entry colname="col4">Owner of the function</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -61,7 +69,7 @@
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_language.oid</entry>
             <entry colname="col4">Implementation language or call interface of this
-              function.</entry>
+              function</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -70,7 +78,7 @@
             <entry colname="col2">float4</entry>
             <entry colname="col3"/>
             <entry colname="col4">Estimated execution cost (in cpu_operator_cost units); if
-              proretset is <codeph>true</codeph>, identifies the cost per row returned.</entry>
+              <codeph>proretset</codeph> is <codeph>true</codeph>, identifies the cost per row returned</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -78,7 +86,7 @@
             </entry>
             <entry colname="col2">float4</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Estimated number of result rows (zero if not proretset)</entry>
+            <entry colname="col4">Estimated number of result rows (zero if not <codeph>proretset</codeph>)</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -87,7 +95,15 @@
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
             <entry colname="col4">Data type of the variadic array parameter's elements, or zero if
-              the function does not have a variadic parameter.</entry>
+              the function does not have a variadic parameter</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>protransform</codeph>
+            </entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Calls to this function can be simplified by this other function</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -95,7 +111,7 @@
             </entry>
             <entry colname="col2">boolean</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Function is an aggregate function.</entry>
+            <entry colname="col4">Function is an aggregate function</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -103,7 +119,7 @@
             </entry>
             <entry colname="col2">boolean</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Function is a window function.</entry>
+            <entry colname="col4">Function is a window function</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -112,7 +128,17 @@
             <entry colname="col2">boolean</entry>
             <entry colname="col3"/>
             <entry colname="col4">Function is a security definer (for example, a 'setuid'
-              function).</entry>
+              function)</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>proleakproof</codeph>
+            </entry>
+            <entry colname="col2">boolean</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The function has no side effects. No information about the arguments
+              is conveyed except via the return value. Any function that might throw an error
+              depending on the values of its arguments is not leak-proof.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -131,7 +157,7 @@
             <entry colname="col2">boolean</entry>
             <entry colname="col3"/>
             <entry colname="col4">Function returns a set (multiple values of the specified data
-              type).</entry>
+              type)</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -152,7 +178,7 @@
             </entry>
             <entry colname="col2">int2</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Number of arguments.</entry>
+            <entry colname="col4">Number of arguments</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -160,7 +186,7 @@
             </entry>
             <entry colname="col2">int2</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Number of arguments that have default values.</entry>
+            <entry colname="col4">Number of arguments that have default values</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -168,7 +194,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_type.oid</entry>
-            <entry colname="col4">Data type of the return value.</entry>
+            <entry colname="col4">Data type of the return value</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -189,9 +215,9 @@
             <entry colname="col3">pg_type.oid</entry>
             <entry colname="col4">An array with the data types of the function arguments. This
               includes all arguments (including <codeph>OUT</codeph> and <codeph>INOUT</codeph>
-              arguments); however, if all the arguments are <codeph>IN</codeph> arguments, this
+              arguments); however, if all of the arguments are <codeph>IN</codeph> arguments, this
               field will be null. Note that subscripting is 1-based, whereas for historical reasons
-              proargtypes is subscripted from 0.</entry>
+              <codeph>proargtypes</codeph> is subscripted from 0.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -203,8 +229,8 @@
                 <codeph>i</codeph> = <codeph>IN</codeph>, <codeph>o</codeph> = <codeph>OUT</codeph>
               , <codeph>b</codeph> = <codeph>INOUT</codeph>, <codeph>v</codeph> =
                 <codeph>VARIADIC</codeph>. If all the arguments are IN arguments, this field will be
-              null. Note that subscripts correspond to positions of proallargtypes not
-              proargtypes.</entry>
+              null. Note that subscripts correspond to positions of <codeph>proallargtypes</codeph>,
+              not <codeph>proargtypes</codeph>.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -215,18 +241,18 @@
             <entry colname="col4">An array with the names of the function arguments. Arguments
               without a name are set to empty strings in the array. If none of the arguments have a
               name, this field will be null. Note that subscripts correspond to positions of
-              proallargtypes not proargtypes.</entry>
+              <codeph>proallargtypes</codeph> not <codeph>proargtypes</codeph>.</entry>
           </row>
           <row>
             <entry colname="col1">
               <codeph>proargdefaults</codeph>
             </entry>
-            <entry colname="col2"> text </entry>
+            <entry colname="col2">pg_node_tree</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Expression trees for default argument values. This is a list with
-              pronargdefaults elements, corresponding to the last <varname>N</varname> input
-              arguments (i.e., the last <varname>N</varname> proargtypes positions). If none of the
-              arguments have defaults, this field is empty.</entry>
+            <entry colname="col4">Expression trees (in <codeph>nodeToString()</codeph> representation) for default argument values. This is a list with
+              <codeph>pronargdefaults</codeph> elements, corresponding to the last <varname>N</varname> input
+              arguments (i.e., the last <varname>N</varname> <codeph>proargtypes</codeph> positions). If none of the
+              arguments have defaults, this field will be null.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -243,7 +269,7 @@
             <entry colname="col1">
               <codeph>probin</codeph>
             </entry>
-            <entry colname="col2">bytea</entry>
+            <entry colname="col2">text</entry>
             <entry colname="col3"/>
             <entry colname="col4">Additional information about how to invoke the function. Again,
               the interpretation is language-specific.</entry>
@@ -252,8 +278,7 @@
             <entry colname="col1"><codeph>proconfig</codeph></entry>
             <entry colname="col2">text[]</entry>
             <entry colname="col3"/>
-            <entry colname="col4">An array with runtime configuration variable settings that are
-              local to function execution.</entry>
+            <entry colname="col4">Function's local settings for run-time configuration variables.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -262,7 +287,7 @@
             <entry colname="col2">aclitem[]</entry>
             <entry colname="col3"/>
             <entry colname="col4">Access privileges for the function as given by
-                <codeph>GRANT</codeph>/<codeph>REVOKE</codeph>.</entry>
+                <codeph>GRANT</codeph>/<codeph>REVOKE</codeph></entry>
           </row>
           <row>
             <entry colname="col1"><codeph>prodataaccess</codeph></entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_type.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_type.xml
@@ -27,11 +27,19 @@
         <tbody>
           <row>
             <entry colname="col1">
+              <codeph>oid</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Row identifier (hidden attribute; must be explicitly selected)</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>typname</codeph>
             </entry>
             <entry colname="col2">name</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Data type name.</entry>
+            <entry colname="col4">Data type name</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -39,7 +47,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_namespace.oid</entry>
-            <entry colname="col4">The OID of the namespace that contains this type.</entry>
+            <entry colname="col4">The OID of the namespace that contains this type</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -47,7 +55,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_authid.oid</entry>
-            <entry colname="col4">Owner of the type.</entry>
+            <entry colname="col4">Owner of the type</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -101,7 +109,7 @@
             <entry colname="col2">boolean</entry>
             <entry colname="col3"/>
             <entry colname="col4">True if the type is a preferred cast target within
-              its <codeph>typcategory</codeph>.</entry>
+              its <codeph>typcategory</codeph></entry>
           </row>
           <row>
             <entry colname="col1">
@@ -129,7 +137,7 @@
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_class.oid</entry>
-            <entry colname="col4">If this is a composite type, then this column points to the
+            <entry colname="col4">If this is a composite type (see <codeph>typtype</codeph>), then this column points to the
                 <codeph>pg_class</codeph> entry that defines the corresponding table. (For a
               free-standing composite type, the <codeph>pg_class</codeph> entry does not really
               represent a table, but it is needed anyway for the type's
@@ -144,9 +152,9 @@
             <entry colname="col3">pg_type.oid</entry>
             <entry colname="col4">If not <codeph>0</codeph> then it identifies another row in
               <codeph>pg_type</codeph>. The current type can then be subscripted like an array yielding values of
-              type <codeph>typelem</codeph>. A true array type is variable length
+              type <codeph>typelem</codeph>. A "true" array type is variable length
                 (<codeph>typlen</codeph> = <codeph>-1</codeph>), but some fixed-length
-                (<codeph>tylpen</codeph> &gt; <codeph>0</codeph>) types also have nonzero
+                (<codeph>typlen</codeph> &gt; <codeph>0</codeph>) types also have nonzero
                 <codeph>typelem</codeph>, for example <codeph>name</codeph> and
                 <codeph>point</codeph>. If a fixed-length type has a <codeph>typelem</codeph> then
               its internal representation must be some number of values of the
@@ -168,7 +176,7 @@
             </entry>
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
-            <entry colname="col4">Input conversion function (text format).</entry>
+            <entry colname="col4">Input conversion function (text format)</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -176,7 +184,7 @@
             </entry>
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
-            <entry colname="col4">Output conversion function (text format).</entry>
+            <entry colname="col4">Output conversion function (text format)</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -184,7 +192,7 @@
             </entry>
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
-            <entry colname="col4">Input conversion function (binary format), or 0 if none.</entry>
+            <entry colname="col4">Input conversion function (binary format), or 0 if none</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -192,7 +200,7 @@
             </entry>
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
-            <entry colname="col4">Output conversion function (binary format), or 0 if none.</entry>
+            <entry colname="col4">Output conversion function (binary format), or 0 if none</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -201,7 +209,7 @@
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
             <entry colname="col4">Type modifier input function, or 0 if the type does not support
-              modifiers.</entry>
+              modifiers</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -210,7 +218,7 @@
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
             <entry colname="col4">Type modifier output function, or 0 to use the standard 
-              format.</entry>
+              format</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -219,7 +227,7 @@
             <entry colname="col2">regproc</entry>
             <entry colname="col3">pg_proc.oid</entry>
             <entry colname="col4">Custom <codeph>ANALYZE</codeph> function, or 0 to use the standard
-              function.</entry>
+              function</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -321,7 +329,7 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Null if the type has no associated default value. If not null,
+            <entry colname="col4">Null if the type has no associated default value. If <codeph>typdefaultbin</codeph> is not null,
               <codeph>typdefault</codeph> must contain a human-readable version of
               the default expression represented
               by <codeph>typdefaultbin</codeph>. If <codeph>typdefaultbin</codeph> is


### PR DESCRIPTION
int this PR:  bring operator-related system catalog tables, and other sys tbls that they reference, to postgresql 9.4:
- pg_am - add oid row, amcanorder, amcanorderbyop, amcanbackward, amsearcharray, amsearchnulls, ampredlocks, amkeytype, amgetbitmap, ambuildempty rows; remove amorderstrategy, amindexnulls, amgetmulti rows; misc edits to descriptions; reformat
- pg_amop - add oid, amopsortfamily rows
- pg_amproc - add oid, amprocfamily, amproclefttype, amprocrighttype rows; remove amopclaid, amprocsubtype rows; reformat
- pg_authid - add oid, rolreplication rows; remove rolconfig row
- pg_namespace - add oid row; remove punctuation, reformat
- pg_opclass - add oid row, opcmethod, opcfamily rows; remove opcamid row; remove punctuation
- pg_operator - add oid row; remove oprlsortop, oprrsortop, oprltcmpop, oprgtcmpop rows; remove punctuation
- pg_opfamily - add oid row
- pg_proc - add oid, protransform, proleakproof rows; misc edits; remove punctuation
- pg_type - add oid row; remove punctuation

doc review site links:
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_am.html#topic1
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_amop.html
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_amproc.html
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_authid.html
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_namespace.html
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_opclass.html
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_operator.html
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_opfamily.html
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_proc.html
- http://docs-lisa-gpdb6.cfapps.io/600/ref_guide/system_catalogs/pg_type.html