### PR TITLE
Support appendoptimized in reloptions as an alias to appendonly

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -222,7 +222,13 @@ accumAOStorageOpt(char *name, char *value,
 
 	initStringInfo(&buf);
 
-	if (pg_strcasecmp(SOPT_APPENDONLY, name) == 0)
+	/*
+	 * "appendoptimized" is a recognized alias for "appendonly", but it's a
+	 * thin alias in the sense that "appendonly" will be saved as the storage
+	 * option.
+	 */
+	if ((pg_strcasecmp(SOPT_APPENDONLY, name) == 0) ||
+		(pg_strcasecmp(SOPT_ALIAS_APPENDOPTIMIZED, name) == 0))
 	{
 		if (!parse_bool(value, &boolval))
 			ereport(ERROR,

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -923,7 +923,7 @@ validate_and_adjust_options(StdRdOptions *result,
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("invalid option \"compresstype\" for base relation"),
-					 errhint("\"compresstype\" is only valid for Append Only relations, create an AO relation to use \"compresstype\"")));
+					 errhint("\"compresstype\" is only valid for Append Only relations, create an AO relation to use \"compresstype\".")));
 
 		if (!compresstype_is_valid(comptype_opt->values.string_val))
 			ereport(ERROR,
@@ -1054,7 +1054,7 @@ validate_and_adjust_options(StdRdOptions *result,
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("invalid option \"checksum\" for base relation"),
-					 errhint("\"checksum\" option only valid for Append Only relations, data checksum for heap relations are turned on at cluster creation")));
+					 errhint("\"checksum\" option only valid for Append Only relations, data checksum for heap relations are turned on at cluster creation.")));
 		result->checksum = checksum_opt->values.bool_val;
 	}
 	/* Disable checksum for heap relations. */
@@ -1271,7 +1271,7 @@ validateAppendOnlyRelOptions(bool ao,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("block size (%d) is smaller gp_safefswritesize (%d)",
 						blocksize, gp_safefswritesize),
-				 errhint("Increase blocksize or decrease gp_safefswritesize if it is safe to do so on this file system")));
+				 errhint("Increase blocksize or decrease gp_safefswritesize if it is safe to do so on this file system.")));
 }
 
 /*

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3161,7 +3161,17 @@ reloption_list:
 reloption_elem:
 			ColLabel '=' def_arg
 				{
-					$$ = makeDefElem($1, (Node *) $3);
+					/*
+					 * appendoptimized is an alias for appendonly in order to
+					 * provide a reloption syntax which better reflects the
+					 * featureset of AO tables. It is implemented as a very
+					 * thin alias, the reloptions and messaging will still
+					 * say appendonly.
+					 */
+					if (strcmp($1, "appendoptimized") == 0)
+						$$ = makeDefElem("appendonly", (Node *) $3);
+					else
+						$$ = makeDefElem($1, (Node *) $3);
 				}
 			| ColLabel
 				{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -590,6 +590,8 @@ extern IndexCheckType gp_indexcheck_vacuum;
 #define SOPT_COMPLEVEL     "compresslevel"
 #define SOPT_CHECKSUM      "checksum"
 #define SOPT_ORIENTATION   "orientation"
+/* Aliases for storage option names */
+#define SOPT_ALIAS_APPENDOPTIMIZED "appendoptimized"
 /* Max number of chars needed to hold value of a storage option. */
 #define MAX_SOPT_VALUE_LEN 15
 

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -44,6 +44,20 @@ CREATE TABLE tenk_ao10 (like tenk_heap) with (compresslevel=5);
 CREATE TABLE tenk_ao11 (like tenk_heap) with (blocksize=8192);
 CREATE TABLE tenk_ao12 (like tenk_heap) with (appendonly=false,blocksize=8192);
 
+-- appendoptimized is an alias for appendonly
+CREATE TABLE tenk_ao13 (like tenk_heap) with (appendoptimized=true);
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendonly=true, appendoptimized=false);
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=maybe);
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, appendoptimized=true);
+
+-- also make sure appendoptimized works in the gp_default_storage_options GUC
+SET gp_default_storage_options = 'appendonly=true,blocksize=32768,compresstype=none,checksum=true,orientation=row,appendoptimized=false';
+SET gp_default_storage_options = 'appendoptimized=true,blocksize=32768,compresstype=none,checksum=true,orientation=row';
+SHOW gp_default_storage_options;
+CREATE TABLE tenk_ao14 (like tenk_heap);
+SELECT relstorage FROM pg_catalog.pg_class WHERE relname = 'tenk_ao14';
+RESET gp_default_storage_options;
+
 -------------------- 
 -- catalog checks
 --------------------

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -62,20 +62,48 @@ HINT:  "blocksize" is only valid for Append Only relations, create an AO relatio
 CREATE TABLE tenk_ao12 (like tenk_heap) with (appendonly=false,blocksize=8192);
 ERROR:  invalid option "blocksize" for base relation
 HINT:  "blocksize" is only valid for Append Only relations, create an AO relation to use "blocksize".
