### PR TITLE
Avoid calling CreateRestartPoint() from startup process.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7366,21 +7366,18 @@ StartupXLOG(void)
 				xlogctl->lastReplayedTLI = ThisTimeLineID;
 				SpinLockRelease(&xlogctl->info_lck);
 
-				/*
-				 * GPDB_84_MERGE_FIXME: Create restartpoints aggressively.
-				 *
-				 * In PostgreSQL, the bgwriter creates restartpoints during archive
-				 * recovery at its own leisure. In GPDB, with WAL replication based
-				 * mirroring, that was tripping the gp_replica_check checks, because
-				 * it bypasses the shared buffer cache and reads directly from disk.
-				 * For now, restore the old behavior, before the upstream change
-				 * to start bgwriter during archive recovery, and create a
-				 * restartpoint immediately after replaying a checkpoint record and
-				 * only if this GUC is set we force aggressive checkpoint, and
-				 * currently gp_replica_check forces this guc on.
-				 */
 				if (create_restartpoint_on_ckpt_record_replay && ArchiveRecoveryRequested)
 				{
+					/*
+					 * Create restartpoint on checkpoint record if requested.
+					 *
+					 * The bgwriter creates restartpoints during archive
+					 * recovery at its own leisure. But gp_replica_check fails
+					 * with this, because it bypasses the shared buffer cache
+					 * and reads directly from disk. So, via GUC it can
+					 * request to force creating restart point mainly to flush
+					 * the shared buffers to disk.
+					 */
 					uint8 xlogRecInfo = record->xl_info & ~XLR_INFO_MASK;
 
 					if (record->xl_rmid == RM_XLOG_ID &&
@@ -7390,7 +7387,7 @@ StartupXLOG(void)
 						if (bgwriterLaunched)
 							RequestCheckpoint(CHECKPOINT_IMMEDIATE | CHECKPOINT_WAIT);
 						else
-							CreateRestartPoint(CHECKPOINT_IMMEDIATE);
+							elog(LOG, "Skipping CreateRestartPoint() as bgwriter is not launched.");
 					}
 				}
 
@@ -9508,14 +9505,7 @@ CreateRestartPoint(int flags)
 	 * checkpoint/restartpoint) to prevent the disk holding the xlog from
 	 * growing full.
 	 */
-	/*
-	 * In GPDB, CreateRestartPoint() gets called from startup process, unlike
-	 * upstream.  When called from startup process, we are only interested in
-	 * flushing shared buffers to disk.  So don't do anything else.
-	 * xlog_redo() depends on ThisTimeLineID to be valid, which is reset in the
-	 * if block below.
-	 */
-	if (!am_startup && IsStandbyMode() && gp_keep_all_xlog == false && _logSegNo)
+	if (!gp_keep_all_xlog && _logSegNo)
 	{
 		XLogRecPtr	receivePtr;
 		XLogRecPtr	replayPtr;


### PR DESCRIPTION
With commit 8a11bff, aggressive restart point creation is not performed in gpdb
as well. Since CreateRestartPoint() is not coded to be called from startup
process, GPDB specific code exception was added in past to work correctly for
previous aggressive restart point creations, calls to which could happen via
startup process.

Now given only when gp_replica_check is running restartpoint is created on
checkpoint record, which should be done via checkpointer process. Eliminate any
case of calling CreateRestartPoint() from startup process and thereby remove
GPDB added exception to CreateRestartPoint() and align to upstream code.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
