### PR TITLE
Make SendTuple do de-toasting for heap as well as memtuples

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -421,80 +421,193 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 	return;
 }
 
+static bool
+CandidateForSerializeDirect(int16 targetRoute, struct directTransportBuffer *b)
+{
+	return targetRoute != BROADCAST_SEGIDX && b->pri != NULL && b->prilen > TUPLE_CHUNK_HEADER_SIZE;
+}
+
 /*
+ *
+ * First try to serialize a tuple directly into a buffer.
+ *
+ * We're called with at least enough space for a tuple-chunk-header.
+ *
  * Convert a HeapTuple into a byte-sequence, and store it directly
  * into a chunklist for transmission.
  *
  * This code is based on the printtup_internal_20() function in printtup.c.
  */
-void
-SerializeTupleIntoChunks(GenericTuple gtuple, SerTupInfo *pSerInfo, TupleChunkList tcList)
+int
+SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTransportBuffer *b, TupleChunkList tcList, int16 targetRoute)
 {
-	TupleChunkListItem tcItem = NULL;
+	int			i;
+	int			natts;
+	int			dataSize = TUPLE_CHUNK_HEADER_SIZE;
 	MemoryContext oldCtxt;
 	TupleDesc	tupdesc;
-	int			i,
-		natts;
+	TupleChunkListItem tcItem = NULL;
+	GenericTuple gtuple = ExecFetchSlotGenericTuple(slot);
 
-	AssertArg(tcList != NULL);
 	AssertArg(gtuple != NULL);
 	AssertArg(pSerInfo != NULL);
+	AssertArg(b != NULL);
 
 	tupdesc = pSerInfo->tupdesc;
 	natts = tupdesc->natts;
 
-	/* get ready to go */
+	if (natts == 0 && CandidateForSerializeDirect(targetRoute, b))
+	{
+		/* TC_EMTPY is just one chunk */
+		SetChunkType(b->pri, TC_EMPTY);
+		SetChunkDataSize(b->pri, 0);
+
+		return TUPLE_CHUNK_HEADER_SIZE;
+	}
+
 	tcList->p_first = NULL;
 	tcList->p_last = NULL;
 	tcList->num_chunks = 0;
 	tcList->serialized_data_length = 0;
 	tcList->max_chunk_length = Gp_max_tuple_chunk_size;
 
-	if (natts == 0)
+	if (is_memtuple(gtuple)) /* memtuple case */
 	{
+		MemTuple	tuple = (MemTuple) gtuple;
+		int			tupleSize;
+		int			paddedSize;
+		bool need_toast = memtuple_get_hasext(tuple);
+
+		if (need_toast)
+		{
+			MemoryContext oldContext;
+			oldContext = MemoryContextSwitchTo(s_tupSerMemCtxt);
+			slot_getallattrs(slot);
+			tuple = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot),
+									  NULL, NULL, true);
+			MemoryContextSwitchTo(oldContext);
+		}
+
+		if (CandidateForSerializeDirect(targetRoute, b))
+		{
+			/*
+			 * Here we first try to in-line serialize the tuple directly into
+			 * buffer.
+			 */
+			tupleSize = memtuple_get_size(tuple);
+
+			paddedSize = TYPEALIGN(TUPLE_CHUNK_ALIGN, tupleSize);
+
+			if (paddedSize + TUPLE_CHUNK_HEADER_SIZE <= b->prilen)
+			{
+				/* will fit. */
+				memcpy(b->pri + TUPLE_CHUNK_HEADER_SIZE, tuple, tupleSize);
+				memset(b->pri + TUPLE_CHUNK_HEADER_SIZE + tupleSize, 0, paddedSize - tupleSize);
+
+				dataSize += paddedSize;
+
+				SetChunkType(b->pri, TC_WHOLE);
+				SetChunkDataSize(b->pri, dataSize - TUPLE_CHUNK_HEADER_SIZE);
+				return dataSize;
+			}
+		}
+
+		/*
+		 * If direct in-line serialization failed then we fallback to chunked
+		 * out-of-line serialization.
+		 */
 		tcItem = getChunkFromCache(&pSerInfo->chunkCache);
 		if (tcItem == NULL)
 		{
 			ereport(FATAL, (errcode(ERRCODE_OUT_OF_MEMORY),
 							errmsg("Could not allocate space for first chunk item in new chunk list.")));
 		}
