### PR TITLE
Fix assertion failure in join planning.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -1362,6 +1362,8 @@ cdbpath_motion_for_join(PlannerInfo *root,
 		/* Last resort: If possible, move all partitions of other rel to single QE. */
 		else if (!other_immovable)
 			other->move_to = single->locus;
+		else
+			goto fail;
 	}							/* singleQE or entry */
 
 	/*

--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -527,11 +527,14 @@ cdbpathlocus_join(JoinType jointype, CdbPathLocus a, CdbPathLocus b)
 	 * keys should be compatible; otherwise the caller should not be building
 	 * a join directly between these two rels (a Motion would be needed).
 	 */
-	Assert(CdbPathLocus_IsHashed(a) || CdbPathLocus_IsHashedOJ(a));
-	Assert(CdbPathLocus_IsHashed(b) || CdbPathLocus_IsHashedOJ(b));
-	Assert(a.distkey != NIL &&
-		   CdbPathLocus_NumSegments(a) == CdbPathLocus_NumSegments(b) &&
-		   list_length(a.distkey) == list_length(b.distkey));
+	if (!(CdbPathLocus_IsHashed(a) || CdbPathLocus_IsHashedOJ(a)))
+		elog(ERROR, "could not be construct join with non-hashed path");
+	if (!(CdbPathLocus_IsHashed(b) || CdbPathLocus_IsHashedOJ(b)))
+		elog(ERROR, "could not be construct join with non-hashed path");
+	if (a.distkey == NIL ||
+		CdbPathLocus_NumSegments(a) != CdbPathLocus_NumSegments(b) ||
+		list_length(a.distkey) != list_length(b.distkey))
+		elog(ERROR, "could not construct hashed join locus with incompatible distribution keys");
 
 	/*
 	 * For a LEFT/RIGHT OUTER JOIN, we can use key of the outer, non-nullable

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -574,3 +574,20 @@ select * from t6215 a full join t6215 b on true;
 (9 rows)
 
 drop table t6215;
+--
+-- This tripped an assertion while deciding the locus for the joins.
+-- The code was failing to handle join between SingleQE and Hash correctly,
+-- when there were join order restricitions. (see
+-- https://github.com/greenplum-db/gpdb/issues/6643
+--
+select a.f1, b.f1, t.thousand, t.tenthous from
+  (select sum(f1) as f1 from int4_tbl i4b) b
+   left outer join
+     (select sum(f1)+1 as f1 from int4_tbl i4a) a ON a.f1 = b.f1
+      left outer join
+        tenk1 t ON b.f1 = t.thousand and (a.f1+b.f1+999) = t.tenthous;
+ f1 | f1 | thousand | tenthous 
+----+----+----------+----------
+    |  0 |          |         
+(1 row)
+

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -620,3 +620,20 @@ select * from t6215 a full join t6215 b on true;
 (9 rows)
 
 drop table t6215;
+--
+-- This tripped an assertion while deciding the locus for the joins.
+-- The code was failing to handle join between SingleQE and Hash correctly,
+-- when there were join order restricitions. (see
+-- https://github.com/greenplum-db/gpdb/issues/6643
+--
+select a.f1, b.f1, t.thousand, t.tenthous from
+  (select sum(f1) as f1 from int4_tbl i4b) b
+   left outer join
+     (select sum(f1)+1 as f1 from int4_tbl i4a) a ON a.f1 = b.f1
+      left outer join
+        tenk1 t ON b.f1 = t.thousand and (a.f1+b.f1+999) = t.tenthous;
+ f1 | f1 | thousand | tenthous 
+----+----+----------+----------
+    |  0 |          |         
+(1 row)
+

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -333,3 +333,17 @@ explain (costs off) select * from t6215 a full join t6215 b on true;
 select * from t6215 a full join t6215 b on true;
 
 drop table t6215;
+
+
+--
+-- This tripped an assertion while deciding the locus for the joins.
+-- The code was failing to handle join between SingleQE and Hash correctly,
+-- when there were join order restricitions. (see
+-- https://github.com/greenplum-db/gpdb/issues/6643
+--
+select a.f1, b.f1, t.thousand, t.tenthous from
+  (select sum(f1) as f1 from int4_tbl i4b) b
+   left outer join
+     (select sum(f1)+1 as f1 from int4_tbl i4a) a ON a.f1 = b.f1
+      left outer join
+        tenk1 t ON b.f1 = t.thousand and (a.f1+b.f1+999) = t.tenthous;


### PR DESCRIPTION
cdbpath_motion_for_join() was sometimes returning an incorrect locus for a
join between SingleQE and Hashed loci. This happened, when even the "last
resort" strategy to move hashed side to the single QE failed. This can
happen at least in the query being added to the regression tests. The
query involves a nested loop join path, when one side is a SingleQE locus
and the other side is a Hashed locus, and there are no join predicates
that can be used to determine the resulting locus.

While we're at it, turn the Assertion that this tripped, into elog()s. No
need to crash the whole server if the planner screws up, and it'd be good
to perform these sanity checks in production, too.

The failure of the "last resort" codepath was left unhandled by commit
0522e96074. Fixes https://github.com/greenplum-db/gpdb/issues/6643.
