### PR TITLE
Add a GUC to specify the method to expand a table

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -344,6 +344,11 @@ int			cdb_total_plans = 0;
 int			cdb_max_slices = 0;
 
 /*
+ * Specify the method to expand a table
+ */
+int			Gp_expand_method = GPEXPAND_METHOD_REBUILD;
+
+/*
  * Local macro to provide string values of numeric defines.
  */
 #define CppNumericAsString(s) CppAsString(s)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -285,8 +285,8 @@ struct DropRelationCallbackState
 #define		ATT_COMPOSITE_TYPE		0x0010
 #define		ATT_FOREIGN_TABLE		0x0020
 
-static void ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd, PartStatus ps);
-static void ATExecExpandTableReshuffle(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd, PartStatus ps);
+static void ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd);
+static void ATExecExpandTableReshuffle(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd);
 
 static void truncate_check_rel(Relation rel);
 static void MergeAttributesIntoExisting(Relation child_rel, Relation parent_rel,
@@ -4660,18 +4660,10 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 		case AT_ExpandTable:
 			if (!recursing)
 			{
-				Oid relid = RelationGetRelid(rel);
-				PartStatus ps = rel_part_status(relid);
+				Oid			relid = RelationGetRelid(rel);
+				PartStatus	ps = rel_part_status(relid);
 
 				ATExternalPartitionCheck(cmd->subtype, rel, recursing);
-
-				if (Gp_role == GP_ROLE_DISPATCH &&
-					rel->rd_cdbpolicy->numsegments == getgpsegmentCount())
-					ereport(ERROR,
-							(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-							 errmsg("cannot expand table \"%s\"",
-									RelationGetRelationName(rel)),
-							 errdetail("table has already been expanded")));
 
 				switch (ps)
 				{
@@ -14564,96 +14556,47 @@ ReshuffleRelationData(Relation rel)
 	return;
 }
 
-static void
-add_part_status_map(ExpandStmtSpec *spec, PartStatus ps, Oid relid)
-{
-	switch (ps)
-	{
-		case PART_STATUS_NONE:
-			spec->ps_none = bms_add_member(spec->ps_none, relid);
-			break;
-		case PART_STATUS_ROOT:
-			spec->ps_root = bms_add_member(spec->ps_root, relid);
-			break;
-		case PART_STATUS_INTERIOR:
-			spec->ps_interior = bms_add_member(spec->ps_interior, relid);
-			break;
-		case PART_STATUS_LEAF:
-			spec->ps_leaf = bms_add_member(spec->ps_leaf, relid);
-			break;
-	}
-}
-
-static PartStatus
-get_ps_from_map(ExpandStmtSpec *spec, Oid relid)
-{
-	PartStatus ps = PART_STATUS_NONE;
-
-	if (bms_is_member(relid, spec->ps_none))
-		ps = PART_STATUS_NONE;
-	else if (bms_is_member(relid, spec->ps_root))
-		ps = PART_STATUS_ROOT;
-	else if (bms_is_member(relid, spec->ps_interior))
-		ps = PART_STATUS_INTERIOR;
-	else if (bms_is_member(relid, spec->ps_leaf))
-		ps = PART_STATUS_LEAF;
-
-	return ps;
-}
-
-#define NTUPLES_THRESHOLD 10000.0
-#define SCALE_THRESHOLD	0.3
-
-static ExpandMethod
-get_expand_method(Relation rel, PartStatus ps, List **wqueue)
-{
-	ListCell	*ltab;
-	float4		reltuples = 0;
-	float4		cluster_size = getgpsegmentCount();
-	float4		table_size = rel->rd_cdbpolicy->numsegments;
-	float4		min_ntuples_move;
-	float4		scale;
-
-	Assert(cluster_size >= table_size);
-
-	foreach(ltab, *wqueue)
-	{
-		AlteredTableInfo *tab = (AlteredTableInfo *) lfirst(ltab);
-		Relation        rel;
-
-		rel = relation_open(tab->relid, NoLock);
-		reltuples += rel->rd_rel->reltuples;
-		relation_close(rel, NoLock);
-	}
-
-	scale = (cluster_size - table_size) / cluster_size;
-	min_ntuples_move = reltuples * scale;
-
-	/* 
-	 * choose expand method by calculating relation tuples and data size to be
-	 * moved
-	 */
-	if (min_ntuples_move < NTUPLES_THRESHOLD)
-		return EXPANDMETHOD_RESHUFFLE;
-
-	if (scale < SCALE_THRESHOLD)
-		return EXPANDMETHOD_RESHUFFLE;
-
-	return EXPANDMETHOD_CTAS;
-}
-
+/*
+ * ALTER TABLE EXPAND TABLE
+ *
+ * Update a table's "numsegments" value to current cluster size, and move
+ * data as needed to the new segments.
+ *
+ * There are two ways we can perform EXPAND TABLE:
+ *
+ * 1. Create a whole new relation file, with the new 'numsegments', copy all
+ *    the data to the new reltion file, and swap it in place of the old one.
+ *    This is called the "CTAS method", because it uses a CREATE TABLE AS
+ *    command internally to create the new physical relation.
+ *
+ * 2. Scan all the data, and perform an UPDATE to move all rows that are in
+ *    wrong segment, according to the new 'numsegments' value. This is called
+ *    the "reshuffle method".
+ *
+ * The reshuffle method has the advantage that it only needs to move those
+ * tuples that are not already in the correct segment. With jump consistent
+ * hashing, if you expand the cluster by one segment, that is only 1/Nth of
+ * the data. However, it leaves behind dead tuples, and it updates indexes
+ * one row at a time, which can be much slower than rebuilding the index
+ * from scratch.
+ *
+ * A mandatory data movement is applied to a randomly distributed table to
+ * avoid data skew. Another choice is don't move any tuples, as all the tuples
+ * can legitimately still reside on the old segments even after expanding.
+ * To rebalance a randomly distributed table after expanding, you can use
+ * WITH (REORGANIZE=TRUE), but that's a completely different codepath.
+ * (REORGANIZE currently always uses the CTAS method.)
+ *
+ * Now, we only use a GUC to decide the expand method.
+ */
 static void
 ATExecExpandTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 {
-	ExpandStmtSpec		*spec;
-	AlteredTableInfo	*tab;
-	AlterTableCmd		*rootCmd;
-	MemoryContext		oldContext;
-	ExpandMethod		method = EXPANDMETHOD_NONE;
-	PartStatus			ps = PART_STATUS_NONE;
-	Oid					relid = RelationGetRelid(rel);
-	GpPolicy			*newPolicy;
-	GpPolicy			*policy = rel->rd_cdbpolicy;
+	AlteredTableInfo *tab;
+	AlterTableCmd *rootCmd;
+	Oid			relid = RelationGetRelid(rel);
+	GpPolicy   *policy = rel->rd_cdbpolicy;
+	GpPolicy   *newPolicy;
 
 	if (Gp_role == GP_ROLE_UTILITY)
 		ereport(ERROR,
@@ -14671,51 +14614,30 @@ ATExecExpandTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 			errmsg("permission denied: \"%s\" is a system catalog", RelationGetRelationName(rel))));
 
-	oldContext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
+	if (rel->rd_cdbpolicy->numsegments == getgpsegmentCount())
+	{
+		/*
+		 * Table is already fully expanded. Nothing to do, just report success.
+		 *
+		 * The caller expects us to close the relation, so do that.
+		 */
+		relation_close(rel, NoLock);
+		return;
+	}
+
+	/* make a modifiable copy of the policy */
 	newPolicy = GpPolicyCopy(policy);
-	MemoryContextSwitchTo(oldContext);
 
 	tab = linitial(*wqueue);
-	rootCmd = (AlterTableCmd *)linitial(tab->subcmds[AT_PASS_MISC]);
+	rootCmd = (AlterTableCmd *) linitial(tab->subcmds[AT_PASS_MISC]);
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_expand_method == GPEXPAND_METHOD_REBUILD)
+		ATExecExpandTableCTAS(rootCmd, rel, cmd);
+	else
 	{
-		ps = rel_part_status(relid);
+		Assert(Gp_expand_method == GPEXPAND_METHOD_MOVE);
 
-		/* only rootCmd is dispatched to QE, we can store */
-		if (rootCmd == cmd)
-			rootCmd->def = (Node*)makeNode(ExpandStmtSpec);
-		spec = (ExpandStmtSpec *)rootCmd->def;
-		Assert(spec);
-		/*
-		 * pg_partition and pg_partitions are empty on QEs,
-		 * so pass partition status info to QEs.
-		 */
-		add_part_status_map(spec, ps, relid);
-
-		/* pass method to QEs */
-		if (rootCmd == cmd)
-			spec->method = get_expand_method(rel, ps, wqueue);
-
-		/* make sure each sub command use the same method */
-		method = spec->method;
-	}
-	else if (Gp_role == GP_ROLE_EXECUTE)
-	{
-		spec = (ExpandStmtSpec *)rootCmd->def;
-		Assert(spec);
-		ps = get_ps_from_map(spec, relid);
-		method = spec->method;
-	}
-
-	Assert(method == EXPANDMETHOD_CTAS || method == EXPANDMETHOD_RESHUFFLE);
-
-	/* two ways to move data */
-	if (method == EXPANDMETHOD_CTAS)
-		ATExecExpandTableCTAS(rootCmd, rel, cmd, ps);	
-	else if (method == EXPANDMETHOD_RESHUFFLE)
-	{
-		ATExecExpandTableReshuffle(rootCmd, rel, cmd, ps);
+		ATExecExpandTableReshuffle(rootCmd, rel, cmd);
 		/*
 		 * little bit tricky here,
 		 * ATExecExpandTableCTAS() close the relation temporarily,
@@ -14736,7 +14658,7 @@ ATExecExpandTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 }
 
 static void
-ATExecExpandTableReshuffle(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd, PartStatus ps)
+ATExecExpandTableReshuffle(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
 {
 	/* only QD drive the real data movement */
 	if (Gp_role != GP_ROLE_DISPATCH)
@@ -14750,14 +14672,14 @@ ATExecExpandTableReshuffle(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *
 }
 
 static void
-ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd, PartStatus ps)
+ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
 {
-	RangeVar			*tmprv;
-	Datum				newOptions;
-	Oid					tmprelid;
-	Oid					relid = RelationGetRelid(rel);
-	char				relstorage = rel->rd_rel->relstorage;
-	ExpandStmtSpec		*spec = (ExpandStmtSpec *)rootCmd->def;
+	RangeVar   *tmprv;
+	Datum		newOptions;
+	Oid			tmprelid;
+	Oid			relid = RelationGetRelid(rel);
+	char		relstorage = rel->rd_rel->relstorage;
+	ExpandStmtSpec *spec = (ExpandStmtSpec *)rootCmd->def;
 
 	/*--
 	 * a) Ensure that the proposed policy is sensible

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3611,10 +3611,6 @@ _copyExpandStmtSpec(const ExpandStmtSpec *from)
 	ExpandStmtSpec *newnode = makeNode(ExpandStmtSpec);
 
 	COPY_SCALAR_FIELD(method);
-	COPY_BITMAPSET_FIELD(ps_none);
-	COPY_BITMAPSET_FIELD(ps_root);
-	COPY_BITMAPSET_FIELD(ps_interior);
-	COPY_BITMAPSET_FIELD(ps_leaf);
 	COPY_SCALAR_FIELD(backendId);
 
 	return newnode;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3093,10 +3093,6 @@ _outExpandStmtSpec(StringInfo str, const ExpandStmtSpec *node)
 {
 	WRITE_NODE_TYPE("EXPANDSTMTSPEC");
 	WRITE_ENUM_FIELD(method, ExpandMethod);
-	WRITE_BITMAPSET_FIELD(ps_none);
-	WRITE_BITMAPSET_FIELD(ps_root);
-	WRITE_BITMAPSET_FIELD(ps_interior);
-	WRITE_BITMAPSET_FIELD(ps_leaf);
 	WRITE_OID_FIELD(backendId);
 }
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1226,10 +1226,6 @@ _readExpandStmtSpec(void)
 	READ_LOCALS(ExpandStmtSpec);
 
 	READ_ENUM_FIELD(method, ExpandMethod);
-	READ_BITMAPSET_FIELD(ps_none);
-	READ_BITMAPSET_FIELD(ps_root);
-	READ_BITMAPSET_FIELD(ps_interior);
-	READ_BITMAPSET_FIELD(ps_leaf);
 	READ_OID_FIELD(backendId);
 
 	READ_DONE();

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -604,6 +604,13 @@ static const struct config_enum_entry optimizer_join_order_options[] = {
 	{NULL, 0}
 };
 
+static const struct config_enum_entry gp_expand_methods[] = {
+	{"rebuild", GPEXPAND_METHOD_REBUILD},
+	{"move", GPEXPAND_METHOD_MOVE},
+	{NULL, 0}
+};
+
+
 IndexCheckType gp_indexcheck_insert = INDEX_CHECK_NONE;
 IndexCheckType gp_indexcheck_vacuum = INDEX_CHECK_NONE;
 
@@ -4934,6 +4941,17 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		},
 		&optimizer_join_order,
 		JOIN_ORDER_EXHAUSTIVE_SEARCH, optimizer_join_order_options,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_expand_method", PGC_USERSET, GP_ARRAY_TUNING,
+			gettext_noop("Specify the method to expand a table."),
+			gettext_noop("Valid values are rebuild, move"),
+			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE
+		},
+		&Gp_expand_method,
+		GPEXPAND_METHOD_REBUILD, gp_expand_methods,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -865,6 +865,18 @@ typedef struct GpId
 								 * a primary and its mirror have the same segIndex */
 } GpId;
 
+/*
+ * Support for multiple "types" of interconnect
+ */
+typedef enum GpExpandMethod
+{
+	GPEXPAND_METHOD_REBUILD = 0,
+	GPEXPAND_METHOD_MOVE,
+} GpExpandMethod;
+
+/* specify the method to expand a table */
+extern int Gp_expand_method;
+
 /* --------------------------------------------------------------------------------------------------
  * Global variable declaration for the data for the single row of gp_id table
  */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2122,15 +2122,7 @@ typedef struct ExpandStmtSpec
 	NodeTag				type;
 	/* method to move data internal */
 	ExpandMethod		method;
-	/*
-	 * QEs has empty pg_partition and pg_partitions
-	 * so we need to pass necessary partition related
-	 * info to QEs.
-	 */
-	Bitmapset			*ps_none;
-	Bitmapset			*ps_root;
-	Bitmapset			*ps_interior;
-	Bitmapset			*ps_leaf;
+
 	/* for ctas method */
 	Oid					backendId;
 } ExpandStmtSpec;

