### PR TITLE
Revert "Missmerge of commit from upstream"

### DIFF
--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -50,6 +50,7 @@ static Node *ParseComplexProjection(ParseState *pstate, char *funcname,
 					   Node *first_arg, int location);
 static void unknown_attribute(ParseState *pstate, Node *relref, char *attname,
 				  int location);
+static bool check_pg_get_expr_arg(ParseState *pstate, Node *arg, int netlevelsup);
 
 typedef struct
 {
@@ -656,6 +657,9 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 				state->p_hasDynamicFunction = true;
 		}
 	}
+
+	/* Hack to protect pg_get_expr() against misuse */
+	check_pg_get_expr_args(pstate, funcid, fargs);
 
 	return retval;
 }
@@ -1875,6 +1879,56 @@ checkTableFunctions_walker(Node *node, check_table_func_context *context)
 									  checkTableFunctions_walker, 
 									  (void *) context);
 	}
+}
+
+/*
+ * pg_get_expr() is a system function that exposes the expression
+ * deparsing functionality in ruleutils.c to users. Very handy, but it was
+ * later realized that the functions in ruleutils.c don't check the input
+ * rigorously, assuming it to come from system catalogs and to therefore
+ * be valid. That makes it easy for a user to crash the backend by passing
+ * a maliciously crafted string representation of an expression to
+ * pg_get_expr().
+ *
+ * There's a lot of code in ruleutils.c, so it's not feasible to add
+ * water-proof input checking after the fact. Even if we did it once, it
+ * would need to be taken into account in any future patches too.
+ *
+ * Instead, we restrict pg_rule_expr() to only allow input from system
+ * catalogs. This is a hack, but it's the most robust and easiest
+ * to backpatch way of plugging the vulnerability.
+ *
+ * This is transparent to the typical usage pattern of
+ * "pg_get_expr(systemcolumn, ...)", but will break "pg_get_expr('foo',
+ * ...)", even if 'foo' is a valid expression fetched earlier from a
+ * system catalog. Hopefully there aren't many clients doing that out there.
+ */
+void
+check_pg_get_expr_args(ParseState *pstate, Oid fnoid, List *args)
+{
+	Node	   *arg;
+
+	/* if not being called for pg_get_expr, do nothing */
+	if (fnoid != F_PG_GET_EXPR && fnoid != F_PG_GET_EXPR_EXT)
+		return;
+
+	/* superusers are allowed to call it anyway (dubious) */
+	if (superuser())
+		return;
+
+	/*
+	 * The first argument must be a Var referencing one of the allowed
+	 * system-catalog columns.  It could be a join alias Var or subquery
+	 * reference Var, though, so we need a recursive subroutine to chase
+	 * through those possibilities.
+	 */
+	Assert(list_length(args) > 1);
+	arg = (Node *) linitial(args);
+
+	if (!check_pg_get_expr_arg(pstate, arg, 0))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("argument to pg_get_expr() must come from system catalogs")));
 }
 
 static bool

--- a/src/backend/parser/parse_oper.c
+++ b/src/backend/parser/parse_oper.c
@@ -1076,6 +1076,9 @@ make_scalar_array_op(ParseState *pstate, List *opname,
 
 	ReleaseSysCache(tup);
 
+	/* Hack to protect pg_get_expr() against misuse */
+	check_pg_get_expr_args(pstate, result->opfuncid, args);
+
 	return (Expr *) result;
 }
 
@@ -1147,6 +1150,9 @@ make_op_expr(ParseState *pstate, Operator op,
 	result->opresulttype = rettype;
 	result->opretset = get_func_retset(opform->oprcode);
 	result->args = args;
+
+	/* Hack to protect pg_get_expr() against misuse */
+	check_pg_get_expr_args(pstate, result->opfuncid, args);
 
 	return (Expr *) result;
 }

--- a/src/include/parser/parse_func.h
+++ b/src/include/parser/parse_func.h
@@ -83,6 +83,8 @@ extern Oid LookupFuncNameTypeNames(List *funcname, List *argtypes,
 extern Oid LookupAggNameTypeNames(List *aggname, List *argtypes,
 					   bool noError);
 
+extern void check_pg_get_expr_args(ParseState *pstate, Oid fnoid, List *args);
+
 extern void parseCheckTableFunctions(ParseState *pstate, Query *qry);
 
 #endif   /* PARSE_FUNC_H */

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -3763,7 +3763,7 @@ NOTICE:  CREATE TABLE will create partition "part_expr_test_list_1_prt_p1" for t
 set session authorization part_expr_role;
 -- This should throw a "not allowed" error.
 select pg_get_expr('bogus', 'pg_class'::regclass);
-ERROR:  unrecognized node type: 654 (ruleutils.c:5055)
+ERROR:  argument to pg_get_expr() must come from system catalogs
 -- But this should
 select p.parrelid::regclass, pr.parchildrelid::regclass,
        pg_get_expr(parrangestart, pr.parchildrelid),


### PR DESCRIPTION
Reinstates parser-based check -- our only guard in Greenplum 5 -- against abusing `pg_get_expr` and crashing the backend.

Without the check, a non-superuser can easily crash the backend [1], effectively dropping every active session from the postmaster.

A little time line:

Commit 9b2d6688f8c in Greenplum 6 removes the vestige of `check_pg_get_expr_args`. At that time we've already merged upstream Postgres 9.1, which introduced `pg_node_tree` pseudo type to better prevent misuse against `pg_get_expr` (commit 303696c3b47). In upstream right before the type-based protection, the old kludgey parser-based check was deleted (commit 8ab6a6b4562). Our merge process didn't seem to have nicely replayed the removal (commit 8ab6a6b4562), hence a follow-up (commit 9b2d6688f8c): the old parser-based code effectively becomes dead once the type-based solution is in place.

We've done the right thing in Greenplum, up until that point. We made a judgement and backported the follow-up removal to Greenplum 5 (commit 22d0c207341). This was unfortunate, because the code removed from 5 wasn't dead. This is very subtle and would have gone undetected, except for the silver lining: commit 9b2d6688f8c (and its back-patch to 5.11 commit 22d0c207341) left behind an unused function `check_pg_get_expr_arg`. We stumbled upon the following compiler warning while working on greenplum-db/gpdb#6417:

> parse_func.c:1881:1: warning: function 'check_pg_get_expr_arg' is not needed and will not be emitted [-Wunneeded-internal-declaration]
> check_pg_get_expr_arg(ParseState *pstate, Node *arg, int netlevelsup)
> ^
> 1 warning generated.

Digging around the dead code led us here.

This reverts commit 22d0c207341f458ca6eb3efc25569eadfa0435ec.

References:

[1] R. Lathia "[BUGS] Server crash while trying to read expression using pg_get_expr()" (https://www.postgresql.org/message-id/flat/AANLkTin5yrTo0JUCADaQA6HDrSHFCNWTURm3TACh9Qjo%40mail.gmail.com)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
