### PR TITLE
Sync float parsing code for complex types with float8in.

### DIFF
--- a/src/backend/utils/adt/complex_type.c
+++ b/src/backend/utils/adt/complex_type.c
@@ -46,112 +46,136 @@
 #define dp_cosh(a) DatumGetFloat8(DirectFunctionCall1(dcosh, Float8GetDatum((a))))
 #define dp_asin(a) DatumGetFloat8(DirectFunctionCall1(dasin, Float8GetDatum((a))))
 
-/* decode a double precision from a cstring */
+/*
+ * decode a double precision from a cstring
+ *
+ * This is copy-pasted from float8in. The difference is that this returns a pointer
+ * to the end of valid float, so that the caller can continue processing.
+ */
 static double
-complex_decode_double(char **num)
+complex_decode_double(char **num_p)
 {
+	char	   *num = *num_p;
+	char	   *orig_num;
+	double		val;
+	char	   *endptr;
+
 	/*
-	 * orig_num points to the original beginning address that we try to decode.
-	 * end_ptr points to the first character after the sequence we recognized
-	 * as a valid floating point number. ptr_iter points to the next character
-	 * need to be decoded
+	 * endptr points to the first character _after_ the sequence we recognized
+	 * as a valid floating point number. orig_num points to the original input
+	 * string.
 	 */
-	char	   *orig_num = *num;
-	char	   *ptr_iter = *num;
-	char	   *end_ptr = *num;
-	double		val = 0;
+	orig_num = num;
 
-	if ('\0' == *ptr_iter)
-	{
-		ereport(ERROR, (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-			errmsg("invalid input syntax for type double: \"%s\"", orig_num)));
-	}
+	/* skip leading whitespace */
+	while (*num != '\0' && isspace((unsigned char) *num))
+		num++;
 
-	/* skip leading whitespaces */
-	while (*ptr_iter != '\0' && isspace((unsigned char) *ptr_iter))
-	{
-		ptr_iter++;
-	}
+	/*
+	 * Check for an empty-string input to begin with, to avoid the vagaries of
+	 * strtod() on different platforms.
+	 */
+	if (*num == '\0')
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+			 errmsg("invalid input syntax for type complex: \"%s\"",
+					orig_num)));
 
 	errno = 0;
-	val = strtod(ptr_iter, &end_ptr);
-	if (end_ptr == ptr_iter || 0 != errno)
+	val = strtod(num, &endptr);
+
+	/* did we not see anything that looks like a double? */
+	if (endptr == num || errno != 0)
 	{
+		int			save_errno = errno;
+
 		/*
-		 * C99 requires that strtod accept NaN and [-]Infinity, but not all platforms
-		 * support that yet (and some accept them but set ERANGE anyway...). Therefore,
-		 * we check for these inputs ourselves.
+		 * C99 requires that strtod() accept NaN, [+-]Infinity, and [+-]Inf,
+		 * but not all platforms support all of these (and some accept them
+		 * but set ERANGE anyway...)  Therefore, we check for these inputs
+		 * ourselves if strtod() fails.
+		 *
+		 * Note: C99 also requires hexadecimal input as well as some extended
+		 * forms of NaN, but we consider these forms unportable and don't try
+		 * to support them.  You can use 'em if your strtod() takes 'em.
 		 */
-		if (pg_strncasecmp(ptr_iter, "NaN", 3) == 0)
+		if (pg_strncasecmp(num, "NaN", 3) == 0)
 		{
 			val = get_float8_nan();
-			end_ptr += 3;
+			endptr = num + 3;
 		}
-		else if (pg_strncasecmp(ptr_iter, "Infinity", 8) == 0)
+		else if (pg_strncasecmp(num, "Infinity", 8) == 0)
 		{
 			val = get_float8_infinity();
-			end_ptr += 8;
+			endptr = num + 8;
 		}
-		else if (pg_strncasecmp(ptr_iter, "-Infinity", 9) == 0)
+		else if (pg_strncasecmp(num, "+Infinity", 9) == 0)
+		{
+			val = get_float8_infinity();
+			endptr = num + 9;
+		}
+		else if (pg_strncasecmp(num, "-Infinity", 9) == 0)
 		{
 			val = -get_float8_infinity();
-			end_ptr += 9;
+			endptr = num + 9;
 		}
-		else if (ERANGE == errno)
+		else if (pg_strncasecmp(num, "inf", 3) == 0)
 		{
-			ereport(ERROR,
-					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-					 errmsg("\"%s\" is out of range for type double precision", orig_num)));
+			val = get_float8_infinity();
+			endptr = num + 3;
+		}
+		else if (pg_strncasecmp(num, "+inf", 4) == 0)
+		{
+			val = get_float8_infinity();
+			endptr = num + 4;
+		}
+		else if (pg_strncasecmp(num, "-inf", 4) == 0)
+		{
+			val = -get_float8_infinity();
+			endptr = num + 4;
+		}
+		else if (save_errno == ERANGE)
+		{
+			/*
+			 * Some platforms return ERANGE for denormalized numbers (those
+			 * that are not zero, but are too close to zero to have full
+			 * precision).  We'd prefer not to throw error for that, so try to
+			 * detect whether it's a "real" out-of-range condition by checking
+			 * to see if the result is zero or huge.
+			 */
+			if (val == 0.0 || val >= HUGE_VAL || val <= -HUGE_VAL)
+				ereport(ERROR,
+						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+				   errmsg("\"%s\" is out of range for type double precision",
+						  orig_num)));
 		}
 		else
