### PR TITLE
Small GPDB GUC cleanup

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1125,15 +1125,6 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
-		{"stats_queue_level", PGC_SUSET, STATS_COLLECTOR,
-			gettext_noop("Collects resource queue-level statistics on database activity."),
-			NULL
-		},
-		&pgstat_collect_queuelevel,
-		false, NULL, NULL
-	},
-
-	{
 		{"update_process_title", PGC_SUSET, STATS_COLLECTOR,
 			gettext_noop("Updates the process title to show the active SQL command."),
 			gettext_noop("Enables updating of the process title every time a new SQL command is received by the server.")

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3004,6 +3004,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 		check_gp_resource_group_bypass, NULL, NULL
 	},
 
+	{
+		{"stats_queue_level", PGC_SUSET, STATS_COLLECTOR,
+			gettext_noop("Collects resource queue-level statistics on database activity."),
+			NULL
+		},
+		&pgstat_collect_queuelevel,
+		false, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -873,10 +873,6 @@ extern char *pgstat_stat_filename;
 
 extern bool pgstat_collect_queuelevel;
 
-extern int	pgstat_track_functions;
-//extern PGDLLIMPORT int pgstat_track_activity_query_size;
-extern char *pgstat_stat_tmpname;
-extern char *pgstat_stat_filename;
 
 /*
  * BgWriter statistics counters are updated directly by bgwriter and bufmgr


### PR DESCRIPTION
Move GPDB stats_queue_level GUC to guc_gp.c: `stats_queue_level` is a Greenplum added GUC and thus belongs in `guc_gp.c` rather than in `guc.c`, to reduce merge conflicts.

Also remove duplicate GUC definitions introduced in the recent merges.