### PR TITLE
Compile client tools on Windows using CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ lib*.pc
 /Debug/
 /Release/
 /CMakeLists.txt
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,142 @@
+cmake_minimum_required(VERSION 3.12)
+if (NOT ${CMAKE_GENERATOR} STREQUAL "Visual Studio 15 2017 Win64")
+    message(FATAL_ERROR "Only Visual Studio 15 2017 Win64 is supported")
+endif()
+
+set (CMAKE_CONFIGURATION_TYPES Release RelWithDebInfo)
+project(gpdb C)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set (GPDB_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+find_package(ZLIB REQUIRED)
+if (ZLIB_FOUND)
+    include_directories(${ZLIB_INCLUDE_DIRS})
+else ()
+    message(FATAL_ERROR "zlib not found")
+endif(ZLIB_FOUND)
+
+include(FindPerl)
+if (NOT PERL_FOUND)
+    message(FATAL_ERROR "Perl not found")
+endif()
+
+include(FindFLEX)
+if (NOT FLEX_FOUND)
+    message(FATAL_ERROR "Flex not found")
+endif()
+
+include(FindBISON)
+if (NOT BISON_FOUND)
+    message(FATAL_ERROR "bison not found")
+endif()
+
+find_package(Python2 COMPONENTS Interpreter Development)
+if (Python2_FOUND)
+    include_directories(${Python2_INCLUDE_DIRS})
+else ()
+    message(FATAL_ERROR "python2 not found")
+endif(Python2_FOUND)
+
+include(FindOpenSSL)
+if (OPENSSL_FOUND)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+else ()
+    message(FATAL_ERROR "openssl not found")
+endif(OPENSSL_FOUND)
+
+set (CPPFLAGS "/MP /wd4996 /wd4018 /wd4090 /wd4102 /wd4244 /wd4267 /wd4273 /wd4715")
+configure_file("${GPDB_SRC_DIR}/src/include/pg_config.h.win32" "${GPDB_SRC_DIR}/src/include/pg_config.h" COPYONLY)
+
+# () specify a subgroup to capature, it matches the PG_MAJOR_VERSION from configure.in.
+# Extract version number from subgroup, into $CMAKE_MATCH_1
+# Append definition to final pg_config.h
+set(VERSION_PATTERN "PG_PACKAGE_VERSION=([0-9\.]*)")
+set(GPDB_VERSION_PATTERN "\\\[Greenplum Database\\\], \\\[([^\]]*)\\\]")
+file(STRINGS "${GPDB_SRC_DIR}/configure.in" CONFIGURE_FILE)
+string(REGEX MATCH "${VERSION_PATTERN}" PG_MAJORVERSION_STRING ${CONFIGURE_FILE})
+set(PG_MAJORVERSION ${CMAKE_MATCH_1})
+file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define PG_MAJORVERSION \"${PG_MAJORVERSION}\"\n" )
+message("PG_MAJORVERSION: " "${PG_MAJORVERSION}")
+
+string(REGEX MATCH "${GPDB_VERSION_PATTERN}" GP_VERSION_STRING ${CONFIGURE_FILE})
+set(GP_VERSION ${CMAKE_MATCH_1})
+file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define GP_VERSION \"${GP_VERSION}\"\n" )
+message("GP_VERSION: " "${GP_VERSION}")
+
+string(REGEX MATCH "[^\.]*" GP_MAJORVERSION ${GP_VERSION})
+file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define GP_MAJORVERSION \"${GP_MAJORVERSION}\"\n" )
+message("GP_MAJORVERSION: " "${GP_MAJORVERSION}")
+
+file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define USE_SSL 1\n")
+file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define HAVE_LIBZ 1\n")
+
+if(NOT DEFINED BLOCKSIZE)
+    set(BLOCKSIZE 32)
+endif()
+math(EXPR BLCKSZ "${BLOCKSIZE}*1024")
+file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define BLCKSZ ${BLCKSZ}\n")
+
+if(NOT DEFINED SEGSIZE)
+    set(SEGSIZE 1)
+endif()
+math(EXPR RELSEG_SIZE "1024/32*${SEGSIZE}*1024")
+file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define RELSEG_SIZE ${RELSEG_SIZE}\n")
+
+
+if(NOT DEFINED WAL_BLOCKSIZE)
+    set(WAL_BLOCKSIZE 32)
+endif()
+math(EXPR XLOG_BLCKSZ "${WAL_BLOCKSIZE}*1024")
+file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define XLOG_BLCKSZ ${XLOG_BLCKSZ}\n")
+
+if(NOT DEFINED WAL_SEGSIZE)
+    set(WAL_SEGSIZE 64)
+endif()
+math(EXPR XLOG_SEG_SIZE "${WAL_SEGSIZE}*1024*1024")
+file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define XLOG_SEG_SIZE ${XLOG_SEG_SIZE}\n")
+
+if(NOT DEFINED FLOAT4BYVAL)
+    set(FLOAT4BYVAL true)
+endif()
+if(FLOAT4BYVAL)
+    file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define USE_FLOAT4_BYVAL 1\n")
+    file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define FLOAT4PASSBYVAL true\n")
+else()
+    file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define FLOAT4PASSBYVAL false\n")
+endif()
+
+if(NOT DEFINED FLOAT8BYVAL)
+    set(FLOAT8BYVAL true)
+endif()
+if(FLOAT8BYVAL)
+    file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define USE_FLOAT8_BYVAL 1\n")
+    file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define FLOAT8PASSBYVAL true\n")
+else()
+    file(APPEND "${GPDB_SRC_DIR}/src/include/pg_config.h" "\n#define FLOAT8PASSBYVAL false\n")
+endif()
+
+configure_file("${GPDB_SRC_DIR}/src/include/pg_config_ext.h.win32" "${GPDB_SRC_DIR}/src/include/pg_config_ext.h" COPYONLY)
+configure_file("${GPDB_SRC_DIR}/src/include/port/win32.h" "${GPDB_SRC_DIR}/src/include/pg_config_os.h" COPYONLY)
+
+# pg_config_paths.h is shared by both port and libpq
+file (WRITE "${GPDB_SRC_DIR}/src/port/pg_config_paths.h"
+    "#define PGBINDIR \"${CMAKE_INSTALL_PREFIX}/bin\""
+    "\n#define PGSHAREDIR \"${CMAKE_INSTALL_PREFIX}/share/postgresql\""
+    "\n#define SYSCONFDIR \"${CMAKE_INSTALL_PREFIX}/etc/postgresql\""
+    "\n#define INCLUDEDIR \"${CMAKE_INSTALL_PREFIX}/include\""
+    "\n#define PKGINCLUDEDIR \"${CMAKE_INSTALL_PREFIX}/include/postgresql\""
+    "\n#define INCLUDEDIRSERVER \"${CMAKE_INSTALL_PREFIX}/include/postgresql/server\""
+    "\n#define LIBDIR \"${CMAKE_INSTALL_PREFIX}/lib\""
+    "\n#define PKGLIBDIR \"${CMAKE_INSTALL_PREFIX}/lib/postgresql\""
+    "\n#define LOCALEDIR \"${CMAKE_INSTALL_PREFIX}/share/locale\""
+    "\n#define DOCDIR \"${CMAKE_INSTALL_PREFIX}/doc/postgresql\""
+    "\n#define HTMLDIR \"${CMAKE_INSTALL_PREFIX}/doc/postgresql\""
+    "\n#define MANDIR \"${CMAKE_INSTALL_PREFIX}/share/man\""
+)
+
+add_subdirectory(src/common)
+add_subdirectory(src/port)
+add_subdirectory(src/interfaces/libpq)
+add_subdirectory(src/bin)
+add_subdirectory(src/backend)
+add_subdirectory(gpMgmt/bin/pythonSrc/PyGreSQL-4.0/)

