### PR TITLE
Do not use hardcoded TemplateDbOid for database access during standby…

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6272,8 +6272,10 @@ UpdateCatalogForStandbyPromotion(void)
 	 * tablespace; our access to the heap is going to be slightly
 	 * limited, so we'll just use some defaults.
 	 */
-	MyDatabaseId = TemplateDbOid;
-	MyDatabaseTableSpace = DEFAULTTABLESPACE_OID;
+	if (!FindMyDatabase(DB_FOR_COMMON_ACCESS, &MyDatabaseId, &MyDatabaseTableSpace))
+		ereport(FATAL,
+				(errcode(ERRCODE_UNDEFINED_DATABASE),
+				 errmsg("database \"%s\" does not exit", DB_FOR_COMMON_ACCESS)));
 
 	/*
 	 * Now we can mark our PGPROC entry with the database ID

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -79,8 +79,6 @@ static volatile bool shutdown_requested = false;
 static volatile bool probe_requested = false;
 static volatile sig_atomic_t got_SIGHUP = false;
 
-static char *probeDatabase = "postgres";
-
 /*
  * FUNCTION PROTOTYPES
  */
@@ -316,10 +314,10 @@ ftsMain(int argc, char *argv[])
 	 * tablespace; our access to the heap is going to be slightly
 	 * limited, so we'll just use some defaults.
 	 */
-	if (!FindMyDatabase(probeDatabase, &MyDatabaseId, &MyDatabaseTableSpace))
+	if (!FindMyDatabase(DB_FOR_COMMON_ACCESS, &MyDatabaseId, &MyDatabaseTableSpace))
 		ereport(FATAL,
 				(errcode(ERRCODE_UNDEFINED_DATABASE),
-				 errmsg("database \"%s\" does not exit", probeDatabase)));
+				 errmsg("database \"%s\" does not exit", DB_FOR_COMMON_ACCESS)));
 
 	/* Now we can mark our PGPROC entry with the database ID */
 	/* (We assume this is an atomic store so no lock is needed) */

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -155,7 +155,6 @@ GlobalDeadLockDetectorMain(int argc, char *argv[])
 	sigjmp_buf	local_sigjmp_buf;
 	Port		portbuf;
 	char	   *fullpath;
-	char	   *knownDatabase = "postgres";
 
 	IsUnderPostmaster = true;
 	am_global_deadlock_detector = true;
@@ -321,10 +320,10 @@ GlobalDeadLockDetectorMain(int argc, char *argv[])
 	 * tablespace; our access to the heap is going to be slightly
 	 * limited, so we'll just use some defaults.
 	 */
-	if (!FindMyDatabase(knownDatabase, &MyDatabaseId, &MyDatabaseTableSpace))
+	if (!FindMyDatabase(DB_FOR_COMMON_ACCESS, &MyDatabaseId, &MyDatabaseTableSpace))
 		ereport(FATAL,
 				(errcode(ERRCODE_UNDEFINED_DATABASE),
-				 errmsg("database \"%s\" does not exit", knownDatabase)));
+				 errmsg("database \"%s\" does not exit", DB_FOR_COMMON_ACCESS)));
 
 	/* Now we can mark our PGPROC entry with the database ID */
 	/* (We assume this is an atomic store so no lock is needed) */
@@ -342,7 +341,7 @@ GlobalDeadLockDetectorMain(int argc, char *argv[])
 	MyProcPort = &portbuf;
 	MyProcPort->user_name = MemoryContextStrdup(TopMemoryContext,
 												GetUserNameFromId(GetAuthenticatedUserId()));
-	MyProcPort->database_name = knownDatabase;
+	MyProcPort->database_name = DB_FOR_COMMON_ACCESS;
 
 	/* close the transaction we started above */
 	CommitTransactionCommand();

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -382,6 +382,15 @@ extern void PreventCommandDuringRecovery(const char *cmdname);
 extern int	trace_recovery_messages;
 extern int	trace_recovery(int trace_level);
 
+/*
+ * database which is used by startup, gdd, fts, etc for catalog access.
+ * We are not using template1 since it seems that users would like to recreate
+ * the template1 database for customization sometimes. That means template1
+ * could be dropped and then recreated and thus that will break
+ * startup, gdd, fts, etc.
+ */
+#define DB_FOR_COMMON_ACCESS	"postgres"
+
 /*****************************************************************************
  *	  pdir.h --																 *
  *			POSTGRES directory path definitions.                             *

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -387,7 +387,10 @@ extern int	trace_recovery(int trace_level);
  * We are not using template1 since it seems that users would like to recreate
  * the template1 database for customization sometimes. That means template1
  * could be dropped and then recreated and thus that will break
- * startup, gdd, fts, etc.
+ * startup, gdd, fts, etc. Also template1 is the default template for the
+ * 'create database' command. Using template1 will make that command fail:
+ * "ERROR:  source database "template1" is being accessed by other users"
+ * "DETAIL:  There are 2 other sessions using the database."
  */
 #define DB_FOR_COMMON_ACCESS	"postgres"
 


### PR DESCRIPTION
… promotion.

TemplateDbOid is for database template1, but template1 could be recreated and
thus its oid is not longer TemplateDbOid.

Use database postgres to find database oid and tablespace like fts and gdd do.
We should better use the same database for such purpose. I thought about which
database gpdb should use: template1 or postgres. Both of them are template
database, but it seems that some users or customers sometimes customize their
own template1 database. Using database postgres seems to make that easier. Of
course users possibly drop the database postgres, but that is a rare case and they
could easily create one for such a purpose. We really do not need to over-design
for such rare case.