### PR TITLE
Disable auto segment rebalance during gpstart.

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -127,13 +127,6 @@ class GpStart:
                 self.master_checksum_value = HeapChecksum(gparray=self.gparray, num_workers=num_workers,
                                                           logger=logger).get_master_value()
 
-            # Do we have an even-number of recovered segments ?
-            if len(self.gparray.recoveredSegmentDbids) > 0 and len(self.gparray.recoveredSegmentDbids) % 2 == 0:
-                logger.info("Master start noticed recovered segments, updating configuration to rebalance.")
-                self.gparray.updateRoleForRecoveredSegs(self.dburl)
-                logger.info("Re-obtaining updated segment details from master...")
-                self.gparray = GpArray.initFromCatalog(self.dburl, utility=True)
-
             if not self.skip_standby_check:
                 self._check_standby_activated()
             else:


### PR DESCRIPTION
gpstart tried to automatically rebalances the cluster if synced
segment pairs are not in their preferred segment roles (primary or
mirror). This worked and was basically free in file replication. As
part of the cluster start, the gpstart utility would see that the
primary and mirror pair were both in up/sync state but segment roles
reversed in the catalog. It was simple to just send the correct
filerep signals to switch their segment roles to their preferred role.

With WAL replication, this is not as trivial.  The primary and mirror
segments themselves are very aware of their segment roles.  If a
segment found a recovery.conf file in their data directory, it'll
automatically start as a mirror.

So, till this is not properly implemented if decided to still be
supported as part of gpstart, removing the currently broken logic in
gpstart.

Note:
I am doing this as multiple developers keep hitting this broken functionality, hence better to not have it, till consensus to provide it or not is reached and properly implemented.