--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -7,6 +7,7 @@ create schema test_reshuffle;
 set search_path=test_reshuffle,public;
 set gp_default_storage_options='appendonly=false';
 set allow_system_table_mods=true;
+set gp_expand_method = move;
 -- Hash distributed tables
 select gp_debug_set_create_table_default_numsegments(2);
  gp_debug_set_create_table_default_numsegments 
@@ -1012,3 +1013,9 @@ DETAIL:  drop cascades to table inherit_t1_p2
 drop cascades to table inherit_t1_p4
 drop cascades to table inherit_t1_p3
 drop cascades to table inherit_t1_p5
+--
+-- Test EXPAND, on a table that doesn't need expanding. Should be a no-op.
+--
+CREATE TABLE expand_noop(i int) distributed by (i);
+ALTER TABLE expand_noop EXPAND TABLE;
+ALTER TABLE expand_noop EXPAND TABLE;

--- a/src/test/regress/expected/reshuffle_ao.out
+++ b/src/test/regress/expected/reshuffle_ao.out
@@ -7,6 +7,7 @@ create schema test_reshuffle_ao;
 set search_path=test_reshuffle_ao,public;
 set gp_default_storage_options='appendonly=true,orientation=row';
 set allow_system_table_mods=true;
+set gp_expand_method = move;
 -- Hash distributed tables
 select gp_debug_set_create_table_default_numsegments(2);
  gp_debug_set_create_table_default_numsegments 

