### PR TITLE
Create replication slots during initialization for primary/mirror pairs

### DIFF
--- a/doc/src/sgml/ref/pg_basebackup.sgml
+++ b/doc/src/sgml/ref/pg_basebackup.sgml
@@ -215,11 +215,32 @@ PostgreSQL documentation
       <listitem>
 
        <para>
-        Write a minimal <filename>recovery.conf</filename> in the output directory (or into
-        the base archive file when using tar format) to ease setting
-        up a standby server.
+        Write a minimal <filename>recovery.conf</filename> in the output
+        directory (or into the base archive file when using tar format) to
+        ease setting up a standby server.
+        The <filename>recovery.conf</filename> file will record the connection
+        settings and, if specified, the replication slot
+        that <application>pg_basebackup</application> is using, so that the
+        streaming replication will use the same settings later on.
        </para>
 
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><option>-S <replaceable>slotname</replaceable></option></term>
+      <term><option>--slot=<replaceable class="parameter">slotname</replaceable></option></term>
+      <listitem>
+       <para>
+        This option can only be used together with <literal>-X
+        stream</literal>.  It causes the WAL streaming to use the specified
+        replication slot.  If the base backup is intended to be used as a
+        streaming replication standby using replication slots, it should then
+        use the same replication slot name
+        in <filename>recovery.conf</filename>.  That way, it is ensured that
+        the server does not remove any necessary WAL data in the time between
+        the end of the base backup and the start of streaming replication.
+       </para>
       </listitem>
      </varlistentry>
 

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -136,7 +136,7 @@ PROCESS_QE () {
     if [ x"" != x"$COPY_FROM_PRIMARY_HOSTADDRESS" ]; then
         LOG_MSG "[INFO]:-Running pg_basebackup to init mirror on ${GP_HOSTADDRESS} using primary on ${COPY_FROM_PRIMARY_HOSTADDRESS} ..." 1
         RUN_COMMAND_REMOTE ${COPY_FROM_PRIMARY_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; echo 'host  replication ${GP_USER} samenet trust' >> ${COPY_FROM_PRIMARY_DIR}/pg_hba.conf; pg_ctl -D ${COPY_FROM_PRIMARY_DIR} reload"
-        RUN_COMMAND_REMOTE ${GP_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; rm -rf ${GP_DIR}; ${GPHOME}/bin/pg_basebackup -x -R -c fast -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D ${GP_DIR} -h ${COPY_FROM_PRIMARY_HOSTADDRESS} -p ${COPY_FROM_PRIMARY_PORT};"
+        RUN_COMMAND_REMOTE ${GP_HOSTADDRESS} "${EXPORT_GPHOME}; . ${GPHOME}/greenplum_path.sh; rm -rf ${GP_DIR}; ${GPHOME}/bin/pg_basebackup --xlog-method=stream --slot='internal_wal_replication_slot' -R -c fast -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -D ${GP_DIR} -h ${COPY_FROM_PRIMARY_HOSTADDRESS} -p ${COPY_FROM_PRIMARY_PORT};"
         REGISTER_MIRROR
         START_QE "-w"
         RETVAL=$?

--- a/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
+++ b/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
@@ -1,0 +1,6 @@
+Feature: Replication Slots
+
+  Scenario: A new cluster setup
+    Given I have a machine with no cluster
+    When I create a cluster
+    Then the primaries and mirrors should be replicating using replication slots

--- a/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
@@ -1,0 +1,51 @@
+import os
+
+from behave import given, when, then
+
+from test.behave_utils.utils import (
+    stop_database,
+    run_command,
+    execute_sql
+)
+
+def create_cluster(context):
+    cmd = """
+    cd ../gpAux/gpdemo; \
+        export MASTER_DEMO_PORT={master_port} && \
+        export DEMO_PORT_BASE={port_base} && \
+        export NUM_PRIMARY_MIRROR_PAIRS={num_primary_mirror_pairs} && \
+        export WITH_MIRRORS={with_mirrors} && \A
+        ./demo_cluster.sh -d && ./demo_cluster.sh -c && \
+        ./demo_cluster.sh
+    """.format(master_port=os.getenv('MASTER_PORT', 15432),
+               port_base=os.getenv('PORT_BASE', 25432),
+               num_primary_mirror_pairs=os.getenv('NUM_PRIMARY_MIRROR_PAIRS', 3),
+               with_mirrors='true')
+
+    run_command(context, cmd)
+
+    if context.ret_code != 0:
+        raise Exception('%s' % context.error_message)
+
+
+@given(u'I have a machine with no cluster')
+def step_impl(context):
+    stop_database(context)
+
+@when(u'I create a cluster')
+def step_impl(context):
+    create_cluster(context)
+
+@then(u'the primaries and mirrors should be replicating using replication slots')
+def step_impl(context):
+    results = execute_sql(
+        "postgres",
+        "select pg_get_replication_slots() from gp_dist_random('gp_id')"
+    )
+
+    if results.rowcount != 3:
+        raise Exception("expected all three primaries to have replication slots")
+
+    for result in results.fetchall():
+        if not result[0].startswith('(internal_wal_replication_slot,,physical,,t,'):
+            raise Exception("expected replication slot to be active")

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -27,10 +27,13 @@ if master_data_dir is None:
 
 
 def execute_sql(dbname, sql):
+    result = None
+
     with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
-        dbconn.execSQL(conn, sql)
+        result = dbconn.execSQL(conn, sql)
         conn.commit()
 
+    return result
 
 def execute_sql_singleton(dbname, sql):
     result = None

--- a/gpcontrib/gp_replica_check/gp_replica_check.c
+++ b/gpcontrib/gp_replica_check/gp_replica_check.c
@@ -230,6 +230,14 @@ sync_wait(void)
 		LWLockAcquire(SyncRepLock, LW_SHARED);
 		for (i = 0; i < max_wal_senders; i++)
 		{
+			/*
+			 * Because we can have more than one type of walreciever connected at
+			 * any time, there may be other walrecievers (like pg_basebackup) in
+			 * the walsnds list.
+			 */
+			if (!WalSndCtl->walsnds[i].is_for_gp_walreceiver)
+				continue;
+
 			/* fail early in-case primary and mirror are not in sync */
 			if (WalSndCtl->walsnds[i].pid == 0
 				|| WalSndCtl->walsnds[i].state != WALSNDSTATE_STREAMING)

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -34,12 +34,6 @@ GetMirrorStatus(FtsResponse *response)
 	response->IsInSync = false;
 	response->RequestRetry = false;
 
-	/*
-	 * Greenplum currently supports only ONE mirror per primary.
-	 * If there are more mirrors, this logic in this function need to be revised.
-	 */
-	Assert(max_wal_senders == 1);
-
 	LWLockAcquire(SyncRepLock, LW_SHARED);
 
 	for (int i = 0; i < max_wal_senders; i++)

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -23,6 +23,24 @@
 /* Set at database system is ready to accept connections */
 extern pg_time_t PMAcceptingConnectionsStartTime;
 
+static bool
+is_mirror_up(WalSnd *walsender)
+{
+	bool walsender_has_pid = walsender->pid != 0;
+
+	/*
+	 * WalSndSetState() resets replica_disconnected_at for
+	 * below states. If modifying below states then be sure
+	 * to update corresponding logic in WalSndSetState() as
+	 * well.
+	 */
+	bool is_communicating_with_mirror = walsender->state == WALSNDSTATE_CATCHUP ||
+		walsender->state == WALSNDSTATE_STREAMING;
+	
+	return walsender->is_for_gp_walreceiver && walsender_has_pid
+		&& is_communicating_with_mirror;
+}
+
 /*
  * Check the WalSndCtl to obtain if mirror is up or down, if the wal sender is
  * in streaming, and if synchronous replication is enabled or not.
@@ -30,6 +48,8 @@ extern pg_time_t PMAcceptingConnectionsStartTime;
 void
 GetMirrorStatus(FtsResponse *response)
 {
+	pg_time_t walsender_replica_disconnected_at = 0;
+
 	response->IsMirrorUp = false;
 	response->IsInSync = false;
 	response->RequestRetry = false;
@@ -38,59 +58,56 @@ GetMirrorStatus(FtsResponse *response)
 
 	for (int i = 0; i < max_wal_senders; i++)
 	{
-		WalSnd   *walsnd = &WalSndCtl->walsnds[i];
-		pg_time_t walsnd_replica_disconnected_at;
+		bool found_mirror_sender = false;
 
-		SpinLockAcquire(&walsnd->mutex);
-		if (walsnd->pid != 0)
+		WalSnd *walsender = &WalSndCtl->walsnds[i];
+
+		SpinLockAcquire(&walsender->mutex);
 		{
-			/*
-			 * WalSndSetState() resets replica_disconnected_at for
-			 * below states. If modifying below states then be sure
-			 * to update corresponding logic in WalSndSetState() as
-			 * well.
-			 */
-			if(walsnd->state == WALSNDSTATE_CATCHUP
-			   || walsnd->state == WALSNDSTATE_STREAMING)
-			{
-				response->IsMirrorUp = true;
-				response->IsInSync = (walsnd->state == WALSNDSTATE_STREAMING);
-			}
+			found_mirror_sender = walsender->is_for_gp_walreceiver;
+			walsender_replica_disconnected_at = walsender->replica_disconnected_at;
+
+			bool is_up = is_mirror_up(walsender);
+			bool is_streaming = (walsender->state == WALSNDSTATE_STREAMING);
+
+			response->IsMirrorUp = is_up;
+			response->IsInSync = (is_up && is_streaming);
 		}
-		walsnd_replica_disconnected_at = walsnd->replica_disconnected_at;
-		SpinLockRelease(&walsnd->mutex);
+		SpinLockRelease(&walsender->mutex);
 
-		if (!response->IsMirrorUp)
+		if (found_mirror_sender)
+			break;
+	}
+
+	if (!response->IsMirrorUp)
+	{
+		/*
+		 * PMAcceptingConnectionStartTime is process-local variable, set in
+		 * postmaster process and inherited by the FTS handler child
+		 * process. This works because the timestamp is set only once by
+		 * postmaster, and is guaranteed to be set before FTS handler child
+		 * processes can be spawned.
+		 */
+		Assert(PMAcceptingConnectionsStartTime);
+		pg_time_t delta = ((pg_time_t) time(NULL)) - Max(walsender_replica_disconnected_at, PMAcceptingConnectionsStartTime);
+		/*
+		 * Report mirror as down, only if it didn't connect for below
+		 * grace period to primary. This helps to avoid marking mirror
+		 * down unnecessarily when restarting primary or due to small n/w
+		 * glitch. During this period, request FTS to probe again.
+		 *
+		 * If the delta is negative, then it's overflowed, meaning it's
+		 * over gp_fts_mark_mirror_down_grace_period since either last
+		 * database accepting connections or last time wal sender
+		 * died. Then, we can safely mark the mirror is down.
+		 */
+		if (delta < gp_fts_mark_mirror_down_grace_period && delta >= 0)
 		{
-			Assert(walsnd_replica_disconnected_at);
-			/*
-			 * PMAcceptingConnectionStartTime is process-local variable, set in
-			 * postmaster process and inherited by the FTS handler child
-			 * process. This works because the timestamp is set only once by
-			 * postmaster, and is guaranteed to be set before FTS handler child
-			 * processes can be spawned.
-			 */
-			Assert(PMAcceptingConnectionsStartTime);
-			pg_time_t delta = ((pg_time_t) time(NULL)) - Max(walsnd_replica_disconnected_at, PMAcceptingConnectionsStartTime);
-			/*
-			 * Report mirror as down, only if it didn't connect for below
-			 * grace period to primary. This helps to avoid marking mirror
-			 * down unnecessarily when restarting primary or due to small n/w
-			 * glitch. During this period, request FTS to probe again.
-			 *
-			 * If the delta is negative, then it's overflowed, meaning it's
-			 * over gp_fts_mark_mirror_down_grace_period since either last
-			 * database accepting connections or last time wal sender
-			 * died. Then, we can safely mark the mirror is down.
-			 */
-			if (delta < gp_fts_mark_mirror_down_grace_period && delta >= 0)
-			{
-				ereport(LOG,
-						(errmsg("requesting fts retry as mirror didn't connect yet but in grace period: " INT64_FORMAT, delta),
-						 errdetail("pid zero at time: " INT64_FORMAT " accept connections start time: " INT64_FORMAT,
-									  walsnd_replica_disconnected_at, PMAcceptingConnectionsStartTime)));
-				response->RequestRetry = true;
-			}
+			ereport(LOG,
+					(errmsg("requesting fts retry as mirror didn't connect yet but in grace period: " INT64_FORMAT, delta),
+					 errdetail("pid zero at time: " INT64_FORMAT " accept connections start time: " INT64_FORMAT,
+							   walsender_replica_disconnected_at, PMAcceptingConnectionsStartTime)));
+			response->RequestRetry = true;
 		}
 	}
 

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -2073,6 +2073,8 @@ InitWalSenderSlot(void)
 			/* don't need the lock anymore */
 			OwnLatch((Latch *) &walsnd->latch);
 			MyWalSnd = (WalSnd *) walsnd;
+			walsnd->is_for_gp_walreceiver =
+				(strcmp(application_name, GP_WALRECEIVER_APPNAME) == 0);
 
 			break;
 		}

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2175,7 +2175,14 @@ static struct config_int ConfigureNamesInt[] =
 			NULL
 		},
 		&max_wal_senders,
