### PR TITLE
Do not consider outer-join quals for non_eq_clauses from the beginning.

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -149,10 +149,6 @@ gen_implied_qual(PlannerInfo *root,
 	if (subexpression_match((Expr *) new_expr, old_rinfo->clause))
 		return;
 
-	/* No inferences may be performed across an outer join */
-	if (old_rinfo->outer_relids)
-		return;
-
 	/*
 	 * Have we seen this clause before? This is needed to avoid infinite
 	 * recursion.
@@ -228,6 +224,9 @@ gen_implied_quals(PlannerInfo *root, RestrictInfo *rinfo)
 	Expr	   *item1;
 	Expr	   *item2;
 	ListCell   *lcec;
+
+	/* No inferences may be performed across an outer join */
+	Assert(rinfo->outer_relids == NULL);
 
 	if (rinfo->pseudoconstant)
 		return;

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -1808,8 +1808,10 @@ distribute_qual_to_rels(PlannerInfo *root, Node *clause,
 	 * derive other clauses from this, though, so remember this qual for later.
 	 * (We cannot do predicate propagation yet, because we haven't built all
 	 * the equivalence classes yet.)
+	 * We do not consider it if it is an outer-join qual.
 	 */
-	root->non_eq_clauses = lappend(root->non_eq_clauses, restrictinfo);
+	if (outerjoin_nonnullable == NULL)
+		root->non_eq_clauses = lappend(root->non_eq_clauses, restrictinfo);
 }
 
 /*


### PR DESCRIPTION
Currently we conduct non-equivalent class deduction only from quals of
inner join. This patch avoids adding outer join quals to non_eq_clauses
from the beginning.

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`