### PR TITLE
Do not enforce join ordering for ANTI and LASJ.

### DIFF
--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -1081,7 +1081,7 @@ deconstruct_recurse(PlannerInfo *root, Node *jtnode, bool below_outer_join,
 		 * except at a FULL JOIN or where join_collapse_limit would be
 		 * exceeded.
 		 */
-		if (j->jointype == JOIN_FULL || j->jointype == JOIN_ANTI || j->jointype == JOIN_LASJ_NOTIN)
+		if (j->jointype == JOIN_FULL)
 		{
 			/* force the join order exactly at this node */
 			joinlist = list_make1(list_make2(leftjoinlist, rightjoinlist));

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -221,22 +221,22 @@ explain select c1 from t1,
 (select c2 from t2 where c2 not in 
 	(select c3 from t3) and c2 > 4) foo 
 	where c1 = foo.c2;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=4.41..7.59 rows=4 width=4)
-   ->  Hash Join  (cost=4.41..7.59 rows=2 width=4)
-         Hash Cond: t1.c1 = t2.c2
-         ->  Seq Scan on t1  (cost=0.00..3.12 rows=3 width=4)
-               Filter: c1 > 4
-         ->  Hash  (cost=4.37..4.37 rows=2 width=4)
-               ->  Hash Left Anti Semi (Not-In) Join  (cost=2.26..4.37 rows=2 width=4)
-                     Hash Cond: t2.c2 = t3.c3
-                     ->  Seq Scan on t2  (cost=0.00..2.06 rows=1 width=4)
-                           Filter: c2 > 4
-                     ->  Hash  (cost=2.15..2.15 rows=3 width=4)
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.15 rows=3 width=4)
-                                 ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
- Optimizer status: legacy query optimizer
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=5.34..8.58 rows=4 width=4)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=5.34..8.58 rows=2 width=4)
+         Hash Cond: (t2.c2 = t3.c3)
+         ->  Hash Join  (cost=3.08..6.26 rows=2 width=8)
+               Hash Cond: (t1.c1 = t2.c2)
+               ->  Seq Scan on t1  (cost=0.00..3.12 rows=3 width=4)
+                     Filter: (c1 > 4)
+               ->  Hash  (cost=3.06..3.06 rows=1 width=4)
+                     ->  Seq Scan on t2  (cost=0.00..3.06 rows=1 width=4)
+                           Filter: (c2 > 4)
+         ->  Hash  (cost=2.15..2.15 rows=3 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.15 rows=3 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+ Optimizer: legacy query optimizer
 (14 rows)
 
 select c1 from t1, 
@@ -309,20 +309,20 @@ select c1 from t1 where c1 > 6 and c1 not in
 --
 explain select c1 from t1,t2 where c1 not in 
 	(select c3 from t3) and c1 = c2;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=4.37..7.62 rows=4 width=4)
-   ->  Hash Left Anti Semi (Not-In) Join  (cost=4.37..7.62 rows=2 width=4)
-         Hash Cond: t1.c1 = t3.c3
-         ->  Hash Join  (cost=2.11..5.30 rows=2 width=4)
-               Hash Cond: t1.c1 = t2.c2
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=5.38..8.62 rows=4 width=4)
+   ->  Hash Join  (cost=5.38..8.62 rows=2 width=4)
+         Hash Cond: (t1.c1 = t2.c2)
+         ->  Hash Left Anti Semi (Not-In) Join  (cost=2.26..5.46 rows=2 width=4)
+               Hash Cond: (t1.c1 = t3.c3)
                ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
-               ->  Hash  (cost=2.05..2.05 rows=2 width=4)
-                     ->  Seq Scan on t2  (cost=0.00..2.05 rows=2 width=4)
-         ->  Hash  (cost=2.15..2.15 rows=3 width=4)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.15 rows=3 width=4)
-                     ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
- Optimizer status: legacy query optimizer
+               ->  Hash  (cost=2.15..2.15 rows=3 width=4)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.15 rows=3 width=4)
+                           ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
+         ->  Hash  (cost=3.05..3.05 rows=2 width=4)
+               ->  Seq Scan on t2  (cost=0.00..3.05 rows=2 width=4)
+ Optimizer: legacy query optimizer
 (12 rows)
 
 select c1 from t1,t2 where c1 not in 

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -195,20 +195,20 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
 -- Test for ALL_SUBLINK pull-up based on both left-hand and right-hand input
 explain (costs off)
 select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
