### PR TITLE
Use mode-specific directory name for pg_rewind tests

### DIFF
--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -38,7 +38,7 @@ PATH=$bindir:$PATH
 export PATH
 
 # Adjust these paths for your environment
-TESTROOT=$PWD/tmp_check
+TESTROOT=$PWD/tmp_check_$TEST_SUITE
 TEST_MASTER=$TESTROOT/data_master
 TEST_STANDBY=$TESTROOT/data_standby
 


### PR DESCRIPTION
The pg_rewind tests are run in two modes: local (copy mode) and remote (libpq mode).  When invoked as "make -C src/bin/pg_rewind installcheck", the same set of tests are run in both the modes.  Each
mode involves initializing two postgres databases under tmp_check subdirectory.  The subsequent mode wipes out the tmp_check directory created for previous mode, resulting in lost evidence when debugging CI failures.  Resolve this by creating tmp_check_local and tmp_check_remote directories for the two modes.
