### PR TITLE
Remove support for parquet relstorage

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2277,21 +2277,6 @@ gpdb::HasSubclassSlow
 }
 
 
-bool
-gpdb::HasParquetChildren
-	(
-	Oid rel_oid
-	)
-{
-	GP_WRAP_START;
-	{
-		/* catalog tables: pg_inherits, pg_class */
-		return has_parquet_children(rel_oid);
-	}
-	GP_WRAP_END;
-	return false;
-}
-
 GpPolicy *
 gpdb::GetDistributionPolicy
 	(

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -632,15 +632,6 @@ CTranslatorRelcacheToDXL::RetrieveRel
 		}
 		is_partitioned = (NULL != part_keys && 0 < part_keys->Size());
 
-		if (is_partitioned && IMDRelation::ErelstorageAppendOnlyParquet != rel_storage_type && IMDRelation::ErelstorageExternal != rel_storage_type)
-		{
-			// mark relation as Parquet if one of its children is parquet
-			if (gpdb::HasParquetChildren(oid))
-			{
-				rel_storage_type = IMDRelation::ErelstorageAppendOnlyParquet;
-			}
-		}
-
 		// get number of leaf partitions
 		if (gpdb::RelPartIsRoot(oid))
 		{

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -4152,35 +4152,6 @@ get_index_opfamilies(Oid oidIndex)
 }
 
 /*
- *  has_parquet_children
- *  Check if relation has a Parquet child relation
- */
-bool
-has_parquet_children(Oid relationId)
-{
-	Assert(InvalidOid != relationId);
-	List *child_oids = find_all_inheritors(relationId, NoLock, NULL);
-	ListCell *lc;
-	
-	foreach (lc, child_oids)
-	{
-		Oid oidChild = lfirst_oid(lc);
-		Relation rel = RelationIdGetRelation(oidChild);
-		Assert(NULL != rel);
-		if (RELSTORAGE_PARQUET == rel->rd_rel->relstorage)
-		{
-			list_free(child_oids);
-			RelationClose(rel);
-			return true;
-		}
-
-		RelationClose(rel);
-	}
-	list_free(child_oids);
-	return false;
-}
-
-/*
  *  relation_policy
  *  Return the distribution policy of a table. 
  */

--- a/src/include/catalog/pg_class.h
+++ b/src/include/catalog/pg_class.h
@@ -200,8 +200,6 @@ DESCR("");
  * RELSTORAGE_HEAP    - stored on disk using heap storage.
  * RELSTORAGE_AOROWS  - stored on disk using append only storage.
  * RELSTORAGE_AOCOLS  - stored on dist using append only column storage.
- * RELSTORAGE_PARQUET - nested data structures in a flat columnar format,
- * 						stored in any Hadoop ecosystem like Hive, Impala, Pig, and Spark.
  * RELSTORAGE_VIRTUAL - has virtual storage, meaning, relation has no
  *						data directly stored forit  (right now this
  *						relates to views and comp types).
@@ -211,7 +209,6 @@ DESCR("");
 #define		  RELSTORAGE_HEAP	'h'
 #define		  RELSTORAGE_AOROWS	'a'
 #define 	  RELSTORAGE_AOCOLS	'c'
-#define		  RELSTORAGE_PARQUET 'p'
 #define		  RELSTORAGE_VIRTUAL	'v'
 #define		  RELSTORAGE_EXTERNAL 'x'
 #define		  RELSTORAGE_FOREIGN 'f'

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -491,9 +491,6 @@ namespace gpdb {
 	// check whether a relation is inherited
 	bool HasSubclassSlow(Oid rel_oid);
 
-    // check whether a relation has parquet children
-    bool HasParquetChildren(Oid rel_oid);
-    
     // return the distribution policy of a relation; if the table is partitioned
     // and the parts are distributed differently, return Random distribution
     GpPolicy *GetDistributionPolicy(Relation rel);

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -223,7 +223,6 @@ extern Node *get_check_constraint_expr_tree(Oid oidCheckconstraint);
 Oid get_check_constraint_relid(Oid oidCheckconstraint);
 
 extern bool has_subclass_slow(Oid relationId);
-extern bool has_parquet_children(Oid relationId);
 extern GpPolicy *relation_policy(Relation rel);
 extern bool child_distribution_mismatch(Relation rel);
 extern bool child_triggers(Oid relationId, int32 triggerType);


### PR DESCRIPTION
The parquet relstorage support was, according to the closed ticket
system, added a long time ago in order to reach code parity with
WAWQ. There was never a way to create a relation with relstorage 'p'
and indeed PARQUET external tables in Greenplum use relstorage 'x'
for external. Having dead code around as a compatibility shim with
another database seems quite pointless, and if ORCA actually ever
calls this then that should be fixed rather than having a lookup
which will always fail.

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`