### PR TITLE
Skip numsegments sanity check in UTILITY mode

### DIFF
--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -316,7 +316,8 @@ GpPolicyFetch(Oid tbloid)
 		 * otherwise, planner will arrange a gang whose size is larger than the size
 		 * of cluster and dispatcher cannot handle this.
 		 */
-		if (numsegments > GP_POLICY_ALL_NUMSEGMENTS)
+		if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) &&
+			numsegments > GP_POLICY_ALL_NUMSEGMENTS)
 		{
 			ReleaseSysCache(gp_policy_tuple);
 			ereport(ERROR,


### PR DESCRIPTION
getgpsegementcount() returns -1 in UTILITY mode which will always
make numsegments sanity check failed, so skip it for UTILITY mode

## Here are some reminders before you submit the pull request
- [ ] ~Add tests for the change~
- [ ] ~Document changes~
- [ ] ~Communicate in the mailing list if needed~
- [ ] Pass `make installcheck`
