### PR TITLE
Fix SIGSEGV causes by double cleanup of gang.

### DIFF
--- a/concourse/pipelines/5X_STABLE-generated.yml
+++ b/concourse/pipelines/5X_STABLE-generated.yml
@@ -1499,7 +1499,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: centos-gpdb-dev-6
     params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c gp_interconnect_type=tcp -c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c gp_connections_per_thread=64 -c gp_interconnect_type=tcp -c optimizer=off' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -1068,6 +1068,7 @@ FaultInjector_NewHashEntry(
 			case AutoVacWorkerBeforeDoAutovacuum:
 			case CreateResourceGroupFail:
 			case CreateGangInProgress:
+			case GangCreated:
 
 			case DecreaseToastMaxChunkSize:
 			case ProcessStartupPacketFault:

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -313,6 +313,16 @@ select 1 from gp_dist_random('gp_id') limit 1;
 select gp_inject_fault('gang_created', 'reset', 1);
 
 --
+-- Test when error happens in createGang, it can correctly clean up
+--
+select cleanupAllGangs();
+select gp_inject_fault('gang_created', 'reset', 1);
+select gp_inject_fault('gang_created', 'skip', 1);
+select 1 from gp_dist_random('gp_id') limit 1;
+select gp_inject_fault('gang_created', 'reset', 1);
+select 1 from gp_dist_random('gp_id') limit 1;
+
+--
 -- Test that an error happens after a big command is dispatched.
 --
 select gp_inject_fault('after_one_slice_dispatched', 'error', 1);

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -210,7 +210,7 @@ select cleanupAllGangs();
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 ERROR:  failed to acquire resources on one or more segments
-DETAIL:  segments is in recovery mode
+DETAIL:  segment(s) are in recovery mode
 set gp_gang_creation_retry_count to 10;
 -- should success and process_startup_packet will be invalid after this query
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
@@ -545,6 +545,44 @@ NOTICE:  Success:
  gp_inject_fault 
 -----------------
  t
+(1 row)
+
+--
+-- Test when error happens in createGang, it can correctly clean up
+--
+select cleanupAllGangs();
+ cleanupallgangs 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('gang_created', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('gang_created', 'skip', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select 1 from gp_dist_random('gp_id') limit 1;
+ERROR:  failed to acquire resources on one or more segments
+select gp_inject_fault('gang_created', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select 1 from gp_dist_random('gp_id') limit 1;
+ ?column? 
+----------
+        1
 (1 row)
 
 --


### PR DESCRIPTION
In function createGang_thread, when createGang fails because
some segments are down, it will clean all gangs. But the code
forgot to set CurrentGangCreating to NULL, then it will double
free it. This commit fix this.

------

For 5X, this bug only exists in thread based gang API. Async based gang API correctly cleans gangs when an error happens.

For master, the bug does not exists because:
1. master have removed thread based API
2. master have refactored gang clean logic, gang is cleaned at a different place from creategang API

So for master, I think it is OK that **not backport** this test. @pivotal-ning-yu @xiong-gang @pengzhout @danielgustafsson @gaos1 @macroyuyang 

Is this reasonable? 

-------

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`

## Here are some reminders when submitting to stable release branches:
- [x] Get green light from PM
- [ ] Is the issue also on master branch? If yes, submit for master first