--- a/src/test/regress/expected/reshuffle_aoco.out
+++ b/src/test/regress/expected/reshuffle_aoco.out
@@ -7,6 +7,7 @@ create schema test_reshuffle_aoco;
 set search_path=test_reshuffle_aoco,public;
 set gp_default_storage_options='appendonly=true,orientation=column';
 set allow_system_table_mods=true;
+set gp_expand_method = move;
 -- Hash distributed tables
 select gp_debug_set_create_table_default_numsegments(2);
  gp_debug_set_create_table_default_numsegments 

--- a/src/test/regress/sql/reshuffle.sql
+++ b/src/test/regress/sql/reshuffle.sql
@@ -9,6 +9,7 @@ create schema test_reshuffle;
 set search_path=test_reshuffle,public;
 set gp_default_storage_options='appendonly=false';
 set allow_system_table_mods=true;
+set gp_expand_method = move;
 
 -- Hash distributed tables
 select gp_debug_set_create_table_default_numsegments(2);
@@ -417,3 +418,10 @@ alter table inherit_t1_p1 expand table;
 select count(*) > 0 from inherit_t1_p1 where gp_segment_id = 2;
 
 DROP TABLE inherit_t1_p1 CASCADE;
+
+--
+-- Test EXPAND, on a table that doesn't need expanding. Should be a no-op.
+--
+CREATE TABLE expand_noop(i int) distributed by (i);
+ALTER TABLE expand_noop EXPAND TABLE;
+ALTER TABLE expand_noop EXPAND TABLE;