-                             QUERY PLAN                              
----------------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Nested Loop Semi Join
-         ->  Hash Left Anti Semi (Not-In) Join
-               Hash Cond: (b.i = c_1.i)
-               ->  Nested Loop
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                           ->  Seq Scan on a
-                     ->  Materialize
+         ->  Nested Loop
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Hash Left Anti Semi (Not-In) Join
+                           Hash Cond: (b.i = c_1.i)
                            ->  Seq Scan on b
-               ->  Hash
-                     ->  Seq Scan on c c_1
-                           Filter: (i <> 10)
+                           ->  Hash
+                                 ->  Seq Scan on c c_1
+                                       Filter: (i <> 10)
+               ->  Materialize
+                     ->  Seq Scan on a
          ->  Materialize
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Seq Scan on c
@@ -811,39 +811,39 @@ select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j 
 (10 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=40000000121.99..40000000122.17 rows=9 width=12)
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=40000000026.22..40000000026.44 rows=10 width=12)
    InitPlan 1 (returns $0)  (slice6)
      ->  Limit  (cost=10000000000.00..10000000001.58 rows=1 width=0)
            ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000000.00..10000000001.58 rows=1 width=0)
                  ->  Limit  (cost=10000000000.00..10000000001.56 rows=1 width=0)
                        ->  Nested Loop  (cost=10000000000.00..10000000005.18 rows=2 width=0)
                              ->  Seq Scan on c c_2  (cost=0.00..3.11 rows=1 width=4)
-                                   Filter: i = 10
+                                   Filter: (i = 10)
                              ->  Seq Scan on a a_1  (cost=0.00..2.06 rows=1 width=4)
-                                   Filter: i = 10
-   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=30000000120.41..30000000120.59 rows=9 width=12)
+                                   Filter: (i = 10)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=30000000024.64..30000000024.86 rows=10 width=12)
          Merge Key: a.i, b.i, c.j
-         ->  Limit  (cost=30000000120.41..30000000120.43 rows=3 width=12)
-               ->  Sort  (cost=30000000120.41..30000000120.43 rows=3 width=12)
+         ->  Limit  (cost=30000000024.64..30000000024.66 rows=4 width=12)
+               ->  Sort  (cost=30000000024.64..30000000025.09 rows=60 width=12)
                      Sort Key: a.i, b.i, c.j
-                     ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=30000000000.00..30000000120.29 rows=3 width=12)
-                           Join Filter: a.j >= c_1.j
-                           ->  Nested Loop  (cost=20000000000.00..20000000019.53 rows=90 width=16)
-                                 ->  Nested Loop  (cost=10000000000.00..10000000008.44 rows=18 width=8)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=6 width=4)
-                                             ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
-                                       ->  Materialize  (cost=0.00..3.13 rows=3 width=4)
-                                             ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
-                                 ->  Materialize  (cost=0.00..2.33 rows=5 width=8)
-                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..2.25 rows=5 width=8)
+                     ->  Nested Loop  (cost=30000000000.00..30000000020.76 rows=60 width=12)
+                           ->  Nested Loop  (cost=20000000000.00..20000000011.37 rows=7 width=8)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=10000000000.00..10000000007.55 rows=4 width=4)
+                                       ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10000000007.41 rows=2 width=4)
+                                             Join Filter: (a.j >= c_1.j)
                                              ->  Seq Scan on a  (cost=0.00..2.05 rows=2 width=8)
+                                             ->  Materialize  (cost=0.00..3.58 rows=9 width=4)
+                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
+                                                         ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                                               One-Time Filter: (NOT $0)
+                                                               ->  Seq Scan on c c_1  (cost=0.00..3.09 rows=3 width=4)
+                                 ->  Materialize  (cost=0.00..3.09 rows=2 width=4)
+                                       ->  Seq Scan on b  (cost=0.00..3.06 rows=2 width=4)
                            ->  Materialize  (cost=0.00..3.58 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.45 rows=9 width=4)
-                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
-                                             One-Time Filter: NOT $0
-                                             ->  Seq Scan on c c_1  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
  Optimizer: legacy query optimizer
 (32 rows)
 


### PR DESCRIPTION
The following identity holds true:

	(A antijoin B on (Pab)) innerjoin C on (Pac)
    	= (A innerjoin C on (Pac)) antijoin B on (Pab)

So we should not enforce join ordering for ANTI. Instead we need to
collapse ANTI join nodes so that they participate fully in the join
order search.

For example:

	select * from a join b on a.i = b.i where
		not exists (select i from c where a.i = c.i);

For this query, the original join order is "(a innerjoin b) antijoin c". If
we enforce ANTI join ordering, this will be the final join order. But
another join order "(a antijoin c) innerjoin b" is also legal. We should
take this order into consideration and pick a cheaper one.

For LASJ, it is the same for ANTI joins.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
