### PR TITLE
Provide more accurate debugging information for demo create failure.

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -50,7 +50,8 @@ checkDemoConfig(){
         echo " This port is needed by the Master Database instance. "
         echo ">>> Edit Makefile to correct the port number (MASTER_PORT). <<<" 
         echo -n " Check to see if the port is free by using : "
-        echo " 'netstat -an | grep ${MASTER_DEMO_PORT}"
+        echo " 'netstat -an | grep ${MASTER_DEMO_PORT}'"
+        echo " If the port is not used please make sure files ${PORT_FILE}* are deleted"
         echo ""
         return 1
     fi
@@ -64,7 +65,8 @@ checkDemoConfig(){
         echo " This port is needed by the Standby Database instance. "
         echo ">>> Edit Makefile to correct the port number (STANDBY_PORT). <<<"
         echo -n " Check to see if the port is free by using : "
-        echo " 'netstat -an | grep ${STANDBY_DEMO_PORT}"
+        echo " 'netstat -an | grep ${STANDBY_DEMO_PORT}'."
+        echo " If the port is not used please make sure files ${PORT_FILE}* are deleted"
         echo ""
         return 1
     fi
@@ -80,7 +82,8 @@ checkDemoConfig(){
             echo " This port is needed for segment database instance."
             echo ">>> Edit Makefile to correct the base ports (PORT_BASE). <<<"
             echo -n " Check to see if the port is free by using : "
-            echo " 'netstat -an | grep ${PORT_NUM}"
+            echo " 'netstat -an | grep ${PORT_NUM}'"
+            echo " If the port is not used please make sure files ${PORT_FILE}* are deleted"
             echo ""
             return 1
         fi


### PR DESCRIPTION
There is a case that a postmaster process is killed-by-9 and then the
process has no chance to remove its temporary files /tmp/.s.PGSQL.${PORT}*,
which are used by the demo create script to check the port usability.
For the above case re-creating demo cluster will fail but the error
message information as below is misleading since apparently the
port is not used.

  Check to see if the port is free by using: 'netstat -an | grep 16432'.
