### PR TITLE
Docs - system columns suppressed in replicated tables

### DIFF
--- a/gpdb-doc/dita/admin_guide/distribution.xml
+++ b/gpdb-doc/dita/admin_guide/distribution.xml
@@ -80,12 +80,13 @@ FROM (SELECT count(*) c, gp_segment_id FROM facts GROUP BY 2) AS a;</codeblock>
           </section>
       <section id="section_unk_dpf_kgb">
         <title>Considerations for Replicated Tables</title>
-        <p>When you create a replicated table (<codeph>DISTRIBUTED REPLICATED)</codeph>, Greenplum
-          Database distributes every table row to every segment instance. Replicated table data is
-          evenly distributed because every segment has the same rows. A query that uses the
-            <codeph>gp_segment_id</codeph> system column on a replicated table to verify evenly
-          distributed data, will fail because Greenplum Database does not allow queries to reference
-          replicated tables' system columns.</p>
+        <p>When you create a replicated table (with the <codeph>CREATE TABLE</codeph> clause
+            <codeph>DISTRIBUTED REPLICATED</codeph>), Greenplum Database distributes every table row
+          to every segment instance. Replicated table data is evenly distributed because every
+          segment has the same rows. A query that uses the <codeph>gp_segment_id</codeph> system
+          column on a replicated table to verify evenly distributed data, will fail because
+          Greenplum Database does not allow queries to reference replicated tables' system
+          columns.</p>
       </section>
         </body>
       </topic>

--- a/gpdb-doc/dita/admin_guide/distribution.xml
+++ b/gpdb-doc/dita/admin_guide/distribution.xml
@@ -78,6 +78,15 @@ FROM (SELECT count(*) c, gp_segment_id FROM facts GROUP BY 2) AS a;</codeblock>
               randomly distributed table are assigned to the first segment and will result
               in data skew. Greenplum Database more evenly distributes data from bulk inserts.</p>
           </section>
+      <section id="section_unk_dpf_kgb">
+        <title>Considerations for Replicated Tables</title>
+        <p>When you create a replicated table (<codeph>DISTRIBUTED REPLICATED)</codeph>, Greenplum
+          Database distributes every table row to every segment instance. Replicated table data is
+          evenly distributed because every segment has the same rows. A query that uses the
+            <codeph>gp_segment_id</codeph> system column on a replicated table to verify evenly
+          distributed data, will fail because Greenplum Database does not allow queries to reference
+          replicated tables' system columns.</p>
+      </section>
         </body>
       </topic>
       <topic id="topic3">

--- a/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
@@ -66,7 +66,7 @@
         database, the <codeph>xmin</codeph> and <codeph>xmax</codeph> values would be the segment's
         local XIDs.</p>
       <note>Greenplum Database distributes all of a replicated table's rows to every segment, so
-        each row is duplicated on every segment. Each segment database maintains its own values for
+        each row is duplicated on every segment. Each segment instance maintains its own values for
         the system columns <codeph>xmin</codeph>, <codeph>xmax</codeph>, <codeph>cmin</codeph>, and
           <codeph>cmax</codeph>, as well as for the <codeph>gp_segment_id</codeph> and
           <codeph>ctid</codeph>system columns. Greenplum Database does not permit user queries to

--- a/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
@@ -65,6 +65,13 @@
         distributed transactions IDs. If you could execute the command in an individual segment
         database, the <codeph>xmin</codeph> and <codeph>xmax</codeph> values would be the segment's
         local XIDs.</p>
+      <note>Greenplum Database distributes all of a replicated table's rows to every segment, so
+        each row is duplicated on every segment. Each segment database maintains its own values for
+        the system columns <codeph>xmin</codeph>, <codeph>xmax</codeph>, <codeph>cmin</codeph>, and
+          <codeph>cmax</codeph>, as well as for the <codeph>gp_segment_id</codeph> and
+          <codeph>ctid</codeph>system columns. Greenplum Database does not permit user queries to
+        access these system columns for replicated tables because they have no single, unambiguous
+        value to evaluate in a query.</note>
     </section>
     <section>
       <title>Transaction ID Wraparound</title>

--- a/gpdb-doc/dita/admin_guide/managing/monitor.xml
+++ b/gpdb-doc/dita/admin_guide/managing/monitor.xml
@@ -40,9 +40,6 @@
         describe how to monitor the health of a Greenplum Database system and examine certain state
         information for a Greenplum Database system.</p>
       <ul>
