### PR TITLE
Fix expression type in FAST_PATH_SET_HOLD_TILL_END_XACT().

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -214,9 +214,9 @@ static int	FastPathLocalUseCount = 0;
  * as fpLockBits.
  */
 #define FAST_PATH_SET_HOLD_TILL_END_XACT(proc, n, bits) \
-	 (proc)->fpHoldTillEndXactBits |= ((bits) & FAST_PATH_MASK) << (FAST_PATH_BITS_PER_SLOT * n)
+	 (proc)->fpHoldTillEndXactBits |= (((uint64) (bits)) & FAST_PATH_MASK) << (FAST_PATH_BITS_PER_SLOT * (n))
 #define FAST_PATH_GET_HOLD_TILL_END_XACT_BITS(proc, n) \
-	(((proc)->fpHoldTillEndXactBits >> (FAST_PATH_BITS_PER_SLOT * n)) & FAST_PATH_MASK)
+	(((proc)->fpHoldTillEndXactBits >> (FAST_PATH_BITS_PER_SLOT * (n))) & FAST_PATH_MASK)
 /*
  * The fast-path lock mechanism is concerned only with relation locks on
  * unshared relations by backends bound to a database.  The fast-path


### PR DESCRIPTION
In macro `FAST_PATH_SET_HOLD_TILL_END_XACT()` we expect an expression to
return uint64 type, however the actual return type depends is decided by
the argument `bits`, when `bits` is 32-bit wide it might not produce
correct result.

Fixed by adding necessary type conversion in the macro.

This issue is detected by Coverity, here is the original report:

    *** CID 190294:  Integer handling issues  (BAD_SHIFT)
    /tmp/build/0e1b53a0/gpdb_src/src/backend/storage/lmgr/lock.c: 4557 in setFPHoldTillEndXact()
    4551
    4552                    if (proc->fpRelId[f] != relid ||
    4553                            (lockbits = FAST_PATH_GET_BITS(proc, f)) == 0)
    4554                            continue;
    4555
    4556                    /* one relid only occupies one slot. */
    >>>     CID 190294:  Integer handling issues  (BAD_SHIFT)
    >>>     In expression "(lockbits & 7U) << 3U * f", left shifting by more than 31 bits has undefined behavior.  The shift amount, "3U * f", is as much as 45.
    4557                    FAST_PATH_SET_HOLD_TILL_END_XACT(proc, f, lockbits);
    4558                    result = true;
    4559                    break;
    4560            }
    4561
    4562            LWLockRelease(proc->backendLock);
    4563
    4564            return result;

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] ~Document changes~
- [ ] ~Communicate in the mailing list if needed~
- [ ] Pass `make installcheck`