### PR TITLE
Add gp_backend_info() for runtime introspection/debugging

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -411,6 +411,7 @@ getCdbComponentInfo(void)
 		pRow->cdbs = component_databases;
 		pRow->config = config;
 		pRow->freelist = NIL;
+		pRow->activelist = NIL;
 		pRow->numIdleQEs = 0;
 		pRow->numActiveQEs = 0;
 
@@ -813,6 +814,7 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 
 	cdbconn_setQEIdentifier(segdbDesc, -1);
 
+	cdbinfo->activelist = lcons(segdbDesc, cdbinfo->activelist);
 	INCR_COUNT(cdbinfo, numActiveQEs);
 
 	MemoryContextSwitchTo(oldContext);
@@ -878,6 +880,8 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 	isWriter = segdbDesc->isWriter;
 
 	/* update num of active QEs */
+	Assert(list_member_ptr(cdbinfo->activelist, segdbDesc));
+	cdbinfo->activelist = list_delete_ptr(cdbinfo->activelist, segdbDesc);
 	DECR_COUNT(cdbinfo, numActiveQEs);
 
 	oldContext = MemoryContextSwitchTo(CdbComponentsContext);

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -44,6 +44,9 @@
 
 #include "utils/guc_tables.h"
 
+#include "funcapi.h"
+#include "utils/builtins.h"
+
 /*
  * All QEs are managed by cdb_component_dbs in QD, QD assigned
  * a unique identifier for each QE, when a QE is created, this
@@ -912,4 +915,188 @@ ResetAllGangs(void)
 {
 	DisconnectAndDestroyAllGangs(true);
 	GpDropTempTables();
+}
+
+/*
+ * Used by gp_backend_info() to find a single character that represents a
+ * backend type.
+ */
+static char
+backend_type(SegmentDatabaseDescriptor *segdb)
+{
+	if (segdb->identifier == -1)
+	{
+		/* QD backend */
+		return 'Q';
+	}
+	if (segdb->segindex == -1)
+	{
+		/* Entry singleton reader. */
+		return 'R';
+	}
+
+	return (segdb->isWriter ? 'w' : 'r');
+}
+
+/*
+ * qsort comparator for SegmentDatabaseDescriptors. Sorts by descriptor ID.
+ */
+static int
+compare_segdb_id(const void *v1, const void *v2)
+{
+	SegmentDatabaseDescriptor *d1 = (SegmentDatabaseDescriptor *) lfirst(*(ListCell **) v1);
+	SegmentDatabaseDescriptor *d2 = (SegmentDatabaseDescriptor *) lfirst(*(ListCell **) v2);
+
+	return d1->identifier - d2->identifier;
+}
+
+/*
+ * Returns a list of rows, each corresponding to a connected segment backend and
+ * containing information on the role and definition of that backend (e.g. host,
+ * port, PID).
+ *
+ * SELECT * from gp_backend_info();
+ */
+Datum
+gp_backend_info(PG_FUNCTION_ARGS)
+{
+	if (Gp_role != GP_ROLE_DISPATCH)
+		ereport(ERROR, (errcode(ERRCODE_GP_COMMAND_ERROR),
+			errmsg("gp_backend_info() could only be called on QD")));
+
+	/* Our struct for funcctx->user_fctx. */
+	struct func_ctx
+	{
+		List	   *segdbs;		/* the SegmentDatabaseDescriptor entries we will output */
+		ListCell   *curpos;		/* pointer to our current position in .segdbs */
+	};
+
+	FuncCallContext *funcctx;
+	struct func_ctx *user_fctx;
+
+	/* Number of attributes we'll return per row. Must match the catalog. */
+#define BACKENDINFO_NATTR    6
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		/* Standard first-call setup. */
+		MemoryContext         oldcontext;
+		TupleDesc             tupdesc;
+		CdbComponentDatabases *cdbs;
+		int                   i;
+
+		funcctx    = SRF_FIRSTCALL_INIT();
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+		funcctx->user_fctx = user_fctx = palloc0(sizeof(*user_fctx));
+
+		/* Construct the list of all known segment DB descriptors. */
+		cdbs = cdbcomponent_getCdbComponents();
+
+		for (i = 0; i < cdbs->total_entry_dbs; ++i)
+		{
+			CdbComponentDatabaseInfo *cdbinfo = &cdbs->entry_db_info[i];
+
+			user_fctx->segdbs =
+				list_concat_unique_ptr(user_fctx->segdbs, cdbinfo->activelist);
+			user_fctx->segdbs =
+				list_concat_unique_ptr(user_fctx->segdbs, cdbinfo->freelist);
+		}
+
+		for (i = 0; i < cdbs->total_segment_dbs; ++i)
+		{
+			CdbComponentDatabaseInfo *cdbinfo = &cdbs->segment_db_info[i];
+
+			user_fctx->segdbs =
+				list_concat_unique_ptr(user_fctx->segdbs, cdbinfo->activelist);
+			user_fctx->segdbs =
+				list_concat_unique_ptr(user_fctx->segdbs, cdbinfo->freelist);
+		}
+		/* Fake a segment descriptor to represent the current QD backend */
+		SegmentDatabaseDescriptor *qddesc = palloc0(sizeof(SegmentDatabaseDescriptor));
+		qddesc->segment_database_info = cdbcomponent_getComponentInfo(MASTER_CONTENT_ID);
+		qddesc->segindex = -1;
+		qddesc->conn = NULL;
+		qddesc->motionListener = 0;
+		qddesc->backendPid = MyProcPid;
+		qddesc->whoami = NULL;
+		qddesc->isWriter = false;
+		qddesc->identifier = -1;
+
+		user_fctx->segdbs = lcons(qddesc, user_fctx->segdbs);
+		/*
+		 * For a slightly better default user experience, sort by descriptor ID.
+		 * Users may of course specify their own ORDER BY if they don't like it.
+		 */
+		user_fctx->segdbs = list_qsort(user_fctx->segdbs, compare_segdb_id);
+		user_fctx->curpos = list_head(user_fctx->segdbs);
+
+		/* Create a descriptor for the records we'll be returning. */
+		tupdesc = CreateTemplateTupleDesc(BACKENDINFO_NATTR);
+		TupleDescInitEntry(tupdesc, 1, "id", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, 2, "type", CHAROID, -1, 0);
+		TupleDescInitEntry(tupdesc, 3, "content", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, 4, "host", TEXTOID, -1, 0);
+		TupleDescInitEntry(tupdesc, 5, "port", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, 6, "pid", INT4OID, -1, 0);
+
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		/* Tell the caller how many rows we'll return. */
+		funcctx->max_calls = list_length(user_fctx->segdbs);
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+
+	/* Construct and return a row for every entry. */
+	if (funcctx->call_cntr < funcctx->max_calls)
+	{
+		Datum                     values[BACKENDINFO_NATTR] = {0};
+		bool nulls[BACKENDINFO_NATTR]                       = {0};
+		HeapTuple                 tuple;
+		SegmentDatabaseDescriptor *dbdesc;
+		CdbComponentDatabaseInfo  *dbinfo;
+
+		user_fctx = funcctx->user_fctx;
+
+		/* Get the next descriptor. */
+		dbdesc = lfirst(user_fctx->curpos);
+		user_fctx->curpos = lnext(user_fctx->curpos);
+
+		/* Fill in the row attributes. */
+		dbinfo = dbdesc->segment_database_info;
+
+		values[0] = Int32GetDatum(dbdesc->identifier);			/* id */
+		values[1] = CharGetDatum(backend_type(dbdesc));	/* type */
+		values[2] = Int32GetDatum(dbdesc->segindex);			/* content */
+
+		if (dbinfo->config->hostname)								/* host */
+			values[3] = CStringGetTextDatum(dbinfo->config->hostname);
+		else
+			nulls[3] = true;
+
+		values[4] = Int32GetDatum(dbinfo->config->port);          /* port */
+		values[5] = Int32GetDatum(dbdesc->backendPid);            /* pid */
+
+		/* Form the new tuple using our attributes and return it. */
+		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+
+		SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+	}
+	else
+	{
+		/* Clean up. */
+		user_fctx = funcctx->user_fctx;
+		if (user_fctx)
+		{
+			list_free(user_fctx->segdbs);
+			pfree(user_fctx);
+
+			funcctx->user_fctx = NULL;
+		}
+
+		SRF_RETURN_DONE(funcctx);
+	}
+#undef BACKENDINFO_NATTR
 }

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302109291
+#define CATALOG_VERSION_NO	302204081
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -11022,6 +11022,10 @@
 { oid => 7182, descr => 'wait until all endpoint of this parallel retrieve cursor has been retrieved finished',
    proname => 'gp_wait_parallel_retrieve_cursor', provolatile => 'v', proparallel => 'u', prorettype => 'bool', proargtypes => 'text int4', proallargtypes => '{text,int4,bool}', proargmodes => '{i,i,o}', proargnames => '{cursorname,timeout_sec,finished}', prosrc => 'gp_wait_parallel_retrieve_cursor', proexeclocation => 'c' },
 
