### PR TITLE
docs - remove reference to java 1.7 in pxf docs

### DIFF
--- a/gpdb-doc/markdown/pxf/install_java.html.md.erb
+++ b/gpdb-doc/markdown/pxf/install_java.html.md.erb
@@ -9,7 +9,7 @@ PXF is a Java service. It requires a Java 1.8 installation on each Greenplum Dat
 
 ## <a id="prereq"></a>Prerequisites
 
-Ensure that you have access to, or superuser permissions to install, Java version 1.7 or 1.8 on each Greenplum Database host.
+Ensure that you have access to, or superuser permissions to install, Java version 1.8 on each Greenplum Database host.
 
 ## <a id="proc"></a>Procedure
 


### PR DESCRIPTION
missed a reference.