### PR TITLE
Remove XLogLocationToString*() and guc Debug_print_qd_mirroring.

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -8019,23 +8019,8 @@ heap_xlog_delete(XLogRecPtr lsn, XLogRecord *record)
 		return;
 	page = (Page) BufferGetPage(buffer);
 
-	if (Debug_print_qd_mirroring)
-	{
-		XLogRecPtr pagelsn = PageGetLSN(page);
-		elog(LOG, "heap_xlog_delete: page lsn = (%X,%X)",
-			 (uint32) (pagelsn >> 32), (uint32) pagelsn);
-	}
-
 	if (lsn <= PageGetLSN(page))	/* changes are applied */
 	{
-		if (Debug_print_qd_mirroring)
-		{
-			XLogRecPtr pagelsn = PageGetLSN(page);
-			elog(LOG, "delete already appplied: lsn (%X,%X), page (%X,%X)",
-				 (uint32) (lsn >> 32), (uint32) lsn,
-				 (uint32) (pagelsn >> 32), (uint32) pagelsn);
-		}
-
 		UnlockReleaseBuffer(buffer);
 		return;
 	}
@@ -8130,13 +8115,6 @@ heap_xlog_insert(XLogRecPtr lsn, XLogRecord *record)
 
 		if (lsn <= PageGetLSN(page))	/* changes are applied */
 		{
-			if (Debug_print_qd_mirroring)
-			{
-				XLogRecPtr pagelsn = PageGetLSN(page);
-				elog(LOG, "insert already appplied: lsn (%X,%X), page (%X,%X)",
-					 (uint32) (lsn >> 32), (uint32) lsn,
-					 (uint32) (pagelsn >> 32), (uint32) pagelsn);
-			}
 			UnlockReleaseBuffer(buffer);
 			return;
 		}

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7228,8 +7228,8 @@ StartupXLOG(void)
 	EndOfLog = EndRecPtr;
 	XLByteToPrevSeg(EndOfLog, endLogSegNo);
 