-		1, 0, 1, /* GPDB doesn't support 1:n replication yet */
+		/*
+		 * GPDB doesn't support 1:n replication yet.  In normal operation,
+		 * when primary and mirror are streaming WAL, only 1 WalSnd should be
+		 * active.  We need 2 during base backup, 1 WalSnd to serve backup
+		 * request and 1 WalSnd to serve the log streamer process started by
+		 * pg_basebackup.
+		 */
+		10, 2, MAX_BACKENDS,
 		NULL, NULL, NULL
 	},
 
@@ -2186,7 +2193,7 @@ static struct config_int ConfigureNamesInt[] =
 			NULL
 		},
 		&max_replication_slots,
-		0, 0, MAX_BACKENDS /* XXX? */ ,
+		10, 1, MAX_BACKENDS /* XXX? */ ,
 		NULL, NULL, NULL
 	},
 

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1536,6 +1536,8 @@ escape_quotes(const char *src)
 	return result;
 }
 
+#define GP_WALRECEIVER_APPNAME "gp_walreceiver"
+
 /*
  * Create a recovery.conf file in memory using a PQExpBuffer
  */
@@ -1592,6 +1594,7 @@ GenerateRecoveryConf(PGconn *conn)
 		free(escaped);
 	}
 
+	appendPQExpBuffer(&conninfo_buf, " application_name=%s", GP_WALRECEIVER_APPNAME);
 	/*
 	 * Escape the connection string, so that it can be put in the config file.
 	 * Note that this is different from the escaping of individual connection

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -242,7 +242,8 @@ usage(void)
 	printf(_("  -r, --max-rate=RATE    maximum transfer rate to transfer data directory\n"
 			 "                         (in kB/s, or use suffix \"k\" or \"M\")\n"));
 	printf(_("  -R, --write-recovery-conf\n"
-			 "                         write recovery.conf for replication\n"));
+			 "                         write recovery.conf after backup\n"));
+	printf(_("  -S, --slot=SLOTNAME    replication slot to use\n"));
 	printf(_("  -T, --tablespace-mapping=OLDDIR=NEWDIR\n"
 	  "                         relocate tablespace in OLDDIR to NEWDIR\n"));
 	printf(_("  -x, --xlog             include required WAL files in backup (fetch mode)\n"));
@@ -1600,6 +1601,13 @@ GenerateRecoveryConf(PGconn *conn)
 	appendPQExpBuffer(recoveryconfcontents, "primary_conninfo = '%s'\n", escaped);
 	free(escaped);
 
+	if (replication_slot)
+	{
+		escaped = escape_quotes(replication_slot);
+		appendPQExpBuffer(recoveryconfcontents, "primary_slot_name = '%s'\n", replication_slot);
+		free(escaped);
+	}
+
 	if (PQExpBufferBroken(recoveryconfcontents) ||
 		PQExpBufferDataBroken(conninfo_buf))
 	{
@@ -1788,7 +1796,7 @@ BaseBackup(void)
 
 	if (num_exclude != 0)
 		free(exclude_list);
-	
+
 	if (PQsendQuery(conn, basebkp) == 0)
 	{
 		fprintf(stderr, _("%s: could not send replication command \"%s\": %s"),
@@ -2073,6 +2081,7 @@ main(int argc, char **argv)
 		{"checkpoint", required_argument, NULL, 'c'},
 		{"max-rate", required_argument, NULL, 'r'},
 		{"write-recovery-conf", no_argument, NULL, 'R'},
+		{"slot", required_argument, NULL, 'S'},
 		{"tablespace-mapping", required_argument, NULL, 'T'},
 		{"xlog", no_argument, NULL, 'x'},
 		{"xlog-method", required_argument, NULL, 'X'},
@@ -2117,7 +2126,7 @@ main(int argc, char **argv)
 	}
 
 	num_exclude = 0;
-	while ((c = getopt_long(argc, argv, "D:F:r:RT:xX:l:zZ:d:c:h:p:U:s:wWvPE:",
+	while ((c = getopt_long(argc, argv, "D:F:r:RT:xX:l:zZ:d:c:h:p:U:s:S:wWvPE:",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -2143,6 +2152,9 @@ main(int argc, char **argv)
 				break;
 			case 'R':
 				writerecoveryconf = true;
+				break;
+			case 'S':
+				replication_slot = pg_strdup(optarg);
 				break;
 			case 'T':
 				tablespace_list_append(optarg);
@@ -2318,6 +2330,16 @@ main(int argc, char **argv)
 	{
 		fprintf(stderr,
 				_("%s: WAL streaming can only be used in plain mode\n"),
+				progname);
+		fprintf(stderr, _("Try \"%s --help\" for more information.\n"),
+				progname);
+		exit(1);
+	}
+
+	if (replication_slot && !streamwal)
+	{
+		fprintf(stderr,
+				_("%s: replication slots can only be used with WAL streaming\n"),
 				progname);
 		fprintf(stderr, _("Try \"%s --help\" for more information.\n"),
 				progname);

--- a/src/bin/pg_rewind/libpq_fetch.c
+++ b/src/bin/pg_rewind/libpq_fetch.c
@@ -655,6 +655,8 @@ escape_quotes(const char *src)
 	return result;
 }
 
+#define GP_WALRECEIVER_APPNAME "gp_walreceiver"
+
 /*
  * Create a recovery.conf file in memory using a PQExpBuffer
  */