--- a/README.win.md
+++ b/README.win.md
@@ -1,0 +1,65 @@
+We only support compilation of client tools on Windows. 
+
+## 1. Install toolchain and dependencies
+
+- CMake: https://cmake.org/download/
+- Visual Studio 2017 Build Tools: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017
+- git: https://git-scm.com/download/win
+- flex, bison via MSYS2: https://www.msys2.org/  
+After install msys64, open MSYS2 command line and run  
+```pacman -S flex bison```
+- perl: https://www.activestate.com/activeperl/downloads
+- python2: https://www.python.org/downloads/release/python-2715/
+- OpenSSL: https://slproweb.com/products/Win32OpenSSL.html
+
+## 2. Compile external dependecies
+Assume you want to download source to `C:\ext-src` and install to `C:\ext`
+- zlib: https://zlib.net/zlib-1.2.11.tar.gz  
+Extract to "C:\ext-src"  
+Open "Developer Command Prompt for VS 2017" and execute
+```
+cd "C:\ext-src\zlib-1.2.11"  
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX:PATH=C:\ext -G "Visual Studio 15 2017 Win64" ..
+msbuild ALL_BUILD.vcxproj /property:Configuration=Release
+msbuild INSTALL.vcxproj /property:Configuration=Release
+```
+- apr: https://apr.apache.org/download.cgi
+Extract to "C:\ext-src"  
+Open "Developer Command Prompt for VS 2017" and execute
+```
+cd  C:\ext-src\apr-1.6.5-win32-src\apr-1.6.5
+mkdir build2
+cd build2
+cmake -DCMAKE_INSTALL_PREFIX:PATH=C:\ext -G "Visual Studio 15 2017 Win64" ..
+msbuild ALL_BUILD.vcxproj /property:Configuration=Release
+msbuild INSTALL.vcxproj /property:Configuration=Release
+```
+- libevent:
+Open "Developer Command Prompt for VS 2017" and execute
+```
+cd C:\ext-src
+git clone https://github.com/libevent/libevent.git
+cd libevent
+git checkout release-2.1.8-stable
+mkdir build
+cd build
+cmake -DEVENT__DISABLE_OPENSSL=ON -DCMAKE_INSTALL_PREFIX:PATH=C:\ext -G "Visual Studio 15 2017 Win64" ..
+msbuild ALL_BUILD.vcxproj /property:Configuration=Release
+msbuild INSTALL.vcxproj /property:Configuration=Release
+```
+
+## 3. Compile GPDB client tools
+Suppose gpdb source code is at `C:\gpdb` and you want to install to `C:\greenplum-db-devel`  
+Open "Developer Command Prompt for VS 2017" and execute
+```
+cd C:\gpdb
+mkdir build
+cd build
+cmake -DCMAKE_PREFIX_PATH:PATH=C:\ext -DCMAKE_INSTALL_PREFIX:PATH=C:\greenplum-db-devel -G "Visual Studio 15 2017 Win64" ..
+msbuild ALL_BUILD.vcxproj /property:Configuration=Release
+msbuild INSTALL.vcxproj /property:Configuration=Release
+```
+There's a Visual Studio Solution generated at `C:\gpdb\build\gpdb.sln`  
+You can also use Visual Studio to build and debug client tools.

