### PR TITLE
Silence warnings about unused variables with assertions disabled.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -1,4 +1,3 @@
-
 /*-------------------------------------------------------------------------
  *
  * cdbdisp.c
@@ -90,11 +89,9 @@ cdbdisp_dispatchToGang(struct CdbDispatcherState *ds,
 					   struct Gang *gp,
 					   int sliceIndex)
 {
-	struct CdbDispatchResults *dispatchResults = ds->primaryResults;
-
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 	Assert(gp && gp->size > 0);
-	Assert(dispatchResults && dispatchResults->resultArray);
+	Assert(ds->primaryResults && ds->primaryResults->resultArray);
 
 	(pDispatchFuncs->dispatchToGang) (ds, gp, sliceIndex);
 }

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -271,15 +271,13 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	Assert(queryDesc->plannedstmt != NULL);
 	Assert(queryDesc->memoryAccountId == MEMORY_OWNER_TYPE_Undefined);
 
-	PlannedStmt *plannedStmt = queryDesc->plannedstmt;
-
 	queryDesc->memoryAccountId = MemoryAccounting_CreateExecutorMemoryAccount();
 
 	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
-	Assert(plannedStmt->intoPolicy == NULL ||
-		GpPolicyIsPartitioned(plannedStmt->intoPolicy) ||
-		GpPolicyIsReplicated(plannedStmt->intoPolicy));
+	Assert(queryDesc->plannedstmt->intoPolicy == NULL ||
+		GpPolicyIsPartitioned(queryDesc->plannedstmt->intoPolicy) ||
+		GpPolicyIsReplicated(queryDesc->plannedstmt->intoPolicy));
 
 	/**
 	 * Perfmon related stuff.


### PR DESCRIPTION
These were only used by Assert()s.
