### PR TITLE
Fix bitmap index bug.

### DIFF
--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -18,6 +18,20 @@ select count(*) from bm_test where i in(1, 3);
     20
 (1 row)
 
+ -- this sql should confirm that the tuple with i=1
+ -- and the tuple with i=5 are on different segments
+select count(distinct gp_segment_id) from bm_test where i in (1, 5);
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from bm_test where i in(1, 5);
+ count 
+-------
+    20
+(1 row)
+
 select * from bm_test where i > 10;
  i | t 
 ---+---
@@ -70,6 +84,39 @@ select * from bm_test where i=5 or t='6';
  6 | 6
  6 | 6
  6 | 6
+(20 rows)
+
+ -- this sql should confirm that the tuple with i=5
+ -- and the tuple with t='1' are on different segments
+ select count(distinct gp_segment_id) from bm_test where i=5 or t='1';
+ count 
+-------
+     2
+(1 row)
+
+select * from bm_test where i=5 or t='1';
+ i | t 
+---+---
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
 (20 rows)
 
 select * from bm_test where i between 1 and 10 and i::text = t;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -18,6 +18,20 @@ select count(*) from bm_test where i in(1, 3);
     20
 (1 row)
 
+ -- this sql should confirm that the tuple with i=1
+ -- and the tuple with i=5 are on different segments
+select count(distinct gp_segment_id) from bm_test where i in (1, 5);
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from bm_test where i in(1, 5);
+ count 
+-------
+    20
+(1 row)
+
 select * from bm_test where i > 10;
  i | t 
 ---+---
@@ -70,6 +84,39 @@ select * from bm_test where i=5 or t='6';
  6 | 6
  6 | 6
  6 | 6
+(20 rows)
+
+ -- this sql should confirm that the tuple with i=5
+ -- and the tuple with t='1' are on different segments
+ select count(distinct gp_segment_id) from bm_test where i=5 or t='1';
+ count 
+-------
+     2
+(1 row)
+
+select * from bm_test where i=5 or t='1';
+ i | t 
+---+---
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
+ 5 | 5
 (20 rows)
 
 select * from bm_test where i between 1 and 10 and i::text = t;

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -7,6 +7,12 @@ insert into bm_test select i % 10, (i % 10)::text  from generate_series(1, 100) 
 create index bm_test_idx on bm_test using bitmap (i);
 select count(*) from bm_test where i=1;
 select count(*) from bm_test where i in(1, 3);
+
+ -- this sql should confirm that the tuple with i=1
+ -- and the tuple with i=5 are on different segments
+select count(distinct gp_segment_id) from bm_test where i in (1, 5);
+select count(*) from bm_test where i in(1, 5);
+
 select * from bm_test where i > 10;
 reindex index bm_test_idx;
 select count(*) from bm_test where i in(1, 3);
@@ -14,6 +20,12 @@ drop index bm_test_idx;
 create index bm_test_multi_idx on bm_test using bitmap(i, t);
 select * from bm_test where i=5 and t='5';
 select * from bm_test where i=5 or t='6';
+
+ -- this sql should confirm that the tuple with i=5
+ -- and the tuple with t='1' are on different segments
+ select count(distinct gp_segment_id) from bm_test where i=5 or t='1';
+select * from bm_test where i=5 or t='1';
+
 select * from bm_test where i between 1 and 10 and i::text = t;
 drop table bm_test;
 


### PR DESCRIPTION
If bmgetbimap cannot acquire a bitmap, it returns
an empty TIDBITMAP. This will cause an error in
the next time loop in MultiExecBitmapIndexScan.

An example is shown here:
```sql
SET enable_seqscan = OFF;
SET enable_indexscan = ON;
SET enable_bitmapscan = ON;

create table bm_test (i int, t text);
insert into bm_test select i % 10, (i % 10)::text  from generate_series(1, 100) i;
create index bm_test_idx on bm_test using bitmap (i);
select count(*) from bm_test where i=1;
select count(*) from bm_test where i in(1, 8);
```
The tuple with `i = 1` and the tuple with `i=8` are
on different segments.

When we execute the expr `i in (1,8)`, we do the
following  work on each segment: loop the array
`(1, 8)` to get two bitmaps and merge them using
OR. (See function `MultiExecBitmapIndexScan`)

Suppose on the segment where `i=8` is, it first tries
to get bitmap for `i=1`. Since there is no bitmap for
`i=1` on this segment, it will return an empty
TIDBitmap(see function `bmgetbitmap`). Then the next
time, we could find `i=8`'s bitmap, but its type is
`StreamBitmap`, we cannot merge it with the previous
TIDBitmap. That is the bug's root cause.

In this commit, we fix this by returning an empty
Streambitmap in the function bmgetbitmap.

Co-authored-by: Shujie Zhang <shzhang@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- ~[ ] Document changes~
- ~[ ] Communicate in the mailing list if needed~
- [x] Pass `make installcheck`