### PR TITLE
Simplify handling of 'mem_manager' in Agg executor code.

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -976,12 +976,11 @@ agg_hash_initial_pass(AggState *aggstate)
 			int tup_len = memtuple_get_size((MemTuple)entry->tuple_and_aggs);
 			MemSet((char *)entry->tuple_and_aggs + MAXALIGN(tup_len), 0,
 				   aggstate->numaggs * sizeof(AggStatePerGroupData));
-			initialize_aggregates(aggstate, aggstate->peragg, hashtable->groupaggs->aggs,
-								  &(aggstate->mem_manager));
+			initialize_aggregates(aggstate, aggstate->peragg, hashtable->groupaggs->aggs);
 		}
 			
 		/* Advance the aggregates */
-		advance_aggregates(aggstate, hashtable->groupaggs->aggs, &(aggstate->mem_manager));
+		advance_aggregates(aggstate, hashtable->groupaggs->aggs);
 		
 		hashtable->num_tuples++;
 
@@ -1855,8 +1854,7 @@ agg_hash_reload(AggState *aggstate)
 										  peraggstate->transtypeByVal,
 										  peraggstate->transtypeLen,
 										  &fcinfo, (void *)aggstate,
-										  aggstate->tmpcontext->ecxt_per_tuple_memory,
-										  &(aggstate->mem_manager));
+										  aggstate->tmpcontext->ecxt_per_tuple_memory);
 				Assert(peraggstate->transtypeByVal ||
 				       (pergroupstate->transValueIsNull ||
 					PointerIsValid(DatumGetPointer(pergroupstate->transValue))));

--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -208,11 +208,9 @@ typedef struct AggStatePerGroupData
 extern void 
 initialize_aggregates(AggState *aggstate,
 					  AggStatePerAgg peragg,
-					  AggStatePerGroup pergroup,
-					  MemoryManagerContainer *mem_manager);
+					  AggStatePerGroup pergroup);
 extern void 
-advance_aggregates(AggState *aggstate, AggStatePerGroup pergroup,
-				   MemoryManagerContainer *mem_manager);
+advance_aggregates(AggState *aggstate, AggStatePerGroup pergroup);
 
 extern Oid resolve_polymorphic_transtype(Oid aggtranstype, Oid aggfnoid,
 										 Oid *inputTypes);
@@ -226,8 +224,7 @@ extern Datum invoke_agg_trans_func(AggState *aggstate,
 								   bool *transValueIsNull, bool transtypeByVal,
 								   int16 transtypeLen,
 								   FunctionCallInfoData *fcinfo, void *funcctx,
-								   MemoryContext tuplecontext,
-								   MemoryManagerContainer *mem_manager);
+								   MemoryContext tuplecontext);
 
 extern Datum datumCopyWithMemManager(Datum oldvalue, Datum value, bool typByVal, int typLen,
 									 MemoryManagerContainer *mem_manager);


### PR DESCRIPTION
All callers passed '&aggstate->mem_manager', so we can simplify the
internal functions by removing it as a separate argument. This is good,
because it makes the function signatures match upstream again.
