### PR TITLE
Check return values of pqPut*() in send_sequence_response().

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -816,18 +816,21 @@ checkSegmentAlive(CdbDispatchCmdAsync *pParms)
 static inline void
 send_sequence_response(PGconn *conn, Oid oid, int64 last, int64 cached, int64 increment, bool overflow, bool error)
 {
-	pqPutMsgStart(SEQ_NEXTVAL_QUERY_RESPONSE, false, conn);
-	pqPutInt(oid, 4, conn);
-	pqPutInt(last >> 32, 4, conn);
-	pqPutInt(last, 4, conn);
-	pqPutInt(cached >> 32, 4, conn);
-	pqPutInt(cached, 4, conn);
-	pqPutInt(increment >> 32, 4, conn);
-	pqPutInt(increment, 4, conn);
-	pqPutc(overflow ? SEQ_NEXTVAL_TRUE : SEQ_NEXTVAL_FALSE, conn);
-	pqPutc(error ? SEQ_NEXTVAL_TRUE : SEQ_NEXTVAL_FALSE, conn);
-	pqPutMsgEnd(conn);
-	pqFlush(conn);
+	if (pqPutMsgStart(SEQ_NEXTVAL_QUERY_RESPONSE, false, conn) < 0 ||
+		pqPutInt(oid, 4, conn) < 0 ||
+		pqPutInt(last >> 32, 4, conn) < 0 ||
+		pqPutInt(last, 4, conn) < 0 ||
+		pqPutInt(cached >> 32, 4, conn) < 0 ||
+		pqPutInt(cached, 4, conn) < 0 ||
+		pqPutInt(increment >> 32, 4, conn) < 0 ||
+		pqPutInt(increment, 4, conn) < 0 ||
+		pqPutc(overflow ? SEQ_NEXTVAL_TRUE : SEQ_NEXTVAL_FALSE, conn) < 0 ||
+		pqPutc(error ? SEQ_NEXTVAL_TRUE : SEQ_NEXTVAL_FALSE, conn) < 0 ||
+		pqPutMsgEnd(conn) < 0 ||
+		pqFlush(conn) < 0)
+	{
+		pqHandleSendFailure(conn);
+	}
 }
 
 /*


### PR DESCRIPTION
The pqPut*() and pqFlush() functions can all return EOF on failures, we
must check and handle them.

This issue is detected by Coverity, here is the original report:

    *** CID 190303:  Error handling issues  (CHECKED_RETURN)
    /tmp/build/0e1b53a0/gpdb_src/src/backend/cdb/dispatcher/cdbdisp_async.c: 829 in send_sequence_response()
    823             pqPutInt(cached >> 32, 4, conn);
    824             pqPutInt(cached, 4, conn);
    825             pqPutInt(increment >> 32, 4, conn);
    826             pqPutInt(increment, 4, conn);
    827             pqPutc(overflow ? SEQ_NEXTVAL_TRUE : SEQ_NEXTVAL_FALSE, conn);
    828             pqPutc(error ? SEQ_NEXTVAL_TRUE : SEQ_NEXTVAL_FALSE, conn);
    >>>     CID 190303:  Error handling issues  (CHECKED_RETURN)
    >>>     Calling "pqPutMsgEnd" without checking return value (as is done elsewhere 42 out of 45 times).
    829             pqPutMsgEnd(conn);
    830             pqFlush(conn);
    831     }
    832
    833     /*
    834      * Receive and process input from one QE.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] ~Document changes~
- [ ] ~Communicate in the mailing list if needed~
- [x] Pass `make installcheck`