### PR TITLE
Little refine of SendEosUDPIFC() to resolve potential issue

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5519,17 +5519,15 @@ SendEosUDPIFC(ChunkTransportState *transportStates,
 					if (retry >= MAX_TRY)
 						break;
 				}
-			}
 
-			if ((!conn->cdbProc) || (icBufferListLength(&conn->unackQueue) == 0 &&
-									 icBufferListLength(&conn->sndQueue) == 0))
-			{
-				conn->state = mcsEosSent;
-				conn->stillActive = false;
-			}
-			else
-			{
-				activeCount++;
+				if ((!conn->cdbProc) || (icBufferListLength(&conn->unackQueue) == 0 &&
+										 icBufferListLength(&conn->sndQueue) == 0))
+				{
+					conn->state = mcsEosSent;
+					conn->stillActive = false;
+				}
+				else
+					activeCount++;
 			}
 		}
 	}


### PR DESCRIPTION
Previously, Even a connection has been explicitly set to inactive, the old code
might still treat the connection as active if conn->cdbProc is not null and
conn->sndQueue is not empty and increase activeCount. In the next loop, because
conn->stillActive is true, conn->unackQueue or conn->sndQueue are never be
freed and activeCount always be non-zeror and might cause an infinite loop.

## Here are some reminders before you submit the pull request
- [ ] ~Add tests for the change~
- [ ] ~Document changes~
- [ ] ~Communicate in the mailing list if needed~
- [ ] Pass `make installcheck`
