### PR TITLE
Add a sanity check for numsegments properity

### DIFF
--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -308,6 +308,24 @@ GpPolicyFetch(Oid tbloid)
 		else
 			numsegments = DatumGetInt32(attr);
 
+		/*
+		 * Sanity check of numsegments.
+		 *
+		 * Currently, Gxact always use a fixed size of cluster after the Gxact started,
+		 * If a table is expanded after Gxact started, we should report an error,
+		 * otherwise, planner will arrange a gang whose size is larger than the size
+		 * of cluster and dispatcher cannot handle this.
+		 */
+		if (numsegments > GP_POLICY_ALL_NUMSEGMENTS)
+		{
+			ReleaseSysCache(gp_policy_tuple);
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_YET),
+					 errmsg("sanity check failed"),
+					 errdetail("\"numsegments\" of table cannot be larger than the size of the cluster"),
+					 errhint("table might be expanded after current global transaction is started, re-run the query")));
+		}
+
 		attr = SysCacheGetAttr(GPPOLICYID, gp_policy_tuple,
 							   Anum_gp_policy_type,
 							   &isNull);

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -8,6 +8,7 @@ drop schema if exists test_partial_table;
 NOTICE:  schema "test_partial_table" does not exist, skipping
 create schema test_partial_table;
 set search_path=test_partial_table,public;
+set allow_system_table_mods=true;
 --
 -- prepare kinds of tables
 --
@@ -4223,3 +4224,14 @@ rollback;
 -- to perform distributed commit on the other segments.
 --
 insert into r1 (c4) values (pg_relation_size('r2'));
+-- Test numsegments properity cannot be larger than the size of cluster
+create table size_sanity_check(c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+update gp_distribution_policy set numsegments = 10 where localoid = 'size_sanity_check'::regclass;
+select * from size_sanity_check;
+ERROR:  sanity check failed
+LINE 1: select * from size_sanity_check;
+                      ^
+DETAIL:  "numsegments" of table cannot be larger than the size of the cluster
+HINT:  table might be expanded after current global transaction is started, re-run the query

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -10,6 +10,7 @@ create extension if not exists gp_debug_numsegments;
 drop schema if exists test_partial_table;
 create schema test_partial_table;
 set search_path=test_partial_table,public;
+set allow_system_table_mods=true;
 
 --
 -- prepare kinds of tables
@@ -584,3 +585,9 @@ rollback;
 -- to perform distributed commit on the other segments.
 --
 insert into r1 (c4) values (pg_relation_size('r2'));
+
+-- Test numsegments properity cannot be larger than the size of cluster
+create table size_sanity_check(c1 int, c2 int);
+update gp_distribution_policy set numsegments = 10 where localoid = 'size_sanity_check'::regclass;
+select * from size_sanity_check;
+


### PR DESCRIPTION
I noticed that we haven't a sanity check for the correctness of
"numsegments" of a table, the numsegments might be larger than
the size of cluster, eg, table is expanded after a global
transaction is started and then the table is accessed in that
transaction or gp_distribution_policy is corrupt in some way,
Dispatcher or interconnect cannot handle such case, so add a
sanity check to error it out.

## Here are some reminders before you submit the pull request
- [] Add tests for the change
- [] Document changes
- [] Communicate in the mailing list if needed
- [] Pass `make installcheck`