### PR TITLE
CentOS vagrant build fixes

### DIFF
--- a/src/tools/vagrant/centos/Vagrantfile
+++ b/src/tools/vagrant/centos/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure(2) do |config|
   # Base box: Centos-7 box
   # NOTE: Over time the VMI below may become outdated, so may need to be
   #       substituted with a more recent VMI
-  config.vm.box = "boxcutter/centos72"
+  config.vm.box = "bento/centos-7"
 
   config.vm.hostname="gpdbvagrant"
 
@@ -32,9 +32,9 @@ Vagrant.configure(2) do |config|
     gpdb.vm.provision "shell", path: "vagrant-build-gpdb.sh", privileged: false, args: "--enable-orca"
   end
 
-  config.vm.define("gpdb_without_gporca") do |gpdb_without_gporca|
-    gpdb_without_gporca.vm.provision "shell", path: "vagrant-setup.sh"
-    gpdb_without_gporca.vm.provision "shell", path: "vagrant-configure-os.sh"
-    gpdb_without_gporca.vm.provision "shell", path: "vagrant-build-gpdb.sh", privileged: false
-  end
+  #config.vm.define("gpdb_without_gporca") do |gpdb_without_gporca|
+  #  gpdb_without_gporca.vm.provision "shell", path: "vagrant-setup.sh"
+  #  gpdb_without_gporca.vm.provision "shell", path: "vagrant-configure-os.sh"
+  #  gpdb_without_gporca.vm.provision "shell", path: "vagrant-build-gpdb.sh", privileged: false
+  #end
 end

--- a/src/tools/vagrant/centos/vagrant-build-gpdb.sh
+++ b/src/tools/vagrant/centos/vagrant-build-gpdb.sh
@@ -12,10 +12,11 @@ popd
 export CC="ccache cc"
 export CXX="ccache c++"
 export PATH=/usr/local/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 rm -rf /usr/local/gpdb
 pushd ~/gpdb
-  ./configure --prefix=/usr/local/gpdb $@
+  ./configure --prefix=/usr/local/gpdb CFLAGS="-I/usr/local/include/ -L/usr/local/lib/" $@
   make clean
   make -j4 -s && make install
 popd

--- a/src/tools/vagrant/centos/vagrant-build-gporca.sh
+++ b/src/tools/vagrant/centos/vagrant-build-gporca.sh
@@ -21,7 +21,7 @@ pushd ~/gpos
   rm -fr build
   mkdir build
   pushd build
-    cmake ../
+    cmake3 ../
     make -j4 && make install
   popd
 popd
@@ -39,7 +39,7 @@ pushd ~/gporca
   rm -fr build
   mkdir build
   pushd build
-    cmake ../
+    cmake3 ../
     make -j4 && make install
   popd
 popd

--- a/src/tools/vagrant/centos/vagrant-configure-os.sh
+++ b/src/tools/vagrant/centos/vagrant-configure-os.sh
@@ -56,3 +56,7 @@ sudo bash -c 'printf "* hard core unlimited\n"         >> /etc/security/limits.d
 sudo sed -i '/RemoveIPC=no/d' /etc/systemd/logind.conf
 sudo bash -c 'echo "RemoveIPC=no" >> /etc/systemd/logind.conf'
 sudo service systemd-logind restart
+
+# Ensure libraries end up in path
+sudo bash -c 'echo "/usr/local/lib" >> /etc/ld.so.conf'
+sudo bash -c 'echo "/usr/local/lib64" >> /etc/ld.so.conf'

--- a/src/tools/vagrant/centos/vagrant-setup.sh
+++ b/src/tools/vagrant/centos/vagrant-setup.sh
@@ -4,39 +4,38 @@ set -x
 
 # install packages needed to build and run GPDB
 sudo yum -y groupinstall "Development tools"
-sudo yum -y install ed
-sudo yum -y install readline-devel
-sudo yum -y install zlib-devel
-sudo yum -y install curl-devel
-sudo yum -y install bzip2-devel
-sudo yum -y install python-devel
-sudo yum -y install apr-devel
-sudo yum -y install libevent-devel
-sudo yum -y install openssl-libs openssl-devel
-sudo yum -y install libyaml libyaml-devel
 sudo yum -y install epel-release
-sudo yum -y install htop
-sudo yum -y install perl-Env
-sudo yum -y install ccache
-sudo yum -y install libffi-devel
-wget https://bootstrap.pypa.io/get-pip.py
-sudo python get-pip.py
-sudo pip install psutil lockfile paramiko setuptools
-rm get-pip.py
+sudo yum -y install \
+ apr-devel \
+ bzip2-devel \
+ ccache \
+ cmake3 \
+ curl-devel \
+ ed \
+ htop \
+ libevent-devel \
+ libffi-devel \
+ libxml2 \
+ libxml2-devel \
+ libyaml \
+ libyaml-devel \
+ openssl-libs \
+ openssl-devel \
+ perl-Env \
+ python-devel \
+ python-pip \
+ readline-devel \
+ zlib-devel 
+
+# Install necessary Python pieces
+sudo pip install --upgrade psutil
+sudo pip install --upgrade lockfile
+sudo pip install --upgrade paramiko
+sudo pip install --upgrade setuptools
+sudo pip install --upgrade epydoc
+sudo pip install --upgrade pyyaml
 
 # Misc
 sudo yum -y install vim mc psmisc
-
-# cmake 3.0
-pushd ~
-  wget http://www.cmake.org/files/v3.0/cmake-3.0.0.tar.gz
-  tar -zxvf cmake-3.0.0.tar.gz
-  pushd cmake-3.0.0
-    ./bootstrap
-    make
-    make install
-    export PATH=/usr/local/bin:$PATH
-  popd
-popd
 
 sudo chown -R vagrant:vagrant /usr/local


### PR DESCRIPTION
Updating the vagrant build for GPDB on CentOS

- Using the bento/centos7 so it should stay current with 7
- Using EPEL repo for cmake3 and pip instead of custom pulling it
- Adding LD_LIBRARY_PATH to gpdb build in order to help solve dependency issues
- Add libxml2-devel to satisfy dependency
- Organize the yum package install into one rather than multiple so less back and forth
