### PR TITLE
Disable explicit lateral support.

### DIFF
--- a/src/backend/catalog/information_schema.sql
+++ b/src/backend/catalog/information_schema.sql
@@ -1527,12 +1527,21 @@ CREATE VIEW sequences AS
            CAST(64 AS cardinal_number) AS numeric_precision,
            CAST(2 AS cardinal_number) AS numeric_precision_radix,
            CAST(0 AS cardinal_number) AS numeric_scale,
-           CAST(p.start_value AS character_data) AS start_value,
-           CAST(p.minimum_value AS character_data) AS minimum_value,
-           CAST(p.maximum_value AS character_data) AS maximum_value,
-           CAST(p.increment AS character_data) AS increment,
-           CAST(CASE WHEN p.cycle_option THEN 'YES' ELSE 'NO' END AS yes_or_no) AS cycle_option
-    FROM pg_namespace nc, pg_class c, LATERAL pg_sequence_parameters(c.oid) p
+           -- LATERAL_FIXME: Use the old implementation. Move to the lateral
+           -- version (See commented out lines below) after the full lateral
+           -- support is ready.
+           CAST((pg_sequence_parameters(c.oid)).start_value AS character_data) AS start_value,
+           CAST((pg_sequence_parameters(c.oid)).minimum_value AS character_data) AS minimum_value,
+           CAST((pg_sequence_parameters(c.oid)).maximum_value AS character_data) AS maximum_value,
+           CAST((pg_sequence_parameters(c.oid)).increment AS character_data) AS increment,
+           CAST(CASE WHEN (pg_sequence_parameters(c.oid)).cycle_option THEN 'YES' ELSE 'NO' END AS yes_or_no) AS cycle_option
+    FROM pg_namespace nc, pg_class c
+           -- CAST(p.start_value AS character_data) AS start_value,
+           -- CAST(p.minimum_value AS character_data) AS minimum_value,
+           -- CAST(p.maximum_value AS character_data) AS maximum_value,
+           -- CAST(p.increment AS character_data) AS increment,
+           -- CAST(CASE WHEN p.cycle_option THEN 'YES' ELSE 'NO' END AS yes_or_no) AS cycle_option
+    -- FROM pg_namespace nc, pg_class c, LATERAL pg_sequence_parameters(c.oid) p
     WHERE c.relnamespace = nc.oid
           AND c.relkind = 'S'
           AND (NOT pg_is_other_temp_schema(nc.oid))

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -665,6 +665,12 @@ transformRangeSubselect(ParseState *pstate, RangeSubselect *r)
 	Query	   *query;
 	RangeTblEntry *rte;
 
+	/* LATERAL_FIXME: lateral is not fully supported. */
+	if (r->lateral)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("lateral is not supported on greenplum")));
+
 	/*
 	 * We require user to supply an alias for a subselect, per SQL92. To relax
 	 * this, we'd have to be prepared to gin up a unique alias for an
@@ -985,6 +991,12 @@ transformRangeFunction(ParseState *pstate, RangeFunction *r)
 	 * there are any lateral cross-references in it.
 	 */
 	is_lateral = r->lateral || contain_vars_of_level((Node *) funcexprs, 0);
