### PR TITLE
Ignore LockAcquire() return value in gp_expand_lock_catalog().

### DIFF
--- a/src/backend/utils/misc/gpexpand.c
+++ b/src/backend/utils/misc/gpexpand.c
@@ -95,7 +95,7 @@ gp_expand_bump_version(PG_FUNCTION_ARGS)
 Datum
 gp_expand_lock_catalog(PG_FUNCTION_ARGS)
 {
-	LockAcquire(&gp_expand_locktag, AccessExclusiveLock, false, false);
+	(void) LockAcquire(&gp_expand_locktag, AccessExclusiveLock, false, false);
 
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
Here is the return values of `LockAcquire()`:

    * LOCKACQUIRE_NOT_AVAIL       lock not available, and dontWait=true
    * LOCKACQUIRE_OK              lock successfully acquired
    * LOCKACQUIRE_ALREADY_HELD    incremented count for lock already held

In our case `dontWait` is false so `LOCKACQUIRE_NOT_AVAIL` is never
returned, the other 2 both indicate that the lock is successfully
acquired.  So simply ignore the return value.

This issue is detected by Coverity, here is the original report:

    *** CID 190295:  Error handling issues  (CHECKED_RETURN)
    /tmp/build/0e1b53a0/gpdb_src/src/backend/utils/misc/gpexpand.c: 98 in gp_expand_lock_catalog()
    92      *
    93      * This should only be called by gpexpand.
    94      */
    95     Datum
    96     gp_expand_lock_catalog(PG_FUNCTION_ARGS)
    97     {
    >>>     CID 190295:  Error handling issues  (CHECKED_RETURN)
    >>>     Calling "LockAcquire" without checking return value (as is done elsewhere 14 out of 16 times).
    98      LockAcquire(&gp_expand_locktag, AccessExclusiveLock, false, false);
    99
    100             PG_RETURN_VOID();
    101     }
    102
    103     /*

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] ~Document changes~
- [ ] ~Communicate in the mailing list if needed~
- [x] Pass `make installcheck`