### PR TITLE
CI: Install each package for open source compilation in a separate yum command

### DIFF
--- a/concourse/scripts/compile_gpdb_open_source_centos.bash
+++ b/concourse/scripts/compile_gpdb_open_source_centos.bash
@@ -11,30 +11,28 @@ function prep_env_for_centos() {
 }
 
 function install_system_deps() {
-  deps_list=" sudo 
-             passwd 
-             openssh-server 
-             ed 
-             readline-devel 
-             zlib-devel 
-             curl-devel 
-             bzip2-devel 
-             python-devel 
-             apr-devel 
-             libevent-devel 
-             openssl-libs 
-             openssl-devel 
-             libyaml 
-             libyaml-devel 
-             epel-release 
-             htop 
-             perl-Env 
-             perl-ExtUtils-Embed 
+  deps_list=" sudo
+             passwd
+             openssh-server
+             ed
+             readline-devel
+             zlib-devel
+             curl-devel
+             bzip2-devel
+             python-devel
+             apr-devel
+             libevent-devel
+             openssl-devel
+             libyaml
+             libyaml-devel
+             epel-release
+             htop
+             perl-ExtUtils-Embed
              libzstd-devel
-             libxml2-devel 
-             libxslt-devel 
+             libxml2-devel
+             libxslt-devel
              libffi-devel "
-  for dep in "$deps_list";
+  for dep in $deps_list;
   do
     yum install -y -d 1 $dep
   done


### PR DESCRIPTION
Background: We tried changing the docker image for the open source compile job and
discovered that libzstd-devel wasn't installing. The issue was that
libzstd comes from epel-release, so epel-release had to be installed
first. The current docker image already has epel-release installed so
this issue never manifested.

Since the existing code looked like it was trying to install each
package with a separate yum command, we opted to make it actually do
that to fix this issue.

We also removed openssl-libs and perl-Env because they don't exist in
any repositories we have and the installation failed when we switched to
using separate yum installs. Since they weren't actually being installed
previously, this doesn't change behavior; it's just cleaning up dead code.

Dev pipeline: [gpdb-dev-kh-bc-oss-clean-up-yum-installs](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-kh-bc-oss-clean-up-yum-installs)

Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>