### PR TITLE
Pass gpstart '-B' ('--parallel') option to gpstop

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -784,7 +784,7 @@ class NewGpStop(Command):
 
 #-----------------------------------------------
 class GpStop(Command):
-    def __init__(self, name, masterOnly=False, verbose=False, quiet=False, restart=False, fast=False, force=False, datadir=None, ctxt=LOCAL, remoteHost=None, logfileDirectory=False, reload=False):
+    def __init__(self, name, masterOnly=False, verbose=False, quiet=False, restart=False, fast=False, force=False, datadir=None, parallel=None, reload=False, ctxt=LOCAL, remoteHost=None, logfileDirectory=False):
         self.cmdStr="$GPHOME/bin/gpstop -a"
         if masterOnly:
             self.cmdStr += " -m"
@@ -800,6 +800,8 @@ class GpStop(Command):
             self.cmdStr += " -v"
         if quiet:
             self.cmdStr += " -q"
+        if parallel:
+            self.cmdStr += " -B %s" % parallel
         if logfileDirectory:
             self.cmdStr += " -l '" + logfileDirectory + "'"
         if reload:
@@ -807,8 +809,8 @@ class GpStop(Command):
         Command.__init__(self,name,self.cmdStr,ctxt,remoteHost)
 
     @staticmethod
-    def local(name,masterOnly=False, verbose=False, quiet=False,restart=False, fast=False, force=False, datadir=None, reload=False):
-        cmd=GpStop(name,masterOnly,verbose,quiet,restart,fast,force,datadir,reload=reload)
+    def local(name,masterOnly=False, verbose=False, quiet=False,restart=False, fast=False, force=False, datadir=None, parallel=None, reload=False):
+        cmd=GpStop(name,masterOnly,verbose,quiet,restart,fast,force,datadir,parallel,reload)
         cmd.run(validateAfter=True)
         return cmd
 

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -144,6 +144,7 @@ class GpStart:
                             fast=True, quiet=logging_is_quiet(),
                             verbose=logging_is_verbose(),
                             datadir=self.master_datadir,
+                            parallel=self.parallel,
                             logfileDirectory=self.logfileDirectory)
             cmd.run()
             logger.debug("results of forcing master shutdown: %s" % cmd)
@@ -264,6 +265,7 @@ class GpStart:
                 cmd = gp.GpStop("Shutting down master", masterOnly=True,
                                 fast=True, quiet=logging_is_quiet(),
                                 verbose=logging_is_verbose(),
+                                parallel=self.parallel,
                                 datadir=self.master_datadir)
                 cmd.run(validateAfter=True)
                 logger.info("Master Stopped...")
@@ -307,7 +309,7 @@ class GpStart:
         gp.GpStop.local("forcing master shutdown", masterOnly=True,
                         verbose=logging_is_verbose,
                         quiet=self.quiet, fast=False,
-                        force=True, datadir=self.master_datadir)
+                        force=True, datadir=self.master_datadir, parallel=self.parallel)
 
     ######
     def _remove_postmaster_tmpfile(self, port):


### PR DESCRIPTION
gpstart calls gpstop, so honor the parallel parameter by passing it along to gpstop. This is a tweak or  missing fix to the following two related commits:
- [Control gpsegstart's thread pool size from gpstart](https://github.com/greenplum-db/gpdb/commit/ee1e6a9fd7be19466a0dce2da2f4feeb391d0b640)
- [Limit the number of workers in gpsegstart's pool](https://github.com/greenplum-db/gpdb/issues/6176)

[Test pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb6_gpstart_parallel_fix)
