### PR TITLE
Add --with-zstd to configure options to compile with zstd

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -21,6 +21,13 @@ function install_gpdb() {
 function configure() {
   source /opt/gcc_env.sh
   pushd gpdb_src
+      # Compile with zstandard compression only for CentOS. More OS
+      # support will come later as respective build images start
+      # containing the library baked in.
+      if [ "$TEST_OS" == "centos" ]; then
+        CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-zstd"
+      fi
+
       # The full set of configure options which were used for building the
       # tree must be used here as well since the toplevel Makefile depends
       # on these options for deciding what to test. Since we don't ship

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -42,6 +42,14 @@ function setup_gpadmin_user() {
     ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash "$TEST_OS"
 }
 
+function setup_configure_vars() {
+    # We need to add GPHOME paths for configure to check for packaged
+    # libraries (e.g. ZStandard).
+    source /usr/local/greenplum-db-devel/greenplum_path.sh
+    export LDFLAGS="-L${GPHOME}/lib"
+    export CPPFLAGS="-I${GPHOME}/include"
+}
+
 function _main() {
     if [ -z "${MAKE_TEST_COMMAND}" ]; then
         echo "FATAL: MAKE_TEST_COMMAND is not set"
@@ -76,9 +84,10 @@ function _main() {
       ln -sf "$libperl_path" /lib64/libperl.so || return 1
     fi
 
-    time configure
     time install_gpdb
     time setup_gpadmin_user
+    time setup_configure_vars
+    time configure
     time make_cluster
     time gen_env
     time run_test

--- a/gpcontrib/zstd/expected/compression_zstd.out
+++ b/gpcontrib/zstd/expected/compression_zstd.out
@@ -5,23 +5,23 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 INSERT INTO zstdtest SELECT g, 'foo' || g FROM generate_series(1, 100000) g;
 INSERT INTO zstdtest SELECT g, 'bar' || g FROM generate_series(1, 100000) g;
 -- Check contents, at the beginning of the table and at the end.
-SELECT * FROM zstdtest ORDER BY id LIMIT 5;
+SELECT * FROM zstdtest ORDER BY (id, t) LIMIT 5;
  id |  t   
 ----+------
   1 | bar1
   1 | foo1
-  2 | foo2
   2 | bar2
+  2 | foo2
   3 | bar3
 (5 rows)
 
-SELECT * FROM zstdtest ORDER BY id DESC LIMIT 5;
+SELECT * FROM zstdtest ORDER BY (id, t) DESC LIMIT 5;
    id   |     t     
 --------+-----------
- 100000 | bar100000
  100000 | foo100000
-  99999 | bar99999
+ 100000 | bar100000
   99999 | foo99999
+  99999 | bar99999
   99998 | foo99998
 (5 rows)
 
@@ -37,46 +37,46 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO zstdtest_1 SELECT g, 'foo' || g FROM generate_series(1, 10000) g;
 INSERT INTO zstdtest_1 SELECT g, 'bar' || g FROM generate_series(1, 10000) g;
-SELECT * FROM zstdtest_1 ORDER BY id LIMIT 5;
+SELECT * FROM zstdtest_1 ORDER BY (id, t) LIMIT 5;
  id |  t   
 ----+------
   1 | bar1
   1 | foo1
-  2 | foo2
   2 | bar2
+  2 | foo2
   3 | bar3
 (5 rows)
 
-SELECT * FROM zstdtest_1 ORDER BY id DESC LIMIT 5;
+SELECT * FROM zstdtest_1 ORDER BY (id, t) DESC LIMIT 5;
   id   |    t     
 -------+----------
  10000 | foo10000
  10000 | bar10000
-  9999 | bar9999
   9999 | foo9999
-  9998 | bar9998
+  9999 | bar9999
+  9998 | foo9998
 (5 rows)
 
 INSERT INTO zstdtest_19 SELECT g, 'foo' || g FROM generate_series(1, 10000) g;
 INSERT INTO zstdtest_19 SELECT g, 'bar' || g FROM generate_series(1, 10000) g;
-SELECT * FROM zstdtest_19 ORDER BY id LIMIT 5;
+SELECT * FROM zstdtest_19 ORDER BY (id, t) LIMIT 5;
  id |  t   
 ----+------
   1 | bar1
   1 | foo1
-  2 | foo2
   2 | bar2
+  2 | foo2
   3 | bar3
 (5 rows)
 
-SELECT * FROM zstdtest_19 ORDER BY id DESC LIMIT 5;
+SELECT * FROM zstdtest_19 ORDER BY (id, t) DESC LIMIT 5;
   id   |    t     
 -------+----------
  10000 | foo10000
  10000 | bar10000
-  9999 | bar9999
   9999 | foo9999
-  9998 | bar9998
+  9999 | bar9999
+  9998 | foo9998
 (5 rows)
 
 -- Test the bounds of compresslevel. None of these are allowed.

--- a/gpcontrib/zstd/sql/compression_zstd.sql
+++ b/gpcontrib/zstd/sql/compression_zstd.sql
@@ -6,8 +6,8 @@ INSERT INTO zstdtest SELECT g, 'foo' || g FROM generate_series(1, 100000) g;
 INSERT INTO zstdtest SELECT g, 'bar' || g FROM generate_series(1, 100000) g;
 
 -- Check contents, at the beginning of the table and at the end.
-SELECT * FROM zstdtest ORDER BY id LIMIT 5;
-SELECT * FROM zstdtest ORDER BY id DESC LIMIT 5;
+SELECT * FROM zstdtest ORDER BY (id, t) LIMIT 5;
+SELECT * FROM zstdtest ORDER BY (id, t) DESC LIMIT 5;
 
 
 -- Test different compression levels:
@@ -17,13 +17,13 @@ CREATE TABLE zstdtest_19 (id int4, t text) WITH (appendonly=true, compresstype=z
 
 INSERT INTO zstdtest_1 SELECT g, 'foo' || g FROM generate_series(1, 10000) g;
 INSERT INTO zstdtest_1 SELECT g, 'bar' || g FROM generate_series(1, 10000) g;
-SELECT * FROM zstdtest_1 ORDER BY id LIMIT 5;
-SELECT * FROM zstdtest_1 ORDER BY id DESC LIMIT 5;
+SELECT * FROM zstdtest_1 ORDER BY (id, t) LIMIT 5;
+SELECT * FROM zstdtest_1 ORDER BY (id, t) DESC LIMIT 5;
 
 INSERT INTO zstdtest_19 SELECT g, 'foo' || g FROM generate_series(1, 10000) g;
 INSERT INTO zstdtest_19 SELECT g, 'bar' || g FROM generate_series(1, 10000) g;
-SELECT * FROM zstdtest_19 ORDER BY id LIMIT 5;
-SELECT * FROM zstdtest_19 ORDER BY id DESC LIMIT 5;
+SELECT * FROM zstdtest_19 ORDER BY (id, t) LIMIT 5;
+SELECT * FROM zstdtest_19 ORDER BY (id, t) DESC LIMIT 5;
 
 
 -- Test the bounds of compresslevel. None of these are allowed.


### PR DESCRIPTION
We want zstd compression to be available as a feature for GPDB 6, so we are now compiling with zstd on CentOS in preparation for the GPDB 6 beta.

We plan to vendor the zstd binaries, as they are not available in the standard CentOS repositories.

- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`