@@ -713,6 +715,7 @@ GenerateRecoveryConf(void)
 		free(escaped);
 	}
 
+	appendPQExpBuffer(&conninfo_buf, " application_name=%s", GP_WALRECEIVER_APPNAME);
 	/*
 	 * Escape the connection string, so that it can be put in the config file.
 	 * Note that this is different from the escaping of individual connection

--- a/src/include/replication/walsender_private.h
+++ b/src/include/replication/walsender_private.h
@@ -91,6 +91,12 @@ typedef struct WalSnd
 	int			sync_standby_priority;
 
 	bool		synchronous;
+
+	/*
+	 * Indicates whether the WalSnd represents a connection with a Greenplum
+	 * mirror in streaming mode
+	 */
+	bool 		is_for_gp_walreceiver;
 } WalSnd;
 
 extern WalSnd *MyWalSnd;
@@ -169,5 +175,7 @@ extern void replication_scanner_init(const char *query_string);
 extern void replication_scanner_finish(void);
 
 extern Node *replication_parse_result;
+
+#define GP_WALRECEIVER_APPNAME "gp_walreceiver"
 
 #endif   /* _WALSENDER_PRIVATE_H */

--- a/src/test/isolation2/expected/segwalrep/pg_basebackup.out
+++ b/src/test/isolation2/expected/segwalrep/pg_basebackup.out
@@ -4,14 +4,14 @@ CREATE
 -- Given a segment running without a replication slot
 0U: select * from pg_drop_replication_slot('some_replication_slot');
 ERROR:  replication slot "some_replication_slot" does not exist
