### PR TITLE
Fix ZSTD context leak on error.

### DIFF
--- a/gpcontrib/zstd/Makefile
+++ b/gpcontrib/zstd/Makefile
@@ -5,7 +5,7 @@ OBJS = zstd_compression.o
 CFLAGS_SL += -lzstd
 LDFLAGS_SL += -lzstd
 
-REGRESS = compression_zstd
+REGRESS = compression_zstd zstd_abort_leak
 
 ifdef USE_PGXS
   PGXS := $(shell pg_config --pgxs)

--- a/gpcontrib/zstd/expected/zstd_abort_leak.out
+++ b/gpcontrib/zstd/expected/zstd_abort_leak.out
@@ -1,0 +1,47 @@
+--
+-- Test abort handling.
+--
+CREATE TABLE zstd_leak_test (distkey int4, id int4, t text)
+WITH (appendonly=true, compresstype=zstd, orientation=column) DISTRIBUTED BY (distkey);
+create function errfunc(int) returns int4 as
+$$
+begin
+  if $1 >= 10 then
+    -- raise division by zero
+    return 1 / 0;
+  end if;
+  return $1;
+end;
+$$ language plpgsql immutable;
+create table foo (x int) distributed by (x);
+insert into foo select generate_series(1, 10);
+-- The insert command in the loop errors out, after starting to insert to the
+-- AO table and initializing the compressor. Repeat many times, so that if
+-- there is a leak on abort, it would become noticeable.
+--
+-- If the ZSTD buffers are leaked, the leak isn't that large, so with a decent
+-- amount of RAM, this still won't error out. But the excessive memory usage
+-- should be visible in 'top', at least, if you look for it.
+create function zstd_error_test(n int) returns int as
+$$
+declare
+  i int;
+  nerr int;
+begin
+  nerr := 0;
+  for i in 1..n loop
+    begin
+      insert into zstd_leak_test select x, errfunc(x) from foo;
+    exception
+      when division_by_zero then nerr := nerr + 1;
+    end;
+  end loop;
+  return nerr;
+end;
+$$ language plpgsql;
+select zstd_error_test(10000);
+ zstd_error_test 
+-----------------
+           10000
+(1 row)
+

--- a/gpcontrib/zstd/sql/zstd_abort_leak.sql
+++ b/gpcontrib/zstd/sql/zstd_abort_leak.sql
@@ -1,0 +1,47 @@
+--
+-- Test abort handling.
+--
+
+CREATE TABLE zstd_leak_test (distkey int4, id int4, t text)
+WITH (appendonly=true, compresstype=zstd, orientation=column) DISTRIBUTED BY (distkey);
+
+create function errfunc(int) returns int4 as
+$$
+begin
+  if $1 >= 10 then
+    -- raise division by zero
+    return 1 / 0;
+  end if;
+  return $1;
+end;
+$$ language plpgsql immutable;
+
+create table foo (x int) distributed by (x);
+insert into foo select generate_series(1, 10);
+
+-- The insert command in the loop errors out, after starting to insert to the
+-- AO table and initializing the compressor. Repeat many times, so that if
+-- there is a leak on abort, it would become noticeable.
+--
+-- If the ZSTD buffers are leaked, the leak isn't that large, so with a decent
+-- amount of RAM, this still won't error out. But the excessive memory usage
+-- should be visible in 'top', at least, if you look for it.
+create function zstd_error_test(n int) returns int as
+$$
+declare
+  i int;
+  nerr int;
+begin
+  nerr := 0;
+  for i in 1..n loop
+    begin
+      insert into zstd_leak_test select x, errfunc(x) from foo;
+    exception
+      when division_by_zero then nerr := nerr + 1;
+    end;
+  end loop;
+  return nerr;
+end;
+$$ language plpgsql;
+
+select zstd_error_test(10000);

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -14,7 +14,10 @@
  */
 
 #include "postgres.h"
-#include "fmgr.h"
+
+#ifdef HAVE_LIBZ
+#include <zlib.h>
+#endif
 
 #include "access/genam.h"
 #include "access/reloptions.h"
@@ -26,6 +29,7 @@
 #include "catalog/dependency.h"
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbappendonlystoragelayer.h"
+#include "fmgr.h"
 #include "nodes/makefuncs.h"
 #include "parser/parse_type.h"
 #include "storage/gp_compress.h"

--- a/src/include/storage/gp_compress.h
+++ b/src/include/storage/gp_compress.h
@@ -16,13 +16,16 @@
 #ifndef GP_COMPRESS_H
 #define GP_COMPRESS_H
 
+#ifdef HAVE_LIBZSTD
+#include "zstd.h"
+#endif
+
 #include "fmgr.h"
 
 #include "catalog/pg_compression.h"
+#include "lib/ilist.h"
+#include "utils/resowner.h"
 
-#ifdef HAVE_LIBZ
-#include <zlib.h>
-#endif
 
 extern void gp_trycompress(
 		 uint8			*sourceData,
@@ -42,5 +45,39 @@ extern void gp_decompress(
 		PGFunction decompressor,
 		CompressionState *compressionState,
 		int64 bufferCount);
+
+/*
+ * We use ZStandard compression in a few different places. These functions
+ * provide support for tracking ZSTD compression/decompression contexts
+ * with ResourceOwners, so that they are not leaked on abort.
+ *
+ * To use:
+ *
+ * zstd_context *ctx = call zstd_alloc_context();
+ * ctx->cctx = ZSTD_createCCtx();
+ *
+ * <use the context using normal ZSTD functions>
+ *
+ * zsd_free_context(ctx);
+ *
+ * If the transaction is aborted, the handle will be automatically closed,
+ * when the resource owner is destroyed.
+ */
+#ifdef HAVE_LIBZSTD
+
+typedef struct
+{
+	ZSTD_CCtx  *cctx;
+	ZSTD_DCtx  *dctx;
+
+	ResourceOwner owner;
+	dlist_node	node;
+} zstd_context;
+
+extern void zstd_free_context(zstd_context *context);
+extern zstd_context *zstd_alloc_context(void);
+
+#endif	/* HAVE_LIBZSTD */
+
 
 #endif

--- a/src/test/regress/checkinc.py
+++ b/src/test/regress/checkinc.py
@@ -85,7 +85,8 @@ fileset = {
     # snowball/libstemmer/header.h includes "api.h", without specifying
     # a path. Don't be alarmed by that.
     'api.h':                 [],
-    'valgrind/memcheck.h':   []
+    'valgrind/memcheck.h':   [],
+    'zstd.h':                []
 }
 
 


### PR DESCRIPTION
Track ZSTD handles with resource owners, so that they can be closed on
abort.