-	elog(LOG,"end of transaction log location is %s",
-		 XLogLocationToString(EndOfLog));
+	elog(LOG,"end of transaction log location is %X/%X",
+		 (uint32) (EndOfLog >> 32), (uint32) EndOfLog);
 
 	/*
 	 * Complain if we did not roll forward far enough to render the backup
@@ -7924,18 +7924,18 @@ ReadCheckpointRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 		{
 			case 1:
 				ereport(LOG,
-						(errmsg("invalid primary checkpoint record at location %s",
-						        XLogLocationToString_Long(RecPtr))));
+						(errmsg("invalid primary checkpoint record at location %X/%X",
+								(uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 			case 2:
 				ereport(LOG,
-						(errmsg("invalid secondary checkpoint record at location %s",
-						        XLogLocationToString_Long(RecPtr))));
+						(errmsg("invalid secondary checkpoint record at location %X/%X",
+								(uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 			default:
 				ereport(LOG,
-						(errmsg("invalid checkpoint record at location %s",
-						        XLogLocationToString_Long(RecPtr))));
+						(errmsg("invalid checkpoint record at location %X/%X",
+								(uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 		}
 		return NULL;
@@ -7946,18 +7946,18 @@ ReadCheckpointRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 		{
 			case 1:
 				ereport(LOG,
-						(errmsg("invalid resource manager ID in primary checkpoint record at location %s",
-						        XLogLocationToString_Long(RecPtr))));
+						(errmsg("invalid resource manager ID in primary checkpoint record at location %X/%X",
+								(uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 			case 2:
 				ereport(LOG,
-						(errmsg("invalid resource manager ID in secondary checkpoint record at location %s",
-						        XLogLocationToString_Long(RecPtr))));
+						(errmsg("invalid resource manager ID in secondary checkpoint record at location %X/%X",
+								(uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 			default:
 				ereport(LOG,
-				(errmsg("invalid resource manager ID in checkpoint record at location %s",
-				        XLogLocationToString_Long(RecPtr))));
+				(errmsg("invalid resource manager ID in checkpoint record at location %X/%X",
+						(uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 		}
 		return NULL;
@@ -7969,18 +7969,18 @@ ReadCheckpointRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 		{
 			case 1:
 				ereport(LOG,
-				   (errmsg("invalid xl_info in primary checkpoint record at location %s",
-				           XLogLocationToString_Long(RecPtr))));
+				   (errmsg("invalid xl_info in primary checkpoint record at location %X/%X",
+						   (uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 			case 2:
 				ereport(LOG,
-				 (errmsg("invalid xl_info in secondary checkpoint record at location %s",
-				         XLogLocationToString_Long(RecPtr))));
+				 (errmsg("invalid xl_info in secondary checkpoint record at location %X/%X",
+						 (uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 			default:
 				ereport(LOG,
-						(errmsg("invalid xl_info in checkpoint record at location %s",
-						        XLogLocationToString_Long(RecPtr))));
+						(errmsg("invalid xl_info in checkpoint record at location %X/%X",
+								(uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 		}
 		return NULL;
@@ -8010,18 +8010,18 @@ ReadCheckpointRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 		{
 			case 1:
 				ereport(LOG,
-					(errmsg("invalid length of primary checkpoint at location %s",
-					        XLogLocationToString_Long(RecPtr))));
+					(errmsg("invalid length of primary checkpoint at location %X/%X",
+							(uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 			case 2:
 				ereport(LOG,
-				  (errmsg("invalid length of secondary checkpoint record at location %s",
-				          XLogLocationToString_Long(RecPtr))));
+				  (errmsg("invalid length of secondary checkpoint record at location %X/%X",
+						  (uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 			default:
 				ereport(LOG,
-						(errmsg("invalid length of checkpoint record at location %s",
-						        XLogLocationToString_Long(RecPtr))));
+						(errmsg("invalid length of checkpoint record at location %X/%X",
+								(uint32) (RecPtr >> 32), (uint32) RecPtr)));
 				break;
 		}
 		return NULL;
@@ -9171,10 +9171,6 @@ CreateRestartPoint(int flags)
 		UpdateControlFile();
 	}
 	LWLockRelease(ControlFileLock);
-
-	elog((Debug_print_qd_mirroring ? LOG : DEBUG1), "RecoveryRestartPoint: checkpoint copy redo location %s, previous checkpoint location %s",
-		 XLogLocationToString(ControlFile->checkPointCopy.redo),
-		 XLogLocationToString(ControlFile->prevCheckPoint));
 
 	/*
 	 * Due to an historical accident multixact truncations are not WAL-logged,
@@ -11163,93 +11159,6 @@ CancelBackup(void)
 				 errdetail("Could not rename \"%s\" to \"%s\": %m.",
 						   BACKUP_LABEL_FILE, BACKUP_LABEL_OLD)));
 	}
-}
-
-static char *
-XLogLocationToBuffer(char *buffer, XLogRecPtr loc, bool longFormat)
-{
-
-	if (longFormat)
-	{
-		uint64 seg = loc / XLogSegSize;
-		uint32 offset = loc % XLogSegSize;
-		sprintf(buffer,
-			    "%X/%X (==> seg " UINT64_FORMAT ", offset 0x%X)",
-			    (uint32) (loc >> 32), (uint32) loc,
-			    seg, offset);
-	}
-	else
-		sprintf(buffer,
-			    "%X/%X",
-			    (uint32) (loc >> 32), (uint32) loc);
-
-	return buffer;
-}
-
-static char xlogLocationBuffer[50];
-static char xlogLocationBuffer2[50];
-static char xlogLocationBuffer3[50];
-static char xlogLocationBuffer4[50];
-static char xlogLocationBuffer5[50];
-
-char *
-XLogLocationToString(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer, loc, Debug_print_qd_mirroring);
-}
-
-char *
-XLogLocationToString2(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer2, loc, Debug_print_qd_mirroring);
-}
-
-char *
-XLogLocationToString3(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer3, loc, Debug_print_qd_mirroring);
-}
-
-char *
-XLogLocationToString4(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer4, loc, Debug_print_qd_mirroring);
-}
-
-char *
-XLogLocationToString5(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer5, loc, Debug_print_qd_mirroring);
-}
-
-char *
-XLogLocationToString_Long(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer, loc, true);
-}
-
-char *
-XLogLocationToString2_Long(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer2, loc, true);
-}
-
-char *
-XLogLocationToString3_Long(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer3, loc, true);
-}
-
-char *
-XLogLocationToString4_Long(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer4, loc, true);
-}
-
-char *
-XLogLocationToString5_Long(XLogRecPtr loc)
-{
-	return XLogLocationToBuffer(xlogLocationBuffer5, loc, true);
 }
 
 /*

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -249,12 +249,13 @@ checkIfFailedDueToRecoveryInProgress(fts_segment_info *ftsInfo)
 			ftsInfo->recovery_making_progress = true;
 			ftsInfo->xlogrecptr = tmpptr;
 			elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,
-				 "FTS: detected segment is in recovery mode replayed (%s) (content=%d) "
-				 "primary dbid=%d, mirror dbid=%d",
-				 XLogLocationToString(tmpptr),
-				 ftsInfo->primary_cdbinfo->segindex,
-				 ftsInfo->mirror_cdbinfo->dbid,
-				 ftsInfo->mirror_cdbinfo->dbid);
+				   "FTS: detected segment is in recovery mode replayed (%X/%X) (content=%d) "
+				   "primary dbid=%d, mirror dbid=%d",
+				   (uint32) (tmpptr >> 32),
+				   (uint32) tmpptr,
+				   ftsInfo->primary_cdbinfo->segindex,
+				   ftsInfo->mirror_cdbinfo->dbid,
+				   ftsInfo->mirror_cdbinfo->dbid);
 		}
 	}
 }

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2298,8 +2298,8 @@ retry1:
 						ereport(FATAL,
 								(errcode(ERRCODE_CANNOT_CONNECT_NOW),
 								 errmsg(POSTMASTER_IN_RECOVERY_MSG),
-								 errdetail(POSTMASTER_IN_RECOVERY_DETAIL_MSG " %s",
-										   XLogLocationToString(recptr))));
+								 errdetail(POSTMASTER_IN_RECOVERY_DETAIL_MSG " %X/%X",
+										   (uint32) (recptr >> 32), (uint32) recptr)));
 					}
 #endif
 				}
@@ -2434,8 +2434,8 @@ retry1:
 			ereport(FATAL,
 					(errcode(ERRCODE_CANNOT_CONNECT_NOW),
 					 errmsg(POSTMASTER_IN_RECOVERY_MSG),
-					 errdetail(POSTMASTER_IN_RECOVERY_DETAIL_MSG " %s",
-						   XLogLocationToString(recptr))));
+					 errdetail(POSTMASTER_IN_RECOVERY_DETAIL_MSG " %X/%X",
+						   (uint32) (recptr >> 32), (uint32) recptr)));
 			break;
 		case CAC_TOOMANY:
 			ereport(FATAL,
@@ -2457,8 +2457,8 @@ retry1:
 			ereport(FATAL,
 					(errcode(ERRCODE_MIRROR_READY),
 					 errmsg(POSTMASTER_IN_RECOVERY_MSG),
-					 errdetail(POSTMASTER_IN_RECOVERY_DETAIL_MSG " %s",
-						   XLogLocationToString(recptr))));
+					 errdetail(POSTMASTER_IN_RECOVERY_DETAIL_MSG " %X/%X",
+						   (uint32) (recptr >> 32), (uint32) recptr)));
 			break;
 		case CAC_OK:
 			break;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -105,7 +105,6 @@ char	   *Debug_dtm_action_sql_command_tag;
 
 bool		Debug_print_full_dtm = false;
 bool		Debug_print_snapshot_dtm = false;
-bool		Debug_print_qd_mirroring = false;
 bool		Debug_disable_distributed_snapshot = false;
 bool		Debug_abort_after_distributed_prepared = false;
 bool		Debug_abort_after_segment_prepared = false;
@@ -1276,17 +1275,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Debug_print_snapshot_dtm,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"debug_print_qd_mirroring", PGC_SUSET, LOGGING_WHAT,
-			gettext_noop("Prints QD mirroring information to server log."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_print_qd_mirroring,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -371,16 +371,6 @@ extern XLogRecPtr GetFlushRecPtr(void);
 extern void GetNextXidAndEpoch(TransactionId *xid, uint32 *epoch);
 
 extern void XLogGetRecoveryStart(char *callerStr, char *reasonStr, XLogRecPtr *redoCheckPointLoc, CheckPoint *redoCheckPoint);
-extern char *XLogLocationToString(XLogRecPtr loc);
-extern char *XLogLocationToString2(XLogRecPtr loc);
-extern char *XLogLocationToString3(XLogRecPtr loc);
-extern char *XLogLocationToString4(XLogRecPtr loc);
-extern char *XLogLocationToString5(XLogRecPtr loc);
-extern char *XLogLocationToString_Long(XLogRecPtr loc);
-extern char *XLogLocationToString2_Long(XLogRecPtr loc);
-extern char *XLogLocationToString3_Long(XLogRecPtr loc);
-extern char *XLogLocationToString4_Long(XLogRecPtr loc);
-extern char *XLogLocationToString5_Long(XLogRecPtr loc);
 
 extern void HandleStartupProcInterrupts(void);
 extern void StartupProcessMain(void);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -222,7 +222,6 @@ extern bool Debug_pretty_print;
 
 extern bool	Debug_print_full_dtm;
 extern bool	Debug_print_snapshot_dtm;
-extern bool	Debug_print_qd_mirroring;
 extern bool Debug_disable_distributed_snapshot;
 extern bool Debug_abort_after_distributed_prepared;
 extern bool Debug_abort_after_segment_prepared;


### PR DESCRIPTION
Most of the code under guc `Debug_print_qd_mirroring` was deleted when special
code for master mirroring like mmxlog and friends were deleted. Delete the
remaining pieces and the GUC.

Also, we were carrying diff against upstream with XLogLocationToString*()
functions. Many of the variants were unused. The ones which were used can be
easily replaced and avoid need for having static string buffer to construct the
string and then print.

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`