### PR TITLE
5X: limit workers in pool in gpsegstart and honor --parallel option in gpstart

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -29,6 +29,9 @@ GPHOME=os.environ.get('GPHOME')
 SEGMENT_TIMEOUT_DEFAULT=600
 SEGMENT_STOP_TIMEOUT_DEFAULT=120
 
+#Maximum allowed number of workers for segstart
+SEGMENT_START_MAX_WORKERS=64
+
 #"Command not found" return code in bash
 COMMAND_NOT_FOUND=127
 

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -29,11 +29,11 @@ GPHOME=os.environ.get('GPHOME')
 SEGMENT_TIMEOUT_DEFAULT=600
 SEGMENT_STOP_TIMEOUT_DEFAULT=120
 
-#Maximum allowed number of workers for segstart
-SEGMENT_START_MAX_WORKERS=64
-
 #"Command not found" return code in bash
 COMMAND_NOT_FOUND=127
+
+#Default size of thread pool for gpstart and gpsegstart
+DEFAULT_GPSTART_NUM_WORKERS=64
 
 def get_postmaster_pid_locally(datadir):
     cmdStr = "ps -ef | grep postgres | grep -v grep | awk '{print $2}' | grep `cat %s/postmaster.pid | head -1` || echo -1" % (datadir)
@@ -777,6 +777,15 @@ class GpSegStartArgs(CmdArgs):
             self.append(data)
         return self
 
+    def set_parallel(self, parallel):
+        """
+        @param parallel - maximum size of a thread pool to start segments
+        """
+        if parallel is not None:
+            self.append("-B")
+            self.append(str(parallel))
+        return self
+
 
 
 class GpSegStartCmd(Command):
@@ -785,7 +794,7 @@ class GpSegStartCmd(Command):
                  timeout=SEGMENT_TIMEOUT_DEFAULT, verbose=False,
                  ctxt=LOCAL, remoteHost=None, pickledTransitionData=None,
                  specialMode=None, wrapper=None, wrapper_args=None,
-                 logfileDirectory=False):
+                 parallel=None, logfileDirectory=False):
 
         # Referenced by calling code (in operations/startSegments.py), create a clone
         self.dblist = [x for x in segments]
@@ -798,6 +807,7 @@ class GpSegStartCmd(Command):
         c.set_transition(pickledTransitionData)
         c.set_wrapper(wrapper, wrapper_args)
         c.set_segments(segments)
+        c.set_parallel(parallel)
 
         cmdStr = str(c)
         logger.debug(cmdStr)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -994,7 +994,7 @@ class NewGpStop(Command):
 
 #-----------------------------------------------
 class GpStop(Command):
-    def __init__(self, name, masterOnly=False, verbose=False, quiet=False, restart=False, fast=False, force=False, datadir=None, ctxt=LOCAL, remoteHost=None, logfileDirectory=False):
+    def __init__(self, name, masterOnly=False, verbose=False, quiet=False, restart=False, fast=False, force=False, datadir=None, parallel=None, ctxt=LOCAL, remoteHost=None, logfileDirectory=False):
         self.cmdStr="$GPHOME/bin/gpstop -a"
         if masterOnly:
             self.cmdStr += " -m"
@@ -1010,13 +1010,15 @@ class GpStop(Command):
             self.cmdStr += " -v"
         if quiet:
             self.cmdStr += " -q"
+        if parallel:
+            self.cmdStr += " -B %s" % parallel
         if logfileDirectory:
             self.cmdStr += " -l '" + logfileDirectory + "'"
         Command.__init__(self,name,self.cmdStr,ctxt,remoteHost)
 
     @staticmethod
-    def local(name,masterOnly=False, verbose=False, quiet=False,restart=False, fast=False, force=False, datadir=None):
-        cmd=GpStop(name,masterOnly,verbose,quiet,restart,fast,force,datadir)
+    def local(name,masterOnly=False, verbose=False, quiet=False,restart=False, fast=False, force=False, datadir=None, parallel=None):
+        cmd=GpStop(name,masterOnly,verbose,quiet,restart,fast,force,datadir,parallel)
         cmd.run(validateAfter=True)
         return cmd
 

--- a/gpMgmt/bin/gppylib/operations/startSegments.py
+++ b/gpMgmt/bin/gppylib/operations/startSegments.py
@@ -58,7 +58,7 @@ class StartSegmentsResult:
 
     def addFailure(self, segment, reason, reasonCode):
         self.__failedSegments.append(FailedSegmentResult(segment, reason, reasonCode))