+{ oid => 7183, descr => 'debugging information for segment backends',
+   proname => 'gp_backend_info', prorettype => 'record', prorows => '1', proretset => 't', proargtypes => '', proallargtypes => '{int4,char,int4,text,int4,int4}', prosrc => 'gp_backend_info', pronargs => 6,
+   proargnames => '{id,type,content,host,port,pid}', proargmodes => '{o,o,o,o,o,o}', proexeclocation => 'c'}
+
 { oid => 7050, oid_symbol => 'BITMAP_INDEXAM_HANDLER_OID', descr => 'bitmap(internal)',
    proname => 'bmhandler', provolatile => 'v', prorettype => 'index_am_handler', proargtypes => 'internal', prosrc => 'bmhandler' },
 
@@ -11481,7 +11485,6 @@
 
 { oid => 6171, descr => 'Legacy cdbhash function',
    proname => 'cdblegacyhash_anyenum', prorettype => 'int4', proargtypes => 'anyenum', prosrc => 'cdblegacyhash_anyenum' },
-
 
 { oid => 6998, descr => 'Create a named restore point on all segments',
    proname => 'gp_create_restore_point', prorows => '1000', proretset => 't', proparallel => 'u', provolatile => 'v', prorettype => 'record', proargtypes => 'text', prosrc => 'gp_create_restore_point' },

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -129,4 +129,6 @@ typedef struct CdbProcess
 
 typedef Gang *(*CreateGangFunc)(List *segments, SegmentType segmentType);
 