+
+	/* LATERAL_FIXME: lateral is not fully supported. */
+	if (r->lateral) /* Do not disable implicit lateral. */
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("lateral is not supported on greenplum")));
 
 	/*
 	 * OK, build an RTE for the function.

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -374,6 +374,9 @@ from generate_series(1, 3) s1,
      lateral (select s2, sum(s1 + s2) sm
               from generate_series(1, 3) s2 group by s2) ss
 order by 1, 2;
+ERROR:  lateral is not supported on greenplum
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Sort
@@ -413,6 +416,7 @@ order by 1, 2;
   3 |  3 |  6
 (9 rows)
 
+-- end_ignore
 explain (verbose, costs off)
 select array(select sum(x+y) s
             from generate_series(1,3) y group by y order by s)

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -388,8 +388,9 @@ from generate_series(1, 3) s1,
      lateral (select s2, sum(s1 + s2) sm
               from generate_series(1, 3) s2 group by s2) ss
 order by 1, 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+ERROR:  lateral is not supported on greenplum
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Sort
@@ -431,6 +432,7 @@ DETAIL:  Feature not supported: LATERAL
   3 |  3 |  6
 (9 rows)
 
+-- end_ignore
 explain (verbose, costs off)
 select array(select sum(x+y) s
             from generate_series(1,3) y group by y order by s)

--- a/src/test/regress/expected/create_view.out
+++ b/src/test/regress/expected/create_view.out
@@ -1457,6 +1457,9 @@ select row(i.*::int8_tbl)::nestedcomposite from int8_tbl i;
 (5 rows)
 
 create view tt16v as select * from int8_tbl i, lateral(values(i)) ss;
+ERROR:  lateral is not supported on greenplum
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
 select * from tt16v;
         q1        |        q2         |               column1                
 ------------------+-------------------+--------------------------------------
@@ -1487,6 +1490,7 @@ select * from int8_tbl i, lateral(values(i.*::int8_tbl)) ss;
  4567890123456789 | -4567890123456789 | (4567890123456789,-4567890123456789)
 (5 rows)
 
+-- end_ignore
 create view tt17v as select * from int8_tbl i where i in (values(i));
 select * from tt17v;
         q1        |        q2         

--- a/src/test/regress/expected/create_view_optimizer.out
+++ b/src/test/regress/expected/create_view_optimizer.out
@@ -1457,6 +1457,8 @@ select row(i.*::int8_tbl)::nestedcomposite from int8_tbl i;
 (5 rows)
 
 create view tt16v as select * from int8_tbl i, lateral(values(i)) ss;
+ERROR:  lateral is not supported on greenplum
+-- start_ignore
 select * from tt16v;
         q1        |        q2         |               column1                
 ------------------+-------------------+--------------------------------------
@@ -1487,6 +1489,7 @@ select * from int8_tbl i, lateral(values(i.*::int8_tbl)) ss;
  4567890123456789 | -4567890123456789 | (4567890123456789,-4567890123456789)
 (5 rows)
 
+-- end_ignore
 create view tt17v as select * from int8_tbl i where i in (values(i));
 select * from tt17v;
         q1        |        q2         

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3195,10 +3195,14 @@ select ss1.d1 from
     on i8.q1 = i4.f1
   on t1.tenthous = ss1.d1
 where t1.unique1 < i4.f1;
+ERROR:  lateral is not supported on greenplum
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
  d1 
 ----
 (0 rows)
 
+-- end_ignore
 --
 -- test extraction of restriction OR clauses from join OR clause
 -- (we used to only do this for indexable clauses)
@@ -3930,6 +3934,7 @@ select * from
 -- test for appropriate join order in the presence of lateral references
 --
 -- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
 explain (verbose, costs off)
 select * from
   text_tbl t1
@@ -4069,8 +4074,9 @@ where tt1.f1 = ss1.c0;
 --
 -- check a case in which a PlaceHolderVar forces join order
 --
---start_ignore
---GPDB_94_STABLE_MERGE_FIXME: This query is lateral related and its plan is
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
+-- This query is lateral related and its plan is
 --different from PostgreSQL's.  Do not know why yet. Ignore its plan
 --temporarily.
 explain (verbose, costs off)
@@ -4112,7 +4118,6 @@ where ss1.c2 = 0;
                Output: i41.f1, i8.q1, i8.q2, i42.f1, i43.f1, (42)
 (25 rows)
 
---end_ignore
 select ss2.* from
   int4_tbl i41
   left join int8_tbl i8
@@ -4126,6 +4131,7 @@ where ss1.c2 = 0;
 ----+----+----+----+----+----
 (0 rows)
 
+--end_ignore
 --
 -- test successful handling of full join underneath left join (bug #14105)
 --
@@ -4530,6 +4536,8 @@ select * from
 --
 -- Test LATERAL
 --
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
 select unique2, x.*
 from tenk1 a, lateral (select * from int4_tbl b where f1 = a.unique1) x;
  unique2 | f1 
@@ -4740,7 +4748,6 @@ select count(*) from tenk1 a,
 (1 row)
 
 -- lateral injecting a strange outer join condition
--- start_ignore
 -- GPDB_93_MERGE_FIXME: These queries are failing at the moment. Need to investigate.
 -- There were a lot of LATERAL fixes in upstream minor versions, so I'm hoping that
 -- these will get fixed once we catch up to those. Or if not, at least it will be
@@ -4825,7 +4832,6 @@ select * from int8_tbl a,
  4567890123456789 | -4567890123456789 | 4567890123456789 | -4567890123456789 |                 
 (57 rows)
 
---end_ignore
 -- lateral reference to a join alias variable
 select * from (select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1,
   lateral (select x) ss2(y);
@@ -5258,7 +5264,6 @@ select * from int4_tbl a,
 -- GPDB_94_STABLE_MERGE_FIXME: The query below gives wrong results. The change
 -- is related to upstream commit acfcd4. Disable this case temporarily and will
 -- come back to fix it when understanding more about that commit.
---start_ignore
 explain (verbose, costs off)
 select * from
   int8_tbl a left join lateral
@@ -5343,7 +5348,6 @@ select * from
  4567890123456789 | -4567890123456789 |                  |                  |                 
 (42 rows)
 
---end_ignore
 -- case requiring nested PlaceHolderVars
 explain (verbose, costs off)
 select * from
@@ -5510,7 +5514,6 @@ select * from
 (6 rows)
 
 -- check we don't try to do a unique-ified semijoin with LATERAL
--- start_ignore
 -- GPDB_94_STABLE_MERGE_FIXME: The query below is 'deeply' correlated
 -- and GPDB would not pull up the sublink into a semijoin (why?), while
 -- PostgreSQL will do. So the following test is meaningless in GPDB.
@@ -5548,7 +5551,6 @@ select * from
   0 | 9998 |  0
 (1 row)
 
---end_ignore
 -- test some error cases where LATERAL should have been used but wasn't
 select f1,g from int4_tbl a, (select f1 as g) ss;
 ERROR:  column "f1" does not exist
@@ -5630,3 +5632,4 @@ ERROR:  invalid reference to FROM-clause entry for table "xx1"
 LINE 1: ...xx1 using lateral (select * from int4_tbl where f1 = x1) ss;
                                                                 ^
 HINT:  There is an entry for table "xx1", but it cannot be referenced from this part of the query.
+-- end_ignore

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3284,10 +3284,14 @@ select ss1.d1 from
     on i8.q1 = i4.f1
   on t1.tenthous = ss1.d1
 where t1.unique1 < i4.f1;
+ERROR:  lateral is not supported on greenplum
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
  d1 
 ----
 (0 rows)
 
+-- end_ignore
 --
 -- test extraction of restriction OR clauses from join OR clause
 -- (we used to only do this for indexable clauses)
@@ -4061,10 +4065,11 @@ select * from
 -- test for appropriate join order in the presence of lateral references
 --
 -- start_ignore
--- GPDB_94_STABLE_MERGE_FIXME: Currently LATERAL is not fully supported in GPDB
+-- LATERAL_FIXME: lateral is not fully supported.
+-- Currently LATERAL is not fully supported in GPDB
 -- and the queries below are failing at the moment (The first one fails with
 -- error and the other two fail with panic). Comment them off temporarily.
-/*
+
  explain (verbose, costs off)
 select * from
   text_tbl t1
@@ -4113,13 +4118,14 @@ select 1 from
   left join text_tbl as tt4 on (tt3.f1 = tt4.f1),
   lateral (select tt4.f1 as c0 from text_tbl as tt5 limit 1) as ss1
 where tt1.f1 = ss1.c0;
-*/
+
 --end_ignore
 --
 -- check a case in which a PlaceHolderVar forces join order
 --
 --start_ignore
