### PR TITLE
Introduce guc to generate plans that avoid skew with aggregates and bump ORCA version to v3.17.0

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.16.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.17.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.16.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.17.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.16.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.17.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.16.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.17.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.16.0@gpdb/stable
+orca/v3.17.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.16.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.17.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -367,6 +367,13 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] =
 		&optimizer_array_constraints,
 		false, // m_negate_param
 		GPOS_WSZ_LIT("Allows the constraint framework to derive array constraints in the optimizer.")
+		},
+
+		{
+		EopttraceForceAggSkewAvoidance,
+		&optimizer_force_agg_skew_avoidance,
+		false, // m_negate_param
+		GPOS_WSZ_LIT("Always pick a plan for aggregate distinct that minimizes skew.")
 		}
 };
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -567,6 +567,7 @@ int			optimizer_cte_inlining_bound;
 bool		optimizer_force_multistage_agg;
 bool		optimizer_force_three_stage_scalar_dqa;
 bool		optimizer_force_expanded_distinct_aggs;
+bool		optimizer_force_agg_skew_avoidance;
 bool		optimizer_prune_computed_columns;
 bool		optimizer_push_requirements_from_consumer_to_producer;
 bool		optimizer_enforce_subplans;
@@ -2897,6 +2898,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_enable_tablescan,
 		true, NULL, NULL
+	},
+
+	{
+		{"optimizer_force_agg_skew_avoidance", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Always pick a plan for aggregate distinct that minimizes skew."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_force_agg_skew_avoidance,
+		true,
+		NULL, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -482,6 +482,7 @@ extern int optimizer_cte_inlining_bound;
 extern bool optimizer_force_multistage_agg;
 extern bool optimizer_force_three_stage_scalar_dqa;
 extern bool optimizer_force_expanded_distinct_aggs;
+extern bool optimizer_force_agg_skew_avoidance;
 extern bool optimizer_prune_computed_columns;
 extern bool optimizer_push_requirements_from_consumer_to_producer;
 extern bool optimizer_enforce_subplans;


### PR DESCRIPTION
This patch introduces a guc `optimizer_force_agg_skew_avoidance` which
can be used to avoid plans which generate a lot of skew when aggregates
are used in the query. The default value of this guc is true.

Co-authored-by: Abhijit Subramanya <asubramanya@pivotal.io>
Co-authored-by: Hans Zeller <hzeller@pivotal.io>

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`