### PR TITLE
pg_dump: set correct numsegments for relations

### DIFF
--- a/contrib/pg_upgrade/check_gp.c
+++ b/contrib/pg_upgrade/check_gp.c
@@ -16,6 +16,7 @@
 
 #include "pg_upgrade.h"
 
+static void check_online_expansion(void);
 static void check_external_partition(void);
 static void check_covering_aoindex(void);
 static void check_partition_indexes(void);
@@ -32,10 +33,91 @@ static void check_orphaned_toastrels(void);
 void
 check_greenplum(void)
 {
+	check_online_expansion();
 	check_external_partition();
 	check_covering_aoindex();
 	check_partition_indexes();
 	check_orphaned_toastrels();
+}
+
+/*
+ *	check_online_expansion
+ *
+ *	Check for online expansion status and refuse the upgrade if online
+ *	expansion is in progress.
+ */
+static void
+check_online_expansion(void)
+{
+	bool		expansion = false;
+	int			dbnum;
+
+	/*
+	 * Only need to check cluster expansion status in gpdb6 or later.
+	 */
+	if (GET_MAJOR_VERSION(old_cluster.major_version) < 804)
+		return;
+
+	/*
+	 * We only need to check the cluster expansion status on master.
+	 * In the other hand the status can not be detected correctly on segments.
+	 */
+	if (user_opts.segment_mode == SEGMENT)
+		return;
+
+	prep_status("Checking for online expansion status");
+
+	/*
+	 * There are many ways to know online expansion progress:
+	 *
+	 * 1. check for existance of $MASTER_DATA_DIRECTORY/gpexpand.status;
+	 * 2. check for existance of helper schema, 'gpexpand' by default;
+	 * 3. check for existance of partially distributed tables;
+	 *
+	 * Here we use approach 3, the shortcoming of it is that there is no index
+	 * on gp_distribution_policy.numsegments so the performance may be bad when
+	 * there are large amount of tables and all fully distributed.
+	 *
+	 * FIXME: We will provide a new UDF to check the status of cluster expansion,
+	 * once that is ready we could replace below detection with query to that UDF.
+	 */
+
+	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		int			ntups;
+		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	   *conn;
+
+		conn = connectToServer(&old_cluster, active_db->db_name);
+		res = executeQueryOrDie(conn,
+								"SELECT true AS expansion "
+								"FROM gp_distribution_policy d "
+								"JOIN gp_toolkit.__gp_number_of_segments n "
+								"ON d.numsegments <> n.numsegments "
+								"LIMIT 1;");
+
+		ntups = PQntuples(res);
+
+		if (ntups > 0)
+			expansion = true;
+
+		PQclear(res);
+		PQfinish(conn);
+
+		if (expansion)
+			break;
+	}
+
+	if (expansion)
+	{
+		pg_log(PG_REPORT, "fatal\n");
+		pg_log(PG_FATAL,
+			   "| Your installation is in progress of online expansion,\n"
+			   "| must complete that job before the upgrade.\n\n");
+	}
+	else
+		check_ok();
 }
 
 /*

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16940,17 +16940,20 @@ addDistributedBy(Archive *fout, PQExpBuffer q, TableInfo *tbinfo, int actual_att
 static void
 updateNumsegments(Archive *fout, PQExpBuffer q, TableInfo *tbinfo)
 {
+	char * relname = NULL;
+
 	if (!isGPDB6000OrLater(fout) ||
 		!binary_upgrade ||
 		tbinfo->numsegments <= 0)
 		return;
 
+	relname = pg_strdup(fmtQualifiedDumpable(tbinfo));
 	appendPQExpBuffer(q,
 					  "UPDATE gp_distribution_policy\n"
 					  "   SET numsegments = %d\n"
-					  " WHERE localoid = '%s'::regclass;\n",
+					  " WHERE localoid = '%s'::pg_catalog.regclass;\n",
 					  tbinfo->numsegments,
-					  tbinfo->dobj.name);
+					  relname);
 
 	/*
 	 * All the sub-partition table's numsegments need to be updated.
@@ -17000,6 +17003,8 @@ updateNumsegments(Archive *fout, PQExpBuffer q, TableInfo *tbinfo)
 		PQclear(partres);
 		destroyPQExpBuffer(partquery);
 	}
+
+	pfree(relname);
 }
 
 /*

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -347,6 +347,11 @@ typedef struct _tableInfo
 	bool		parparent;		/* true if the table is partition parent */
 	int			numTriggers;	/* number of triggers for table */
 	struct _triggerInfo *triggers;		/* array of TriggerInfo structs */
+
+	/*
+	 * GPDB specific attributes
+	 */
+	int			numsegments;	/* data distribution segments, used by binary_upgrade */
 } TableInfo;
 
 typedef struct _attrDefInfo

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -584,3 +584,8 @@ rollback;
 -- to perform distributed commit on the other segments.
 --
 insert into r1 (c4) values (pg_relation_size('r2'));
+
+-- start_ignore
+reset search_path;
+drop schema test_partial_table cascade;
+-- end_ignore


### PR DESCRIPTION
pg_dump dump relations as CREATE commands, however the internal
numsegments property cannot be specified in CREATE commands, their
values are decided on execution from the cluster size, however as a
utility mode master is used to restore the tables the invalid cluster
size is used as numsegments for all the tables.

To fix the issue we generate an UPDATE gp_distribution_policy command
after each CREATE command to correct the numsegments property, so no
matter there are partially distributed tables or not they can always be
correctly restored.

A new UDF which is used to check expansion status is provided,
for more details please refer the commit message.

## Background
Previous discussion can be found in https://github.com/greenplum-db/gpdb/pull/6326 and https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/Jfbj3DQgn0w/SKwo3PYaBQAJ, this PR is to fix the issue in binary upgrade.  The check of expansion status will be in a separate PR, but we also have included a temporary one in this PR, once that PR is ready we could replace the temporary one with it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
