### PR TITLE
Fix split node's flow type.

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -1322,6 +1322,7 @@ jobs:
           uaocs_compaction/threshold
           updatable_views
           update
+          update_gp
           vacuum_full_ao
           vacuum_full_freeze_heap
           vacuum_full_heap

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1522,8 +1522,15 @@ make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan, RangeTblEntr
 	splitupdate->plan.total_cost += (splitupdate->plan.plan_rows * cpu_tuple_cost);
 	splitupdate->plan.plan_width = subplan->plan_width;
 
-	/* We need a motion node above the SplitUpdate, so mark it as strewn */
-	mark_plan_strewn((Plan *) splitupdate, subplan->flow->numsegments);
+	/*
+	 * A redistributed-motion has to be added above	the split node in
+	 * the plan and this can be achieved by marking the split node strew.
+	 * However, if the subplan is an entry, we should not mark it strew.
+	 */
+	if (subplan->flow->locustype != CdbLocusType_Entry)
+		mark_plan_strewn((Plan *) splitupdate, subplan->flow->numsegments);
+	else
+		mark_plan_entry((Plan *) splitupdate);
 
 	mt->action_col_idxes = lappend_int(mt->action_col_idxes, actionColIdx);
 	mt->ctid_col_idxes = lappend_int(mt->ctid_col_idxes, ctidColIdx);

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1524,8 +1524,8 @@ make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan, RangeTblEntr
 
 	/*
 	 * A redistributed-motion has to be added above	the split node in
-	 * the plan and this can be achieved by marking the split node strew.
-	 * However, if the subplan is an entry, we should not mark it strew.
+	 * the plan and this can be achieved by marking the split node strewn.
+	 * However, if the subplan is an entry, we should not mark it strewn.
 	 */
 	if (subplan->flow->locustype != CdbLocusType_Entry)
 		mark_plan_strewn((Plan *) splitupdate, subplan->flow->numsegments);

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -502,13 +502,40 @@ explain update nosplitupdate set a=0 where a=1 and a<1;
  Update on nosplitupdate  (cost=0.00..0.01 rows=1 width=0)
    ->  Result  (cost=0.00..0.01 rows=1 width=0)
          One-Time Filter: false
+ Planning time: 0.271 ms
  Optimizer: legacy query optimizer
-(4 rows)
+(5 rows)
 
+-- test split-update when split-node's flow is entry
+create table tsplit_entry (c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tsplit_entry values (1), (2);
+explain update tsplit_entry set c = s.a from (select count(*) as a from gp_segment_configuration) s;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Update on tsplit_entry  (cost=10000000001.00..10000000003.18 rows=3 width=54)
+   ->  Redistribute Motion 1:3  (slice2)  (cost=10000000001.00..10000000003.18 rows=7 width=54)
+         Hash Key: ((s.a)::integer)
+         ->  Split  (cost=10000000001.00..10000000003.18 rows=7 width=54)
+               ->  Nested Loop  (cost=10000000001.00..10000000003.12 rows=4 width=54)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.06 rows=2 width=14)
+                           ->  Seq Scan on tsplit_entry  (cost=0.00..2.02 rows=1 width=14)
+                     ->  Materialize  (cost=1.00..1.03 rows=1 width=40)
+                           ->  Subquery Scan on s  (cost=1.00..1.02 rows=1 width=40)
+                                 ->  Aggregate  (cost=1.00..1.01 rows=1 width=8)
+                                       ->  Seq Scan on gp_segment_configuration  (cost=0.00..1.00 rows=1 width=0)
+ Planning time: 1.088 ms
+ Optimizer: legacy query optimizer
+(13 rows)
+
+update tsplit_entry set c = s.a from (select count(*) as a from gp_segment_configuration) s;
 -- start_ignore
 drop table r;
 drop table s;
 drop table update_dist;
 drop table ao_table;
 drop table aoco_table;
+drop table nosplitupdate;
+drop table tsplit_entry;
 -- end_ignore

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -511,13 +511,40 @@ explain update nosplitupdate set a=0 where a=1 and a<1;
                            ->  Result  (cost=0.00..0.00 rows=0 width=18)
                                  ->  Result  (cost=0.00..0.00 rows=0 width=18)
                                        One-Time Filter: false
- Optimizer: PQO version 2.70.0
-(9 rows)
+ Planning time: 17.926 ms
+ Optimizer: PQO version 3.16.0
+(10 rows)
 
+-- test split-update when split-node's flow is entry
+create table tsplit_entry (c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tsplit_entry values (1), (2);
+explain update tsplit_entry set c = s.a from (select count(*) as a from gp_segment_configuration) s;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Update on tsplit_entry  (cost=10000000001.00..10000000003.18 rows=3 width=54)
+   ->  Redistribute Motion 1:3  (slice2)  (cost=10000000001.00..10000000003.18 rows=7 width=54)
+         Hash Key: ((s.a)::integer)
+         ->  Split  (cost=10000000001.00..10000000003.18 rows=7 width=54)
+               ->  Nested Loop  (cost=10000000001.00..10000000003.12 rows=4 width=54)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.06 rows=2 width=14)
+                           ->  Seq Scan on tsplit_entry  (cost=0.00..2.02 rows=1 width=14)
+                     ->  Materialize  (cost=1.00..1.03 rows=1 width=40)
+                           ->  Subquery Scan on s  (cost=1.00..1.02 rows=1 width=40)
+                                 ->  Aggregate  (cost=1.00..1.01 rows=1 width=8)
+                                       ->  Seq Scan on gp_segment_configuration  (cost=0.00..1.00 rows=1 width=0)
+ Planning time: 13.063 ms
+ Optimizer: legacy query optimizer
+(13 rows)
+
+update tsplit_entry set c = s.a from (select count(*) as a from gp_segment_configuration) s;
 -- start_ignore
 drop table r;
 drop table s;
 drop table update_dist;
 drop table ao_table;
 drop table aoco_table;
+drop table nosplitupdate;
+drop table tsplit_entry;
 -- end_ignore

--- a/src/test/regress/sql/update_gp.sql
+++ b/src/test/regress/sql/update_gp.sql
@@ -243,6 +243,13 @@ select * from s;
 create table nosplitupdate (a int) distributed by (a);
 explain update nosplitupdate set a=0 where a=1 and a<1;
 
+-- test split-update when split-node's flow is entry
+create table tsplit_entry (c int);
+insert into tsplit_entry values (1), (2);
+
+explain update tsplit_entry set c = s.a from (select count(*) as a from gp_segment_configuration) s;
+update tsplit_entry set c = s.a from (select count(*) as a from gp_segment_configuration) s;
+
 -- start_ignore
 drop table r;
 drop table s;
@@ -250,4 +257,5 @@ drop table update_dist;
 drop table ao_table;
 drop table aoco_table;
 drop table nosplitupdate;
+drop table tsplit_entry;
 -- end_ignore


### PR DESCRIPTION
Split-update is used for update-statement on a hash-distributed
table's hash-columns. A redistributed-motion has to be added above
the split node in the plan and this was achieved by marking the split
node strew. However, if the split node is an entry, we should not
mark it strew.

Co-authored-by: Shujie Zhang <zlv@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- ~[] Document changes~
- ~[] Communicate in the mailing list if needed~
- [x] Pass `make installcheck`