### PR TITLE
Introduce new class to hold context for Query->DXL translation.

### DIFF
--- a/src/backend/gpopt/translate/CContextQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CContextQueryToDXL.cpp
@@ -1,0 +1,41 @@
+//---------------------------------------------------------------------------
+//  Greenplum Database
+//	Copyright (C) 2018-Present Pivotal Software, Inc.
+//
+//	@filename:
+//		CContextQueryToDXL.cpp
+//
+//	@doc:
+//		Implementation of the methods used to hold information about
+//		the whole query, when translate a query into DXL tree. All
+//		translator methods allocate memory in the provided memory pool,
+//		and the caller is responsible for freeing it
+//
+//---------------------------------------------------------------------------
+#include "postgres.h"
+
+#include "gpopt/translate/CContextQueryToDXL.h"
+#include "gpopt/translate/CTranslatorUtils.h"
+
+#include "naucrates/dxl/CIdGenerator.h"
+
+using namespace gpdxl;
+
+CContextQueryToDXL::CContextQueryToDXL
+	(
+	IMemoryPool *mp
+	)
+  :
+  m_mp(mp),
+  m_has_distributed_tables(false)
+{
+	// map that stores gpdb att to optimizer col mapping
+	m_colid_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_COL_ID_START);
+	m_cte_id_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_CTE_ID_START);
+}
+
+CContextQueryToDXL::~CContextQueryToDXL()
+{
+	GPOS_DELETE(m_colid_counter);
+	GPOS_DELETE(m_cte_id_counter);
+}

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -872,23 +872,9 @@ CTranslatorRelcacheToDXL::GetDefaultColumnValue
 	}
 
 	// translate the default value expression
-	CTranslatorScalarToDXL scalar_translator
-							(
-							mp,
-							md_accessor,
-							NULL, /* pulidgtorCol */
-							NULL, /* pulidgtorCTE */
-							0, /* query_level */
-							true, /* m_fQuery */
-							NULL, /* query_level_to_cte_map */
-							NULL /* cte_dxlnode_array */
-							);
-
-	return scalar_translator.TranslateScalarToDXL
-							(
-							(Expr *) node,
-							NULL /* var_colid_mapping --- subquery or external variable are not supported in default expression */
-							);
+	return CTranslatorScalarToDXL::TranslateStandaloneExprToDXL(mp, md_accessor,
+								    NULL, /* var_colid_mapping --- subquery or external variable are not supported in default expression */
+								    (Expr *) node);
 }
 
 //---------------------------------------------------------------------------
@@ -2070,18 +2056,6 @@ CTranslatorRelcacheToDXL::RetrieveCheckConstraints
 	Node *node = gpdb::PnodeCheckConstraint(check_constraint_oid);
 	GPOS_ASSERT(NULL != node);
 
-	CTranslatorScalarToDXL scalar_translator
-							(
-							mp,
-							md_accessor,
-							NULL, /* pulidgtorCol */
-							NULL, /* pulidgtorCTE */
-							0, /* query_level */
-							true, /* m_fQuery */
-							NULL, /* query_level_to_cte_map */
-							NULL /* cte_dxlnode_array */
-							);
-
 	// generate a mock mapping between var to column information
 	CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
 	CDXLColDescrArray *dxl_col_descr_array = GPOS_NEW(mp) CDXLColDescrArray(mp);
@@ -2110,7 +2084,7 @@ CTranslatorRelcacheToDXL::RetrieveCheckConstraints
 	var_colid_mapping->LoadColumns(0 /*query_level */, 1 /* rteIndex */, dxl_col_descr_array);
 
 	// translate the check constraint expression
-	CDXLNode *scalar_dxlnode = scalar_translator.TranslateScalarToDXL((Expr *) node, var_colid_mapping);
+	CDXLNode *scalar_dxlnode = CTranslatorScalarToDXL::TranslateStandaloneExprToDXL(mp, md_accessor, var_colid_mapping, (Expr *) node);
 
 	// cleanup
 	dxl_col_descr_array->Release();
@@ -3594,25 +3568,13 @@ CTranslatorRelcacheToDXL::RetrievePartConstraintFromNode
 		return NULL;
 	}
 
-	CTranslatorScalarToDXL scalar_translator
-							(
-							mp,
-							md_accessor,
-							NULL, // pulidgtorCol
-							NULL, // pulidgtorCTE
-							0, // query_level
-							true, // m_fQuery
-							NULL, // query_level_to_cte_map
-							NULL // cte_dxlnode_array
-							);
-
 	// generate a mock mapping between var to column information
 	CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
 
 	var_colid_mapping->LoadColumns(0 /*query_level */, 1 /* rteIndex */, dxl_col_descr_array);
 
 	// translate the check constraint expression
-	CDXLNode *scalar_dxlnode = scalar_translator.TranslateScalarToDXL((Expr *) part_constraints, var_colid_mapping);
+	CDXLNode *scalar_dxlnode = CTranslatorScalarToDXL::TranslateStandaloneExprToDXL(mp, md_accessor, var_colid_mapping, (Expr *) part_constraints);
 
 	// cleanup
 	GPOS_DELETE(var_colid_mapping);

