### PR TITLE
Dispatcher should use DISPATCH_WAIT_FINISH mode to wait QEs for init …

### DIFF
--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1075,12 +1075,6 @@ PG_TRY();
 			prm->isnull = false;
 			found = true;
 
-			if (shouldDispatch)
-			{
-				/* Tell MPP we're done with this plan. */
-				ExecSquelchNode(planstate);
-			}
-
 			break;
 		}
 


### PR DESCRIPTION
…plans

GPDB always set the REWIND flag for subplans include init plans, in 6195b96780,
we enhanced the restriction that if a node is not eager free, we cannot squelch
a node earlier include init plans, this exposes a few hidden bugs: if init plan
contains a motion node that needs to be squelched earlier, the whole query will
get stuck in cdbdisp_checkDispatchResult() because some QEs are still keep
sending tuples.

To resolve this, we use DISPATCH_WAIT_FINISH mode for dispatcher to wait the
dispatch results of init plan, init plan with motion is always executed on
QD and should always be a SELECT-like plan, init plan must already fetched
all the tuples it needed before dispatcher waiting for the QEs,
DISPATCH_WAIT_FINISH is the right mode for init plan.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
