### PR TITLE
Add 'printf' attributes to a few gpperfmon logging functions.

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -701,7 +701,7 @@ static void* conm_main(apr_thread_t* thread_, void* arg_)
 					{
 						if (GPSMON_TIMEOUT_RESTART == h->connect_timeout)
 						{
-							gpmon_warning(FLINE, "Failed to reconnect gpsmon on %d, maybe network isolation or other process occupied the port", active_hostname);
+							gpmon_warning(FLINE, "Failed to reconnect gpsmon on %s, maybe network isolation or other process occupied the port", active_hostname);
 						}
 						else if (GPSMON_TIMEOUT_NONE == h->connect_timeout)
 						{
@@ -803,7 +803,7 @@ static void* harvest_main(apr_thread_t* thread_, void* arg_)
 
 			if (status != APR_SUCCESS)
 			{
-				gpmon_warningx(FLINE, 0, "harvest failure: accumulated tail file size is %llu bytes", ax._tail_buffer_bytes);
+				gpmon_warningx(FLINE, 0, "harvest failure: accumulated tail file size is %lu bytes", ax._tail_buffer_bytes);
 				consecutive_failures++;
 			}
 
@@ -845,7 +845,7 @@ static void* message_main(apr_thread_t* thread_, void* arg_)
 	apr_status_t status;
 
 	TR2(("In message_main: error_disk_space_percentage = %d, warning_disk_space_percentage = %d, disk_space_interval = %d, max_disk_space_messages_per_interval = %d\n",
-			opt.error_disk_space_percentage, opt.warning_disk_space_percentage, opt.disk_space_interval, opt.max_disk_space_messages_per_interval));
+		 opt.error_disk_space_percentage, opt.warning_disk_space_percentage, (int) opt.disk_space_interval, opt.max_disk_space_messages_per_interval));
 	while (1)
 	{
 		query = NULL;
@@ -869,7 +869,7 @@ static void* message_main(apr_thread_t* thread_, void* arg_)
 		{ // send the message
 			if (!gpdb_exec_search_for_at_least_one_row((const char *)query, NULL))
 			{
-				TR0(("message_main ERROR: query %s failed. Cannot send message\n", query));
+				TR0(("message_main ERROR: query %s failed. Cannot send message\n", (char *) query));
 			}
 			free(query);
 		}

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -331,7 +331,7 @@ static apr_status_t agg_put_query_metrics(agg_t* agg, const gpmon_qlog_t* qlog, 
 		node->last_updated_generation = generation;
 		node->num_metrics_packets++;
 		TR2(("Query Metrics: (host %s ssid %d ccnt %d) (cpuelapsed %d cpupct %f) / %d\n",
-			qlog->user, qlog->key.ssid, qlog->key.ccnt, node->qlog.cpu_elapsed, node->qlog.p_metrics.cpu_pct,
+			 qlog->user, qlog->key.ssid, qlog->key.ccnt, (int) node->qlog.cpu_elapsed, node->qlog.p_metrics.cpu_pct,
 			node->num_metrics_packets));
 	}
 	return 0;
@@ -346,7 +346,7 @@ static apr_status_t agg_put_qlog(agg_t* agg, const gpmon_qlog_t* qlog,
 	if (node) {
 		node->qlog = *qlog;
 		if (0 != strcmp(qlog->db, GPMON_DB)) {
-			TR2(("agg_put_qlog: found %d.%d.%d generation %d recorded %d\n", qlog->key.tmid, qlog->key.ssid, qlog->key.ccnt, generation, node->recorded));
+			TR2(("agg_put_qlog: found %d.%d.%d generation %d recorded %d\n", qlog->key.tmid, qlog->key.ssid, qlog->key.ccnt, (int) generation, node->recorded));
 		}
 	} else {
 		node = apr_pcalloc(agg->pool, sizeof(*node));
@@ -373,7 +373,7 @@ static apr_status_t agg_put_qlog(agg_t* agg, const gpmon_qlog_t* qlog,
 
 		apr_hash_set(agg->qtab, &node->qlog.key, sizeof(node->qlog.key), node);
 		if (0 != strcmp(qlog->db, GPMON_DB)) {
-			TR2(("agg_put: new %d.%d.%d generation %d recorded %d\n", qlog->key.tmid, qlog->key.ssid, qlog->key.ccnt, generation, node->recorded));
+			TR2(("agg_put: new %d.%d.%d generation %d recorded %d\n", qlog->key.tmid, qlog->key.ssid, qlog->key.ccnt, (int) generation, node->recorded));
 		}
 	}
 	node->last_updated_generation = generation;
@@ -526,7 +526,7 @@ apr_status_t agg_dup(agg_t** retagg, agg_t* oldagg, apr_pool_t* parent_pool, apr
 			dp->qlog.status = status;
 
 		if (0 != strcmp(dp->qlog.db, GPMON_DB)) {
-			TR2( ("agg_dup: add %d.%d.%d, generation %d, recorded %d:\n", dp->qlog.key.tmid, dp->qlog.key.ssid, dp->qlog.key.ccnt, dp->last_updated_generation, dp->recorded));
+			TR2( ("agg_dup: add %d.%d.%d, generation %d, recorded %d:\n", dp->qlog.key.tmid, dp->qlog.key.ssid, dp->qlog.key.ccnt, (int) dp->last_updated_generation, dp->recorded));
 		}
 
 		/* dup this entry */
@@ -703,8 +703,8 @@ apr_status_t agg_dump(agg_t* agg)
 		{
 			if (!qdnode->recorded && ((qdnode->qlog.tfin - qdnode->qlog.tstart) >= min_query_time))
 			{
-				TR1(("queries_tail: %x add query %d.%d.%d, status %d, generation %d, recorded %d\n",
-						agg->qtab, qdnode->qlog.key.tmid, qdnode->qlog.key.ssid, qdnode->qlog.key.ccnt, qdnode->qlog.status, qdnode->last_updated_generation, qdnode->recorded));
+				TR1(("queries_tail: %p add query %d.%d.%d, status %d, generation %d, recorded %d\n",
+					 agg->qtab, qdnode->qlog.key.tmid, qdnode->qlog.key.ssid, qdnode->qlog.key.ccnt, qdnode->qlog.status, (int) qdnode->last_updated_generation, qdnode->recorded));
 
 				temp_bytes_written += write_qlog_full(fp_queries_tail, qdnode, nowstr);
 				incremement_tail_bytes(temp_bytes_written);
@@ -1109,7 +1109,7 @@ static void _get_sum_seg_info(apr_hash_t* segtab, apr_int64_t* total_data_out, i
 		apr_hash_this(hi, 0, 0, &valptr);
 		seg_data_sum = (apr_int64_t*) valptr;
 		*total_data_out += *seg_data_sum;
-		TR2(("(SKEW) Segment resource usage: %d\n", *seg_data_sum));
+		TR2(("(SKEW) Segment resource usage: %d\n", (int) *seg_data_sum));
 		(*segcount_out)++;
 	}
 }
@@ -1127,7 +1127,7 @@ static void _get_sum_deviation_squared(apr_hash_t* segtab, const apr_int64_t dat
 		apr_hash_this(hi, NULL, NULL, &valptr);
 		seg_data_sum = (apr_int64_t*) valptr;
 		dev = *seg_data_sum - data_avg;
-		TR2(("(SKEW) Deviation: %d\n", dev));
+		TR2(("(SKEW) Deviation: %d\n", (int) dev));
 		*total_deviation_squared_out += dev * dev;
 	}
 }

--- a/gpAux/gpperfmon/src/gpmon/gpmondb.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmondb.c
@@ -533,8 +533,7 @@ void gpdb_get_hostlist(int* hostcnt, host_t** host_table, apr_pool_t* global_poo
 
 	const char* errmsg = gpdb_exec(&conn, &result, QUERY);
 
-	TR2((QUERY));
-	TR2(("\n"));
+	TR2(("%s\n", QUERY));
 
 	if (errmsg)
 	{
@@ -869,7 +868,7 @@ static apr_status_t check_partition(const char* tbl, apr_pool_t* pool, PGconn* c
 
 	if (year[0] < 1 || month[0] < 1 || year[0] > 2030 || month[0] > 12)
 	{
-		gpmon_warning(FLINE, "invalid current month/year in check_partition %u/%u\n", month, year);
+		gpmon_warning(FLINE, "invalid current month/year in check_partition %u/%u\n", month[0], year[0]);
 		return APR_EGENERAL;
 	}
 

--- a/gpAux/gpperfmon/src/gpmon/gpmonlib.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmonlib.h
@@ -47,16 +47,16 @@ extern int verbose;
 
 
 /* fatal & warning messages */
-extern int gpmon_print(const char* fmt, ...);
-extern int gpmon_fatal(const char* fline, const char* fmt, ...);
-extern int gpmon_fatalx(const char* fline, int e, const char* fmt, ...);
-extern int gpmon_warning(const char* fline, const char* fmt, ...);
-extern int gpmon_warningx(const char* fline, int e, const char* fmt, ...);
+extern int gpmon_print(const char* fmt, ...) pg_attribute_printf(1, 2);
+extern int gpmon_fatal(const char* fline, const char* fmt, ...)  pg_attribute_printf(2, 3);
+extern int gpmon_fatalx(const char* fline, int e, const char* fmt, ...)  pg_attribute_printf(3, 4);
+extern int gpmon_warning(const char* fline, const char* fmt, ...)  pg_attribute_printf(2, 3);
+extern int gpmon_warningx(const char* fline, int e, const char* fmt, ...)  pg_attribute_printf(3, 4);
 extern void gpmon_print_file(const char* header_line, FILE* fp);
 
 // fatal messages for smon -- go to stdout only
-extern int gpsmon_fatal(const char* fline, const char* fmt, ...);
-extern int gpsmon_fatalx(const char* fline, int e, const char* fmt, ...);
+extern int gpsmon_fatal(const char* fline, const char* fmt, ...)  pg_attribute_printf(2,3);
+extern int gpsmon_fatalx(const char* fline, int e, const char* fmt, ...) pg_attribute_printf(3, 4);
 
 /* convert packets to host order */
 extern apr_status_t gpmon_ntohpkt(apr_int32_t magic, apr_int16_t version, apr_int16_t pkttype);

--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -799,7 +799,7 @@ static void gx_gettcpcmd(SOCKET sock, short event, void* arg)
 			apr_hash_this(hi, 0, 0, &vptr);
 			pidrec = vptr;
 
-			TR2(("tmid %d ssid %d ccnt %d pid %d (CPU elapsed %d CPU Percent %.2f)\n",
+			TR2(("tmid %d ssid %d ccnt %d pid %d (CPU elapsed %ld CPU Percent %.2f)\n",
 				pidrec->query_key.tmid, pidrec->query_key.ssid, pidrec->query_key.ccnt, pidrec->pid,
 				pidrec->cpu_elapsed, pidrec->p_metrics.cpu_pct));
 
@@ -843,7 +843,7 @@ static void gx_gettcpcmd(SOCKET sock, short event, void* arg)
 			ppkt->u.qlog.cpu_elapsed = pidrec->cpu_elapsed;
 			ppkt->u.qlog.p_metrics.cpu_pct = pidrec->p_metrics.cpu_pct;
 
-			TR2(("SEND tmid %d ssid %d ccnt %d (CPU elapsed %d CPU Percent %.2f)\n",
+			TR2(("SEND tmid %d ssid %d ccnt %d (CPU elapsed %ld CPU Percent %.2f)\n",
 				ppkt->u.qlog.key.tmid, ppkt->u.qlog.key.ssid, ppkt->u.qlog.key.ccnt,
 				ppkt->u.qlog.cpu_elapsed, ppkt->u.qlog.p_metrics.cpu_pct));
 
@@ -993,7 +993,7 @@ static void gx_recvsegment(gpmon_packet_t* pkt)
 
 	p = &pkt->u.seginfo;
 
-	TR2(("Received segment packet for dbid %d (dynamic_memory_used, dynamic_memory_available) (%llu %llu)\n", p->dbid, p->dynamic_memory_used, p->dynamic_memory_available));
+	TR2(("Received segment packet for dbid %d (dynamic_memory_used, dynamic_memory_available) (%lu %lu)\n", p->dbid, p->dynamic_memory_used, p->dynamic_memory_available));
 
 	rec = apr_hash_get(gx.segmenttab, &p->dbid, sizeof(p->dbid));
 	if (rec)
@@ -1117,7 +1117,7 @@ static void gx_recvfrom(SOCKET sock, short event, void* arg)
 
 	if (n != sizeof(pkt))
 	{
-		gpmon_warning(FLINE, "bad packet (length %d). Expected packet size %d", n, sizeof(pkt));
+		gpmon_warning(FLINE, "bad packet (length %d). Expected packet size %d", n, (int) sizeof(pkt));
 		return;
 	}
 
@@ -1475,7 +1475,7 @@ static void setup_sigar(void)
 		do_destroy = 0;
 	}
 	cnt = 0;
-	TR2(("sigar fsnumber: %d\n", sigar_fslist.number));
+	TR2(("sigar fsnumber: %lu\n", sigar_fslist.number));
 	for (i = 0; i < sigar_fslist.number; i++)
 	{
 		if (sigar_fslist.data[i].type == SIGAR_FSTYPE_LOCAL_DISK)


### PR DESCRIPTION
GCC was generating compiler warnings about these for me:

gpmonlib.c: In function ‘gpmon_print’:
gpmonlib.c:124:5: warning: function might be possible candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
     vfprintf(stdout, fmt, ap);
     ^~~~~~~~

That sems like a good idea, so I added 'printf' attributes to all those
logging functions.

That produced a bunch of new warnings, mainly for harmless mixups of %d,
%u, %ld, etc. But there were a few cases of mixing up %d and %s, too. Fix
the format strings to eliminate those warnings, too.
