### PR TITLE
Fix msvc build for client tools

### DIFF
--- a/src/include/pg_config.h.win32
+++ b/src/include/pg_config.h.win32
@@ -715,7 +715,7 @@
 /* Define to 1 to use Intel SSE 4.2 CRC instructions with a runtime check. */
 #if (_MSC_VER < 1500)
 #define USE_SLICING_BY_8_CRC32C 1
-#end
+#endif
 
 /* Define to 1 use Intel SSE 4.2 CRC instructions. */
 /* #undef USE_SSE42_CRC32C */

--- a/src/include/port/win32_msvc/dirent.h
+++ b/src/include/port/win32_msvc/dirent.h
@@ -6,12 +6,13 @@
 
 #ifndef _WIN32VC_DIRENT_H
 #define _WIN32VC_DIRENT_H
+#include "pg_config_manual.h"
 struct dirent
 {
 	long		d_ino;
 	unsigned short d_reclen;
 	unsigned short d_namlen;
-	char		d_name[MAX_PATH];
+	char		d_name[MAXPGPATH];
 };
 
 typedef struct DIR DIR;

--- a/src/tools/msvc/Install.pm
+++ b/src/tools/msvc/Install.pm
@@ -107,13 +107,22 @@ sub Install
 		'Import libraries',
 		$target . '/lib/',
 		"$conf\\",
-		"postgres\\postgres.lib",
 		"libpq\\libpq.lib",
-		"libecpg\\libecpg.lib",
 		"libpgcommon\\libpgcommon.lib",
-		"libpgport\\libpgport.lib",
-		"libpgtypes\\libpgtypes.lib",
-		"libecpg_compat\\libecpg_compat.lib");
+		"libpgport\\libpgport.lib");
+
+	if ($insttype ne "client")
+	{
+		CopyFiles(
+			'Import libraries',
+			$target . '/lib/',
+			"$conf\\",
+			"postgres\\postgres.lib",
+			"libecpg\\libecpg.lib",
+			"libpgtypes\\libpgtypes.lib",
+			"libecpg_compat\\libecpg_compat.lib");
+	}
+
 	CopyContribFiles($config, $target);
 	CopyIncludeFiles($target);
 
@@ -565,6 +574,8 @@ sub CopyIncludeFiles
 	lcopy('src/include/libpq/pqcomm.h', $target . '/include/internal/libpq/')
 	  || croak 'Could not copy pqcomm.h';
 
+	if ($insttype ne "client")
+	{
 	CopyFiles(
 		'Server headers',
 		$target . '/include/server/',
@@ -620,6 +631,7 @@ sub CopyIncludeFiles
 		$target . '/include/informix/esql/',
 		'src/interfaces/ecpg/include/',
 		split /\s+/, $1);
+	}
 }
 
 sub GenerateNLSFiles

--- a/src/tools/msvc/MSBuildProject.pm
+++ b/src/tools/msvc/MSBuildProject.pm
@@ -34,10 +34,16 @@ sub WriteHeader
 EOF
 	$self->WriteConfigurationHeader($f, 'Debug');
 	$self->WriteConfigurationHeader($f, 'Release');
+	my $sdkversion=$ENV{'WindowsSDKVersion'};
+	if ($sdkversion =~ /.*\\$/)
+	{
+		chop $sdkversion;
+	}
 	print $f <<EOF;
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>$self->{guid}</ProjectGuid>
+    <WindowsTargetPlatformVersion>$sdkversion</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="\$(VCTargetsPath)\\Microsoft.Cpp.Default.props" />
 EOF

--- a/src/tools/msvc/Mkvcbuild.pm
+++ b/src/tools/msvc/Mkvcbuild.pm
@@ -51,11 +51,13 @@ my $contrib_extraincludes =
 my $contrib_extrasource = {
 	'cube' => [ 'cubescan.l', 'cubeparse.y' ],
 	'seg'  => [ 'segscan.l',  'segparse.y' ], };
