### PR TITLE
Resolve FIXME for validating partition for ADD or SPLIT

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -7490,6 +7490,15 @@ is_exchangeable(Relation rel, Relation oldrel, Relation newrel, bool throw)
 							"which is not a table")));
 	}
 
+	if(oldrel->rd_rel->relpersistence != newrel->rd_rel->relpersistence)
+	{
+		congruent = FALSE;
+		if (throw)
+			ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					errmsg("cannot exchange relations with differing persistence types")));
+	}
+
 	if (RelationIsExternal(newrel))
 	{
 		if (rel_is_default_partition(oldrel->rd_id))

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -124,6 +124,8 @@ extern Oid get_settable_tablespace_oid(char *tablespacename);
 extern List * MergeAttributes(List *schema, List *supers, bool istemp, bool isPartitioned,
 			List **supOids, List **supconstr, int *supOidCount);
 
+extern void SetSchemaAndConstraints(RangeVar *rangeVar, List **schema, List **constraints);
+
 extern DistributedBy *make_distributedby_for_rel(Relation rel);
 
 extern Oid transformFkeyCheckAttrs(Relation pkrel,

--- a/src/test/regress/expected/partition_unlogged.out
+++ b/src/test/regress/expected/partition_unlogged.out
@@ -24,6 +24,14 @@ SELECT relpersistence, relname FROM pg_class WHERE relname IN (SELECT partitiont
  u              | unlogged_pt1_1_prt_p2
 (3 rows)
 
+-- Given a permanent table
+CREATE TABLE perm_tab(a INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- When I exchange partition 2 from unlogged_pt1 with this permanent table, perm_tab
+ALTER TABLE unlogged_pt1 EXCHANGE PARTITION FOR (3) WITH TABLE perm_tab;
+ERROR:  cannot exchange relations with differing persistence types
+-- Then it ERRORs out
 --start_ignore
 DROP TABLE IF EXISTS unlogged_pt1;
 --end_ignore

--- a/src/test/regress/expected/partition_unlogged.out
+++ b/src/test/regress/expected/partition_unlogged.out
@@ -1,0 +1,29 @@
+-- Given an unlogged partition table with two leaf partitions
+CREATE UNLOGGED TABLE unlogged_pt1(a int) PARTITION BY RANGE(a) (START(1) END(4) EVERY (2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "unlogged_pt1_1_prt_1" for table "unlogged_pt1"
+NOTICE:  CREATE TABLE will create partition "unlogged_pt1_1_prt_2" for table "unlogged_pt1"
+SELECT relpersistence, relname FROM pg_class WHERE relname IN (SELECT partitiontablename FROM pg_partitions WHERE tablename = 'unlogged_pt1');
+ relpersistence |       relname        
+----------------+----------------------
+ u              | unlogged_pt1_1_prt_1
+ u              | unlogged_pt1_1_prt_2
+(2 rows)
+
+-- When I split the first partition
+ALTER TABLE unlogged_pt1 SPLIT PARTITION FOR(2) AT(2) INTO (PARTITION p1, PARTITION p2);
+NOTICE:  CREATE TABLE will create partition "unlogged_pt1_1_prt_p1" for table "unlogged_pt1"
+NOTICE:  CREATE TABLE will create partition "unlogged_pt1_1_prt_p2" for table "unlogged_pt1"
+-- Then the resulting two new relations have relation persistence type 'u' for unlogged
+SELECT relpersistence, relname FROM pg_class WHERE relname IN (SELECT partitiontablename FROM pg_partitions WHERE tablename = 'unlogged_pt1');
+ relpersistence |        relname        
+----------------+-----------------------
+ u              | unlogged_pt1_1_prt_2
+ u              | unlogged_pt1_1_prt_p1
+ u              | unlogged_pt1_1_prt_p2
+(3 rows)
+
+--start_ignore
+DROP TABLE IF EXISTS unlogged_pt1;
+--end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -78,7 +78,7 @@ test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_grou
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.
-test: partition partition1 partition_indexing parruleord partition_storage partition_ddl partition_with_user_defined_function
+test: partition partition1 partition_indexing parruleord partition_storage partition_ddl partition_with_user_defined_function partition_unlogged
 # 'partition_locking' gets confused if other backends run concurrently and
 # hold locks.
 test: partition_locking

--- a/src/test/regress/sql/partition_unlogged.sql
+++ b/src/test/regress/sql/partition_unlogged.sql
@@ -5,6 +5,13 @@ SELECT relpersistence, relname FROM pg_class WHERE relname IN (SELECT partitiont
 ALTER TABLE unlogged_pt1 SPLIT PARTITION FOR(2) AT(2) INTO (PARTITION p1, PARTITION p2);
 -- Then the resulting two new relations have relation persistence type 'u' for unlogged
 SELECT relpersistence, relname FROM pg_class WHERE relname IN (SELECT partitiontablename FROM pg_partitions WHERE tablename = 'unlogged_pt1');
+
+-- Given a permanent table
+CREATE TABLE perm_tab(a INT);
+-- When I exchange partition 2 from unlogged_pt1 with this permanent table, perm_tab
+ALTER TABLE unlogged_pt1 EXCHANGE PARTITION FOR (3) WITH TABLE perm_tab;
+-- Then it ERRORs out
+
 --start_ignore
 DROP TABLE IF EXISTS unlogged_pt1;
 --end_ignore

--- a/src/test/regress/sql/partition_unlogged.sql
+++ b/src/test/regress/sql/partition_unlogged.sql
@@ -1,0 +1,10 @@
+-- Given an unlogged partition table with two leaf partitions
+CREATE UNLOGGED TABLE unlogged_pt1(a int) PARTITION BY RANGE(a) (START(1) END(4) EVERY (2));
+SELECT relpersistence, relname FROM pg_class WHERE relname IN (SELECT partitiontablename FROM pg_partitions WHERE tablename = 'unlogged_pt1');
+-- When I split the first partition
+ALTER TABLE unlogged_pt1 SPLIT PARTITION FOR(2) AT(2) INTO (PARTITION p1, PARTITION p2);
+-- Then the resulting two new relations have relation persistence type 'u' for unlogged
+SELECT relpersistence, relname FROM pg_class WHERE relname IN (SELECT partitiontablename FROM pg_partitions WHERE tablename = 'unlogged_pt1');
+--start_ignore
+DROP TABLE IF EXISTS unlogged_pt1;
+--end_ignore


### PR DESCRIPTION
Create new function to get the attribute names and constraints from the root partition when adding a new leaf partition as part of ADD or SPLIT partition.

The FIXME was about the relpersistence passed in for the previous function. It was checked in MergeAttributes. In our replacement for MergeAttributes, we don't even consider a conflicting relpersistence for a leaf partition as part of ADD or SPLIT, as the leaf will always be the same as the root (either permanent or unlogged).