--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/CMakeLists.txt
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.12)
+project(pygresql)
+add_definitions("/D FRONTEND")
+add_definitions("${CPPFLAGS}")
+file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" "")
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include/
+    ${GPDB_SRC_DIR}/src/interfaces/libpq
+    ${GPDB_SRC_DIR}/src/include/port
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+    ${GPDB_SRC_DIR}/src/port
+    ${Python2_INCLUDE_DIRS})
+include_directories(${HEADER_DIRS})
+add_library (pygresql SHARED pgmodule.c)
+target_link_libraries(pygresql libpq port common ws2_32 secur32 ${Python2_LIBRARIES})
+set_target_properties(pygresql PROPERTIES OUTPUT_NAME "_pg")
+set_target_properties(pygresql PROPERTIES SUFFIX ".pyd")
+install(TARGETS pygresql DESTINATION lib/python/pygresql)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pg.py DESTINATION lib/python/pygresql)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pgdb.py DESTINATION lib/python/pygresql)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py DESTINATION lib/python/pygresql)
+

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(CATALOGDIR ${GPDB_SRC_DIR}/src/backend/catalog)
+
+# utils/errcodes.h
+execute_process(COMMAND ${PERL_EXECUTABLE} "generate-errcodes.pl" "errcodes.txt"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/utils
+    OUTPUT_FILE "${GPDB_SRC_DIR}/src/include/utils/errcodes.h")

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+
+add_subdirectory(psql)
+add_subdirectory(pg_config)
+add_subdirectory(pg_dump)
+add_subdirectory(scripts)
+add_subdirectory(gpfdist)

