### PR TITLE
Introduce guc to generate plans that avoid skew with aggregates.

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -370,6 +370,13 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] =
 		&optimizer_array_constraints,
 		false, // m_negate_param
 		GPOS_WSZ_LIT("Allows the constraint framework to derive array constraints in the optimizer.")
+		},
+
+		{
+		EopttraceEnableAggSkewAvoidance,
+		&optimizer_enable_agg_skew_avoidance,
+		false, // m_negate_param
+		GPOS_WSZ_LIT("Force the optimizer to pick a plan that minimizes skew but adds an extra motion node when aggs are used.")
 		}
 };
 

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -373,10 +373,10 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] =
 		},
 
 		{
-		EopttraceEnableAggSkewAvoidance,
-		&optimizer_enable_agg_skew_avoidance,
+		EopttraceForceAggSkewAvoidance,
+		&optimizer_force_agg_skew_avoidance,
 		false, // m_negate_param
-		GPOS_WSZ_LIT("Force the optimizer to pick a plan that minimizes skew but adds an extra motion node when aggs are used.")
+		GPOS_WSZ_LIT("Always pick a plan for aggregate distinct that minimizes skew.")
 		}
 };
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -381,6 +381,7 @@ bool		optimizer_enable_hashjoin;
 bool		optimizer_enable_dynamictablescan;
 bool		optimizer_enable_indexscan;
 bool		optimizer_enable_tablescan;
+bool		optimizer_enable_agg_skew_avoidance;
 
 /* Optimizer plan enumeration related GUCs */
 bool		optimizer_enumerate_plans;
@@ -2515,6 +2516,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_tablescan,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_agg_skew_avoidance", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Force the optimizer to pick a plan that minimizes skew but adds an extra motion node when aggs are used."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_agg_skew_avoidance,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -381,7 +381,6 @@ bool		optimizer_enable_hashjoin;
 bool		optimizer_enable_dynamictablescan;
 bool		optimizer_enable_indexscan;
 bool		optimizer_enable_tablescan;
-bool		optimizer_enable_agg_skew_avoidance;
 
 /* Optimizer plan enumeration related GUCs */
 bool		optimizer_enumerate_plans;
@@ -415,6 +414,7 @@ int			optimizer_cte_inlining_bound;
 bool		optimizer_force_multistage_agg;
 bool		optimizer_force_three_stage_scalar_dqa;
 bool		optimizer_force_expanded_distinct_aggs;
+bool		optimizer_force_agg_skew_avoidance;
 bool		optimizer_prune_computed_columns;
 bool		optimizer_push_requirements_from_consumer_to_producer;
 bool		optimizer_enforce_subplans;
@@ -2521,12 +2521,12 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_agg_skew_avoidance", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Force the optimizer to pick a plan that minimizes skew but adds an extra motion node when aggs are used."),
+		{"optimizer_force_agg_skew_avoidance", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Always pick a plan for aggregate distinct that minimizes skew."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
-		&optimizer_enable_agg_skew_avoidance,
+		&optimizer_force_agg_skew_avoidance,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -468,6 +468,7 @@ extern bool optimizer_enable_hashjoin;
 extern bool optimizer_enable_dynamictablescan;
 extern bool optimizer_enable_indexscan;
 extern bool optimizer_enable_tablescan;
+extern bool optimizer_enable_agg_skew_avoidance;
 
 /* Optimizer plan enumeration related GUCs */
 extern bool optimizer_enumerate_plans;

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -468,7 +468,6 @@ extern bool optimizer_enable_hashjoin;
 extern bool optimizer_enable_dynamictablescan;
 extern bool optimizer_enable_indexscan;
 extern bool optimizer_enable_tablescan;
-extern bool optimizer_enable_agg_skew_avoidance;
 
 /* Optimizer plan enumeration related GUCs */
 extern bool optimizer_enumerate_plans;
@@ -502,6 +501,7 @@ extern int optimizer_cte_inlining_bound;
 extern bool optimizer_force_multistage_agg;
 extern bool optimizer_force_three_stage_scalar_dqa;
 extern bool optimizer_force_expanded_distinct_aggs;
+extern bool optimizer_force_agg_skew_avoidance;
 extern bool optimizer_prune_computed_columns;
 extern bool optimizer_push_requirements_from_consumer_to_producer;
 extern bool optimizer_enforce_subplans;


### PR DESCRIPTION
This patch introduces a guc `optimizer_enable_agg_skew_avoidance` which
can be used to avoid plans which generate a lot of skew when aggregates
are used in the query. The default value of this guc is true.

Co-authored-by: Abhijit Subramanya <asubramanya@pivotal.io>
Co-authored-by: Hans Zeller <hzeller@pivotal.io>

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`