### PR TITLE
Fix incorrect ExecSquelchNode() for NestLoop and MergeJoin Node

### DIFF
--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -164,6 +164,14 @@ ExecMotion(MotionState *node)
 {
 	Motion	   *motion = (Motion *) node->ps.plan;
 
+	/* sanity check */
+	if (node->stopRequested)
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("unexpected internal error"),
+				 errmsg("Already stopped motion node is executed again, data will lost"),
+				 errhint("Likely motion node is incorrectly squelched earlier")));
+
 	/*
 	 * at the top here we basically decide: -- SENDER vs. RECEIVER and --
 	 * SORTED vs. UNSORTED
@@ -1616,6 +1624,9 @@ ExecStopMotion(MotionState *node)
 	Motion	   *motion;
 
 	AssertArg(node != NULL);
+
+	if (node->stopRequested)
+		return;
 
 	motion = (Motion *) node->ps.plan;
 	node->stopRequested = true;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2277,7 +2277,7 @@ typedef struct NestLoopState
 	JoinState	js;				/* its first field is NodeTag */
 	bool		nl_NeedNewOuter;
 	bool		nl_MatchedOuter;
-	bool		nl_innerSquelchNeeded;	/*CDB*/
+	bool		nl_squelchInner; /* flag for early end of retrieval from inner */
 	bool		shared_outer;
 	bool		prefetch_inner;
 	bool		reset_inner; /*CDB-OLAP*/
@@ -2335,7 +2335,7 @@ typedef struct MergeJoinState
 	ExprContext *mj_OuterEContext;
 	ExprContext *mj_InnerEContext;
 	bool		prefetch_inner; /* MPP-3300 */
-	bool		mj_squelchInner; /* MPP-3300 */
+	bool		mj_squelchInner; /* flag for early end of retrieval from inner */
 } MergeJoinState;
 
 /* ----------------

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2277,7 +2277,6 @@ typedef struct NestLoopState
 	JoinState	js;				/* its first field is NodeTag */
 	bool		nl_NeedNewOuter;
 	bool		nl_MatchedOuter;
-	bool		nl_squelchInner; /* flag for early end of retrieval from inner */
 	bool		shared_outer;
 	bool		prefetch_inner;
 	bool		reset_inner; /*CDB-OLAP*/
@@ -2335,7 +2334,6 @@ typedef struct MergeJoinState
 	ExprContext *mj_OuterEContext;
 	ExprContext *mj_InnerEContext;
 	bool		prefetch_inner; /* MPP-3300 */
-	bool		mj_squelchInner; /* flag for early end of retrieval from inner */
 } MergeJoinState;
 
 /* ----------------

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3769,6 +3769,27 @@ SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND q
 (1 row)
 
 -- ----------------------------------------------------------------------
+-- Test: Nestloop within a correlated subquery.
+-- Nestloop get empty results from outer in the first run and we cannot
+-- squelch (early end of retrieval) inner node if the outer expected to
+-- be rescanned.
+-- ----------------------------------------------------------------------
+CREATE TABLE qp_nl_tab1 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE qp_nl_tab2 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO qp_nl_tab1 values (1, 0), (1, 1);
+INSERT INTO qp_nl_tab2 values (1, 1), (1, 1);
+VACUUM qp_nl_tab2;
+SELECT * FROM qp_nl_tab1 t1 WHERE t1.c1 + 5 > ANY(SELECT t2.c2 FROM qp_nl_tab2 t2, generate_series(1, 1) i WHERE i = t1.c2 LIMIT 1);
+ c1 | c2 
+----+----
+  1 |  1
+(1 row)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3948,6 +3948,27 @@ SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND q
 (1 row)
 
 -- ----------------------------------------------------------------------
+-- Test: Nestloop within a correlated subquery.
+-- Nestloop get empty results from outer in the first run and we cannot
+-- squelch (early end of retrieval) inner node if the outer expected to
+-- be rescanned.
+-- ----------------------------------------------------------------------
+CREATE TABLE qp_nl_tab1 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE qp_nl_tab2 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO qp_nl_tab1 values (1, 0), (1, 1);
+INSERT INTO qp_nl_tab2 values (1, 1), (1, 1);
+VACUUM qp_nl_tab2;
+SELECT * FROM qp_nl_tab1 t1 WHERE t1.c1 + 5 > ANY(SELECT t2.c2 FROM qp_nl_tab2 t2, generate_series(1, 1) i WHERE i = t1.c2 LIMIT 1);
+ c1 | c2 
+----+----
+  1 |  1
+(1 row)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -892,8 +892,23 @@ EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b
 SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);
 
 -- ----------------------------------------------------------------------
+-- Test: Nestloop within a correlated subquery.
+-- Nestloop get empty results from outer in the first run and we cannot
+-- squelch (early end of retrieval) inner node if the outer expected to
+-- be rescanned.
+-- ----------------------------------------------------------------------
+CREATE TABLE qp_nl_tab1 (c1 int, c2 int);
+CREATE TABLE qp_nl_tab2 (c1 int, c2 int);
+INSERT INTO qp_nl_tab1 values (1, 0), (1, 1);
+INSERT INTO qp_nl_tab2 values (1, 1), (1, 1);
+VACUUM qp_nl_tab2;
+SELECT * FROM qp_nl_tab1 t1 WHERE t1.c1 + 5 > ANY(SELECT t2.c2 FROM qp_nl_tab2 t2, generate_series(1, 1) i WHERE i = t1.c2 LIMIT 1);
+
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
+
 
 -- start_ignore
 drop schema qp_correlated_query cascade;


### PR DESCRIPTION
ExecSquelchNode() is designed to early end up retrieving tuples
from a subplan so QEs in lower gangs won't keep trying to send
to us. This function should be called carefully because once it
was called, we cannot get tuples from underlying motion anymore.

NestLoop and MergeJoin used to squelch inner node when no tuple
can be retrieved from outer node, there is no check to see if
it's safe to end up inner node earlier  except an optimization:
if inner node is prefetched, there is no need to squelch the inner
node again because all tuples have been prefetched from motion. As
a result, if outer node gets empty tuple, the inner node is early
ended up, then the outer node is rescanned and it cannot get
tuples from motion under inner node anymore.

To fix this, we use the same safty check logic with eager free,
they have similar motivation and similar consideration for rescanning.

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`