-
-		/* TC_EMTPY is just one chunk */
-		SetChunkType(tcItem->chunk_data, TC_EMPTY);
+		SetChunkType(tcItem->chunk_data, TC_WHOLE);
 		tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 		appendChunkToTCList(tcList, tcItem);
 
-		return;
+		AssertState(s_tupSerMemCtxt != NULL);
+
+		addByteStringToChunkList(tcList, (char *) tuple, memtuple_get_size(tuple), &pSerInfo->chunkCache);
+		addPadding(tcList, &pSerInfo->chunkCache, memtuple_get_size(tuple));
+
+		MemoryContextReset(s_tupSerMemCtxt);
 	}
-
-	tcItem = getChunkFromCache(&pSerInfo->chunkCache);
-	if (tcItem == NULL)
+	else /* heaptuple case */
 	{
-		ereport(FATAL, (errcode(ERRCODE_OUT_OF_MEMORY),
-						errmsg("Could not allocate space for first chunk item in new chunk list.")));
-	}
-
-	/* assume that we'll take a single chunk */
-	SetChunkType(tcItem->chunk_data, TC_WHOLE);
-	tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
-	appendChunkToTCList(tcList, tcItem);
-
-	AssertState(s_tupSerMemCtxt != NULL);
-
-	if (is_memtuple(gtuple))
-	{
-		MemTuple mtuple = (MemTuple) gtuple;
-		addByteStringToChunkList(tcList, (char *) mtuple, memtuple_get_size(mtuple), &pSerInfo->chunkCache);
-		addPadding(tcList, &pSerInfo->chunkCache, memtuple_get_size(mtuple));
-	}
-	else
-	{
-		HeapTuple tuple = (HeapTuple) gtuple;
-		HeapTupleHeader t_data = tuple->t_data;
+		HeapTuple	tuple = (HeapTuple) gtuple;
 		TupSerHeader tsh;
 
 		unsigned int	datalen;
 		unsigned int	nullslen;
+
+		HeapTupleHeader t_data = tuple->t_data;
+
+		unsigned char *pos;
+
+		if (CandidateForSerializeDirect(targetRoute, b))
+		{
+			/*
+			 * Here we first try to in-line serialize the tuple directly into
+			 * buffer.
+			 */
+			datalen = tuple->t_len - t_data->t_hoff;
+			if (HeapTupleHasNulls(tuple))
+				nullslen = BITMAPLEN(HeapTupleHeaderGetNatts(t_data));
+			else
+				nullslen = 0;
+
+			tsh.tuplen = sizeof(TupSerHeader) + TYPEALIGN(TUPLE_CHUNK_ALIGN, nullslen) + TYPEALIGN(TUPLE_CHUNK_ALIGN, datalen);
+			tsh.natts = HeapTupleHeaderGetNatts(t_data);
+			tsh.infomask = t_data->t_infomask;
+
+
+			if (dataSize + tsh.tuplen <= b->prilen &&
+				(tsh.infomask & HEAP_HASEXTERNAL) == 0)
+			{
+				pos = b->pri + TUPLE_CHUNK_HEADER_SIZE;
+
+				memcpy(pos, (char *) &tsh, sizeof(TupSerHeader));
+				pos += sizeof(TupSerHeader);
+
+				if (nullslen)
+				{
+					memcpy(pos, (char *) t_data->t_bits, nullslen);
+					pos += nullslen;
+					memset(pos, 0, TYPEALIGN(TUPLE_CHUNK_ALIGN, nullslen) - nullslen);
+					pos += TYPEALIGN(TUPLE_CHUNK_ALIGN, nullslen) - nullslen;
+				}
+
+				memcpy(pos, (char *) t_data + t_data->t_hoff, datalen);
+				pos += datalen;
+				memset(pos, 0, TYPEALIGN(TUPLE_CHUNK_ALIGN, datalen) - datalen);
+				pos += TYPEALIGN(TUPLE_CHUNK_ALIGN, datalen) - datalen;
+
+				dataSize += tsh.tuplen;
+
+				SetChunkType(b->pri, TC_WHOLE);
+				SetChunkDataSize(b->pri, dataSize - TUPLE_CHUNK_HEADER_SIZE);
+
+				return dataSize;
+			}
+		}
+
+		/*
+		 * If direct in-line serialization failed then we fallback to chunked
+		 * out-of-line serialization.
+		 */
+		tcItem = getChunkFromCache(&pSerInfo->chunkCache);
+		if (tcItem == NULL)
+		{
+			ereport(FATAL,
+					(errcode(ERRCODE_OUT_OF_MEMORY),
+					 errmsg("could not allocate space for first chunk item in new chunk list")));
+		}
+		SetChunkType(tcItem->chunk_data, TC_WHOLE);
+		tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
+		appendChunkToTCList(tcList, tcItem);
+
+		AssertState(s_tupSerMemCtxt != NULL);
 
 		datalen = tuple->t_len - t_data->t_hoff;
 		if (HeapTupleHasNulls(tuple))
@@ -636,120 +749,10 @@ SerializeTupleIntoChunks(GenericTuple gtuple, SerTupInfo *pSerInfo, TupleChunkLi
 		 */
 	}
 
-	return;
-}
-
-/*
- * Serialize a tuple directly into a buffer.
- *
- * We're called with at least enough space for a tuple-chunk-header.
- */
-int
-SerializeTupleDirect(GenericTuple gtuple, SerTupInfo *pSerInfo, struct directTransportBuffer *b)
-{
-	int natts;
-	int dataSize = TUPLE_CHUNK_HEADER_SIZE;
-	TupleDesc	tupdesc;
-
-	AssertArg(gtuple != NULL);
-	AssertArg(pSerInfo != NULL);
-	AssertArg(b != NULL);
-
-	tupdesc = pSerInfo->tupdesc;
-	natts = tupdesc->natts;
-
-	do
-	{
-		if (natts == 0)
-		{
-			/* TC_EMTPY is just one chunk */
-			SetChunkType(b->pri, TC_EMPTY);
-			SetChunkDataSize(b->pri, 0);
-
-			break;
-		}
-
-		/* easy case */
-		if (is_memtuple(gtuple))
-		{
-			MemTuple	tuple = (MemTuple) gtuple;
-			int			tupleSize;
-			int			paddedSize;
-
-			tupleSize = memtuple_get_size(tuple);
-			paddedSize = TYPEALIGN(TUPLE_CHUNK_ALIGN, tupleSize);
-
-			if (paddedSize + TUPLE_CHUNK_HEADER_SIZE > b->prilen)
-				return 0;
-
-			/* will fit. */
-			memcpy(b->pri + TUPLE_CHUNK_HEADER_SIZE, tuple, tupleSize);
-			memset(b->pri + TUPLE_CHUNK_HEADER_SIZE + tupleSize, 0, paddedSize - tupleSize);
-
-			dataSize += paddedSize;
-
-			SetChunkType(b->pri, TC_WHOLE);
-			SetChunkDataSize(b->pri, dataSize - TUPLE_CHUNK_HEADER_SIZE);
-			break;
-		}
-		else
-		{
-			HeapTuple	tuple = (HeapTuple) gtuple;
-			TupSerHeader tsh;
-
-			unsigned int	datalen;
-			unsigned int	nullslen;
-
-			HeapTupleHeader t_data = tuple->t_data;
-
-			unsigned char *pos;
-
-			datalen = tuple->t_len - t_data->t_hoff;
-			if (HeapTupleHasNulls(tuple))
-				nullslen = BITMAPLEN(HeapTupleHeaderGetNatts(t_data));
-			else
-				nullslen = 0;
-
-			tsh.tuplen = sizeof(TupSerHeader) + TYPEALIGN(TUPLE_CHUNK_ALIGN, nullslen) + TYPEALIGN(TUPLE_CHUNK_ALIGN, datalen);
-			tsh.natts = HeapTupleHeaderGetNatts(t_data);
-			tsh.infomask = t_data->t_infomask;
-
-			if (dataSize + tsh.tuplen > b->prilen ||
-				(tsh.infomask & HEAP_HASEXTERNAL) != 0)
-				return 0;
-
-			pos = b->pri + TUPLE_CHUNK_HEADER_SIZE;
-
-			memcpy(pos, (char *)&tsh, sizeof(TupSerHeader));
-			pos += sizeof(TupSerHeader);
-
-			if (nullslen)
-			{
-				memcpy(pos, (char *)t_data->t_bits, nullslen);
-				pos += nullslen;
-				memset(pos, 0, TYPEALIGN(TUPLE_CHUNK_ALIGN, nullslen) - nullslen);
-				pos += TYPEALIGN(TUPLE_CHUNK_ALIGN, nullslen) - nullslen;
-			}
-
-			memcpy(pos,  (char *)t_data + t_data->t_hoff, datalen);
-			pos += datalen;
-			memset(pos, 0, TYPEALIGN(TUPLE_CHUNK_ALIGN, datalen) - datalen);
-			pos += TYPEALIGN(TUPLE_CHUNK_ALIGN, datalen) - datalen;
-
-			dataSize += tsh.tuplen;
-
-			SetChunkType(b->pri, TC_WHOLE);
-			SetChunkDataSize(b->pri, dataSize - TUPLE_CHUNK_HEADER_SIZE);
-
-			break;
-		}
-
-		/* tuple that we can't handle here (big ?) -- do the older "out-of-line" serialization */
-		return 0;
-	}
-	while (0);
-
-	return dataSize;   
+	/*
+	 * performed "out-of-line" serialization
+	 */
+	return 0;
 }
 
 /*

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4982,7 +4982,7 @@ PROCESS_SEGMENT_DATA:
 						Oid			tupleOid;
 						MemTuple	mtuple;
 
-						mtuple = ExecFetchSlotMemTuple(slot, false);
+						mtuple = ExecFetchSlotMemTuple(slot);
 
 						if (cstate->oids && file_has_oids)
 							MemTupleSetOid(mtuple, resultRelInfo->ri_aoInsertDesc->mt_bind, loaded_oid);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14263,7 +14263,7 @@ split_rows(Relation intoa, Relation intob, Relation temprel)
 				MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 			}
 
-			mtuple = ExecFetchSlotMemTuple(targetSlot, false);
+			mtuple = ExecFetchSlotMemTuple(targetSlot);
 			appendonly_insert(*targetAODescPtr, mtuple, &tupleOid, &aoTupleId);
 
 			/* cache TID for later updating of indexes */

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3237,7 +3237,7 @@ ExecInsert(TupleTableSlot *slot,
 
 		}
 
