### PR TITLE
[WIP] Modify gpcheckcat to perform check for filesystem objects in order to identify leaked files

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -22,6 +22,8 @@ import re
 import sys
 import time
 from datetime import datetime
+from os import listdir
+from os.path import isfile, join
 
 try:
     from gppylib.db import dbconn
@@ -1906,6 +1908,92 @@ def checkPGNamespace():
 
 
 #############
+def doCheckRelfilenodeFilesystemConsistency(qry):
+    logger.debug('%s' % qry)
+
+    batch = []
+    threads = []
+    i = 1
+
+    # parallelise queries
+    for dbid in GV.cfg:
+        c = GV.cfg[dbid]
+        db = connect2(c)
+
+        thread = execThread(c, db, qry)
+        thread.start()
+        logger.debug('launching query thread %s for dbid %i' %
+                     (thread.getName(), dbid))
+        threads.append(thread)
+
+        # we don't want too much going on at once
+        if (i % GV.opt['-B']) == 0:
+            # process this batch of threads
+            batch.extend(processThread(threads))
+            threads = []
+
+        i += 1
+
+    # process the rest of threads
+    batch.extend(processThread(threads))
+
+    err = []
+
+    for [cfg, curs] in batch:
+        relfilenodeInCatalogList = []
+        relfilenodeInSystem = {}
+        fileOnlyInSystem = []
+        db2 = connect2(cfg)
+        datidnames = db2.query('select oid, datname from pg_database').dictresult()
+        for row in datidnames:
+            if row['datname'] == GV.dbname:
+                dbid = row['oid']
+        for row in curs.dictresult():
+            relfilenode = row['relfilenode']
+            # If it is relmapped relation, need to fetch the mapping from relmap file
+            if relfilenode == 0:
+                relfilenode = db2.query('select pg_relation_filenode(%d)' % row['oid']).dictresult()[0]['pg_relation_filenode']
+            relfilenodeInCatalogList.append(relfilenode)
+
+        filepath = cfg['datadir'] + '/base/%s' % dbid
+        onlyfiles = [f for f in listdir(filepath) if isfile(join(filepath, f))]
+        for f in onlyfiles:
+            fl = f.lower()
+            if fl.startswith('pg') or fl.startswith('t_') or fl.endswith('_fsm') or fl.endswith('_vm') or not fl.replace('.','',1).isdigit():
+                continue
+            relfilenodeInSystem[int(float(fl))] = fl
+
+        relfilenodeOnlyInSystem = set(relfilenodeInSystem.keys()) - set(relfilenodeInCatalogList)
+        for key in relfilenodeOnlyInSystem:
+            fileOnlyInSystem.append(relfilenodeInSystem[key])
+        if len(fileOnlyInSystem) > 0:
+            err.append([cfg, {"extra file in filesystem": list(fileOnlyInSystem)}])
+    return err;
+
+
+#############
+def checkRelfilenodeFilesystemConsistency():
+    logger.info('-----------------------------------')
+    logger.info('Checking relfilenode filesystem consistency ...')
+    qry = '''
+    SELECT relfilenode, oid
+    FROM pg_class
+    WHERE reltablespace = 0
+    '''
+    err = doCheckRelfilenodeFilesystemConsistency(qry)
+    if not err:
+        logger.info('[OK] relfilenode filesystem consistency')
+    else:
+        GV.checkStatus = False
+        setError(ERROR_NOREPAIR)
+        logger.info('[WARN] relfilenode filesystem inconsistency')
+        logger.error('found %d relfilenode filesystem inconsistency' % len(err))
+        logger.error(qry)
+        for e in err:
+            logger.error(e)
+
+
+#############
 '''
 Produce repair scripts to remove dangling entries of gp_fastsequence:
 	- one file per segment dbid
@@ -3028,6 +3116,14 @@ all_checks = {
             "version": 'main',
             "order": 13,
             "online": True
+        },
+        "relfilenode_filesystem_consistency":
+        {
+            "description": "Check consistency between relfilenode and filesystem",
+            "fn": lambda: checkRelfilenodeFilesystemConsistency(),
+            "version": 'main',
+            "order": 14,
+            "online": False
         },
 }
 


### PR DESCRIPTION
If delebrately `touch ./gpAux/gpdemo/datadirs/dbfast2/demoDataDir1/base/16384/12345`

Run `gpcheckcat -R relfilenode_filesystem_consistency  pivotal`(The command means runs test `relfilenode_filesystem_consistency` only on database `pivotal`, 16384 is the dbid of database named pivotal)

will see output `extra file in filesystem': ['12345']`
```
Connected as user 'sbai' to database 'pivotal', port '15432', gpdb version '6.0'
-------------------------------------------------------------------
Batch size: 4
20190106:22:19:39:033595 gpcheckcat:ShaoqiBaisMBP2:sbai-[INFO]:------------------------------------
20190106:22:19:39:033595 gpcheckcat:ShaoqiBaisMBP2:sbai-[INFO]:-Checking for leaked temporary schemas
20190106:22:19:39:033595 gpcheckcat:ShaoqiBaisMBP2:sbai-[INFO]:-[OK] temporary schemas
Performing test 'relfilenode_filesystem_consistency'
20190106:22:19:39:033595 gpcheckcat:ShaoqiBaisMBP2:sbai-[INFO]:------------------------------------
20190106:22:19:39:033595 gpcheckcat:ShaoqiBaisMBP2:sbai-[INFO]:-Checking relfilenode filesystem consistency ...
20190106:22:19:39:033595 gpcheckcat:ShaoqiBaisMBP2:sbai-[INFO]:-[WARN] relfilenode filesystem inconsistency
20190106:22:19:39:033595 gpcheckcat:ShaoqiBaisMBP2:sbai-[ERROR]:-found 1 relfilenode filesystem inconsistency
20190106:22:19:39:033595 gpcheckcat:ShaoqiBaisMBP2:sbai-[ERROR]:-
    SELECT relfilenode, oid
    FROM pg_class
    WHERE reltablespace = 0

20190106:22:19:39:033595 gpcheckcat:ShaoqiBaisMBP2:sbai-[ERROR]:-[{'definedprimary': 't', 'dbid': 3, 'hostname': 'ShaoqiBaisMBP2.lan', 'content': 1, 'datadir': '/Users/sbai/work/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1', 'address': 'ShaoqiBaisMBP2.lan', 'isprimary': 't', 'port': 25433}, {'extra file in filesystem': ['12345']}]
Total runtime for test 'relfilenode_filesystem_consistency': 0:00:00.05

SUMMARY REPORT
===================================================================
Completed 1 test(s) on database 'pivotal' at 2019-01-06 22:19:39 with elapsed time 0:00:00
Failed test(s) that are not reported here: relfilenode_filesystem_consistency
```
If list all test, will see the newly added test `relfilenode_filesystem_consistency` in the last line of the following output

```
-> gpcheckcat -l

List of gpcheckcat tests:

   unique_index_violation: Check for violated unique indexes
                duplicate: Check for duplicate entries
       missing_extraneous: Cross consistency check for missing or extraneous entries
             inconsistent: Cross consistency check for master segment inconsistency
              foreign_key: Check foreign keys
                      acl: Cross consistency check for access control privileges
                  pgclass: Check pg_class entry that does not have any correspond pg_attribute entry
                namespace: Check for schemas with a missing schema definition
      distribution_policy: Check constraints on randomly distributed tables
               dependency: Check for dependency on non-existent objects
                    owner: Check table ownership that is inconsistent with the master database
           part_integrity: Check pg_partition branch integrity, partition with oids, partition distribution policy
          part_constraint: Check constraints on partitioned tables
 relfilenode_filesystem_consistency: Check consistency between relfilenode and filesystem
```

To fullfill the newly added test `relfilenode_filesystem_consistency`, add a function `checkRelfilenodeFilesystemConsistency`, and there is a function `doCheckRelfilenodeFilesystemConsistency` is called in it.
The basic logic is 
1.  `SELECT relfilenode, oid FROM pg_class WHERE reltablespace = 0` to find all relfilenode in `/base/` directory,  so it does not check user defined tablespace.  if relfilenode == 0, it use `select pg_relation_filenode(oid)` to fetch the mapping from relmap file if it is relmapped relation.

2.  use python builtin function `listdir` to recurse the directory `/base/` to find all file, but skip filename starts with `pg` or `t_` or ends with` _fsm` or `_vm` , and convert any float-like filename to int.
3.  do a set subtraction between list generated from step 2  and step1, will get extra file in filesystem that are not in pg_class's relfilenode 

But here is a problem, when drop a table,  the entry in pg_class will disapear, but the file is still in filesystem.
```
pivotal=# create table test(a int);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE

pivotal=# select pg_relation_filepath('test');
 pg_relation_filepath
----------------------
 base/16384/16384
(1 row)

pivotal=# drop table test;
DROP TABLE
pivotal=# vacuum full;
```
you will still find file 16384 in the filesystem.  Although it will disappear minutes laters finally.
```
-> find . -name '16384'
./dbfast_mirror2/demoDataDir1/base/16384
./qddir/demoDataDir-1/base/16384
./qddir/demoDataDir-1/base/16384/16384
./dbfast_mirror3/demoDataDir2/base/16384
./dbfast2/demoDataDir1/base/16384
./dbfast2/demoDataDir1/base/16384/16384
./dbfast3/demoDataDir2/base/16384
./dbfast3/demoDataDir2/base/16384/16384
./dbfast_mirror1/demoDataDir0/base/16384
./dbfast1/demoDataDir0/base/16384
./dbfast1/demoDataDir0/base/16384/16384
./standby/base/16384
```

The PR pipeline is red because of `relfilenode_filesystem_consistency` test is failed, because test `relfilenode_filesystem_consistency` have found extra file in filesystem.

The pr needs doc modifiyed, but the pr is still WIP, so will ask doc team members to help me if the pr is OK in most part.