### PR TITLE
Clean up TimeSliceCheck() in interrupt check path

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -580,6 +580,16 @@ static const struct config_enum_entry gp_gpperfmon_log_alert_level[] = {
 	{NULL, 0}
 };
 
+static const struct config_enum_entry test_time_slice_report_level_options[] = {
+	{"notice", NOTICE},
+	{"warning", WARNING},
+	{"error", ERROR},
+	{"log", LOG},
+	{"fatal", FATAL},
+	{"panic", PANIC},
+	{NULL, 0}
+};
+
 static const struct config_enum_entry password_hash_algorithm_options[] = {
 	/* {"none", PASSWORD_HASH_NONE}, * this option is not exposed */
 	{"MD5", PASSWORD_HASH_MD5},
@@ -4680,7 +4690,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_test_time_slice_report_level,
-		ERROR, server_message_level_options,
+		ERROR, test_time_slice_report_level_options,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/utils/testutils.h
+++ b/src/include/utils/testutils.h
@@ -18,7 +18,6 @@
 
 #ifdef USE_TEST_UTILS
 
-#define CHECK_TIME_SLICE()      TimeSliceCheck(__FILE__, __LINE__)
 
 /* external variables */
 extern PGDLLIMPORT volatile int32 InterruptHoldoffCount;
@@ -27,6 +26,8 @@ extern PGDLLIMPORT volatile int32 CritSectionCount;
 /* time slicing */
 extern void TimeSliceReset(void);
 extern void TimeSliceCheck(const char *file, int line);
+
+#define CHECK_TIME_SLICE()      TimeSliceCheck(__FILE__, __LINE__)
 
 #if defined(__i386) || defined(__x86_64__)
 


### PR DESCRIPTION
Commit 2f628da3a7bc63cfa128bb79e71852288fbc65aa optimized the check for interrupts codepath for the normal case. In case testutils are enabled we run an additional check in CFI, `TimeSliceCheck()`. This codepath was less optimized as it was running a few uninteresting asserts, and it was also leaking memory for configured elevels lower than `ERROR`. Fix by making the elevel GUC use a tailored enum and free the memory explicitly. Also perform minor cleanups along the way like tidying up the `ereport()` call and moving the macro defining `CHECK_TIME_SLICE` to after `TimeSliceCheck()` has been prototyped.

The careful observer will note that this still won't compile without some manual fiddling, since GPDB testutils broke during the 9.4 merge. I have another branch sitting here which cleans up all of that, but since this was a small independent piece I wanted to break it out for easier review.