-		mtuple = ExecFetchSlotMemTuple(slot, false);
+		mtuple = ExecFetchSlotMemTuple(slot);
 		appendonly_insert(resultRelInfo->ri_aoInsertDesc, mtuple, &newId, (AOTupleId *) &lastTid);
 	}
 	else if (rel_is_aocols)
@@ -3865,7 +3865,7 @@ lreplace:;
 					appendonly_update_init(resultRelationDesc, ActiveSnapshot, resultRelInfo->ri_aosegno);
 			}
 
-			mtuple = ExecFetchSlotMemTuple(slot, false);
+			mtuple = ExecFetchSlotMemTuple(slot);
 
 			result = appendonly_update(resultRelInfo->ri_updateDesc,
 									   mtuple, (AOTupleId *) tupleid, (AOTupleId *) &lastTid);

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -758,7 +758,8 @@ ExecFetchSlotHeapTuple(TupleTableSlot *slot)
 MemTuple
 ExecFetchSlotMemTuple(TupleTableSlot *slot)
 {
-	MemoryContext oldContext;
+	MemTuple newTuple;
+	uint32 tuplen;
 
 	Assert(!TupIsNull(slot));
 	Assert(slot->tts_mt_bind);
@@ -766,11 +767,28 @@ ExecFetchSlotMemTuple(TupleTableSlot *slot)
 	if(slot->PRIVATE_tts_memtuple)
 		return slot->PRIVATE_tts_memtuple;
 
-	oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
-	slot->PRIVATE_tts_memtuple = ExecCopySlotMemTuple(slot);
-	MemoryContextSwitchTo(oldContext);
+	slot_getallattrs(slot);
 
-	return slot->PRIVATE_tts_memtuple;
+	tuplen = slot->PRIVATE_tts_mtup_buf_len;
+	newTuple = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot),
+				(MemTuple) slot->PRIVATE_tts_mtup_buf, &tuplen, false);
+
+	if(!newTuple)
+	{
+		if(slot->PRIVATE_tts_mtup_buf)
+			pfree(slot->PRIVATE_tts_mtup_buf);
+
+		slot->PRIVATE_tts_mtup_buf = MemoryContextAlloc(slot->tts_mcxt, tuplen);
+		slot->PRIVATE_tts_mtup_buf_len = tuplen;
+
+		newTuple = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot),
+			(MemTuple) slot->PRIVATE_tts_mtup_buf, &tuplen, false);
+	}
+
+	Assert(newTuple);
+	slot->PRIVATE_tts_memtuple = newTuple;
+
+	return newTuple;
 }
 
 /* --------------------------------

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -756,50 +756,21 @@ ExecFetchSlotHeapTuple(TupleTableSlot *slot)
  * --------------------------------
  */
 MemTuple
