### PR TITLE
Disable materialized view on greenplum.

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1809,7 +1809,6 @@ heap_create_with_catalog(const char *relname,
 		switch (relkind)
 		{
 			case RELKIND_RELATION:
-				// GPDB_93_MERGE_FIXME: What about MATVIEW?
 				break;
 			case RELKIND_INDEX:
 				subtyp = "INDEX";
@@ -1819,6 +1818,9 @@ heap_create_with_catalog(const char *relname,
 				break;
 			case RELKIND_VIEW:
 				subtyp = "VIEW";
+				break;
+			case RELKIND_MATVIEW:
+				subtyp = "MATVIEW";
 				break;
 			default:
 				doIt = false;

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -150,6 +150,8 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	int			save_sec_context;
 	int			save_nestlevel;
 
+	/* MATERIALIZED_VIEW_FIXME: Refresh MatView is not MPP-fied. */
+
 	/* Determine strength of lock needed. */
 	concurrent = stmt->concurrent;
 	lockmode = concurrent ? ExclusiveLock : AccessExclusiveLock;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3236,6 +3236,10 @@ transformCreateTableAsStmt(ParseState *pstate, CreateTableAsStmt *stmt)
 	/* additional work needed for CREATE MATERIALIZED VIEW */
 	if (stmt->relkind == OBJECT_MATVIEW)
 	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("materialized view is not supported on greenplum")));
+
 		/*
 		 * Prohibit a data-modifying CTE in the query used to create a
 		 * materialized view. It's not sufficiently clear what the user would

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -110,10 +110,7 @@ test: namespace
 # ----------
 test: privileges security_label collate lock replica_identity
 
-# GPDB_93_MERGE_FIXME: Materialized views have not been "MPP-ified", and don't
-# currently work. Disable test, until it's fixed. (If they still don't work when
-# we make a release, we should add a check in code, to throw a proper "not
-# supported" error message.)
+# MATERIALIZED_VIEW_FIXME : matview is not supported on greenplum. Enable the test when the feature is ready.
 #test: matview
 
 # ----------

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -98,7 +98,8 @@ ignore: prepared_xacts
 test: privileges
 test: security_label
 test: collate
-test: matview
+# MATERIALIZED_VIEW_FIXME : matview is not supported on greenplum. Enable the test when the feature is ready.
+#test: matview
 test: lock
 test: replica_identity
 test: alter_generic


### PR DESCRIPTION
This feature will not be supported in the oncoming gpdb major release.
Explicitly disable it for now.