---GPDB_94_STABLE_MERGE_FIXME: This query is lateral related and its plan is
+-- LATERAL_FIXME: lateral is not fully supported.
+--This query is lateral related and its plan is
 --different from PostgreSQL's.  Do not know why yet. Ignore its plan
 --temporarily.
 explain (verbose, costs off)
@@ -4178,7 +4184,6 @@ where ss1.c2 = 0;
  Settings: optimizer=on
 (42 rows)
 
---end_ignore
 select ss2.* from
   int4_tbl i41
   left join int8_tbl i8
@@ -4192,6 +4197,7 @@ where ss1.c2 = 0;
 ----+----+----+----+----+----
 (0 rows)
 
+--end_ignore
 --
 -- test successful handling of full join underneath left join (bug #14105)
 --
@@ -4688,6 +4694,8 @@ select * from
 --
 -- Test LATERAL
 --
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
 select unique2, x.*
 from tenk1 a, lateral (select * from int4_tbl b where f1 = a.unique1) x;
  unique2 | f1 
@@ -4898,7 +4906,6 @@ select count(*) from tenk1 a,
 (1 row)
 
 -- lateral injecting a strange outer join condition
--- start_ignore
 -- GPDB_93_MERGE_FIXME: These queries are failing at the moment. Need to investigate.
 -- There were a lot of LATERAL fixes in upstream minor versions, so I'm hoping that
 -- these will get fixed once we catch up to those. Or if not, at least it will be
@@ -4983,7 +4990,6 @@ select * from int8_tbl a,
  4567890123456789 | -4567890123456789 | 4567890123456789 | -4567890123456789 |                 
 (57 rows)
 
---end_ignore
 -- lateral reference to a join alias variable
 select * from (select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1,
   lateral (select x) ss2(y);
@@ -5416,7 +5422,6 @@ select * from int4_tbl a,
 -- GPDB_94_STABLE_MERGE_FIXME: The query below gives wrong results. The change
 -- is related to upstream commit acfcd4. Disable this case temporarily and will
 -- come back to fix it when understanding more about that commit.
---start_ignore
 explain (verbose, costs off)
 select * from
   int8_tbl a left join lateral
@@ -5502,7 +5507,6 @@ select * from
  4567890123456789 | -4567890123456789 |                  |                  |                 
 (42 rows)
 
---end_ignore
 -- case requiring nested PlaceHolderVars
 explain (verbose, costs off)
 select * from
@@ -5668,7 +5672,6 @@ select * from
 (6 rows)
 
 -- check we don't try to do a unique-ified semijoin with LATERAL
--- start_ignore
 -- GPDB_94_STABLE_MERGE_FIXME: The query below is 'deeply' correlated
 -- and GPDB would not pull up the sublink into a semijoin (why?), while
 -- PostgreSQL will do. So the following test is meaningless in GPDB.
@@ -5714,7 +5717,6 @@ select * from
   0 | 9998 |  0
 (1 row)
 
---end_ignore
 -- test some error cases where LATERAL should have been used but wasn't
 select f1,g from int4_tbl a, (select f1 as g) ss;
 ERROR:  column "f1" does not exist
@@ -5796,3 +5798,4 @@ ERROR:  invalid reference to FROM-clause entry for table "xx1"
 LINE 1: ...xx1 using lateral (select * from int4_tbl where f1 = x1) ss;
                                                                 ^
 HINT:  There is an entry for table "xx1", but it cannot be referenced from this part of the query.
+--end_ignore

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -1193,6 +1193,8 @@ SELECT * FROM (VALUES (1),(2),(3)) v(r), unnest(array[r*10,r*20,r*30]) WITH ORDI
 (9 rows)
 
 -- deep nesting
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
 SELECT * FROM (VALUES (1),(2),(3)) v1(r1),
               LATERAL (SELECT r1, * FROM (VALUES (10),(20),(30)) v2(r2)
                                          LEFT JOIN generate_series(21,23) f(i) ON ((r2+i)<100) OFFSET 0) s1;
@@ -1347,6 +1349,7 @@ SELECT * FROM (VALUES (1),(2),(3)) v1(r1),
   3 |  3 | 30 | 8
 (45 rows)
 
+-- end_ignore
 DROP FUNCTION foo_sql(int,int);
 DROP FUNCTION foo_mat(int,int);
 DROP SEQUENCE foo_rescan_seq1;

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -1195,6 +1195,8 @@ SELECT * FROM (VALUES (1),(2),(3)) v(r), unnest(array[r*10,r*20,r*30]) WITH ORDI
 (9 rows)
 
 -- deep nesting
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
 SELECT * FROM (VALUES (1),(2),(3)) v1(r1),
               LATERAL (SELECT r1, * FROM (VALUES (10),(20),(30)) v2(r2)
                                          LEFT JOIN generate_series(21,23) f(i) ON ((r2+i)<100) OFFSET 0) s1;
@@ -1349,6 +1351,7 @@ SELECT * FROM (VALUES (1),(2),(3)) v1(r1),
   3 |  3 | 30 | 8
 (45 rows)
 
+-- end_ignore
 DROP FUNCTION foo_sql(int,int);
 DROP FUNCTION foo_mat(int,int);
 DROP SEQUENCE foo_rescan_seq1;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -724,6 +724,9 @@ select val.x
     values ((select s.i + 1)), (s.i + 101)
   ) as val(x)
 where s.i < 10 and (select val.x) < 110;
+ERROR:  lateral is not supported on greenplum
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
   x  
 -----
    2
@@ -745,6 +748,7 @@ where s.i < 10 and (select val.x) < 110;
   10
 (17 rows)
 
+-- end_ignore
 --
 -- Check sane behavior with nested IN SubLinks
 -- GPDB_94_MERGE_FIXME: ORCA plan is correct but very pricy. Should we fallback to planner?

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -755,6 +755,9 @@ select val.x
     values ((select s.i + 1)), (s.i + 101)
   ) as val(x)
 where s.i < 10 and (select val.x) < 110;
