### PR TITLE
Remove the distributed log on new segments

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -758,6 +758,11 @@ DistributedLog_Startup(TransactionId oldestActiveXid,
 		Assert(currentPage <= TransactionIdToPage(MaxTransactionId));
 		Assert(endPage <= TransactionIdToPage(MaxTransactionId));
 
+		/*
+		 * Clean the pg_distributedlog directory
+		 */
+		SimpleLruTruncateWithLock(DistributedLogCtl, currentPage);
+
 		do
 		{
 			if (currentPage > TransactionIdToPage(MaxTransactionId))

--- a/src/backend/access/transam/test/distributedlog_test.c
+++ b/src/backend/access/transam/test/distributedlog_test.c
@@ -123,6 +123,10 @@ test_BinaryUpgradeZeroesOutDistributedLogFittingOnSinglePage(void **state)
 
 	setup(nextXid);
 
+	expect_value(SimpleLruTruncateWithLock, ctl, DistributedLogCtl);
+	expect_value(SimpleLruTruncateWithLock, cutoffPage, TransactionIdToPage(oldestActiveXid));
+	will_be_called(SimpleLruTruncateWithLock);
+
 	expect_value(SimpleLruZeroPage, ctl, DistributedLogCtl);
 	expect_value(SimpleLruZeroPage, pageno, TransactionIdToPage(oldestActiveXid));
 	will_return(SimpleLruZeroPage, 0);
@@ -142,6 +146,10 @@ test_BinaryUpgradeZeroesOutDistributedLogFittingOnThreePages(void **state)
 	TransactionId nextXid = FirstNormalTransactionId + ENTRIES_PER_PAGE * 2;
 
 	setup(nextXid);
+
+	expect_value(SimpleLruTruncateWithLock, ctl, DistributedLogCtl);
+	expect_value(SimpleLruTruncateWithLock, cutoffPage, TransactionIdToPage(oldestActiveXid));
+	will_be_called(SimpleLruTruncateWithLock);
 
 	expect_value(SimpleLruZeroPage, ctl, DistributedLogCtl);
 	expect_value(SimpleLruZeroPage, pageno, TransactionIdToPage(oldestActiveXid));
@@ -171,6 +179,10 @@ test_BinaryUpgradeZeroesOutDistributedLogWithTransactionIdWraparound(void **stat
 
 	setup(nextXid);
 
+	expect_value(SimpleLruTruncateWithLock, ctl, DistributedLogCtl);
+	expect_value(SimpleLruTruncateWithLock, cutoffPage, TransactionIdToPage(oldestActiveXid));
+	will_be_called(SimpleLruTruncateWithLock);
+
 	expect_value(SimpleLruZeroPage, ctl, DistributedLogCtl);
 	expect_value(SimpleLruZeroPage, pageno, TransactionIdToPage(oldestActiveXid));
 	will_return(SimpleLruZeroPage, 0);
@@ -195,6 +207,10 @@ test_ConvertMasterDataDirToSegmentZeroesOutDistributedLogFittingOnSinglePage(voi
 
 	setup(nextXid);
 
+	expect_value(SimpleLruTruncateWithLock, ctl, DistributedLogCtl);
+	expect_value(SimpleLruTruncateWithLock, cutoffPage, TransactionIdToPage(oldestActiveXid));
+	will_be_called(SimpleLruTruncateWithLock);
+
 	expect_value(SimpleLruZeroPage, ctl, DistributedLogCtl);
 	expect_value(SimpleLruZeroPage, pageno, TransactionIdToPage(oldestActiveXid));
 	will_return(SimpleLruZeroPage, 0);
@@ -214,6 +230,10 @@ test_ConvertMasterDataDirToSegmentZeroesOutDistributedLogFittingOnThreePages(voi
 	TransactionId nextXid = FirstNormalTransactionId + ENTRIES_PER_PAGE * 2;
 
 	setup(nextXid);
+
+	expect_value(SimpleLruTruncateWithLock, ctl, DistributedLogCtl);
+	expect_value(SimpleLruTruncateWithLock, cutoffPage, TransactionIdToPage(oldestActiveXid));
+	will_be_called(SimpleLruTruncateWithLock);
 
 	expect_value(SimpleLruZeroPage, ctl, DistributedLogCtl);
 	expect_value(SimpleLruZeroPage, pageno, TransactionIdToPage(oldestActiveXid));
@@ -242,6 +262,10 @@ test_ConvertMasterDataDirToSegmentZeroesOutDistributedLogWithTransactionIdWrapar
 	TransactionId nextXid = MaxTransactionId + 10;
 
 	setup(nextXid);
+
+	expect_value(SimpleLruTruncateWithLock, ctl, DistributedLogCtl);
+	expect_value(SimpleLruTruncateWithLock, cutoffPage, TransactionIdToPage(oldestActiveXid));
+	will_be_called(SimpleLruTruncateWithLock);
 
 	expect_value(SimpleLruZeroPage, ctl, DistributedLogCtl);
 	expect_value(SimpleLruZeroPage, pageno, TransactionIdToPage(oldestActiveXid));


### PR DESCRIPTION
df19119c208 eliminate distributed transaction log creation 
and maintenance on QD (Only a 32K `pg_distributedlog/0000`
 file exists). Gpexpand will copy data files from
QD to new segments, So in the new segments the oldestXID
 is 3 (loaded from pg_controlfile which copied from QD).

After new segments join the cluster, they will maintain the 
oldestXmin, so it will loop to find the page which is in the 
distributed transaction log.

If the local transaction ID (xid) is huge on new segments, it will 
lead to a hole between 0000 and TransactionIdToPage(xid), 
then an error will be raised.

In this PR we truncate the distributedlog with cutoff of oldestxid
on new segments,  then the hole is gone, so the oldestXmin will be
initialized to oldestLocalXmin.

----

Reproduced steps:

```
1. make create-demo-cluster
2. Run the regression test case autovacuum-template0 (which
    will bump the QD's local transaction ID to a huge number).
3. run gpexpand 
```

The error message:

```
20181228:06:27:02:099009 gpexpand:96fc971f-88cd-479b-7b0a-dde38df5e639:gpadmin-[INFO]:-Unlocking catalog
20181228:06:27:02:099009 gpexpand:96fc971f-88cd-479b-7b0a-dde38df5e639:gpadmin-[INFO]:-Unlocked catalog
20181228:06:27:03:099009 gpexpand:96fc971f-88cd-479b-7b0a-dde38df5e639:gpadmin-[INFO]:-Creating expansion schema
20181228:06:27:03:099009 gpexpand:96fc971f-88cd-479b-7b0a-dde38df5e639:gpadmin-[ERROR]:-gpexpand failed: error 'ERROR:  could not access status of transaction 4096 (slru.c:896)  (seg3 10.254.1.26:25438 pid=99972) (slru.c:896)
DETAIL:  Could not read from file "pg_distributedlog/0000" at offset 32768: Success.
' in 'CREATE SCHEMA gpexpand' 
```




## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
