### PR TITLE
Optimize CHECK_FOR_INTERRUPTS()

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -31,6 +31,7 @@
 #include "cdb/cdbdisp.h"
 #include "lib/stringinfo.h"
 #include "libpq/libpq-be.h"
+#include "postmaster/backoff.h"
 #include "utils/resource_manager.h"
 #include "utils/resgroup-ops.h"
 #include "storage/proc.h"

--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -40,6 +40,7 @@
 #include "utils/formatting.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
+#include "utils/resource_manager.h"
 #include "executor/execdesc.h"
 #include "utils/resscheduler.h"
 #include "utils/syscache.h"

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -48,6 +48,7 @@
 #include "utils/memutils.h"
 #include "utils/ps_status.h"
 #include "utils/resscheduler.h"
+#include "utils/resource_manager.h"
 #include "utils/resowner_private.h"
 
 

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -67,6 +67,7 @@
 #include "port/atomics.h"
 #include "postmaster/fts.h"
 #include "tcop/idle_resource_cleaner.h"
+#include "utils/resource_manager.h"
 #include "utils/resscheduler.h"
 #include "utils/session_state.h"
 

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -35,6 +35,7 @@
 #include "executor/spi.h"
 #include "postmaster/autostats.h"
 #include "postmaster/backoff.h"
+#include "utils/resource_manager.h"
 #include "utils/resscheduler.h"
 #include "utils/metrics_utils.h"
 #include "utils/tqual.h"

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -49,6 +49,7 @@
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/resgroup.h"
+#include "utils/resource_manager.h"
 #include "utils/resscheduler.h"
 #include "utils/syscache.h"
 

--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -26,6 +26,7 @@
 #include "miscadmin.h"
 #include "utils/builtins.h"
 #include "utils/memutils.h"
+#include "utils/resource_manager.h"
 #include "utils/resscheduler.h"
 
 #include "cdb/ml_ipc.h"

--- a/src/backend/utils/resowner/resowner.c
+++ b/src/backend/utils/resowner/resowner.c
@@ -28,6 +28,7 @@
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
+#include "utils/resource_manager.h"
 #include "utils/resowner_private.h"
 #include "utils/snapmgr.h"
 

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -40,6 +40,7 @@
 #include "utils/portal.h"
 #include "utils/ps_status.h"
 #include "utils/resowner.h"
+#include "utils/resource_manager.h"
 #include "utils/resscheduler.h"
 #include "cdb/memquota.h"
 #include "commands/queue.h"

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -43,6 +43,7 @@
 #include "utils/guc.h"
 #include "utils/fmgroids.h"
 #include "utils/memutils.h"
+#include "utils/resource_manager.h"
 #include "utils/resscheduler.h"
 #include "utils/syscache.h"
 #include "utils/metrics_utils.h"

--- a/src/include/postmaster/backoff.h
+++ b/src/include/postmaster/backoff.h
@@ -8,7 +8,7 @@
 #ifndef BACKOFF_H_
 #define BACKOFF_H_
 
-#include "storage/proc.h"
+#include "fmgr.h"
 
 /* GUCs */
 extern bool gp_enable_resqueue_priority;
@@ -21,7 +21,6 @@ extern char* gp_resqueue_priority_default_value;
 
 extern void BackoffBackendEntryInit(int sessionid, int commandcount, int weight);
 extern void BackoffBackendEntryExit(void);
-extern void BackoffBackendTick(void);
 extern void BackoffStateInit(void);
 extern Datum gp_adjust_priority_int(PG_FUNCTION_ARGS);
 extern Datum gp_adjust_priority_value(PG_FUNCTION_ARGS);


### PR DESCRIPTION
CHECK_FOR_INTERRUPTS() had grown quite bloated, given how frequently it runs.
It called IsResQueueEnabled(), which added the overhead of a function call,
even if resource queues were not enabled. If they were enabled, it would
call BackoffBackendTick(), which adds another function call.
BackoffBackendTick() checked a lot of other conditions, so it would still
often not do anything.

It turns out to be cheaper to always increment the "tick" counter, to avoid
the overhead of checking whether we need it or not. Move all the the checks
for whether the whole backoff mechanism is even needed, into a function
that only runs when the tick counter expires.

I've seen those calls take up to 5% of CPU overhead, when profiling some
queries with linux 'perf'. This should shave off the time spent on that.
