### PR TITLE
Fix uninitialized value "useHeapMultiInsert"

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3613,6 +3613,10 @@ CopyFrom(CopyState cstate)
 	{
 		useHeapMultiInsert = false;
 	}
+	else
+	{
+		useHeapMultiInsert = true;
+	}
 
 	/* Prepare to catch AFTER triggers. */
 	AfterTriggerBeginQuery();
@@ -3992,11 +3996,9 @@ CopyFrom(CopyState cstate)
 			if (useHeapMultiInsert)
 			{
 				char relstorage = RelinfoGetStorage(resultRelInfo);
-				if (relstorage != RELSTORAGE_AOROWS &&
-					relstorage != RELSTORAGE_AOCOLS &&
-					relstorage != RELSTORAGE_EXTERNAL)
-					useHeapMultiInsert = true;
-				else
+				if (relstorage == RELSTORAGE_AOROWS ||
+					relstorage == RELSTORAGE_AOCOLS ||
+					relstorage == RELSTORAGE_EXTERNAL)
 					useHeapMultiInsert = false;
 			}
 


### PR DESCRIPTION
```
>>>     Using uninitialized value "useHeapMultiInsert".
4130            if (useHeapMultiInsert)
```

Set to true by default, switch it off in special cases. Also refine the
lines to make it clear.