### PR TITLE
Reset synchronous_standby_names on FTS mirror promotion.

### DIFF
--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -339,7 +339,18 @@ HandleFtsWalRepPromote(void)
 	 */
 	DBState state = GetCurrentDBState();
 	if (state == DB_IN_STANDBY_MODE)
+	{
+		/*
+		 * Reset sync_standby_names on promotion. This is to avoid commits
+		 * hanging/waiting for replication till next FTS probe. Next FTS probe
+		 * will detect this node to be not in sync and reset the same which
+		 * can take a min. Since we know on mirror promotion its marked as not
+		 * in sync in gp_segment_configuration, best to right away clean the
+		 * sync_standby_names.
+		 */
+		UnsetSyncStandbysDefined();
 		SignalPromote();
+	}
 	else
 	{
 		elog(LOG, "ignoring promote request, walreceiver not running,"

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -136,6 +136,7 @@ test_HandleFtsWalRepPromoteMirror(void **state)
 	am_mirror = true;
 
 	will_return(GetCurrentDBState, DB_IN_STANDBY_MODE);
+	will_be_called(UnsetSyncStandbysDefined);
 	will_be_called(SignalPromote);
 
 	FtsResponse mockresponse;

--- a/src/backend/utils/adt/misc.c
+++ b/src/backend/utils/adt/misc.c
@@ -28,6 +28,7 @@
 #include "funcapi.h"
 #include "miscadmin.h"
 #include "parser/keywords.h"
+#include "postmaster/fts.h"
 #include "postmaster/syslogger.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/fd.h"
@@ -225,7 +226,7 @@ pg_terminate_backend_msg(PG_FUNCTION_ARGS)
 Datum
 pg_reload_conf(PG_FUNCTION_ARGS)
 {
-	if (!superuser())
+	if (!am_ftshandler && !superuser())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 (errmsg("must be superuser to signal the postmaster"))));

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -57,6 +57,7 @@
 #include "postmaster/autovacuum.h"
 #include "postmaster/bgworker.h"
 #include "postmaster/bgwriter.h"
+#include "postmaster/fts.h"
 #include "postmaster/postmaster.h"
 #include "postmaster/syslogger.h"
 #include "postmaster/walwriter.h"
@@ -6998,7 +6999,7 @@ AlterSystemSetConfigFile(AlterSystemStmt *altersysstmt)
 	struct stat st;
 	void	   *newextra = NULL;
 
-	if (!superuser())
+	if (!am_ftshandler && !superuser())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 			 (errmsg("must be superuser to execute ALTER SYSTEM command"))));


### PR DESCRIPTION
**Reset synchronous_standby_names on FTS mirror promotion.**

    When FTS promotes mirror, in gp_segment_configuration it marks mirror as
    not in sync ('n'). Hence, on mirror when promotion request is received,
    best to reset the synchronous_standby_names. If this is not done,
    commits hang/wait after promotion till next FTS probe cycle to detect
    this condition and reset the synchronous_standby_names.

While adding that fix, encountered the issue mentioned in #4764 hence fixing the same here.

**Avoid superuser() from FTS message handler process.**

    FTS message handler process is special system process, which doesn't
    have access to catalog. Hence, it shouldn't be performing any catalog
    access. Calling `superuser()` via `set_gp_replication_config()` or
    `pg_reload_conf()` results in error for the same reason. Hence, if
    `am_ftshandler` process avoid calling `superuser()` and thereby avoid
    catalog access. Rest all the stuff performed by this process doesn't
    need catalog access.

    Fixes #4764 github issue.




## Here are some reminders before you submit the pull request
- [X] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [X] Pass `make installcheck`