### PR TITLE
5X: resgroup: allow shared memory as operator memory

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -32,6 +32,7 @@
 #include "utils/elog.h"
 #include "cdb/memquota.h"
 #include "utils/workfile_mgr.h"
+#include "utils/resource_manager.h"
 
 #include "access/hash.h"
 
@@ -541,6 +542,7 @@ calcHashAggTableSizes(double memquota,	/* Memory quota in bytes. */
 					  HashAggTableSizes   *out_hats)
 {
 	double entrysize, nbuckets, nentries;
+	double orig_memquota = memquota;
 
 	/* Assume we don't need to spill */
 	bool expectSpill = false;
@@ -554,6 +556,9 @@ calcHashAggTableSizes(double memquota,	/* Memory quota in bytes. */
 	elog(HHA_MSG_LVL, "HashAgg: ngroups = %g, memquota = %g, entrysize = %g",
 		 ngroups, memquota, entrysize);
 
+	if (out_hats)
+		out_hats->memquota = memquota;
+
 	/*
 	 * When all groups can not fit in the memory, we compute
 	 * the number of batches to store spilled groups. Currently, we always
@@ -564,6 +569,15 @@ calcHashAggTableSizes(double memquota,	/* Memory quota in bytes. */
 		nbatches = gp_hashagg_default_nbatches;
 		batchfile_mem = BATCHFILE_METADATA * (1 + nbatches);
 		expectSpill = true;
+
+		/* In resource group the memory quota could be dynamically enlarged */
+		if (IsResGroupEnabled() && memquota < batchfile_mem)
+		{
+			if (out_hats)
+				out_hats->memquota += batchfile_mem - memquota;
+
+			memquota = batchfile_mem;
+		}
 
 		/*
 		 * If the memory quota is smaller than the overhead for batch files,
@@ -589,6 +603,15 @@ calcHashAggTableSizes(double memquota,	/* Memory quota in bytes. */
 	/* but at least a few hash entries as required */
 	nentries = Max(nentries, gp_hashagg_groups_per_bucket);
 	entries_mem = nentries * entrywidth;
+
+	/* In resource group the memory quota could be dynamically enlarged */
+	if (IsResGroupEnabled() && memquota < entries_mem)
+	{
+		if (out_hats)
+			out_hats->memquota += 1 + entries_mem - memquota;
+
+		memquota = 1 + entries_mem;
+	}
 
 	/*
 	 * If the memory quota is smaller than the minimum number of entries
@@ -629,6 +652,15 @@ calcHashAggTableSizes(double memquota,	/* Memory quota in bytes. */
 	nbuckets = Max(nbuckets, gp_hashagg_default_nbatches);
 	buckets_mem = nbuckets * OVERHEAD_PER_BUCKET;
 
+	/* In resource group the memory quota could be dynamically enlarged */
+	if (IsResGroupEnabled() && memquota < buckets_mem)
+	{
+		if (out_hats)
+			out_hats->memquota += buckets_mem - memquota;
+
+		memquota = buckets_mem;
+	}
+
 	/* Reserve memory for the entries + hash table */
 	memquota -= buckets_mem;
 
@@ -664,6 +696,18 @@ calcHashAggTableSizes(double memquota,	/* Memory quota in bytes. */
 		out_hats->spill = expectSpill;
 		out_hats->workmem_initial = (unsigned)(batchfile_mem);
 		out_hats->workmem_per_entry = (unsigned) entrysize;
+
+		if (IsResGroupEnabled() && out_hats->memquota > orig_memquota)
+		{
+			ereport(WARNING,
+					(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+					 errmsg("No enough memory quota reserved for AggHash operator."),
+					 errdetail("The operator needs a minimal of %.0f bytes memory, "
+							   "but only %.0f bytes are reserved.  "
+							   "Temporarily increased the memory quota to execute the operator.",
+							   out_hats->memquota, orig_memquota),
+					 errhint("Consider increase memory_spill_ratio for better performance.")));
+		}
 	}
 	
 	elog(HHA_MSG_LVL, "HashAgg: nbuckets = %d, nentries = %d, nbatches = %d",
@@ -791,7 +835,7 @@ create_agg_hash_table(AggState *aggstate)
 
 	MemoryContextSwitchTo(oldcxt);
 
-	hashtable->max_mem = 1024.0 * operatorMemKB;
+	hashtable->max_mem = hashtable->hats.memquota;
 	hashtable->mem_for_metadata = sizeof(HashAggTable) +
 			hashtable->nbuckets * OVERHEAD_PER_BUCKET +
 			sizeof(GroupKeysAndAggs);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -79,6 +79,7 @@
 #include "utils/typcache.h"
 #include "utils/workfile_mgr.h"
 #include "utils/faultinjector.h"
+#include "utils/resource_manager.h"
 
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_class.h"
@@ -299,8 +300,14 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 		/**
 		 * There are some statements that do not go through the resource queue, so we cannot
 		 * put in a strong assert here. Someday, we should fix resource queues.
+		 *
+		 * In resource group mode we always assign some memory to operators
+		 * even if the amount is larger than the spill memory, the memory can
+		 * be actually allocated from the shared memory.  If there is not enough
+		 * shared memory OOM will be raised on executors.
 		 */
-		if (queryDesc->plannedstmt->query_mem > 0)
+		if (IsResGroupEnabled() ||
+			queryDesc->plannedstmt->query_mem > 0)
 		{
 			switch(*gp_resmanager_memory_policy)
 			{

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -1082,8 +1082,10 @@ PolicyEagerFreeAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memAvailableByte
 	 * Make sure there is enough operator memory in resource group mode.
 	 */
 	autoIncOpMemForResGroup(&ctx.groupTree->groupMemKB,
-							ctx.groupTree->numNonMemIntenseOps +
-							ctx.groupTree->numMemIntenseOps);
+							Max(ctx.groupTree->numNonMemIntenseOps,
+								ctx.groupTree->maxNumConcNonMemIntenseOps) +
+							Max(ctx.groupTree->numMemIntenseOps,
+								ctx.groupTree->maxNumConcMemIntenseOps));
 
 	/*
 	 * Check if memory exceeds the limit in the root group

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -53,6 +53,7 @@ typedef struct PolicyAutoContext
 /**
  * Forward declarations.
  */
+static void autoIncOpMemForResGroup(uint64 *opMemKB, int numOps);
 static bool PolicyAutoPrelimWalker(Node *node, PolicyAutoContext *context);
 static bool	PolicyAutoAssignWalker(Node *node, PolicyAutoContext *context);
 static bool IsAggMemoryIntensive(Agg *agg);
@@ -108,6 +109,64 @@ typedef struct PolicyEagerFreeContext
 	uint64 queryMemKB; /* the query memory limit */
 	PlannedStmt *plannedStmt; /* pointer to the planned statement */
 } PolicyEagerFreeContext;
+
+/*
+ * Automatically increase operator memory buffer in resource group mode.
+ *
+ * In resource group if the operator memory buffer is too small for the
+ * operators we still allow the query to execute by temporarily increasing the
+ * buffer size, each operator will be assigned 100KB memory no matter it is
+ * memory intensive or not.  The query can execute as long as there is enough
+ * resource group shared memory, the performance might not be best as 100KB is
+ * rather small for memory intensive operators.  If there is no enought shared
+ * memory it will run into OOM error on operators.
+ *
+ * @param opMemKB the original operator memory buffer size, will be in-place
+ *        updated if not large enough
+ * @param numOps the number of operators, both memory intensive and
+ *        non-intensive
+ */
+static void
+autoIncOpMemForResGroup(uint64 *opMemKB, int numOps)
+{
+	uint64		perOpMemKB;		/* per-operator buffer size */
+	uint64		minOpMemKB;		/* minimal buffer size for all the operators */
+
+	/* Only adjust operator memory buffer for resource group */
+	if (!IsResGroupEnabled())
+		return;
+
+	/*
+	 * The buffer reserved for a memory intensive operator is the same as
+	 * non-intensive ones, by default it is 100KB
+	 */
+	perOpMemKB = *gp_resmanager_memory_policy_auto_fixed_mem;
+	minOpMemKB = perOpMemKB * numOps;
+
+	/* No need to change operator memory buffer if already large enough */
+	if (*opMemKB >= minOpMemKB)
+		return;
+
+	/*
+	 * FIXME: a `SET hello<TAB>` auto completion will trigger this WARNING if
+	 * the group memory setting is low, which causes a messy command line
+	 * prompt.
+	 *
+	 * Is there any way to hide this WARNING for auto completion?
+	 */
+	ereport(WARNING,
+			(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+			 errmsg("No enough operator memory for current query."),
+			 errdetail("Current query contains %d operators, "
+					   "the minimal operator memory requirement is " INT64_FORMAT " KB, "
+					   "however there is only " INT64_FORMAT " KB reserved.  "
+					   "Temporarily increased the operator memory to execute the query.",
+					   numOps, minOpMemKB, *opMemKB),
+			 errhint("Consider increase memory_spill_ratio for better performance.")));
+
+	/* Adjust the buffer */
+	*opMemKB = minOpMemKB;
+}
 
 /**
  * Is an agg operator memory intensive? The following cases mean it is:
@@ -433,6 +492,13 @@ void PolicyAutoAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memAvailableByte
 
 	 Assert(!result);
 	 Assert(ctx.numMemIntensiveOperators + ctx.numNonMemIntensiveOperators > 0);
+
+	/*
+	 * Make sure there is enough operator memory in resource group mode.
+	 */
+	autoIncOpMemForResGroup(&ctx.queryMemKB,
+							ctx.numNonMemIntensiveOperators +
+							ctx.numMemIntensiveOperators);
 
 	 if (ctx.queryMemKB <= ctx.numNonMemIntensiveOperators * (*gp_resmanager_memory_policy_auto_fixed_mem))
 	 {
@@ -1011,6 +1077,13 @@ PolicyEagerFreeAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memAvailableByte
 	 */
 	ctx.groupNode = NULL;
 	ctx.nextGroupId = 0;
+
+	/*
+	 * Make sure there is enough operator memory in resource group mode.
+	 */
+	autoIncOpMemForResGroup(&ctx.groupTree->groupMemKB,
+							ctx.groupTree->numNonMemIntenseOps +
+							ctx.groupTree->numMemIntenseOps);
 
 	/*
 	 * Check if memory exceeds the limit in the root group

--- a/src/include/executor/execHHashagg.h
+++ b/src/include/executor/execHHashagg.h
@@ -127,6 +127,7 @@ typedef struct HashAggTableSizes
 	unsigned  workmem_initial;    /* Estimated work_mem bytes at #entries=0 */
 	unsigned  workmem_per_entry;  /* Additional work_mem bytes per entry */
 	bool      spill;      /* Do we expect to spill ? */
+	double    memquota;   /* Minimal required memquota */
 } HashAggTableSizes;
 
 /*

--- a/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
@@ -18,7 +18,7 @@ DROP RESOURCE GROUP rg2_opmem_test;
 -- we have to keep the columns provided by them in the target list, instead of
 -- composing a long SELECT c1,c2,... list we use SELECT * here, but we should
 -- not output the groupid as it changes each time.
-CREATE OR REPLACE VIEW many_ops AS SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config ;
+CREATE OR REPLACE VIEW many_ops AS SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 ;
 CREATE
 
 CREATE RESOURCE GROUP rg1_opmem_test WITH (cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0, concurrency=20, memory_spill_ratio=0);
@@ -34,6 +34,9 @@ GRANT
 -- each operator, no matter it is memory intensive or not.  As long as there is
 -- enough shared memory the query should be executed successfully.
 --
+-- some operators like HashAgg require more memory to run, the memory quota is
+-- also dynamically increased to meet their minimal requirements.
+--
 -- note: when there is no enough operator memory there should be a warning,
 -- however warnings are not displayed in isolation2 tests.
 
@@ -46,9 +49,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+(1 row)
 RESET role;
 RESET
 
@@ -57,9 +61,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+(1 row)
 RESET role;
 RESET
 
@@ -106,9 +111,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+(1 row)
 RESET role;
 RESET
 
@@ -117,9 +123,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+(1 row)
 RESET role;
 RESET
 
@@ -143,9 +150,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+(1 row)
 RESET role;
 RESET
 
@@ -154,9 +162,10 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
-groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
--------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-(0 rows)
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+(1 row)
 RESET role;
 RESET
 

--- a/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
@@ -1,0 +1,172 @@
+SET optimizer TO off;
+SET
+
+--
+-- setup
+--
+
+--start_ignore
+DROP VIEW IF EXISTS many_ops;
+DROP ROLE r1_opmem_test;
+DROP RESOURCE GROUP rg1_opmem_test;
+DROP RESOURCE GROUP rg2_opmem_test;
+--end_ignore
+
+-- this view contains many operators in the plan, which is used to trigger
+-- the issue.  gp_toolkit.gp_resgroup_config is a large JOIN view of many
+-- relations, to prevent the source relations being optimized out from the plan
+-- we have to keep the columns provided by them in the target list, instead of
+-- composing a long SELECT c1,c2,... list we use SELECT * here, but we should
+-- not output the groupid as it changes each time.
+CREATE OR REPLACE VIEW many_ops AS SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config ;
+CREATE
+
+CREATE RESOURCE GROUP rg1_opmem_test WITH (cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0, concurrency=20, memory_spill_ratio=0);
+CREATE
+
+CREATE ROLE r1_opmem_test RESOURCE GROUP rg1_opmem_test;
+CREATE
+GRANT ALL ON many_ops TO r1_opmem_test;
+GRANT
+
+-- rg1 has very low per-xact memory quota, there will be no enough operator
+-- memory reserved, however in resource group mode we assign at least 100KB to
+-- each operator, no matter it is memory intensive or not.  As long as there is
+-- enough shared memory the query should be executed successfully.
+--
+-- note: when there is no enough operator memory there should be a warning,
+-- however warnings are not displayed in isolation2 tests.
+
+--
+-- positive: there is enough global shared memory
+--
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+(0 rows)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+(0 rows)
+RESET role;
+RESET
+
+--
+-- negative: there is not enough shared memory
+--
+
+-- rg1 has no group level shared memory, and most memory are granted to rg2,
+-- there is only very little global shared memory due to integer rounding.
+CREATE RESOURCE GROUP rg2_opmem_test WITH (cpu_rate_limit=10, memory_limit=40);
+CREATE
+
+-- this query can execute but will raise OOM error.
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+ERROR:  Out of memory
+DETAIL:  Resource group memory limit reached
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+ERROR:  Out of memory
+DETAIL:  Resource group memory limit reached
+RESET role;
+RESET
+
+--
+-- positive: there is enough group shared memory
+--
+
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 100;
+ALTER
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+(0 rows)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+(0 rows)
+RESET role;
+RESET
+
+--
+-- positive: increased group memory settings
+--
+
+DROP RESOURCE GROUP rg2_opmem_test;
+DROP
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_limit 40;
+ALTER
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 50;
+ALTER
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_spill_ratio 30;
+ALTER
+ALTER RESOURCE GROUP rg1_opmem_test SET concurrency 1;
+ALTER
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+(0 rows)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname|concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+---------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+(0 rows)
+RESET role;
+RESET
+
+--
+-- cleanup
+--
+
+DROP VIEW many_ops;
+DROP
+DROP ROLE r1_opmem_test;
+DROP
+DROP RESOURCE GROUP rg1_opmem_test;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -32,6 +32,7 @@ test: resgroup/resgroup_cancel_terminate_concurrency
 
 # regression tests
 test: resgroup/resgroup_recreate
+test: resgroup/resgroup_operator_memory
 
 # parallel tests
 #test: resgroup/restore_default_resgroup

--- a/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
@@ -18,26 +18,26 @@ DROP RESOURCE GROUP rg2_opmem_test;
 -- composing a long SELECT c1,c2,... list we use SELECT * here, but we should
 -- not output the groupid as it changes each time.
 CREATE OR REPLACE VIEW many_ops AS
-       SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
-EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+      SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
+UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
 ;
 
 CREATE RESOURCE GROUP rg1_opmem_test
@@ -51,6 +51,9 @@ GRANT ALL ON many_ops TO r1_opmem_test;
 -- memory reserved, however in resource group mode we assign at least 100KB to
 -- each operator, no matter it is memory intensive or not.  As long as there is
 -- enough shared memory the query should be executed successfully.
+--
+-- some operators like HashAgg require more memory to run, the memory quota is
+-- also dynamically increased to meet their minimal requirements.
 --
 -- note: when there is no enough operator memory there should be a warning,
 -- however warnings are not displayed in isolation2 tests.

--- a/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
@@ -1,0 +1,135 @@
+SET optimizer TO off;
+
+--
+-- setup
+--
+
+--start_ignore
+DROP VIEW IF EXISTS many_ops;
+DROP ROLE r1_opmem_test;
+DROP RESOURCE GROUP rg1_opmem_test;
+DROP RESOURCE GROUP rg2_opmem_test;
+--end_ignore
+
+-- this view contains many operators in the plan, which is used to trigger
+-- the issue.  gp_toolkit.gp_resgroup_config is a large JOIN view of many
+-- relations, to prevent the source relations being optimized out from the plan
+-- we have to keep the columns provided by them in the target list, instead of
+-- composing a long SELECT c1,c2,... list we use SELECT * here, but we should
+-- not output the groupid as it changes each time.
+CREATE OR REPLACE VIEW many_ops AS
+       SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+EXCEPT SELECT * FROM gp_toolkit.gp_resgroup_config
+;
+
+CREATE RESOURCE GROUP rg1_opmem_test
+  WITH (cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0,
+        concurrency=20, memory_spill_ratio=0);
+
+CREATE ROLE r1_opmem_test RESOURCE GROUP rg1_opmem_test;
+GRANT ALL ON many_ops TO r1_opmem_test;
+
+-- rg1 has very low per-xact memory quota, there will be no enough operator
+-- memory reserved, however in resource group mode we assign at least 100KB to
+-- each operator, no matter it is memory intensive or not.  As long as there is
+-- enough shared memory the query should be executed successfully.
+--
+-- note: when there is no enough operator memory there should be a warning,
+-- however warnings are not displayed in isolation2 tests.
+
+--
+-- positive: there is enough global shared memory
+--
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO auto;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+--
+-- negative: there is not enough shared memory
+--
+
+-- rg1 has no group level shared memory, and most memory are granted to rg2,
+-- there is only very little global shared memory due to integer rounding.
+CREATE RESOURCE GROUP rg2_opmem_test
+  WITH (cpu_rate_limit=10, memory_limit=40);
+
+-- this query can execute but will raise OOM error.
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO auto;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+--
+-- positive: there is enough group shared memory
+--
+
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 100;
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO auto;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+--
+-- positive: increased group memory settings
+--
+
+DROP RESOURCE GROUP rg2_opmem_test;
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_limit 40;
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 50;
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_spill_ratio 30;
+ALTER RESOURCE GROUP rg1_opmem_test SET concurrency 1;
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+SET gp_resgroup_memory_policy TO auto;
+SET ROLE TO r1_opmem_test;
+SELECT * FROM many_ops;
+RESET role;
+
+--
+-- cleanup
+--
+
+DROP VIEW many_ops;
+DROP ROLE r1_opmem_test;
+DROP RESOURCE GROUP rg1_opmem_test;


### PR DESCRIPTION
This PR is to backport https://github.com/greenplum-db/gpdb/pull/6390 and https://github.com/greenplum-db/gpdb/pull/6445 from master to fix https://github.com/greenplum-db/gpdb/issues/6349 on 5X:

    commit d62faf5ee53b2e4785974b7e11e1e04cca5a04d4 (HEAD -> resgroup_op_mem.5X, nyu/resgroup_op_mem.5X)
    Author: Ning Yu <nyu@pivotal.io>
    Date:   Tue Dec 11 08:35:14 2018 +0800
    
        resgroup: allow operators enlarge their memory quota
    
        Operators like HashAgg might need more memory quota than granted.  In
        resource group mode this could be allowed as memory can be allocated
        from global or per-group shared memory.
    
        By supporting this we improved the support for low-end resgroups, as
        long as there is enough shared memory low-end resgroups could still run
        large queries although the performance might not be the best.
    
        (cherry picked from commit 90795402be4a303dfdf8fd1ac99be7f17ab11d7e)
    
    commit 59e425050c1e5730106fdd378180b597ec8aca32
    Author: Ning Yu <nyu@pivotal.io>
    Date:   Thu Dec 6 12:54:15 2018 +0800
    
        resgroup: allow shared memory as operator memory
    
        GPDB assigns 100KB for each non memory intensive operator, and report an
        error if there is not enough memory reserved for the operators.  In low
        memory resource groups it is easy to trigger this error with large
        queries.
    
        Improved by always assign at least 100KB memory to operators, both
        memory intensive or non-intensive, the memory can be allocated from
        shared memory, and will raise OOM error if there is not enough shared
        memory.
    
        (cherry picked from commit 98f9b1744ffc8d6383b7bdcaee80fb2f2d26cae1)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] ~Document changes~
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`