+-- appendoptimized is an alias for appendonly
+CREATE TABLE tenk_ao13 (like tenk_heap) with (appendoptimized=true);
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendonly=true, appendoptimized=false);
+ERROR:  parameter "appendonly" specified more than once
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=maybe);
+ERROR:  invalid value for option "appendonly"
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, appendoptimized=true);
+ERROR:  parameter "appendonly" specified more than once
+-- also make sure appendoptimized works in the gp_default_storage_options GUC
+SET gp_default_storage_options = 'appendonly=true,blocksize=32768,compresstype=none,checksum=true,orientation=row,appendoptimized=false';
+ERROR:  parameter "appendonly" specified more than once
+SET gp_default_storage_options = 'appendoptimized=true,blocksize=32768,compresstype=none,checksum=true,orientation=row';
+SHOW gp_default_storage_options;
+                           gp_default_storage_options                            
+---------------------------------------------------------------------------------
+ appendonly=true,blocksize=32768,compresstype=none,checksum=true,orientation=row
+(1 row)
+
+CREATE TABLE tenk_ao14 (like tenk_heap);
+SELECT relstorage FROM pg_catalog.pg_class WHERE relname = 'tenk_ao14';
+ relstorage 
+------------
+ a
+(1 row)
+
+RESET gp_default_storage_options;
 -------------------- 
 -- catalog checks
 --------------------
 -- check pg_appendonly
 SELECT c.relname, a.blocksize, a.compresstype, a.compresslevel, a.checksum FROM pg_class c, pg_appendonly a
        WHERE c.relname LIKE 'tenk_ao%' AND c.oid=a.relid AND c.relname not like 'tenk_aocs%' ORDER BY c.relname;
- relname  | blocksize | compresstype | compresslevel | checksum 
-----------+-----------+--------------+---------------+----------
- tenk_ao1 |     32768 |              |             0 | t
- tenk_ao2 |    262144 |              |             0 | t
- tenk_ao3 |   1048576 | zlib         |             6 | t
- tenk_ao4 |     32768 | zlib         |             1 | t
- tenk_ao5 |   1048576 | zlib         |             6 | t
-(5 rows)
+  relname  | blocksize | compresstype | compresslevel | checksum 
+-----------+-----------+--------------+---------------+----------
+ tenk_ao1  |     32768 |              |             0 | t
+ tenk_ao13 |     32768 |              |             0 | t
+ tenk_ao14 |     32768 |              |             0 | t
+ tenk_ao2  |    262144 |              |             0 | t
+ tenk_ao3  |   1048576 | zlib         |             6 | t
+ tenk_ao4  |     32768 | zlib         |             1 | t
+ tenk_ao5  |   1048576 | zlib         |             6 | t
+(7 rows)
 
 --------------------
 -- fn needed later
@@ -436,14 +464,16 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'un
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT c.relname, a.blocksize, a.compresstype, a.compresslevel, a.checksum FROM pg_class c, pg_appendonly a
        WHERE c.relname LIKE 'tenk_ao%' AND c.oid=a.relid AND c.relname not like 'tenk_aocs%' ORDER BY c.relname;
- relname  | blocksize | compresstype | compresslevel | checksum 
-----------+-----------+--------------+---------------+----------
- tenk_ao1 |     32768 |              |             0 | t
- tenk_ao2 |    262144 |              |             0 | t
- tenk_ao3 |   1048576 | zlib         |             6 | t
- tenk_ao4 |     32768 | zlib         |             1 | t
- tenk_ao5 |   1048576 | zlib         |             6 | t
-(5 rows)
+  relname  | blocksize | compresstype | compresslevel | checksum 
+-----------+-----------+--------------+---------------+----------
+ tenk_ao1  |     32768 |              |             0 | t
+ tenk_ao13 |     32768 |              |             0 | t
+ tenk_ao14 |     32768 |              |             0 | t
+ tenk_ao2  |    262144 |              |             0 | t
+ tenk_ao3  |   1048576 | zlib         |             6 | t
+ tenk_ao4  |     32768 | zlib         |             1 | t
+ tenk_ao5  |   1048576 | zlib         |             6 | t
+(7 rows)
 
 SELECT count(*) FROM tenk_ao1;
  count 


### PR DESCRIPTION
AO tables are long since Append Optimized and not Append Only, but the reloptions keyword (and much of the backend nomenclature) is still "appendonly". This adds support for "appendoptimized" as an alias for "appendonly". The created table will have "appendonly" set as the reloption as this is only a thin alias.
```
db=# create table t (a integer, b integer) with (appendoptimized=true);
CREATE TABLE
db=# \d+ t
                    Append-Only Table "public.t"
 Column |  Type   | Modifiers | Storage | Stats target | Description
--------+---------+-----------+---------+--------------+-------------
 a      | integer |           | plain   |              |
 b      | integer |           | plain   |              |
Compression Type: None
Compression Level: 0
Block Size: 32768
Checksum: t
Distributed by: (a)
Options: appendonly=true
```
The rationale for making it a thin alias is that it would be quite invasive to make everything "appendonly" also be "appendoptimized" for little gain compared to the added code complexity. This will allow new users for whom "appendonly" is strange to use a more reasonable reloption in their code.

As per request from @ashwinstar and (I think) @ivannovick 