--- a/src/bin/gpfdist/CMakeLists.txt
+++ b/src/bin/gpfdist/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.12)
+project(gpfdist)
+#copy gfile.c and fstream.c files to current directory
+file(COPY "${GPDB_SRC_DIR}/src/backend/utils/misc/fstream/gfile.c"
+  DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
+file(COPY "${GPDB_SRC_DIR}/src/backend/utils/misc/fstream/fstream.c"
+  DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_definitions("/D FRONTEND")
+add_definitions("${CPPFLAGS}")
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/include/port
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+    ${GPDB_SRC_DIR}/src/backend
+    ${GPDB_SRC_DIR}/src/port
+)
+
+set(APR_LIB "c:/ext/lib/libapr-1.lib")
+set(EVENT_LIB "c:/ext/lib/event.lib")
+
+#set include dirs
+include_directories("c:/ext/include")
+include_directories(${HEADER_DIRS})
+
+#set source files
+add_executable(gpfdist gpfdist.c gfile.c fstream.c gpfdist_helper.c)
+
+#set lib dirs
+target_link_libraries(gpfdist ${ZLIB_LIBRARIES} ${APR_LIB} ${EVENT_LIB} ${OPENSSL_LIBRARIES} port ws2_32 Crypt32)
+
+set_target_properties(gpfdist PROPERTIES FOLDER bin)
+install(TARGETS gpfdist DESTINATION bin)

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -18,7 +18,9 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef WIN32
 #include <strings.h>
+#endif
 #ifdef GPFXDIST
 #include <regex.h>
 #include <gpfxdist.h>
@@ -1293,7 +1295,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 {
 	int 		size;
 	const int 	whole_rows = 1; /* gpfdist must not read data with partial rows */
-	struct fstream_filename_and_offset fos = {};
+	struct fstream_filename_and_offset fos = {0};
 
 	session_t *session = r->session;
 
@@ -2140,6 +2142,8 @@ static void do_accept(int fd, short event, void* arg)
 	r->id = ++REQUEST_SEQ;
 	r->pool = pool;
 	r->sock = sock;
+
+	event_set(&r->ev, 0, 0, 0, 0);
 
 	/* use the block size specified by -m option */
 	r->outblock.data = palloc_safe(r, pool, opt.m, "out of memory when allocating buffer: %d bytes", opt.m);
@@ -4215,7 +4219,7 @@ static void do_close(int fd, short event, void *arg)
 		gwarning(r, "gpfdist shutdown the connection, while have not received response from segment");
 	}
 
-	int ret = read(r->sock, buffer, sizeof(buffer) - 1);
+	int ret = recv(r->sock, buffer, sizeof(buffer) - 1, 0);
 	if (ret < 0)
 	{
 		gwarning(r, "gpfdist read error after shutdown. errno: %d, msg: %s", errno, strerror(errno));

--- a/src/bin/pg_config/CMakeLists.txt
+++ b/src/bin/pg_config/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.12)
+project(pg_config)
+
+add_definitions("/D FRONTEND /D ENABLE_THREAD_SAFETY")
+add_definitions("${CPPFLAGS}")
+
+set(SOURCE_FILES
+    pg_config.c
+)
+
+set(HEADER_FILES
+    ${GPDB_SRC_DIR}/src/include/pg_config.h
+)
+
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+)
+
+include_directories(${HEADER_DIRS})
+
+add_executable(pg_config ${HEADER_FILES} ${SOURCE_FILES})
+target_link_libraries(pg_config port common ws2_32 secur32)
+set_target_properties(pg_config PROPERTIES FOLDER bin)
+install(TARGETS pg_config DESTINATION bin)