-        
+
     def clearSuccessfulSegments(self):
         self.__successfulSegments = []
 
@@ -67,13 +67,13 @@ class StartSegmentsOperation:
        This operation, to be run from the master, will start the segments up
             and, if necessary, convert them to the proper mode
 
-       Note that this can be used to start only a subset of the segments 
+       Note that this can be used to start only a subset of the segments
 
     """
 
     def __init__(self, workerPool, quiet, localeData, gpVersion,
                  gpHome, masterDataDirectory, master_checksum_value=None, timeout=SEGMENT_TIMEOUT_DEFAULT,
-                 specialMode=None, wrapper=None, wrapper_args=None,
+                 specialMode=None, wrapper=None, wrapper_args=None, parallel=gp.DEFAULT_GPSTART_NUM_WORKERS,
                  logfileDirectory=False):
         checkNotNone("workerPool", workerPool)
         self.__workerPool = workerPool
@@ -87,6 +87,7 @@ class StartSegmentsOperation:
         self.__specialMode = specialMode
         self.__wrapper = wrapper
         self.__wrapper_args = wrapper_args
+        self.__parallel = parallel
         self.master_checksum_value = master_checksum_value
         self.logfileDirectory = logfileDirectory
 
@@ -215,6 +216,7 @@ class StartSegmentsOperation:
                                    specialMode=self.__specialMode,
                                    wrapper=self.__wrapper,
                                    wrapper_args=self.__wrapper_args,
+                                   parallel=self.__parallel,
                                    logfileDirectory=self.logfileDirectory)
             self.__workerPool.addCommand(cmd)
             dispatchCount+=1

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpsegstart.py
@@ -15,7 +15,7 @@ class GpSegStartTestCase(unittest.TestCase):
     @patch('gpsegstart.base.WorkerPool')
     def test_check_postmasters_01(self, mk1, mk2, mk3):
         db = '1|1|p|p|s|u|mdw|mdw-1|2000|2001|/data/gpseg-1s||'
-        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None, None)
+        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None, None, None)
         result = gpseg.checkPostmasters(False)
         self.assertTrue(result)
 
@@ -25,7 +25,7 @@ class GpSegStartTestCase(unittest.TestCase):
     @patch('gpsegstart.base.WorkerPool')
     def test_check_postmasters_02(self, mk1, mk2, mk3, mk4):
         db = '1|1|p|p|s|u|mdw|mdw-1|2000|2001|/data/gpseg-1s||'
-        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None, None)
+        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None, None, None)
         result = gpseg.checkPostmasters(False)
         self.assertFalse(result)
 
@@ -35,7 +35,7 @@ class GpSegStartTestCase(unittest.TestCase):
     @patch('gpsegstart.base.WorkerPool')
     def test_check_postmasters_03(self, mk1, mk2, mk3, mk4):
         db = '1|1|p|p|s|u|mdw|mdw-1|2000|2001|/data/gpseg-1s||'
-        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None, None)
+        gpseg = GpSegStart([db], None, 'col1:col2:col3', 'quiescent', None, None, None, None, None, None, None, None, None)
         result = gpseg.checkPostmasters(False)
         self.assertFalse(result)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -79,6 +79,7 @@ class GpStart(GpTestCase):
         self.mock_gp.get_masterdatadir.return_value = 'masterdatadir'
         self.mock_gp.GpCatVersion.local.return_value = 1
         self.mock_gp.GpCatVersionDirectory.local.return_value = 1
+        self.mock_gp.DEFAULT_GPSTART_NUM_WORKERS = gp.DEFAULT_GPSTART_NUM_WORKERS
         sys.argv = ["gpstart"]  # reset to relatively empty args list
 
     def tearDown(self):

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -38,7 +38,6 @@ try:
 except ImportError, e:
     sys.exit('Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
-DEFAULT_NUM_WORKERS = 64
 logger = get_default_logger()
 
 
@@ -49,7 +48,7 @@ class GpStart:
                  wrapper,
                  wrapper_args,
                  skip_standby_check,
-                 parallel=DEFAULT_NUM_WORKERS,
+                 parallel=gp.DEFAULT_GPSTART_NUM_WORKERS,
                  quiet=False,
                  masteronly=False,
                  interactive=False,
@@ -457,7 +456,7 @@ class GpStart:
         # this will eventually start gpsegstart.py
         segmentStartOp = StartSegmentsOperation(self.pool, self.quiet, localeData, self.gpversion,
                                                 self.gphome, self.master_datadir, self.master_checksum_value,
-                                                self.timeout, self.specialMode, self.wrapper, self.wrapper_args,
+                                                self.timeout, self.specialMode, self.wrapper, self.wrapper_args, self.parallel,
                                                 logfileDirectory=self.logfileDirectory)
         segmentStartResult = segmentStartOp.startSegments(self.gparray, segmentsToStart, startMode, self.era)
 
@@ -823,8 +822,8 @@ class GpStart:
                          help='start master instance only in maintenance mode')
         addTo.add_option('-y', '--no_standby', dest="start_standby", action='store_false', default=True,
                          help='do not start master standby server')
-        addTo.add_option('-B', '--parallel', type="int", default=DEFAULT_NUM_WORKERS, metavar="<parallel_processes>",
-                         help='number of segment hosts to run in parallel. Default is %d' % DEFAULT_NUM_WORKERS)
+        addTo.add_option('-B', '--parallel', type="int", default=gp.DEFAULT_GPSTART_NUM_WORKERS, metavar="<parallel_processes>",
+                         help='number of segment hosts to run in parallel. Default is %d' % gp.DEFAULT_GPSTART_NUM_WORKERS)
         addTo.add_option('-R', '--restricted', action='store_true',
                          help='start in restricted mode. Only users with superuser privilege are allowed to connect.')
         addTo.add_option('-t', '--timeout', dest='timeout', default=SEGMENT_TIMEOUT_DEFAULT, type='int',

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -157,6 +157,7 @@ class GpStart:
                             fast=True, quiet=logging_is_quiet(),
                             verbose=logging_is_verbose(),
                             datadir=self.master_datadir,
+                            parallel=self.parallel,
                             logfileDirectory=self.logfileDirectory)
             cmd.run()
             logger.debug("results of forcing master shutdown: %s" % cmd)
@@ -285,7 +286,8 @@ class GpStart:
                 cmd = gp.GpStop("Shutting down master", masterOnly=True,
                                 fast=True, quiet=logging_is_quiet(),
                                 verbose=logging_is_verbose(),
-                                datadir=self.master_datadir)
+                                datadir=self.master_datadir,
+                                parallel=self.parallel)
                 cmd.run(validateAfter=True)
                 logger.info("Master Stopped...")
                 raise ExceptionNoStackTraceNeeded("Standby activated, this node no more can act as master.")
@@ -328,7 +330,7 @@ class GpStart:
         gp.GpStop.local("forcing master shutdown", masterOnly=True,
                         verbose=logging_is_verbose,
                         quiet=self.quiet, fast=False,
-                        force=True, datadir=self.master_datadir)
+                        force=True, datadir=self.master_datadir, parallel=self.parallel)
 
     ######
     def _remove_postmaster_tmpfile(self, port):

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -165,7 +165,7 @@ class GpSegStart:
 
         # initialize state
         #
-        self.pool                  = base.WorkerPool(numWorkers=len(dblist))
+        self.pool                  = base.WorkerPool(numWorkers=min(len(dblist), gp.SEGMENT_START_MAX_WORKERS))
         self.logger                = logger
         self.overall_status        = None
 

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -3,7 +3,7 @@
 # Invalid name  - pylint: disable=C0103
 #
 # Copyright (c) EMC/Greenplum Inc 2011. All Rights Reserved.
-# Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
+# Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
 """
 Internal Use Function.
