### PR TITLE
Stop creating an immediate restartpoint at replay of every checkpoint record

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7375,8 +7375,11 @@ StartupXLOG(void)
 				 * it bypasses the shared buffer cache and reads directly from disk.
 				 * For now, restore the old behavior, before the upstream change
 				 * to start bgwriter during archive recovery, and create a
-				 * restartpoint immediately after replaying a checkpoint record.
+				 * restartpoint immediately after replaying a checkpoint record and
+				 * only if this GUC is set we force aggressive checkpoint, and
+				 * currently gp_replica_check forces this guc on.
 				 */
+				if (create_restartpoint_on_ckpt_record_replay && ArchiveRecoveryRequested)
 				{
 					uint8 xlogRecInfo = record->xl_info & ~XLR_INFO_MASK;
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -216,6 +216,8 @@ int			gp_connection_send_timeout;
 
 int			WalSendClientTimeout = 30000;		/* 30 seconds. */
 
+bool create_restartpoint_on_ckpt_record_replay = false;
+
 char	   *data_directory;
 
 static char *gp_resource_manager_str;
@@ -3009,6 +3011,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 			NULL
 		},
 		&pgstat_collect_queuelevel,
+		false, NULL, NULL
+	},
+
+	{
+		{"create_restartpoint_on_ckpt_record_replay", PGC_SIGHUP, DEVELOPER_OPTIONS,
+			gettext_noop("create a restartpoint only on mirror immediately after replaying a checkpoint record."),
+			NULL
+		},
+		&create_restartpoint_on_ckpt_record_replay,
 		false, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -404,6 +404,8 @@ extern int	gp_connection_send_timeout;
 
 extern int  WalSendClientTimeout;
 
+extern bool create_restartpoint_on_ckpt_record_replay;
+
 extern char  *data_directory;
 
 /* ORCA related definitions */


### PR DESCRIPTION
There is a issue record a fixme `GPDB_84_MERGE_FIXME: Create restartpoints aggressively.`
https://github.com/greenplum-db/gpdb/issues/4114

https://github.com/greenplum-db/gpdb/pull/6516 is needed, because without it, the pipeline would fail on `fts_recovery_in_progress`,  although the test can pass on my local mac book

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`