+ERROR:  lateral is not supported on greenplum
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
   x  
 -----
    2
@@ -776,6 +779,7 @@ where s.i < 10 and (select val.x) < 110;
   10
 (17 rows)
 
+-- end_ignore
 --
 -- Check sane behavior with nested IN SubLinks
 -- GPDB_94_MERGE_FIXME: ORCA plan is correct but very pricy. Should we fallback to planner?

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -110,12 +110,15 @@ from generate_series(1, 3) s1,
      lateral (select s2, sum(s1 + s2) sm
               from generate_series(1, 3) s2 group by s2) ss
 order by 1, 2;
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
 select s1, s2, sm
 from generate_series(1, 3) s1,
      lateral (select s2, sum(s1 + s2) sm
               from generate_series(1, 3) s2 group by s2) ss
 order by 1, 2;
 
+-- end_ignore
 explain (verbose, costs off)
 select array(select sum(x+y) s
             from generate_series(1,3) y group by y order by s)

--- a/src/test/regress/sql/create_view.sql
+++ b/src/test/regress/sql/create_view.sql
@@ -498,9 +498,14 @@ select pg_get_viewdef('tt15v', true);
 select row(i.*::int8_tbl)::nestedcomposite from int8_tbl i;
 
 create view tt16v as select * from int8_tbl i, lateral(values(i)) ss;
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
+/*
 select * from tt16v;
 select pg_get_viewdef('tt16v', true);
 select * from int8_tbl i, lateral(values(i.*::int8_tbl)) ss;
+*/
+-- end_ignore
 
 create view tt17v as select * from int8_tbl i where i in (values(i));
 select * from tt17v;

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -1221,6 +1221,7 @@ select * from
 -- test for appropriate join order in the presence of lateral references
 --
 -- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
 -- GPDB_94_STABLE_MERGE_FIXME: Currently LATERAL is not fully supported in GPDB
 -- and the queries below are failing at the moment (The first one fails with
 -- error and the other two fail with panic). Comment them off temporarily.