-my @contrib_excludes = ('pgcrypto', 'intagg', 'sepgsql');
+my @contrib_excludes = ('pgcrypto', 'intagg', 'sepgsql', 'sasdemo');
 
 sub mkvcbuild
 {
+	my $mf;
 	our $config = shift;
+	our $buildclient = shift;
 
 	chdir('..\..\..') if (-d '..\msvc' && -d '..\..\..\src');
 	die 'Must run from root or msvc directory'
@@ -91,6 +93,8 @@ sub mkvcbuild
 	$libpgcommon->AddDefine('FRONTEND');
 	$libpgcommon->AddFiles('src\common', @pgcommonfrontendfiles);
 
+	if (!$buildclient)
+	{
 	$postgres = $solution->AddProject('postgres', 'exe', '', 'src\backend');
 	$postgres->AddIncludeDir('src\backend');
 	$postgres->AddDir('src\backend\port\win32');
@@ -409,6 +413,7 @@ sub mkvcbuild
 		die "Unable to find $solution->{options}->{tcl}\\lib\\tcl<version>.lib"
 			unless $found;
 	}
+	}
 
 	$libpq = $solution->AddProject('libpq', 'dll', 'interfaces',
 		'src\interfaces\libpq');
@@ -424,6 +429,8 @@ sub mkvcbuild
 		'src\interfaces\libpq\libpq.rc');
 	$libpq->AddReference($libpgport);
 
+	if (!$buildclient)
+	{
 	my $libpqwalreceiver =
 	  $solution->AddProject('libpqwalreceiver', 'dll', '',
 		'src\backend\replication\libpqwalreceiver');
@@ -543,6 +550,7 @@ sub mkvcbuild
 	$pgevent->RemoveFile('src\bin\pgevent\win32ver.rc');
 	$pgevent->UseDef('src\bin\pgevent\pgevent.def');
 	$pgevent->DisableLinkerWarnings('4104');
+	}
 
 	my $psql = AddSimpleFrontend('psql', 1);
 	$psql->AddIncludeDir('src\bin\pg_dump');
@@ -584,6 +592,8 @@ sub mkvcbuild
 	$pgrestore->AddFile('src\backend\parser\kwlookup.c');
 	$pgrestore->AddLibrary('ws2_32.lib');
 
+	if (!$buildclient)
+	{
 	my $zic = $solution->AddProject('zic', 'exe', 'utils');
 	$zic->AddFiles('src\timezone', 'zic.c');
 	$zic->AddReference($libpgcommon, $libpgport);
@@ -653,7 +663,7 @@ sub mkvcbuild
 	}
 	$pgcrypto->AddReference($postgres);
 	$pgcrypto->AddLibrary('wsock32.lib');
-	my $mf = Project::read_file('contrib/pgcrypto/Makefile');
+	$mf = Project::read_file('contrib/pgcrypto/Makefile');
 	GenerateContribSqlFiles('pgcrypto', $mf);
 
 	my $D;
@@ -687,6 +697,7 @@ sub mkvcbuild
 				'src\backend\utils\mb\conversion_procs\\' . $sub . '\\' . $1);
 		}
 		$p->AddReference($postgres);
+	}
 	}
 
 	$mf = Project::read_file('src\bin\scripts\Makefile');
@@ -731,6 +742,8 @@ sub mkvcbuild
 		$proj->AddLibrary('ws2_32.lib');
 	}
 
+	if (!$buildclient)
+	{
 	# Regression DLL and EXE
 	my $regress = $solution->AddProject('regress', 'dll', 'misc');
 	$regress->AddFile('src\test\regress\regress.c');
@@ -760,8 +773,9 @@ sub mkvcbuild
 	copy(
 		'src/backend/access/transam/xlogreader.c',
 		'contrib/pg_xlogdump/xlogreader.c');
+	}
 
-	$solution->Save();
+	$solution->Save($buildclient);
 	return $solution->{vcver};
 }
 

--- a/src/tools/msvc/Solution.pm
+++ b/src/tools/msvc/Solution.pm
@@ -125,6 +125,7 @@ sub copyFile
 sub GenerateFiles
 {
 	my $self = shift;
+	my $buildclient = shift;
 	my $bits = $self->{platform} eq 'Win32' ? 32 : 64;
 
 	# Parse configure.in to get version numbers
@@ -132,7 +133,11 @@ sub GenerateFiles
 	  || confess("Could not open configure.in for reading\n");
 	while (<C>)
 	{
-		if (/^AC_INIT\(\[PostgreSQL\], \[([^\]]+)\]/)
+		if (/^AC_INIT\(\[Greenplum Database\], \[([^\]]+)\]/)
+		{
+			$self->{gpdbver} = $1;
+		}
+		if (/\[PG_PACKAGE_VERSION=([^\]]+)\]/)
 		{
 			$self->{strver} = $1;
 			if ($self->{strver} !~ /^(\d+)\.(\d+)(?:\.(\d+))?/)
@@ -170,6 +175,7 @@ sub GenerateFiles
 s{PG_VERSION_STR "[^"]+"}{__STRINGIFY(x) #x\n#define __STRINGIFY2(z) __STRINGIFY(z)\n#define PG_VERSION_STR "PostgreSQL $self->{strver}, compiled by Visual C++ build " __STRINGIFY2(_MSC_VER) ", $bits-bit"};
 			print O;
 		}
+		print O "#define GP_VERSION \"$self->{gpdbver}\"\n";
 		print O "#define PG_MAJORVERSION \"$self->{majorver}\"\n";
 		print O "#define LOCALEDIR \"/share/locale\"\n"
 		  if ($self->{options}->{nls});
@@ -429,6 +435,8 @@ EOF
 		close(O);
 	}
 