--- a/src/bin/pg_dump/CMakeLists.txt
+++ b/src/bin/pg_dump/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.12)
+project(pg_dump)
+
+add_definitions("/D FRONTEND /D ENABLE_THREAD_SAFETY")
+add_definitions("${CPPFLAGS}")
+
+set(SOURCE_FILES
+    pg_backup_archiver.c
+    pg_backup_db.c
+    pg_backup_custom.c
+	pg_backup_null.c
+    pg_backup_tar.c
+    pg_backup_directory.c
+	pg_backup_utils.c
+    parallel.c
+    compress_io.c
+)
+
+set(HEADER_FILES
+    compress_io.h
+    dumputils.h
+    parallel.h
+    pg_backup.h
+    pg_backup_archiver.h
+    pg_backup_db.h
+    pg_backup_tar.h
+    pg_backup_utils.h
+    pg_dump.h
+    ${GPDB_SRC_DIR}/src/include/pg_config.h
+)
+
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/bin/psql
+    ${GPDB_SRC_DIR}/src/bin/pg_dump
+    ${GPDB_SRC_DIR}/src/interfaces/libpq
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+)
+
+include_directories(${HEADER_DIRS})
+
+set(PG_DUMP_FILES
+    ${SOURCE_FILES}
+    pg_dump.c
+    common.c
+    pg_dump_sort.c
+)
+add_executable(pg_dump ${HEADER_FILES} ${PG_DUMP_FILES})
+target_link_libraries(pg_dump port libpq common ws2_32 secur32 ${ZLIB_LIBRARIES})
+
+set(PG_DUMPALL_FILES
+    ${KEYWORD_FILES}
+    pg_dumpall.c
+)
+add_executable(pg_dumpall ${HEADER_FILES} ${PG_DUMPALL_FILES})
+target_link_libraries(pg_dumpall port libpq common ws2_32 secur32)
+
+set_target_properties(pg_dump pg_dumpall PROPERTIES FOLDER bin)
+install(TARGETS pg_dump pg_dumpall DESTINATION bin)

--- a/src/bin/psql/CMakeLists.txt
+++ b/src/bin/psql/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.12)
+project(psql)
+
+execute_process(COMMAND ${PERL_EXECUTABLE} "${GPDB_SRC_DIR}/src/bin/psql/create_help.pl" 
+    "${GPDB_SRC_DIR}/doc/src/sgml/ref" "${GPDB_SRC_DIR}/src/bin/psql/sql_help")
+execute_process(COMMAND ${FLEX_EXECUTABLE} -Cfe "-o${GPDB_SRC_DIR}/src/bin/psql/psqlscan.c" 
+    "${GPDB_SRC_DIR}/src/bin/psql/psqlscan.l")
+
+add_definitions("/D FRONTEND /D ENABLE_THREAD_SAFETY")
+add_definitions("${CPPFLAGS}")
+
+set(SOURCE_FILES
+    command.c
+    common.c
+    copy.c
+    describe.c
+    help.c
+    input.c
+    large_obj.c
+    mainloop.c
+    mbprint.c
+    print.c
+    prompt.c
+    startup.c
+    stringutils.c
+    tab-complete.c
+    variables.c
+    ${GPDB_SRC_DIR}/src/bin/pg_dump/keywords.c
+    ${GPDB_SRC_DIR}/src/backend/parser/kwlookup.c
+    ${GPDB_SRC_DIR}/src/bin/pg_dump/dumputils.c
+    sql_help.c
+)
+
+set(HEADER_FILES
+    command.h
+    common.h
+    copy.h
+    describe.h
+    help.h
+    input.h
+    large_obj.h
+    mainloop.h
+    prompt.h
+    psqlscan.h
+    settings.h
+    stringutils.h
+    sql_help.h
+    tab-complete.h
+    variables.h
+    ${GPDB_SRC_DIR}/src/include/pg_config.h
+)
+
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/bin/psql
+    ${GPDB_SRC_DIR}/src/bin/pg_dump
+    ${GPDB_SRC_DIR}/src/interfaces/libpq
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+)
+
+include_directories(${HEADER_DIRS})
+
+add_executable(psql ${HEADER_FILES} ${SOURCE_FILES})
+target_link_libraries(psql port libpq common ws2_32 secur32)
+
+set_target_properties(psql PROPERTIES FOLDER bin)
+install(TARGETS psql DESTINATION bin)

