### PR TITLE
Fix distributed snapshot xmax check.

### DIFF
--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -176,9 +176,9 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 
 	/*
 	 * Any xid >= xmax is in-progress, distributed xmax points to the
-	 * committer, so it must be visible, so ">" instead of ">="
+	 * latestCompletedDxid + 1.
 	 */
-	if (distribXid > ds->xmax)
+	if (distribXid >= ds->xmax)
 	{
 		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
 			 "distributedsnapshot committed but invisible: distribXid %d dxmax %d dxmin %d distribSnapshotId %d",

--- a/src/test/isolation2/expected/distributed_snapshot.out
+++ b/src/test/isolation2/expected/distributed_snapshot.out
@@ -1,4 +1,6 @@
--- Test to validate GetSnapshotData()'s computation of globalXmin using
+-- Distributed snapshot tests
+
+-- Scenario1: Test to validate GetSnapshotData()'s computation of globalXmin using
 -- distributed snapshot. It mainly uses a old read-only transaction to help
 -- create situation where globalXmin can be lower than distributed oldestXmin
 -- when calling DistributedLog_AdvanceOldestXmin().
@@ -59,4 +61,31 @@ t
 ?column?
 --------
 t       
+(1 row)
+
+-- Scenario2: This scenario tests the boundary condition for Xmax in distributed snapshot
+
+-- Setup
+CREATE TABLE distributed_snapshot_test2 (a int);
+CREATE
+
+-- start transaction assigns distributed xid.
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+-- this sets latestCompletedXid
+2: INSERT INTO distributed_snapshot_test2 VALUES(1);
+INSERT 1
+-- here, take distributed snapshot
+1: SELECT 123 AS "establish snapshot";
+establish snapshot
+------------------
+123               
+(1 row)
+2: INSERT INTO distributed_snapshot_test2 VALUES(2);
+INSERT 1
+-- expected to see just VALUES(1)
+1: SELECT * FROM distributed_snapshot_test2;
+a
+-
+1
 (1 row)

--- a/src/test/isolation2/sql/distributed_snapshot.sql
+++ b/src/test/isolation2/sql/distributed_snapshot.sql
@@ -1,4 +1,6 @@
--- Test to validate GetSnapshotData()'s computation of globalXmin using
+-- Distributed snapshot tests
+
+-- Scenario1: Test to validate GetSnapshotData()'s computation of globalXmin using
 -- distributed snapshot. It mainly uses a old read-only transaction to help
 -- create situation where globalXmin can be lower than distributed oldestXmin
 -- when calling DistributedLog_AdvanceOldestXmin().
@@ -36,3 +38,18 @@ CREATE TABLE distributed_snapshot_test1 (a int);
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'reset', dbid)
    from gp_segment_configuration where content = 0 and role = 'p';
 3<:
+
+-- Scenario2: This scenario tests the boundary condition for Xmax in distributed snapshot
+
+-- Setup
+CREATE TABLE distributed_snapshot_test2 (a int);
+
+-- start transaction assigns distributed xid.
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+-- this sets latestCompletedXid
+2: INSERT INTO distributed_snapshot_test2 VALUES(1);
+-- here, take distributed snapshot
+1: SELECT 123 AS "establish snapshot";
+2: INSERT INTO distributed_snapshot_test2 VALUES(2);
+-- expected to see just VALUES(1)
+1: SELECT * FROM distributed_snapshot_test2;


### PR DESCRIPTION
As part of commit dc78e56, logic for distributed snapshot was modified
to use latestCompletedDxid. This changed the logic from xmax being
inclusive range to not inclusive for visible transactions in snapshot.
Hence, updating the check to return
DISTRIBUTEDSNAPSHOT_COMMITTED_INPROGRESS even for transaction id equal
to global xmax now. Other way to fix is using latestCompletedDxid
without +1 for xmax, but better is to keep logic similar to local
snapshot check and not have xmax in inclusive range of visible
transactions.

This was exposed in CI by test
isolation/results/heap-repeatable-read-vacuum-freeze failing
intermittently.  This was due to isolation framework itself triggering
query on pg_locks to check for deadlocks. This commit adds explicitely
test to cover the scenario.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
