### PR TITLE
Add GUC for ORCA Eager Agg and bump to 3.27.0

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.26.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.27.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.26.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.27.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13994,7 +13994,7 @@ int
 main ()
 {
 
-return strncmp("3.26.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.27.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -14004,7 +14004,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.26.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.27.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -87,7 +87,7 @@ sync_tools: opt_write_test
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.26.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.27.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -119,7 +119,7 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] =
 		false, // m_negate_param
 		GPOS_WSZ_LIT("Generate optimizer minidump.")
 		},
-             	
+
 		{
 		EopttraceDisableMotions,
 		&optimizer_enable_motions,
@@ -377,6 +377,13 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] =
 		&optimizer_force_agg_skew_avoidance,
 		false, // m_negate_param
 		GPOS_WSZ_LIT("Always pick a plan for aggregate distinct that minimizes skew.")
+        },
+
+        {
+		EopttraceEnableEagerAgg,
+		&optimizer_enable_eageragg,
+		false, // m_negate_param
+		GPOS_WSZ_LIT("Enable Eager Agg transform for pushing aggregate below an innerjoin.")
 		}
 };
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -420,6 +420,7 @@ bool		optimizer_array_constraints;
 bool		optimizer_cte_inlining;
 bool		optimizer_enable_space_pruning;
 bool		optimizer_enable_associativity;
+bool		optimizer_enable_eageragg;
 
 /* Analyze related GUCs for Optimizer */
 bool		optimizer_analyze_root_partition;
@@ -3039,6 +3040,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_enable_global_deadlock_detector,
 		false, NULL, NULL
+    },
+
+	{
+		{"optimizer_enable_eageragg", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable Eager Agg transform for pushing aggregate below an innerjoin."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_eageragg,
+		false,
+		NULL, NULL, NULL
 	},
 
 	/* End-of-list marker */
@@ -5162,7 +5174,7 @@ set_gp_replication_config(const char *name, const char *value)
 	List *args = list_make1(&aconst);
 	VariableSetStmt setstmt = {.type = T_VariableSetStmt, .kind = VAR_SET_VALUE, .name = pstrdup(name), .args = args};
 	AlterSystemStmt alterSystemStmt = {.type = T_AlterSystemStmt, .setstmt = &setstmt};
-	
+    
 	AlterSystemSetConfigFile(&alterSystemStmt);
 }
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -484,6 +484,7 @@ extern bool optimizer_enable_hashjoin;
 extern bool optimizer_enable_dynamictablescan;
 extern bool optimizer_enable_indexscan;
 extern bool optimizer_enable_tablescan;
+extern bool optimizer_enable_eageragg;
 
 /* Optimizer plan enumeration related GUCs */
 extern bool optimizer_enumerate_plans;


### PR DESCRIPTION
Eager Agg is an experimental feature in ORCA and is gated using a new GUC: `optimizer_enable_eageragg` with default value as `off`. 