### PR TITLE
Make SET command two-phase-commit aware

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -87,6 +87,7 @@
 #include "utils/xml.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbvars.h"
+#include "utils/faultinjector.h"
 
 #ifndef PG_KRB_SRVTAB
 #define PG_KRB_SRVTAB ""
@@ -7177,6 +7178,8 @@ void
 ExecSetVariableStmt(VariableSetStmt *stmt, bool isTopLevel)
 {
 	GucAction	action = stmt->is_local ? GUC_ACTION_LOCAL : GUC_ACTION_SET;
+
+	SIMPLE_FAULT_INJECTOR(VariableSet);
 
 	switch (stmt->kind)
 	{

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -253,6 +253,8 @@ FI_IDENT(CreateGangInProgress, "create_gang_in_progress")
 FI_IDENT(DecreaseToastMaxChunkSize, "decrease_toast_max_chunk_size")
 /* inject fault to let cleanupGang return false */
 FI_IDENT(CleanupQE, "cleanup_qe")
+/* inject fault to make SET command fail */
+FI_IDENT(VariableSet, "variable_set")
 #endif
 
 /*

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -436,5 +436,21 @@ language plpgsql volatile;
 set gp_cached_segworkers_threshold to 1;
 select count(*) from dispatch_foo, dispatch_bar where exists (select dispatch_foo_func());
 reset gp_cached_segworkers_threshold;
+--
+-- Test SET command also need two phase commit
+--
+set default_with_oids to true;
+select gp_inject_fault('variable_set', 'reset', 2);
+select gp_inject_fault('variable_set', 'error', 2);
+-- set command should fail, default_with_oids should still be true
+set default_with_oids to false;
+-- insert tuples to all segments, we should see tuples on all segments has oid
+create table set_test_t1 (c1 int, c2 int);
+insert into set_test_t1 select i, i from generate_series(1, 10) i;
+-- should be zero
+select count(*) from set_test_t1 where oid=0;
+-- reset fault
+select gp_inject_fault('variable_set', 'reset', 2);
 \c regression
 DROP DATABASE dispatch_test_db;
+

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -439,16 +439,15 @@ reset gp_cached_segworkers_threshold;
 --
 -- Test SET command also need two phase commit
 --
-set default_with_oids to true;
+CREATE OR REPLACE FUNCTION gp_execute_on_server(content int, query text) returns text
+language C as '@abs_builddir@/regress@DLSUFFIX@', 'gp_execute_on_server';
 select gp_inject_fault('variable_set', 'reset', 2);
 select gp_inject_fault('variable_set', 'error', 2);
--- set command should fail, default_with_oids should still be true
-set default_with_oids to false;
--- insert tuples to all segments, we should see tuples on all segments has oid
-create table set_test_t1 (c1 int, c2 int);
-insert into set_test_t1 select i, i from generate_series(1, 10) i;
--- should be zero
-select count(*) from set_test_t1 where oid=0;
+set log_min_messages to error ;
+-- set command should fail, log_min_messages should still be warning 
+select gp_execute_on_server(0, 'show log_min_messages');
+select gp_execute_on_server(1, 'show log_min_messages');
+select gp_execute_on_server(2, 'show log_min_messages');
 -- reset fault
 select gp_inject_fault('variable_set', 'reset', 2);
 \c regression

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -773,5 +773,48 @@ select count(*) from dispatch_foo, dispatch_bar where exists (select dispatch_fo
 (1 row)
 
 reset gp_cached_segworkers_threshold;
+--
+-- Test SET command also need two phase commit
+--
+set default_with_oids to true;
+select gp_inject_fault('variable_set', 'reset', 2);
+NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=458627)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('variable_set', 'error', 2);
+NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=458627)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- set command should fail, default_with_oids should still be true
+set default_with_oids to false;
+ERROR:  fault triggered, fault name:'variable_set' fault type:'error'  (seg0 10.153.101.106:25432 pid=458636)
+-- insert tuples to all segments, we should see tuples on all segments has oid
+create table set_test_t1 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  OIDS=TRUE is not recommended for user-created tables
+HINT:  Use OIDS=FALSE to prevent wrap-around of the OID counter.
+insert into set_test_t1 select i, i from generate_series(1, 10) i;
+-- should be zero
+select count(*) from set_test_t1 where oid=0;
+ count 
+-------
+     0
+(1 row)
+
+-- reset fault
+select gp_inject_fault('variable_set', 'reset', 2);
+NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=458627)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
 \c regression
 DROP DATABASE dispatch_test_db;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -776,7 +776,8 @@ reset gp_cached_segworkers_threshold;
 --
 -- Test SET command also need two phase commit
 --
-set default_with_oids to true;
+CREATE OR REPLACE FUNCTION gp_execute_on_server(content int, query text) returns text
+language C as '/data1/tpz/gpdb/src/test/regress/regress.so', 'gp_execute_on_server';
 select gp_inject_fault('variable_set', 'reset', 2);
 NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=458627)
  gp_inject_fault 
@@ -791,21 +792,25 @@ NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=458627)
  t
 (1 row)
 
--- set command should fail, default_with_oids should still be true
-set default_with_oids to false;
-ERROR:  fault triggered, fault name:'variable_set' fault type:'error'  (seg0 10.153.101.106:25432 pid=458636)
--- insert tuples to all segments, we should see tuples on all segments has oid
-create table set_test_t1 (c1 int, c2 int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  OIDS=TRUE is not recommended for user-created tables
-HINT:  Use OIDS=FALSE to prevent wrap-around of the OID counter.
-insert into set_test_t1 select i, i from generate_series(1, 10) i;
--- should be zero
-select count(*) from set_test_t1 where oid=0;
- count 
--------
-     0
+set log_min_messages to error ;
+ERROR:  fault triggered, fault name:'variable_set' fault type:'error'  (seg0 10.153.101.106:25432 pid=35374)
+-- set command should fail, log_min_messages should still be warning 
+select gp_execute_on_server(0, 'show log_min_messages');
+ gp_execute_on_server 
+----------------------
+ warning
+(1 row)
+
+select gp_execute_on_server(1, 'show log_min_messages');
+ gp_execute_on_server 
+----------------------
+ warning
+(1 row)
+
+select gp_execute_on_server(2, 'show log_min_messages');
+ gp_execute_on_server 
+----------------------
+ warning
 (1 row)
 
 -- reset fault


### PR DESCRIPTION
The flag two-phase-commit is used to be false for SET commands which
make SET commands cannot be rolled back in a transaction which does
not match the upstream, this commit fixes this defect.
