### PR TITLE
WalSnd struct is not well protected and manipulated.

### DIFF
--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -74,6 +74,7 @@ test_GetMirrorStatus_Pid_Zero(void **state)
 	max_wal_senders = 1;
 	WalSndCtl = &data;
 	data.walsnds[0].pid = 0;
+	SpinLockInit(&data.walsnds[0].mutex);
 	/*
 	 * This would make sure Mirror is reported as DOWN, as grace period
 	 * duration is taken into account.
@@ -103,6 +104,7 @@ test_GetMirrorStatus_RequestRetry(void **state)
 	max_wal_senders = 1;
 	WalSndCtl = &data;
 	data.walsnds[0].pid = 0;
+	SpinLockInit(&data.walsnds[0].mutex);
 	/*
 	 * Make the pid zero time within the grace period.
 	 */
@@ -133,6 +135,7 @@ test_GetMirrorStatus_Delayed_AcceptingConnectionsStartTime(void **state)
 	max_wal_senders = 1;
 	WalSndCtl = &data;
 	data.walsnds[0].pid = 0;
+	SpinLockInit(&data.walsnds[0].mutex);
 	/*
 	 * wal sender pid zero time over the grace period
 	 * Mirror will be marked down, and no retry.
@@ -163,6 +166,7 @@ test_GetMirrorStatus_Overflow(void **state)
 	max_wal_senders = 1;
 	WalSndCtl = &data;
 	data.walsnds[0].pid = 0;
+	SpinLockInit(&data.walsnds[0].mutex);
 	/*
 	 * This would make sure Mirror is reported as DOWN, as grace period
 	 * duration is taken into account.
@@ -185,6 +189,7 @@ test_GetMirrorStatus_WALSNDSTATE_STARTUP(void **state)
 	WalSndCtlData data;
 
 	test_setup(&data, WALSNDSTATE_STARTUP);
+	SpinLockInit(&data.walsnds[0].mutex);
 	/*
 	 * This would make sure Mirror is not reported as DOWN, as still in grace
 	 * period.
@@ -207,6 +212,7 @@ test_GetMirrorStatus_WALSNDSTATE_BACKUP(void **state)
 	WalSndCtlData data;
 
 	test_setup(&data, WALSNDSTATE_BACKUP);
+	SpinLockInit(&data.walsnds[0].mutex);
 	/*
 	 * This would make sure Mirror is reported as DOWN, as grace period
 	 * duration is taken into account.
@@ -233,6 +239,7 @@ test_GetMirrorStatus_WALSNDSTATE_CATCHUP(void **state)
 	WalSndCtlData data;
 
 	test_setup(&data, WALSNDSTATE_CATCHUP);
+	SpinLockInit(&data.walsnds[0].mutex);
 	GetMirrorStatus(&response);
 
 	assert_true(response.IsMirrorUp);
@@ -246,6 +253,7 @@ test_GetMirrorStatus_WALSNDSTATE_STREAMING(void **state)
 	WalSndCtlData data;
 
 	test_setup(&data, WALSNDSTATE_STREAMING);
+	SpinLockInit(&data.walsnds[0].mutex);
 	GetMirrorStatus(&response);
 
 	assert_true(response.IsMirrorUp);

--- a/src/include/replication/walsender_private.h
+++ b/src/include/replication/walsender_private.h
@@ -67,6 +67,12 @@ typedef struct WalSnd
 	 */
 	XLogRecPtr	xlogCleanUpTo;
 
+	/*
+	 * Records time, either during initialization or due to disconnection.
+	 * This helps to detect time passed since mirror didn't connect.
+	 */
+	pg_time_t   replica_disconnected_at;
+
 	/* Protects shared variables shown above. */
 	slock_t		mutex;
 
@@ -84,12 +90,6 @@ typedef struct WalSnd
 	int			sync_standby_priority;
 
 	bool		synchronous;
-
-	/*
-	 * Records time, either during initialization or due to disconnection.
-	 * This helps to detect time passed since mirror didn't connect.
-	 */
-	pg_time_t   replica_disconnected_at;
 } WalSnd;
 
 extern WalSnd *MyWalSnd;


### PR DESCRIPTION
Its member replica_disconnected_at is not protected by lock. Now we
protect it using walsnd->mutex, and this member is not initialized
sometimes. These sometimes lead to an assert failure with stack as below,

\#2  0x0000000000acfff4 in ExceptionalCondition (conditionName=0xdb08f0 "!(walsnd_replica_disconnected_at)", errorType=0xdb08c1 "FailedAssertion", fileName=0xdb08b0 "gp_replication.c", lineNumber=68) at assert.c:66
\#3  0x0000000000916148 in GetMirrorStatus (response=0x7ffe81dbb620) at gp_replication.c:68
\#4  0x00000000007a4aa9 in HandleFtsWalRepProbe () at ftsmessagehandler.c:264
\#5  0x00000000007a4c91 in HandleFtsMessage (query_string=0x23c92f0 "PROBE") at ftsmessagehandler.c:359

Besides, GetMirrorStatus() does not manipulate WalSnd under lock.