-!\retcode rm -rf /tmp/some_pg_basebackup;
+!\retcode rm -rf /tmp/some_isolation2_pg_basebackup;
 -- start_ignore
 
 -- end_ignore
 (exited with code 0)
 
 -- When pg_basebackup runs with --slot and stream as xlog-method
-select pg_basebackup(address, port, 'some_replication_slot', '/tmp/some_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, port, 'some_replication_slot', '/tmp/some_isolation2_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
 pg_basebackup
 -------------
              
@@ -33,14 +33,14 @@ pg_drop_replication_slot
 ------------------------
                         
 (1 row)
-!\retcode rm -rf /tmp/some_pg_basebackup;
+!\retcode rm -rf /tmp/some_isolation2_pg_basebackup;
 -- start_ignore
 
 -- end_ignore
 (exited with code 0)
 
 -- When pg_basebackup runs without --slot
-select pg_basebackup(address, port, null, '/tmp/some_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, port, null, '/tmp/some_isolation2_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
 pg_basebackup
 -------------
              
@@ -52,3 +52,51 @@ count
 -----
 0    
 (1 row)
+
+-- Given that we suspend a WAL sender
+create extension if not exists gp_inject_fault;
+CREATE
+select gp_inject_fault_infinite('wal_sender_loop', 'suspend', 2);
+gp_inject_fault_infinite
+------------------------
+t                       
+(1 row)
+!\retcode rm -rf /tmp/some_isolation2_pg_basebackup;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- And we make a call pg_basebackup that will lead to WAL sender fork
+1&:select pg_basebackup(address, port, null, '/tmp/some_isolation2_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';  <waiting ...>
+SELECT gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
+
+-- Then we expect that the application_name of the  WAL sender is not the same
+-- 'gp_walreceiver' application name used by primary/mirror WAL sender
+0U: select count(application_name) > 0 as has_replication_app_names from pg_stat_replication where application_name <> 'gp_walreceiver';
+has_replication_app_names
+-------------------------
+t                        
+(1 row)
+
+select gp_inject_fault('wal_sender_loop', 'resume', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+select gp_inject_fault('wal_sender_loop', 'reset', 2);
+gp_inject_fault
+---------------
+t              
+(1 row)
+
+1<:  <... completed>
+pg_basebackup
+-------------
+             
+(1 row)
+

--- a/src/test/isolation2/expected/segwalrep/pg_basebackup.out
+++ b/src/test/isolation2/expected/segwalrep/pg_basebackup.out
@@ -12,9 +12,9 @@ ERROR:  replication slot "some_replication_slot" does not exist
 
 -- When pg_basebackup runs with --slot and stream as xlog-method
 select pg_basebackup(address, port, 'some_replication_slot', '/tmp/some_isolation2_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
-pg_basebackup
--------------
-             
+ pg_basebackup 
+---------------
+               
 (1 row)
 
 -- Then a replication slot gets created on that segment with the slot
@@ -22,16 +22,16 @@ pg_basebackup
 -- WAL streamer process utilized this slot for streaming WAL during
 -- base backup
 0U: select slot_name, slot_type, active, restart_lsn is not NULL as slot_was_used from pg_get_replication_slots() where slot_name = 'some_replication_slot';
-slot_name            |slot_type|active|slot_was_used
----------------------+---------+------+-------------
-some_replication_slot|physical |f     |t            
+ slot_name             | slot_type | active | slot_was_used 
+-----------------------+-----------+--------+---------------
+ some_replication_slot | physical  | f      | t             
 (1 row)
 
 -- Given we remove the replication slot
 0U: select * from pg_drop_replication_slot('some_replication_slot');
-pg_drop_replication_slot
-------------------------
-                        
+ pg_drop_replication_slot 
+--------------------------
+                          
 (1 row)
 !\retcode rm -rf /tmp/some_isolation2_pg_basebackup;
 -- start_ignore
@@ -41,25 +41,25 @@ pg_drop_replication_slot
 
 -- When pg_basebackup runs without --slot
 select pg_basebackup(address, port, null, '/tmp/some_isolation2_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
-pg_basebackup
--------------
-             
+ pg_basebackup 
+---------------
+               
 (1 row)
 
 -- Then there should NOT be a replication slot
 0U: select count(1) from pg_get_replication_slots() where slot_name = 'some_replication_slot';
-count
------
-0    
+ count 
+-------
+ 0     
 (1 row)
 
 -- Given that we suspend a WAL sender
 create extension if not exists gp_inject_fault;
 CREATE
 select gp_inject_fault_infinite('wal_sender_loop', 'suspend', 2);
-gp_inject_fault_infinite
-------------------------
-t                       
+ gp_inject_fault_infinite 
+--------------------------
+ t                        
 (1 row)
 !\retcode rm -rf /tmp/some_isolation2_pg_basebackup;
 -- start_ignore
@@ -70,33 +70,33 @@ t
 -- And we make a call pg_basebackup that will lead to WAL sender fork
 1&:select pg_basebackup(address, port, null, '/tmp/some_isolation2_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';  <waiting ...>
 SELECT gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
-gp_wait_until_triggered_fault
------------------------------
-t                            
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t                             
 (1 row)
 
 -- Then we expect that the application_name of the  WAL sender is not the same
 -- 'gp_walreceiver' application name used by primary/mirror WAL sender
 0U: select count(application_name) > 0 as has_replication_app_names from pg_stat_replication where application_name <> 'gp_walreceiver';
-has_replication_app_names
--------------------------
-t                        
+ has_replication_app_names 
+---------------------------
+ t                         
 (1 row)
 
 select gp_inject_fault('wal_sender_loop', 'resume', 2);
-gp_inject_fault
----------------
-t              
+ gp_inject_fault 
+-----------------
+ t               
 (1 row)
 select gp_inject_fault('wal_sender_loop', 'reset', 2);
-gp_inject_fault
----------------
-t              
+ gp_inject_fault 
+-----------------
+ t               
 (1 row)
 
 1<:  <... completed>
-pg_basebackup
--------------
-             
+ pg_basebackup 
+---------------
+               
 (1 row)
 

--- a/src/test/isolation2/expected/segwalrep/pg_basebackup.out
+++ b/src/test/isolation2/expected/segwalrep/pg_basebackup.out
@@ -1,0 +1,54 @@
+include: helpers/gp_management_utils_helpers.sql;
+CREATE
+
+-- Given a segment running without a replication slot
+0U: select * from pg_drop_replication_slot('some_replication_slot');
+ERROR:  replication slot "some_replication_slot" does not exist
+!\retcode rm -rf /tmp/some_pg_basebackup;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- When pg_basebackup runs with --slot and stream as xlog-method
+select pg_basebackup(address, port, 'some_replication_slot', '/tmp/some_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
+pg_basebackup
+-------------
+             
+(1 row)
+
+-- Then a replication slot gets created on that segment with the slot
+-- name and the slot's restart_lsn is not NULL, indicating that the
+-- WAL streamer process utilized this slot for streaming WAL during
+-- base backup
+0U: select slot_name, slot_type, active, restart_lsn is not NULL as slot_was_used from pg_get_replication_slots() where slot_name = 'some_replication_slot';
+slot_name            |slot_type|active|slot_was_used
+---------------------+---------+------+-------------
+some_replication_slot|physical |f     |t            
+(1 row)
+
+-- Given we remove the replication slot
+0U: select * from pg_drop_replication_slot('some_replication_slot');
+pg_drop_replication_slot
+------------------------
+                        
+(1 row)
+!\retcode rm -rf /tmp/some_pg_basebackup;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- When pg_basebackup runs without --slot
+select pg_basebackup(address, port, null, '/tmp/some_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
+pg_basebackup
+-------------
+             
+(1 row)
+
+-- Then there should NOT be a replication slot
+0U: select count(1) from pg_get_replication_slots() where slot_name = 'some_replication_slot';
+count
+-----
+0    
+(1 row)

--- a/src/test/isolation2/helpers/gp_management_utils_helpers.sql
+++ b/src/test/isolation2/helpers/gp_management_utils_helpers.sql
@@ -1,0 +1,25 @@
+create or replace language plpythonu;
+
+--
+-- pg_basebackup:
+--   host: host of the gpdb segment to back up
+--   port: port of the gpdb segment to back up
+--   slotname: desired slot name to create and associate with backup
+--   datadir: destination data directory of the backup
+--
+-- usage: `select pg_basebackup('somehost', 12345, 'some_slot_name', '/some/destination/data/directory')`
+--
+create or replace function pg_basebackup(host text, port int, slotname text, datadir text) returns text as $$
+    import subprocess
+    cmd = 'pg_basebackup -h %s -p %d --xlog-method stream -R -D %s' % (host, port, datadir)
+
+    if slotname is not None:
+        cmd += ' --slot %s' % (slotname)
+
+    try:
+        results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+    except subprocess.CalledProcessError as e:
+        results = str(e) + "\ncommand output: " + e.output
+
+    return results
+$$ language plpythonu;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -137,6 +137,7 @@ test: segwalrep/fts_unblock_primary
 test: segwalrep/mirror_promotion
 test: segwalrep/cancel_commit_pending_replication
 test: segwalrep/twophase_tolerance_with_mirror_promotion
+test: segwalrep/pg_basebackup
 
 # Tests for crash recovery
 test: crash_recovery

--- a/src/test/isolation2/sql/segwalrep/pg_basebackup.sql
+++ b/src/test/isolation2/sql/segwalrep/pg_basebackup.sql
@@ -2,10 +2,10 @@ include: helpers/gp_management_utils_helpers.sql;
 
 -- Given a segment running without a replication slot
 0U: select * from pg_drop_replication_slot('some_replication_slot');
-!\retcode rm -rf /tmp/some_pg_basebackup;
+!\retcode rm -rf /tmp/some_isolation2_pg_basebackup;
 
 -- When pg_basebackup runs with --slot and stream as xlog-method
-select pg_basebackup(address, port, 'some_replication_slot', '/tmp/some_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, port, 'some_replication_slot', '/tmp/some_isolation2_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then a replication slot gets created on that segment with the slot
 -- name and the slot's restart_lsn is not NULL, indicating that the
@@ -15,10 +15,29 @@ select pg_basebackup(address, port, 'some_replication_slot', '/tmp/some_pg_baseb
 
 -- Given we remove the replication slot
 0U: select * from pg_drop_replication_slot('some_replication_slot');
-!\retcode rm -rf /tmp/some_pg_basebackup;
+!\retcode rm -rf /tmp/some_isolation2_pg_basebackup;
 
 -- When pg_basebackup runs without --slot
-select pg_basebackup(address, port, null, '/tmp/some_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, port, null, '/tmp/some_isolation2_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then there should NOT be a replication slot
 0U: select count(1) from pg_get_replication_slots() where slot_name = 'some_replication_slot';
+
+-- Given that we suspend a WAL sender
+create extension if not exists gp_inject_fault;
+select gp_inject_fault_infinite('wal_sender_loop', 'suspend', 2);
+!\retcode rm -rf /tmp/some_isolation2_pg_basebackup;
+
+-- And we make a call pg_basebackup that will lead to WAL sender fork
+1&:select pg_basebackup(address, port, null, '/tmp/some_isolation2_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
+SELECT gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+
+-- Then we expect that the application_name of the  WAL sender is not the same
+-- 'gp_walreceiver' application name used by primary/mirror WAL sender
+0U: select count(application_name) > 0 as has_replication_app_names from pg_stat_replication where application_name <> 'gp_walreceiver';
+
+select gp_inject_fault('wal_sender_loop', 'resume', 2);
+select gp_inject_fault('wal_sender_loop', 'reset', 2);
+
+1<:
+

--- a/src/test/isolation2/sql/segwalrep/pg_basebackup.sql
+++ b/src/test/isolation2/sql/segwalrep/pg_basebackup.sql
@@ -1,0 +1,24 @@
+include: helpers/gp_management_utils_helpers.sql;
+
+-- Given a segment running without a replication slot
+0U: select * from pg_drop_replication_slot('some_replication_slot');
+!\retcode rm -rf /tmp/some_pg_basebackup;
+
+-- When pg_basebackup runs with --slot and stream as xlog-method
+select pg_basebackup(address, port, 'some_replication_slot', '/tmp/some_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
+
+-- Then a replication slot gets created on that segment with the slot
+-- name and the slot's restart_lsn is not NULL, indicating that the
+-- WAL streamer process utilized this slot for streaming WAL during
+-- base backup
+0U: select slot_name, slot_type, active, restart_lsn is not NULL as slot_was_used from pg_get_replication_slots() where slot_name = 'some_replication_slot';
+
+-- Given we remove the replication slot
+0U: select * from pg_drop_replication_slot('some_replication_slot');
+!\retcode rm -rf /tmp/some_pg_basebackup;
+
+-- When pg_basebackup runs without --slot
+select pg_basebackup(address, port, null, '/tmp/some_pg_basebackup') from gp_segment_configuration where content = 0 and role = 'p';
+
+-- Then there should NOT be a replication slot
+0U: select count(1) from pg_get_replication_slots() where slot_name = 'some_replication_slot';

--- a/src/test/walrep/expected/replication_views_mirrored.out
+++ b/src/test/walrep/expected/replication_views_mirrored.out
@@ -16,9 +16,9 @@ SELECT count(*) FROM gp_segment_configuration where preferred_role='m' and mode=
 SELECT gp_segment_id, application_name, state, sync_state FROM gp_stat_replication;
  gp_segment_id | application_name |   state   | sync_state 
 ---------------+------------------+-----------+------------
-             0 | walreceiver      | streaming | sync
-             1 | walreceiver      | streaming | sync
-             2 | walreceiver      | streaming | sync
-            -1 | walreceiver      | streaming | sync
+             0 | gp_walreceiver   | streaming | sync
+             1 | gp_walreceiver   | streaming | sync
+             2 | gp_walreceiver   | streaming | sync
+            -1 | gp_walreceiver   | streaming | sync
 (4 rows)
 


### PR DESCRIPTION
In order to create replication slots we pulled upstream commit f5d071d to pass in `--slot` to `pg_basebackup`.  We then fixed up the management utils to pass slot name accordingly. We are delaying decision of appropriate default GUC values for `max_wal_senders` and `max_replication_slots` as they are not required to setup replication slots.  Appropriate changes will be deferred until later PRs. Because pg_basebackup creates additional WAL sender slots we had to introduce logic in `GetMirrorStatus()` to distinguish between these slots.  We chose to leverage `application_name` in order to do so.

See commit messages for more detailed descriptions.