### PR TITLE
resgroup: improve stabality of operator memory tests.

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
@@ -21,7 +21,7 @@ DROP RESOURCE GROUP rg2_opmem_test;
 CREATE OR REPLACE VIEW many_ops AS SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 ;
 CREATE
 
-CREATE RESOURCE GROUP rg1_opmem_test WITH (cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0, concurrency=20, memory_spill_ratio=0);
+CREATE RESOURCE GROUP rg1_opmem_test WITH (cpu_rate_limit=10, memory_limit=1, memory_shared_quota=0, concurrency=20, memory_spill_ratio=0);
 CREATE
 
 CREATE ROLE r1_opmem_test RESOURCE GROUP rg1_opmem_test;
@@ -86,7 +86,7 @@ RESET
 
 -- rg1 has no group level shared memory, and most memory are granted to rg2,
 -- there is only very little global shared memory due to integer rounding.
-CREATE RESOURCE GROUP rg2_opmem_test WITH (cpu_rate_limit=10, memory_limit=40);
+CREATE RESOURCE GROUP rg2_opmem_test WITH (cpu_rate_limit=10, memory_limit=59);
 CREATE
 
 -- this query can execute but will raise OOM error.
@@ -125,6 +125,10 @@ RESET
 -- positive: there is enough group shared memory
 --
 
+ALTER RESOURCE GROUP rg2_opmem_test SET memory_limit 40;
+ALTER
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_limit 20;
+ALTER
 ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 100;
 ALTER
 
@@ -165,7 +169,7 @@ RESET role;
 RESET
 
 --
--- positive: increased group memory settings
+-- positive: the spill memory is large enough, no adjustment is needed
 --
 
 DROP RESOURCE GROUP rg2_opmem_test;

--- a/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
@@ -41,7 +41,7 @@ UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437
 ;
 
 CREATE RESOURCE GROUP rg1_opmem_test
-  WITH (cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0,
+  WITH (cpu_rate_limit=10, memory_limit=1, memory_shared_quota=0,
         concurrency=20, memory_spill_ratio=0);
 
 CREATE ROLE r1_opmem_test RESOURCE GROUP rg1_opmem_test;
@@ -84,7 +84,7 @@ RESET role;
 -- rg1 has no group level shared memory, and most memory are granted to rg2,
 -- there is only very little global shared memory due to integer rounding.
 CREATE RESOURCE GROUP rg2_opmem_test
-  WITH (cpu_rate_limit=10, memory_limit=40);
+  WITH (cpu_rate_limit=10, memory_limit=59);
 
 -- this query can execute but will raise OOM error.
 
@@ -107,6 +107,8 @@ RESET role;
 -- positive: there is enough group shared memory
 --
 
+ALTER RESOURCE GROUP rg2_opmem_test SET memory_limit 40;
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_limit 20;
 ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 100;
 
 SET gp_resgroup_memory_policy TO none;
@@ -125,7 +127,7 @@ SELECT * FROM many_ops;
 RESET role;
 
 --
--- positive: increased group memory settings
+-- positive: the spill memory is large enough, no adjustment is needed
 --
 
 DROP RESOURCE GROUP rg2_opmem_test;


### PR DESCRIPTION
The resource group test case resgroup_improve_op_mem_tests triggers
several kinds of memory related warnings/errors, it relies on a
simulated 2GB memory environment to produce stable results.  However the
simulation itself is not precise enough due to integer rounding, so the
test case does not always produce expected output.

Improved by putting more buffer on the resource group settings.

## Here are some reminders before you submit the pull request
- [x] ~Add tests for the change~
- [ ] ~Document changes~
- [ ] ~Communicate in the mailing list if needed~
- [x] Pass `make installcheck`