@@ -1280,7 +1281,8 @@ where tt1.f1 = ss1.c0;
 -- check a case in which a PlaceHolderVar forces join order
 --
 
---start_ignore
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
 --GPDB_94_STABLE_MERGE_FIXME: This query is lateral related and its plan is
 --different from PostgreSQL's.  Do not know why yet. Ignore its plan
 --temporarily.
@@ -1294,7 +1296,6 @@ select ss2.* from
   on i41.f1 = ss1.c1,
   lateral (select i41.*, i8.*, ss1.* from text_tbl limit 1) ss2
 where ss1.c2 = 0;
---end_ignore
 
 select ss2.* from
   int4_tbl i41
@@ -1306,6 +1307,7 @@ select ss2.* from
   lateral (select i41.*, i8.*, ss1.* from text_tbl limit 1) ss2
 where ss1.c2 = 0;
 
+--end_ignore
 --
 -- test successful handling of full join underneath left join (bug #14105)
 --
@@ -1500,6 +1502,9 @@ select * from
 -- Test LATERAL
 --
 
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
+/*
 select unique2, x.*
 from tenk1 a, lateral (select * from int4_tbl b where f1 = a.unique1) x;
 explain (costs off)
@@ -1551,7 +1556,6 @@ select count(*) from tenk1 a,
   tenk1 b join lateral (values(a.unique1)) ss(x) on b.unique2 = ss.x;
 
 -- lateral injecting a strange outer join condition
--- start_ignore
 -- GPDB_93_MERGE_FIXME: These queries are failing at the moment. Need to investigate.
 -- There were a lot of LATERAL fixes in upstream minor versions, so I'm hoping that
 -- these will get fixed once we catch up to those. Or if not, at least it will be
@@ -1564,7 +1568,6 @@ explain (costs off)
 select * from int8_tbl a,
   int8_tbl x left join lateral (select a.q1 from int4_tbl y) ss(z)
     on x.q2 = ss.z;
---end_ignore
 
 -- lateral reference to a join alias variable
 select * from (select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1,
@@ -1649,7 +1652,6 @@ select * from int4_tbl a,
 -- GPDB_94_STABLE_MERGE_FIXME: The query below gives wrong results. The change
 -- is related to upstream commit acfcd4. Disable this case temporarily and will
 -- come back to fix it when understanding more about that commit.
---start_ignore
 explain (verbose, costs off)
 select * from
   int8_tbl a left join lateral
@@ -1661,7 +1663,6 @@ select * from
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
---end_ignore
 
 -- case requiring nested PlaceHolderVars
 explain (verbose, costs off)
@@ -1706,7 +1707,6 @@ select * from
   ) as q2;
 
 -- check we don't try to do a unique-ified semijoin with LATERAL
--- start_ignore
 -- GPDB_94_STABLE_MERGE_FIXME: The query below is 'deeply' correlated
 -- and GPDB would not pull up the sublink into a semijoin (why?), while
 -- PostgreSQL will do. So the following test is meaningless in GPDB.
@@ -1721,7 +1721,6 @@ select * from
   lateral (select f1 from int4_tbl
            where f1 = any (select unique1 from tenk1
                            where unique2 = v.x offset 0)) ss;
---end_ignore
 
 -- test some error cases where LATERAL should have been used but wasn't
 select f1,g from int4_tbl a, (select f1 as g) ss;
@@ -1753,3 +1752,5 @@ update xx1 set x2 = f1 from xx1, lateral (select * from int4_tbl where f1 = x1) 
 delete from xx1 using (select * from int4_tbl where f1 = x1) ss;
 delete from xx1 using (select * from int4_tbl where f1 = xx1.x1) ss;
 delete from xx1 using lateral (select * from int4_tbl where f1 = x1) ss;
+*/
+-- end_ignore

--- a/src/test/regress/sql/rangefuncs.sql
+++ b/src/test/regress/sql/rangefuncs.sql
@@ -310,6 +310,9 @@ SELECT * FROM (VALUES (1),(2),(3)) v(r), unnest(array[r*10,r*20,r*30]) WITH ORDI
 
 -- deep nesting
 
+-- start_ignore
+-- LATERAL_FIXME: lateral is not fully supported.
+/*
 SELECT * FROM (VALUES (1),(2),(3)) v1(r1),
               LATERAL (SELECT r1, * FROM (VALUES (10),(20),(30)) v2(r2)
                                          LEFT JOIN generate_series(21,23) f(i) ON ((r2+i)<100) OFFSET 0) s1;
@@ -322,7 +325,8 @@ SELECT * FROM (VALUES (1),(2),(3)) v1(r1),
 SELECT * FROM (VALUES (1),(2),(3)) v1(r1),
               LATERAL (SELECT r1, * FROM (VALUES (10),(20),(30)) v2(r2)
                                          LEFT JOIN generate_series(r1,2+r2/5) f(i) ON ((r2+i)<100) OFFSET 0) s1;
-
+*/
+-- end_ignore
 DROP FUNCTION foo_sql(int,int);
 DROP FUNCTION foo_mat(int,int);
 DROP SEQUENCE foo_rescan_seq1;


### PR DESCRIPTION
That means users should not use the LATERAL keyword in SQL.  Implicit lateral
is not disabled in current gpdb since that is carefully used in some gpdb
specific code change like EXPR/ANY sublink pullup. Users should avoid writing
implicit LATERAL SQLs given implicit lateral might fail and thus is not
officially supported on current gpdb also.