### PR TITLE
Fix insertion into inherited AO tables.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -91,6 +91,7 @@
 #include "utils/faultinjector.h"
 #include "utils/resource_manager.h"
 
+#include "catalog/pg_inherits_fn.h"
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_class.h"
 
@@ -1739,7 +1740,7 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 		{
 			List	   *resultRelations = plannedstmt->resultRelations;
 			int			numResultRelations = list_length(resultRelations);
-			List 	*all_relids = NIL;
+			List	   *all_relids;
 			Oid		 relid = getrelid(linitial_int(plannedstmt->resultRelations), rangeTable);
 
 			if (rel_is_child_partition(relid))
@@ -1752,9 +1753,7 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 			/*
 			 * list all the relids that may take part in this insert operation
 			 */
-			all_relids = lappend_oid(all_relids, relid);
-			all_relids = list_concat(all_relids,
-									 all_partition_relids(estate->es_result_partitions));
+			all_relids = find_all_inheritors(relid, NoLock, NULL);
 
 			/*
 			 * We also assign a segno for a deletion operation.

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -702,6 +702,34 @@ COPY trigger_aocs_test FROM STDIN;
 SELECT * FROM trigger_ao_test;
 SELECT * FROM trigger_aocs_test;
 
+-----------------
+-- Inheritance
+-----------------
+
+CREATE TABLE ao_inh_p1(a int, b int) WITH (appendonly = true);
+CREATE TABLE ao_inh_p2(a int, b int) INHERITS (ao_inh_p1) WITH (appendonly = true);
+CREATE TABLE ao_inh_p3(a int, b int) INHERITS (ao_inh_p1) WITH (appendonly = true);
+CREATE TABLE ao_inh_p4(a int, b int, c int) INHERITS (ao_inh_p2) WITH (appendonly = true);
+
+insert into ao_inh_p1 values (1, 1);
+insert into ao_inh_p2 values (2, 2);
+insert into ao_inh_p3 values (3, 3);
+insert into ao_inh_p4 values (4, 4);
+insert into ao_inh_p4 select g, g, g from generate_series(10, 15) g;
+
+select * from ao_inh_p1;
+select * from ao_inh_p2;
+select * from ao_inh_p4;
+
+update ao_inh_p1 set a = a + 1;
+update ao_inh_p2 set b = b + 1;
+
+delete from ao_inh_p1 where a = 13;
+
+select * from ao_inh_p1;
+select * from ao_inh_p4;
+
+
 --------------------------------------------------------------------------------
 -- Finally check to detect if any dangling gp_fastsequence entries are left
 -- behind by this SQL file

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1466,6 +1466,92 @@ SELECT * FROM trigger_aocs_test;
   2 | barcopy
 (2 rows)
 
+-----------------
+-- Inheritance
+-----------------
+CREATE TABLE ao_inh_p1(a int, b int) WITH (appendonly = true);
+CREATE TABLE ao_inh_p2(a int, b int) INHERITS (ao_inh_p1) WITH (appendonly = true);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+CREATE TABLE ao_inh_p3(a int, b int) INHERITS (ao_inh_p1) WITH (appendonly = true);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+CREATE TABLE ao_inh_p4(a int, b int, c int) INHERITS (ao_inh_p2) WITH (appendonly = true);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+insert into ao_inh_p1 values (1, 1);
+insert into ao_inh_p2 values (2, 2);
+insert into ao_inh_p3 values (3, 3);
+insert into ao_inh_p4 values (4, 4);
+insert into ao_inh_p4 select g, g, g from generate_series(10, 15) g;
+select * from ao_inh_p1;
+ a  | b  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+ 10 | 10
+ 11 | 11
+ 12 | 12
+ 13 | 13
+ 14 | 14
+ 15 | 15
+(10 rows)
+
+select * from ao_inh_p2;
+ a  | b  
+----+----
+  2 |  2
+  4 |  4
+ 10 | 10
+ 11 | 11
+ 12 | 12
+ 13 | 13
+ 14 | 14
+ 15 | 15
+(8 rows)
+
+select * from ao_inh_p4;
+ a  | b  | c  
+----+----+----
+  4 |  4 |   
+ 10 | 10 | 10
+ 11 | 11 | 11
+ 12 | 12 | 12
+ 13 | 13 | 13
+ 14 | 14 | 14
+ 15 | 15 | 15
+(7 rows)
+
+update ao_inh_p1 set a = a + 1;
+update ao_inh_p2 set b = b + 1;
+delete from ao_inh_p1 where a = 13;
+select * from ao_inh_p1;
+ a  | b  
+----+----
+  2 |  1
+  3 |  3
+  4 |  3
+  5 |  5
+ 11 | 11
+ 12 | 12
+ 14 | 14
+ 15 | 15
+ 16 | 16
+(9 rows)
+
+select * from ao_inh_p4;
+ a  | b  | c  
+----+----+----
+  5 |  5 |   
+ 11 | 11 | 10
+ 12 | 12 | 11
+ 14 | 14 | 13
+ 15 | 15 | 14
+ 16 | 16 | 15
+(6 rows)
+
 --------------------------------------------------------------------------------
 -- Finally check to detect if any dangling gp_fastsequence entries are left
 -- behind by this SQL file


### PR DESCRIPTION
When we assign the AO segments to insert to, we do that for all inherited
tables that we might insert to, not just partitions. Otherwise, the insertion
fails with:

ERROR:  append-only table "child" file segment "-1" entry does not exist

or you get an assertion failure if assertions are enabled.

Fixes https://github.com/greenplum-db/gpdb/issues/6068.