-        <li id="kj166984">
-          <xref href="#topic4" type="topic" format="dita"/>
-        </li>
         <li id="kj167000">
           <xref href="#topic12" type="topic" format="dita"/>
         </li>
@@ -194,11 +191,11 @@
     <topic id="topic20" xml:lang="en">
       <title id="kj155117">Checking for Data Distribution Skew</title>
       <body>
-        <p>All tables in Greenplum Database are distributed, meaning their data is divided evenly
-          across all of the segments in the system. Unevenly distributed data may diminish query
-          processing performance. A table's distribution policy is determined at table creation
-          time. For information about choosing the table distribution policy, see the following
-          topics:</p>
+        <p>All tables in Greenplum Database are distributed, meaning their data is divided across
+        all of the segments in the system. Unevenly distributed data may diminish query processing
+        performance. A table's distribution policy, set at table creation time, determines how the
+        table's rows are distributed. For information about choosing the table distribution policy,
+        see the following topics:</p>
         <ul>
           <li id="kj191663">
             <xref href="#topic21" type="topic" format="dita"/>
@@ -232,6 +229,11 @@ Has OIDs: no
 Distributed by: (sale_id)
 </codeblock>
           </p>
+        <p>When you create a <i>replicated</i> table, Greenplum Database stores all rows in the
+          table on every segment. Replicated tables have no distribution key. Where the
+            <codeph>\d+</codeph> meta-command reports the distribution key for a normally
+          distributed table, it shows <codeph>Distributed Replicated</codeph> for a replicated
+          table.</p>
         </body>
       </topic>
       <topic id="topic22" xml:lang="en">
@@ -246,6 +248,12 @@ Distributed by: (sale_id)
           </p>
           <p>A table is considered to have a balanced distribution if all segments have roughly the
             same number of rows.</p>
+        <note>
+          <p>If you run this query on a replicated table it fails because Greenplum Database does
+            not permit user queries to reference system columns in replicated tables. Because every
+            segment has all of the tables' rows, replicated tables are evenly distributed by
+            definition.</p>
+        </note>
         </body>
       </topic>
       <topic id="topic23" xml:lang="en">
@@ -266,6 +274,9 @@ Distributed by: (sale_id)
           </p>
           <p>This will show the number of rows returned by segment for the given
               <codeph>WHERE</codeph> predicate.</p>
+        <p>As noted in <xref href="#topic22" format="dita"/>, this query will fail if you run it on
+          a replicated table because you cannot reference the <codeph>gp_segment_id</codeph> system
+          column in a query on a replicated table.</p>
           <section>
             <title>Avoiding an Extreme Skew Warning</title>
             <p>You may receive the following warning message while executing a query that performs a

--- a/gpdb-doc/dita/admin_guide/managing/monitor.xml
+++ b/gpdb-doc/dita/admin_guide/managing/monitor.xml
@@ -250,9 +250,9 @@ Distributed by: (sale_id)
             same number of rows.</p>
         <note>
           <p>If you run this query on a replicated table it fails because Greenplum Database does
-            not permit user queries to reference system columns in replicated tables. Because every
-            segment has all of the tables' rows, replicated tables are evenly distributed by
-            definition.</p>
+            not permit user queries to reference the <codeph>gp_segment_id</codeph> system column in
+            replicated tables. Because every segment has all of the tables' rows, replicated tables
+            are evenly distributed by definition.</p>
         </note>
         </body>
       </topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -170,7 +170,10 @@
         to improve query performance by preventing broadcast motions for the table. The
           <codeph>DISTRIBUTED REPLICATED</codeph> clause cannot be used with the <codeph>PARTITION
           BY</codeph> clause or the <codeph>INHERITS</codeph> clause. A replicated table also cannot
-        be inherited by another table.</p>
+        be inherited by another table. The hidden system columns (<codeph>ctid</codeph>,
+          <codeph>cmin</codeph>, <codeph>cmax</codeph>, <codeph>xmin</codeph>,
+        <codeph>xmax</codeph>, and <codeph>gp_segment_id</codeph>) cannot be referenced in user
+        queries on replicated tables because they have no single, unambiguous value.</p>
       <p>The <codeph>PARTITION BY</codeph> clause allows you to divide the table into multiple
         sub-tables (or parts) that, taken together, make up the parent table and share its schema.
         Though the sub-tables exist as independent tables, the Greenplum Database restricts their


### PR DESCRIPTION
Updates the few places in the docs that mention system columns to note that you cannot access them on replicated tables.  Mostly these mentions are about calculating skew using gp_segment_id, which is not useful for replicated tables anyway. 

