### PR TITLE
Simplify initialization of motion layer.

### DIFF
--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -477,15 +477,12 @@ typedef struct MotionLayerState
 	/*
 	 * MOTION NODE STATE - Initialized and used on per-statement basis.
 	 */
-
-#define MNE_INITIAL_COUNT (10)
 	int			mneCount;
 	MotionNodeEntry *mnEntries;
 
 	/*
 	 * GLOBAL MOTION-LAYER STATISTICS
 	 */
-
 	uint32		stat_total_chunks_sent; /* Tuple-chunks sent. */
 	uint32		stat_total_bytes_sent;	/* Bytes sent, including headers. */
 	uint32		stat_tuple_bytes_sent;	/* Bytes of pure tuple-data sent. */

--- a/src/include/cdb/cdbmotion.h
+++ b/src/include/cdb/cdbmotion.h
@@ -48,10 +48,7 @@ extern int Gp_max_tuple_chunk_size;
 /* API FUNCTION CALLS */
 
 /* Initialization of motion layer for this query */
-extern void initMotionLayerStructs(MotionLayerState **ml_states);
-
-/* Initialization of each motion node in execution plan. */
-extern void InitMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID);
+extern MotionLayerState *createMotionLayerState(int maxMotNodeID);
 
 /* Initialization of each motion node in execution plan. */
 extern void UpdateMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool preserveOrder,


### PR DESCRIPTION
We know the number of Motion nodes upfront, so we can allocate the
'mnEntries' array to the right size when we create the motion layer. No
need to expand it incrementally.