-		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-			errmsg("invalid input syntax for type complex:\"%s\"", orig_num)));
-		}
+			 errmsg("invalid input syntax for type complex: \"%s\"",
+					orig_num)));
 	}
 #ifdef HAVE_BUGGY_SOLARIS_STRTOD
 	else
 	{
 		/*
 		 * Many versions of Solaris have a bug wherein strtod sets endptr to
-		 * point one byte beyond the end of the string when gvin "inf" or
+		 * point one byte beyond the end of the string when given "inf" or
 		 * "infinity".
 		 */
-		if (endptr != ptr_iter && '\0' == endptr[-1])
-		{
-			end_ptr--;
-		}
+		if (endptr != num && endptr[-1] == '\0')
+			endptr--;
 	}
 #endif   /* HAVE_BUGGY_SOLARIS_STRTOD */
 
-#ifdef HAVE_BUGGY_IRIX_STRTOD
-	/*
-	 * In some IRIX versions, strtod() recogonize only "inf", so if the input
-	 * is "Infinity" we have to skip over "inity". Also, it may return positive
-	 * infinity for "-inf".
-	 */
-	if (isinf(val))
-	{
-		if (pg_strncasecmp(ptr_iter, "Infinity", 8) == 0)
-		{
-			val = get_float8_infinity();
-			end_ptr = ptr_iter + 8;
-		}
-		else if (pg_strncasecmp(ptr_iter, "-Infinity", 9) == 0)
-		{
-			val = -get_float8_infinity();
-			end_ptr = ptr_iter + 9;
-		}
-		else if (pg_strncasecmp(ptr_iter, "-inf", 4))
-		{
-			val = -get_float8_infinity();
-			end_ptr = ptr_iter + 4;
-		}
-	}
-#endif   /* HAVE_BUGGY_IRIX_STRTOD */
+	/*** end of float8in ***/
 
-	*num = end_ptr;
+	/*
+	 * Instead of checking for garbage at end of the string, return pointer
+	 * to where we stopped.
+	 */
+
+	*num_p = endptr;
 	return val;
 }
 

--- a/src/test/regress/expected/complex.out
+++ b/src/test/regress/expected/complex.out
@@ -109,15 +109,15 @@ ERROR:  invalid input syntax for type complex: ""
 LINE 1: INSERT INTO complex_ttbl(c) VALUES ('');
                                             ^
 INSERT INTO complex_ttbl(c) VALUES ('    ');
-ERROR:  invalid input syntax for type complex:"    "
+ERROR:  invalid input syntax for type complex: "    "
 LINE 1: INSERT INTO complex_ttbl(c) VALUES ('    ');
                                             ^
 INSERT INTO complex_ttbl(c) VALUES ('xyi');
-ERROR:  invalid input syntax for type complex:"xyi"
+ERROR:  invalid input syntax for type complex: "xyi"
 LINE 1: INSERT INTO complex_ttbl(c) VALUES ('xyi');
                                             ^
 INSERT INTO complex_ttbl(c) VALUES ('i'); 
-ERROR:  invalid input syntax for type complex:"i"
+ERROR:  invalid input syntax for type complex: "i"
 LINE 1: INSERT INTO complex_ttbl(c) VALUES ('i');
                                             ^
 INSERT INTO complex_ttbl(c) VALUES ('5.0.0 + 1i'); 
@@ -129,7 +129,7 @@ ERROR:  invalid input syntax for type complex: "5.0 + 1 i"
 LINE 1: INSERT INTO complex_ttbl(c) VALUES ('5.0 + 1 i');
                                             ^
 INSERT INTO complex_ttbl(c) VALUES ('5.0 + i1');    
-ERROR:  invalid input syntax for type complex:"i1"
+ERROR:  invalid input syntax for type complex: "i1"
 LINE 1: INSERT INTO complex_ttbl(c) VALUES ('5.0 + i1');
                                             ^
 -- re


### PR DESCRIPTION
The 'complex_decode_double' subroutine, used in the input function for the
'complex' datatype, was copy-pasted from float8in, and modified. However,
those modifications broke compilation with HAVE_BUGGY_SOLARIS_STRTOD,
the code inside the #ifdef referenced to non-existent 'endptr' local
variable (it was called 'end_ptr').

To make maintenance of this function easier, copy-paste it verbatim from
float8in, and avoid making any unnecessary changes to it. I don't have
access to Solaris machines, but this should compile on Solaris now.

In the passing, fix a missing space from the error message.

Fixes https://github.com/greenplum-db/gpdb/issues/5879.
