### PR TITLE
Fallback 'default_transaction_isolation' guc from serializable to repeatable read

### DIFF
--- a/src/backend/commands/variable.c
+++ b/src/backend/commands/variable.c
@@ -618,6 +618,22 @@ show_XactIsoLevel(void)
 	}
 }
 
+bool
+check_DefaultXactIsoLevel(int *newval, void **extra, GucSource source)
+{
+	/*
+	 * As the fixme in assign_XactIsoLevel, DefaultXactIsoLevel also need
+	 * to fallback from 'serializable' to 'repeatable read'
+	 */
+	if (*newval == XACT_SERIALIZABLE)
+	{
+		elog(LOG, "default serializable isolation requested, falling back to "
+				  "repeatable read until serializable is supported in Greenplum");
+		*newval = XACT_REPEATABLE_READ;
+	}
+
+	return true;
+}
 /*
  * SET TRANSACTION [NOT] DEFERRABLE
  */

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3397,6 +3397,17 @@ static struct config_enum ConfigureNamesEnum[] =
 	},
 
 	{
+		/*
+		 * Greenplum needs to reconcile conflict detection based
+		 * on predicate locks across cluster to support true
+		 * serializability.  See merge fixme in
+		 * assign_XactIsoLevel(). String guc sets the value of the
+		 * corresponding variable via the assign hook, but enum guc
+		 * sets it in set_config_option by new_val. We can't change
+		 * the value of newval in the assignment hook, it's the
+		 * reason why assign hook function method didn't work in
+		 * past. Use the check hook to change 'newval'.
+		 */
 		{"default_transaction_isolation", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Sets the transaction isolation level of each new transaction."),
 			NULL

--- a/src/include/commands/variable.h
+++ b/src/include/commands/variable.h
@@ -24,6 +24,7 @@ extern const char *show_log_timezone(void);
 extern bool check_transaction_read_only(bool *newval, void **extra, GucSource source);
 extern bool check_XactIsoLevel(char **newval, void **extra, GucSource source);
 extern void assign_XactIsoLevel(const char *newval, void *extra);
+extern bool check_DefaultXactIsoLevel(int *newval, void **extra, GucSource source);
 extern const char *show_XactIsoLevel(void);
 extern bool check_transaction_deferrable(bool *newval, void **extra, GucSource source);
 extern bool check_random_seed(double *newval, void **extra, GucSource source);

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -120,3 +120,49 @@ SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
  12-12-2017
 (3 rows)
 
+-- Test default_transaction_isolation and transaction_isolation fallback from serializable to repeatable read
+CREATE TABLE test_serializable(a int);
+insert into test_serializable values(1);
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL serializable;
+show default_transaction_isolation;
+ default_transaction_isolation 
+-------------------------------
+ repeatable read
+(1 row)
+
+SELECT * FROM test_serializable;
+ a 
+---
+ 1
+(1 row)
+
+SET default_transaction_isolation = 'read committed';
+SET default_transaction_isolation = 'serializable';
+show default_transaction_isolation;
+ default_transaction_isolation 
+-------------------------------
+ repeatable read
+(1 row)
+
+SELECT * FROM test_serializable;
+ a 
+---
+ 1
+(1 row)
+
+SET default_transaction_isolation = 'read committed';
+BEGIN TRANSACTION ISOLATION LEVEL serializable;
+	show transaction_isolation;
+ transaction_isolation 
+-----------------------
+ repeatable read
+(1 row)
+
+	SELECT * FROM test_serializable;
+ a 
+---
+ 1
+(1 row)
+
+COMMIT;
+DROP TABLE test_serializable;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -86,3 +86,21 @@ SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
 RESET timezone;
 SHOW timezone;
 SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
+
+-- Test default_transaction_isolation and transaction_isolation fallback from serializable to repeatable read
+CREATE TABLE test_serializable(a int);
+insert into test_serializable values(1);
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL serializable;
+show default_transaction_isolation;
+SELECT * FROM test_serializable;
+SET default_transaction_isolation = 'read committed';
+SET default_transaction_isolation = 'serializable';
+show default_transaction_isolation;
+SELECT * FROM test_serializable;
+SET default_transaction_isolation = 'read committed';
+
+BEGIN TRANSACTION ISOLATION LEVEL serializable;
+	show transaction_isolation;
+	SELECT * FROM test_serializable;
+COMMIT;
+DROP TABLE test_serializable;


### PR DESCRIPTION
Serializable is not yet supported, so we need to fallback gucs
'transaction_isolation' and 'default_transaction_isolation' from
serializable to repeatable read. Before, we just right fallback the
transaction_isolation. For default_transaction_isolation, we only use
the correct fallback when using the ‘SET SESSION CHARACTERISTICS AS
TRANSACTION ISOLATION LEVEL serializable’ statement. But we do not
fallback when using 'SET default_transaction_isolation = 'serializable''.
Add a check hook 'check_DefaultXactIsoLevel' to fix it.

String guc sets the value of the corresponding variable via the assign hook, but enum guc sets it in set_config_option by new_val. We can't change the value of newval in the assignment hook, it's the reason why assign hook function method didn't work in past.

Will fix the assert failure https://github.com/greenplum-db/gpdb/issues/6388
## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`