### PR TITLE
Remove 9.4 Merge FIXME regarding pm_launch_walreceiver

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -155,6 +155,7 @@ void FtsProbeMain(int argc, char *argv[]);
  * assumption is am_ftshandler must be set if this is set.
  */
 bool am_mirror = false;
+/* GPDB specific flag to handle deadlocks during parallel segment start. */
 bool pm_launch_walreceiver = false;
 
 /*
@@ -6167,7 +6168,7 @@ MaybeStartWalReceiver(void)
 	{
 		WalReceiverPID = StartWalReceiver();
 		WalReceiverRequested = false;
-		/* GPDB_94_MERGE_FIXME: pg94 stable does not have pm_launch_walreceiver. Do we need that? */
+
 		/* wal receiver has been launched */
 		pm_launch_walreceiver = true;
 	}


### PR DESCRIPTION
The pm_launch_walreceiver variable is still needed to handle deadlocks
during parallel segment start. Removing the logic will result in
CAC_STARTUP being received and pg_ctl being stuck waiting for PQPING_OK.
The pm_launch_walreceiver variable is used to send Greenplum-specific
CAC_MIRROR_READY so that pg_ctl can continue.

Relative commit:
https://github.com/greenplum-db/gpdb/commit/b824fe8f269934987e30a4c177605b250703d20f

Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>
Co-authored-by: Jimmy Yih <jyih@pivotal.io>
