### PR TITLE
Fix gpperfmon bug that Gpmon return "WARNING:  gpmon - bad magic 0" with explain plan

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -174,3 +174,15 @@ Feature: gpperfmon
         And wait until the process "gpsmon" is up
         # Note that the code considers partition_age + 1 as the number of partitions to keep
         Then wait until the results from boolean sql "SELECT count(*) = 5 FROM pg_partitions WHERE tablename = 'diskspace_history'" is "true"
+
+    @gpperfmon_index_scan
+    Scenario: Gpmon should not return "WARNING:  gpmon - bad magic 0" with explain plan includes index_scan
+        Given gpperfmon is configured and running in qamode
+        Then the user runs "psql -f 'test/behave/mgmt_utils/steps/data/gpperfmon/index_scan.sql'"
+        Then psql should not print "gpmon - bad magic 0" error message
+
+    @gpperfmon_bitmap_index_scan
+    Scenario: Gpmon should not return "WARNING:  gpmon - bad magic 0" with explain plan includes bitmap index_scan
+        Given gpperfmon is configured and running in qamode
+        Then the user runs "psql -f 'test/behave/mgmt_utils/steps/data/gpperfmon/bitmap_index_scan.sql'"
+        Then psql should not print "gpmon - bad magic 0" error message

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpperfmon/bitmap_index_scan.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpperfmon/bitmap_index_scan.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS bitmapIndexScanTest;
+CREATE TABLE bitmapIndexScanTest(id int) distributed by (id);
+CREATE INDEX idx_bitmapIndexScanTest ON bitmapIndexScanTest USING bitmap (id);
+INSERT INTO bitmapIndexScanTest SELECT * FROM generate_series(1,1000);
+SET enable_seqscan=off;
+SET enable_indexscan=off;
+SET enable_bitmapscan=on;
+
+EXPLAIN SELECT * FROM bitmapIndexScanTest WHERE id>4;

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpperfmon/index_scan.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpperfmon/index_scan.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS indexScanTest;
+CREATE TABLE indexScanTest(id int) distributed by (id);
+CREATE INDEX idx_indexScanTest ON indexScanTest(id);
+INSERT INTO indexScanTest SELECT * FROM generate_series(1,1000);
+SET enable_seqscan=off;
+SET enable_bitmapscan=off;
+SET enable_indexscan=on;
+EXPLAIN SELECT * FROM indexScanTest WHERE id=4;

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -742,6 +742,9 @@ def impl(context, command, out_msg):
 def impl(context, command, out_msg):
     check_string_not_present_stdout(context, out_msg)
 
+@then('{command} should not print "{err_msg}" error message')
+def impl(context, command, err_msg):
+    check_string_not_present_stderr(context, err_msg)
 
 @then('{command} should print "{out_msg}" to stdout {num} times')
 def impl(context, command, out_msg, num):

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -171,6 +171,11 @@ def check_string_not_present_stdout(context, msg):
         err_str = "Did not expect stdout string '%s' but found: '%s'" % (msg, context.stdout_message)
         raise Exception(err_str)
 
+def check_string_not_present_stderr(context, msg):
+    pat = re.compile(msg)
+    if pat.search(context.error_message):
+        err_str = "Did not expect stderr string '%s' but found: '%s'" % (msg, context.error_message)
+        raise Exception(err_str)
 
 def check_err_msg(context, err_msg):
     if not hasattr(context, 'exception'):

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -211,6 +211,8 @@ ExecInitBitmapIndexScan(BitmapIndexScan *node, EState *estate, int eflags)
 	scanState->ss.ps.plan = (Plan *) node;
 	scanState->ss.ps.state = estate;
 
+	initGpmonPktForBitmapIndexScan((Plan *)node, &scanState->ss.ps.gpmon_pkt, estate);
+
 	/*
 	 * If we are just doing EXPLAIN (ie, aren't going to run the plan), stop
 	 * here.  This allows an index-advisor plugin to EXPLAIN a plan containing
@@ -227,8 +229,6 @@ ExecInitBitmapIndexScan(BitmapIndexScan *node, EState *estate, int eflags)
 	 * the heap relation throughout the execution of the plan tree.
 	 */
 	Assert(NULL == scanState->ss.ss_currentRelation);
-
-	initGpmonPktForBitmapIndexScan((Plan *)node, &scanState->ss.ps.gpmon_pkt, estate);
 
 	return indexstate;
 }

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -594,6 +594,8 @@ ExecInitIndexScan(IndexScan *node, EState *estate, int eflags)
 	ExecAssignResultTypeFromTL(&indexstate->ss.ps);
 	ExecAssignScanProjectionInfo(&indexstate->ss);
 
+	initGpmonPktForIndexScan((Plan *)node, &indexstate->ss.ps.gpmon_pkt, estate);
+
 	/*
 	 * If we are just doing EXPLAIN (ie, aren't going to run the plan), stop
 	 * here.  This allows an index-advisor plugin to EXPLAIN a plan containing
@@ -635,8 +637,6 @@ ExecInitIndexScan(IndexScan *node, EState *estate, int eflags)
 	 * Initialize index-specific scan state
 	 */
 	indexstate->iss_RuntimeKeysReady = false;
-
-	initGpmonPktForIndexScan((Plan *)node, &indexstate->ss.ps.gpmon_pkt, estate);
 
 	/*
 	 * If eflag contains EXEC_FLAG_REWIND or EXEC_FLAG_BACKWARD or EXEC_FLAG_MARK,


### PR DESCRIPTION
Before this PR, if explaining a SQL which hits IndexScan or BitmapIndexScan, it will output a WARNING: gpmon - bad magic 0.
The reason is gpmon packet not initialize in this two procnode.
After this PR, gpmon packet is initialize anyway, even for explain command.

Co-authored-by: Wenlin Zhang <wzhang@pivotal.io>
Co-authored-by: Bing Xu <bxu@pivotal.io>

@magi345 