### PR TITLE
Markdownify the checkboxes in the PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Here are some reminders before you submit the pull request
-- [] Add tests for the change
-- [] Document changes
-- [] Communicate in the mailing list if needed
-- [] Pass `make installcheck`
+- [ ] Add tests for the change
+- [ ] Document changes
+- [ ] Communicate in the mailing list if needed
+- [ ] Pass `make installcheck`


### PR DESCRIPTION
In order to be rendered as checkboxes by Github, the square brackets
need a space between them.

Co-authored-by: Taylor Vesely <tvesely@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>