-ExecFetchSlotMemTuple(TupleTableSlot *slot, bool inline_toast)
+ExecFetchSlotMemTuple(TupleTableSlot *slot)
 {
-	MemTuple newTuple;
-	MemTuple oldTuple = NULL;
-	uint32 tuplen;
+	MemoryContext oldContext;
 
 	Assert(!TupIsNull(slot));
 	Assert(slot->tts_mt_bind);
 
 	if(slot->PRIVATE_tts_memtuple)
-	{
-		if(!inline_toast || !memtuple_get_hasext(slot->PRIVATE_tts_memtuple))
-			return slot->PRIVATE_tts_memtuple;
+		return slot->PRIVATE_tts_memtuple;
 
-		oldTuple = slot->PRIVATE_tts_mtup_buf;
-		slot->PRIVATE_tts_mtup_buf = NULL;
-		slot->PRIVATE_tts_mtup_buf_len = 0;
-	}
+	oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+	slot->PRIVATE_tts_memtuple = ExecCopySlotMemTuple(slot);
+	MemoryContextSwitchTo(oldContext);
 
-	slot_getallattrs(slot);
-
-	tuplen = slot->PRIVATE_tts_mtup_buf_len;
-	newTuple = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot),
-			(MemTuple) slot->PRIVATE_tts_mtup_buf, &tuplen, inline_toast);
-
-	if(!newTuple)
-	{
-		if(slot->PRIVATE_tts_mtup_buf)
-			pfree(slot->PRIVATE_tts_mtup_buf);
-
-		slot->PRIVATE_tts_mtup_buf = MemoryContextAlloc(slot->tts_mcxt, tuplen);
-		slot->PRIVATE_tts_mtup_buf_len = tuplen;
-
-		newTuple = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot),
-			(MemTuple) slot->PRIVATE_tts_mtup_buf, &tuplen, inline_toast);
-	}
-
-	Assert(newTuple);
-	slot->PRIVATE_tts_memtuple = newTuple;
-
-	if(oldTuple)
-		pfree(oldTuple);
-
-	return newTuple;
+	return slot->PRIVATE_tts_memtuple;
 }
 
 /* --------------------------------

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -939,7 +939,7 @@ ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
 					TupleTableSlot *slot,
 					uint32 hashvalue)
 {
-	MemTuple tuple = ExecFetchSlotMemTuple(slot, false);
+	MemTuple tuple = ExecFetchSlotMemTuple(slot);
 	HashJoinBatchData  *batch;
 	int			bucketno;
 	int			batchno;

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -329,7 +329,7 @@ ExecHashJoin(HashJoinState *node)
 				 */
 				Assert(batchno != 0);
 				Assert(batchno > hashtable->curbatch);