+extern Datum gp_backend_info(PG_FUNCTION_ARGS);
+
 #endif   /* _CDBGANG_H_ */

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -70,6 +70,7 @@ struct CdbComponentDatabaseInfo
 	int16		hostSegs;	/* number of primary segments on the same hosts */
 	List		*freelist;	/* list of idle segment dbs */
 	int			numIdleQEs;
+	List		*activelist;	/* list of active segment dbs */
 	int			numActiveQEs;
 };
 

--- a/src/test/regress/expected/gp_backend_info.out
+++ b/src/test/regress/expected/gp_backend_info.out
@@ -1,0 +1,227 @@
+-- Tests for the gp_backend_info() function.
+-- At first there should be no segment backends; we haven't performed any
+-- queries yet. There should only be a QD backend
+SELECT COUNT(*) = 1 FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT type, content FROM gp_backend_info();
+ type | content 
+------+---------
+ Q    |      -1
+(1 row)
+
+--
+-- Spin up the writer gang.
+--
+CREATE TEMPORARY TABLE temp();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+--start_ignore
+-- Help debugging by printing the results. Since most contents will be different
+-- on every machine, we do the actual verification below.
+SELECT * from gp_backend_info();
+ id | type | content |          host           | port |  pid  
+----+------+---------+-------------------------+------+-------
+ -1 | Q    |      -1 | vanjared-a01.vmware.com | 7000 | 89615
+  0 | w    |       0 | vanjared-a01.vmware.com | 7002 | 89619
+  1 | w    |       1 | vanjared-a01.vmware.com | 7003 | 89620
+  2 | w    |       2 | vanjared-a01.vmware.com | 7004 | 89621
+(4 rows)
+
+--end_ignore
+-- Now we should have as many backends as primaries +1 QD, and all primaries
+-- backend should be marked as writers
+SELECT COUNT(*) AS num_primaries FROM gp_segment_configuration
+    WHERE content >= 0 AND role = 'p'
+\gset
+SELECT COUNT(*) = :num_primaries +1 FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'w';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = 1 FROM gp_backend_info() WHERE type = 'Q';
+ ?column? 
+----------
+ t
+(1 row)
+
+-- All IDs and PIDs should be distinct.
+SELECT COUNT(DISTINCT id) = :num_primaries +1 FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(DISTINCT content) = :num_primaries +1 FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(DISTINCT pid) = :num_primaries +1 FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+--
+-- Spin up a parallel reader gang.
+--
+CREATE TEMPORARY TABLE temp2();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+SELECT * FROM temp JOIN (SELECT * FROM temp2) temp2 ON (temp = temp2);
+--
+(0 rows)
+
+--start_ignore
+-- Debugging helper (see above).
+SELECT * from gp_backend_info();
+ id | type | content |          host           | port |  pid  
+----+------+---------+-------------------------+------+-------
+ -1 | Q    |      -1 | vanjared-a01.vmware.com | 7000 | 89615
+  0 | w    |       0 | vanjared-a01.vmware.com | 7002 | 89619
+  1 | w    |       1 | vanjared-a01.vmware.com | 7003 | 89620
+  2 | w    |       2 | vanjared-a01.vmware.com | 7004 | 89621
+  3 | r    |       0 | vanjared-a01.vmware.com | 7002 | 89625
+  4 | r    |       1 | vanjared-a01.vmware.com | 7003 | 89626
+  5 | r    |       2 | vanjared-a01.vmware.com | 7004 | 89627
+(7 rows)
+
+--end_ignore
+-- Now we should have double the number of backends; the new ones should be
+-- readers.
+SELECT COUNT(*) = (:num_primaries * 2) +1 FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'w';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'r';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = 1 FROM gp_backend_info() WHERE type = 'Q';
+ ?column? 
+----------
+ t
+(1 row)
+
+-- IDs and PIDs should still be distinct.
+SELECT COUNT(DISTINCT id) = (:num_primaries * 2) +1 FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(DISTINCT pid) = (:num_primaries * 2) +1 FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Content IDs should be there twice (a reader and a writer for each segment).
+SELECT COUNT(DISTINCT content) = :num_primaries +1 FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(DISTINCT content) = :num_primaries FROM gp_backend_info()
+WHERE content >= 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT DISTINCT COUNT(content) FROM gp_backend_info() WHERE content >= 0
+GROUP BY content;
+ count 
+-------
+     2
+(1 row)
+
+--
+-- Start up a singleton reader.
+--
+SELECT * FROM temp JOIN (SELECT oid FROM pg_class) temp2 on (temp = temp2);
+ oid 
+-----
+(0 rows)
+
+--start_ignore
+-- Debugging helper (see above).
+SELECT * from gp_backend_info();
+ id | type | content |          host           | port |  pid  
+----+------+---------+-------------------------+------+-------
+ -1 | Q    |      -1 | vanjared-a01.vmware.com | 7000 | 89615
+  0 | w    |       0 | vanjared-a01.vmware.com | 7002 | 89619
+  1 | w    |       1 | vanjared-a01.vmware.com | 7003 | 89620
+  2 | w    |       2 | vanjared-a01.vmware.com | 7004 | 89621
+  3 | r    |       0 | vanjared-a01.vmware.com | 7002 | 89625
+  4 | r    |       1 | vanjared-a01.vmware.com | 7003 | 89626
+  5 | r    |       2 | vanjared-a01.vmware.com | 7004 | 89627
+  6 | R    |      -1 | vanjared-a01.vmware.com | 7000 | 89629
+(8 rows)
+
+--end_ignore
+-- We should have added only one backend -- the singleton reader on the master.
+SELECT COUNT(*) = (:num_primaries * 2 + 2) FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'w';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'r';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = 1 FROM gp_backend_info() WHERE type = 'R' and content = -1;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = 1 FROM gp_backend_info() WHERE type = 'Q' and content = -1;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- IDs and PIDs should still be distinct.
+SELECT COUNT(DISTINCT id) = (:num_primaries * 2 + 2) FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(DISTINCT pid) = (:num_primaries * 2 + 2) FROM gp_backend_info();
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -32,28 +32,24 @@ else:
 res = plpy.execute("SELECT address FROM gp_segment_configuration;", 1)
 hostip = socket.gethostbyname(res[0]['address'])
 