--- a/src/bin/scripts/CMakeLists.txt
+++ b/src/bin/scripts/CMakeLists.txt
@@ -1,0 +1,77 @@
+cmake_minimum_required(VERSION 3.12)
+project(scripts)
+
+add_definitions("/D FRONTEND /D ENABLE_THREAD_SAFETY")
+add_definitions("${CPPFLAGS}")
+
+set(HEADER_FILES
+    common.h
+    ${GPDB_SRC_DIR}/src/include/pg_config.h
+)
+
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/bin/psql
+    ${GPDB_SRC_DIR}/src/bin/pg_dump
+    ${GPDB_SRC_DIR}/src/interfaces/libpq
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+)
+
+include_directories(${HEADER_DIRS})
+
+set(CREATEDB_FILES
+    createdb.c
+    common.c
+)
+
+add_executable(createdb ${HEADER_FILES} ${CREATEDB_FILES})
+target_link_libraries(createdb port libpq common ws2_32 secur32)
+
+set(CREATELANG_FILES
+    createlang.c
+    common.c
+)
+
+add_executable(createlang ${HEADER_FILES} ${CREATELANG_FILES})
+target_link_libraries(createlang port libpq common ws2_32 secur32)
+
+set(CREATEUSER_FILES
+    createuser.c
+    common.c
+)
+
+add_executable(createuser ${HEADER_FILES} ${CREATEUSER_FILES})
+target_link_libraries(createuser port libpq common ws2_32 secur32)
+
+set(DROPDB_FILES
+    dropdb.c
+    common.c
+)
+
+add_executable(dropdb ${HEADER_FILES} ${DROPDB_FILES})
+target_link_libraries(dropdb port libpq common ws2_32 secur32)
+
+set(DROPLANG_FILES
+    droplang.c
+    common.c
+)
+
+add_executable(droplang ${HEADER_FILES} ${DROPLANG_FILES})
+target_link_libraries(droplang port libpq common ws2_32 secur32)
+
+set(DROPUSER_FILES
+    dropuser.c
+    common.c
+)
+
+add_executable(dropuser ${HEADER_FILES} ${DROPUSER_FILES})
+target_link_libraries(dropuser port libpq common ws2_32 secur32)
+
+set(CLUSTERDB_FILES
+    clusterdb.c
+    common.c
+)
+
+set_target_properties(createdb createlang createuser dropdb droplang dropuser PROPERTIES FOLDER bin)
+install(TARGETS createdb createlang createuser dropdb droplang dropuser DESTINATION bin)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.12)
+project(common)
+
+add_definitions("/D MAX_PATH=260")
+add_definitions("/D FRONTEND /D ENABLE_THREAD_SAFETY /wd4996 /wd4018 /wd4090 /wd4244 /wd4267")
+
+set(SOURCE_FILES
+   exec.c
+   fe_memutils.c
+   psprintf.c
+   relpath.c
+   username.c
+   wait_error.c
+   ${GPDB_SRC_DIR}/src/bin/psql/print.c
+   ${GPDB_SRC_DIR}/src/bin/psql/mbprint.c
+   ${GPDB_SRC_DIR}/src/bin/pg_dump/keywords.c
+   ${GPDB_SRC_DIR}/src/bin/pg_dump/dumputils.c
+   ${GPDB_SRC_DIR}/src/backend/parser/kwlookup.c
+)
+
+set(HEADER_FILES
+    ${GPDB_SRC_DIR}/src/include/common/fe_memutils.h
+    ${GPDB_SRC_DIR}/src/include/common/relpath.h
+)
+
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/interfaces/libpq
+    ${GPDB_SRC_DIR}/src/bin/psql
+    ${GPDB_SRC_DIR}/src/bin/pg_dump
+    ${GPDB_SRC_DIR}/src/include/port
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+)
+
+include_directories(${HEADER_DIRS})
+
+add_library(common ${HEADER_FILES} ${SOURCE_FILES})

--- a/src/include/pg_config.h.win32
+++ b/src/include/pg_config.h.win32
@@ -636,6 +636,9 @@
 /* PostgreSQL version as a number */
 #define PG_VERSION_NUM 90420
 
+/* GreenplumDB version as a number */
+#define GP_VERSION_NUM 60000
+
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "greenplum"
 
@@ -709,7 +712,7 @@
 /* Define to 1 to use Intel SSE 4.2 CRC instructions with a runtime check. */
 #if (_MSC_VER < 1500)
 #define USE_SLICING_BY_8_CRC32C 1
-#end
+#endif
 
 /* Define to 1 use Intel SSE 4.2 CRC instructions. */
 /* #undef USE_SSE42_CRC32C */