@@ -29,7 +29,7 @@ Starts a set of one or more segment databases.
 """
 
 HELP = ["""
-Utility should only be used by other GP utilities.  
+Utility should only be used by other GP utilities.
 
 Return codes:
   0 - All segments started successfully
@@ -56,10 +56,10 @@ class StartResult:
         self.started    = started
         self.reason     = reason
         self.reasoncode = reasoncode
-    
+
     def __str__(self):
         return "".join([
-                "STATUS", 
+                "STATUS",
                 "--DIR:", str(self.datadir),
                 "--STARTED:", str(self.started),
                 "--REASONCODE:", str(self.reasoncode),
@@ -75,7 +75,7 @@ class OverallStatus:
     def __init__(self, dblist):
         """
         Build the datadir->segment mapping and remember the original size.
-        Since segments which fail to start will be removed from the mapping, 
+        Since segments which fail to start will be removed from the mapping,
         we later test the size of the map against the original size when
         returning the appropriate status code to the caller.
         """
@@ -132,7 +132,7 @@ class GpSegStart:
 
     def __init__(self, dblist, gpversion, collation, mirroringMode, num_cids, era, 
                  timeout, pickledTransitionData, specialMode, wrapper, wrapper_args,
-                 master_checksum_version, logfileDirectory=False):
+                 master_checksum_version, parallel, logfileDirectory=False):
 
         # validate/store arguments
         #
@@ -165,7 +165,7 @@ class GpSegStart:
 
         # initialize state
         #
-        self.pool                  = base.WorkerPool(numWorkers=min(len(dblist), gp.SEGMENT_START_MAX_WORKERS))
+        self.pool                  = base.WorkerPool(numWorkers=min(len(dblist), parallel))
         self.logger                = logger
         self.overall_status        = None
 
@@ -289,7 +289,7 @@ class GpSegStart:
         # segments would start.
         for datadir, seg in self.overall_status.dirmap.items():
 
-            cmd = gp.SegmentStart("Starting seg at dir %s" % datadir, 
+            cmd = gp.SegmentStart("Starting seg at dir %s" % datadir,
                                   seg,
                                   self.num_cids,
                                   self.era,
@@ -307,7 +307,7 @@ class GpSegStart:
             if res.rc != 0:
 
                 # we should also read in last entries in startup.log here
-                
+
                 datadir    = cmd.segment.getSegmentDataDirectory()
                 msg        = "PG_CTL failed.\nstdout:%s\nstderr:%s\n" % (res.stdout, res.stderr)
                 reasoncode = gp.SEGSTART_ERROR_PG_CTL_FAILED
@@ -407,10 +407,10 @@ class GpSegStart:
 
 
         # ensure segments in a bad state are stopped
-        # 
+        #
         for seg in toStop:
             datadir, port = (seg.getSegmentDataDirectory(), seg.getSegmentPort())
-            
+
             msg = "Stopping segment %s, %s because of failure sending transition" % (datadir, port)
             self.logger.info(msg)
 
@@ -513,8 +513,8 @@ class GpSegStart:
         Logic to start the segments.
         """
 
-        # we initialize an overall status object which maintains a mapping 
-        # from each segment's data directory to the segment object as well 
+        # we initialize an overall status object which maintains a mapping
+        # from each segment's data directory to the segment object as well
         # as a list of specific success/failure results.
         #
         self.overall_status = OverallStatus(self.dblist)
@@ -543,7 +543,7 @@ class GpSegStart:
         self.overall_status.log_results()
         return self.overall_status.exit_code()
 
-    
+
 
     def cleanup(self):
         """
@@ -551,7 +551,7 @@ class GpSegStart:
         """
         if self.pool:
             self.pool.haltWork()
-    
+
 
     @staticmethod
     def createParser():
@@ -587,8 +587,10 @@ class GpSegStart:
         parser.add_option('', '--wrapper', dest="wrapper", default=None, type='string')
         parser.add_option('', '--wrapper-args', dest="wrapper_args", default=None, type='string')
         parser.add_option('', '--master-checksum-version', dest="master_checksum_version", default=None, type='string', action="store")
-        
+        parser.add_option('-B', '--parallel', type="int", dest="parallel", default=gp.DEFAULT_GPSTART_NUM_WORKERS, help='maximum size of a threadpool to start segments')
+
         return parser
+
 
     @staticmethod
     def createProgram(options, args):
@@ -608,9 +610,10 @@ class GpSegStart:
                           options.wrapper,
                           options.wrapper_args,
                           options.master_checksum_version,
+                          options.parallel,
                           logfileDirectory=logfileDirectory)
 
-#------------------------------------------------------------------------- 
+#-------------------------------------------------------------------------
 if __name__ == '__main__':
     mainOptions = { 'setNonuserOnToolLogger':True}
     simple_main( GpSegStart.createParser, GpSegStart.createProgram, mainOptions )


### PR DESCRIPTION
Two backports and a missing tweak to one of them:
- [Limit the number of workers in gpsegstart's pool](https://github.com/greenplum-db/gpdb/issues/6176)
- [Control gpsegstart's thread pool size from gpstart](https://github.com/greenplum-db/gpdb/commit/ee1e6a9fd7be19466a0dce2da2f4feeb391d0b640)
- [Pass gpstart '-B' ('--parallel') option to gpstop](https://github.com/greenplum-db/gpdb/commit/5df940da5186ed05b1e895dba6e3cd7cde79f326)

Test pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/162421891-5x-backport-gpsegstartpy

@skahler-pivotal has "blessed" for merge into 5x