-res = plpy.execute("SELECT current_setting('gp_session_id');", 1)
-qd_backend_conn_id = res[0]['current_setting']
+res = plpy.execute("SELECT pid from gp_backend_info();")
+pids_to_check = [r['pid'] for r in res]
 
-for process in psutil.process_iter():
-    # We iterate through all backends related to connection id
-    # of current session
-    # Exclude zombies to avoid psutil.ZombieProcess exceptions
-    # on calling process.cmdline()
-    if process.name() == 'postgres' and process.status() != psutil.STATUS_ZOMBIE:
-        if ' con' + qd_backend_conn_id + ' ' in process.cmdline()[0]:
-            motion_socket_count = 0
-            plpy.info('Checking postgres backend {}'.format(process.cmdline()[0]))
-            for conn in process.connections():
-                if conn.type == expected_socket_kind and conn.raddr == () \
-                and conn.laddr.ip == hostip:
-                    motion_socket_count += 1
+for pid in pids_to_check:
+    # We iterate through all backends related to current session
+    motion_socket_count = 0
+    process = psutil.Process(pid)
+    plpy.info('Checking postgres backend {}'.format(process.cmdline()[0]))
+    for conn in process.connections():
+        if conn.type == expected_socket_kind and conn.raddr == () \
+        and conn.laddr.ip == hostip:
+            motion_socket_count += 1
 