--- a/src/interfaces/libpq/CMakeLists.txt
+++ b/src/interfaces/libpq/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.12)
+project(libpq)
+
+add_definitions("/D FRONTEND /D ENABLE_THREAD_SAFETY ${CPPFLAGS}")
+
+set(GPDB_BACKEND_SRC_DIR "${GPDB_SRC_DIR}/src/backend")
+
+set(SOURCE_FILES
+    fe-auth.c
+    fe-connect.c
+    fe-exec.c
+    fe-lobj.c
+    fe-misc.c
+    fe-print.c
+    fe-protocol2.c
+    fe-protocol3.c
+    fe-secure.c
+    libpq-events.c
+    pqexpbuffer.c
+    pthread-win32.c
+    win32.c
+    ${GPDB_BACKEND_SRC_DIR}/libpq/md5.c
+    ${GPDB_BACKEND_SRC_DIR}/libpq/ip.c
+    ${GPDB_BACKEND_SRC_DIR}/utils/mb/wchar.c
+    ${GPDB_BACKEND_SRC_DIR}/utils/mb/encnames.c
+)
+
+set(HEADER_FILES
+    fe-auth.h
+    libpq-events.h
+    libpq-fe.h
+    libpq-int.h
+    pqexpbuffer.h
+    #pthread-win32.h
+    win32.h
+    ${GPDB_SRC_DIR}/src/include/pg_config.h
+)
+
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/include/libpq
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+    ${GPDB_SRC_DIR}/src/port
+)
+
+include_directories(${HEADER_DIRS})
+
+add_library(libpq ${HEADER_FILES} ${SOURCE_FILES})
+target_link_libraries(libpq ${OPENSSL_LIBRARIES})

--- a/src/port/CMakeLists.txt
+++ b/src/port/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.12)
+project(port)
+
+add_definitions("/D MAX_PATH=260")
+add_definitions("/D FRONTEND /D ENABLE_THREAD_SAFETY")
+add_definitions("${CPPFLAGS}")
+
+set(SOURCE_FILES
+    chklocale.c
+    crypt.c
+    dirent.c
+    dirmod.c
+    erand48.c
+    fls.c
+    fseeko.c
+    getaddrinfo.c
+    getopt.c
+    getopt_long.c
+    getpeereid.c
+    getrusage.c
+    gettimeofday.c
+    glob.c
+    inet_aton.c
+    inet_net_ntop.c
+    isinf.c
+    kill.c
+    noblock.c
+    open.c
+    path.c
+    pg_crc.c
+    pg_crc32c_choose.c
+    pg_crc32c_sb8.c
+    pg_crc32c_sse42.c
+    pgcheckdir.c
+    pgmkdirp.c
+    pgsleep.c
+    pgstrcasecmp.c
+    pqsignal.c
+    qsort.c
+    qsort_arg.c
+    quotes.c
+    random.c
+    snprintf.c
+    sprompt.c
+    srandom.c
+    strlcat.c
+    strlcpy.c
+    system.c
+    tar.c
+    thread.c
+    win32env.c
+    win32error.c
+    win32setlocale.c
+)
+
+set(HEADER_FILES
+    glob.h
+    pg_config_paths.h
+    ${GPDB_SRC_DIR}/src/include/pg_config.h
+)
+
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/include/port
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+)
+
+include_directories(${HEADER_DIRS})
+
+add_library(port ${HEADER_FILES} ${SOURCE_FILES})


### PR DESCRIPTION
Add CMake build scripts for following client components:
- SQL CLI: psql
- DB dump tools: pg_dump, pg_dumpall
- Wrapper scripts: createdb, createlang, createuser, dropdb,
droplang, dropuser
- Loaders: gpload.py, pygresql

External dependencies:
- Perl: to generate sql_help
- Flex: to generate psqlscan
- OpenSSL: SSL support for psql, gpfdist
- zlib: gpfdist
- Python2: pygresql

Code changes for gpfdist.c
- read on Windows doesn't work well for socket if latest C/C++
runtime is used. Change to recv which does the same thing.
- we upgraded to latest libevent, which requires the event struct
to be set once before it's ready to use. Should be harmless if we
compiled with older libevent on linux.

