### PR TITLE
Remove Travis CI badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-**Concourse Pipeline** [![Concourse Build Status](https://prod.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/gpdb_master/badge)](https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master) |
-**Travis Build** [![Travis Build Status](https://travis-ci.org/greenplum-db/gpdb.svg?branch=master)](https://travis-ci.org/greenplum-db/gpdb)
+**Concourse Pipeline** [![Concourse Build Status](https://prod.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/gpdb_master/badge)](https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master)
 
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
The Travis badge was added in the distant past when we (briefly) had a pipeline building and testing master.  The pipeline has long since been removed and the badge now shows status for the PR build pipeline we have which is less than interesting, as the aggregate sum of PRs building or failing says little about the state of the master branch.