-            if motion_socket_count != expected_socket_count_per_segment:
-                plpy.error('Expected {} motion sockets but found {}. '\
-                'For backend process {}. connections= {}'\
-                .format(expected_socket_count_per_segment, process,\
-                motion_socket_count, process.connections()))
+    if motion_socket_count != expected_socket_count_per_segment:
+        plpy.error('Expected {} motion sockets but found {}. '\
+        'For backend process {}. connections= {}'\
+        .format(expected_socket_count_per_segment, process,\
+        motion_socket_count, process.connections()))
 
 
 $$ LANGUAGE plpython3u EXECUTE ON MASTER;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -37,7 +37,7 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp resource_queue_with_rule gp_types gp_index cluster_gp combocid_gp gp_sort gp_prepared_xacts
+test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp resource_queue_with_rule gp_types gp_index cluster_gp combocid_gp gp_sort gp_prepared_xacts gp_backend_info
 test: spi_processed64bit
 test: gp_tablespace_with_faults
 # below test(s) inject faults so each of them need to be in a separate group

--- a/src/test/regress/sql/gp_backend_info.sql
+++ b/src/test/regress/sql/gp_backend_info.sql
@@ -1,0 +1,84 @@
+-- Tests for the gp_backend_info() function.
+
+-- At first there should be no segment backends; we haven't performed any
+-- queries yet. There should only be a QD backend
+SELECT COUNT(*) = 1 FROM gp_backend_info();
+
+SELECT type, content FROM gp_backend_info();
+--
+-- Spin up the writer gang.
+--
+
+CREATE TEMPORARY TABLE temp();
+
+--start_ignore
+-- Help debugging by printing the results. Since most contents will be different
+-- on every machine, we do the actual verification below.
+SELECT * from gp_backend_info();
+--end_ignore
+
+-- Now we should have as many backends as primaries +1 QD, and all primaries
+-- backend should be marked as writers
+SELECT COUNT(*) AS num_primaries FROM gp_segment_configuration
+    WHERE content >= 0 AND role = 'p'
+\gset
+SELECT COUNT(*) = :num_primaries +1 FROM gp_backend_info();
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'w';
+SELECT COUNT(*) = 1 FROM gp_backend_info() WHERE type = 'Q';
+
+-- All IDs and PIDs should be distinct.
+SELECT COUNT(DISTINCT id) = :num_primaries +1 FROM gp_backend_info();
+SELECT COUNT(DISTINCT content) = :num_primaries +1 FROM gp_backend_info();
+SELECT COUNT(DISTINCT pid) = :num_primaries +1 FROM gp_backend_info();
+
+--
+-- Spin up a parallel reader gang.
+--
+
+CREATE TEMPORARY TABLE temp2();
+SELECT * FROM temp JOIN (SELECT * FROM temp2) temp2 ON (temp = temp2);
+
+--start_ignore
+-- Debugging helper (see above).
+SELECT * from gp_backend_info();
+--end_ignore
+
+-- Now we should have double the number of backends; the new ones should be
+-- readers.
+SELECT COUNT(*) = (:num_primaries * 2) +1 FROM gp_backend_info();
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'w';
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'r';
+SELECT COUNT(*) = 1 FROM gp_backend_info() WHERE type = 'Q';
+
+-- IDs and PIDs should still be distinct.
+SELECT COUNT(DISTINCT id) = (:num_primaries * 2) +1 FROM gp_backend_info();
+SELECT COUNT(DISTINCT pid) = (:num_primaries * 2) +1 FROM gp_backend_info();
+
+-- Content IDs should be there twice (a reader and a writer for each segment).
+SELECT COUNT(DISTINCT content) = :num_primaries +1 FROM gp_backend_info();
+SELECT COUNT(DISTINCT content) = :num_primaries FROM gp_backend_info()
+WHERE content >= 0;
+SELECT DISTINCT COUNT(content) FROM gp_backend_info() WHERE content >= 0
+GROUP BY content;
+
+--
+-- Start up a singleton reader.
+--
+
+SELECT * FROM temp JOIN (SELECT oid FROM pg_class) temp2 on (temp = temp2);
+
+--start_ignore
+-- Debugging helper (see above).
+SELECT * from gp_backend_info();
+--end_ignore
+
+-- We should have added only one backend -- the singleton reader on the master.
+SELECT COUNT(*) = (:num_primaries * 2 + 2) FROM gp_backend_info();
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'w';
+SELECT COUNT(*) = :num_primaries FROM gp_backend_info() WHERE type = 'r';
+SELECT COUNT(*) = 1 FROM gp_backend_info() WHERE type = 'R' and content = -1;
+SELECT COUNT(*) = 1 FROM gp_backend_info() WHERE type = 'Q' and content = -1;
+
+-- IDs and PIDs should still be distinct.
+SELECT COUNT(DISTINCT id) = (:num_primaries * 2 + 2) FROM gp_backend_info();
+SELECT COUNT(DISTINCT pid) = (:num_primaries * 2 + 2) FROM gp_backend_info();


### PR DESCRIPTION
To debug into the master backend for a given Postgres session, you can `SELECT pg_backend_pid()` and attach a debugger to the resulting process ID. We currently have no corresponding function for the segment backends, however -- developers have to read the output of `ps` and try
to correlate their connected session to the correct backends. This is error-prone, especially if there are many sessions in flight.

`gp_backend_info()` is an attempt to fill this gap. Running
```sql
SELECT * FROM gp_backend_info();
```
will return a table of the following format:
```
 id | type | content |   host    | port  |  pid
----+------+---------+-----------+-------+-------
 -1 | Q    |      -1 | pchampion | 25431 | 50430
  0 | w    |       0 | pchampion | 25432 | 50431
  1 | w    |       1 | pchampion | 25433 | 50432
  2 | w    |       2 | pchampion | 25434 | 50433
```
This allows developers to jump directly to the correct host and PID for
a given backend. This patch supports backends for 
writer gangs (type 'w' in the table), 
reader gangs ('r'), 
master QD backend ('Q') and
master singleton readers ('R').

The first commit here adds support to `CdbComponentDatabaseInfo` for retrieving the active segment backend information (in addition to idle backends, which were already exposed). The second commit implements the core functionality and adds tests.