### PR TITLE
Remove dependency of test AIX to release candidate

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -59,7 +59,8 @@ JOBS_THAT_ARE_GATES = ['gate_icw_start',
 JOBS_THAT_SHOULD_NOT_BLOCK_RELEASE = [
     'compile_gpdb_binary_swap_centos6',
     'icw_gporca_centos6_gpos_memory',
-    'walrep_2'
+    'walrep_2',
+    'client_loader_remote_test_aix'
 ] + RELEASE_VALIDATOR_JOB + JOBS_THAT_ARE_GATES
 
 def suggested_git_remote():

--- a/concourse/pipelines/gpdb_master-generated.yml
+++ b/concourse/pipelines/gpdb_master-generated.yml
@@ -2227,7 +2227,6 @@ jobs:
       - icw_planner_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - icw_extensions_gpcloud_ubuntu16
-      - client_loader_remote_test_aix
       - resource_group_centos6
       - resource_group_centos7
       - resource_group_sles12

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -2338,7 +2338,6 @@ jobs:
       - icw_planner_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - icw_extensions_gpcloud_ubuntu16
-      - client_loader_remote_test_aix
       - resource_group_centos6
       - resource_group_centos7
       - resource_group_sles12


### PR DESCRIPTION
The AIX server in not available, so we remove the test job to
release candidate. This is temp change until the server is available.

Just modify release pipeline, no need to add test case 
