### PR TITLE
resgroup: improve operator memory tests

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -308,14 +308,8 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		/**
 		 * There are some statements that do not go through the resource queue, so we cannot
 		 * put in a strong assert here. Someday, we should fix resource queues.
-		 *
-		 * In resource group mode we always assign some memory to operators
-		 * even if the amount is larger than the spill memory, the memory can
-		 * be actually allocated from the shared memory.  If there is not enough
-		 * shared memory OOM will be raised on executors.
 		 */
-		if (IsResGroupEnabled() ||
-			queryDesc->plannedstmt->query_mem > 0)
+		if (queryDesc->plannedstmt->query_mem > 0)
 		{
 			switch(*gp_resmanager_memory_policy)
 			{

--- a/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
@@ -5,12 +5,10 @@ DROP
 -- start_ignore
 DROP RESOURCE GROUP rg_dumpinfo_test;
 ERROR:  resource group "rg_dumpinfo_test" does not exist
-DROP LANGUAGE IF EXISTS plpythonu;
-DROP
--- end_ignore
-
 CREATE LANGUAGE plpythonu;
 CREATE
+-- end_ignore
+
 CREATE FUNCTION dump_test_check() RETURNS bool as $$ import json import pygresql.pg as pg 
 def validate(json_obj, segnum): array = json_obj.get("info") #validate segnum if len(array) != segnum: return False qd_info = [j for j in array if j["segid"] == -1][0] #validate keys keys = ["segid", "segmentsOnMaster", "loaded", "totalChunks", "freeChunks", "chunkSizeInBits", "groups"] for key in keys: if key not in qd_info: return False 
 groups = [g for g in qd_info["groups"] if g["group_id"] > 6438] #validate user created group if len(groups) != 1: return False group = groups[0] #validate group keys keys = ["group_id", "nRunning", "locked_for_drop", "memExpected", "memQuotaGranted", "memSharedGranted", "memQuotaUsed", "memUsage", "memSharedUsage"] for key in keys: if key not in group: return False 
@@ -63,7 +61,7 @@ CREATE
 SET ROLE role_permission;
 SET
 select value from pg_resgroup_get_status_kv('dump');
-ERROR:  Only superusers can call this function.
+ERROR:  only superusers can call this function
 
 SET ROLE gpadmin;
 SET

--- a/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
@@ -12,6 +12,13 @@ DROP RESOURCE GROUP rg1_opmem_test;
 DROP RESOURCE GROUP rg2_opmem_test;
 --end_ignore
 
+CREATE LANGUAGE plpythonu;
+CREATE
+
+-- a helper function to run query via SPI
+CREATE OR REPLACE FUNCTION f1_opmem_test() RETURNS void AS $$ plpy.execute("""select * from gp_dist_random('gp_id')""") $$ LANGUAGE plpythonu;
+CREATE
+
 -- this view contains many operators in the plan, which is used to trigger
 -- the issue.  gp_toolkit.gp_resgroup_config is a large JOIN view of many
 -- relations, to prevent the source relations being optimized out from the plan
@@ -21,7 +28,11 @@ DROP RESOURCE GROUP rg2_opmem_test;
 CREATE OR REPLACE VIEW many_ops AS SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 UNION SELECT * FROM gp_toolkit.gp_resgroup_config WHERE groupid=6437 ;
 CREATE
 
-CREATE RESOURCE GROUP rg1_opmem_test WITH (cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0, concurrency=20, memory_spill_ratio=0);
+-- we must ensure spill to be small enough but still > 0.
+-- - rg1's memory quota is 682 * 1% = 6;
+-- - per-xact quota is 6/3=2;
+-- - spill memory is 2 * 60% = 1;
+CREATE RESOURCE GROUP rg1_opmem_test WITH (cpu_rate_limit=10, memory_limit=1, memory_shared_quota=0, concurrency=3, memory_spill_ratio=60);
 CREATE
 
 CREATE ROLE r1_opmem_test RESOURCE GROUP rg1_opmem_test;
@@ -86,7 +97,7 @@ RESET
 
 -- rg1 has no group level shared memory, and most memory are granted to rg2,
 -- there is only very little global shared memory due to integer rounding.
-CREATE RESOURCE GROUP rg2_opmem_test WITH (cpu_rate_limit=10, memory_limit=40);
+CREATE RESOURCE GROUP rg2_opmem_test WITH (cpu_rate_limit=10, memory_limit=59);
 CREATE
 
 -- this query can execute but will raise OOM error.
@@ -125,7 +136,13 @@ RESET
 -- positive: there is enough group shared memory
 --
 
+ALTER RESOURCE GROUP rg2_opmem_test SET memory_limit 40;
+ALTER
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_limit 20;
+ALTER
 ALTER RESOURCE GROUP rg1_opmem_test SET memory_shared_quota 100;
+ALTER
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_spill_ratio 20;
 ALTER
 
 SET gp_resgroup_memory_policy TO none;
@@ -165,7 +182,7 @@ RESET role;
 RESET
 
 --
--- positive: increased group memory settings
+-- positive: the spill memory is large enough, no adjustment is needed
 --
 
 DROP RESOURCE GROUP rg2_opmem_test;
@@ -211,6 +228,64 @@ SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
 6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
+RESET role;
+RESET
+
+--
+-- positive: when spill memory is zero, work memory is used
+--
+
+ALTER RESOURCE GROUP rg1_opmem_test SET memory_spill_ratio 0;
+ALTER
+
+SET gp_resgroup_memory_policy TO none;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
+SELECT f1_opmem_test();
+f1_opmem_test
+-------------
+             
+(1 row)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
+SELECT f1_opmem_test();
+f1_opmem_test
+-------------
+             
+(1 row)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_opmem_test;
+SET
+SELECT * FROM many_ops;
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio|memory_auditor|cpuset
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------+--------------+------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         |vmtracker     |-1    
+(1 row)
+SELECT f1_opmem_test();
+f1_opmem_test
+-------------
+             
 (1 row)
 RESET role;
 RESET

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -1,3 +1,5 @@
+CREATE LANGUAGE plpythonu;
+
 -- start_ignore
 ! rmdir @cgroup_mnt_point@/cpu/gpdb;
 ! rmdir @cgroup_mnt_point@/cpuacct/gpdb;
@@ -7,35 +9,58 @@
 ! mkdir @cgroup_mnt_point@/cpuset/gpdb;
 -- end_ignore
 
+-- we want to simulate a 3-primary cluster with 2GB memory and
+-- gp_resource_group_memory_limit=100%, suppose:
+--
+-- - total: the total memory on the system;
+-- - nseg: the max per-host segment count (including both master and primaries);
+-- - limit: the gp_resource_group_memory_limit used for the simulation;
+--
+-- then we have: total * limit / nsegs = 2GB * 1.0 / 3
+-- so: limit = 2GB * 1.0 / 3 * nsegs / total
+--
+-- with the simulation each primary segment should manage 682MB memory.
+CREATE OR REPLACE FUNCTION adjust_memory_limit(nsegs bigint) RETURNS int AS $$
+    import os
+    import psutil
+
+    mem = psutil.virtual_memory().total
+    swap = psutil.swap_memory().total
+    overcommit = int(open('/proc/sys/vm/overcommit_ratio').readline())
+    total = swap + mem * overcommit / 100.
+
+    limit = (2 << 30) * 1.0 * nsegs / 3 / total
+    return os.system('gpconfig -c gp_resource_group_memory_limit -v {:f}'.format(limit))
+$$ LANGUAGE plpythonu VOLATILE;
+
+SELECT adjust_memory_limit(count(hostname)) FROM gp_segment_configuration
+ WHERE preferred_role = 'p'
+ GROUP BY hostname
+ ORDER BY count(hostname) DESC
+ LIMIT 1;
+
+DROP FUNCTION adjust_memory_limit(bigint);
+
 -- enable resource group and restart cluster.
 -- start_ignore
-! rm -f /tmp/.resgroup_mem_helper.sh;
-! echo 'mem=$(free -b | grep "^Mem:" | (read a b c; echo $b))' >>/tmp/.resgroup_mem_helper.sh;
-! echo 'swap=$(free -b | grep "^Swap:" | (read a b c; echo $b))' >>/tmp/.resgroup_mem_helper.sh;
-! echo 'overcommit=$(cat /proc/sys/vm/overcommit_ratio)' >>/tmp/.resgroup_mem_helper.sh;
-! echo 'total=$((swap + mem * overcommit / 100))' >>/tmp/.resgroup_mem_helper.sh;
-! echo 'limit=$(((2 << 30) * 10000 * 4 / 3 / total))' >>/tmp/.resgroup_mem_helper.sh;
-! echo '[ "$limit" -le 9000 ] || limit=9000' >>/tmp/.resgroup_mem_helper.sh;
-! echo 'limitf=$(printf "0.%04d" $limit)' >>/tmp/.resgroup_mem_helper.sh;
-! echo 'gpconfig -c gp_resource_group_memory_limit -v $limitf' >>/tmp/.resgroup_mem_helper.sh;
-! bash /tmp/.resgroup_mem_helper.sh;
-! rm -f /tmp/.resgroup_mem_helper.sh;
 ! gpconfig -c gp_resource_manager -v group;
 ! gpconfig -c gp_resource_group_cpu_limit -v 0.9;
 ! gpconfig -c max_connections -v 250 -m 25;
 ! gpstop -rai;
 -- end_ignore
 
-SHOW gp_resource_manager;
+-- after the restart we need a new connection to run the queries
+
+0: SHOW gp_resource_manager;
 
 -- resource queue statistics should not crash
-SELECT * FROM pg_resqueue_status;
-SELECT * FROM gp_toolkit.gp_resqueue_status;
-SELECT * FROM gp_toolkit.gp_resq_priority_backend;
+0: SELECT * FROM pg_resqueue_status;
+0: SELECT * FROM gp_toolkit.gp_resqueue_status;
+0: SELECT * FROM gp_toolkit.gp_resq_priority_backend;
 
 -- by default admin_group has concurrency set to -1 which leads to
 -- very small memory quota for each resgroup slot, correct it.
-ALTER RESOURCE GROUP admin_group SET concurrency 2;
+0: ALTER RESOURCE GROUP admin_group SET concurrency 2;
 -- in later cases we will SHOW memory_spill_ratio as first command
 -- to verify that it can be correctly loaded even for bypassed commands
-ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
+0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;

--- a/src/test/isolation2/output/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup.source
@@ -1,3 +1,6 @@
+CREATE LANGUAGE plpythonu;
+CREATE
+
 -- start_ignore
 ! rmdir @cgroup_mnt_point@/cpu/gpdb;
 
@@ -10,70 +13,75 @@
 ! mkdir @cgroup_mnt_point@/cpuacct/gpdb;
 
 ! mkdir @cgroup_mnt_point@/cpuset/gpdb;
+
 -- end_ignore
+
+-- we want to simulate a 3-primary cluster with 2GB memory and
+-- gp_resource_group_memory_limit=100%, suppose:
+--
+-- - total: the total memory on the system;
+-- - nseg: the max per-host segment count (including both master and primaries);
+-- - limit: the gp_resource_group_memory_limit used for the simulation;
+--
+-- then we have: total * limit / nsegs = 2GB * 1.0 / 3
+-- so: limit = 2GB * 1.0 / 3 * nsegs / total
+--
+-- with the simulation each primary segment should manage 682MB memory.
+CREATE OR REPLACE FUNCTION adjust_memory_limit(nsegs bigint) RETURNS int AS $$ import os import psutil 
+mem = psutil.virtual_memory().total swap = psutil.swap_memory().total overcommit = int(open('/proc/sys/vm/overcommit_ratio').readline()) total = swap + mem * overcommit / 100. 
+limit = (2 << 30) * 1.0 * nsegs / 3 / total return os.system('gpconfig -c gp_resource_group_memory_limit -v {:f}'.format(limit)) $$ LANGUAGE plpythonu VOLATILE;
+CREATE
+
+SELECT adjust_memory_limit(count(hostname)) FROM gp_segment_configuration WHERE preferred_role = 'p' GROUP BY hostname ORDER BY count(hostname) DESC LIMIT 1;
+adjust_memory_limit
+-------------------
+0                  
+(1 row)
+
+DROP FUNCTION adjust_memory_limit(bigint);
+DROP
 
 -- enable resource group and restart cluster.
 -- start_ignore
-! rm -f /tmp/.resgroup_mem_helper.sh;
-
-! echo 'mem=$(free -b | grep "^Mem:" | (read a b c; echo $b))' >>/tmp/.resgroup_mem_helper.sh;
-
-! echo 'swap=$(free -b | grep "^Swap:" | (read a b c; echo $b))' >>/tmp/.resgroup_mem_helper.sh;
-
-! echo 'overcommit=$(cat /proc/sys/vm/overcommit_ratio)' >>/tmp/.resgroup_mem_helper.sh;
-
-! echo 'total=$((swap + mem * overcommit / 100))' >>/tmp/.resgroup_mem_helper.sh;
-
-! echo 'limit=$(((2 << 30) * 10000 * 4 / 3 / total))' >>/tmp/.resgroup_mem_helper.sh;
-
-! echo '[ "$limit" -le 9000 ] || limit=9000' >>/tmp/.resgroup_mem_helper.sh;
-
-! echo 'limitf=$(printf "0.%04d" $limit)' >>/tmp/.resgroup_mem_helper.sh;
-
-! echo 'gpconfig -c gp_resource_group_memory_limit -v $limitf' >>/tmp/.resgroup_mem_helper.sh;
-
-! bash /tmp/.resgroup_mem_helper.sh;
-20170713:03:19:18:063942 gpconfig:ad3e397dc7b9:gpadmin-[INFO]:-completed successfully
-
-! rm -f /tmp/.resgroup_mem_helper.sh;
-
 ! gpconfig -c gp_resource_manager -v group;
 20170502:01:28:13:000367 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully
 
 ! gpconfig -c gp_resource_group_cpu_limit -v 0.9;
 20170731:09:42:33:021079 gpconfig:sdw8:nyu-[INFO]:-completed successfully
 
-! gpconfig -c max_connections -v 125 -m 25;
+! gpconfig -c max_connections -v 250 -m 25;
 20170731:09:42:34:021163 gpconfig:sdw8:nyu-[INFO]:-completed successfully
 
 ! gpstop -rai;
 -- end_ignore
 
-SHOW gp_resource_manager;
+-- after the restart we need a new connection to run the queries
+
+0: SHOW gp_resource_manager;
 gp_resource_manager
 -------------------
 group              
 (1 row)
 
 -- resource queue statistics should not crash
-SELECT * FROM pg_resqueue_status;
+0: SELECT * FROM pg_resqueue_status;
 rsqname|rsqcountlimit|rsqcountvalue|rsqcostlimit|rsqcostvalue|rsqwaiters|rsqholders
 -------+-------------+-------------+------------+------------+----------+----------
 (0 rows)
-SELECT * FROM gp_toolkit.gp_resqueue_status;
+0: SELECT * FROM gp_toolkit.gp_resqueue_status;
 queueid|rsqname|rsqcountlimit|rsqcountvalue|rsqcostlimit|rsqcostvalue|rsqmemorylimit|rsqmemoryvalue|rsqwaiters|rsqholders
 -------+-------+-------------+-------------+------------+------------+--------------+--------------+----------+----------
 (0 rows)
-SELECT * FROM gp_toolkit.gp_resq_priority_backend;
+0: SELECT * FROM gp_toolkit.gp_resq_priority_backend;
 rqpsession|rqpcommand|rqppriority|rqpweight
 ----------+----------+-----------+---------
 (0 rows)
 
 -- by default admin_group has concurrency set to -1 which leads to
 -- very small memory quota for each resgroup slot, correct it.
-ALTER RESOURCE GROUP admin_group SET concurrency 2;
+0: ALTER RESOURCE GROUP admin_group SET concurrency 2;
 ALTER
 -- in later cases we will SHOW memory_spill_ratio as first command
 -- to verify that it can be correctly loaded even for bypassed commands
-ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
+0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
 ALTER

--- a/src/test/isolation2/sql/.gitignore
+++ b/src/test/isolation2/sql/.gitignore
@@ -8,5 +8,4 @@ resgroup_alter_memory.sql
 pt_io_in_progress_deadlock.sql
 resgroup_bypass.sql
 resgroup_cpuset.sql
-resgroup_dumpinfo.sql
 gp_collation.sql

--- a/src/test/isolation2/sql/resgroup/resgroup_dumpinfo.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_dumpinfo.sql
@@ -2,10 +2,9 @@ DROP ROLE IF EXISTS role_dumpinfo_test;
 DROP ROLE IF EXISTS role_permission;
 -- start_ignore
 DROP RESOURCE GROUP rg_dumpinfo_test;
-DROP LANGUAGE IF EXISTS plpythonu;
+CREATE LANGUAGE plpythonu;
 -- end_ignore
 
-CREATE LANGUAGE plpythonu;
 CREATE FUNCTION dump_test_check() RETURNS bool
 as $$
 import json


### PR DESCRIPTION
This PR contains 3 commits to improve stability of operator memory tests as well as related changes:

    commit a7b6e85e7c05ef0aa91454cc04aab60d88eacab3
    Author: Ning Yu <nyu@pivotal.io>
    Date:   Thu Dec 13 16:42:21 2018 +0800
    
        resgroup: fix memory size simulation in tests.
    
        Resource group memory related tests are sensitive to system memory size,
        to get stable output we simulation a 3-primary cluster with 2GB memory
        by setting proper value to gp_resource_group_memory_limit.
    
        However the calculation was based on some hard coded values and would
        simulate wrong memory size on 5X resgroup pipelines.
    
        Corrected and refactored the calculation.
    
    commit 8f618e2dad494e944b379fc29b5f2352b414352d
    Author: Ning Yu <nyu@pivotal.io>
    Date:   Thu Dec 13 16:52:25 2018 +0800
    
        resgroup: go back to old behavior when spill memory is zero.
    
        When spill memory is zero the original behavior is to use work memory
        instead, however we modified this for resource group to use dynamic
        spill memory in 98f9b1744ffc8d6383b7bdcaee80fb2f2d26cae1.  This is not
        always the expected behavior, especially when a warning is generated.
    
        Change back to old behavior.
    
    commit dfbaa564bda004c9ce247a146c11c245e93f01bd
    Author: Ning Yu <nyu@pivotal.io>
    Date:   Thu Dec 13 20:52:56 2018 +0800
    
        resgroup: update test case resgroup_dumpinfo.
    
        Moved from input/ to sql/, updated the error message, also wrap CREATE
        LANGUAGE with start_ignore block.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] ~Document changes~
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`