+	if (!$buildclient)
+	{
 	my $mf = Project::read_file('src\backend\catalog\Makefile');
 	$mf =~ s{\\s*[\r\n]+}{}mg;
 	$mf =~ /^POSTGRES_BKI_SRCS\s*:?=[^,]+,(.*)\)$/gm
@@ -453,6 +461,7 @@ EOF
 				'src\include\catalog\schemapg.h');
 			last;
 		}
+	}
 	}
 
 	open(O, ">doc/src/sgml/version.sgml")
@@ -552,10 +561,10 @@ sub AddProject
 
 sub Save
 {
-	my ($self) = @_;
+	my ($self, $buildclient) = @_;
 	my %flduid;
 
-	$self->GenerateFiles();
+	$self->GenerateFiles($buildclient);
 	foreach my $fld (keys %{ $self->{projects} })
 	{
 		foreach my $proj (@{ $self->{projects}->{$fld} })

--- a/src/tools/msvc/Solution.pm
+++ b/src/tools/msvc/Solution.pm
@@ -535,10 +535,20 @@ sub AddProject
 	}
 	if ($self->{options}->{gss})
 	{
-		$proj->AddIncludeDir($self->{options}->{gss} . '\inc\krb5');
-		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\krb5_32.lib');
-		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\comerr32.lib');
-		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\gssapi32.lib');
+		if ($self->{platform} eq 'Win32')
+		{
+			$proj->AddIncludeDir($self->{options}->{gss} . '\inc\krb5');
+			$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\krb5_32.lib');
+			$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\comerr32.lib');
+			$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\gssapi32.lib');
+		}
+		else
+		{
+			$proj->AddIncludeDir($self->{options}->{gss} . '\include');
+			$proj->AddLibrary($self->{options}->{gss} . '\lib\krb5_64.lib');
+			$proj->AddLibrary($self->{options}->{gss} . '\lib\comerr64.lib');
+			$proj->AddLibrary($self->{options}->{gss} . '\lib\gssapi64.lib');
+		}
 	}
 	if ($self->{options}->{iconv})
 	{

--- a/src/tools/msvc/build.pl
+++ b/src/tools/msvc/build.pl
@@ -33,10 +33,7 @@ our $config;
 require "config_default.pl";
 require "config.pl" if (-f "src/tools/msvc/config.pl");
 
-my $vcver = Mkvcbuild::mkvcbuild($config);
-
 # check what sort of build we are doing
-
 my $bconf     = $ENV{CONFIG} || "Release";
 my $buildwhat = $ARGV[1]     || "";
 if (uc($ARGV[0]) eq 'DEBUG')
@@ -48,6 +45,13 @@ elsif (uc($ARGV[0]) ne "RELEASE")
 	$buildwhat = $ARGV[0] || "";
 }
 
+my $buildclient = 0;
+if ($buildwhat eq "client")
+{
+	$buildclient = 1;
+	$buildwhat = $ARGV[1] || "";
+}
+my $vcver = Mkvcbuild::mkvcbuild($config, $buildclient);
 # ... and do it
 
 if ($buildwhat and $vcver >= 10.00)


### PR DESCRIPTION
Postgres has its own build system for Windows using MSVC. We can
reuse it to build client tools on windows.

- Add 'fullbuild' option to the default config file. By default,
it is set to 0. Only client tools will be built.
- Only generate project file for client tools
- Add detection for MSVC SDK version. If this field is missing,
8.1 is assumed. The latest compiler will complain about this.
- Add glob.c to libpgport, used by gpfdist
- Only install client tools
