### PR TITLE
Remove 'sel_wr_wait' / 'sel_rd_wait'

### DIFF
--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -473,8 +473,6 @@ typedef struct MotionNodeEntry
 	uint64          stat_tuples_available;  /* Total tuples awaiting receive. */
 	uint64          stat_tuples_available_hwm;              /* High-water-mark of this
 		* value. */
-	uint64          sel_rd_wait;            /* Total time (usec) spent in select wait trying to read */
-	uint64          sel_wr_wait;            /* Total time spent (usec) in select wait trying to write */
 }       MotionNodeEntry;
 
 

--- a/src/include/cdb/cdbmotion.h
+++ b/src/include/cdb/cdbmotion.h
@@ -47,8 +47,6 @@ extern int Gp_max_tuple_chunk_size;
 
 /* API FUNCTION CALLS */
 
-extern MotionNodeEntry *getMotionNodeEntry(MotionLayerState *mlStates, int16 motNodeID);
-
 /* Initialization of motion layer for this query */
 extern void initMotionLayerStructs(MotionLayerState **ml_states);
 


### PR DESCRIPTION
It might be somewhat interesting to log the time spent waiting on
select(), but the implementation had some issues:

* It was only implemented for the TCP interconnect, the fields were left
  zero with UDP.

* It relied on non-portable, Linux-specific, behavior of select(), to
  update the 'timeout' argument.

* It punched through abstraction layers, calling getMotionNodeEntry()
  from the lower level functions in ic_tcp.c.

* Looking up the MotionNodeEntry node, and updating the fields, is not
  entirely free. I've seen getMotionNodeEntry() show up in CPU profiles.
  Although this caller isn't the worst offender, it's just overhead when
  verbose logging is not enabled.

None of these would be show-stopper, but put it all together, and I think
we're better off just removing this.

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`