--- a/src/backend/gpopt/translate/Makefile
+++ b/src/backend/gpopt/translate/Makefile
@@ -23,6 +23,7 @@ OBJS =  CMappingColIdVar.o \
 		CTranslatorDXLToScalar.o \
 		CTranslatorUtils.o \
 		CTranslatorRelcacheToDXL.o \
+		CContextQueryToDXL.o \
 		CTranslatorQueryToDXL.o \
 		CTranslatorDXLToPlStmt.o 
 

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -696,13 +696,6 @@ COptTasks::OptimizeTask
 			// scope for MD accessor
 			CMDAccessor mda(mp, CMDCache::Pcache(), default_sysid, relcache_provider);
 
-			// ColId generator
-			CIdGenerator colid_generator(GPDXL_COL_ID_START);
-			CIdGenerator cteid_generator(GPDXL_CTE_ID_START);
-
-			// map that stores gpdb att to optimizer col mapping
-			CMappingVarColId *var_colid_mapping = GPOS_NEW(mp) CMappingVarColId(mp);
-
 			ULONG num_segments = gpdb::GetGPSegmentCount();
 			ULONG num_segments_for_costing = optimizer_segments;
 			if (0 == num_segments_for_costing)
@@ -715,11 +708,7 @@ COptTasks::OptimizeTask
 							(
 							mp,
 							&mda,
-							&colid_generator,
-							&cteid_generator,
-							var_colid_mapping,
-							(Query*) opt_ctxt->m_query,
-							0 /* query_level */
+							(Query*) opt_ctxt->m_query
 							);
 
 			ICostModel *cost_model = GetCostModel(mp, num_segments_for_costing);

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -7,7 +7,7 @@
 //
 //	@doc:
 //		Class providing access to CIdGenerators (needed to number initplans, motion
-//		nodes as well as params), list of RangeTableEntires and Subplans
+//		nodes as well as params), list of RangeTableEntries and Subplans
 //		generated so far during DXL-->PlStmt translation.
 //
 //	@test:
@@ -51,7 +51,7 @@ namespace gpdxl
 	//
 	//	@doc:
 	//		Class providing access to CIdGenerators (needed to number initplans, motion
-	//		nodes as well as params), list of RangeTableEntires and Subplans
+	//		nodes as well as params), list of RangeTableEntries and Subplans
 	//		generated so far during DXL-->PlStmt translation.
 	//
 	//---------------------------------------------------------------------------

--- a/src/include/gpopt/translate/CContextQueryToDXL.h
+++ b/src/include/gpopt/translate/CContextQueryToDXL.h
@@ -1,0 +1,73 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2011 Greenplum, Inc.
+//
+//	@filename:
+//		CContextQueryToDXL.h
+//
+//	@doc:
+//		Class to hold information about a whole top-level query, while
+//		recursively translating a Query tree to DXL tree.
+//
+//---------------------------------------------------------------------------
+
+#ifndef GPDXL_CContextQueryToDXL_H
+#define GPDXL_CContextQueryToDXL_H
+
+#include "gpopt/translate/CTranslatorUtils.h"
+
+#include "gpos/base.h"
+
+#include "naucrates/dxl/operators/CDXLNode.h"
+#include "naucrates/dxl/CIdGenerator.h"
+
+#define GPDXL_CTE_ID_START 1
+#define GPDXL_COL_ID_START 1
+
+namespace gpdxl
+{
+	// fwd declarations
+	class CTranslatorQueryToDXL;
+	class CTranslatorScalarToDXL;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CContextQueryToDXL
+	//
+	//	@doc:
+	//		Class to hold information about a whole top-level query, while
+	//		recursively translating a Query tree to DXL tree.
+	//
+	//---------------------------------------------------------------------------
+	class CContextQueryToDXL
+	{
+		friend CTranslatorQueryToDXL;
+		friend CTranslatorScalarToDXL;
+
+		private:
+			// memory pool
+			IMemoryPool *m_mp;
+
+			// counter for generating unique column ids
+			CIdGenerator *m_colid_counter;
+
+			// counter for generating unique CTE ids
+			CIdGenerator *m_cte_id_counter;
+
+			// does the query have any distributed tables?
+			BOOL m_has_distributed_tables;
+
+		public:
+			// ctor
+			CContextQueryToDXL
+				(
+				IMemoryPool *mp
+				);
+
+			// dtor
+			~CContextQueryToDXL();
+	};
+}
+#endif // GPDXL_CContextQueryToDXL_H
+
+//EOF

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -17,7 +17,7 @@
 #define GPDXL_CTranslatorUtils_H
 #define GPDXL_SYSTEM_COLUMNS 8
 
-#include "gpopt/translate/CTranslatorScalarToDXL.h"
+#include "gpopt/translate/CMappingVarColId.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CBitSet.h"


### PR DESCRIPTION
The new class, CContextDXLToPlStmt, holds information that's global for
the whole query. This makes subquery planning less awkward, as we don't
need to pass global information up and down the query levels.


I extracted this from https://github.com/greenplum-db/gpdb/pull/6327. Seems best to handle this as a separate PR, because this is a sensible change on its own, and anything that we can take off from that massive PR makes it easier to review.