### PR TITLE
Silence compiler warning about strncpy length argument.

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -606,7 +606,7 @@ generate_uao_sourcefiles(char *src_dir, char *dest_dir, char *suffix, replacemen
 
 		while (fgets(line, sizeof(line), infile))
 		{
-			strncpy(line_row, line, sizeof(line));
+			strlcpy(line_row, line, sizeof(line_row));
 			repls->orientation = "row";
 			convert_line(line_row, repls);
 			repls->orientation = "column";


### PR DESCRIPTION
GCC 8.2 started giving this warning:

pg_regress.c: In function ‘generate_uao_sourcefiles’:
pg_regress.c:609:34: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
    strncpy(line_row, line, sizeof(line));
                                  ^

In this case, 'line' and 'line_row' actually have the same size, 1024
bytes, so this is just pedantry.

While we're at it, switch to using strlcpy(), because this would not work
correctly if the buffer isn't NULL-terminated. The buffer is supposed to
"large enough", so that that never happens anyway, but might as well be
safe here.