--- a/src/test/regress/sql/reshuffle_ao.sql
+++ b/src/test/regress/sql/reshuffle_ao.sql
@@ -9,6 +9,7 @@ create schema test_reshuffle_ao;
 set search_path=test_reshuffle_ao,public;
 set gp_default_storage_options='appendonly=true,orientation=row';
 set allow_system_table_mods=true;
+set gp_expand_method = move;
 
 -- Hash distributed tables
 select gp_debug_set_create_table_default_numsegments(2);

--- a/src/test/regress/sql/reshuffle_aoco.sql
+++ b/src/test/regress/sql/reshuffle_aoco.sql
@@ -9,6 +9,7 @@ create schema test_reshuffle_aoco;
 set search_path=test_reshuffle_aoco,public;
 set gp_default_storage_options='appendonly=true,orientation=column';
 set allow_system_table_mods=true;
+set gp_expand_method = move;
 
 -- Hash distributed tables
 select gp_debug_set_create_table_default_numsegments(2);


### PR DESCRIPTION
Originally, we use the percentage of data that need to move to decide
the method to expand a table, the old percentage 30% is a little bit
hasty and not well tested, actually, there are many other factors that
need to be considered like index, table type, disk usage, etc. So we
decide to provide a GUC to control the method for expanding tables,
so users can decide the method by themselves and change it when a method
is proved to be slow.

This commit also added some comments about two expanding methods and
removed unnecessary structures which are code reviewed by Heikki in
PR #6308

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
