### PR TITLE
Initdb: Ignore distributed log check.

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1345,8 +1345,13 @@ GetOldestXmin(Relation rel, bool ignoreVacuum)
 	 * During binary upgrade, we don't have distributed transactions, so we're
 	 * done there too. This ensures correct operation of VACUUM FREEZE during
 	 * pg_upgrade.
+	 *
+	 * In bootstrap or standalone backend case as well ignore the distributed
+	 * logs using IsPostmasterEnvironment. Otherwise, during initdb can't
+	 * vacuum freeze template0.
 	 */
-	if (!IS_QUERY_DISPATCHER() && !IsBinaryUpgrade)
+	if (IsPostmasterEnvironment && !IS_QUERY_DISPATCHER() &&
+		!IsBinaryUpgrade)
 	{
 		TransactionId distribOldestXmin;
 


### PR DESCRIPTION
Without this commit, after initdb datfrozenxid for all databases
remains 3. Ideally, databases should get freezed during initdb as
tools like pg_upgrade make assumptions on the same.

Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>
