### PR TITLE
Update continuous-integration to gp-continuous-integration

### DIFF
--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -88,15 +88,15 @@ fly -t gpdb-prod \
     set-pipeline \
     -p gpdb_master \
     -c gpdb_master-generated.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.yml
 
 fly -t gpdb-prod \
     set-pipeline \
     -p gpdb_master_without_asserts \
     -c gpdb_master-generated.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_master_without_asserts-ci-secrets.yml
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master_without_asserts-ci-secrets.yml
 ```
 
 The generated pipeline file `gpdb_master-generated.yml` will be set,
@@ -134,9 +134,9 @@ fly -t gpdb-dev \
     set-pipeline \
     -p gpdb-dpm-curry \
     -c gpdb-dpm-curry.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.dev.yml \
-    -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.dev.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \
     -v gpdb-git-remote=<https://github.com/<github-user>/gpdb> \
     -v gpdb-git-branch=<branch-name>
 ```
@@ -162,9 +162,9 @@ fly -t gpdb-dev \
     set-pipeline \
     -p gpdb-cs-durant \
     -c gpdb-cs-durant.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.dev.yml \
-    -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.dev.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \
     -v gpdb-git-remote=<https://github.com/<github-user>/gpdb> \
     -v gpdb-git-branch=<branch-name>
 ```

--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -167,23 +167,23 @@ def how_to_use_generated_pipeline_message():
         msg += '    set-pipeline \\\n'
         msg += '    -p gpdb_master \\\n'
         msg += '    -c %s \\\n' % ARGS.output_filepath
-        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
-        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml\n\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.yml\n\n'
         msg += 'fly -t gpdb-prod \\\n'
         msg += '    set-pipeline \\\n'
         msg += '    -p gpdb_master_without_asserts \\\n'
         msg += '    -c %s \\\n' % ARGS.output_filepath
-        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
-        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_master_without_asserts-ci-secrets.yml\n' # pylint: disable=line-too-long
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master_without_asserts-ci-secrets.yml\n' # pylint: disable=line-too-long
     else:
         msg += 'NOTE: You can set the developer pipeline with the following:\n\n'
         msg += 'fly -t gpdb-dev \\\n'
         msg += '    set-pipeline \\\n'
         msg += '    -p %s \\\n' % os.path.basename(ARGS.output_filepath).rsplit('.', 1)[0]
         msg += '    -c %s \\\n' % ARGS.output_filepath
-        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
-        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.dev.yml \\\n'
-        msg += '    -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \\\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.dev.yml \\\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \\\n'
         msg += '    -v gpdb-git-remote=%s \\\n' % suggested_git_remote()
         msg += '    -v gpdb-git-branch=%s \n' % suggested_git_branch()
 


### PR DESCRIPTION
The repo name was changed after the github migration. The previous paths
will not work correctly for new clones of the repository.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>