### PR TITLE
Remove redundant index on pg_stat_last_operation.

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301811151
+#define CATALOG_VERSION_NO	301812111
 
 #endif

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -329,9 +329,6 @@ DECLARE_UNIQUE_INDEX(gp_fastsequence_objid_objmod_index, 6067, on gp_fastsequenc
 #define FastSequenceObjidObjmodIndexId 6067
 
 /* MPP-6929: metadata tracking */
-DECLARE_INDEX(pg_statlastop_classid_objid_index, 6053, on pg_stat_last_operation using btree(classid oid_ops, objid oid_ops));
-#define StatLastOpClassidObjidIndexId  6053
-
 DECLARE_UNIQUE_INDEX(pg_statlastop_classid_objid_staactionname_index, 6054, on pg_stat_last_operation using btree(classid oid_ops, objid oid_ops, staactionname name_ops));
 #define StatLastOpClassidObjidStaactionnameIndexId  6054
 

--- a/src/test/regress/expected/bfv_catalog.out
+++ b/src/test/regress/expected/bfv_catalog.out
@@ -589,3 +589,30 @@ select prosrc from pg_proc where proname = 'function_with_long_body';
  
 (1 row)
 
+--
+-- Check for assertion failure that happened in VACUUM FULL of
+-- pg_stat_last_operation. The VACUUM FULL of reindexing its indexes
+-- inserted an entry to pg_stat_last_operation, but there's an assertion
+-- that you don't try to insert into an index that's currently being
+-- reindexed, or pending reindexing. This no longer happens, because
+-- pg_stat_last_operation now only has one index, so that there is no
+-- pending indexes left for it after indexing the first one.
+--
+-- first, delete all existing entries on pg_stat_last_operation, for the
+-- table and its indexes. Otherwise, the update might be a HOT update,
+-- and not touch the indexes.
+set allow_system_table_mods=on;
+delete from pg_stat_last_operation
+  where classid='pg_class'::regclass and objid::regclass::text like 'pg_stat%last%';
+set allow_system_table_mods=off;
+-- VACUUM FULL should insert an entry, for building the index after rebuilding
+-- the heap.
+vacuum full pg_stat_last_operation;
+select classid::regclass, objid::regclass, staactionname, stasubtype from pg_stat_last_operation
+  where classid='pg_class'::regclass and objid::regclass::text like 'pg_stat%last%';
+ classid  |                      objid                      | staactionname | stasubtype 
+----------+-------------------------------------------------+---------------+------------
+ pg_class | pg_stat_last_operation                          | VACUUM        | FULL
+ pg_class | pg_statlastop_classid_objid_staactionname_index | VACUUM        | REINDEX
+(2 rows)
+

--- a/src/test/regress/expected/bfv_catalog_optimizer.out
+++ b/src/test/regress/expected/bfv_catalog_optimizer.out
@@ -594,3 +594,30 @@ select prosrc from pg_proc where proname = 'function_with_long_body';
  
 (1 row)
 
+--
+-- Check for assertion failure that happened in VACUUM FULL of
+-- pg_stat_last_operation. The VACUUM FULL of reindexing its indexes
+-- inserted an entry to pg_stat_last_operation, but there's an assertion
+-- that you don't try to insert into an index that's currently being
+-- reindexed, or pending reindexing. This no longer happens, because
+-- pg_stat_last_operation now only has one index, so that there is no
+-- pending indexes left for it after indexing the first one.
+--
+-- first, delete all existing entries on pg_stat_last_operation, for the
+-- table and its indexes. Otherwise, the update might be a HOT update,
+-- and not touch the indexes.
+set allow_system_table_mods=on;
+delete from pg_stat_last_operation
+  where classid='pg_class'::regclass and objid::regclass::text like 'pg_stat%last%';
+set allow_system_table_mods=off;
+-- VACUUM FULL should insert an entry, for building the index after rebuilding
+-- the heap.
+vacuum full pg_stat_last_operation;
+select classid::regclass, objid::regclass, staactionname, stasubtype from pg_stat_last_operation
+  where classid='pg_class'::regclass and objid::regclass::text like 'pg_stat%last%';
+ classid  |                      objid                      | staactionname | stasubtype 
+----------+-------------------------------------------------+---------------+------------
+ pg_class | pg_stat_last_operation                          | VACUUM        | FULL
+ pg_class | pg_statlastop_classid_objid_staactionname_index | VACUUM        | REINDEX
+(2 rows)
+

--- a/src/test/regress/sql/bfv_catalog.sql
+++ b/src/test/regress/sql/bfv_catalog.sql
@@ -709,3 +709,28 @@ $function$;
 -- Check that it's detoasted correctly when it's sent to the client, in
 -- printtup()
 select prosrc from pg_proc where proname = 'function_with_long_body';
+
+
+--
+-- Check for assertion failure that happened in VACUUM FULL of
+-- pg_stat_last_operation. The VACUUM FULL of reindexing its indexes
+-- inserted an entry to pg_stat_last_operation, but there's an assertion
+-- that you don't try to insert into an index that's currently being
+-- reindexed, or pending reindexing. This no longer happens, because
+-- pg_stat_last_operation now only has one index, so that there is no
+-- pending indexes left for it after indexing the first one.
+--
+
+-- first, delete all existing entries on pg_stat_last_operation, for the
+-- table and its indexes. Otherwise, the update might be a HOT update,
+-- and not touch the indexes.
+set allow_system_table_mods=on;
+delete from pg_stat_last_operation
+  where classid='pg_class'::regclass and objid::regclass::text like 'pg_stat%last%';
+set allow_system_table_mods=off;
+
+-- VACUUM FULL should insert an entry, for building the index after rebuilding
+-- the heap.
+vacuum full pg_stat_last_operation;
+select classid::regclass, objid::regclass, staactionname, stasubtype from pg_stat_last_operation
+  where classid='pg_class'::regclass and objid::regclass::text like 'pg_stat%last%';


### PR DESCRIPTION
It had two indexes:

* pg_statlastop_classid_objid_index on (classid oid_ops, objid oid_ops), and
* pg_statlastop_classid_objid_staactionname_index on (classid oid_ops, objid
  oid_ops, staactionname name_ops)

The first one is completely redundant with the second one. Remove it.

Fixes assertion failure https://github.com/greenplum-db/gpdb/issues/6362.
The failure happened on "VACUUM FULL pg_stat_last_operation", if the
VACUUM FULL itself added a new row to the table. The insertion also
inserted entries in the indexes, which tripped the assertion that checks
that you don't try to insert entries into an index that's currently being
reindexed, or pending reindexing:

> (gdb) bt
> #0  0x00007f02f5189783 in __select_nocancel () from /lib64/libc.so.6
> #1  0x0000000000be76ef in pg_usleep (microsec=30000000) at pgsleep.c:53
> #2  0x0000000000ad75aa in elog_debug_linger (edata=0x11bf760 <errordata>) at elog.c:5293
> #3  0x0000000000acdba4 in errfinish (dummy=0) at elog.c:675
> #4  0x0000000000acc3bf in ExceptionalCondition (conditionName=0xc15798 "!(!ReindexIsProcessingIndex(((indexRelation)->rd_id)))", errorType=0xc156ef "FailedAssertion",
>     fileName=0xc156d0 "indexam.c", lineNumber=215) at assert.c:46
> #5  0x00000000004fded5 in index_insert (indexRelation=0x7f02f6b6daa0, values=0x7ffdb43915e0, isnull=0x7ffdb43915c0 "", heap_t_ctid=0x240bd64, heapRelation=0x24efa78,
>     checkUnique=UNIQUE_CHECK_YES) at indexam.c:215
> #6  0x00000000005bda59 in CatalogIndexInsert (indstate=0x240e5d0, heapTuple=0x240bd60) at indexing.c:136
> #7  0x00000000005bdaaa in CatalogUpdateIndexes (heapRel=0x24efa78, heapTuple=0x240bd60) at indexing.c:162
> #8  0x00000000005b2203 in MetaTrackAddUpdInternal (classid=1259, objoid=6053, relowner=10, actionname=0xc51543 "VACUUM", subtype=0xc5153b "REINDEX", rel=0x24efa78,
>     old_tuple=0x0) at heap.c:744
> #9  0x00000000005b229d in MetaTrackAddObject (classid=1259, objoid=6053, relowner=10, actionname=0xc51543 "VACUUM", subtype=0xc5153b "REINDEX") at heap.c:773
> #10 0x00000000005b2553 in MetaTrackUpdObject (classid=1259, objoid=6053, relowner=10, actionname=0xc51543 "VACUUM", subtype=0xc5153b "REINDEX") at heap.c:856
> #11 0x00000000005bd271 in reindex_index (indexId=6053, skip_constraint_checks=1 '\001') at index.c:3741
> #12 0x00000000005bd418 in reindex_relation (relid=6052, flags=2) at index.c:3870
> #13 0x000000000067ba71 in finish_heap_swap (OIDOldHeap=6052, OIDNewHeap=16687, is_system_catalog=1 '\001', swap_toast_by_content=0 '\000', swap_stats=1 '\001',
>     check_constraints=0 '\000', is_internal=1 '\001', frozenXid=821, cutoffMulti=1) at cluster.c:1667
> #14 0x0000000000679ed5 in rebuild_relation (OldHeap=0x7f02f6b7a6f0, indexOid=0, verbose=0 '\000') at cluster.c:648
> #15 0x0000000000679913 in cluster_rel (tableOid=6052, indexOid=0, recheck=0 '\000', verbose=0 '\000', printError=1 '\001') at cluster.c:461
> #16 0x0000000000717580 in vacuum_rel (onerel=0x0, relid=6052, vacstmt=0x2533c38, lmode=8, for_wraparound=0 '\000') at vacuum.c:2315
> #17 0x0000000000714ce7 in vacuumStatement_Relation (vacstmt=0x2533c38, relid=6052, relations=0x24c12f8, bstrategy=0x24c1220, do_toast=1 '\001', for_wraparound=0 '\000',
>     isTopLevel=1 '\001') at vacuum.c:787
> #18 0x0000000000714303 in vacuum (vacstmt=0x2403260, relid=0, do_toast=1 '\001', bstrategy=0x24c1220, for_wraparound=0 '\000', isTopLevel=1 '\001') at vacuum.c:337
> #19 0x0000000000969cd2 in standard_ProcessUtility (parsetree=0x2403260, queryString=0x24027e0 "vacuum full;", context=PROCESS_UTILITY_TOPLEVEL, params=0x0, dest=0x2403648,
>     completionTag=0x7ffdb4392550 "") at utility.c:804
> #20 0x00000000009691be in ProcessUtility (parsetree=0x2403260, queryString=0x24027e0 "vacuum full;", context=PROCESS_UTILITY_TOPLEVEL, params=0x0, dest=0x2403648,
>     completionTag=0x7ffdb4392550 "") at utility.c:373

In this scenario, we had just reindexed one of the indexes of
pg_stat_last_operation, and the metatrack update of that tried to insert a
row into the same table. But the second index in the table was pending
reindexing, which triggered the assertion.

After removing the redundant index, pg_stat_last_operation only has one
index, and that scenario no longer happens. This is a bit fragile fix,
because the problem will reappear as soon as you add a second index on the
table. But we have no plans of doing that, and I believe no harm would be
done in production builds with assertions disabled, anyway. So this will
do for now.
