### PR TITLE
Provide more debug information in test fts_recovery_in_progress.

### DIFF
--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -5,11 +5,11 @@
 -- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- end_ignore
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
- role | preferred_role | mode 
-------+----------------+------
- p    | p              | s
- m    | m              | s
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
+ role | preferred_role | mode | status 
+------+----------------+------+--------
+ p    | p              | s    | u
+ m    | m              | s    | u
 (2 rows)
 
 select gp_inject_fault_infinite('fts_conn_startup_packet', 'skip', dbid)
@@ -60,11 +60,11 @@ NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
  t
 (1 row)
 
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
- role | preferred_role | mode 
-------+----------------+------
- p    | p              | s
- m    | m              | s
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
+ role | preferred_role | mode | status 
+------+----------------+------+--------
+ p    | p              | s    | u
+ m    | m              | s    | u
 (2 rows)
 
 -- test other scenario where recovery on primary is hung and hence FTS marks
@@ -94,16 +94,16 @@ select gp_request_fts_probe_scan();
  t
 (1 row)
 
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
- role | preferred_role | mode 
-------+----------------+------
- m    | p              | n
- p    | m              | n
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
+ role | preferred_role | mode | status 
+------+----------------+------+--------
+ m    | p              | n    | d
+ p    | m              | n    | u
 (2 rows)
 
 -- The remaining steps are to bring back the cluster to original state.
 -- start_ignore
-\! gprecoverseg -a
+\! gprecoverseg -av
 -- end_ignore
 -- loop while segments come in sync
 do $$
@@ -116,15 +116,15 @@ begin
   end loop;
 end;
 $$;
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
- role | preferred_role | mode 
-------+----------------+------
- p    | m              | s
- m    | p              | s
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
+ role | preferred_role | mode | status 
+------+----------------+------+--------
+ p    | m              | s    | u
+ m    | p              | s    | u
 (2 rows)
 
 -- start_ignore
-\! gprecoverseg -ar
+\! gprecoverseg -arv
 -- end_ignore
 -- loop while segments come in sync
 do $$
@@ -137,11 +137,11 @@ begin
   end loop;
 end;
 $$;
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
- role | preferred_role | mode 
-------+----------------+------
- p    | p              | s
- m    | m              | s
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
+ role | preferred_role | mode | status 
+------+----------------+------+--------
+ p    | p              | s    | u
+ m    | m              | s    | u
 (2 rows)
 
 -- start_ignore

--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -5,7 +5,7 @@
 -- start_ignore
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- end_ignore
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
 select gp_inject_fault_infinite('fts_conn_startup_packet', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 -- to make test deterministic and fast
@@ -28,7 +28,7 @@ show gp_fts_probe_retries;
 select gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_conn_startup_packet', 3, dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
 
 -- test other scenario where recovery on primary is hung and hence FTS marks
 -- primary down and promotes mirror. When 'fts_recovery_in_progress' is set to
@@ -41,11 +41,10 @@ from gp_segment_configuration where content = 0 and role = 'p';
 -- see the effect due to the fault.
 select gp_request_fts_probe_scan();
 select gp_request_fts_probe_scan();
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
-
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
 -- The remaining steps are to bring back the cluster to original state.
 -- start_ignore
-\! gprecoverseg -a
+\! gprecoverseg -av
 -- end_ignore
 
 -- loop while segments come in sync
@@ -59,10 +58,10 @@ begin
   end loop;
 end;
 $$;
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
 
 -- start_ignore
-\! gprecoverseg -ar
+\! gprecoverseg -arv
 -- end_ignore
 
 -- loop while segments come in sync
@@ -76,7 +75,7 @@ begin
   end loop;
 end;
 $$;
-select role, preferred_role, mode from gp_segment_configuration where content = 0;
+select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
 
 -- start_ignore
 \!gpconfig -r gp_fts_probe_retries --masteronly


### PR DESCRIPTION
Test fts_recovery_in_progress failures have been seen some times
before on either master pipeline or merge pipeline. This patch
adds verbose output of the gprecoverseg tool and the status column
of gp_segment_configuration to result file to make debugging easier.