-				ExecHashJoinSaveTuple(&node->js.ps, ExecFetchSlotMemTuple(outerTupleSlot, false),
+				ExecHashJoinSaveTuple(&node->js.ps, ExecFetchSlotMemTuple(outerTupleSlot),
 									  hashvalue,
 									  hashtable,
 									  &hashtable->batches[batchno]->outerside,

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -1434,7 +1434,6 @@ void
 doSendTuple(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot)
 {
 	int16		    targetRoute;
-	GenericTuple tuple;
 	SendReturnCode  sendRC;
 	ExprContext    *econtext = node->ps.ps_ExprContext;
 	
@@ -1500,8 +1499,6 @@ doSendTuple(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot)
 		Assert(!is_null);
 	}
 
-	tuple = ExecFetchSlotGenericTuple(outerTupleSlot, true);
-
 	CheckAndSendRecordCache(node->ps.state->motionlayer_context,
 							node->ps.state->interconnect_context,
 							motion->motionID,
@@ -1511,7 +1508,7 @@ doSendTuple(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot)
 	sendRC = SendTuple(node->ps.state->motionlayer_context,
 			node->ps.state->interconnect_context,
 			motion->motionID,
-			tuple,
+			outerTupleSlot,
 			targetRoute);
 
 	Assert(sendRC == SEND_COMPLETE || sendRC == STOP_SENDING);
@@ -1532,7 +1529,8 @@ doSendTuple(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot)
 				motion->motionID,
 				targetRoute,
 				node->numTuplesToAMS);
-		formatTuple(&buf, tuple, ExecGetResultType(&node->ps),
+		formatTuple(&buf, ExecFetchSlotGenericTuple(outerTupleSlot),
+				ExecGetResultType(&node->ps),
 				node->outputFunArray);
 		elog(DEBUG3, buf.data);
 		pfree(buf.data);

--- a/src/backend/executor/nodeRowTrigger.c
+++ b/src/backend/executor/nodeRowTrigger.c
@@ -412,12 +412,12 @@ AssignTuplesForTriggers(void **newTuple, void **oldTuple,  RowTrigger *plannode,
 	{
 		if (plannode->newValuesColIdx != NIL)
 		{
-			*newTuple = ExecFetchSlotMemTuple(node->newTuple, !rel_is_aorows);
+			*newTuple = ExecFetchSlotMemTuple(node->newTuple);
 		}
 
 		if (plannode->oldValuesColIdx != NIL)
 		{
-			*oldTuple = ExecFetchSlotMemTuple(node->oldTuple, !rel_is_aorows);
+			*oldTuple = ExecFetchSlotMemTuple(node->oldTuple);
 		}
 	}
 

--- a/src/include/cdb/cdbmotion.h
+++ b/src/include/cdb/cdbmotion.h
@@ -105,7 +105,7 @@ extern void CheckAndSendRecordCache(MotionLayerState *mlStates,
 extern SendReturnCode SendTuple(MotionLayerState *mlStates,
 								ChunkTransportState *transportStates,
 								int16 motNodeID,
-								GenericTuple tuple,
+		  						TupleTableSlot *slot,
 								int16 targetRoute);
 
 

--- a/src/include/cdb/tupser.h
+++ b/src/include/cdb/tupser.h
@@ -82,11 +82,8 @@ extern void SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 										   TupleChunkList tcList,
 										   MotionConn *conn);
 
-/* Convert a HeapTuple into chunks ready to send out, in one pass */
-extern void SerializeTupleIntoChunks(GenericTuple tuple, SerTupInfo *pSerInfo, TupleChunkList tcList);
-
 /* Convert a HeapTuple into chunks directly in a set of transport buffers */
-extern int SerializeTupleDirect(GenericTuple tuple, SerTupInfo *pSerInfo, struct directTransportBuffer *b);
+extern int SerializeTuple(TupleTableSlot *tuple, SerTupInfo *pSerInfo, struct directTransportBuffer *b, TupleChunkList tcList, int16 targetRoute);
 
 /* Deserialize a HeapTuple's data from a byte-array. */
 extern HeapTuple DeserializeTuple(SerTupInfo * pSerInfo, StringInfo serialTup);

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -396,18 +396,18 @@ extern MemTuple ExecCopySlotMemTuple(TupleTableSlot *slot);
 extern MemTuple ExecCopySlotMemTupleTo(TupleTableSlot *slot, MemoryContext pctxt, char *dest, unsigned int *len);
 
 extern HeapTuple ExecFetchSlotHeapTuple(TupleTableSlot *slot);
-extern MemTuple ExecFetchSlotMemTuple(TupleTableSlot *slot, bool inline_toast);
+extern MemTuple ExecFetchSlotMemTuple(TupleTableSlot *slot);
 
 extern Datum ExecFetchSlotTupleDatum(TupleTableSlot *slot);
 
 static inline GenericTuple
-ExecFetchSlotGenericTuple(TupleTableSlot *slot, bool mtup_inline_toast)
+ExecFetchSlotGenericTuple(TupleTableSlot *slot)
 {
 	Assert(!TupIsNull(slot));
 	if (slot->PRIVATE_tts_memtuple == NULL && slot->PRIVATE_tts_heaptuple != NULL)
 		return (GenericTuple) slot->PRIVATE_tts_heaptuple;
 
-	return (GenericTuple) ExecFetchSlotMemTuple(slot, mtup_inline_toast);
+	return (GenericTuple) ExecFetchSlotMemTuple(slot);
 }
 
 static inline TupleTableSlot *

--- a/src/test/regress/expected/toast.out
+++ b/src/test/regress/expected/toast.out
@@ -118,3 +118,30 @@ SELECT encode(substring(a from 521*26+1 for 26), 'escape') FROM toast_chunk_test
  abcdefghijklmnopqrstuvwxyz
 (1 row)
 
+CREATE TABLE test_reuse_detoasted_tuple(a int, b text) DISTRIBUTED BY (a);
+INSERT INTO test_reuse_detoasted_tuple SELECT i, repeat('a' || i, 355448) FROM generate_series(1,2)i;
+SET optimizer=off;
+EXPLAIN SELECT DISTINCT ON (a,b) * FROM test_reuse_detoasted_tuple;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.03..1.04 rows=2 width=1028)
+   Merge Key: a, b
+   ->  Unique  (cost=1.03..1.04 rows=1 width=1028)
+         Group By: a, b
+         ->  Sort  (cost=1.03..1.03 rows=1 width=1028)
+               Sort Key (Distinct): a, b
+               ->  Seq Scan on test_reuse_detoasted_tuple  (cost=0.00..1.02 rows=1 width=1028)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+-- The Unique node in following query uses the previous tuple de-toasted by the
+-- Gather Motion sender to compare with the new tuple obtained from the Sort
+-- node for eliminating duplicates.
+SELECT DISTINCT ON (a,b) a FROM test_reuse_detoasted_tuple;
+ a 
+---
+ 1
+ 2
+(2 rows)
+


### PR DESCRIPTION
This PR backports a fix for use-after-free bug in memtuple de-toasting.  There were no significant cherry-pick conflicts.  It adds a testcase that wan't added to master branch (in master the issue is masked out an extra unique node at the top of the query plan).

Following PRs were relevant in discussion:
- https://github.com/greenplum-db/gpdb/pull/6448
- https://github.com/greenplum-db/gpdb/pull/6527